### PR TITLE
Bump go version to 1.19

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Install MSYS2 & libgit2 (Windows)
         shell: cmd

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Install MSYS2 & libgit2 (Windows)
         shell: cmd

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 
 ARG image_version
 ARG client

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubescape/kubescape/v2
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/containeranalysis v0.4.0

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubescape/kubescape/v2/httphandler
 
-go 1.18
+go 1.19
 
 replace github.com/kubescape/kubescape/v2 => ../
 


### PR DESCRIPTION
In this PR we are bumping the go version to `1.19`