### PR TITLE
added GitLab repo scanning support

### DIFF
--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -38,6 +38,17 @@ func isGitTokenPresent(gitURL giturl.IGitAPI) bool {
 	return true
 }
 
+// Get the error message according to the provider
+func getProviderError(gitURL giturl.IGitAPI) error {
+	switch gitURL.GetProvider(){
+	case "github":
+		return fmt.Errorf("%w", errors.New("GITHUB_TOKEN is not present"))
+	case "gitlab":
+		return fmt.Errorf("%w", errors.New("GITLAB_TOKEN is not present"))
+	}
+	return fmt.Errorf("%w", errors.New("unable to find the host name"))
+}
+
 // cloneRepo clones a repository to a local temporary directory and returns the directory
 func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 
@@ -60,9 +71,9 @@ func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 		auth = nil
 	} else {
 
-		// Return Error if the GITHUB_TOKEN is not present
+		// Return Error if the AUTH_TOKEN is not present
 		if isGitTokenPresent := isGitTokenPresent(gitURL); !isGitTokenPresent {
-			return "", fmt.Errorf("%w", errors.New("GITHUB_TOKEN is not present"))
+			return "", getProviderError(gitURL)
 		}
 		auth = &http.BasicAuth{
 			Username: "anything Except Empty String",


### PR DESCRIPTION
Signed-off-by: Anubhav Gupta <mail.anubhav06@gmail.com>


## Describe your changes
Added support for scanning remote repository hosted on GitLab
This PR is linked with "[added GitLab API support](https://github.com/kubescape/go-git-url/pull/4)" PR, and that needs to be merged before, in order for this to work.

## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #953 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

