### PR TITLE
Suspicious assignment

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_root = "github.com/Cvr421/kubescape"

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -55,6 +55,7 @@ func (lp *LoadPolicy) GetControl(controlName string) (*reporthandling.Control, e
 		} else {
 			for _, ctrl := range framework.Controls {
 				if strings.EqualFold(ctrl.Name, controlName) || strings.EqualFold(ctrl.ControlID, controlName) {
+					ctrl := ctrl
 					control = &ctrl
 					break
 				}

--- a/httphandler/docs/server.go
+++ b/httphandler/docs/server.go
@@ -22,7 +22,7 @@ const (
 var specJSONBytes []byte
 
 // ServeOpenAPISpec returns the OpenAPI specification file
-func ServeOpenAPISpec(w http.ResponseWriter, r *http.Request) {
+func ServeOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(specJSONBytes)
 }


### PR DESCRIPTION
## Describe your changes
   suspicious assignment of 'ctrl'. range-loop variables always have the same address
   
   Range variables in a loop are reused at each iteration. This rule warns when assigning the address of the variable, passing the 
   address to append() or using it in a map.


## Screenshots - If Any (Optional)

## This PR fixes:
    #805

-   Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

[✓ ] My code follows the style guidelines of this project
[✓] I have commented my code, particularly in hard-to-understand areas
[✓] I have performed a self-review of my code
[   ] If it is a core feature, I have added thorough tests.
[✓] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
