### PR TITLE
Add support for fixing Individual Files using "fix" command 

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -68,7 +68,7 @@ func isSupportedScanningTarget(report *reporthandlingv2.PostureReport) error {
 		return nil
 	}
 
-	return fmt.Errorf("unsupported scanning target. Only local git, directory and file scanning targets are supported")
+	return fmt.Errorf("unsupported scanning target. Supported scanning targets are: a local git repo, a directory or a file")
 }
 
 func getLocalPath(report *reporthandlingv2.PostureReport) string {

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -80,7 +81,7 @@ func getLocalPath(report *reporthandlingv2.PostureReport) string {
 	}
 
 	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.File {
-		return report.Metadata.ContextMetadata.FileContextMetadata.FilePath
+		return filepath.Dir(report.Metadata.ContextMetadata.FileContextMetadata.FilePath)
 	}
 
 	return ""

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -62,11 +62,12 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 }
 
 func isSupportedScanningTarget(report *reporthandlingv2.PostureReport) error {
-	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.GitLocal || report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.Directory {
+	scanningTarget := report.Metadata.ScanMetadata.ScanningTarget
+	if scanningTarget == reporthandlingv2.GitLocal || scanningTarget == reporthandlingv2.Directory || scanningTarget == reporthandlingv2.File {
 		return nil
 	}
 
-	return fmt.Errorf("unsupported scanning target. Only local git and directory scanning targets are supported")
+	return fmt.Errorf("unsupported scanning target. Only local git, directory and file scanning targets are supported")
 }
 
 func getLocalPath(report *reporthandlingv2.PostureReport) string {
@@ -76,6 +77,10 @@ func getLocalPath(report *reporthandlingv2.PostureReport) string {
 
 	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.Directory {
 		return report.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath
+	}
+
+	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.File {
+		return report.Metadata.ContextMetadata.FileContextMetadata.FilePath
 	}
 
 	return ""

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -88,6 +88,7 @@ func (fileHandler *FileResourceHandler) GetResources(sessionObj *cautils.OPASess
 }
 
 func getResourcesFromPath(path string) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
+
 	workloadIDToSource := make(map[string]reporthandling.Source, 0)
 	workloads := []workloadinterface.IMetadata{}
 
@@ -116,7 +117,13 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 	for source, ws := range sourceToWorkloads {
 		workloads = append(workloads, ws...)
 
-		relSource, err := filepath.Rel(repoRoot, source)
+		var relSource string
+		if repoRoot == source {
+			relSource = repoRoot
+		} else {
+			relSource, err = filepath.Rel(repoRoot, source)
+		}
+
 		if err == nil {
 			source = relSource
 		}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -109,7 +109,8 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 		repoRoot, _ = filepath.Abs(path)
 	}
 
-	// Adjusting the repoRoot incase a file is passed to scan
+	// when scanning a single file, we consider the repository root to be
+	// the directory of the scanned file
 	if cautils.IsYaml(repoRoot) {
 		repoRoot = filepath.Dir(repoRoot)
 	}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -119,6 +119,7 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 
 		var relSource string
 		if repoRoot == source {
+			// This is to preserve the relSource of individual files.
 			relSource = repoRoot
 		} else {
 			relSource, err = filepath.Rel(repoRoot, source)

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -109,6 +109,11 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 		repoRoot, _ = filepath.Abs(path)
 	}
 
+	// Adjusting the repoRoot incase a file is passed to scan
+	if cautils.IsYaml(repoRoot) {
+		repoRoot = filepath.Dir(repoRoot)
+	}
+
 	// load resource from local file system
 	sourceToWorkloads := cautils.LoadResourcesFromFiles(path, repoRoot)
 
@@ -117,13 +122,7 @@ func getResourcesFromPath(path string) (map[string]reporthandling.Source, []work
 	for source, ws := range sourceToWorkloads {
 		workloads = append(workloads, ws...)
 
-		var relSource string
-		if repoRoot == source {
-			// This is to preserve the relSource of individual files.
-			relSource = repoRoot
-		} else {
-			relSource, err = filepath.Rel(repoRoot, source)
-		}
+		relSource, err := filepath.Rel(repoRoot, source)
 
 		if err == nil {
 			source = relSource


### PR DESCRIPTION
### Currently, `fix` command doesn't support individual files. Added support in this PR

## Command to get `output.json` (`first.yml` is present in the working directory)
```
./kubescape scan first.yml --format json --format-version v2 --output output.json
```
`Note: This is required when automatically creating pull requests using GitHub Actions`
## Before
![Before](https://github.com/suhasgumma/ImagesForGitHub/blob/master/before%20ind%20fix.png?raw=true)

## After
![After](https://github.com/suhasgumma/ImagesForGitHub/blob/master/after%20ind%20fix.png?raw=true)
