### PR TITLE
fixed Include-Exclude namespaces

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -71,7 +71,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. Recommended: kube-system,kube-public")
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "kubernetes-dashboard,kube-system,kube-public,kube-node-lease", "Namespaces to exclude from scanning. Recommended: kube-system,kube-public")
 
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 

--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -38,7 +38,9 @@ func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 	fieldSelectors := ""
 	for _, n := range strings.Split(es.namespace, ",") {
 		if n != "" {
-			fieldSelectors += getNamespacesSelector(resource, n, "!=") + ","
+			if fs := getNamespacesSelector(resource, n, "!="); fs != "" { 
+				fieldSelectors += getNamespacesSelector(resource, n, "!=") + ","
+			}
 		}
 	}
 	return []string{fieldSelectors}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -60,7 +60,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(sessionObj *cautils.OPASessio
 	// get namespace and labels from designator (ignore cluster labels)
 	_, namespace, labels := armotypes.DigestPortalDesignator(designator)
 
-	// pull k8s recourses
+	// pull k8s resourses
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl)
 
 	// map of Kubescape resources to control_ids
@@ -208,6 +208,11 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupV
 	listOptions := metav1.ListOptions{}
 	fieldSelectors := k8sHandler.fieldSelector.GetNamespacesSelectors(resource)
 	for i := range fieldSelectors {
+
+		// If field selector is an empty string, i.e. not a K8's namespaced resource, then return without getting the list of it's resources
+		if fieldSelectors[i] == "" {
+			return resourceList, nil
+		}
 
 		listOptions.FieldSelector = fieldSelectors[i]
 


### PR DESCRIPTION
## Describe your changes
- Fixed [Including Namespaces](https://github.com/kubescape/kubescape/issues/608) issue: 
  Added `kube-system`, `kube-public`, `kube-node-lease`, `kubernetes-dashboard` to exclude-namespaces flag's default value.
  KubeScape, by default scans all the namespaces. Added the above core-k8s namespaces to not scan them by default. 
  They can now be only scanned, if we explicitly define them to be scanned, using `--include-namespaces "kube-system,etc."`

- Fixed [Excluding Namespaces](https://github.com/kubescape/kubescape/issues/95) issue:
  Now, by default, `kube-system`, `kube-public`, `kube-node-lease` & `kubernetes-dashboard` namespaces are excluded. 
  We can explicitly define to exclude only some of them, by using `--exclude-namespaces "kube-public,etc."` 

  
## Screenshots - If Any (Optional)
1. `kubescape scan  -v`: Scans only the default namespace (and any-other non core-K8s namespace)
![0](https://user-images.githubusercontent.com/43821031/192110457-d8006625-727b-4fd3-b0f3-a37dc38ccdd6.png)

2. `kubescape scan --include-namespaces "kube-system" -v`: Scans only the defined namespace & does not show result from any other namespace.
![1](https://user-images.githubusercontent.com/43821031/192110458-a27e9bbb-1047-4e09-a23d-f8c9fe0571f0.png)

3. `kubescape scan --exclude-namespaces "kube-system" -v`: Includes scan results from all namespaces (including core-k8s namespaces) except the defined namespace.
![2](https://user-images.githubusercontent.com/43821031/192110459-fe9ff8c0-66c5-4603-822c-bbc503794d11.png)



## This PR fixes:

* Resolved #95 
* Resolved #608 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
