### PR TITLE
added override values for helm feature

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -65,7 +65,6 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -100,6 +100,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().MarkHidden("omit-raw-resources")
 	scanCmd.PersistentFlags().MarkHidden("print-attack-tree")
 
+	scanCmd.PersistentFlags().StringVar(&scanInfo.HelmValueFilePath, "helm-value-file", "", "If you want to override the helm values.yaml file. For multiple files separate them with `,`")
+
 	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go
 	scanCmd.PersistentFlags().AddGoFlag(flag.Lookup("kubeconfig"))
 

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,13 @@ func onlineBoutiquePath() string {
 func helmChartPath() string {
 	o, _ := os.Getwd()
 	return filepath.Join(filepath.Dir(o), "..", "examples", "helm_chart")
+}
+
+func helmValuePath() []string {
+	o, _ := os.Getwd()
+	path := filepath.Join(filepath.Dir(o), "..", "examples", "helm_chart")
+	var temp = []string{"", fmt.Sprintf("%s:%s/newvalues.yaml", path, path)}
+	return temp
 }
 
 func TestListFiles(t *testing.T) {
@@ -44,31 +52,33 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
-	sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(helmChartPath())
-	assert.Equal(t, 6, len(sourceToWorkloads))
+	var expectedResults = []string{"* * 1 * *", "* * 2 * *"}
+	for index, data := range helmValuePath() {
+		sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(helmChartPath(), data)
+		for file, workloads := range sourceToWorkloads {
+			assert.Equalf(t, 1, len(workloads), "expected 1 workload in file %s", file)
 
-	for file, workloads := range sourceToWorkloads {
-		assert.Equalf(t, 1, len(workloads), "expected 1 workload in file %s", file)
+			w := workloads[0]
+			assert.True(t, localworkload.IsTypeLocalWorkload(w.GetObject()), "Expected localworkload as object type")
+			assert.Equal(t, "kubescape", sourceToChartName[file])
 
-		w := workloads[0]
-		assert.True(t, localworkload.IsTypeLocalWorkload(w.GetObject()), "Expected localworkload as object type")
-		assert.Equal(t, "kubescape", sourceToChartName[file])
-
-		switch filepath.Base(file) {
-		case "serviceaccount.yaml":
-			assert.Equal(t, "/v1//ServiceAccount/kubescape-discovery", getRelativePath(w.GetID()))
-		case "clusterrole.yaml":
-			assert.Equal(t, "rbac.authorization.k8s.io/v1//ClusterRole/-kubescape", getRelativePath(w.GetID()))
-		case "cronjob.yaml":
-			assert.Equal(t, "batch/v1//CronJob/-kubescape", getRelativePath(w.GetID()))
-		case "role.yaml":
-			assert.Equal(t, "rbac.authorization.k8s.io/v1//Role/-kubescape", getRelativePath(w.GetID()))
-		case "rolebinding.yaml":
-			assert.Equal(t, "rbac.authorization.k8s.io/v1//RoleBinding/-kubescape", getRelativePath(w.GetID()))
-		case "clusterrolebinding.yaml":
-			assert.Equal(t, "rbac.authorization.k8s.io/v1//ClusterRoleBinding/-kubescape", getRelativePath(w.GetID()))
-		default:
-			assert.Failf(t, "missing case for file: %s", filepath.Base(file))
+			switch filepath.Base(file) {
+			case "serviceaccount.yaml":
+				assert.Equal(t, "/v1//ServiceAccount/kubescape-discovery", getRelativePath(w.GetID()))
+			case "clusterrole.yaml":
+				assert.Equal(t, "rbac.authorization.k8s.io/v1//ClusterRole/-kubescape", getRelativePath(w.GetID()))
+			case "cronjob.yaml":
+				assert.Equal(t, "batch/v1//CronJob/-kubescape", getRelativePath(w.GetID()))
+                                assert.Equal(t, expectedResults[index], w.GetWorkload()["spec"].(map[string]interface{})["schedule"] )
+			case "role.yaml":
+				assert.Equal(t, "rbac.authorization.k8s.io/v1//Role/-kubescape", getRelativePath(w.GetID()))
+			case "rolebinding.yaml":
+				assert.Equal(t, "rbac.authorization.k8s.io/v1//RoleBinding/-kubescape", getRelativePath(w.GetID()))
+			case "clusterrolebinding.yaml":
+				assert.Equal(t, "rbac.authorization.k8s.io/v1//ClusterRoleBinding/-kubescape", getRelativePath(w.GetID()))
+			default:
+				assert.Failf(t, "missing case for file: %s", filepath.Base(file))
+			}
 		}
 	}
 }
@@ -90,7 +100,7 @@ func TestListDirs(t *testing.T) {
 		assert.Contains(t, dirs[i], expectedDirs[i])
 	}
 }
-
+ 
 func TestLoadFile(t *testing.T) {
 	files, _ := listFiles(filepath.Join(onlineBoutiquePath(), "adservice.yaml"))
 	assert.Equal(t, 1, len(files))

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -123,6 +123,7 @@ type ScanInfo struct {
 	CreateAccount         bool               // Create account in Kubescape Cloud BE if no account found in local cache
 	ScanID                string             // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag        // Deploy Kubescape K8s host scanner to collect data from certain controls
+	HelmValueFilePath     string             // To override the helm value file store the location of new values.yaml file
 	HostSensorYamlPath    string             // Path to hostsensor file
 	Local                 bool               // Do not submit results
 	Credentials           Credentials        // account ID

--- a/core/pkg/policyhandler/handlenotification.go
+++ b/core/pkg/policyhandler/handlenotification.go
@@ -65,7 +65,7 @@ func (policyHandler *PolicyHandler) getResources(policyIdentifier []cautils.Poli
 		setCloudMetadata(opaSessionObj)
 	}
 
-	resourcesMap, allResources, ksResources, err := policyHandler.resourceHandler.GetResources(opaSessionObj, &policyIdentifier[0].Designators)
+	resourcesMap, allResources, ksResources, err := policyHandler.resourceHandler.GetResources(opaSessionObj, &policyIdentifier[0].Designators, scanInfo)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -45,7 +45,7 @@ func NewK8sResourceHandler(k8s *k8sinterface.KubernetesApi, fieldSelector IField
 	}
 }
 
-func (k8sHandler *K8sResourceHandler) GetResources(sessionObj *cautils.OPASessionObj, designator *armotypes.PortalDesignator) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error) {
+func (k8sHandler *K8sResourceHandler) GetResources(sessionObj *cautils.OPASessionObj, designator *armotypes.PortalDesignator, scanInfo *cautils.ScanInfo) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error) {
 	allResources := map[string]workloadinterface.IMetadata{}
 
 	// get k8s resources

--- a/core/pkg/resourcehandler/resourceshandler.go
+++ b/core/pkg/resourcehandler/resourceshandler.go
@@ -8,6 +8,6 @@ import (
 )
 
 type IResourceHandler interface {
-	GetResources(*cautils.OPASessionObj, *armotypes.PortalDesignator) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error)
+	GetResources(*cautils.OPASessionObj, *armotypes.PortalDesignator, *cautils.ScanInfo) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error)
 	GetClusterAPIServerInfo() *version.Info
 }

--- a/examples/helm_chart/newvalues.yaml
+++ b/examples/helm_chart/newvalues.yaml
@@ -1,0 +1,78 @@
+# Default values for kubescape.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Frequency of running the scan
+#       ┌────────────── timezone (optional)
+#       |  ┌───────────── minute (0 - 59)
+#       |  │ ┌───────────── hour (0 - 23)
+#       |  │ │ ┌───────────── day of the month (1 - 31)
+#       |  │ │ │ ┌───────────── month (1 - 12)
+#       |  │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+#       |  │ │ │ │ │                         7 is also Sunday on some systems)
+#       |  │ │ │ │ │
+#       |  │ │ │ │ │
+#      UTC * * * * *
+schedule: "* * 2 * *"
+
+# -- Image and version to deploy
+image:
+  repository: quay.io/armosec
+  imageName: kubescape
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Service account that runs the scan and has permissions to view the cluster
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kubescape-discovery"
+
+# -- ARMO customer information
+configMap:
+  create: false
+  params:
+    customerGUID: <MyGUID>
+    clusterName: <MyK8sClusterName>
+
+podAnnotations: {}
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
+# -- Default resources for running the service in cluster
+# The values are overriden
+resources:
+  limits:
+    cpu: 800m
+    memory: 1024Mi
+  requests:
+    cpu: 400m
+    memory: 512Mi
+
+# added new values to override
+override:
+  test: pass
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
fixes #901

With merge of this PR kubescape will support a flag `--helm-value-file` which takes input of path/paths of value file seperated by `,` and override the default value file of helm.

EDITED : 

now the flag takes a string value seperated by space e.g. 
`--helm-value-file=path/to/chart1:path/to/value/file1,path/to/value/file2 path/to/chart2:path/to/value/path1....."  `

Approach:

The working of this feature is similiar to what `helm/helm` repo handles overriding however due to different structures I could not use those functions. ref https://github.com/helm/helm/blob/main/pkg/cli/values/options.go#L42