### PR TITLE
Tutorials missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Want to contribute? Want to discuss something? Have an issue?
 * [Scan Kubescape on an air-gapped environment (offline support)](https://youtu.be/IGXL9s37smM)
 * [Managing exceptions in the Kubescape SaaS version](https://youtu.be/OzpvxGmCR80)
 * [Configure and run customized frameworks](https://youtu.be/12Sanq_rEhs)
-* Customize control configurations. [Kubescape CLI](https://youtu.be/955psg6TVu4), [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
+* [Customize control configurations](https://www.youtube.com/watch?v=lIMVSVhH33o) 
+* [Kubescape CLI](https://youtu.be/955psg6TVu4) 
+* [Kubescape SaaS](https://youtu.be/lIMVSVhH33o)
 
 ## Install on Windows
 


### PR DESCRIPTION
## Describe your changes
In The Tutorial section link for the Customize control configurations was missing.
So I find the tutorial video on ARMO youtube and upload the link.
## Screenshots - If Any (Optional)
![186350319-eae3ac70-aa37-4d59-8897-1dae8befa011](https://user-images.githubusercontent.com/33636054/186424998-7b0471c1-446c-4939-a5b0-85564c0f1386.png)

## Issue ticket number and link
I didn't create the issue I just created the PR

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
