### PR TITLE
added Tutorials missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Want to contribute? Want to discuss something? Have an issue?
 * [Scan Kubescape on an air-gapped environment (offline support)](https://youtu.be/IGXL9s37smM)
 * [Managing exceptions in the Kubescape SaaS version](https://youtu.be/OzpvxGmCR80)
 * [Configure and run customized frameworks](https://youtu.be/12Sanq_rEhs)
-* Customize control configurations. [Kubescape CLI](https://youtu.be/955psg6TVu4), [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
+* [Customize control configurations](https://www.youtube.com/watch?v=lIMVSVhH33o) 
+* [Kubescape CLI](https://youtu.be/955psg6TVu4) 
+* [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
 
 ## Install on Windows
 


### PR DESCRIPTION
## Describe your changes
In The Tutorial section link for the `Customize control configurations` was missing.
So I find the tutorial video on ARMO youtube and upload the link.
## Screenshots - If Any (Optional)
![armo](https://user-images.githubusercontent.com/33636054/186348572-1c917c54-db20-4efe-866f-07df734d57b8.png)
Now it looks like this
## Issue ticket number and link
I didn't create the issue I just created the PR


