### PR TITLE
Fix/deprecated excluded status

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -74,7 +74,7 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 					rulev1 := rulesv1[rulev2.GetName()]
 					status := rulev2.GetStatus(&helpersv1.Filters{FrameworkNames: []string{frameworkName}})
 
-					if status.IsFailed() || status.IsExcluded() {
+					if status.IsFailed() {
 
 						// rule response
 						ruleResponse := reporthandling.RuleResponse{}

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -64,20 +64,17 @@ func TestProcessResourcesResult(t *testing.T) {
 	summaryDetails := opaSessionObj.Report.SummaryDetails
 	assert.Equal(t, 1, summaryDetails.NumberOfResources().All())
 	assert.Equal(t, 1, summaryDetails.NumberOfResources().Failed())
-	assert.Equal(t, 0, summaryDetails.NumberOfResources().Excluded())
 	assert.Equal(t, 0, summaryDetails.NumberOfResources().Passed())
 
 	// test resource listing
 	assert.Equal(t, 1, summaryDetails.ListResourcesIDs().All().Len())
 	assert.Equal(t, 1, len(summaryDetails.ListResourcesIDs().Failed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Excluded()))
 	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Passed()))
 
 	// test control listing
 	assert.Equal(t, res.ListControlsIDs(nil).All().Len(), summaryDetails.NumberOfControls().All())
 	assert.Equal(t, len(res.ListControlsIDs(nil).Passed()), summaryDetails.NumberOfControls().Passed())
 	assert.Equal(t, len(res.ListControlsIDs(nil).Failed()), summaryDetails.NumberOfControls().Failed())
-	assert.Equal(t, len(res.ListControlsIDs(nil).Excluded()), summaryDetails.NumberOfControls().Excluded())
 	assert.True(t, summaryDetails.GetStatus().IsFailed())
 
 	opaSessionObj.Exceptions = []armotypes.PostureExceptionPolicy{*mocks.MockExceptionAllKinds(&armotypes.PosturePolicy{FrameworkName: frameworks[0].Name})}
@@ -85,9 +82,7 @@ func TestProcessResourcesResult(t *testing.T) {
 
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
 	assert.Equal(t, 2, res.ListControlsIDs(nil).All().Len())
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Excluded()))
 	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Passed()))
-	assert.True(t, res.GetStatus(nil).IsExcluded())
 	assert.False(t, res.GetStatus(nil).IsPassed())
 	assert.False(t, res.GetStatus(nil).IsFailed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
@@ -96,6 +91,5 @@ func TestProcessResourcesResult(t *testing.T) {
 	summaryDetails = opaSessionObj.Report.SummaryDetails
 	assert.Equal(t, 1, summaryDetails.ListResourcesIDs().All().Len())
 	assert.Equal(t, 1, len(summaryDetails.ListResourcesIDs().Failed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Excluded()))
 	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Passed()))
 }

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -12,14 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
-	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func NewOPAProcessorMock() *OPAProcessor {
 	return &OPAProcessor{}
 }
 func TestProcessResourcesResult(t *testing.T) {
-
 	// set k8s
 	k8sResources := make(cautils.K8SResources)
 
@@ -82,8 +80,8 @@ func TestProcessResourcesResult(t *testing.T) {
 
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
 	assert.Equal(t, 2, res.ListControlsIDs(nil).All().Len())
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Passed()))
-	assert.False(t, res.GetStatus(nil).IsPassed())
+	assert.Equal(t, 2, len(res.ListControlsIDs(nil).Passed())) // previously 1 excluded, now count as passed
+	assert.True(t, res.GetStatus(nil).IsPassed())
 	assert.False(t, res.GetStatus(nil).IsFailed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
 

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -21,7 +21,7 @@ import (
 //   - adds exceptions
 //   - summarizes results
 func (opap *OPAProcessor) updateResults(ctx context.Context) {
-	ctx, span := otel.Tracer("").Start(ctx, "OPAProcessor.updateResults")
+	ctx, span := otel.Tracer("").Start(ctx, "OPAstringProcessor.updateResults")
 	defer span.End()
 	// remove data from all objects
 	for i := range opap.AllResources {
@@ -35,7 +35,12 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 
 		// first set exceptions
 		if resource, ok := opap.AllResources[i]; ok {
-			t.SetExceptions(resource, opap.Exceptions, cautils.ClusterName)
+			t.SetExceptions(
+				resource,
+				opap.Exceptions,
+				cautils.ClusterName,
+				opap.AllPolicies.Controls, // exceptions are evaluated only on failed controls
+			)
 		}
 
 		// summarize the resources
@@ -74,7 +79,7 @@ func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[str
 }
 
 func isEmptyResources(counters reportsummary.ICounters) bool {
-	return counters.Failed() == 0 && counters.Excluded() == 0 && counters.Passed() == 0
+	return counters.Failed() == 0 && counters.Passed() == 0
 }
 
 func getAllSupportedObjects(k8sResources *cautils.K8SResources, ksResources *cautils.KSResources, allResources map[string]workloadinterface.IMetadata, rule *reporthandling.PolicyRule) []workloadinterface.IMetadata {

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -28,6 +28,16 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 		removeData(opap.AllResources[i])
 	}
 
+	// An exception inherits part of its status from the control
+	const allocControlsHeuristic = 100
+	controls := make(map[string]reporthandling.Control, allocControlsHeuristic)
+	for _, framework := range opap.Policies {
+		for _, controlToPin := range framework.Controls {
+			control := controlToPin
+			controls[control.ControlID] = control
+		}
+	}
+
 	// set exceptions
 	for i := range opap.ResourcesResult {
 
@@ -39,7 +49,7 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 				resource,
 				opap.Exceptions,
 				cautils.ClusterName,
-				opap.AllPolicies.Controls, // exceptions are evaluated only on failed controls
+				controls, // update status depending on action required
 			)
 		}
 

--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -41,7 +41,7 @@ func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo [
 		row[columnName] = controlSummary.GetName()
 	}
 	row[columnCounterFailed] = fmt.Sprintf("%d", controlSummary.NumberOfResources().Failed())
-	row[columnCounterExclude] = fmt.Sprintf("%d", controlSummary.NumberOfResources().Excluded())
+	row[columnCounterExclude] = fmt.Sprintf("%d", 0)
 	row[columnCounterAll] = fmt.Sprintf("%d", controlSummary.NumberOfResources().All())
 	row[columnRiskScore] = getRiskScoreColumn(controlSummary, infoToPrintInfo)
 

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -105,7 +105,7 @@ func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 func (pp *PdfPrinter) printHeader(m pdf.Maroto) {
 	// Retrieve current time (we need it for the report timestamp).
 	t := time.Now()
-	// Enconde PNG into Base64 to embed it into the pdf.
+	// Encode PNG into Base64 to embed it into the pdf.
 	kubescapeLogoEnc := b64.StdEncoding.EncodeToString(kubescapeLogo)
 
 	m.SetPageMargins(10, 15, 10)
@@ -208,7 +208,7 @@ func (pp *PdfPrinter) printFinalResult(m pdf.Maroto, summaryDetails *reportsumma
 			})
 		})
 		m.Col(2, func() {
-			m.Text(fmt.Sprintf("%d", summaryDetails.NumberOfResources().Excluded()), props.Text{
+			m.Text(fmt.Sprintf("%d", 0), props.Text{
 				Align:  consts.Left,
 				Size:   8.0,
 				Style:  consts.Bold,

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -105,7 +105,7 @@ func (pp *PrettyPrinter) printSummary(controlName string, controlSummary reports
 	}
 	cautils.SimpleDisplay(pp.writer, "Summary - ")
 	cautils.SuccessDisplay(pp.writer, "Passed:%v   ", controlSummary.NumberOfResources().Passed())
-	cautils.WarningDisplay(pp.writer, "Excluded:%v   ", controlSummary.NumberOfResources().Excluded())
+	cautils.WarningDisplay(pp.writer, "Excluded:%v   ", 0)
 	cautils.FailureDisplay(pp.writer, "Failed:%v   ", controlSummary.NumberOfResources().Failed())
 	cautils.InfoDisplay(pp.writer, "Total:%v\n", controlSummary.NumberOfResources().All())
 	if controlSummary.GetStatus().IsFailed() {
@@ -121,8 +121,6 @@ func (pp *PrettyPrinter) printTitle(controlSummary reportsummary.IControlSummary
 		cautils.InfoDisplay(pp.writer, "skipped %v\n", emoji.ConfusedFace)
 	case apis.StatusFailed:
 		cautils.FailureDisplay(pp.writer, "failed %v\n", emoji.SadButRelievedFace)
-	case apis.StatusExcluded:
-		cautils.WarningDisplay(pp.writer, "excluded %v\n", emoji.NeutralFace)
 	case apis.StatusIrrelevant:
 		cautils.SuccessDisplay(pp.writer, "irrelevant %v\n", emoji.ConfusedFace)
 	case apis.StatusError:
@@ -140,7 +138,6 @@ func (pp *PrettyPrinter) printResources(controlSummary reportsummary.IControlSum
 	workloadsSummary := listResultSummary(controlSummary, allResources)
 
 	failedWorkloads := groupByNamespaceOrKind(workloadsSummary, workloadSummaryFailed)
-	excludedWorkloads := groupByNamespaceOrKind(workloadsSummary, workloadSummaryExclude)
 
 	var passedWorkloads map[string][]WorkloadSummary
 	if pp.verboseMode {
@@ -149,10 +146,6 @@ func (pp *PrettyPrinter) printResources(controlSummary reportsummary.IControlSum
 	if len(failedWorkloads) > 0 {
 		cautils.FailureDisplay(pp.writer, "Failed:\n")
 		pp.printGroupedResources(failedWorkloads)
-	}
-	if len(excludedWorkloads) > 0 {
-		cautils.WarningDisplay(pp.writer, "Excluded:\n")
-		pp.printGroupedResources(excludedWorkloads)
 	}
 	if len(passedWorkloads) > 0 {
 		cautils.SuccessDisplay(pp.writer, "Passed:\n")
@@ -207,7 +200,7 @@ func generateFooter(summaryDetails *reportsummary.SummaryDetails) []string {
 	row := make([]string, _rowLen)
 	row[columnName] = "Resource Summary"
 	row[columnCounterFailed] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().Failed())
-	row[columnCounterExclude] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().Excluded())
+	row[columnCounterExclude] = fmt.Sprintf("%d", 0)
 	row[columnCounterAll] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().All())
 	row[columnSeverity] = " "
 	row[columnRiskScore] = fmt.Sprintf("%.2f%s", summaryDetails.Score, "%")
@@ -297,11 +290,11 @@ func renderSeverityCountersSummary(counters reportsummary.ISeverityCounters) str
 }
 
 func controlCountersForSummary(counters reportsummary.ICounters) string {
-	return fmt.Sprintf("Controls: %d (Failed: %d, Excluded: %d, Skipped: %d)", counters.All(), counters.Failed(), counters.Excluded(), counters.Skipped())
+	return fmt.Sprintf("Controls: %d (Failed: %d, Excluded: %d, Skipped: %d)", counters.All(), counters.Failed(), 0, counters.Skipped())
 }
 
 func controlCountersForResource(l *helpersv1.AllLists) string {
-	return fmt.Sprintf("Controls: %d (Failed: %d, Excluded: %d)", l.All().Len(), len(l.Failed()), len(l.Excluded()))
+	return fmt.Sprintf("Controls: %d (Failed: %d, Excluded: %d)", l.All().Len(), len(l.Failed()), 0)
 }
 func getSeparator(sep string) string {
 	s := ""

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -245,27 +245,27 @@ type Metrics struct {
 }
 
 func (mrs *mRiskScore) set(resources reportsummary.ICounters, controls reportsummary.ICounters) {
-	mrs.resourcesCountExcluded = resources.Excluded()
+	mrs.resourcesCountExcluded = 0
 	mrs.resourcesCountFailed = resources.Failed()
 	mrs.resourcesCountPassed = resources.Passed()
-	mrs.controlsCountExcluded = controls.Excluded()
+	mrs.controlsCountExcluded = 0
 	mrs.controlsCountFailed = controls.Failed()
 	mrs.controlsCountPassed = controls.Passed()
 	mrs.controlsCountSkipped = controls.Skipped()
 }
 
 func (mfrs *mFrameworkRiskScore) set(resources reportsummary.ICounters, controls reportsummary.ICounters) {
-	mfrs.resourcesCountExcluded = resources.Excluded()
+	mfrs.resourcesCountExcluded = 0
 	mfrs.resourcesCountFailed = resources.Failed()
 	mfrs.resourcesCountPassed = resources.Passed()
-	mfrs.controlsCountExcluded = controls.Excluded()
+	mfrs.controlsCountExcluded = 0
 	mfrs.controlsCountFailed = controls.Failed()
 	mfrs.controlsCountPassed = controls.Passed()
 	mfrs.controlsCountSkipped = controls.Skipped()
 }
 
 func (mcrs *mControlRiskScore) set(resources reportsummary.ICounters) {
-	mcrs.resourcesCountExcluded = resources.Excluded()
+	mcrs.resourcesCountExcluded = 0
 	mcrs.resourcesCountFailed = resources.Failed()
 	mcrs.resourcesCountPassed = resources.Passed()
 }

--- a/core/pkg/resultshandling/printer/v2/summaryhelpers.go
+++ b/core/pkg/resultshandling/printer/v2/summaryhelpers.go
@@ -80,7 +80,6 @@ func listResultSummary(controlSummary reportsummary.IControlSummary, allResource
 	workloadsSummary := []WorkloadSummary{}
 
 	workloadsSummary = append(workloadsSummary, newListWorkloadsSummary(allResources, controlSummary.ListResourcesIDs().Failed(), apis.StatusFailed)...)
-	workloadsSummary = append(workloadsSummary, newListWorkloadsSummary(allResources, controlSummary.ListResourcesIDs().Excluded(), apis.StatusExcluded)...)
 	workloadsSummary = append(workloadsSummary, newListWorkloadsSummary(allResources, controlSummary.ListResourcesIDs().Passed(), apis.StatusPassed)...)
 
 	return workloadsSummary

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/containeranalysis v0.6.0
-	github.com/armosec/armoapi-go v0.0.119
+	github.com/armosec/armoapi-go v0.0.151
 	github.com/armosec/utils-go v0.0.12
 	github.com/armosec/utils-k8s-go v0.0.12
 	github.com/briandowns/spinner v1.18.1
@@ -18,8 +18,8 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/kubescape/go-git-url v0.0.23
 	github.com/kubescape/go-logger v0.0.8
-	github.com/kubescape/k8s-interface v0.0.98
-	github.com/kubescape/opa-utils v0.0.223
+	github.com/kubescape/k8s-interface v0.0.99
+	github.com/kubescape/opa-utils v0.0.231
 	github.com/kubescape/rbac-utils v0.0.19
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-isatty v0.0.17

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.119 h1:7XbvBbOKp26Bpp72LQ8Spw4FBpbXu3+qZFQyPEwTPFk=
-github.com/armosec/armoapi-go v0.0.119/go.mod h1:2zoNzb3Fy9ZByeczJZ47ftDRLRzTykVdTISS3GTc/JU=
+github.com/armosec/armoapi-go v0.0.151 h1:vyoQVk1y8cb4DHlfRKyFqDtiB1G13w4o5aoG8+YUMq0=
+github.com/armosec/armoapi-go v0.0.151/go.mod h1:5MQAHYUFm1JrTSgb4+EglR5vNsrqUD0krh/5xWm2RdI=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=
@@ -1089,10 +1089,10 @@ github.com/kubescape/go-git-url v0.0.23 h1:Xj4IPYGeqiTuIRpZf6TcRgn+T38tJE+LBQg6S
 github.com/kubescape/go-git-url v0.0.23/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kubescape/go-logger v0.0.8 h1:YHC5WmOy2AegJkUeuEw93hssa5VcgM55EkzWbaPviVs=
 github.com/kubescape/go-logger v0.0.8/go.mod h1:FOCfZgMK/QC2CY1rJnzb72x29PAjjlzYmw19SUe6MEI=
-github.com/kubescape/k8s-interface v0.0.98 h1:1bYaFKDD6/aKDFWp+D3OLY6mhgOxeeoaWgf1LA7hxTI=
-github.com/kubescape/k8s-interface v0.0.98/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
-github.com/kubescape/opa-utils v0.0.223 h1:t39+P5eW1nsmt55Sx7NZU3Tv9IDBo0ljEYbOi9nlgVc=
-github.com/kubescape/opa-utils v0.0.223/go.mod h1:cKWsKl2t2XP7Mc3t1c3hNdf8Kg0sxikUcqATfq09vzU=
+github.com/kubescape/k8s-interface v0.0.99 h1:Bk7P694WkYPORW4c+ojpvCIQQ83Ku8durElNlvgM0Qg=
+github.com/kubescape/k8s-interface v0.0.99/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
+github.com/kubescape/opa-utils v0.0.231 h1:vYRRyeKK+mociNbZ7KMbZcUJAy8yRBlRIlRpdGu/zlQ=
+github.com/kubescape/opa-utils v0.0.231/go.mod h1:BGhH5ZFc++VgClqe/VMkFRUmCAGVhFd4T1Aw7tssIMw=
 github.com/kubescape/rbac-utils v0.0.19 h1:7iydgVxlMLW15MgHORfMBMqNj9jHtFGACd744fdtrFs=
 github.com/kubescape/rbac-utils v0.0.19/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Overview
With opa-utils v0.0.227, a few breaking changes have been introduced:
* the Excluded status has been deprecated.
* exception processing requires controls to be injected
 
This PR adapts kubescape to support these changes, as this block other changes that require an update of opa-utils.

Reports now show 0 for exclusions.
Unit tests that counted exclusions now count these as passed.

cc: @dwertent @amirmalka 

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
