### PR TITLE
Loading kubeconfig name from env when running as a microservice  

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -47,7 +47,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 
 	// ================== setup tenant object ======================================
 	ctxTenant, spanTenant := otel.Tracer("").Start(ctx, "setup tenant")
-	tenantConfig := getTenantConfig(&scanInfo.Credentials, scanInfo.KubeContext, scanInfo.CustomClusterName, k8s)
+	tenantConfig := getTenantConfig(&scanInfo.Credentials, k8sinterface.GetContextName(), scanInfo.CustomClusterName, k8s)
 
 	// Set submit behavior AFTER loading tenant config
 	setSubmitBehavior(scanInfo, tenantConfig)

--- a/core/pkg/policyhandler/handlenotification.go
+++ b/core/pkg/policyhandler/handlenotification.go
@@ -137,7 +137,7 @@ func getCloudMetadata(opaSessionObj *cautils.OPASessionObj, config *clientcmdapi
 // check if the server is AKS. e.g. https://XXX.XX.XXX.azmk8s.io:443
 func isAKS(config *clientcmdapi.Config) bool {
 	const serverIdentifierAKS = "azmk8s.io"
-	if cluster, ok := config.Clusters[config.CurrentContext]; ok {
+	if cluster, ok := config.Clusters[k8sinterface.GetContextName()]; ok {
 		return strings.Contains(cluster.Server, serverIdentifierAKS)
 	}
 	return false
@@ -145,7 +145,7 @@ func isAKS(config *clientcmdapi.Config) bool {
 
 // check if the server is EKS. e.g. arn:aws:eks:eu-west-1:xxx:cluster/xxxx
 func isEKS(config *clientcmdapi.Config) bool {
-	if context, ok := config.Contexts[config.CurrentContext]; ok {
+	if context, ok := config.Contexts[k8sinterface.GetContextName()]; ok {
 		return strings.Contains(context.Cluster, cloudsupportv1.EKS)
 	}
 	return false
@@ -153,7 +153,7 @@ func isEKS(config *clientcmdapi.Config) bool {
 
 // check if the server is GKE. e.g. gke_xxx-xx-0000_us-central1-c_xxxx-1
 func isGKE(config *clientcmdapi.Config) bool {
-	if context, ok := config.Contexts[config.CurrentContext]; ok {
+	if context, ok := config.Contexts[k8sinterface.GetContextName()]; ok {
 		return strings.Contains(context.Cluster, cloudsupportv1.GKE)
 	}
 	return false

--- a/core/pkg/policyhandler/handlenotification_test.go
+++ b/core/pkg/policyhandler/handlenotification_test.go
@@ -104,7 +104,7 @@ func Test_getCloudMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.args.kubeConfig.CurrentContext = tt.args.context
+			k8sinterface.SetClusterContextName(tt.args.context)
 			got := getCloudMetadata(tt.args.opaSessionObj, tt.args.kubeConfig)
 			if got == nil {
 				t.Errorf("getCloudMetadata() = %v, want %v", got, tt.want.Provider())
@@ -140,7 +140,7 @@ func Test_isGKE(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// set context
-			tt.args.config.CurrentContext = tt.args.context
+			k8sinterface.SetClusterContextName(tt.args.context)
 			if got := isGKE(tt.args.config); got != tt.want {
 				t.Errorf("isGKE() = %v, want %v", got, tt.want)
 			}
@@ -171,7 +171,7 @@ func Test_isEKS(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// set context
-			tt.args.config.CurrentContext = tt.args.context
+			k8sinterface.SetClusterContextName(tt.args.context)
 			if got := isEKS(tt.args.config); got != tt.want {
 				t.Errorf("isEKS() = %v, want %v", got, tt.want)
 			}
@@ -202,7 +202,7 @@ func Test_isAKS(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// set context
-			tt.args.config.CurrentContext = tt.args.context
+			k8sinterface.SetClusterContextName(tt.args.context)
 			if got := isAKS(tt.args.config); got != tt.want {
 				t.Errorf("isAKS() = %v, want %v", got, tt.want)
 			}

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
 	github.com/kubescape/go-logger v0.0.8
+	github.com/kubescape/k8s-interface v0.0.98
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
 	github.com/kubescape/opa-utils v0.0.223
 	github.com/stretchr/testify v1.8.1
@@ -200,7 +201,6 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/kubescape/go-git-url v0.0.23 // indirect
-	github.com/kubescape/k8s-interface v0.0.98 // indirect
 	github.com/kubescape/rbac-utils v0.0.19 // indirect
 	github.com/kubescape/regolibrary v1.0.250 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/armosec/utils-go/boolutils"
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 	"github.com/kubescape/kubescape/v2/core/core"
@@ -131,6 +132,9 @@ func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *ca
 	scanInfo.Output = filepath.Join(OutputDir, scanID)
 	// *** end ***
 
+	// Set default KubeContext from scanInfo input
+	k8sinterface.SetClusterContextName(scanInfo.KubeContext)
+
 	return scanInfo
 }
 
@@ -149,6 +153,8 @@ func defaultScanInfo() *cautils.ScanInfo {
 	if !envToBool("KS_DOWNLOAD_ARTIFACTS", false) {
 		scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape fom downloading the artifacts every time)
 	}
+	scanInfo.KubeContext = envToString("KS_CONTEXT", "") // publish results to Kubescape SaaS
+
 	return scanInfo
 }
 


### PR DESCRIPTION
Signed-off-by: David Wertenteil <dwertent@armosec.io>

## Overview

### Issue

The ARMO Portal breaks down the cluster name to a more readable name:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/64066841/217673343-86f046be-1319-4db8-853b-f780dc6c0acc.png">

Under the hood, Kubescape uses the context for splitting the name based on the cloud provider.

This does not work when running Kubescape as a microservice since the context is empty.
So it looks like the following:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/64066841/217673655-4994caef-969c-41ee-be3e-e76004831961.png">

We could not use the name for this because the name can be modified by the user.

### Solution

In this PR, I added the option of loading a "context" from the environment variable. Because Kubescape is running as a microservice, this will have no effect on the running.
 
I will open an additional PR in the helm-chart with the environment variable.

/cc: @yossi77 