### PR TITLE
Fixed: Kubescape not excluding cluster-scoped resources when --include-namespaces is involved

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -49,7 +49,9 @@ func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 	fieldSelectors := []string{}
 	for _, n := range strings.Split(is.namespace, ",") {
 		if n != "" {
-			fieldSelectors = append(fieldSelectors, getNamespacesSelector(resource, n, "=="))
+			if namespaceSelector := getNamespacesSelector(resource, n, "=="); namespaceSelector != "" {
+				fieldSelectors = append(fieldSelectors, namespaceSelector)
+			}
 		}
 	}
 	return fieldSelectors

--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -49,6 +49,7 @@ func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 	fieldSelectors := []string{}
 	for _, n := range strings.Split(is.namespace, ",") {
 		if n != "" {
+			// Do not add any fieldSelector for cluster-scoped resources
 			if namespaceSelector := getNamespacesSelector(resource, n, "=="); namespaceSelector != "" {
 				fieldSelectors = append(fieldSelectors, namespaceSelector)
 			}


### PR DESCRIPTION
## About This PR:
* Resolves #608 
* Please visit the Issue to have the full context.

## Kubescape not excluding cluster-scoped resources is the root cause of this issue.

 
`Kubescape scans and includes a ServiceAccount from the namespace "kube-system" which should not be included in the scan.`

I believe this is happening because that ServiceAccount is related to an RBAC resource which Kubescape did not exclude from the scan. Here is a scenario. This is the scan result of minikube cluster including only "default" namespace

`kubescape scan --include-namespaces "default"`

![Config Scanning](https://github.com/suhasgumma/ImagesForGitHub/blob/master/config%20scanning.png?raw=true)
![ClusterRole](https://github.com/suhasgumma/ImagesForGitHub/blob/master/clusterRoleBinding.png?raw=true)
![Subject](https://github.com/suhasgumma/ImagesForGitHub/blob/master/subject%20ServiceAccount.png?raw=true)


## Why Kubescape is not excluding cluster-scoped resources? 
It's because of this line. 


![Field Selector](https://github.com/suhasgumma/ImagesForGitHub/blob/master/fieldselector.png?raw=true)

### we are passing an `empty string`  as a field selector for cluster-scoped resources. Instead, if we do not give any field selector, the resource will be excluded. 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented on my code, particularly in hard-to-understand areas
- [ x ] I have performed a self-review of my code
- [ x ] If it is a core feature, I have added thorough tests.
- [ x ] New and existing unit tests pass locally with my changes