### PR TITLE
Fixed typos on multiple files

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -10,7 +10,7 @@ import (
 )
 
 var scanCmdExamples = `
-  Scan command is for scanning an existing cluster or kubernetes manifest files based on pre-defind frameworks 
+  Scan command is for scanning an existing cluster or kubernetes manifest files based on pre-defined frameworks 
   
   # Scan current cluster with all frameworks
   kubescape scan --submit --enable-host-scan --verbose

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -178,7 +178,7 @@ KS_ACCOUNT_ID
 KS_CLIENT_ID
 KS_SECRET_KEY
 
-TODO - supprot:
+TODO - support:
 KS_CACHE // path to cached files
 */
 type ClusterConfig struct {

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -30,7 +30,7 @@ const (
 	JSON_FILE_FORMAT FileFormat = "json"
 )
 
-// LoadResourcesFromHelmCharts scans a given path (recuresively) for helm charts, renders the templates and returns a map of workloads and a map of chart names
+// LoadResourcesFromHelmCharts scans a given path (recursively) for helm charts, renders the templates and returns a map of workloads and a map of chart names
 func LoadResourcesFromHelmCharts(basePath string) (map[string][]workloadinterface.IMetadata, map[string]string) {
 	directories, _ := listDirs(basePath)
 	helmDirectories := make([]string, 0)
@@ -262,7 +262,7 @@ func glob(root, pattern string, onlyDirectories bool) ([]string, error) {
 			return err
 		}
 
-		// listing only directotries
+		// listing only directories
 		if onlyDirectories {
 			if info.IsDir() {
 				if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -111,7 +111,7 @@ type ScanInfo struct {
 	View               string             // Display all of the input resources and not only failed resources
 	Format             string             // Format results (table, json, junit ...)
 	Output             string             // Store results in an output file, Output file name
-	FormatVersion      string             // Output object can be differnet between versions, this is for testing and backward compatibility
+	FormatVersion      string             // Output object can be different between versions, this is for testing and backward compatibility
 	ExcludedNamespaces string             // used for host scanner namespace
 	IncludeNamespaces  string             //
 	InputPatterns      []string           // Yaml files input patterns

--- a/core/pkg/containerscan/elasticdatastructures.go
+++ b/core/pkg/containerscan/elasticdatastructures.go
@@ -12,7 +12,7 @@ type ElasticContainerVulnerabilityResult struct {
 	Timestamp         int64     `json:"timestamp"`
 	IsFixed           int       `json:"isFixed"`
 	IntroducedInLayer string    `json:"layerHash"`
-	RelevantLinks     []string  `json:"links"` // shitty SE practice
+	RelevantLinks     []string  `json:"links"` // Bad SE practice
 
 	Vulnerability `json:",inline"`
 }

--- a/core/pkg/registryadaptors/armosec/v1/datastructures.go
+++ b/core/pkg/registryadaptors/armosec/v1/datastructures.go
@@ -22,7 +22,7 @@ type V2ListRequest struct {
 	// How to order (sort) the list, field name + sort order (asc/desc), like https://www.w3schools.com/sql/sql_orderby.asp
 	// Example: "timestamp:asc,severity:desc"
 	OrderBy string `json:"orderBy,omitempty"`
-	// Cursor to the next page of former requset. Not supported yet
+	// Cursor to the next page of former request. Not supported yet
 	// Cursor cannot be used with another parameters of this struct
 	Cursor string `json:"cursor,omitempty"`
 	// FieldsList allow us to return only subset of the source document fields

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -61,7 +61,7 @@ func (resultsHandler *ResultsHandler) GetResults() *reporthandlingv2.PostureRepo
 	return printerv2.FinalizeResults(resultsHandler.scanData)
 }
 
-// HandleResults handle the scan results according to the pre defind interfaces
+// HandleResults handle the scan results according to the pre defined interfaces
 func (resultsHandler *ResultsHandler) HandleResults() error {
 
 	resultsHandler.printerObj.ActionPrint(resultsHandler.scanData)
@@ -77,7 +77,7 @@ func (resultsHandler *ResultsHandler) HandleResults() error {
 	return nil
 }
 
-// NewPrinter defind output format
+// NewPrinter defined output format
 func NewPrinter(printFormat, formatVersion string, verboseMode bool, viewType cautils.ViewTypes) printer.IPrinter {
 
 	switch printFormat {


### PR DESCRIPTION
## Describe your changes
Fixed comment typos on multiple files, I have attached the file links under Screenshots.

## Screenshots - If Any (Optional)
**Typo 1 - Different is mistyped as "differnet":** https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/cautils/scaninfo.go#L114

**Typo 2 - Support is mistyped as "supprot":**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/cautils/customerloader.go#L181

**Typo 3 - Recursively and Directories are mistypes as "recuresively" & "directotries" respectively:**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/cautils/fileutils.go#L33
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/cautils/fileutils.go#L265

**Typo 4 - Changed shitty to Bad as it can feel good:**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/pkg/containerscan/elasticdatastructures.go#L15

**Typo 5 - Request is mistyped as "requset":**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/pkg/registryadaptors/armosec/v1/datastructures.go#L25

**Typo 6 - Defined is mistypes as "defind":**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/pkg/resultshandling/results.go#L64
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/core/pkg/resultshandling/results.go#L80

**Typo 7 - Pre-defined is mistyped as "pre-defind":**
https://github.com/kubescape/kubescape/blob/6e2dda799336bd857a7c68ee86f9815f4a3d5a42/cmd/scan/scan.go#L13

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
