### PR TITLE
fix: branchRef.Remote can be a gitUrl

### DIFF
--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -73,6 +73,10 @@ func (g *LocalGitRepository) GetRemoteUrl() (string, error) {
 	branchName := g.GetBranchName()
 	if branchRef, branchFound := g.config.Branches[branchName]; branchFound {
 		remoteName := branchRef.Remote
+		// branchRef.Remote can be a reference to a config.Remotes entry or directly a gitUrl
+		if _, found := g.config.Remotes[remoteName]; !found {
+			return remoteName, nil
+		}
 		if len(g.config.Remotes[remoteName].URLs) == 0 {
 			return "", fmt.Errorf("expected to find URLs for remote '%s', branch '%s'", remoteName, branchName)
 		}


### PR DESCRIPTION
## Describe your changes
Fix a nil panic when calling scan from a git repository populated from `gh pr checkout 123`.
The `branch.remote` in a gitconfig file can be either a reference to a `remote` entry (what we check today) or directly a url:
```
[remote "origin"]
        url = git@github.com:matthyx/kubescape.git
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "dev"]
        remote = origin
        merge = refs/heads/dev
[branch "azure-scanning"]
        remote = git@github.com:anubhav06/kubescape.git
        pushRemote = git@github.com:anubhav06/kubescape.git
        merge = refs/heads/azure-scanning
```

## Screenshots - If Any (Optional)

## This PR fixes:

* Resolved #

## Checklist before requesting a review
<!-- put an [x] in the box to get it checked -->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
