### PR TITLE
Fix Bad Request error when scanning with Account ID that isn’t a valid UUID

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dwertent/go-logger/helpers"
 
 	"github.com/enescakir/emoji"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -124,6 +125,11 @@ func flagValidationFramework(scanInfo *cautils.ScanInfo) error {
 	}
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
 		return fmt.Errorf("bad argument: out of range threshold")
+	}
+
+	accountID := scanInfo.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
 	}
 	return nil
 }


### PR DESCRIPTION
# What this PR does
This PR fixes a Bad Request error when running a Kubescape scan with an Account ID that is not a valid UUID.

Now, when attempting to run a scan and submit results to an Account ID that is not a valid UUID, Kubescape returns a descriptive error:
```
~/kubescape$ ./kubescape scan --account=myid
Error: bad argument: account ID must be a valid UUID
Usage:
  kubescape scan [flags]
  kubescape scan [command]

Examples:

  Scan command is for scanning an existing cluster or kubernetes manifest files based on pre-defind frameworks

[ SNIPPED ]

Global Flags:
      --cache-dir string   Cache directory [$KS_CACHE_DIR] (default "~/.kubescape")
      --disable-color      Disable Color output for logging
  -l, --logger string      Logger level. Supported: debug/info/success/warning/error/fatal [$KS_LOGGER] (default "info")

Use "kubescape scan [command] --help" for more information about a command.

[fatal] bad argument: account ID must be a valid UUID
```