### PR TITLE
Fixed: Wrong Relative Path When scanning Local Directory

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -143,7 +143,7 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 		}
 
 		workloadSource := reporthandling.Source{
-			RelativePath: source,
+			RelativePath: relSource,
 			FileType:     filetype,
 			LastCommit:   lastCommit,
 		}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -103,6 +103,8 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 	gitRepo, err := cautils.NewLocalGitRepository(path)
 	if err == nil && gitRepo != nil {
 		repoRoot, _ = gitRepo.GetRootDir()
+	} else {
+		repoRoot, _ = filepath.Abs(path)
 	}
 
 	// load resource from local file system


### PR DESCRIPTION
Storing Absolute path Instead of Relative Path. The screenshots below are of `output.json` files form scan results. Observe `resources.Source.relativePath` field. 

## Before 

![Error Opening](https://github.com/suhasgumma/ImagesForGitHub/blob/master/beforerel.png?raw=true)

## After

![Error Opening](https://github.com/suhasgumma/ImagesForGitHub/blob/master/after%20rel.png?raw=true)
