### PR TITLE
Fix reading frameworks from local file

### DIFF
--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -65,16 +65,16 @@ func (lp *LoadPolicy) GetControl(controlName string) (*reporthandling.Control, e
 }
 
 func (lp *LoadPolicy) GetFramework(frameworkName string) (*reporthandling.Framework, error) {
-	framework := &reporthandling.Framework{}
+	var framework reporthandling.Framework
 	var err error
 	for _, filePath := range lp.filePaths {
+		framework = reporthandling.Framework{}
 		f, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}
-
-		if err = json.Unmarshal(f, framework); err != nil {
-			return framework, err
+		if err = json.Unmarshal(f, &framework); err != nil {
+			return nil, err
 		}
 		if strings.EqualFold(frameworkName, framework.Name) {
 			break
@@ -84,7 +84,7 @@ func (lp *LoadPolicy) GetFramework(frameworkName string) (*reporthandling.Framew
 
 		return nil, fmt.Errorf("framework from file not matching")
 	}
-	return framework, err
+	return &framework, err
 }
 
 func (lp *LoadPolicy) GetFrameworks() ([]reporthandling.Framework, error) {


### PR DESCRIPTION
## Describe your changes
When kubescape takes the frameworks from a local file, it takes the data incorrectly.
And this causes the results when scanning with the `--use-artifact-from` flag, they different than when scanning normally.
The reason for this is that the object that holds the frameworks is shared by all the frameworks and if there are fields (like attributes) that are not in all the controls, they get the information from other controls

## This PR fixes:

* Resolved #619 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
