### PR TITLE
Fixed Typo Function name `sumObj.ListOfDangerousArtifcats`

### DIFF
--- a/core/pkg/containerscan/containerscan_test.go
+++ b/core/pkg/containerscan/containerscan_test.go
@@ -29,8 +29,8 @@ func TestDecodeScanWIthDangearousArtifacts(t *testing.T) {
 	if sumObj.Status != "Success" {
 		t.Errorf("sumObj.Status = %v", sumObj.Status)
 	}
-	if len(sumObj.ListOfDangerousArtifcats) != 3 {
-		t.Errorf("sumObj.ListOfDangerousArtifcats = %v", sumObj.ListOfDangerousArtifcats)
+	if len(sumObj.ListOfDangerousArtifacts) != 3 {
+		t.Errorf("sumObj.ListOfDangerousArtifacts = %v", sumObj.ListOfDangerousArtifacts)
 	}
 }
 
@@ -84,7 +84,7 @@ func TestCalculateFixed(t *testing.T) {
 		ImgTag:  "",
 		Version: "",
 	}})
-	if 0 != res {
+	if res != 0 {
 		t.Errorf("wrong fix status: %v", res)
 	}
 }


### PR DESCRIPTION
## Describe your changes

typo Function name `sumObj.ListOfDangerousArtifcats` is fixed by this PR

## Issue ticket number and link

Fixes :- #653
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
