### PR TITLE
V2.2.1 patches

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -46,6 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     if: "${{ github.repository_owner }} == kubescape"
     needs: create-release
+    env:
+      # overriding the GITHUB_REF so the action can extract the right tag -> https://github.com/rajatjindal/krew-release-bot/blob/v0.0.43/pkg/cicd/github/actions.go#L25
+      GITHUB_REF: refs/tags/${{ needs.retag.outputs.NEW_TAG }} 
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -46,14 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     if: "${{ github.repository_owner }} == kubescape"
     needs: create-release
-    env:
-      # overriding the GITHUB_REF so the action can extract the right tag -> https://github.com/rajatjindal/krew-release-bot/blob/v0.0.43/pkg/cicd/github/actions.go#L25
-      GITHUB_REF: refs/tags/${{ needs.retag.outputs.NEW_TAG }} 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Update new version in krew-index
+        env:
+          # overriding the GITHUB_REF so the action can extract the right tag -> https://github.com/rajatjindal/krew-release-bot/blob/v0.0.43/pkg/cicd/github/actions.go#L25
+          GITHUB_REF: refs/tags/${{ needs.retag.outputs.NEW_TAG }} 
         uses: rajatjindal/krew-release-bot@v0.0.43
 
   publish-image:

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -273,10 +273,15 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 
 // getUIPrinter returns a printer that will be used to print to the program’s UI (terminal)
 func getUIPrinter(ctx context.Context, verboseMode bool, formatVersion string, attackTree bool, viewType cautils.ViewTypes) printer.IPrinter {
-	p := printerv2.NewPrettyPrinter(verboseMode, formatVersion, attackTree, viewType)
+	var p printer.IPrinter
+	if helpers.ToLevel(logger.L().GetLevel()) >= helpers.WarningLevel {
+		p = &printerv2.SilentPrinter{}
+	} else {
+		p = printerv2.NewPrettyPrinter(verboseMode, formatVersion, attackTree, viewType)
 
-	// Since the UI of the program is a CLI (Stdout), it means that it should always print to Stdout
-	p.SetWriter(ctx, os.Stdout.Name())
+		// Since the UI of the program is a CLI (Stdout), it means that it should always print to Stdout
+		p.SetWriter(ctx, os.Stdout.Name())
+	}
 
 	return p
 }

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -5,7 +5,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_getUIPrinter(t *testing.T) {
@@ -14,27 +17,91 @@ func Test_getUIPrinter(t *testing.T) {
 		VerboseMode:   true,
 		View:          "control",
 	}
-	wantFormatVersion := scanInfo.FormatVersion
-	wantVerboseMode := scanInfo.VerboseMode
-	wantViewType := cautils.ViewTypes(scanInfo.View)
-
-	got := getUIPrinter(context.TODO(), scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View))
-
-	gotValue := reflect.ValueOf(got).Elem()
-	gotFormatVersion := gotValue.FieldByName("formatVersion").String()
-	gotVerboseMode := gotValue.FieldByName("verboseMode").Bool()
-	gotViewType := cautils.ViewTypes(gotValue.FieldByName("viewType").String())
-
-	if gotFormatVersion != wantFormatVersion {
-		t.Errorf("Got: %s, want: %s", gotFormatVersion, wantFormatVersion)
+	type args struct {
+		ctx           context.Context
+		formatVersion string
+		viewType      cautils.ViewTypes
+		verboseMode   bool
+		printAttack   bool
+		loggerLevel   helpers.Level
+	}
+	type wantTypes struct {
+		structType    string
+		formatVersion string
+		viewType      cautils.ViewTypes
+		verboseMode   bool
+	}
+	tests := []struct {
+		name          string
+		args          args
+		want          wantTypes
+		testAllFields bool
+	}{
+		{
+			name: "Test getUIPrinter PrettyPrinter",
+			args: args{
+				ctx:           context.TODO(),
+				verboseMode:   scanInfo.VerboseMode,
+				formatVersion: scanInfo.FormatVersion,
+				printAttack:   scanInfo.PrintAttackTree,
+				viewType:      cautils.ViewTypes(scanInfo.View),
+				loggerLevel:   helpers.InfoLevel,
+			},
+			want: wantTypes{
+				structType:    "*printer.PrettyPrinter",
+				formatVersion: scanInfo.FormatVersion,
+				verboseMode:   scanInfo.VerboseMode,
+				viewType:      cautils.ViewTypes(scanInfo.View),
+			},
+			testAllFields: true,
+		},
+		{
+			name: "Test getUIPrinter SilentPrinter",
+			args: args{
+				ctx:           context.TODO(),
+				verboseMode:   scanInfo.VerboseMode,
+				formatVersion: scanInfo.FormatVersion,
+				printAttack:   scanInfo.PrintAttackTree,
+				viewType:      cautils.ViewTypes(scanInfo.View),
+				loggerLevel:   helpers.WarningLevel,
+			},
+			want: wantTypes{
+				structType:    "*printer.SilentPrinter",
+				formatVersion: "",
+				verboseMode:   false,
+				viewType:      cautils.ViewTypes(""),
+			},
+			testAllFields: false,
+		},
 	}
 
-	if gotVerboseMode != wantVerboseMode {
-		t.Errorf("Got: %t, want: %t", gotVerboseMode, wantVerboseMode)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger.L().SetLevel(tt.args.loggerLevel.String())
+			got := getUIPrinter(tt.args.ctx, tt.args.verboseMode, tt.args.formatVersion, tt.args.printAttack, tt.args.viewType)
 
-	if gotViewType != wantViewType {
-		t.Errorf("Got: %v, want: %v", gotViewType, wantViewType)
-	}
+			assert.Equal(t, tt.want.structType, reflect.TypeOf(got).String())
 
+			if !tt.testAllFields {
+				return
+			}
+
+			gotValue := reflect.ValueOf(got).Elem()
+			gotFormatVersion := gotValue.FieldByName("formatVersion").String()
+			gotVerboseMode := gotValue.FieldByName("verboseMode").Bool()
+			gotViewType := cautils.ViewTypes(gotValue.FieldByName("viewType").String())
+
+			if gotFormatVersion != tt.want.formatVersion {
+				t.Errorf("Got: %s, want: %s", gotFormatVersion, tt.want.formatVersion)
+			}
+
+			if gotVerboseMode != tt.want.verboseMode {
+				t.Errorf("Got: %t, want: %t", gotVerboseMode, tt.want.verboseMode)
+			}
+
+			if gotViewType != tt.want.viewType {
+				t.Errorf("Got: %v, want: %v", gotViewType, tt.want.viewType)
+			}
+		})
+	}
 }

--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -38,9 +38,6 @@ spec:
       containers:
       - name: host-sensor
         image: quay.io/kubescape/host-scanner:v1.0.45
-        env:
-        - name: OTEL_COLLECTOR_SVC
-          value: "otel-collector.kubescape:4317"
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -26,6 +26,8 @@ const (
 //go:embed html/report.gohtml
 var reportTemplate string
 
+var _ printer.IPrinter = &HtmlPrinter{}
+
 type HTMLReportingCtx struct {
 	OPASessionObj     *cautils.OPASessionObj
 	ResourceTableView ResourceTableView

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -19,6 +19,8 @@ const (
 	jsonOutputExt  = ".json"
 )
 
+var _ printer.IPrinter = &JsonPrinter{}
+
 type JsonPrinter struct {
 	writer *os.File
 }

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -23,10 +23,8 @@ const (
 	junitOutputExt  = ".xml"
 )
 
-/*
-riskScore
-status
-*/
+var _ printer.IPrinter = &JunitPrinter{}
+
 type JunitPrinter struct {
 	writer  *os.File
 	verbose bool

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -32,6 +32,8 @@ var (
 	kubescapeLogo []byte
 )
 
+var _ printer.IPrinter = &PdfPrinter{}
+
 type PdfPrinter struct {
 	writer *os.File
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -24,6 +24,8 @@ const (
 	prettyPrinterOutputExt  = ".txt"
 )
 
+var _ printer.IPrinter = &PrettyPrinter{}
+
 type PrettyPrinter struct {
 	writer          *os.File
 	formatVersion   string

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
+var _ printer.IPrinter = &PrometheusPrinter{}
+
 type PrometheusPrinter struct {
 	writer      *os.File
 	verboseMode bool

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -51,6 +51,8 @@ func scoreFactorToSARIFSeverityLevel(score float32) sarifSeverityLevel {
 	return sarifSeverityLevelNote
 }
 
+var _ printer.IPrinter = &SARIFPrinter{}
+
 // SARIFPrinter is a printer that emits the report in the SARIF format
 type SARIFPrinter struct {
 	// outputFile is the name of the output file

--- a/core/pkg/resultshandling/printer/v2/silentprinter.go
+++ b/core/pkg/resultshandling/printer/v2/silentprinter.go
@@ -1,11 +1,23 @@
 package printer
 
 import (
+	"context"
+
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer"
 )
 
+var _ printer.IPrinter = &SilentPrinter{}
+
+// SilentPrinter is a printer that does not print anything
 type SilentPrinter struct {
 }
 
-func (silentPrinter *SilentPrinter) ActionPrint(opaSessionObj *cautils.OPASessionObj) {
+func (silentPrinter *SilentPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj) {
+}
+
+func (silentPrinter *SilentPrinter) SetWriter(ctx context.Context, outputFile string) {
+}
+
+func (silentPrinter *SilentPrinter) Score(score float32) {
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -17,9 +17,9 @@ import (
 
 type ResultsHandler struct {
 	reporterObj reporter.IReport
-	printerObjs []printer.IPrinter
 	uiPrinter   printer.IPrinter
 	scanData    *cautils.OPASessionObj
+	printerObjs []printer.IPrinter
 }
 
 func NewResultsHandler(reporterObj reporter.IReport, printerObjs []printer.IPrinter, uiPrinter printer.IPrinter) *ResultsHandler {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kubescape/go-logger v0.0.9
 	github.com/kubescape/k8s-interface v0.0.99
 	github.com/kubescape/opa-utils v0.0.238
-	github.com/kubescape/rbac-utils v0.0.19
+	github.com/kubescape/rbac-utils v0.0.20
 	github.com/kubescape/regolibrary v1.0.250
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-isatty v0.0.17

--- a/go.sum
+++ b/go.sum
@@ -1092,8 +1092,8 @@ github.com/kubescape/k8s-interface v0.0.99 h1:Bk7P694WkYPORW4c+ojpvCIQQ83Ku8durE
 github.com/kubescape/k8s-interface v0.0.99/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
 github.com/kubescape/opa-utils v0.0.238 h1:i8uuMOi0T4Lj+svq3OlM056YFrKDt7zGAnxxqbFAnAI=
 github.com/kubescape/opa-utils v0.0.238/go.mod h1:eAZN82Zj4GgpcQlhMox0P6s8iL5YZnWrbX+/az3UWHI=
-github.com/kubescape/rbac-utils v0.0.19 h1:7iydgVxlMLW15MgHORfMBMqNj9jHtFGACd744fdtrFs=
-github.com/kubescape/rbac-utils v0.0.19/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
+github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
+github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
 github.com/kubescape/regolibrary v1.0.250/go.mod h1:SQkyJbA51qjNji/1nG5jABkC0GfyZtZqDDJJB5Cczn8=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/kubescape/go-git-url v0.0.24 // indirect
-	github.com/kubescape/rbac-utils v0.0.19 // indirect
+	github.com/kubescape/rbac-utils v0.0.20 // indirect
 	github.com/kubescape/regolibrary v1.0.250 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1097,8 +1097,8 @@ github.com/kubescape/k8s-interface v0.0.99 h1:Bk7P694WkYPORW4c+ojpvCIQQ83Ku8durE
 github.com/kubescape/k8s-interface v0.0.99/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
 github.com/kubescape/opa-utils v0.0.238 h1:i8uuMOi0T4Lj+svq3OlM056YFrKDt7zGAnxxqbFAnAI=
 github.com/kubescape/opa-utils v0.0.238/go.mod h1:eAZN82Zj4GgpcQlhMox0P6s8iL5YZnWrbX+/az3UWHI=
-github.com/kubescape/rbac-utils v0.0.19 h1:7iydgVxlMLW15MgHORfMBMqNj9jHtFGACd744fdtrFs=
-github.com/kubescape/rbac-utils v0.0.19/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
+github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
+github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
 github.com/kubescape/regolibrary v1.0.250/go.mod h1:SQkyJbA51qjNji/1nG5jABkC0GfyZtZqDDJJB5Cczn8=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Overview
* Fixing krew release
* Removing OTEL from host scanner env. The host scanner will send telemetry when Kubescape runs as a microservice, and that env is set by the helm chart

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
