### PR TITLE
Installation guide links fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Want to contribute? Want to discuss something? Have an issue?
 * [Configure and run customized frameworks](https://youtu.be/12Sanq_rEhs)
 * Customize controls configurations. [Kubescape CLI](https://youtu.be/955psg6TVu4), [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
 
-<details><summary>Windows</summary>
+
 
 ## Install on Windows
 
@@ -104,9 +104,7 @@ Note: if you get an error you might need to change the execution policy (i.e. en
 ``` powershell
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 ```
-</details>
 
-<details><summary>MacOS</summary>
 
 ## Install on macOS
 
@@ -116,9 +114,7 @@ Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 2. ```sh
     brew install kubescape-cli
     ```
-</details>
 
-<details><summary>Nix/NixOS</summary>
 
 ## Install on NixOS or with nix (Community)
 
@@ -152,7 +148,7 @@ home-manager:
 
 Or to your profile (not preferred): `nix-env --install -A nixpkgs.kubescape`
 
-</details>
+
 
 ## Usage & Examples
 


### PR DESCRIPTION
Installation guide links for different platforms mentioned in the section [Installation guide](https://github.com/kubescape/kubescape#install) do not work on the details tag which is in the collapsed state.
All details tag collapsed by default so putting a link for them will not work.

# Solution
1. Remove links and add details sections in the place of links.
2. Remove details tag so that links can work.

I'd have made changes to adopt the second solution. 
Looking forward work on this issue.

Suggestions are welcome.