### PR TITLE
fixed a bug in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,11 @@ for pdir in ${PATH//:/ }; do
     fi
 done
 
+# Create install dir if it does not exist
+if [ ! -d "$install_dir" ]; then
+  $SUDO mkdir -p $install_dir
+fi
+
 chmod +x $OUTPUT 2>/dev/null 
 $SUDO rm -f /usr/local/bin/$KUBESCAPE_EXEC 2>/dev/null || true # clearning up old install
 $SUDO cp $OUTPUT $install_dir/$KUBESCAPE_EXEC 


### PR DESCRIPTION
## Overview
This PR fixes a bug in which the installation of Kubescape failed using the `install.sh` script.

Root cause: `bin` directory was missing in the `/usr/local/` path, as a result the script will not copy the Kubescape binary.
Fix: Create the full destination path for installation before copying the binary.

Bug found in MacOS Monterey

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [X] My code follows the style guidelines of this project
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 