### PR TITLE
refactor: update node scanner daemonset tolerations

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -27,14 +27,9 @@ spec:
         name: host-scanner
     spec:
       tolerations:
-      # this toleration is to have the DaemonDet runnable on master nodes
+      # this toleration is to have the DaemonDet runnable on all nodes (including masters)
       # remove it if your masters can't run pods
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
       containers:
       - name: host-sensor
         image: quay.io/kubescape/host-scanner:v1.0.45


### PR DESCRIPTION
## Overview
I have updated the tolerations for node scanner Daemonset to make it runnable on all nodes of a cluster, regardless of present taints.

Current values:
- node-role.kubernetes.io/control-plane
- node-role.kubernetes.io/master

New value:
An empty key with the operator `Exists` matches all keys, values, and effects which means this will tolerate everything. 
[Reference](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)


## Additional Information
Kubernetes nodes may be tainted for different reasons or in some cases, tainted differently than what we expect, for instance, a cluster setup with RKE can have additional taints on its masters which prevents the node scanner to meet desired state.

Example of taints:
``` yaml
  taints:
  - effect: NoSchedule
    key: node-role.kubernetes.io/controlplane
    value: "true"
  - effect: NoExecute
    key: node-role.kubernetes.io/etcd
    value: "true"
```

In this example having an additional taint `node-role.kubernetes.io/etcd` will lead to the error below:
```
◓[error] failed to validate host-sensor pods status. error: host-sensor pods number (10) differ than nodes number (13) after deadline exceeded. Kubescape will take data only from the pods below: map[host-scanner-4j9kl:worker-10 host-scanner-58k4d:worker-8 host-scanner-6znqt:worker-9 host-scanner-b4wdn:worker-1 host-scanner-b62w6:worker-2 host-scanner-bvfjk:worker-4 host-scanner-p7cjj:worker-3 host-scanner-qqzpp:worker-7 host-scanner-tv492:worker-6 host-scanner-z898x:worker-5]
```
<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

