### PR TITLE
Fix missing upstream panic

### DIFF
--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -79,10 +79,13 @@ func (g *LocalGitRepository) GetRemoteUrl() (string, error) {
 	}
 
 	const defaultRemoteName string = "origin"
-	if len(g.config.Remotes[defaultRemoteName].URLs) == 0 {
+	defaultRemote, ok := g.config.Remotes[defaultRemoteName]
+	if !ok {
+		return "", fmt.Errorf("did not find a default remote with name '%s'", defaultRemoteName)
+	} else if len(defaultRemote.URLs) == 0 {
 		return "", fmt.Errorf("expected to find URLs for remote '%s'", defaultRemoteName)
 	}
-	return g.config.Remotes[defaultRemoteName].URLs[0], nil
+	return defaultRemote.URLs[0], nil
 }
 
 // GetName get origin name without the .git suffix

--- a/core/pkg/containerscan/gojayunmarshaller.go
+++ b/core/pkg/containerscan/gojayunmarshaller.go
@@ -64,7 +64,7 @@ func (pkgs *LinuxPkgs) UnmarshalJSONArray(dec *gojay.Decoder) error {
 	return nil
 }
 
-//--------Vul fixed in----------------------------------
+// --------Vul fixed in----------------------------------
 func (fx *FixedIn) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err error) {
 
 	switch key {

--- a/core/pkg/containerscan/rawdatastrucutres.go
+++ b/core/pkg/containerscan/rawdatastrucutres.go
@@ -71,19 +71,19 @@ type PackageFile struct {
 
 // types to provide unmarshalling:
 
-//VulnerabilitiesList -s.e
+// VulnerabilitiesList -s.e
 type LayersList []ScanResultLayer
 
-//VulnerabilitiesList -s.e
+// VulnerabilitiesList -s.e
 type VulnerabilitiesList []Vulnerability
 
-//LinuxPkgs - slice of linux pkgs
+// LinuxPkgs - slice of linux pkgs
 type LinuxPkgs []LinuxPackage
 
-//VulFixes - information bout when/how this vul was fixed
+// VulFixes - information bout when/how this vul was fixed
 type VulFixes []FixedIn
 
-//PkgFiles - slice of files belong to specific pkg
+// PkgFiles - slice of files belong to specific pkg
 type PkgFiles []PackageFile
 
 func (v *ScanResultReport) AsFNVHash() string {

--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -40,7 +40,7 @@ func isGitTokenPresent(gitURL giturl.IGitAPI) bool {
 
 // Get the error message according to the provider
 func getProviderError(gitURL giturl.IGitAPI) error {
-	switch gitURL.GetProvider(){
+	switch gitURL.GetProvider() {
 	case "github":
 		return fmt.Errorf("%w", errors.New("GITHUB_TOKEN is not present"))
 	case "gitlab":


### PR DESCRIPTION
## Describe your changes

This change fixes the case in which Kubescape would panic when scanning a local Git repository that:
- has the current branch that does not have an upstream set
- does not have an `origin` branch to fall back on

The panic happened because we did not check if the `origin` key exists in the map of upstreams. This change adds a test for this scenario and makes it pass by checking if the key exists. If it does not, it returns an error.

## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #1005 

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
