### PR TITLE
Fixed: Kubescape fails to authenticate remote private Github repo

### DIFF
--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -18,7 +18,7 @@ func cloneGitRepo(path *string) (string, error) {
 	var clonedDir string
 
 	// Clone git repository if needed
-	gitURL, err := giturl.NewGitURL(*path)
+	gitURL, err := giturl.NewGitAPI(*path)
 	if err == nil {
 		logger.L().Info("cloning", helpers.String("repository url", gitURL.GetURL().String()))
 		cautils.StartSpinner()

--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -66,7 +66,7 @@ func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 		}
 		auth = &http.BasicAuth{
 			Username: "anything Except Empty String",
-			Password: os.Getenv("GITHUB_TOKEN"),
+			Password: gitURL.GetToken(),
 		}
 	}
 

--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -1,6 +1,7 @@
 package resourcehandler
 
 import (
+	"errors"
 	"fmt"
 	nethttp "net/http"
 	"os"
@@ -29,6 +30,14 @@ func isGitRepoPublic(URL string) bool {
 	return false
 }
 
+// Check if the GITHUB_TOKEN is present
+func isGitTokenPresent(gitURL giturl.IGitAPI) bool {
+	if token := gitURL.GetToken(); token == "" {
+		return false
+	}
+	return true
+}
+
 // cloneRepo clones a repository to a local temporary directory and returns the directory
 func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 
@@ -50,6 +59,11 @@ func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 		// No authentication needed if repository is public
 		auth = nil
 	} else {
+
+		// Return Error if the GITHUB_TOKEN is not present
+		if isGitTokenPresent := isGitTokenPresent(gitURL); !isGitTokenPresent {
+			return "", fmt.Errorf("%w", errors.New("GITHUB_TOKEN is not present"))
+		}
 		auth = &http.BasicAuth{
 			Username: "anything Except Empty String",
 			Password: os.Getenv("GITHUB_TOKEN"),

--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -30,7 +30,7 @@ func isGitRepoPublic(URL string) bool {
 }
 
 // cloneRepo clones a repository to a local temporary directory and returns the directory
-func cloneRepo(gitURL giturl.IGitURL) (string, error) {
+func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 
 	// Create temp directory
 	tmpDir, err := os.MkdirTemp("", "")


### PR DESCRIPTION
## Describe your changes
* Checked if the Git Repository is Public or Private.
* No Authentication is required for scanning Public Git Repositories
* Added authentication using GITHUB_TOKEN for scanning private Git repositories

## Issue ticket number and link
 #710

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
