### PR TITLE
updated go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubescape/kubescape/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/armosec/armoapi-go v0.0.115


### PR DESCRIPTION
## Describe your changes
Updated go version in go.mod file. Kubescape uses go version 1.18 and I updated to 1.19
## Screenshots - If Any (Optional)

## This PR fixes:
This PR updates go version only in go.mod file not in any other file or directory.
