### PR TITLE
added Tutorials missing link

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -1,0 +1,3 @@
+- name: GitHub Action for Helm Templates Validation
+  uses: igabaydulin/helm-check-action@0.1.4
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Want to contribute? Want to discuss something? Have an issue?
 * [Scan Kubescape on an air-gapped environment (offline support)](https://youtu.be/IGXL9s37smM)
 * [Managing exceptions in the Kubescape SaaS version](https://youtu.be/OzpvxGmCR80)
 * [Configure and run customized frameworks](https://youtu.be/12Sanq_rEhs)
-* Customize control configurations. [Kubescape CLI](https://youtu.be/955psg6TVu4), [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
+* [Customize control configurations](https://www.youtube.com/watch?v=lIMVSVhH33o) 
+* [Kubescape CLI](https://youtu.be/955psg6TVu4) 
+* [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
 
 ## Install on Windows
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="docs/kubescape.png" width="300" alt="logo" align="center">
 
-[![build](https://github.com/kubescape/kubescape/actions/workflows/build.yaml/badge.svg)](https://github.com/kubescape/kubescape/actions/workflows/build.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kubescape/kubescape)](https://goreportcard.com/report/github.com/kubescape/kubescape)
+[![build](https://github.com/armosec/kubescape/actions/workflows/build.yaml/badge.svg)](https://github.com/armosec/kubescape/actions/workflows/build.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/armosec/kubescape)](https://goreportcard.com/report/github.com/armosec/kubescape)
 
 
 
@@ -13,15 +13,24 @@ Kubescape integrates natively with other DevOps tools, including Jenkins, Circle
 
 </br>
 
+<!-- # Kubescape Coverage
+<img src="docs/ksfromcodetodeploy.png">
+
+</br> -->
+
+
 # Kubescape CLI:
 <img src="docs/demo.gif">
 
 </br>
 
+<!-- # Kubescape overview:
+<img src="docs/ARMO-header-2022.gif"> -->
+
 # TL;DR
 ## Install:
 ```sh
-curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+curl -s https://raw.githubusercontent.com/armosec/kubescape/master/install.sh | /bin/bash
 ```
 
 [Install on windows](#install-on-windows)
@@ -45,7 +54,7 @@ kubescape scan --submit --enable-host-scan --verbose
 
 </br>
 
-### Click [👍](https://github.com/kubescape/kubescape/stargazers) if you want us to continue to develop and improve Kubescape 😀
+### Click [👍](https://github.com/armosec/kubescape/stargazers) if you want us to continue to develop and improve Kubescape 😀
 
 </br>
 
@@ -83,14 +92,14 @@ Want to contribute? Want to discuss something? Have an issue?
 * [Kubescape CLI](https://youtu.be/955psg6TVu4) 
 * [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
 
-## Install on Windows
-
 <details><summary>Windows</summary>
+
+## Install on Windows
 
 **Requires powershell v5.0+**
 
 ``` powershell
-iwr -useb https://raw.githubusercontent.com/kubescape/kubescape/master/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/armosec/kubescape/master/install.ps1 | iex
 ```
 
 Note: if you get an error you might need to change the execution policy (i.e. enable Powershell) with
@@ -100,10 +109,9 @@ Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 ```
 </details>
 
+<details><summary>MacOS</summary>
 
 ## Install on macOS
-
-<details><summary>MacOS</summary>
 
 1. ```sh
     brew tap kubescape/tap
@@ -113,9 +121,9 @@ Set-ExecutionPolicy RemoteSigned -scope CurrentUser
     ```
 </details>
 
-## Install on NixOS or with nix (Community)
-
 <details><summary>Nix/NixOS</summary>
+
+## Install on NixOS or with nix (Community)
 
 Direct issues installing `kubescape` via `nix` through the channels mentioned [here](https://nixos.wiki/wiki/Support)
 
@@ -195,7 +203,7 @@ kubescape scan *.yaml --submit
 
 #### Scan kubernetes manifest files from a git repository [and submit the results](https://hub.armosec.io/docs/repository-scanning?utm_source=github&utm_medium=repository)
 ```
-kubescape scan https://github.com/kubescape/kubescape --submit
+kubescape scan https://github.com/armosec/kubescape --submit
 ```
 
 #### Display all scanned resources (including the resources which passed) 
@@ -293,9 +301,9 @@ View Kubescape scan results directly in [Lens IDE](https://k8slens.dev/) using k
 
 # Building Kubescape
 
-## Build on Windows
-
 <details><summary>Windows</summary>
+
+## Windows
 
 1. Install MSYS2 & build libgit _(needed only for the first time)_
 
@@ -318,9 +326,9 @@ View Kubescape scan results directly in [Lens IDE](https://k8slens.dev/) using k
     ```
 </details>
 
-## Build on Linux/MacOS
-
 <details><summary>Linux / MacOS</summary>
+
+## Linux / MacOS
 
 1. Install libgit2 dependency _(needed only for the first time)_
    
@@ -406,7 +414,7 @@ The results by default are printed in a pretty "console friendly" manner, but th
 Kubescape is an open source project, we welcome your feedback and ideas for improvement. We’re also aiming to collaborate with the Kubernetes community to help make the tests more robust and complete as Kubernetes develops.
 
 ## Thanks to all the contributors ❤️
-<a href = "https://github.com/kubescape/kubescape/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=kubescape/kubescape"/>
+<a href = "https://github.com/armosec/kubescape/graphs/contributors">
+  <img src = "https://contrib.rocks/image?repo=armosec/kubescape"/>
 </a>
 


### PR DESCRIPTION
## Describe your changes
In The Tutorial section link for the Customize control configurations was missing.
So I find the tutorial video on ARMO youtube and upload the link.

## Screenshots - If Any (Optional)
![armo](https://user-images.githubusercontent.com/33636054/186350319-eae3ac70-aa37-4d59-8897-1dae8befa011.png)

## Issue ticket number and link
I didn't create the issue I just created the PR

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
