### PR TITLE
Build on pre-configured killercoda's ubuntu playground (added documentation & Link to readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,31 @@ View Kubescape scan results directly in [Lens IDE](https://k8slens.dev/) using k
 
 </details>
 
+
+## Build on pre-configured killercoda's ubuntu playground
+
+* [Pre-configured Killercoda's Ubuntu Playground](https://killercoda.com/suhas-gumma/scenario/kubescape-build-for-development)
+
+<details><summary> Pre-programmed actions executed by the playground </summary>
+
+
+* Clone the official GitHub repository of `Kubescape`.
+* Install cmake.
+* Install `libgit2` dependency inside 'kubescape' directory.
+* Execute `make build` inside 'kubescape' directory.
+* The entire process involves executing multiple commands in order and it takes around 5-6 minutes to execute them all.
+
+</details>
+
+<details>
+<summary>Instructions to use the playground</summary>
+
+* Apply changes you wish to make to the kubescape directory using text editors like `Vim`.
+* Execute `make build` after the changes. (This will build the `kubescape` binary)
+* Now, you can use Kubescape just like a normal user. Instead of using `kubescape`, use `./kubescape`. (Make sure you are inside kubescape directory because the command will execute the binary named `kubescape` in `kubescape directory`.
+
+</details>
+
 ## VS code configuration samples
 
 You can use the sample files below to setup your VS code environment for building and debugging purposes.

--- a/README.md
+++ b/README.md
@@ -368,9 +368,7 @@ View Kubescape scan results directly in [Lens IDE](https://k8slens.dev/) using k
 
 
 * Clone the official GitHub repository of `Kubescape`.
-* Install cmake.
-* Install `libgit2` dependency inside 'kubescape' directory.
-* Execute `make build` inside 'kubescape' directory.
+* [Automate the build process on Linux](https://github.com/kubescape/kubescape#build-on-linuxmacos)
 * The entire process involves executing multiple commands in order and it takes around 5-6 minutes to execute them all.
 
 </details>
@@ -379,7 +377,7 @@ View Kubescape scan results directly in [Lens IDE](https://k8slens.dev/) using k
 <summary>Instructions to use the playground</summary>
 
 * Apply changes you wish to make to the kubescape directory using text editors like `Vim`.
-* Execute `make build` after the changes. (This will build the `kubescape` binary)
+* [Build on Linux](https://github.com/kubescape/kubescape#build-on-linuxmacos)
 * Now, you can use Kubescape just like a normal user. Instead of using `kubescape`, use `./kubescape`. (Make sure you are inside kubescape directory because the command will execute the binary named `kubescape` in `kubescape directory`.
 
 </details>


### PR DESCRIPTION
## Build on pre-configured killercoda's ubuntu playground
* [Pre-configured Killercoda's Ubuntu Playground](https://killercoda.com/suhas-gumma/scenario/kubescape-build-for-development)

* For people having trouble building in their local machines, killercoda's ubuntu playground will be extremely useful. But, as you know the playground lasts for only 60 minutes. Executing each command manually every hour is not a pleasant experience.  So, I've created this custom playground. The user just had to start the playground and wait for 5-6 minutes. 

## Pre-programmed actions executed by the playground
* Clone the official GitHub repository of `Kubescape`.
* Install cmake.
* Install `libgit2` dependency inside 'kubescape' directory.
* Execute `make build` inside 'kubescape' directory.
* The entire process involves executing multiple commands in order and it takes around 5-6 minutes to execute them all.


## Instructions to use the playground
* Apply changes you wish to make to the kubescape directory using text editors like `Vim`.
* Execute `make build` after the changes. (This will build the `kubescape` binary)
* Now, you can use Kubescape just like a normal user. Instead of using `kubescape`, use `./kubescape`. (Make sure you are inside kubescape directory because the command will execute the binary named `kubescape` in `kubescape directory`.