### PR TITLE
don't add host scanner as excluded ns, use exception instead

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -76,10 +76,6 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 		logger.L().Ctx(ctxHostScanner).Error("failed to init host scanner", helpers.Error(err))
 		hostSensorHandler = &hostsensorutils.HostSensorHandlerMock{}
 	}
-	// excluding hostsensor namespace
-	if len(scanInfo.IncludeNamespaces) == 0 && hostSensorHandler.GetNamespace() != "" {
-		scanInfo.ExcludedNamespaces = fmt.Sprintf("%s,%s", scanInfo.ExcludedNamespaces, hostSensorHandler.GetNamespace())
-	}
 	spanHostScanner.End()
 
 	// ================== setup registry adaptors ======================================


### PR DESCRIPTION
Signed-off-by: YiscahLevySilas1 <yiscahls@armosec.io>

## Overview
Don't exclude "kubescape-host-scanner" namespace. That resulted in cluster-wide resources (like nodes, clusterroles..) being excluded on every scan that uses --enable-host-scan.
## Additional Information
We'll be using system exceptions instead.
*Important* - this PR is blocked by this (PR)[https://github.com/kubescape/regolibrary/pull/301] - adding the exception of host-scanner in regolibrary

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
