### PR TITLE
Store Git Repo's root path as localRootPath

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -419,7 +419,7 @@ func metadataGitLocal(input string) (*reporthandlingv2.RepoContextMetadata, erro
 		Date:          commit.Committer.Date,
 		CommitterName: commit.Committer.Name,
 	}
-	context.LocalRootPath = getAbsPath(input)
+	context.LocalRootPath, _ = gitParser.GetRootDir()
 
 	return context, nil
 }


### PR DESCRIPTION
## The problem
* Suppose the Git root repo is `orgname/kubernetes-manifests` and we are scanning from `orgname/kubernetes-manifests/deployments`, the `localRootPath` is being stored as `orgname/kubernetes-manifests/deployments` instead of `orgname/kubernetes-manifests`. 

* This creates inconsistencies when forming the paths of resource files from relative paths.