### PR TITLE
Typos fixed in container-image-vulnerability-adaptor.md

### DIFF
--- a/docs/proposals/container-image-vulnerability-adaptor.md
+++ b/docs/proposals/container-image-vulnerability-adaptor.md
@@ -11,7 +11,7 @@ source #287
 
 ### Relation to this proposal
 
-Multiple changes and design decisions need to be made before Kubescape will support the above outlined controls. However, a focal point in the whole picutre is the ability to access vulnerability of databases of container images. We anticipate that most container image repositories will support image vulnerability scanning, like some major players already do. Since there is no single API available which all of these data sources support, it is important to create an adaption layer within Kubescape so that different datasources can serve Kubescape's goals.
+Multiple changes and design decisions need to be made before Kubescape will support the above outlined controls. However, a focal point in the whole picture is the ability to access vulnerability of databases of container images. We anticipate that most container image repositories will support image vulnerability scanning, like some major players already do. Since there is no single API available which all of these data sources support, it is important to create an adaption layer within Kubescape so that different datasources can serve Kubescape's goals.
 
 ## High level design of Kubescape
 
@@ -19,7 +19,7 @@ Multiple changes and design decisions need to be made before Kubescape will supp
 
 * Controls and Rules: That actual control logic implementation, the "tests" themselves. Implemented in rego
 * OPA engine: the [OPA](https://github.com/open-policy-agent/opa) rego interpreter 
-* Rules processor: Kubescape component, it enumerates and runs the controls while also preparing the all the input data that the controls need for running
+* Rules processor: Kubescape component, it enumerates and runs the controls while also preparing all the input data that the controls need for running
 * Data sources: Set of different modules providing data to the Rules processor so that it can run the controls with them. Examples: Kubernetes objects, cloud vendor API objects and adding the vulnerability information in this proposal 
 * Cloud Image Vulnerability adaption interface: The subject of this proposal, it gives a common interface for different registry/vulnerability vendors to adapt to.
 * CIV adaptors: Specific implementation of the CIV interface, example Harbor adaption


### PR DESCRIPTION
## Describe your changes
Typos `picutre` is fixed by this PR.


## Issue ticket number and link
Fixes :- #673
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
