### PR TITLE
Fixed: Misconfiguration in "close-typos-issues.yaml" GITHUB Actions file

### DIFF
--- a/.github/workflows/close-typos-issues.yaml
+++ b/.github/workflows/close-typos-issues.yaml
@@ -3,16 +3,21 @@ on:
     types: [opened, labeled]
 
 jobs:
-  build:
-    if: ${{ github.event.label.name == 'typo' }}
+  open_PR_message:
+    if: github.event.label.name == 'typo'
     runs-on: ubuntu-latest
+    steps:
+      - uses: ben-z/actions-comment-on-issue@1.0.2
+        with:
+          message: "Hello! :wave:\n\nThis issue is being automatically closed, Please open a PR with a relevant fix."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          
+          
   auto_close_issues:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Automatically close typo issues
-        uses: lucasbento/auto-close-issues@v1.0.2
+      - uses: lee-dohm/close-matching-issues@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-close-message: "@${issue.user.login}: Hello! :wave:\n\nThis issue is being automatically closed, Please open a PR with a relevant fix."
+          query: 'label:typo'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Describe your changes
* The workflow was intended to automatically comment & close any issues labelled "typo". Instead, it is throwing an error "PR run fail" and sending unnecessary emails for a PR due to a misconfiguartion.
* Corrected the above problem.

* Commenting automatically on issues labelled "typo" to open a PR with a relevant fix.

* Closing issues labelled typo automatically.

## Screenshots 
![alt text](https://github.com/suhasgumma/ImagesForGitHub/blob/master/close-typos-issues.png?raw=true)
## Issue ticket number and link
#754 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


Closes #754 
