### PR TITLE
Spelling-Correct in index.html title

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 
 <head>
     <title>
-        Kubscape Website
+        Kubescape Website
     </title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
## Describe your changes
There is a spelling mistake in "docs/index.html" file at the title of the website, So i have just changed it from "Kubscape" to "Kubescape"
![Screenshot from 2022-09-16 02-53-24](https://user-images.githubusercontent.com/91390132/190520893-c35cc36c-1fdd-4621-a89e-fe6b83d67af9.png)
![Screenshot from 2022-09-16 02-53-30](https://user-images.githubusercontent.com/91390132/190520899-25ea4356-c600-4428-a61d-89ab84d9fb5d.png)

## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
