### PR TITLE
Inform User if something is wrong with "controls-inputs" file they provided

### DIFF
--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
-	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/opa-utils/reporthandling"
 )
 
@@ -133,17 +132,17 @@ func (lp *LoadPolicy) GetControlsInputs(clusterName string) (map[string][]string
 	f, err := os.ReadFile(filePath)
 	fileName := filepath.Base(filePath)
 	if err != nil {
-		logger.L().Error(fmt.Sprintf("Error opening %s file, \"controls-config\" will be downloaded from ARMO management portal", fileName))
-		return nil, err
+		formattedError := fmt.Errorf("Error opening %s file, \"controls-config\" will be downloaded from ARMO management portal", fileName)
+		return nil, formattedError
 	}
 
 	if err = json.Unmarshal(f, &accountConfig.Settings.PostureControlInputs); err == nil {
 		return accountConfig.Settings.PostureControlInputs, nil
 	}
 
-	logger.L().Error(fmt.Sprintf("Error reading %s file, %s, \"controls-config\" will be downloaded from ARMO management portal", fileName, err.Error()))
+	formattedError := fmt.Errorf("Error reading %s file, %s, \"controls-config\" will be downloaded from ARMO management portal", fileName, err.Error())
 
-	return nil, err
+	return nil, formattedError
 }
 
 // temporary support for a list of files

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/opa-utils/reporthandling"
 )
 
@@ -130,13 +131,18 @@ func (lp *LoadPolicy) GetControlsInputs(clusterName string) (map[string][]string
 	filePath := lp.filePath()
 	accountConfig := &armotypes.CustomerConfig{}
 	f, err := os.ReadFile(filePath)
+	fileName := filepath.Base(filePath)
 	if err != nil {
+		logger.L().Error(fmt.Sprintf("Error opening %s file, \"controls-config\" will be downloaded from ARMO management portal", fileName))
 		return nil, err
 	}
 
 	if err = json.Unmarshal(f, &accountConfig.Settings.PostureControlInputs); err == nil {
 		return accountConfig.Settings.PostureControlInputs, nil
 	}
+
+	logger.L().Error(fmt.Sprintf("Error reading %s file, %s, \"controls-config\" will be downloaded from ARMO management portal", fileName, err.Error()))
+
 	return nil, err
 }
 

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -41,6 +41,8 @@ func (policyHandler *PolicyHandler) getPolicies(policyIdentifier []cautils.Polic
 	controlsInputs, err := policyHandler.getters.ControlsInputsGetter.GetControlsInputs(cautils.ClusterName)
 	if err == nil {
 		policiesAndResources.RegoInputData.PostureControlInputs = controlsInputs
+	} else {
+		logger.L().Error(err.Error())
 	}
 	cautils.StopSpinner()
 


### PR DESCRIPTION
## Describe your changes

* Currently, the user will have no idea if Kubescape fails to read the file passed to the "controls-config" flag and it might be confusing if the user doesn't get the expected results from the scan.

* If the file passed to the "controls-config" flag cannot be opened or if there is any misconfiguration in the file, the user is notified of the error and the fact that the "controls-configs" are downloaded from the ARMO portal. 
### If Kubescape could not open the `file passed to the "controls-config" flag`

![Error Opening](https://github.com/suhasgumma/ImagesForGitHub/blob/master/error%20opening.jpg?raw=true)

### If there is any misconfiguration in the `file passed to the "controls-config" flag`
![Error end](https://github.com/suhasgumma/ImagesForGitHub/blob/master/error%20end.jpg?raw=true)
![Error between](https://github.com/suhasgumma/ImagesForGitHub/blob/master/error%20between.png?raw=true) 
