### PR TITLE
fix(build): LICENSE file in release tarballs

### DIFF
--- a/build.py
+++ b/build.py
@@ -77,7 +77,7 @@ def main():
 
     with tarfile.open(tar_file, 'w:gz') as archive:
         archive.add(ks_file, "kubescape")
-        archive.add(ks_file, "LICENSE")
+        archive.add("LICENSE", "LICENSE")
 
     print("Build Done")
 


### PR DESCRIPTION
Signed-off-by: Hollow Man <hollowman@opensuse.org>

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

I don't know if anyone had ever noticed, but the kubescape-xxxx-latest.tar.gz files in your release actually have the wrong LICENSE file.

https://github.com/kubescape/kubescape/releases/tag/v2.1.3

## Additional Information

Correct the LICENSE file with the one that currently in the code base.

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
