### PR TITLE
Per 335 removing support for submitting results without accountid

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh 
 
 ## Run:
 ```sh
-kubescape scan --submit --enable-host-scan --verbose
+kubescape scan --enable-host-scan --verbose
 ```
 
 <img src="docs/summary.png">
@@ -170,22 +170,22 @@ Or to your profile (not preferred): `nix-env --install -A nixpkgs.kubescape`
 ### Examples
 
 
-#### Scan a running Kubernetes cluster and submit results to the [Kubescape SaaS version](https://cloud.armosec.io?utm_source=github&utm_medium=repository)
+#### Scan a running Kubernetes cluster
 ```
-kubescape scan --submit --enable-host-scan  --verbose
+kubescape scan --enable-host-scan  --verbose
 ```
 
 > Read [here](https://hub.armosec.io/docs/host-sensor?utm_source=github&utm_medium=repository) more about the `enable-host-scan` flag
 
-#### Scan a running Kubernetes cluster with [`nsa`](https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/) framework and submit results to the [Kubescape SaaS version](https://cloud.armosec.io?utm_source=github&utm_medium=repository)
+#### Scan a running Kubernetes cluster with [`nsa`](https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/) framework
 ```
-kubescape scan framework nsa --submit
+kubescape scan framework nsa
 ```
 
 
-#### Scan a running Kubernetes cluster with [`MITRE ATT&CK®`](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/) framework and submit results to the [Kubescape SaaS version](https://cloud.armosec.io?utm_source=github&utm_medium=repository)
+#### Scan a running Kubernetes cluster with [`MITRE ATT&CK®`](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/) framework
 ```
-kubescape scan framework mitre --submit
+kubescape scan framework mitre
 ```
 
 
@@ -209,14 +209,13 @@ kubescape scan --include-namespaces development,staging,production
 kubescape scan --exclude-namespaces kube-system,kube-public
 ```
 
-#### Scan local `yaml`/`json` files before deploying. [Take a look at the demonstration](https://youtu.be/Ox6DaR7_4ZI). Submit the results in case the directory is a git repo. [docs](https://hub.armosec.io/docs/repository-scanning?utm_source=github&utm_medium=repository)
+#### Scan local `yaml`/`json` files before deploying. [Take a look at the demonstration](https://youtu.be/Ox6DaR7_4ZI).
 ```
-kubescape scan *.yaml --submit
+kubescape scan *.yaml
 ```
 
-#### Scan Kubernetes manifest files from a git repository [and submit the results](https://hub.armosec.io/docs/repository-scanning?utm_source=github&utm_medium=repository)
-```
-kubescape scan https://github.com/kubescape/kubescape --submit
+#### Scan Kubernetes manifest files from a git repository 
+kubescape scan https://github.com/kubescape/kubescape
 ```
 
 #### Display all scanned resources (including the resources which passed) 
@@ -263,13 +262,13 @@ kubescape scan --exceptions examples/exceptions/exclude-kube-namespaces.json
 
 #### Scan Helm charts 
 ```
-kubescape scan </path/to/directory> --submit
+kubescape scan </path/to/directory>
 ```
 > Kubescape will load the default value file
 
 #### Scan Kustomize Directory 
 ```
-kubescape scan </path/to/directory> --submit
+kubescape scan </path/to/directory>
 ```
 > Kubescape will generate Kubernetes Yaml Objects using 'Kustomize' file and scans them for security.
 

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -84,7 +84,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.ResourceViewType), fmt.Sprintf("View results based on the %s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.ResourceViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")
-	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Submit, "submit", "", false, "Send the scan results to ARMO management portal where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HostSensorYamlPath, "host-scan-yaml", "", "Override default host scanner DaemonSet. Use this flag cautiously")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v1", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomClusterName, "cluster-name", "", "Set the custom name of the cluster. Not same as the kube-context flag")
@@ -93,9 +92,14 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Silent, "silent", "s", false, "Silent progress messages")
 	scanCmd.PersistentFlags().MarkDeprecated("silent", "use '--logger' flag instead. Flag will be removed at 1.May.2022")
 
+	// Deprecated flags - remove 1.May.2022
+	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Submit, "submit", "", false, "Send the scan results to ARMO management portal where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
+	scanCmd.PersistentFlags().MarkDeprecated("submit", "use only '--account' flag. If you have an account linked to kubescape we submit. Flag will be removed at 1.Jan.2023")
+
 	// hidden flags
 	scanCmd.PersistentFlags().MarkHidden("host-scan-yaml") // this flag should be used very cautiously. We prefer users will not use it at all unless the DaemonSet can not run pods on the nodes
 	scanCmd.PersistentFlags().MarkHidden("silent")         // this flag should be deprecated since we added the --logger support
+	scanCmd.PersistentFlags().MarkHidden("submit")         // this flag should be deprecated since the submit is related if there is an account linked to kubescape.
 	// scanCmd.PersistentFlags().MarkHidden("format-version") // meant for testing different output approaches and not for common use
 
 	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -78,7 +78,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html"`)
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
-	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to ARMO backend. Use this flag if you ran with the '--submit' flag in the past and you do not want to submit your current scan results")
+	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.ResourceViewType), fmt.Sprintf("View results based on the %s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.ResourceViewType))
@@ -92,14 +92,13 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Silent, "silent", "s", false, "Silent progress messages")
 	scanCmd.PersistentFlags().MarkDeprecated("silent", "use '--logger' flag instead. Flag will be removed at 1.May.2022")
 
-	// Deprecated flags - remove 1.May.2022
+	// Deprecated flags - remove 1.Jan.2023
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Submit, "submit", "", false, "Send the scan results to ARMO management portal where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
-	scanCmd.PersistentFlags().MarkDeprecated("submit", "use only '--account' flag. If you have an account linked to kubescape we submit. Flag will be removed at 1.Jan.2023")
+	scanCmd.PersistentFlags().MarkDeprecated("submit", "Kubescape will automatically submit the scan results whenever an account ID is configured. An account ID can be configured either with (1) '--account' flag (2) Kubescape configuration (3) 'KS_ACCOUNT_ID' environment variable. '--submit' flag will be removed at 1.Jan.2023")
 
 	// hidden flags
 	scanCmd.PersistentFlags().MarkHidden("host-scan-yaml") // this flag should be used very cautiously. We prefer users will not use it at all unless the DaemonSet can not run pods on the nodes
 	scanCmd.PersistentFlags().MarkHidden("silent")         // this flag should be deprecated since we added the --logger support
-	scanCmd.PersistentFlags().MarkHidden("submit")         // this flag should be deprecated since the submit is related if there is an account linked to kubescape.
 	// scanCmd.PersistentFlags().MarkHidden("format-version") // meant for testing different output approaches and not for common use
 
 	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -160,15 +160,12 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 		return
 	}
 
-	// 	if tenantConfig.GetAccountID() == "" {
-	// 		scanInfo.Submit = false
-	// 	} else {
+	// If There is no account, or if the account is not legal, do not submit
 	if _, err := uuid.Parse(tenantConfig.GetAccountID()); err != nil {
 		scanInfo.Submit = false
 	} else {
 		scanInfo.Submit = true
 	}
-	// 	}
 
 }
 

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -130,13 +130,11 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 	/*
 		If CloudReportURL not set - Do not send report
 
-		If "First run (local config not found)" -
-			Default/keep-local - Do not send report
-			Submit - Create tenant & Submit report
+		If There is no account - Do not send report
 
-		If "Submitted" -
+		If There is account -
 			keep-local - Do not send report
-			Default/Submit - Submit report
+			Default - Submit report
 
 	*/
 
@@ -157,18 +155,20 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 		return
 	}
 
-	if tenantConfig.IsConfigFound() { // config found in cache (submitted)
-		if !scanInfo.Local {
-			if tenantConfig.GetAccountID() != "" {
-				if _, err := uuid.Parse(tenantConfig.GetAccountID()); err != nil {
-					scanInfo.Submit = false
-					return
-				}
-			}
-			// Submit report
-			scanInfo.Submit = true
-		}
+	if scanInfo.Local {
+		scanInfo.Submit = false
+		return
 	}
+
+	// 	if tenantConfig.GetAccountID() == "" {
+	// 		scanInfo.Submit = false
+	// 	} else {
+	if _, err := uuid.Parse(tenantConfig.GetAccountID()); err != nil {
+		scanInfo.Submit = false
+	} else {
+		scanInfo.Submit = true
+	}
+	// 	}
 
 }
 

--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -101,7 +101,6 @@ When scanning is not in progress
   "excludedNamespaces": [<str>], // list of namespaces to exclude (same as 'kubescape scan --excluded-namespaces')
   "includeNamespaces": [<str>],  // list of namespaces to include (same as 'kubescape scan --include-namespaces')
   "useCachedArtifacts"`: <bool>, // use the cached artifacts instead of downloading (offline support)
-  "submit": <bool>,              // submit results to Kubescape cloud (same as 'kubescape scan --submit')
   "hostScanner": <bool>,         // deploy Kubescape K8s host-scanner DaemonSet in the scanned cluster (same as 'kubescape scan --enable-host-scan')
   "keepLocal": <bool>,           // do not submit results to Kubescape cloud (same as 'kubescape scan --keep-local')
   "account": <str>,              // account ID (same as 'kubescape scan --account')
@@ -132,7 +131,7 @@ When scanning is not in progress
 
 1. Trigger kubescape scan
   ```bash
-  curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true, "submit": true}' http://127.0.0.1:8080/v1/scan
+  curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true}' http://127.0.0.1:8080/v1/scan
   ```
 
 2. Get kubescape scan results
@@ -143,13 +142,13 @@ When scanning is not in progress
 #### Trigger scan and wait for the scan to end  
 
 ```bash
-curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true, "submit": true}' http://127.0.0.1:8080/v1/scan?wait -o scan_results.json
+curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true}' http://127.0.0.1:8080/v1/scan?wait -o scan_results.json
 ```
 #### Scan single namespace with a specific framework
 ```bash
 curl --header "Content-Type: application/json" \
   --request POST \
-  --data '{"hostScanner":true, "submit":true, "includeNamespaces": ["kubescape"], "targetType": "framework", "targetNames": ["nsa"] }' \
+  --data '{"hostScanner":true, "includeNamespaces": ["kubescape"], "targetType": "framework", "targetNames": ["nsa"] }' \
   http://127.0.0.1:8080/v1/scan
 ```
 
@@ -171,7 +170,6 @@ go tool pprof http://localhost:6060/debug/pprof/heap
 ## Supported environment variables
 
 * `KS_ACCOUNT`: Account ID
-* `KS_SUBMIT`: Submit the results to the Kubescape SaaS version
 * `KS_EXCLUDE_NAMESPACES`: List of namespaces to exclude, e.g. `KS_EXCLUDE_NAMESPACES=kube-system,kube-public`
 * `KS_INCLUDE_NAMESPACES`: List of namespaces to include, rest of the namespaces will be ignored. e.g. `KS_INCLUDE_NAMESPACES=dev,prod`
 * `KS_HOST_SCAN_YAML`: Full path to the host scanner YAML

--- a/httphandler/examples/microservice/README.md
+++ b/httphandler/examples/microservice/README.md
@@ -10,7 +10,7 @@
     ```bash
     curl --header "Content-Type: application/json" \
     --request POST \
-    --data '{"account":"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX","hostScanner":true, "submit":true}' \
+    --data '{"account":"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX","hostScanner":true}' \
     http://127.0.0.1:8080/v1/scan
     ```
 


### PR DESCRIPTION
## Describe your changes
Removing support for submitting results without accountID  
1. If account ID is empty, kubescape not create a new tenant 
2. If account ID is set, submit results (unless the --keep-local is set).


## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
