### PR TITLE
fix(hostsensorsutils): remove hostNetwork and hostPort from deployment

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -45,7 +45,6 @@ spec:
           procMount: Unmasked
         ports:
           - name: scanner # Do not change port name
-            hostPort: 7888
             containerPort: 7888
             protocol: TCP
         resources:
@@ -72,6 +71,5 @@ spec:
           path: /
           type: Directory
         name: host-filesystem
-      hostNetwork: true
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
## Overview
This fix removes the `hostNetwork` and `hostPort` parameters from the `host-scanner` deployment, since we don't need them anymore.
Thanks to @matthyx for the suggested fix.

## How to Test
Run `kubescape scan --enable-host-scanner` to deploy the `host-scanner` on the cluster.
To test the parameters have been removed you can check for open port on the cluster: `nc -zv cluster.ip 7888`.
If you get no answer, then the parameters have been removed properly.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
