### PR TITLE
:bug: fix/panic

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -324,7 +324,6 @@ func setContextMetadata(contextMetadata *reporthandlingv2.ContextMetadata, input
 			ContextName: k8sinterface.GetContextName(),
 		}
 	case ContextGitURL:
-		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		// url
 		context, err := metadataGitURL(input)
 		if err != nil {
@@ -332,19 +331,16 @@ func setContextMetadata(contextMetadata *reporthandlingv2.ContextMetadata, input
 		}
 		contextMetadata.RepoContextMetadata = context
 	case ContextDir:
-		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		contextMetadata.DirectoryContextMetadata = &reporthandlingv2.DirectoryContextMetadata{
 			BasePath: getAbsPath(input),
 			HostName: getHostname(),
 		}
 	case ContextFile:
-		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		contextMetadata.FileContextMetadata = &reporthandlingv2.FileContextMetadata{
 			FilePath: getAbsPath(input),
 			HostName: getHostname(),
 		}
 	case ContextGitLocal:
-		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		// local
 		context, err := metadataGitLocal(input)
 		if err != nil {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -324,6 +324,7 @@ func setContextMetadata(contextMetadata *reporthandlingv2.ContextMetadata, input
 			ContextName: k8sinterface.GetContextName(),
 		}
 	case ContextGitURL:
+		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		// url
 		context, err := metadataGitURL(input)
 		if err != nil {
@@ -331,16 +332,19 @@ func setContextMetadata(contextMetadata *reporthandlingv2.ContextMetadata, input
 		}
 		contextMetadata.RepoContextMetadata = context
 	case ContextDir:
+		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		contextMetadata.DirectoryContextMetadata = &reporthandlingv2.DirectoryContextMetadata{
 			BasePath: getAbsPath(input),
 			HostName: getHostname(),
 		}
 	case ContextFile:
+		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		contextMetadata.FileContextMetadata = &reporthandlingv2.FileContextMetadata{
 			FilePath: getAbsPath(input),
 			HostName: getHostname(),
 		}
 	case ContextGitLocal:
+		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 		// local
 		context, err := metadataGitLocal(input)
 		if err != nil {

--- a/core/pkg/policyhandler/handlenotification.go
+++ b/core/pkg/policyhandler/handlenotification.go
@@ -60,7 +60,10 @@ func (policyHandler *PolicyHandler) CollectResources(policyIdentifier []cautils.
 func (policyHandler *PolicyHandler) getResources(policyIdentifier []cautils.PolicyIdentifier, opaSessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) error {
 	opaSessionObj.Report.ClusterAPIServerInfo = policyHandler.resourceHandler.GetClusterAPIServerInfo()
 
-	setCloudMetadata(opaSessionObj)
+	// set cloud metadata only when scanning a cluster
+	if opaSessionObj.Metadata.ScanMetadata.ScanningTarget == reportv2.Cluster {
+		setCloudMetadata(opaSessionObj)
+	}
 
 	resourcesMap, allResources, ksResources, err := policyHandler.resourceHandler.GetResources(opaSessionObj, &policyIdentifier[0].Designators)
 	if err != nil {

--- a/core/pkg/policyhandler/handlenotification_test.go
+++ b/core/pkg/policyhandler/handlenotification_test.go
@@ -248,13 +248,13 @@ func Test_getResources(t *testing.T) {
 	}
 	policyIdentifier := []cautils.PolicyIdentifier{{}}
 
-	assert.Panics(t, func() {
+	assert.NotPanics(t, func() {
 		policyHandler.getResources(policyIdentifier, objSession, &cautils.ScanInfo{})
 	}, "Cluster named .*eks.* without a cloud config panics on cluster scan !")
 
 	assert.NotPanics(t, func() {
 		objSession.Metadata.ScanMetadata.ScanningTarget = reportv2.File
 		policyHandler.getResources(policyIdentifier, objSession, &cautils.ScanInfo{})
-	}, "Cluster named .*eks.* without a cloud config not panicking on non-cluster scan !")
+	}, "Cluster named .*eks.* without a cloud config panics on non-cluster scan !")
 
 }

--- a/core/pkg/policyhandler/handlenotification_test.go
+++ b/core/pkg/policyhandler/handlenotification_test.go
@@ -1,15 +1,25 @@
 package policyhandler
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/pkg/resourcehandler"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	reportv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -198,4 +208,53 @@ func Test_isAKS(t *testing.T) {
 			}
 		})
 	}
+}
+
+type iResourceHandlerMock struct{}
+
+func (*iResourceHandlerMock) GetResources(*cautils.OPASessionObj, *armotypes.PortalDesignator) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error) {
+	return nil, nil, nil, nil
+}
+func (*iResourceHandlerMock) GetClusterAPIServerInfo() *version.Info {
+	return nil
+}
+
+// https://github.com/kubescape/kubescape/pull/1004
+// Cluster named .*eks.* config without a cloudconfig panics whereas we just want to scan a file
+func getResourceHandlerMock() *resourcehandler.K8sResourceHandler {
+	client := fakeclientset.NewSimpleClientset()
+	fakeDiscovery := client.Discovery()
+
+	k8s := &k8sinterface.KubernetesApi{
+		KubernetesClient: client,
+		DynamicClient:    fake.NewSimpleDynamicClient(runtime.NewScheme()),
+		DiscoveryClient:  fakeDiscovery,
+		Context:          context.Background(),
+	}
+
+	return resourcehandler.NewK8sResourceHandler(k8s, &resourcehandler.EmptySelector{}, nil, nil, nil)
+}
+func Test_getResources(t *testing.T) {
+	policyHandler := &PolicyHandler{resourceHandler: getResourceHandlerMock()}
+	objSession := &cautils.OPASessionObj{
+		Metadata: &reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reportv2.Cluster,
+			},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			ClusterAPIServerInfo: nil,
+		},
+	}
+	policyIdentifier := []cautils.PolicyIdentifier{{}}
+
+	assert.Panics(t, func() {
+		policyHandler.getResources(policyIdentifier, objSession, &cautils.ScanInfo{})
+	}, "Cluster named .*eks.* without a cloud config panics on cluster scan !")
+
+	assert.NotPanics(t, func() {
+		objSession.Metadata.ScanMetadata.ScanningTarget = reportv2.File
+		policyHandler.getResources(policyIdentifier, objSession, &cautils.ScanInfo{})
+	}, "Cluster named .*eks.* without a cloud config not panicking on non-cluster scan !")
+
 }


### PR DESCRIPTION
## Describe your changes
Fix panic while scanning files/dirs.

## Screenshots - If Any (Optional)
```
kubescape scan test.yaml
go build -v -tags="static" .
github.com/kubescape/kubescape/v2/core/pkg/policyhandler
github.com/kubescape/kubescape/v2/core/core
[info] Kubescape scanner starting
[warning] unknown build number, this might affect your scan results. Please make sure you are updated to latest version
[info] Downloading/Loading policy definitions
[success] Downloaded/Loaded policy
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x33e61fe]

goroutine 1 [running]:
github.com/kubescape/kubescape/v2/core/pkg/policyhandler.setCloudMetadata(0xc0012b4000)
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/core/pkg/policyhandler/handlenotification.go:91 +0x9e
github.com/kubescape/kubescape/v2/core/pkg/policyhandler.(*PolicyHandler).getResources(0xc0017a37f0, {0xc0006a0a80, 0x6, 0x8?}, 0xc0012b4000, 0x3a43bc0?)
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/core/pkg/policyhandler/handlenotification.go:63 +0x6d
github.com/kubescape/kubescape/v2/core/pkg/policyhandler.(*PolicyHandler).CollectResources(0xc0017a37f0, {0xc0006a0a80, 0x6, 0x8}, 0xc00028ab40)
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/core/pkg/policyhandler/handlenotification.go:48 +0xb9
github.com/kubescape/kubescape/v2/core/core.(*Kubescape).Scan(0x3c41a00?, 0xc00028ab40)
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/core/core/scan.go:158 +0x6b9
github.com/kubescape/kubescape/v2/cmd/scan.getFrameworkCmd.func2(0x36bb7e0?, {0xc0002e3b00, 0x2, 0x2})
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/cmd/scan/framework.go:106 +0x46c
github.com/kubescape/kubescape/v2/cmd/scan.GetScanCommand.func1(0xc00042fb00?, {0xc000383890, 0x1, 0x1?})
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/cmd/scan/scan.go:46 +0x166
github.com/spf13/cobra.(*Command).ValidateArgs(...)
	/home/rbuisson/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1072
github.com/spf13/cobra.(*Command).execute(0xc00042fb00?, {0xc000383790?, 0x1?, 0x1?})
	/home/rbuisson/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:885 +0x653
github.com/spf13/cobra.(*Command).ExecuteC(0xc00042f200)
	/home/rbuisson/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/rbuisson/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/kubescape/kubescape/v2/cmd.Execute()
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/cmd/root.go:87 +0x2d
main.main()
	/home/rbuisson/Documents/go/src/github.com/kubescape/kubescape/main.go:9 +0x1d
```

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
