### PR TITLE
Per 550 support loading attack tracks from cache kubescape

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -36,6 +36,8 @@ var (
   # Download the configured controls-inputs 
   kubescape download controls-inputs 
 
+  # Download the attack tracks
+  kubescape download attack-tracks
 `
 )
 

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 )
 
 // =======================================================================================================================
@@ -151,4 +152,19 @@ func (lp *LoadPolicy) filePath() string {
 		return lp.filePaths[0]
 	}
 	return ""
+}
+
+func (lp *LoadPolicy) GetAttackTracks() ([]v1alpha1.AttackTrack, error) {
+	attackTracks := []v1alpha1.AttackTrack{}
+
+	f, err := os.ReadFile(lp.filePath())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(f, &attackTracks); err != nil {
+		return nil, err
+	}
+	return attackTracks, nil
 }

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -40,6 +40,7 @@ const (
 	// ScanLocalFiles             string = "yaml"
 	localControlInputsFilename string = "controls-inputs.json"
 	localExceptionsFilename    string = "exceptions.json"
+	LocalAttackTracksFilename  string = "attack-tracks.json"
 )
 
 type BoolPtrFlag struct {

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
+	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 )
 
 var downloadFunc = map[string]func(*metav1.DownloadInfo) error{
@@ -124,6 +125,21 @@ func downloadExceptions(downloadInfo *metav1.DownloadInfo) error {
 	}
 	logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("path", filepath.Join(downloadInfo.Path, downloadInfo.FileName)))
 	return nil
+}
+
+func downloadAttackTracks(downloadInfo *metav1.DownloadInfo) error {
+	var err error
+	tenant := getTenantConfig(&downloadInfo.Credentials, "", "", getKubernetesApi())
+
+	attackTracksGetter := getAttackTracksGetter(tenant.GetAccountID(), nil)
+	attackTracks := []v1alpha1.AttackTrack{}
+	if tenant.GetAccountID() != "" {
+		attackTracks, err = attackTracksGetter.GetAttackTracks()
+		if err != nil {
+			return err
+		}
+	}
+
 }
 
 func downloadFramework(downloadInfo *metav1.DownloadInfo) error {

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -249,7 +249,7 @@ func getAttackTracksGetter(accountID string, downloadReleasedPolicy *getter.Down
 	}
 	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
 		logger.L().Warning("failed to get attack tracks from github release, loading attack tracks from cache", helpers.Error(err))
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath("attackTracks.json")})
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
 	}
 	return downloadReleasedPolicy
 }

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -247,8 +247,9 @@ func getAttackTracksGetter(accountID string, downloadReleasedPolicy *getter.Down
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
-	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil {
-		logger.L().Warning("failed to get attack tracks from github release, this may affect the scanning results", helpers.Error(err))
+	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
+		logger.L().Warning("failed to get attack tracks from github release, loading attack tracks from cache", helpers.Error(err))
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath("attackTracks.json")})
 	}
 	return downloadReleasedPolicy
 }

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -21,7 +21,8 @@ func NewResourcesPrioritizationHandler(attackTracksGetter getter.IAttackTracksGe
 		attackTracks: make([]v1alpha1.IAttackTrack, 0),
 	}
 
-	if tracks, err := attackTracksGetter.GetAttackTracks(); err != nil {
+	tracks, err := attackTracksGetter.GetAttackTracks()
+	if err != nil {
 		return nil, err
 	} else {
 		for _, attackTrack := range tracks {
@@ -36,6 +37,12 @@ func NewResourcesPrioritizationHandler(attackTracksGetter getter.IAttackTracksGe
 
 	if len(handler.attackTracks) == 0 {
 		return nil, fmt.Errorf("expected to find at least one attack track")
+	}
+
+	// Store attack tracks in cache
+	cache := getter.GetDefaultPath("attackTracks.json")
+	if err := getter.SaveInFile(tracks, cache); err != nil {
+		logger.L().Warning("failed to cache file", helpers.String("file", cache), helpers.Error(err))
 	}
 
 	return handler, nil

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -40,7 +40,7 @@ func NewResourcesPrioritizationHandler(attackTracksGetter getter.IAttackTracksGe
 	}
 
 	// Store attack tracks in cache
-	cache := getter.GetDefaultPath("attackTracks.json")
+	cache := getter.GetDefaultPath(cautils.LocalAttackTracksFilename)
 	if err := getter.SaveInFile(tracks, cache); err != nil {
 		logger.L().Warning("failed to cache file", helpers.String("file", cache), helpers.Error(err))
 	}


### PR DESCRIPTION
## Describe your changes
Support loading attack tracks from the cache, when failing to load from the GitHub repo.
Support in `kubescape download attack-tracks` command
When using the `download artifacts` command, download also attack-tracks.

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
