### PR TITLE
feat: add `--kubeconfig` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ kubescape scan framework mitre --submit
 kubescape scan control "Privileged container"
 ```
 
+#### Scan using an anternative kubeconfig file
+```
+kubescape scan --kubeconfig cluster.conf
+```
+
 #### Scan specific namespaces
 ```
 kubescape scan --include-namespaces development,staging,production

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -96,6 +97,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().MarkHidden("host-scan-yaml") // this flag should be used very cautiously. We prefer users will not use it at all unless the DaemonSet can not run pods on the nodes
 	scanCmd.PersistentFlags().MarkHidden("silent")         // this flag should be deprecated since we added the --logger support
 	// scanCmd.PersistentFlags().MarkHidden("format-version") // meant for testing different output approaches and not for common use
+
+	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go
+	scanCmd.PersistentFlags().AddGoFlag(flag.Lookup("kubeconfig"))
 
 	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "enable-host-scan", "", "Deploy ARMO K8s host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://github.com/kubescape/kubescape/blob/master/core/pkg/hostsensorutils/hostsensor.yaml")
 	hostF.NoOptDefVal = "true"


### PR DESCRIPTION
## Describe your changes
The code provides the `--kubeconfig` flag, used to use the kubeconfig file at that location.
As you can see in the code below, there's no need to write your own flag with **cobra**, because it is already coded by the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime#L39) package.

## This PR fixes: 

* Resolved #479

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
