### PR TITLE
typo: In the title and h1 element

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,9 +1,9 @@
 <html>
     <head>
         <title>
-            Kubscape Website
+            Kubescape Website
         </title>
-        <h1>Kubscape Website</h1>
+        <h1>Kubescape Website</h1>
     </head>
     <body>
 <h2>


### PR DESCRIPTION
Their was a typo in index.html file.

## Describe your changes
Their was a small error as the title and h1 contains kubscape, and the name of our organisation is kubescape so, I've made that change to correct that typo
