### PR TITLE
Scanning with include or exclude namespace, is only scan namespaced scope

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -71,7 +71,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. Recommended: kube-system,kube-public")
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")
 
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -126,15 +126,23 @@ func NewLocalConfig(
 	lc.backendAPI.SetSecretKey(lc.configObj.SecretKey)
 	if lc.configObj.CloudAPIURL != "" {
 		lc.backendAPI.SetCloudAPIURL(lc.configObj.CloudAPIURL)
+	} else {
+		lc.configObj.CloudAPIURL = lc.backendAPI.GetCloudAPIURL()
 	}
 	if lc.configObj.CloudAuthURL != "" {
 		lc.backendAPI.SetCloudAuthURL(lc.configObj.CloudAuthURL)
+	} else {
+		lc.configObj.CloudAuthURL = lc.backendAPI.GetCloudAuthURL()
 	}
 	if lc.configObj.CloudReportURL != "" {
 		lc.backendAPI.SetCloudReportURL(lc.configObj.CloudReportURL)
+	} else {
+		lc.configObj.CloudReportURL = lc.backendAPI.GetCloudReportURL()
 	}
 	if lc.configObj.CloudUIURL != "" {
 		lc.backendAPI.SetCloudUIURL(lc.configObj.CloudUIURL)
+	} else {
+		lc.configObj.CloudUIURL = lc.backendAPI.GetCloudUIURL()
 	}
 	logger.L().Debug("Kubescape Cloud URLs", helpers.String("api", lc.backendAPI.GetCloudAPIURL()), helpers.String("auth", lc.backendAPI.GetCloudAuthURL()), helpers.String("report", lc.backendAPI.GetCloudReportURL()), helpers.String("UI", lc.backendAPI.GetCloudUIURL()))
 
@@ -260,15 +268,23 @@ func NewClusterConfig(k8s *k8sinterface.KubernetesApi, backendAPI getter.IBacken
 	c.backendAPI.SetSecretKey(c.configObj.SecretKey)
 	if c.configObj.CloudAPIURL != "" {
 		c.backendAPI.SetCloudAPIURL(c.configObj.CloudAPIURL)
+	} else {
+		c.configObj.CloudAPIURL = c.backendAPI.GetCloudAPIURL()
 	}
 	if c.configObj.CloudAuthURL != "" {
 		c.backendAPI.SetCloudAuthURL(c.configObj.CloudAuthURL)
+	} else {
+		c.configObj.CloudAuthURL = c.backendAPI.GetCloudAuthURL()
 	}
 	if c.configObj.CloudReportURL != "" {
 		c.backendAPI.SetCloudReportURL(c.configObj.CloudReportURL)
+	} else {
+		c.configObj.CloudReportURL = c.backendAPI.GetCloudReportURL()
 	}
 	if c.configObj.CloudUIURL != "" {
 		c.backendAPI.SetCloudUIURL(c.configObj.CloudUIURL)
+	} else {
+		c.configObj.CloudUIURL = c.backendAPI.GetCloudUIURL()
 	}
 	logger.L().Debug("Kubescape Cloud URLs", helpers.String("api", c.backendAPI.GetCloudAPIURL()), helpers.String("auth", c.backendAPI.GetCloudAuthURL()), helpers.String("report", c.backendAPI.GetCloudReportURL()), helpers.String("UI", c.backendAPI.GetCloudUIURL()))
 

--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -10,6 +10,7 @@ import (
 
 type IFieldSelector interface {
 	GetNamespacesSelectors(*schema.GroupVersionResource) []string
+	GetClusterScope(*schema.GroupVersionResource) bool
 }
 
 type EmptySelector struct {
@@ -17,6 +18,10 @@ type EmptySelector struct {
 
 func (es *EmptySelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
 	return []string{""} //
+}
+
+func (es *EmptySelector) GetClusterScope(*schema.GroupVersionResource) bool {
+	return true
 }
 
 type ExcludeSelector struct {
@@ -27,6 +32,14 @@ func NewExcludeSelector(ns string) *ExcludeSelector {
 	return &ExcludeSelector{namespace: ns}
 }
 
+func (es *ExcludeSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
+	// for selector, 'namespace' is in Namespaced scope
+	if resource.Resource == "namespaces" {
+		return true
+	}
+	return false
+}
+
 type IncludeSelector struct {
 	namespace string
 }
@@ -34,6 +47,15 @@ type IncludeSelector struct {
 func NewIncludeSelector(ns string) *IncludeSelector {
 	return &IncludeSelector{namespace: ns}
 }
+
+func (is *IncludeSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
+	// for selector, 'namespace' is in Namespaced scope
+	if resource.Resource == "namespaces" {
+		return true
+	}
+	return false
+}
+
 func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
 	fieldSelectors := ""
 	for _, n := range strings.Split(es.namespace, ",") {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -230,10 +230,14 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupV
 
 		// set dynamic object
 		var clientResource dynamic.ResourceInterface
-		if namespace != "" && k8sinterface.IsNamespaceScope(resource) {
-			clientResource = k8sHandler.k8s.DynamicClient.Resource(*resource).Namespace(namespace)
-		} else {
+		if namespace != "" {
 			clientResource = k8sHandler.k8s.DynamicClient.Resource(*resource)
+		} else if k8sinterface.IsNamespaceScope(resource) {
+			clientResource = k8sHandler.k8s.DynamicClient.Resource(*resource).Namespace(namespace)
+		} else if k8sHandler.fieldSelector.GetClusterScope(*&resource) {
+			clientResource = k8sHandler.k8s.DynamicClient.Resource(*resource)
+		} else {
+			continue
 		}
 
 		// list resources


### PR DESCRIPTION
## Describe your changes
When running kubescape with `--include-namespace` or `--exclude-namespace` flags,
kubescape scan only Namespaced scop and not cluster scop, such as `cluster rule` etc.


## This PR fixes:

* Resolved #608 
* Resolved #95 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
