### PR TITLE
Add missing return

### DIFF
--- a/cautils/apis/backendconnectormethods.go
+++ b/cautils/apis/backendconnectormethods.go
@@ -21,7 +21,7 @@ func MakeBackendConnector(client *http.Client, baseURL string, loginDetails *Cus
 
 func ValidateBEConnectorMakerInput(client *http.Client, baseURL string, loginDetails *CustomerLoginDetails) error {
 	if client == nil {
-		fmt.Errorf("You must provide an initialized httpclient")
+		return fmt.Errorf("You must provide an initialized httpclient")
 	}
 	if len(baseURL) == 0 {
 		return fmt.Errorf("you must provide a valid backend url")


### PR DESCRIPTION
This is a very small PR to fix a missing `return` keyword.

Currently, if the `client` argument in `ValidateBEConnectorMakerInput` is `nil`, the error on L24 is not returned. If the other arguments were valid, the program would continue in a bad state until a `nil`-pointer exception occurred here:

https://github.com/armosec/kubescape/blob/0adb9dd540b039d41f5413a61e74693198733c2e/cautils/apis/backendconnectormethods.go#L55

This PR fixes that issue.

`go test ./...` passes. Let me know if there are any other required steps - I didn't see any in the repo documentation.