### PR TITLE
Fixed: CIS control link not working for html output format

### DIFF
--- a/core/pkg/resultshandling/printer/v2/html/report.gohtml
+++ b/core/pkg/resultshandling/printer/v2/html/report.gohtml
@@ -142,7 +142,7 @@
         <tr>
           <td class="resourceSeverityCell">{{ .Severity }}</td>
           <td class="resourceNameCell">{{ .Name }}</td>
-          <td class="resourceURLCell"><a href="https://hub.armosec.io/docs/{{ lower .URL }}">{{ .URL }}</a></td>
+          <td class="resourceURLCell"><a href="{{ lower .URL }}">{{ .ID }}</a></td>
           <td class="resourceRemediationCell">{{ range .FailedPaths }} <p>{{ . }}</p> {{ end }}</td>
         </tr>
         {{ end }}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -130,10 +130,11 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary) ResourceControlResult {
 	ctlSeverity := apis.ControlSeverityToString(control.GetScoreFactor())
 	ctlName := resourceControl.GetName()
-	ctlURL := resourceControl.GetID()
+	ctlID := resourceControl.GetID()
+	ctlURL := cautils.GetControlLink(resourceControl.GetID())
 	failedPaths := append(failedPathsToString(&resourceControl), fixPathsToString(&resourceControl)...)
 
-	return ResourceControlResult{ctlSeverity, ctlName, ctlURL, failedPaths}
+	return ResourceControlResult{ctlSeverity, ctlName, ctlID, ctlURL, failedPaths}
 }
 
 func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails) []ResourceControlResult {

--- a/core/pkg/resultshandling/printer/v2/reportingstructs.go
+++ b/core/pkg/resultshandling/printer/v2/reportingstructs.go
@@ -14,6 +14,7 @@ type ResourceResult struct {
 type ResourceControlResult struct {
 	Severity    string
 	Name        string
+	ID          string
 	URL         string
 	FailedPaths []string
 }


### PR DESCRIPTION
* For CIS control links old conventions are being passed when HTML output is generated. 
* Updated the link to new convention as decided in #904 
