### PR TITLE
chore: Explicit set allowPrivilegeEscalation=true

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -38,6 +38,7 @@ spec:
       - name: host-sensor
         image: quay.io/kubescape/host-scanner:v1.0.39
         securityContext:
+          allowPrivilegeEscalation: true
           privileged: true
           readOnlyRootFilesystem: true
           procMount: Unmasked


### PR DESCRIPTION
## Describe your changes

The value of allowPrivilegeEscalation followed implicit default of Kubernetes:
> AllowPrivilegeEscalation is true always when the container is:
> 1) run as Privileged
> 2) has CAP_SYS_ADMIN

For users still using PodSecurityPolicy (or a follow-up product like OPA Gatekeeper or Kyverno), there might be mutating admission controllers which defaults this field to `false` if unset. A value of `false` would then conflict with `privileged: true`.

## Screenshots - If Any (Optional)

`-`

## This PR fixes:

`-`

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
