### PR TITLE
chore: retarget a ListFrameworks fix, suggest targeting master in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,4 @@ put an [x] in the box to get it checked
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] New and existing unit tests pass locally with my changes
 
-**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
-
--->
- 
+--> 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please follow our [code of conduct](CODE_OF_CONDUCT.md) in all of your interacti
    build.
 2. Update the README.md with details of changes to the interface, this includes new environment 
    variables, exposed ports, useful file locations and container parameters.
-3. Open Pull Request to `dev` branch - we test the component before merging into the `master` branch
+3. Open Pull Request to the `master` branch.
 4. We will merge the Pull Request once you have the sign-off.
 
 ## Developer Certificate of Origin

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -160,7 +160,7 @@ func (lp *LoadPolicy) ListFrameworks() ([]string, error) {
 			continue
 		}
 
-		if contains(frameworkNames, framework.Name) {
+		if framework.Name == "" || contains(frameworkNames, framework.Name) {
 			continue
 		}
 

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -179,6 +179,29 @@ func TestLoadPolicy(t *testing.T) {
 			require.Equal(t, extraFramework, fws[1])
 		})
 
+		t.Run("should not return an empty framework", func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				extraFramework = "NSA"
+				attackTracks   = "attack-tracks"
+				controlsInputs = "controls-inputs"
+			)
+			p := NewLoadPolicy([]string{
+				testFrameworkFile(testFramework),
+				testFrameworkFile(extraFramework),
+				testFrameworkFile(attackTracks),   // should be ignored
+				testFrameworkFile(controlsInputs), // should be ignored
+			})
+			fws, err := p.ListFrameworks()
+			require.NoError(t, err)
+			require.Len(t, fws, 2)
+			require.NotContains(t, fws, "")
+
+			require.Equal(t, testFramework, fws[0])
+			require.Equal(t, extraFramework, fws[1])
+		})
+
 		t.Run("should fail on file error", func(t *testing.T) {
 			t.Parallel()
 

--- a/core/cautils/getter/testdata/controls-inputs.json
+++ b/core/cautils/getter/testdata/controls-inputs.json
@@ -1,0 +1,125 @@
+{
+  "publicRegistries": [],
+  "untrustedRegistries": [],
+  "listOfDangerousArtifacts": [
+    "bin/bash",
+    "sbin/sh",
+    "bin/ksh",
+    "bin/tcsh",
+    "bin/zsh",
+    "usr/bin/scsh",
+    "bin/csh",
+    "bin/busybox",
+    "usr/bin/busybox"
+  ],
+  "sensitiveKeyNames": [
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "azure_batchai_storage_account",
+    "azure_batchai_storage_key",
+    "azure_batch_account",
+    "azure_batch_key",
+    "secret",
+    "key",
+    "password",
+    "pwd",
+    "token",
+    "jwt",
+    "bearer",
+    "credential"
+  ],
+  "servicesNames": [
+    "nifi-service",
+    "argo-server",
+    "minio",
+    "postgres",
+    "workflow-controller-metrics",
+    "weave-scope-app",
+    "kubernetes-dashboard"
+  ],
+  "memory_limit_max": [],
+  "cpu_request_min": [],
+  "wlKnownNames": [
+    "coredns",
+    "kube-proxy",
+    "event-exporter-gke",
+    "kube-dns",
+    "17-default-backend",
+    "metrics-server",
+    "ca-audit",
+    "ca-dashboard-aggregator",
+    "ca-notification-server",
+    "ca-ocimage",
+    "ca-oracle",
+    "ca-posture",
+    "ca-rbac",
+    "ca-vuln-scan",
+    "ca-webhook",
+    "ca-websocket",
+    "clair-clair"
+  ],
+  "sensitiveInterfaces": [
+    "nifi",
+    "argo-server",
+    "weave-scope-app",
+    "kubeflow",
+    "kubernetes-dashboard",
+    "jenkins",
+    "prometheus-deployment"
+  ],
+  "max_high_vulnerabilities": [
+    "10"
+  ],
+  "sensitiveValues": [
+    "BEGIN \\w+ PRIVATE KEY",
+    "PRIVATE KEY",
+    "eyJhbGciO",
+    "JWT",
+    "Bearer",
+    "_key_",
+    "_secret_"
+  ],
+  "memory_request_max": [],
+  "memory_request_min": [],
+  "cpu_request_max": [],
+  "cpu_limit_max": [],
+  "cpu_limit_min": [],
+  "insecureCapabilities": [
+    "SETPCAP",
+    "NET_ADMIN",
+    "NET_RAW",
+    "SYS_MODULE",
+    "SYS_RAWIO",
+    "SYS_PTRACE",
+    "SYS_ADMIN",
+    "SYS_BOOT",
+    "MAC_OVERRIDE",
+    "MAC_ADMIN",
+    "PERFMON",
+    "ALL",
+    "BPF"
+  ],
+  "max_critical_vulnerabilities": [
+    "5"
+  ],
+  "sensitiveValuesAllowed": [],
+  "memory_limit_min": [],
+  "recommendedLabels": [
+    "app",
+    "tier",
+    "phase",
+    "version",
+    "owner",
+    "env"
+  ],
+  "k8sRecommendedLabels": [
+    "app.kubernetes.io/name",
+    "app.kubernetes.io/instance",
+    "app.kubernetes.io/version",
+    "app.kubernetes.io/component",
+    "app.kubernetes.io/part-of",
+    "app.kubernetes.io/managed-by",
+    "app.kubernetes.io/created-by"
+  ],
+  "imageRepositoryAllowList": []
+}


### PR DESCRIPTION
## Overview

I mistakenly merged #1046 into `dev`, when we moved to targeting `master`. This change re-targets the misrouted commit, documents that we target `master` in new PRs and updates the Pull Request template accordingly.

## Related issues/PRs:

Includes #1046.
Fixes #1040.
 