### PR TITLE
fix: filepath.Dir requires trailing slash

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -16,8 +16,8 @@ import (
 	"github.com/google/uuid"
 )
 
-var OutputDir = "./results"
-var FailedOutputDir = "./failed"
+var OutputDir = "./results/"
+var FailedOutputDir = "./failed/"
 
 // A Scan Response object
 //


### PR DESCRIPTION
## Describe your changes

While contributing read-only root filesystem to the helm chart of Kubescape over here: https://github.com/kubescape/helm-charts/pull/26, I observed that the failed scan files are created in the wrong directory: See screenshot.

I then studied the codeblock here:
https://github.com/kubescape/kubescape/blob/6e9a2f55fd48fb629e2b65f73966459175747642/core/pkg/resultshandling/printer/printresults.go#L32-L35

The filepath.Dir requires a trailing slash for the use case here. See golang docs:
![golang docs for filepath.Dir](https://user-images.githubusercontent.com/7290987/203415454-f1cc0360-3557-432e-9bf2-847d941cf586.png)


## Screenshots - If Any (Optional)
![image](https://user-images.githubusercontent.com/7290987/203357526-73452908-d8a8-4b02-bcec-36a3d8d03443.png)

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
