### PR TITLE
add flag validation for --account-id (#605)

### DIFF
--- a/cmd/delete/exceptions.go
+++ b/cmd/delete/exceptions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"github.com/google/uuid"
+	"github.com/kubescape/kubescape/v2/core/cautils"
 )
 
 func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command {
@@ -42,9 +42,7 @@ func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command 
 // Check if the flag entered are valid
 func flagValidationDelete(deleteInfo *v1.Delete) error {
 
-	accountID := deleteInfo.Credentials.Account
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
-		return fmt.Errorf("bad argument: account must be a valid UUID")
-	}
-	return nil
+
+	// Validate the user's credentials : accountID, clientID, secretKey
+	return cautils.ValidateCredentials(deleteInfo.Credentials.Account, deleteInfo.Credentials.ClientID, deleteInfo.Credentials.SecretKey)
 }

--- a/cmd/delete/exceptions.go
+++ b/cmd/delete/exceptions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"github.com/kubescape/kubescape/v2/core/cautils"
 )
 
 func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command {
@@ -23,7 +22,7 @@ func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command 
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			
+
 			if err := flagValidationDelete(deleteInfo); err != nil {
 				logger.L().Fatal(err.Error())
 			}
@@ -42,7 +41,6 @@ func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command 
 // Check if the flag entered are valid
 func flagValidationDelete(deleteInfo *v1.Delete) error {
 
-
-	// Validate the user's credentials : accountID, clientID, secretKey
-	return cautils.ValidateCredentials(deleteInfo.Credentials.Account, deleteInfo.Credentials.ClientID, deleteInfo.Credentials.SecretKey)
+	// Validate the user's credentials
+	return deleteInfo.Credentials.Validate()
 }

--- a/cmd/delete/exceptions.go
+++ b/cmd/delete/exceptions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
+	"github.com/google/uuid"
 )
 
 func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command {
@@ -22,6 +23,11 @@ func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command 
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			
+			if err := flagValidationDelete(deleteInfo); err != nil {
+				logger.L().Fatal(err.Error())
+			}
+
 			exceptionsNames := strings.Split(args[0], ";")
 			if len(exceptionsNames) == 0 {
 				logger.L().Fatal("missing exceptions names")
@@ -31,4 +37,14 @@ func getExceptionsCmd(ks meta.IKubescape, deleteInfo *v1.Delete) *cobra.Command 
 			}
 		},
 	}
+}
+
+// Check if the flag entered are valid
+func flagValidationDelete(deleteInfo *v1.Delete) error {
+
+	accountID := deleteInfo.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+	return nil
 }

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"github.com/google/uuid"
 )
 
 var (
@@ -88,10 +87,7 @@ func GeDownloadCmd(ks meta.IKubescape) *cobra.Command {
 
 // Check if the flag entered are valid
 func flagValidationDownload(downloadInfo *v1.DownloadInfo) error {
-
-	accountID := downloadInfo.Credentials.Account
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
-		return fmt.Errorf("bad argument: account must be a valid UUID")
-	}
-	return nil
+	
+	// Validate the user's credentials : accountID, clientID, secretKey
+	return cautils.ValidateCredentials(downloadInfo.Credentials.Account, downloadInfo.Credentials.ClientID, downloadInfo.Credentials.SecretKey)
 }

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -87,7 +87,7 @@ func GeDownloadCmd(ks meta.IKubescape) *cobra.Command {
 
 // Check if the flag entered are valid
 func flagValidationDownload(downloadInfo *v1.DownloadInfo) error {
-	
-	// Validate the user's credentials : accountID, clientID, secretKey
-	return cautils.ValidateCredentials(downloadInfo.Credentials.Account, downloadInfo.Credentials.ClientID, downloadInfo.Credentials.SecretKey)
+
+	// Validate the user's credentials
+	return downloadInfo.Credentials.Validate()
 }

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
+	"github.com/google/uuid"
 )
 
 var (
@@ -59,6 +60,10 @@ func GeDownloadCmd(ks meta.IKubescape) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if err := flagValidationDownload(&downloadInfo); err != nil {
+				return err
+			}
+
 			if filepath.Ext(downloadInfo.Path) == ".json" {
 				downloadInfo.Path, downloadInfo.FileName = filepath.Split(downloadInfo.Path)
 			}
@@ -79,4 +84,14 @@ func GeDownloadCmd(ks meta.IKubescape) *cobra.Command {
 	downloadCmd.Flags().StringVarP(&downloadInfo.Path, "output", "o", "", "Output file. If not specified, will save in `~/.kubescape/<policy name>.json`")
 
 	return downloadCmd
+}
+
+// Check if the flag entered are valid
+func flagValidationDownload(downloadInfo *v1.DownloadInfo) error {
+
+	accountID := downloadInfo.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+	return nil
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
+	"github.com/google/uuid"
 )
 
 var (
@@ -51,6 +52,11 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			
+			if err := flagValidationList(&listPolicies); err != nil {
+				return err
+			}
+
 			listPolicies.Target = args[0]
 
 			if err := ks.List(&listPolicies); err != nil {
@@ -66,4 +72,14 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 	listCmd.PersistentFlags().BoolVarP(&listPolicies.ListIDs, "id", "", false, "List control ID's instead of controls names")
 
 	return listCmd
+}
+
+// Check if the flag entered are valid
+func flagValidationList(listPolicies *v1.ListPolicies) error {
+
+	accountID := listPolicies.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+	return nil
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"github.com/google/uuid"
 )
 
 var (
@@ -77,9 +76,6 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 // Check if the flag entered are valid
 func flagValidationList(listPolicies *v1.ListPolicies) error {
 
-	accountID := listPolicies.Credentials.Account
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
-		return fmt.Errorf("bad argument: account must be a valid UUID")
-	}
-	return nil
+	// Validate the user's credentials : accountID, clientID, secretKey
+	return cautils.ValidateCredentials(listPolicies.Credentials.Account, listPolicies.Credentials.ClientID, listPolicies.Credentials.SecretKey)
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -51,7 +51,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			
+
 			if err := flagValidationList(&listPolicies); err != nil {
 				return err
 			}
@@ -76,6 +76,6 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 // Check if the flag entered are valid
 func flagValidationList(listPolicies *v1.ListPolicies) error {
 
-	// Validate the user's credentials : accountID, clientID, secretKey
-	return cautils.ValidateCredentials(listPolicies.Credentials.Account, listPolicies.Credentials.ClientID, listPolicies.Credentials.SecretKey)
+	// Validate the user's credentials
+	return listPolicies.Credentials.Validate()
 }

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -58,6 +58,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if err := flagValidationFramework(scanInfo); err != nil {
+				return err
+			}
+			
 			// flagValidationControl(scanInfo)
 			scanInfo.PolicyIdentifier = []cautils.PolicyIdentifier{}
 

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -126,7 +126,6 @@ func flagValidationFramework(scanInfo *cautils.ScanInfo) error {
 		return fmt.Errorf("bad argument: out of range threshold")
 	}
 
-	// Validate the user's credentials : accountID, clientID, secretKey
-	return cautils.ValidateCredentials(scanInfo.Credentials.Account, scanInfo.Credentials.ClientID, scanInfo.Credentials.SecretKey)
-
+	// Validate the user's credentials
+	return scanInfo.Credentials.Validate()
 }

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 
 	"github.com/enescakir/emoji"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -126,9 +125,8 @@ func flagValidationFramework(scanInfo *cautils.ScanInfo) error {
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
 		return fmt.Errorf("bad argument: out of range threshold")
 	}
-	accountID := scanInfo.Credentials.Account
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
-		return fmt.Errorf("bad argument: account must be a valid UUID")
-	}
-	return nil
+
+	// Validate the user's credentials : accountID, clientID, secretKey
+	return cautils.ValidateCredentials(scanInfo.Credentials.Account, scanInfo.Credentials.ClientID, scanInfo.Credentials.SecretKey)
+
 }

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/kubescape/v2/core/meta"
 
 	"github.com/enescakir/emoji"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -124,6 +125,10 @@ func flagValidationFramework(scanInfo *cautils.ScanInfo) error {
 	}
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
 		return fmt.Errorf("bad argument: out of range threshold")
+	}
+	accountID := scanInfo.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
 	}
 	return nil
 }

--- a/cmd/submit/exceptions.go
+++ b/cmd/submit/exceptions.go
@@ -21,6 +21,11 @@ func getExceptionsCmd(ks meta.IKubescape, submitInfo *metav1.Submit) *cobra.Comm
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+
+			if err := flagValidationSubmit(submitInfo); err != nil {
+				logger.L().Fatal(err.Error())
+			}
+
 			if err := ks.SubmitExceptions(&submitInfo.Credentials, args[0]); err != nil {
 				logger.L().Fatal(err.Error())
 			}

--- a/cmd/submit/rbac.go
+++ b/cmd/submit/rbac.go
@@ -36,6 +36,10 @@ func getRBACCmd(ks meta.IKubescape, submitInfo *v1.Submit) *cobra.Command {
 		Short:   "Submit cluster's Role-Based Access Control(RBAC)",
 		Long:    ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			
+			if err := flagValidationSubmit(submitInfo); err != nil {
+				return err
+			}
 
 			k8s := k8sinterface.NewKubernetesApi()
 
@@ -82,4 +86,14 @@ func getTenantConfig(credentials *cautils.Credentials, clusterName string, k8s *
 		return cautils.NewLocalConfig(getter.GetKSCloudAPIConnector(), credentials, clusterName)
 	}
 	return cautils.NewClusterConfig(k8s, getter.GetKSCloudAPIConnector(), credentials, clusterName)
+}
+
+// Check if the flag entered are valid
+func flagValidationSubmit(submitInfo *v1.Submit) error {
+
+	accountID := submitInfo.Credentials.Account
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+	return nil
 }

--- a/cmd/submit/rbac.go
+++ b/cmd/submit/rbac.go
@@ -36,7 +36,7 @@ func getRBACCmd(ks meta.IKubescape, submitInfo *v1.Submit) *cobra.Command {
 		Short:   "Submit cluster's Role-Based Access Control(RBAC)",
 		Long:    ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			
+
 			if err := flagValidationSubmit(submitInfo); err != nil {
 				return err
 			}
@@ -91,6 +91,6 @@ func getTenantConfig(credentials *cautils.Credentials, clusterName string, k8s *
 // Check if the flag entered are valid
 func flagValidationSubmit(submitInfo *v1.Submit) error {
 
-	// Validate the user's credentials : accountID, clientID, secretKey
-	return cautils.ValidateCredentials(submitInfo.Credentials.Account, submitInfo.Credentials.ClientID, submitInfo.Credentials.SecretKey)
+	// Validate the user's credentials
+	return submitInfo.Credentials.Validate()
 }

--- a/cmd/submit/rbac.go
+++ b/cmd/submit/rbac.go
@@ -91,9 +91,6 @@ func getTenantConfig(credentials *cautils.Credentials, clusterName string, k8s *
 // Check if the flag entered are valid
 func flagValidationSubmit(submitInfo *v1.Submit) error {
 
-	accountID := submitInfo.Credentials.Account
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
-		return fmt.Errorf("bad argument: account must be a valid UUID")
-	}
-	return nil
+	// Validate the user's credentials : accountID, clientID, secretKey
+	return cautils.ValidateCredentials(submitInfo.Credentials.Account, submitInfo.Credentials.ClientID, submitInfo.Credentials.SecretKey)
 }

--- a/cmd/submit/results.go
+++ b/cmd/submit/results.go
@@ -54,6 +54,11 @@ func getResultsCmd(ks meta.IKubescape, submitInfo *v1.Submit) *cobra.Command {
 		Short: "Submit a pre scanned results file. The file must be in json format",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if err := flagValidationSubmit(submitInfo); err != nil {
+				return err
+			}
+
 			if len(args) == 0 {
 				return fmt.Errorf("missing results file")
 			}

--- a/core/cautils/rootinfo.go
+++ b/core/cautils/rootinfo.go
@@ -2,9 +2,9 @@ package cautils
 
 import (
 	"fmt"
+
 	"github.com/google/uuid"
 )
-
 
 type RootInfo struct {
 	Logger       string // logger level
@@ -25,19 +25,19 @@ type Credentials struct {
 }
 
 // To check if the user's credentials: accountID / clientID / secretKey are valid.
-func ValidateCredentials (accountID string, clientID string, secretKey string) error {
-	
+func (credentials *Credentials) Validate() error {
+
 	// Check if the Account-ID is valid
-	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+	if _, err := uuid.Parse(credentials.Account); credentials.Account != "" && err != nil {
 		return fmt.Errorf("bad argument: account must be a valid UUID")
 	}
 	// Check if the Client-ID is valid
-	if _, err := uuid.Parse(clientID); clientID != "" && err != nil {
+	if _, err := uuid.Parse(credentials.ClientID); credentials.ClientID != "" && err != nil {
 		return fmt.Errorf("bad argument: account must be a valid UUID")
 	}
 
 	// Check if the Secret-Key is valid
-	if _, err := uuid.Parse(secretKey); secretKey != "" && err != nil {
+	if _, err := uuid.Parse(credentials.SecretKey); credentials.SecretKey != "" && err != nil {
 		return fmt.Errorf("bad argument: account must be a valid UUID")
 	}
 

--- a/core/cautils/rootinfo.go
+++ b/core/cautils/rootinfo.go
@@ -1,5 +1,11 @@
 package cautils
 
+import (
+	"fmt"
+	"github.com/google/uuid"
+)
+
+
 type RootInfo struct {
 	Logger       string // logger level
 	LoggerName   string // logger name ("pretty"/"zap"/"none")
@@ -16,4 +22,24 @@ type Credentials struct {
 	Account   string
 	ClientID  string
 	SecretKey string
+}
+
+// To check if the user's credentials: accountID / clientID / secretKey are valid.
+func ValidateCredentials (accountID string, clientID string, secretKey string) error {
+	
+	// Check if the Account-ID is valid
+	if _, err := uuid.Parse(accountID); accountID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+	// Check if the Client-ID is valid
+	if _, err := uuid.Parse(clientID); clientID != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+
+	// Check if the Secret-Key is valid
+	if _, err := uuid.Parse(secretKey); secretKey != "" && err != nil {
+		return fmt.Errorf("bad argument: account must be a valid UUID")
+	}
+
+	return nil
 }

--- a/core/cautils/rootinfo_test.go
+++ b/core/cautils/rootinfo_test.go
@@ -1,0 +1,71 @@
+package cautils
+
+import "testing"
+
+func TestCredentials_Validate(t *testing.T) {
+	type fields struct {
+		Account   string
+		ClientID  string
+		SecretKey string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "valid account ID",
+			fields: fields{
+				Account: "22019933-feac-4012-a8eb-e81461ba6655",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid account ID",
+			fields: fields{
+				Account: "22019933-feac-4012-a8eb-e81461ba665",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid client ID",
+			fields: fields{
+				ClientID: "22019933-feac-4012-a8eb-e81461ba6655",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid client ID",
+			fields: fields{
+				ClientID: "22019933-feac-4012-a8eb-e81461ba665",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid secret key",
+			fields: fields{
+				SecretKey: "22019933-feac-4012-a8eb-e81461ba6655",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid secret key",
+			fields: fields{
+				SecretKey: "22019933-feac-4012-a8eb-e81461ba665",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentials := &Credentials{
+				Account:   tt.fields.Account,
+				ClientID:  tt.fields.ClientID,
+				SecretKey: tt.fields.SecretKey,
+			}
+			if err := credentials.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Credentials.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Anubhav Gupta <mail.anubhav06@gmail.com>

## Describe your changes
Fixes a Bad Request error when running a Kubescape scan with an Account ID that is not a valid UUID

This PR is in continuation to #577 
I've added the flag validation to all the commands (and their respective subcommands as well) which use the `--account` flag.

The commands which are covered are as follows:
1. `scan`
-> Subcommands: `framework`, `control`
2. `download`
3.  `delete`
-> Subcommands: `exceptions`
4. `list`
5. `submit`
-> Subcommands: `results`, `rbac`, `exceptions`


## Screenshots - If Any (Optional)
**Some** examples: 

![Screenshot (219)](https://user-images.githubusercontent.com/43821031/189214973-b1fdc310-61a9-453c-8303-fd0414948e41.png)

![3](https://user-images.githubusercontent.com/43821031/189215000-160e7ac0-a67b-4b17-9989-4b1193d90cde.png)

![4](https://user-images.githubusercontent.com/43821031/189215003-6e210e5f-cdfd-405b-8c1e-9be41d79e2c2.png)


## This PR fixes:

* Resolved #605 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
