### PR TITLE
Support Getting Outputs in multiple formats

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -191,37 +191,6 @@ func (scanInfo *ScanInfo) GetFormats() []string {
 	return strings.Split(scanInfo.Format, ",")
 }
 
-func (scanInfo *ScanInfo) GetOutputFiles() []string {
-	formats := scanInfo.GetFormats()
-	outputs := make([]string, 0)
-
-	for _, format := range formats {
-		if scanInfo.Output == "" {
-			outputs = append(outputs, "")
-		}
-
-		output := scanInfo.Output
-
-		if format == "json" {
-			if filepath.Ext(output) != ".json" {
-				output += ".json"
-			}
-		}
-		if format == "junit" {
-			if filepath.Ext(output) != ".xml" {
-				output += ".xml"
-			}
-		}
-		if format == "pdf" {
-			if filepath.Ext(output) != ".pdf" {
-				output += ".pdf"
-			}
-		}
-		outputs = append(outputs, output)
-	}
-	return outputs
-}
-
 func (scanInfo *ScanInfo) SetPolicyIdentifiers(policies []string, kind apisv1.NotificationPolicyKind) {
 	for _, policy := range policies {
 		if !scanInfo.contains(policy) {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -140,7 +140,6 @@ type Getters struct {
 
 func (scanInfo *ScanInfo) Init() {
 	scanInfo.setUseFrom()
-	scanInfo.setOutputFile()
 	scanInfo.setUseArtifactsFrom()
 	if scanInfo.ScanID == "" {
 		scanInfo.ScanID = uuid.NewString()
@@ -188,25 +187,39 @@ func (scanInfo *ScanInfo) setUseFrom() {
 	}
 }
 
-func (scanInfo *ScanInfo) setOutputFile() {
-	if scanInfo.Output == "" {
-		return
-	}
-	if scanInfo.Format == "json" {
-		if filepath.Ext(scanInfo.Output) != ".json" {
-			scanInfo.Output += ".json"
+func (scanInfo *ScanInfo) GetFormats() []string {
+	return strings.Split(scanInfo.Format, ",")
+}
+
+func (scanInfo *ScanInfo) GetOutputFiles() []string {
+	formats := scanInfo.GetFormats()
+	outputs := make([]string, 0)
+
+	for _, format := range formats {
+		if scanInfo.Output == "" {
+			outputs = append(outputs, "")
 		}
-	}
-	if scanInfo.Format == "junit" {
-		if filepath.Ext(scanInfo.Output) != ".xml" {
-			scanInfo.Output += ".xml"
+
+		output := scanInfo.Output
+
+		if format == "json" {
+			if filepath.Ext(output) != ".json" {
+				output += ".json"
+			}
 		}
-	}
-	if scanInfo.Format == "pdf" {
-		if filepath.Ext(scanInfo.Output) != ".pdf" {
-			scanInfo.Output += ".pdf"
+		if format == "junit" {
+			if filepath.Ext(output) != ".xml" {
+				output += ".xml"
+			}
 		}
+		if format == "pdf" {
+			if filepath.Ext(output) != ".pdf" {
+				output += ".pdf"
+			}
+		}
+		outputs = append(outputs, output)
 	}
+	return outputs
 }
 
 func (scanInfo *ScanInfo) SetPolicyIdentifiers(policies []string, kind apisv1.NotificationPolicyKind) {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -95,12 +95,11 @@ func getInterfaces(scanInfo *cautils.ScanInfo) componentInterfaces {
 
 	// setup printers
 	formats := scanInfo.GetFormats()
-	outputs := scanInfo.GetOutputFiles()
 
 	printerHandlers := make([]printer.IPrinter, 0)
-	for formatIdx, format := range formats {
+	for _, format := range formats {
 		printerHandler := resultshandling.NewPrinter(format, scanInfo.FormatVersion, scanInfo.VerboseMode, cautils.ViewTypes(scanInfo.View))
-		printerHandler.SetWriter(outputs[formatIdx])
+		printerHandler.SetWriter(scanInfo.Output)
 		printerHandlers = append(printerHandlers, printerHandler)
 	}
 

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	logger "github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 )
 
@@ -42,4 +43,10 @@ func GetWriter(outputFile string) *os.File {
 	}
 	return os.Stdout
 
+}
+
+func LogOutputFile(fileName string) {
+	if fileName != "/dev/stdout" && fileName != "/dev/stderr" {
+		logger.L().Success("Scan results saved", helpers.String("filename", fileName))
+	}
 }

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -4,10 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer"
+)
+
+const (
+	jsonOutputFile = "report"
+	jsonOutputExt  = ".json"
 )
 
 type JsonPrinter struct {
@@ -19,6 +26,12 @@ func NewJsonPrinter() *JsonPrinter {
 }
 
 func (jsonPrinter *JsonPrinter) SetWriter(outputFile string) {
+	if strings.TrimSpace(outputFile) == "" {
+		outputFile = jsonOutputFile
+	}
+	if filepath.Ext(strings.TrimSpace(outputFile)) != jsonOutputExt {
+		outputFile = outputFile + jsonOutputExt
+	}
 	jsonPrinter.writer = printer.GetWriter(outputFile)
 }
 
@@ -41,7 +54,13 @@ func (jsonPrinter *JsonPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj
 	if err != nil {
 		logger.L().Fatal("failed to convert posture report object")
 	}
-	jsonPrinter.writer.Write(postureReportStr)
 
-	printer.LogOutputFile(jsonPrinter.writer.Name())
+	_, err = jsonPrinter.writer.Write(postureReportStr)
+
+	if err != nil {
+		logger.L().Fatal("failed to Write posture report object into JSON output")
+	} else {
+		printer.LogOutputFile(jsonPrinter.writer.Name())
+	}
+
 }

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -42,4 +42,6 @@ func (jsonPrinter *JsonPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj
 		logger.L().Fatal("failed to convert posture report object")
 	}
 	jsonPrinter.writer.Write(postureReportStr)
+
+	printer.LogOutputFile(jsonPrinter.writer.Name())
 }

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -30,15 +30,15 @@ func (prometheusPrinter *PrometheusPrinter) Score(score float32) {
 	fmt.Printf("\n# Overall risk-score (0- Excellent, 100- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
 }
 
-func (printer *PrometheusPrinter) printResources(allResources map[string]workloadinterface.IMetadata, resourcesIDs *reporthandling.ResourcesIDs, frameworkName, controlName string) {
-	printer.printDetails(allResources, resourcesIDs.GetFailedResources(), frameworkName, controlName, "failed")
-	printer.printDetails(allResources, resourcesIDs.GetWarningResources(), frameworkName, controlName, "excluded")
-	if printer.verboseMode {
-		printer.printDetails(allResources, resourcesIDs.GetPassedResources(), frameworkName, controlName, "passed")
+func (prometheusPrinter *PrometheusPrinter) printResources(allResources map[string]workloadinterface.IMetadata, resourcesIDs *reporthandling.ResourcesIDs, frameworkName, controlName string) {
+	prometheusPrinter.printDetails(allResources, resourcesIDs.GetFailedResources(), frameworkName, controlName, "failed")
+	prometheusPrinter.printDetails(allResources, resourcesIDs.GetWarningResources(), frameworkName, controlName, "excluded")
+	if prometheusPrinter.verboseMode {
+		prometheusPrinter.printDetails(allResources, resourcesIDs.GetPassedResources(), frameworkName, controlName, "passed")
 	}
 
 }
-func (printer *PrometheusPrinter) printDetails(allResources map[string]workloadinterface.IMetadata, resourcesIDs []string, frameworkName, controlName, status string) {
+func (prometheusPrinter *PrometheusPrinter) printDetails(allResources map[string]workloadinterface.IMetadata, resourcesIDs []string, frameworkName, controlName, status string) {
 	objs := make(map[string]map[string]map[string]int)
 	for _, resourceID := range resourcesIDs {
 		resource := allResources[resourceID]
@@ -56,18 +56,18 @@ func (printer *PrometheusPrinter) printDetails(allResources map[string]workloadi
 	for gvk, namespaces := range objs {
 		for namespace, names := range namespaces {
 			for name, value := range names {
-				fmt.Fprintf(printer.writer, "# Failed object from \"%s\" control \"%s\"\n", frameworkName, controlName)
+				fmt.Fprintf(prometheusPrinter.writer, "# Failed object from \"%s\" control \"%s\"\n", frameworkName, controlName)
 				if namespace != "" {
-					fmt.Fprintf(printer.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",namespace=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, namespace, name, gvk, value)
+					fmt.Fprintf(prometheusPrinter.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",namespace=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, namespace, name, gvk, value)
 				} else {
-					fmt.Fprintf(printer.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, name, gvk, value)
+					fmt.Fprintf(prometheusPrinter.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, name, gvk, value)
 				}
 			}
 		}
 	}
 }
 
-func (printer *PrometheusPrinter) printReports(allResources map[string]workloadinterface.IMetadata, frameworks []reporthandling.FrameworkReport) error {
+func (prometheusPrinter *PrometheusPrinter) printReports(allResources map[string]workloadinterface.IMetadata, frameworks []reporthandling.FrameworkReport) error {
 	for _, frameworkReport := range frameworks {
 		for _, controlReport := range frameworkReport.ControlReports {
 			if controlReport.GetNumberOfResources() == 0 {
@@ -76,21 +76,24 @@ func (printer *PrometheusPrinter) printReports(allResources map[string]workloadi
 			if controlReport.Passed() {
 				continue // control passed, do not print results
 			}
-			fmt.Fprintf(printer.writer, "# Number of resources found as part of %s control %s\nkubescape_resources_found_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfResources())
-			fmt.Fprintf(printer.writer, "# Number of resources excluded as part of %s control %s\nkubescape_resources_excluded_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfWarningResources())
-			fmt.Fprintf(printer.writer, "# Number of resources failed as part of %s control %s\nkubescape_resources_failed_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfFailedResources())
+			fmt.Fprintf(prometheusPrinter.writer, "# Number of resources found as part of %s control %s\nkubescape_resources_found_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfResources())
+			fmt.Fprintf(prometheusPrinter.writer, "# Number of resources excluded as part of %s control %s\nkubescape_resources_excluded_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfWarningResources())
+			fmt.Fprintf(prometheusPrinter.writer, "# Number of resources failed as part of %s control %s\nkubescape_resources_failed_count{framework=\"%s\",control=\"%s\"} %d\n", frameworkReport.Name, controlReport.Name, frameworkReport.Name, controlReport.Name, controlReport.GetNumberOfFailedResources())
 
-			printer.printResources(allResources, controlReport.ListResourcesIDs(), frameworkReport.Name, controlReport.Name)
+			prometheusPrinter.printResources(allResources, controlReport.ListResourcesIDs(), frameworkReport.Name, controlReport.Name)
 		}
 	}
 	return nil
 }
 
-func (printer *PrometheusPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
+func (prometheusPrinter *PrometheusPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
 	report := cautils.ReportV2ToV1(opaSessionObj)
 
-	err := printer.printReports(opaSessionObj.AllResources, report.FrameworkReports)
+	err := prometheusPrinter.printReports(opaSessionObj.AllResources, report.FrameworkReports)
 	if err != nil {
 		logger.L().Fatal(err.Error())
+	} else {
+		printer.LogOutputFile(prometheusPrinter.writer.Name())
 	}
+
 }

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -107,7 +107,10 @@ func (htmlPrinter *HtmlPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj
 	err := tpl.Execute(htmlPrinter.writer, reportingCtx)
 	if err != nil {
 		logger.L().Error("failed to render template", helpers.Error(err))
+	} else {
+		printer.LogOutputFile(htmlPrinter.writer.Name())
 	}
+
 }
 
 func (htmlPrinter *HtmlPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -39,7 +39,7 @@ func NewHtmlPrinter() *HtmlPrinter {
 }
 
 func (htmlPrinter *HtmlPrinter) SetWriter(outputFile string) {
-	if outputFile == "" {
+	if strings.TrimSpace(outputFile) == "" {
 		outputFile = htmlOutputFile
 	}
 	if filepath.Ext(strings.TrimSpace(outputFile)) != htmlOutputExt {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -4,11 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer"
+)
+
+const (
+	jsonOutputFile = "report"
+	jsonOutputExt  = ".json"
 )
 
 type JsonPrinter struct {
@@ -20,6 +27,12 @@ func NewJsonPrinter() *JsonPrinter {
 }
 
 func (jsonPrinter *JsonPrinter) SetWriter(outputFile string) {
+	if strings.TrimSpace(outputFile) == "" {
+		outputFile = jsonOutputFile
+	}
+	if filepath.Ext(strings.TrimSpace(outputFile)) != jsonOutputExt {
+		outputFile = outputFile + jsonOutputExt
+	}
 	jsonPrinter.writer = printer.GetWriter(outputFile)
 }
 

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -33,8 +33,9 @@ func (jsonPrinter *JsonPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj
 		logger.L().Fatal("failed to Marshal posture report object")
 	}
 
-	logOUtputFile(jsonPrinter.writer.Name())
 	if _, err := jsonPrinter.writer.Write(r); err != nil {
 		logger.L().Error("failed to write results", helpers.Error(err))
+	} else {
+		printer.LogOutputFile(jsonPrinter.writer.Name())
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -107,9 +107,10 @@ func (junitPrinter *JunitPrinter) ActionPrint(opaSessionObj *cautils.OPASessionO
 		logger.L().Fatal("failed to Marshal xml result object", helpers.Error(err))
 	}
 
-	logOUtputFile(junitPrinter.writer.Name())
 	if _, err := junitPrinter.writer.Write(postureReportStr); err != nil {
 		logger.L().Error("failed to write results", helpers.Error(err))
+	} else {
+		printer.LogOutputFile(junitPrinter.writer.Name())
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -14,6 +15,11 @@ import (
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/shared"
+)
+
+const (
+	junitOutputFile = "report"
+	junitOutputExt  = ".xml"
 )
 
 /*
@@ -93,6 +99,12 @@ func NewJunitPrinter(verbose bool) *JunitPrinter {
 }
 
 func (junitPrinter *JunitPrinter) SetWriter(outputFile string) {
+	if strings.TrimSpace(outputFile) == "" {
+		outputFile = junitOutputFile
+	}
+	if filepath.Ext(strings.TrimSpace(outputFile)) != junitOutputExt {
+		outputFile = outputFile + junitOutputExt
+	}
 	junitPrinter.writer = printer.GetWriter(outputFile)
 }
 

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -93,9 +93,10 @@ func (pdfPrinter *PdfPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) 
 		return
 	}
 
-	logOUtputFile(pdfPrinter.writer.Name())
 	if _, err := pdfPrinter.writer.Write(outBuff.Bytes()); err != nil {
 		logger.L().Error("failed to write results", helpers.Error(err))
+	} else {
+		printer.LogOutputFile(pdfPrinter.writer.Name())
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -41,7 +41,7 @@ func NewPdfPrinter() *PdfPrinter {
 
 func (pdfPrinter *PdfPrinter) SetWriter(outputFile string) {
 	// Ensure to have an available output file, otherwise create it.
-	if outputFile == "" {
+	if strings.TrimSpace(outputFile) == "" {
 		outputFile = pdfOutputFile
 	}
 	// Ensure to have the right file extension.

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -50,6 +50,7 @@ func (prettyPrinter *PrettyPrinter) ActionPrint(opaSessionObj *cautils.OPASessio
 }
 
 func (prettyPrinter *PrettyPrinter) SetWriter(outputFile string) {
+
 	prettyPrinter.writer = printer.GetWriter(outputFile)
 }
 

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -32,7 +32,7 @@ func (prometheusPrinter *PrometheusPrinter) Score(score float32) {
 	fmt.Printf("\n# Overall risk-score (0- Excellent, 100- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
 }
 
-func (printer *PrometheusPrinter) generatePrometheusFormat(
+func (prometheusPrinter *PrometheusPrinter) generatePrometheusFormat(
 	resources map[string]workloadinterface.IMetadata,
 	results map[string]resourcesresults.Result,
 	summaryDetails *reportsummary.SummaryDetails) *Metrics {
@@ -44,12 +44,13 @@ func (printer *PrometheusPrinter) generatePrometheusFormat(
 	return m
 }
 
-func (printer *PrometheusPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
+func (prometheusPrinter *PrometheusPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
 
-	metrics := printer.generatePrometheusFormat(opaSessionObj.AllResources, opaSessionObj.ResourcesResult, &opaSessionObj.Report.SummaryDetails)
+	metrics := prometheusPrinter.generatePrometheusFormat(opaSessionObj.AllResources, opaSessionObj.ResourcesResult, &opaSessionObj.Report.SummaryDetails)
 
-	logOUtputFile(printer.writer.Name())
-	if _, err := printer.writer.Write([]byte(metrics.String())); err != nil {
+	if _, err := prometheusPrinter.writer.Write([]byte(metrics.String())); err != nil {
 		logger.L().Error("failed to write results", helpers.Error(err))
+	} else {
+		printer.LogOutputFile(prometheusPrinter.writer.Name())
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -66,7 +66,7 @@ func (sp *SARIFPrinter) Score(score float32) {
 }
 
 func (sp *SARIFPrinter) SetWriter(outputFile string) {
-	if outputFile == "" {
+	if strings.TrimSpace(outputFile) == "" {
 		outputFile = sarifOutputFile
 	}
 	if filepath.Ext(strings.TrimSpace(outputFile)) != sarifOutputExt {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -144,6 +144,8 @@ func (sp *SARIFPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
 	report.AddRun(run)
 
 	report.PrettyWrite(sp.writer)
+
+	printer.LogOutputFile(sp.writer.Name())
 }
 
 func (sp *SARIFPrinter) resolveFixLocation(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) locationresolver.Location {

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	logger "github.com/kubescape/go-logger"
-	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -82,11 +80,4 @@ func finalizeResources(results []resourcesresults.Result, allResources map[strin
 		}
 	}
 	return resources
-}
-
-func logOUtputFile(fileName string) {
-	if fileName != "/dev/stdout" && fileName != "/dev/stderr" {
-		logger.L().Success("Scan results saved", helpers.String("filename", fileName))
-	}
-
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -65,18 +65,15 @@ func (resultsHandler *ResultsHandler) GetResults() *reporthandlingv2.PostureRepo
 // HandleResults handle the scan results according to the pre defined interfaces
 func (resultsHandler *ResultsHandler) HandleResults() error {
 
-	printerObjs := resultsHandler.printerObjs
-
-	for _, printerObj := range printerObjs {
-		printerObj.ActionPrint(resultsHandler.scanData)
-	}
-
 	if err := resultsHandler.reporterObj.Submit(resultsHandler.scanData); err != nil {
 		return err
 	}
 
-	for _, printerObj := range printerObjs {
-		printerObj.Score(resultsHandler.GetRiskScore())
+	printerObjs := resultsHandler.printerObjs
+
+	for i := range printerObjs {
+		printerObjs[i].Score(resultsHandler.GetRiskScore())
+		printerObjs[i].ActionPrint(resultsHandler.scanData)
 	}
 
 	resultsHandler.reporterObj.DisplayReportURL()

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -16,14 +16,14 @@ import (
 
 type ResultsHandler struct {
 	reporterObj reporter.IReport
-	printerObj  printer.IPrinter
+	printerObjs []printer.IPrinter
 	scanData    *cautils.OPASessionObj
 }
 
-func NewResultsHandler(reporterObj reporter.IReport, printerObj printer.IPrinter) *ResultsHandler {
+func NewResultsHandler(reporterObj reporter.IReport, printerObjs []printer.IPrinter) *ResultsHandler {
 	return &ResultsHandler{
 		reporterObj: reporterObj,
-		printerObj:  printerObj,
+		printerObjs: printerObjs,
 	}
 }
 
@@ -43,8 +43,8 @@ func (resultsHandler *ResultsHandler) SetData(data *cautils.OPASessionObj) {
 }
 
 // GetPrinter get printer object
-func (resultsHandler *ResultsHandler) GetPrinter() printer.IPrinter {
-	return resultsHandler.printerObj
+func (resultsHandler *ResultsHandler) GetPrinters() []printer.IPrinter {
+	return resultsHandler.printerObjs
 }
 
 // GetReporter get reporter object
@@ -65,13 +65,19 @@ func (resultsHandler *ResultsHandler) GetResults() *reporthandlingv2.PostureRepo
 // HandleResults handle the scan results according to the pre defined interfaces
 func (resultsHandler *ResultsHandler) HandleResults() error {
 
-	resultsHandler.printerObj.ActionPrint(resultsHandler.scanData)
+	printerObjs := resultsHandler.printerObjs
+
+	for _, printerObj := range printerObjs {
+		printerObj.ActionPrint(resultsHandler.scanData)
+	}
 
 	if err := resultsHandler.reporterObj.Submit(resultsHandler.scanData); err != nil {
 		return err
 	}
 
-	resultsHandler.printerObj.Score(resultsHandler.GetRiskScore())
+	for _, printerObj := range printerObjs {
+		printerObj.Score(resultsHandler.GetRiskScore())
+	}
 
 	resultsHandler.reporterObj.DisplayReportURL()
 


### PR DESCRIPTION
## Changes Made:
* Added support for getting outputs in multiple formats.
* Currently, the required formats are passed in a `single string separated by commas(,)` to the formats flag. Could change the input of formats flag to slice if required in the future.

* Takes a single output file as input and adds the required extensions to generate multiple output files for multiple formats.

![Multi Format](https://github.com/suhasgumma/ImagesForGitHub/blob/master/multiformat.png?raw=true)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
