### PR TITLE
fix(giturlparse): fixes panic on unexpected gitlab remote URL

### DIFF
--- a/core/cautils/gitparse_test.go
+++ b/core/cautils/gitparse_test.go
@@ -1,0 +1,16 @@
+package cautils
+
+import (
+	"testing"
+
+	giturl "github.com/kubescape/go-git-url"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureRemoteParsed(t *testing.T) {
+	const remote = "git@gitlab.com:foobar/gitlab-tests/sample-project.git"
+
+	require.NotPanics(t, func() {
+		_, _ = giturl.NewGitURL(remote)
+	})
+}

--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/armosec/go-git-url/apis"
 	gitv5 "github.com/go-git/go-git/v5"
 	configv5 "github.com/go-git/go-git/v5/config"
 	plumbingv5 "github.com/go-git/go-git/v5/plumbing"
+	"github.com/kubescape/go-git-url/apis"
 	git2go "github.com/libgit2/git2go/v33"
 )
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -10,7 +10,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 
-	giturl "github.com/armosec/go-git-url"
+	giturl "github.com/kubescape/go-git-url"
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	giturl "github.com/armosec/go-git-url"
+	giturl "github.com/kubescape/go-git-url"
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"

--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -6,11 +6,11 @@ import (
 	nethttp "net/http"
 	"os"
 
-	giturl "github.com/armosec/go-git-url"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	giturl "github.com/kubescape/go-git-url"
 )
 
 // To Check if the given repository is Public(No Authentication needed), send a HTTP GET request to the URL

--- a/core/pkg/resourcehandler/urlloader.go
+++ b/core/pkg/resourcehandler/urlloader.go
@@ -1,7 +1,7 @@
 package resourcehandler
 
 import (
-	giturl "github.com/armosec/go-git-url"
+	giturl "github.com/kubescape/go-git-url"
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/kubescape/kubescape/v2
 
 go 1.18
 
+// TODO: replace this local copy by new tagged version, onece kubescape/go-git-url#2 is merged
+replace github.com/kubescape/go-git-url => /home/fred/src/github.com/kubescape/go-git-url
+
 require (
 	cloud.google.com/go/containeranalysis v0.4.0
 	github.com/armosec/armoapi-go v0.0.119
-	github.com/armosec/go-git-url v0.0.15
 	github.com/armosec/utils-go v0.0.12
 	github.com/armosec/utils-k8s-go v0.0.12
 	github.com/briandowns/spinner v1.18.1
@@ -15,6 +17,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/uuid v1.3.0
 	github.com/johnfercher/maroto v0.37.0
+	github.com/kubescape/go-git-url v0.0.16
 	github.com/kubescape/go-logger v0.0.6
 	github.com/kubescape/k8s-interface v0.0.89
 	github.com/kubescape/opa-utils v0.0.200
@@ -29,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/api v0.85.0
 	google.golang.org/genproto v0.0.0-20220708155623-50e5f4832e73
 	google.golang.org/protobuf v1.28.1
@@ -169,7 +173,6 @@ require (
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/armosec/armoapi-go v0.0.119 h1:7XbvBbOKp26Bpp72LQ8Spw4FBpbXu3+qZFQyPEwTPFk=
 github.com/armosec/armoapi-go v0.0.119/go.mod h1:2zoNzb3Fy9ZByeczJZ47ftDRLRzTykVdTISS3GTc/JU=
-github.com/armosec/go-git-url v0.0.15 h1:sDtu0WNvAhrDJ2begTyWP8T4tE1j1K6D0ZJ6t3Cx8k4=
-github.com/armosec/go-git-url v0.0.15/go.mod h1:GzfssG3IW9KiURSpK7c/bySBRTlghpObQ7NQ1O4hcMI=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=


### PR DESCRIPTION
## Describe your changes

* replaced dependencies to github.com/armosec/go-git-url by github.com/kubescape/go-git-url

NOTE: this requires kubescape/go-git-url#2 to be merged, a new release of that repo to be cut, in order to finalize the dependency update.
## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #789

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [ ] My code follows the style guidelines of this project
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>