### PR TITLE
fix(hostsensorutils): improve cloud provider detection

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorgetfrompod.go
+++ b/core/pkg/hostsensorutils/hostsensorgetfrompod.go
@@ -225,7 +225,7 @@ func (hsh *HostSensorHandler) GetKubeletConfigurations(ctx context.Context) ([]h
 // hasCloudProviderInfo iterate over the []hostsensor.HostSensorDataEnvelope list to find info about cloud provider.
 // If information are found, ther return true. Return false otherwise.
 func hasCloudProviderInfo(cpi []hostsensor.HostSensorDataEnvelope) bool {
-	for index, _ := range cpi {
+	for index := range cpi {
 		if !reflect.DeepEqual(cpi[index].GetData(), json.RawMessage("{}\n")) {
 			return true
 		}


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This **PR** fixes a weak check used to determine **kubescape** was scanning a cloud provider.
Now **kubescape** searches for cloud provider info, so, if at least one node has these kind of information, then we assumes that we are in a cloud provider environment (or at least in an hybrid one).

## How to Test

Tested on an **aws** environment and locally with **kind**, to have both the samples environments.
 
## Related issues/PRs:

It is related to this other PR: #1098 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

