### PR TITLE
fix: add check to skip controlplaneinfo in case of cloud providers

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorgetfrompod.go
+++ b/core/pkg/hostsensorutils/hostsensorgetfrompod.go
@@ -323,24 +323,27 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 		res = append(res, kcData...)
 	}
 
-	// GetControlPlaneInfo
-	kcData, err = hsh.GetControlPlaneInfo(ctx)
-	if err != nil {
-		addInfoToMap(ControlPlaneInfo, infoMap, err)
-		logger.L().Ctx(ctx).Warning(err.Error())
-	}
-	if len(kcData) > 0 {
-		res = append(res, kcData...)
-	}
-
 	// GetCloudProviderInfo
 	kcData, err = hsh.GetCloudProviderInfo(ctx)
+	isCloudProvider := (kcData != nil)
 	if err != nil {
 		addInfoToMap(CloudProviderInfo, infoMap, err)
 		logger.L().Ctx(ctx).Warning(err.Error())
 	}
 	if len(kcData) > 0 {
 		res = append(res, kcData...)
+	}
+
+	// GetControlPlaneInfo
+	if !isCloudProvider { // we retrieve control plane info only if we are not using a cloud provider
+		kcData, err = hsh.GetControlPlaneInfo(ctx)
+		if err != nil {
+			addInfoToMap(ControlPlaneInfo, infoMap, err)
+			logger.L().Ctx(ctx).Warning(err.Error())
+		}
+		if len(kcData) > 0 {
+			res = append(res, kcData...)
+		}
 	}
 
 	// GetCNIInfo


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This PR fixes the error messages provided by kubescape when the host-scanner runs in a kubernetes managed by cloud providers.
In a managed kubernetes you don't have access to the control plan, so the `contrlPlaneInfo` endpoint was generating these errors.

## How to Test

Tests have to be done using a managed kubernetes. I used an instance of **EKS** on my side.

## Examples/Screenshots

![photo_2023-02-13_17-24-42](https://user-images.githubusercontent.com/16689706/218514236-5db6b00c-eda8-4baa-88ea-4442dd052ce2.jpg)

This was an example of the generated errors.

## Related issues/PRs:

No issue were provided for this PR.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes