### PR TITLE
docs: fixed some grammatical mistakes in kubescape/httphandler/README…

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -23,7 +23,7 @@ Running `kubescape` will start up a web-server on port `8080` which will serve t
 
 ### Get results
 * GET `/v1/results` -  request kubescape scan results
-* * query `id=<string>` -> request results of a specific scan ID. If empty will return latest results
+* * query `id=<string>` -> request results of a specific scan ID. If empty will return the latest results
 * * query `keep=true` -> keep the results in the local storage after returning. default is `keep=false` - the results will be deleted from local storage after they are returned
 
 [Response](#response-object):
@@ -55,7 +55,7 @@ When scanning is in progress
 }
 ```
 ### Check scanning progress status
-Check the scanning status - is the scanning in progress or done. This is meant for a waiting mechanize since the API does not return the entire results object when the scanning is done
+Check the scanning status - is the scanning in progress or done? This is meant for a waiting mechanize since the API does not return the entire results object when the scanning is done
 
 * GET `/v1/status` -  Request kubescape scan status
 * * query `id=<string>` -> Check status of a specific scan. If empty will check if any scan is in progress
@@ -88,7 +88,7 @@ When scanning is not in progress
 ### Prometheus support API
 
 * GET/POST `/v1/metrics` - will trigger cluster scan. will respond with prometheus metrics once they have been scanned. This will respond 503 if the scan failed.
-* `/livez` - will respond 200 is server is alive
+* `/livez` - will respond 200 if the server is alive
 * `/readyz` - will respond 200 if server can receive requests 
 
 ## Objects
@@ -140,7 +140,7 @@ When scanning is not in progress
   curl --request GET http://127.0.0.1:8080/v1/results -o response.json
   ```
 
-#### Trigger scan and wait for scan to end  
+#### Trigger scan and wait for the scan to end  
 
 ```bash
 curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true, "submit": true}' http://127.0.0.1:8080/v1/scan?wait -o scan_results.json


### PR DESCRIPTION
## Describe your changes

I fixed some grammatical mistakes in `kubescape/httphandler/README.md` file

 ✅  Edited `/livez - will respond 200 is server is alive` to 
 `/livez - will respond to 200 if the server is alive `

 ✅  Edited `query id=<string> -> request results of a specific scan ID. If empty will return latest results` to 
`query id=<string> -> request results of a specific scan ID. If empty will return the latest results `

 ✅  Edited `Trigger scan and wait for scan to end ` to
`Trigger scan and wait for the scan to end`

 ✅  Edited `Check the scanning status - is the scanning in progress or done.` to
`Check the scanning status - is the scanning in progress or done? `

## Screenshots - If Any (Optional) 

## Issue ticket number and link
#736 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)