### PR TITLE
Spell-Correct in title

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 
 <head>
     <title>
-        Kubscape Website
+        Kubescape Website
     </title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
There is a spelling mistake in "docs/index.html" file, in the title of the website , So i have just changed it from "kubscape" to "Kubescape" 

## Screenshots - If Any (Optional)
![Screenshot from 2022-09-16 02-53-24](https://user-images.githubusercontent.com/91390132/190518314-70af9f4c-6166-4193-8e6d-0925916549e3.png)
![Screenshot from 2022-09-16 02-53-30](https://user-images.githubusercontent.com/91390132/190518323-18fe854b-c56c-47fe-b982-5cd0bf644c4b.png)


## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
