### PR TITLE
Default frameworks

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -15,6 +15,7 @@ import (
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 	"github.com/kubescape/kubescape/v2/core/meta"
 
 	"github.com/spf13/cobra"
@@ -72,6 +73,9 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			}
 			scanInfo.FrameworkScan = true
 
+			// We do not scan all frameworks by default when triggering scan from the CLI
+			scanInfo.ScanAll = false
+
 			var frameworks []string
 
 			if len(args) == 0 { // scan all frameworks
@@ -81,11 +85,12 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				frameworks = strings.Split(args[0], ",")
 				if cautils.StringInSlice(frameworks, "all") != cautils.ValueNotFound {
 					scanInfo.ScanAll = true
-					frameworks = []string{}
+					frameworks = getter.NativeFrameworks
 				}
 				if len(args) > 1 {
 					if len(args[1:]) == 0 || args[1] != "-" {
 						scanInfo.InputPatterns = args[1:]
+						logger.L().Debug("List of input files", helpers.Interface("patterns", scanInfo.InputPatterns))
 					} else { // store stdin to file - do NOT move to separate function !!
 						tempFile, err := os.CreateTemp(".", "tmp-kubescape*.yaml")
 						if err != nil {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -3,9 +3,11 @@ package scan
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 	"github.com/kubescape/kubescape/v2/core/meta"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +43,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				if args[0] != "framework" && args[0] != "control" {
-					scanInfo.ScanAll = true
 					return getFrameworkCmd(ks, &scanInfo).RunE(cmd, append([]string{"all"}, args...))
 				}
 			}
@@ -50,8 +51,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) == 0 {
-				scanInfo.ScanAll = true
-				return getFrameworkCmd(ks, &scanInfo).RunE(cmd, []string{"all"})
+				return getFrameworkCmd(ks, &scanInfo).RunE(cmd, []string{strings.Join(getter.NativeFrameworks, ",")})
 			}
 			return nil
 		},

--- a/core/cautils/getter/kscloudapiutils.go
+++ b/core/cautils/getter/kscloudapiutils.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var NativeFrameworks = []string{"nsa", "mitre", "armobest", "devopsbest"}
+var NativeFrameworks = []string{"allcontrols", "nsa", "mitre"}
 
 func (api *KSCloudAPI) getFrameworkURL(frameworkName string) string {
 	u := url.URL{}

--- a/core/pkg/opaprocessor/cosign_has_signature.go
+++ b/core/pkg/opaprocessor/cosign_has_signature.go
@@ -2,25 +2,20 @@ package opaprocessor
 
 import (
 	"context"
+
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/kubescape/go-logger"
-	"github.com/kubescape/go-logger/helpers"
 	"github.com/sigstore/cosign/pkg/cosign"
 )
-
 
 func has_signature(img string) bool {
 	ref, err := name.ParseReference(img)
 	if err != nil {
-		logger.L().Error("parsing reference", helpers.Error(err))
 		return false
 	}
 	sins, err := cosign.FetchSignaturesForReference(context.Background(), ref)
 
 	if err != nil {
-		logger.L().Error("verifying signature", helpers.Error(err))
 		return false
-
 	}
 
 	return len(sins) > 0

--- a/core/pkg/opaprocessor/cosign_verify.go
+++ b/core/pkg/opaprocessor/cosign_verify.go
@@ -18,29 +18,29 @@ import (
 // nolint
 type VerifyCommand struct {
 	options.RegistryOptions
-	CheckClaims                  bool
-	KeyRef                       string
-	CertRef                      string
+	Annotations                  sigs.AnnotationsMap
+	CertChain                    string
 	CertEmail                    string
+	CertOidcProvider             string
 	CertIdentity                 string
 	CertOidcIssuer               string
 	CertGithubWorkflowTrigger    string
 	CertGithubWorkflowSha        string
 	CertGithubWorkflowName       string
-	CertGithubWorkflowRepository string
+	KeyRef                       string
 	CertGithubWorkflowRef        string
-	CertChain                    string
-	CertOidcProvider             string
-	EnforceSCT                   bool
-	Sk                           bool
+	SignatureRef                 string
+	CertRef                      string
+	CertGithubWorkflowRepository string
+	Attachment                   string
 	Slot                         string
 	Output                       string
 	RekorURL                     string
-	Attachment                   string
-	Annotations                  sigs.AnnotationsMap
-	SignatureRef                 string
 	HashAlgorithm                crypto.Hash
+	Sk                           bool
+	CheckClaims                  bool
 	LocalImage                   bool
+	EnforceSCT                   bool
 }
 
 // Exec runs the verification command

--- a/core/pkg/opaprocessor/utils.go
+++ b/core/pkg/opaprocessor/utils.go
@@ -3,6 +3,8 @@ package opaprocessor
 import (
 	"fmt"
 
+	logger "github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -64,7 +66,11 @@ var cosignVerifySignatureDefinition = func(bctx rego.BuiltinContext, a, b *ast.T
 	if err != nil {
 		return nil, fmt.Errorf("invalid parameter type: %v", err)
 	}
-	result, _ := verify(string(aStr), string(bStr))
+	result, err := verify(string(aStr), string(bStr))
+	if err != nil {
+		// Do not change this log from debug level. We might find a lot of images without signature
+		logger.L().Debug("failed to verify signature", helpers.String("image", string(aStr)), helpers.String("key", string(bStr)), helpers.Error(err))
+	}
 	return ast.BooleanTerm(result), nil
 }
 

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -59,6 +59,7 @@ func (policyHandler *PolicyHandler) getScanPolicies(ctx context.Context, policyI
 	switch getScanKind(policyIdentifier) {
 	case apisv1.KindFramework: // Download frameworks
 		for _, rule := range policyIdentifier {
+			logger.L().Debug("Downloading framework", helpers.String("framework", rule.Identifier))
 			receivedFramework, err := policyHandler.getters.PolicyGetter.GetFramework(rule.Identifier)
 			if err != nil {
 				return frameworks, policyDownloadError(err)
@@ -79,6 +80,7 @@ func (policyHandler *PolicyHandler) getScanPolicies(ctx context.Context, policyI
 		var receivedControl *reporthandling.Control
 		var err error
 		for _, policy := range policyIdentifier {
+			logger.L().Debug("Downloading control", helpers.String("control", policy.Identifier))
 			receivedControl, err = policyHandler.getters.PolicyGetter.GetControl(policy.Identifier)
 			if err != nil {
 				return frameworks, policyDownloadError(err)


### PR DESCRIPTION
## Overview
* Update the list of default frameworks to `AllControls`, `NSA`. `MITRE`
* Change cosign feature error logs from error level to debug level

## Additional Information

In the current behavior, when running `lubescape scan`, Kubescape will fetch all of the available frameworks.
In this PR will are changing the behavior so Kubescape will fetch a specific list of chosen frameworks.

e.g.

Kubescape will scan the `AllControls`, `NSA`. `MITRE` frameworks when running
```
kubescape scan --logger debug
```

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
