### PR TITLE
change linux runner to 20.04 instead of ubuntu-latest (#960)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,8 +55,8 @@ jobs:
           CGO_ENABLED: 1
         run: python3 --version && python3 build.py
  
-      - name: Upload release binaries
-        id: upload-release-asset
+      - name: Upload release binaries (Windows / MacOS)
+        id: upload-release-asset-win-macos
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,9 +65,22 @@ jobs:
           asset_path: build/${{ matrix.os }}/kubescape
           asset_name: kubescape-${{ matrix.os }}
           asset_content_type: application/octet-stream
+        if: matrix.os != 'ubuntu-20.04'
 
-      - name: Upload release hash
-        id: upload-release-hash
+      - name: Upload release binaries (Linux)
+        id: upload-release-asset-linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: build/ubuntu-latest/kubescape
+          asset_name: kubescape-ubuntu-latest
+          asset_content_type: application/octet-stream
+        if: matrix.os == 'ubuntu-20.04'
+
+      - name: Upload release hash (Windows / MacOS)
+        id: upload-release-hash-win-macos
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +89,20 @@ jobs:
           asset_path: build/${{ matrix.os }}/kubescape.sha256
           asset_name: kubescape-${{ matrix.os }}-sha256
           asset_content_type: application/octet-stream
-  
+        if: matrix.os != 'ubuntu-20.04'
+
+      - name: Upload release hash (Linux)
+        id: upload-release-hash-linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: build/ubuntu-latest/kubescape.sha256
+          asset_name: kubescape-ubuntu-latest-sha256
+          asset_content_type: application/octet-stream     
+        if: matrix.os == 'ubuntu-20.04'
+
   publish-image:
     uses: ./.github/workflows/build-image.yaml
     needs: create-release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,14 +19,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Cache Go modules (Linux)
-        if: matrix.os == 'ubuntu-latest' 
+        if: matrix.os == 'ubuntu-20.04'
         uses: actions/cache@v3
         with:
           path: |
@@ -85,9 +85,16 @@ jobs:
           CGO_ENABLED: 1
         run: python3 --version && python3 build.py
 
-      - name: Smoke Testing
+      - name: Smoke Testing (Windows / MacOS)
         env:
           RELEASE: ${{ inputs.release }} 
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/${{ matrix.os }}/kubescape
-        
+        if: matrix.os != 'ubuntu-20.04'
+
+      - name: Smoke Testing (Linux)
+        env:
+          RELEASE: ${{ inputs.release }} 
+          KUBESCAPE_SKIP_UPDATE_CHECK: "true"
+        run: python3 smoke_testing/init.py ${PWD}/build/ubuntu-latest/kubescape
+        if: matrix.os == 'ubuntu-20.04'        


### PR DESCRIPTION
Co-authored-by: Amir Malka <amirm@armosec.io>

## Describe your changes

## Screenshots - If Any (Optional)

## This PR fixes:

Linux binary which is built on runner `ubuntu-latest` (22.04) was not working on ubuntu 20.04. GH updated runner version recently.

As a temporary WA - changed runner to previous version until issue is solved using latest runner version.
Ubuntu binary is now working both on ubuntu 22.04 and 20.04.

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [X] My code follows the style guidelines of this project
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
