### PR TITLE
feat: unify severity threshold into one CLI flag

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -92,6 +92,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 
 			scanInfo.FrameworkScan = false
 
+			if err := validateControlScanInfo(scanInfo); err != nil {
+				return err
+			}
+
 			results, err := ks.Scan(scanInfo)
 			if err != nil {
 				logger.L().Fatal(err.Error())
@@ -110,4 +114,12 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			return nil
 		},
 	}
+}
+
+// validateControlScanInfo validates the ScanInfo struct for the `control` command
+func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
+	if err := validateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -58,7 +58,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := flagValidationFramework(scanInfo); err != nil {
+			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}
 			

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -110,7 +110,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				logger.L().Fatal("scan risk-score is above permitted threshold", helpers.String("risk-score", fmt.Sprintf("%.2f", results.GetRiskScore())), helpers.String("fail-threshold", fmt.Sprintf("%.2f", scanInfo.FailThreshold)))
 			}
 
-			enforceSeverityThresholds(&results.GetResults().SummaryDetails.SeverityCounters, scanInfo)
+			enforceSeverityThresholds(&results.GetResults().SummaryDetails.SeverityCounters, scanInfo, terminateOnExceedingSeverity)
 			return nil
 		},
 	}
@@ -118,7 +118,9 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 
 // validateControlScanInfo validates the ScanInfo struct for the `control` command
 func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
-	if err := validateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+	severity := scanInfo.FailThresholdSeverity
+
+	if err := validateSeverity(severity); severity != "" && err != nil {
 		return err
 	}
 	return nil

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -67,7 +67,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := flagValidationFramework(scanInfo); err != nil {
+			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}
 			scanInfo.FrameworkScan = true
@@ -193,7 +193,8 @@ func validateSeverity(severity string) error {
 
 }
 
-func flagValidationFramework(scanInfo *cautils.ScanInfo) error {
+// validateFrameworkScanInfo validates the scan info struct for the `scan framework` command
+func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if scanInfo.Submit && scanInfo.Local {
 		return fmt.Errorf("you can use `keep-local` or `submit`, but not both")
 	}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/meta"
-	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +74,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 
-	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", reporthandlingapis.SeverityHighString, "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html"`)
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -2,11 +2,11 @@ package scan
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/meta"
+	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/spf13/cobra"
 )
 
@@ -75,10 +75,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 
-	scanCmd.PersistentFlags().IntVar(&scanInfo.FailThresholdCritical, "threshold-critical", math.MaxInt, "Critical threshold is the amount of resources that have critical failed controls above which the command fails and returns exit code 1")
-	scanCmd.PersistentFlags().IntVar(&scanInfo.FailThresholdHigh, "threshold-high", math.MaxInt, "The amount of resources that have failed controls with High severity above which the command fails and returns exit code 1")
-	scanCmd.PersistentFlags().IntVar(&scanInfo.FailThresholdMedium, "threshold-medium", math.MaxInt, "The amount of resources that have failed controls with Medium severity above which the command fails and returns exit code 1")
-	scanCmd.PersistentFlags().IntVar(&scanInfo.FailThresholdLow, "threshold-low", math.MaxInt, "The amount of resources that have failed controls with Low severity above which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", reporthandlingapis.SeverityHighString, "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html"`)
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -1,0 +1,125 @@
+package scan
+
+import (
+	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"testing"
+)
+
+func TestExceedsSeverity(t *testing.T) {
+	testCases := []struct {
+		Description      string
+		ScanInfo         *cautils.ScanInfo
+		SeverityCounters reportsummary.ISeverityCounters
+		Want             bool
+		Error            error
+	}{
+		{
+			Description:      "Critical failed resource should exceed Critical threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "critical"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Critical failed resource should exceed Critical threshold set as constant",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "High failed resource should not exceed Critical threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "critical"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithHighSeverityCounter: 1},
+			Want:             false,
+		},
+		{
+			Description:      "Critical failed resource exceeds High threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "high"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "High failed resource exceeds High threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "high"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithHighSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Medium failed resource does not exceed High threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "high"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithMediumSeverityCounter: 1},
+			Want:             false,
+		},
+		{
+			Description:      "Critical failed resource exceeds Medium threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "medium"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "High failed resource exceeds Medium threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "medium"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithHighSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Medium failed resource exceeds Medium threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "medium"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithMediumSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Low failed resource does not exceed Medium threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "medium"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithLowSeverityCounter: 1},
+			Want:             false,
+		},
+		{
+			Description:      "Critical failed resource exceeds Low threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "low"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "High failed resource exceeds Low threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "low"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithHighSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Medium failed resource exceeds Low threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "low"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithMediumSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Low failed resource exceeds Low threshold",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "low"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithLowSeverityCounter: 1},
+			Want:             true,
+		},
+		{
+			Description:      "Unknown severity returns an error",
+			ScanInfo:         &cautils.ScanInfo{FailThresholdSeverity: "unknown"},
+			SeverityCounters: &reportsummary.SeverityCounters{ResourcesWithLowSeverityCounter: 1},
+			Want:             false,
+			Error:            ErrUnknownSeverity,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			got, err := countersExceedSeverityThreshold(testCase.SeverityCounters, testCase.ScanInfo)
+			want := testCase.Want
+
+			if got != want {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+
+			if err != testCase.Error {
+				t.Errorf(`got error "%v", want "%v"`, err, testCase.Error)
+			}
+		})
+	}
+}

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -1,9 +1,15 @@
 package scan
 
 import (
+	logger "github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+
 	"github.com/kubescape/kubescape/v2/core/cautils"
-	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+
+	"os"
+	"reflect"
 	"testing"
 )
 
@@ -121,5 +127,128 @@ func TestExceedsSeverity(t *testing.T) {
 				t.Errorf(`got error "%v", want "%v"`, err, testCase.Error)
 			}
 		})
+	}
+}
+
+func Test_enforceSeverityThresholds(t *testing.T) {
+	testCases := []struct {
+		Description      string
+		SeverityCounters *reportsummary.SeverityCounters
+		ScanInfo         *cautils.ScanInfo
+		Want             bool
+	}{
+		{
+			"Exceeding Critical severity counter should call the terminating function",
+			&reportsummary.SeverityCounters{ResourcesWithCriticalSeverityCounter: 1},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
+			true,
+		},
+		{
+			"Non-exceeding severity counter should call not the terminating function",
+			&reportsummary.SeverityCounters{},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.Description,
+			func(t *testing.T) {
+				severityCounters := tc.SeverityCounters
+				scanInfo := tc.ScanInfo
+				want := tc.Want
+
+				got := false
+				onExceed := func(*cautils.ScanInfo, logger.ILogger) {
+					got = true
+				}
+
+				enforceSeverityThresholds(severityCounters, scanInfo, onExceed)
+
+				if got != want {
+					t.Errorf("got: %v, want %v", got, want)
+				}
+			},
+		)
+	}
+}
+
+type spyLogMessage struct {
+	Message string
+	Details map[string]string
+}
+
+type spyLogger struct {
+	setItems []spyLogMessage
+}
+
+func (l *spyLogger) Error(msg string, details ...helpers.IDetails)   {}
+func (l *spyLogger) Success(msg string, details ...helpers.IDetails) {}
+func (l *spyLogger) Warning(msg string, details ...helpers.IDetails) {}
+func (l *spyLogger) Info(msg string, details ...helpers.IDetails)    {}
+func (l *spyLogger) Debug(msg string, details ...helpers.IDetails)   {}
+func (l *spyLogger) SetLevel(level string) error                     { return nil }
+func (l *spyLogger) GetLevel() string                                { return "" }
+func (l *spyLogger) SetWriter(w *os.File)                            {}
+func (l *spyLogger) GetWriter() *os.File                             { return &os.File{} }
+func (l *spyLogger) LoggerName() string                              { return "" }
+
+func (l *spyLogger) Fatal(msg string, details ...helpers.IDetails) {
+	firstDetail := details[0]
+	detailsMap := map[string]string{firstDetail.Key(): firstDetail.Value().(string)}
+
+	newMsg := spyLogMessage{msg, detailsMap}
+	l.setItems = append(l.setItems, newMsg)
+}
+
+func (l *spyLogger) GetSpiedItems() []spyLogMessage {
+	return l.setItems
+}
+
+func Test_terminateOnExceedingSeverity(t *testing.T) {
+	expectedMessage := "result exceeds severity threshold"
+	expectedKey := "set severity threshold"
+
+	testCases := []struct {
+		Description     string
+		ExpectedMessage string
+		ExpectedKey     string
+		ExpectedValue   string
+		Logger          *spyLogger
+	}{
+		{
+			"Should log the Critical threshold that was set in scan info",
+			expectedMessage,
+			expectedKey,
+			apis.SeverityCriticalString,
+			&spyLogger{},
+		},
+		{
+			"Should log the High threshold that was set in scan info",
+			expectedMessage,
+			expectedKey,
+			apis.SeverityHighString,
+			&spyLogger{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.Description,
+			func(t *testing.T) {
+				want := []spyLogMessage{
+					{tc.ExpectedMessage, map[string]string{tc.ExpectedKey: tc.ExpectedValue}},
+				}
+				scanInfo := &cautils.ScanInfo{FailThresholdSeverity: tc.ExpectedValue}
+
+				terminateOnExceedingSeverity(scanInfo, tc.Logger)
+
+				got := tc.Logger.GetSpiedItems()
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("got: %v, want: %v", got, want)
+				}
+			},
+		)
 	}
 }

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -1,0 +1,32 @@
+package scan
+
+import "testing"
+
+func Test_validateSeverity(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Input       string
+		Want        error
+	}{
+		{"low should be a valid severity", "low", nil},
+		{"Low should be a valid severity", "Low", nil},
+		{"medium should be a valid severity", "medium", nil},
+		{"Medium should be a valid severity", "Medium", nil},
+		{"high should be a valid severity", "high", nil},
+		{"Critical should be a valid severity", "Critical", nil},
+		{"critical should be a valid severity", "critical", nil},
+		{"Unknown should be an invalid severity", "Unknown", ErrUnknownSeverity},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			input := testCase.Input
+			want := testCase.Want
+			got := validateSeverity(input)
+
+			if got != want {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -1,6 +1,87 @@
 package scan
 
-import "testing"
+import (
+	"github.com/kubescape/kubescape/v2/core/cautils"
+	"testing"
+)
+
+func Test_validateControlScanInfo(t *testing.T) {
+	testCases := []struct {
+		Description string
+		ScanInfo    *cautils.ScanInfo
+		Want        error
+	}{
+		{
+			"Empty severity should be valid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: ""},
+			nil,
+		},
+		{
+			"High severity should be valid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: "High"},
+			nil,
+		},
+		{
+			"Unknown severity should be invalid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
+			ErrUnknownSeverity,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.Description,
+			func(t *testing.T) {
+				var want error = tc.Want
+
+				got := validateControlScanInfo(tc.ScanInfo)
+
+				if got != want {
+					t.Errorf("got: %v, want: %v", got, want)
+				}
+			},
+		)
+	}
+}
+
+func Test_validateFrameworkScanInfo(t *testing.T) {
+	testCases := []struct {
+		Description string
+		ScanInfo    *cautils.ScanInfo
+		Want        error
+	}{
+		{
+			"Empty severity should be valid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: ""},
+			nil,
+		},
+		{
+			"High severity should be valid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: "High"},
+			nil,
+		},
+		{
+			"Unknown severity should be invalid for scan info",
+			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
+			ErrUnknownSeverity,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.Description,
+			func(t *testing.T) {
+				var want error = tc.Want
+
+				got := flagValidationFramework(tc.ScanInfo)
+
+				if got != want {
+					t.Errorf("got: %v, want: %v", got, want)
+				}
+			},
+		)
+	}
+}
 
 func Test_validateSeverity(t *testing.T) {
 	testCases := []struct {

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+// Test_validateControlScanInfo tests how scan info is validated for the `scan control` command
 func Test_validateControlScanInfo(t *testing.T) {
 	testCases := []struct {
 		Description string
@@ -44,6 +45,7 @@ func Test_validateControlScanInfo(t *testing.T) {
 	}
 }
 
+// Test_validateFrameworkScanInfo tests how scan info is validated for the `scan framework` command
 func Test_validateFrameworkScanInfo(t *testing.T) {
 	testCases := []struct {
 		Description string
@@ -73,7 +75,7 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 			func(t *testing.T) {
 				var want error = tc.Want
 
-				got := flagValidationFramework(tc.ScanInfo)
+				got := validateFrameworkScanInfo(tc.ScanInfo)
 
 				if got != want {
 					t.Errorf("got: %v, want: %v", got, want)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -118,10 +118,7 @@ type ScanInfo struct {
 	InputPatterns         []string           // Yaml files input patterns
 	Silent                bool               // Silent mode - Do not print progress logs
 	FailThreshold         float32            // Failure score threshold
-	FailThresholdCritical int                // Threshold for failing based on the amount of resources with Critical severity failed controls
-	FailThresholdHigh     int                // Threshold for failing based on the amount of resources with High severity failed controls
-	FailThresholdMedium   int                // Threshold for failing based on the amount of resources with Medium severity failed controls
-	FailThresholdLow      int                // Threshold for failing based on the amount of resources with Low severity failed controls
+	FailThresholdSeverity string             // Severity at and above which the command should fail
 	Submit                bool               // Submit results to Kubescape Cloud BE
 	ScanID                string             // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag        // Deploy Kubescape K8s host scanner to collect data from certain controls

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/johnfercher/maroto v0.37.0
 	github.com/kubescape/go-logger v0.0.6
 	github.com/kubescape/k8s-interface v0.0.83
-	github.com/kubescape/opa-utils v0.0.192
+	github.com/kubescape/opa-utils v0.0.194
 	github.com/kubescape/rbac-utils v0.0.17
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-isatty v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -841,8 +841,8 @@ github.com/kubescape/go-logger v0.0.6 h1:ynhAmwrz0O7Jtqq1CdmCZUrKveji25hVP+B/FAb
 github.com/kubescape/go-logger v0.0.6/go.mod h1:DnVWEvC90LFY1nNMaNo6nBVOcqkLMK3S0qzXP1fzRvI=
 github.com/kubescape/k8s-interface v0.0.83 h1:yQ1kWNZmKfBim/+NmxpPI/j7L9ASDq2h3mCNdmYgzqY=
 github.com/kubescape/k8s-interface v0.0.83/go.mod h1:ihX96yqar+xogHl45mFE8zT9DLI06iy7XQPAP+j5KJE=
-github.com/kubescape/opa-utils v0.0.192 h1:eV3+v3dPWA8F5nZdVIxB9GbCqjQj0AzmLCCW/oGWz2M=
-github.com/kubescape/opa-utils v0.0.192/go.mod h1:frMpD9wuK6rE3tMRIy6EM1X9zi+sSbXoDWjcSaq11og=
+github.com/kubescape/opa-utils v0.0.194 h1:DroUvGV1R/PXsLPF6H4GB9LzcEylEMUKULs8vQBOU3w=
+github.com/kubescape/opa-utils v0.0.194/go.mod h1:frMpD9wuK6rE3tMRIy6EM1X9zi+sSbXoDWjcSaq11og=
 github.com/kubescape/rbac-utils v0.0.17 h1:B78kjlTKqjYK/PXwmi4GPysHsFxIwVz1KFb4+IGT29w=
 github.com/kubescape/rbac-utils v0.0.17/go.mod h1:pBwjpcrVeuH/no+DiCZWvlhYtCDzd3U0o/hEZKi+eM8=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/kubescape/go-logger v0.0.6
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
-	github.com/kubescape/opa-utils v0.0.192
+	github.com/kubescape/opa-utils v0.0.194
 	github.com/stretchr/testify v1.8.0
 	k8s.io/utils v0.0.0-20220706174534-f6158b442e7c
 )

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -897,8 +897,8 @@ github.com/kubescape/go-logger v0.0.6 h1:ynhAmwrz0O7Jtqq1CdmCZUrKveji25hVP+B/FAb
 github.com/kubescape/go-logger v0.0.6/go.mod h1:DnVWEvC90LFY1nNMaNo6nBVOcqkLMK3S0qzXP1fzRvI=
 github.com/kubescape/k8s-interface v0.0.83 h1:yQ1kWNZmKfBim/+NmxpPI/j7L9ASDq2h3mCNdmYgzqY=
 github.com/kubescape/k8s-interface v0.0.83/go.mod h1:ihX96yqar+xogHl45mFE8zT9DLI06iy7XQPAP+j5KJE=
-github.com/kubescape/opa-utils v0.0.192 h1:eV3+v3dPWA8F5nZdVIxB9GbCqjQj0AzmLCCW/oGWz2M=
-github.com/kubescape/opa-utils v0.0.192/go.mod h1:frMpD9wuK6rE3tMRIy6EM1X9zi+sSbXoDWjcSaq11og=
+github.com/kubescape/opa-utils v0.0.194 h1:DroUvGV1R/PXsLPF6H4GB9LzcEylEMUKULs8vQBOU3w=
+github.com/kubescape/opa-utils v0.0.194/go.mod h1:frMpD9wuK6rE3tMRIy6EM1X9zi+sSbXoDWjcSaq11og=
 github.com/kubescape/rbac-utils v0.0.17 h1:B78kjlTKqjYK/PXwmi4GPysHsFxIwVz1KFb4+IGT29w=
 github.com/kubescape/rbac-utils v0.0.17/go.mod h1:pBwjpcrVeuH/no+DiCZWvlhYtCDzd3U0o/hEZKi+eM8=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=


### PR DESCRIPTION
## Describe your changes

Before this PR, severity threshold flags were separated by severity. This PR unifies these thresholds into one flag that forces Kubescape to terminate with an exit code 1 if there was at least one failed control at the specified severity threshold or above.

Requires kubescape/opa-utils#35

## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
