### PR TITLE
Fix macos build - add missing pkg-config

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -136,6 +136,10 @@ jobs:
         run: .\build.bat all
         if: matrix.os == 'windows-latest'
 
+      - name: Install pkg-config (macOS)
+        run: brew install pkg-config
+        if: matrix.os == 'macos-latest'
+
       - name: Install libgit2 (Linux/macOS)
         run: make libgit2
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -130,6 +130,10 @@ jobs:
         run: .\build.bat all
         if: matrix.os == 'windows-latest'
 
+      - name: Install pkg-config (macOS)
+        run: brew install pkg-config
+        if: matrix.os == 'macos-latest'
+
       - name: Install libgit2 (Linux/macOS)
         run: make libgit2
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Overview

Building Kubescape on macOS fails due to missing `pkg-config`.
Added `pkg-config` to the build process with brew; temporary, until issue below is resolved.

Root cause: https://github.com/actions/runner-images/pull/7125 (PR has been merged but macOS runner images were not published)
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
