### PR TITLE
ci: pin workflows versions to fixed commits

### DIFF
--- a/.github/workflows/00-pr-scanner.yaml
+++ b/.github/workflows/00-pr-scanner.yaml
@@ -1,9 +1,8 @@
 name: 00-pr_scanner
-
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    branches: 
+    branches:
       - 'master'
       - 'main'
       - 'dev'
@@ -16,15 +15,12 @@ on:
       - 'docs/*'
       - 'build/*'
       - '.github/*'
-
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
-
-  
 jobs:
   pr-scanner:
-    permissions: 
+    permissions:
       pull-requests: write
     uses: ./.github/workflows/a-pr-scanner.yaml
     with:

--- a/.github/workflows/01-code-review-approved.yaml
+++ b/.github/workflows/01-code-review-approved.yaml
@@ -14,18 +14,12 @@ on:
       - 'docs/*'
       - 'build/*'
       - '.github/*'
-
-
 concurrency:
   group: code-review-approved
   cancel-in-progress: true
-
 jobs:
-
   binary-build:
-    if: ${{ github.event.review.state == 'approved' && 
-            contains( github.event.pull_request.labels.*.name, 'trigger-integration-test') && 
-            github.event.pull_request.base.ref == 'master' }} ## run only if labeled as "trigger-integration-test" and base branch is master
+    if: ${{ github.event.review.state == 'approved' && contains( github.event.pull_request.labels.*.name, 'trigger-integration-test') && github.event.pull_request.base.ref == 'master' }} ## run only if labeled as "trigger-integration-test" and base branch is master
     uses: ./.github/workflows/b-binary-build-and-e2e-tests.yaml
     with:
       COMPONENT_NAME: kubescape
@@ -35,19 +29,16 @@ jobs:
       RELEASE: ""
       CLIENT: test
     secrets: inherit
-
-
   merge-to-master:
     needs: binary-build
     env:
       GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-    if: ${{ (github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'master') && 
-            (always() && (contains(needs.*.result, 'success') || contains(needs.*.result, 'skipped')) && !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled'))) }}
+    if: ${{ (github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'master') && (always() && (contains(needs.*.result, 'success') || contains(needs.*.result, 'skipped')) && !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled'))) }}
     runs-on: ubuntu-latest
     steps:
       - name: merge-to-master
         if: ${{ env.GH_PERSONAL_ACCESS_TOKEN }}
-        uses: pascalgn/automerge-action@v0.15.5
+        uses: pascalgn/automerge-action@eb68b061739cb9d81564f8e812d0b3c45f0fb09a # ratchet:pascalgn/automerge-action@v0.15.5
         env:
           GITHUB_TOKEN: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
           MERGE_COMMIT_MESSAGE: "Merge to master - PR number: {pullRequest.number}"

--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -1,23 +1,19 @@
 name: 02-create_release
-
 on:
   push:
     tags:
-    - 'v*.*.*-rc.*'
-
+      - 'v*.*.*-rc.*'
 jobs:
   retag:
     outputs:
       NEW_TAG: ${{ steps.tag-calculator.outputs.NEW_TAG }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
       - id: tag-calculator
         uses: ./.github/actions/tag-action
         with:
           SUB_STRING: "-rc"
-
   binary-build:
     needs: [retag]
     uses: ./.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -29,40 +25,37 @@ jobs:
       RELEASE: ${{ needs.retag.outputs.NEW_TAG }}
       CLIENT: release
     secrets: inherit
-
   create-release:
     permissions:
-      contents: write    
+      contents: write
     needs: [retag, binary-build]
     uses: ./.github/workflows/c-create-release.yaml
     with:
       RELEASE_NAME: "Release ${{ needs.retag.outputs.NEW_TAG }}"
       TAG: ${{ needs.retag.outputs.NEW_TAG }}
       DRAFT: false
-    secrets: inherit    
-
+    secrets: inherit
   publish-krew-plugin:
     name: Publish Krew plugin
     runs-on: ubuntu-latest
     if: "${{ github.repository_owner }} == kubescape"
     needs: create-release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           submodules: recursive
       - name: Update new version in krew-index
         env:
           # overriding the GITHUB_REF so the action can extract the right tag -> https://github.com/rajatjindal/krew-release-bot/blob/v0.0.43/pkg/cicd/github/actions.go#L25
-          GITHUB_REF: refs/tags/${{ needs.retag.outputs.NEW_TAG }} 
-        uses: rajatjindal/krew-release-bot@v0.0.43
-
+          GITHUB_REF: refs/tags/${{ needs.retag.outputs.NEW_TAG }}
+        uses: rajatjindal/krew-release-bot@92da038bbf995803124a8e50ebd438b2f37bbbb0 # ratchet:rajatjindal/krew-release-bot@v0.0.43
   publish-image:
     permissions:
       id-token: write
       packages: write
-      contents: read    
+      contents: read
     uses: ./.github/workflows/d-publish-image.yaml
-    needs: [ create-release, retag ]
+    needs: [create-release, retag]
     with:
       client: "image-release"
       image_name: "quay.io/${{ github.repository_owner }}/kubescape"

--- a/.github/workflows/03-post-release.yaml
+++ b/.github/workflows/03-post-release.yaml
@@ -1,19 +1,17 @@
 name: 03-create_release_digests
-
 on:
   release:
-    types: [ published ]
+    types: [published]
     branches:
-    - 'master'
-    - 'main'
-  
+      - 'master'
+      - 'main'
 jobs:
   create_release_digests:
     name: Creating digests
     runs-on: ubuntu-latest
     steps:
       - name: Digest
-        uses: MCJack123/ghaction-generate-release-hashes@v1
+        uses: MCJack123/ghaction-generate-release-hashes@c03f3111b39432dde3edebe401c5a8d1ffbbf917 # ratchet:MCJack123/ghaction-generate-release-hashes@v1
         with:
           hash-type: sha1
           file-name: kubescape-release-digests

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -1,5 +1,4 @@
 name: a-pr-scanner
-
 on:
   workflow_call:
     inputs:
@@ -11,27 +10,23 @@ on:
         description: 'Client name'
         required: true
         type: string
-
-
 jobs:
   scanners:
     env:
-       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     name: PR Scanner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - uses: actions/setup-go@v3 # Install go because go-licenses use it
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # Install go because go-licenses use it ratchet:actions/setup-go@v3
         name: Installing go
         with:
           go-version: '1.19'
           cache: true
-
       - name: Scanning - Forbidden Licenses (go-licenses)
         id: licenses-scan
         continue-on-error: true
@@ -40,43 +35,39 @@ jobs:
           go install github.com/google/go-licenses@latest
           echo "## Scanning for forbiden licenses ##"
           go-licenses check .
-
       - name: Scanning - Credentials (GitGuardian)
         if: ${{ env.GITGUARDIAN_API_KEY }}
-        continue-on-error: true      
+        continue-on-error: true
         id: credentials-scan
-        uses: GitGuardian/ggshield-action@master
+        uses: GitGuardian/ggshield-action@4ab2994172fadab959240525e6b833d9ae3aca61 # ratchet:GitGuardian/ggshield-action@master
         with:
-          args: -v --all-policies        
+          args: -v --all-policies
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
           GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-
       - name: Scanning - Vulnerabilities (Snyk)
         if: ${{ env.SNYK_TOKEN }}
         id: vulnerabilities-scan
         continue-on-error: true
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@806182742461562b67788a64410098c9d9b96adb # ratchet:snyk/actions/golang@master
         with:
           command: test --all-projects
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
       - name: Comment results to PR
         continue-on-error: true # Warning: This might break opening PRs from forks
-        uses: peter-evans/create-or-update-comment@v2.1.0
+        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808 # ratchet:peter-evans/create-or-update-comment@v2.1.0
         with:
-          issue-number:  ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
             Scan results:
             - License scan: ${{ steps.licenses-scan.outcome }}
             - Credentials scan: ${{ steps.credentials-scan.outcome }}
             - Vulnerabilities scan: ${{ steps.vulnerabilities-scan.outcome }}
           reactions: 'eyes'
-
   basic-tests:
     needs: scanners
     name: Create cross-platform build
@@ -89,13 +80,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           submodules: recursive
-
       - name: Cache Go modules (Linux)
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~/.cache/go-build
@@ -103,10 +93,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Cache Go modules (macOS)
-        if: matrix.os == 'macos-latest' 
-        uses: actions/cache@v3
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~/Library/Caches/go-build
@@ -114,10 +103,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Cache Go modules (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~\AppData\Local\go-build
@@ -125,56 +113,46 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # ratchet:actions/setup-go@v3
         with:
           go-version: 1.19
-
       - name: Install MSYS2 & libgit2 (Windows)
         shell: cmd
         run: .\build.bat all
         if: matrix.os == 'windows-latest'
-
       - name: Install pkg-config (macOS)
         run: brew install pkg-config
         if: matrix.os == 'macos-latest'
-
       - name: Install libgit2 (Linux/macOS)
         run: make libgit2
         if: matrix.os != 'windows-latest'
- 
       - name: Test core pkg
         run: go test "-tags=static,gitenabled" -v ./...
-
       - name: Test httphandler pkg
         run: cd httphandler && go test "-tags=static,gitenabled" -v ./...
-
       - name: Build
         env:
           RELEASE: ${{ inputs.RELEASE }}
           CLIENT: ${{ inputs.CLIENT }}
           CGO_ENABLED: 1
         run: python3 --version && python3 build.py
-
       - name: Smoke Testing (Windows / MacOS)
         env:
-          RELEASE: ${{ inputs.RELEASE }} 
+          RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/kubescape-${{ matrix.os }}
         if: matrix.os != 'ubuntu-20.04'
-
       - name: Smoke Testing (Linux)
         env:
-          RELEASE: ${{ inputs.RELEASE }} 
+          RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/kubescape-ubuntu-latest
-        if: matrix.os == 'ubuntu-20.04'      
-
+        if: matrix.os == 'ubuntu-20.04'
       - name: golangci-lint
-        if: matrix.os == 'ubuntu-20.04'      
+        if: matrix.os == 'ubuntu-20.04'
         continue-on-error: true
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # ratchet:golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --timeout 10m --build-tags=static

--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -22,26 +22,8 @@ on:
         default: 1
       BINARY_TESTS:
         type: string
-        default: '[
-                    "scan_nsa",                                                                                            
-                    "scan_mitre",                                                                                          
-                    "scan_with_exceptions",                                                                                
-                    "scan_repository",                                                                                     
-                    "scan_local_file",                                                                                     
-                    "scan_local_glob_files",                                                                               
-                    "scan_local_list_of_files",                                                                            
-                    "scan_nsa_and_submit_to_backend",                                                                      
-                    "scan_mitre_and_submit_to_backend",                                                                    
-                    "scan_local_repository_and_submit_to_backend",                                                         
-                    "scan_repository_from_url_and_submit_to_backend",                                                      
-                    "scan_with_exception_to_backend",                                                                      
-                    "scan_with_custom_framework",                                                                                                                                                                
-                    "scan_customer_configuration",                                                                         
-                    "host_scanner"
-                  ]'
-
+        default: '[ "scan_nsa", "scan_mitre", "scan_with_exceptions", "scan_repository", "scan_local_file", "scan_local_glob_files", "scan_local_list_of_files", "scan_nsa_and_submit_to_backend", "scan_mitre_and_submit_to_backend", "scan_local_repository_and_submit_to_backend", "scan_repository_from_url_and_submit_to_backend", "scan_with_exception_to_backend", "scan_with_custom_framework", "scan_customer_configuration", "host_scanner" ]'
 jobs:
-
   check-secret:
     name: secret-validator
     runs-on: ubuntu-latest
@@ -51,28 +33,18 @@ jobs:
       - name: check if the necessary secrets are set in github secrets
         id: check-secret-set
         env:
-            CUSTOMER: ${{ secrets.CUSTOMER }}
-            USERNAME: ${{ secrets.USERNAME }}
-            PASSWORD: ${{ secrets.PASSWORD }}
-            CLIENT_ID: ${{ secrets.CLIENT_ID_PROD }}
-            SECRET_KEY: ${{ secrets.SECRET_KEY_PROD }}
-            REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
-            REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-        run: |
-            echo "is-secret-set=${{ env.CUSTOMER != '' && 
-                                    env.USERNAME != '' &&
-                                    env.PASSWORD != '' &&
-                                    env.CLIENT_ID != '' &&
-                                    env.SECRET_KEY != '' &&
-                                    env.REGISTRY_USERNAME != '' &&
-                                    env.REGISTRY_PASSWORD != ''
-                                  }}" >> $GITHUB_OUTPUT
-
-
+          CUSTOMER: ${{ secrets.CUSTOMER }}
+          USERNAME: ${{ secrets.USERNAME }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID_PROD }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY_PROD }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: "echo \"is-secret-set=${{ env.CUSTOMER != '' && \n                        env.USERNAME != '' &&\n                        env.PASSWORD != '' &&\n                        env.CLIENT_ID != '' &&\n                        env.SECRET_KEY != '' &&\n                        env.REGISTRY_USERNAME != '' &&\n                        env.REGISTRY_PASSWORD != ''\n                      }}\" >> $GITHUB_OUTPUT\n"
   binary-build:
     name: Create cross-platform build
     outputs:
-      TEST_NAMES: ${{ steps.export_tests_to_env.outputs.TEST_NAMES }}    
+      TEST_NAMES: ${{ steps.export_tests_to_env.outputs.TEST_NAMES }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ${{ matrix.os }}
@@ -80,15 +52,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
-
       - name: Cache Go modules (Linux)
-        if: matrix.os == 'ubuntu-20.04' 
-        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-20.04'
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~/.cache/go-build
@@ -96,10 +66,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Cache Go modules (macOS)
-        if: matrix.os == 'macos-latest' 
-        uses: actions/cache@v3
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~/Library/Caches/go-build
@@ -107,10 +76,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
       - name: Cache Go modules (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # ratchet:actions/cache@v3
         with:
           path: |
             ~\AppData\Local\go-build
@@ -118,131 +86,108 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # ratchet:actions/setup-go@v3
         name: Installing go
         with:
           go-version: ${{ inputs.GO_VERSION }}
           cache: true
-
       - name: Install MSYS2 & libgit2 (Windows)
         shell: cmd
         run: .\build.bat all
         if: matrix.os == 'windows-latest'
-
       - name: Install pkg-config (macOS)
         run: brew install pkg-config
         if: matrix.os == 'macos-latest'
-
       - name: Install libgit2 (Linux/macOS)
         run: make libgit2
         if: matrix.os != 'windows-latest'
- 
       - name: Test core pkg
         run: go test "-tags=static,gitenabled" -v ./...
-
       - name: Test httphandler pkg
         run: cd httphandler && go test "-tags=static,gitenabled" -v ./...
-
       - name: Build
         env:
           RELEASE: ${{ inputs.RELEASE }}
           CLIENT: ${{ inputs.CLIENT }}
           CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
         run: python3 --version && python3 build.py
-
       - name: Smoke Testing (Windows / MacOS)
         env:
-          RELEASE: ${{ inputs.RELEASE }} 
+          RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/kubescape-${{ matrix.os }}
         if: matrix.os != 'ubuntu-20.04'
-
       - name: Smoke Testing (Linux)
         env:
-          RELEASE: ${{ inputs.RELEASE }} 
+          RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/kubescape-ubuntu-latest
-        if: matrix.os == 'ubuntu-20.04'      
-
+        if: matrix.os == 'ubuntu-20.04'
       - name: golangci-lint
-        if: matrix.os == 'ubuntu-20.04'      
+        if: matrix.os == 'ubuntu-20.04'
         continue-on-error: true
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # ratchet:golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --timeout 10m --build-tags=static
           only-new-issues: true
-
       - id: export_tests_to_env
         name: set test name
         run: |
           echo "TEST_NAMES=$input" >> $GITHUB_OUTPUT
         env:
           input: ${{ inputs.BINARY_TESTS }}
-
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # ratchet:actions/upload-artifact@v3.1.1
         name: Upload artifact (Linux)
         if: matrix.os == 'ubuntu-20.04'
         with:
           name: kubescape-ubuntu-latest
           path: build/
           if-no-files-found: error
-
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # ratchet:actions/upload-artifact@v3.1.1
         name: Upload artifact (MacOS, Win)
         if: matrix.os != 'ubuntu-20.04'
         with:
           name: kubescape-${{ matrix.os }}
           path: build/
           if-no-files-found: error
-
   run-tests:
     strategy:
-      fail-fast: false    
+      fail-fast: false
       matrix:
         TEST: ${{ fromJson(needs.binary-build.outputs.TEST_NAMES) }}
     needs: [check-secret, binary-build]
     if: needs.check-secret.outputs.is-secret-set == 'true'
     runs-on: ubuntu-latest # This cannot change
     steps:
-
-      - uses: actions/download-artifact@v3.0.2
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # ratchet:actions/download-artifact@v3.0.2
         id: download-artifact
         with:
           name: kubescape-ubuntu-latest
           path: "~"
-
       - run: ls -laR
-
       - name: chmod +x
         run: chmod +x -R ${{steps.download-artifact.outputs.download-path}}/kubescape-ubuntu-latest
-
       - name: Checkout systests repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           repository: armosec/system-tests
           path: .
-          
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # ratchet:actions/setup-python@v4
         with:
           python-version: '3.8.13'
           cache: 'pip'
-
       - name: create env
         run: ./create_env.sh
-
       - name: Generate uuid
         id: uuid
-        run: | 
+        run: |
           echo "RANDOM_UUID=$(uuidgen)" >> $GITHUB_OUTPUT
-
       - name: Create k8s Kind Cluster
         id: kind-cluster-install
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # ratchet:helm/kind-action@v1.3.0
         with:
           cluster_name: ${{ steps.uuid.outputs.RANDOM_UUID }}
-
       - name: run-tests
         env:
           CUSTOMER: ${{ secrets.CUSTOMER }}
@@ -252,7 +197,6 @@ jobs:
           SECRET_KEY: ${{ secrets.SECRET_KEY_PROD }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-
         run: |
           echo "Test history:"
           echo " ${{ matrix.TEST }} " >/tmp/testhistory
@@ -266,14 +210,11 @@ jobs:
             --duration 3                     \
             --logger DEBUG                   \
             --kwargs kubescape=${{steps.download-artifact.outputs.download-path}}/kubescape-ubuntu-latest
-          
+
           deactivate
-          
       - name: Test Report
-        uses: mikepenz/action-junit-report@v3.6.1
+        uses: mikepenz/action-junit-report@6e9933f4a97f4d2b99acef4d7b97924466037882 # ratchet:mikepenz/action-junit-report@v3.6.1
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/results_xml_format/**.xml'
           commit: ${{github.event.workflow_run.head_sha}}
-
-          

--- a/.github/workflows/c-create-release.yaml
+++ b/.github/workflows/c-create-release.yaml
@@ -15,22 +15,19 @@ on:
         required: false
         type: boolean
         default: false
-
 jobs:
-
   create-release:
     name: create-release
     runs-on: ubuntu-latest
     # permissions:
     #   contents: write    
     steps:
-      - uses: actions/download-artifact@v3.0.2
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # ratchet:actions/download-artifact@v3.0.2
         id: download-artifact
         with:
           path: .
-
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # ratchet:softprops/action-gh-release@v1
         env:
           MAC_OS: macos-latest
           UBUNTU_OS: ubuntu-latest
@@ -53,5 +50,3 @@ jobs:
             ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}
             ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}.sha256
             ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}.tar.gz
- 
-            

--- a/.github/workflows/d-publish-image.yaml
+++ b/.github/workflows/d-publish-image.yaml
@@ -1,5 +1,4 @@
 name: d-publish-image
-
 on:
   workflow_call:
     inputs:
@@ -25,7 +24,6 @@ on:
         default: true
         type: boolean
         description: 'support amd64/arm64'
-
 jobs:
   check-secret:
     name: check if QUAYIO_REGISTRY_USERNAME & QUAYIO_REGISTRY_PASSWORD is set in github secrets
@@ -36,44 +34,36 @@ jobs:
       - name: check if QUAYIO_REGISTRY_USERNAME & QUAYIO_REGISTRY_PASSWORD is set in github secrets
         id: check-secret-set
         env:
-            QUAYIO_REGISTRY_USERNAME: ${{ secrets.QUAYIO_REGISTRY_USERNAME }}
-            QUAYIO_REGISTRY_PASSWORD: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
+          QUAYIO_REGISTRY_USERNAME: ${{ secrets.QUAYIO_REGISTRY_USERNAME }}
+          QUAYIO_REGISTRY_PASSWORD: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
         run: |
-            echo "is-secret-set=${{ env.QUAYIO_REGISTRY_USERNAME != '' && env.QUAYIO_REGISTRY_PASSWORD != '' }}" >> $GITHUB_OUTPUT
-
+          echo "is-secret-set=${{ env.QUAYIO_REGISTRY_USERNAME != '' && env.QUAYIO_REGISTRY_PASSWORD != '' }}" >> $GITHUB_OUTPUT
   build-image:
     needs: [check-secret]
     if: needs.check-secret.outputs.is-secret-set == 'true'
     name: Build image and upload to registry
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           submodules: recursive
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # ratchet:docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # ratchet:docker/setup-buildx-action@v2
       - name: Login to Quay.io
         env:
           QUAY_PASSWORD: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
           QUAY_USERNAME: ${{ secrets.QUAYIO_REGISTRY_USERNAME }}
         run: docker login -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
-
       - name: Build and push image
         if: ${{ inputs.support_platforms }}
         run: docker buildx build . --file build/Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --push --platform linux/amd64,linux/arm64
-
       - name: Build and push image without amd64/arm64 support
         if: ${{ !inputs.support_platforms }}
-        run: docker buildx build . --file build/Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --push 
-
+        run: docker buildx build . --file build/Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --push
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@4079ad3567a89f68395480299c77e40170430341 # ratchet:sigstore/cosign-installer@main
         with:
           cosign-release: 'v1.12.0'
       - name: sign kubescape container image
@@ -81,5 +71,4 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-            cosign sign --force ${{ inputs.image_name }}
-
+          cosign sign --force ${{ inputs.image_name }}

--- a/.github/workflows/z-close-typos-issues.yaml
+++ b/.github/workflows/z-close-typos-issues.yaml
@@ -1,23 +1,19 @@
 on:
   issues:
     types: [opened, labeled]
-
 jobs:
   open_PR_message:
     if: github.event.label.name == 'typo'
     runs-on: ubuntu-latest
     steps:
-      - uses: ben-z/actions-comment-on-issue@1.0.2
+      - uses: ben-z/actions-comment-on-issue@10be23f9c43ac792663043420fda29dde07e2f0f # ratchet:ben-z/actions-comment-on-issue@1.0.2
         with:
           message: "Hello! :wave:\n\nThis issue is being automatically closed, Please open a PR with a relevant fix."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          
-          
   auto_close_issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/close-matching-issues@v2
+      - uses: lee-dohm/close-matching-issues@e9e43aad2fa6f06a058cedfd8fb975fd93b56d8f # ratchet:lee-dohm/close-matching-issues@v2
         with:
           query: 'label:typo'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview
This PR provides a simple security improvement in our CI workflows.
By pinning the workflows to a specific commit, we can ensure that the **github-action** we are using will not change during the time (if we don't update it).
This allows us to depend on a specific sha, still knowing what the original pinned version was.

## Related issues/PRs:
Closes #1107 .

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

