### PR TITLE
Fixed Error message and changed const variable name

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -19,7 +19,7 @@ const (
 	scanPath              = "/v1/scan"
 	statusPath            = "/v1/status"
 	resultsPath           = "/v1/results"
-	prometheusMmeticsPath = "/v1/metrics"
+	prometheusMetricsPath = "/v1/metrics"
 	livePath              = "/livez"
 	readyPath             = "/readyz"
 )
@@ -45,7 +45,7 @@ func SetupHTTPListener() error {
 	// listen
 	httpHandler := handlerequestsv1.NewHTTPHandler()
 
-	rtr.HandleFunc(prometheusMmeticsPath, httpHandler.Metrics)
+	rtr.HandleFunc(prometheusMetricsPath, httpHandler.Metrics)
 	rtr.HandleFunc(scanPath, httpHandler.Scan)
 	rtr.HandleFunc(statusPath, httpHandler.Status)
 	rtr.HandleFunc(resultsPath, httpHandler.Results)
@@ -75,7 +75,7 @@ func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
 
 	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("filed to load key pair: %v", err)
+		return nil, fmt.Errorf("failed to load key pair: %v", err)
 	}
 	return &pair, nil
 }


### PR DESCRIPTION
## Describe your changes

1. Error message is fixed to `fmt.Errorf("failed to load key pair: %v", err)`
2. const variable name is changed into `prometheusMetricsPath`

## Issue ticket number and link
Fixes :- #649

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

