### PR TITLE
feat: integrate support to retrieve eks policies

### DIFF
--- a/core/cautils/workloadmappingutils.go
+++ b/core/cautils/workloadmappingutils.go
@@ -27,6 +27,7 @@ var (
 		cloudapis.CloudProviderDescribeKind,
 		cloudapis.CloudProviderDescribeRepositoriesKind,
 		cloudapis.CloudProviderListEntitiesForPoliciesKind,
+		cloudapis.CloudProviderPolicyVersionKind,
 		string(cloudsupport.TypeApiServerInfo),
 	}
 )

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -35,6 +35,7 @@ var cloudResourceGetterMapping = map[string]cloudResourceGetter{
 	cloudapis.CloudProviderDescribeKind:                cloudsupport.GetDescriptiveInfoFromCloudProvider,
 	cloudapis.CloudProviderDescribeRepositoriesKind:    cloudsupport.GetDescribeRepositoriesFromCloudProvider,
 	cloudapis.CloudProviderListEntitiesForPoliciesKind: cloudsupport.GetListEntitiesForPoliciesFromCloudProvider,
+	cloudapis.CloudProviderPolicyVersionKind:           cloudsupport.GetPolicyVersionFromCloudProvider,
 }
 
 type K8sResourceHandler struct {
@@ -136,7 +137,6 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	if err := k8sHandler.collectRbacResources(allResources); err != nil {
 		logger.L().Ctx(ctx).Warning("failed to collect rbac resources", helpers.Error(err))
 	}
-
 	cloudResources := cautils.MapCloudResources(ksResourceMap)
 
 	setMapNamespaceToNumOfResources(ctx, allResources, sessionObj)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/containeranalysis v0.6.0
-	github.com/armosec/armoapi-go v0.0.151
+	github.com/armosec/armoapi-go v0.0.169
 	github.com/armosec/utils-go v0.0.12
 	github.com/armosec/utils-k8s-go v0.0.12
 	github.com/briandowns/spinner v1.18.1
@@ -18,7 +18,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/kubescape/go-git-url v0.0.24
 	github.com/kubescape/go-logger v0.0.10
-	github.com/kubescape/k8s-interface v0.0.99
+	github.com/kubescape/k8s-interface v0.0.103
 	github.com/kubescape/opa-utils v0.0.238
 	github.com/kubescape/rbac-utils v0.0.20
 	github.com/kubescape/regolibrary v1.0.250
@@ -278,6 +278,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.1 // indirect
+	github.com/stripe/stripe-go/v74 v74.8.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.151 h1:vyoQVk1y8cb4DHlfRKyFqDtiB1G13w4o5aoG8+YUMq0=
-github.com/armosec/armoapi-go v0.0.151/go.mod h1:5MQAHYUFm1JrTSgb4+EglR5vNsrqUD0krh/5xWm2RdI=
+github.com/armosec/armoapi-go v0.0.169 h1:5X1rpKCwjG3UPTw6TLq2wSk14sfoyOqPDLb55bO7V9Y=
+github.com/armosec/armoapi-go v0.0.169/go.mod h1:xlW8dGq0vVzbuk+kDZqMQIkfU9P/iiiiDavoCIboqgI=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=
@@ -1088,8 +1088,8 @@ github.com/kubescape/go-git-url v0.0.24 h1:+Ryb+bA+6Kx8dBHR7nnoK7ZFvtfWkwI4exYhk
 github.com/kubescape/go-git-url v0.0.24/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kubescape/go-logger v0.0.10 h1:aMciNf1B8wInpFJva4e4gQVsLK51bzRQgaSl+sCGOeQ=
 github.com/kubescape/go-logger v0.0.10/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
-github.com/kubescape/k8s-interface v0.0.99 h1:Bk7P694WkYPORW4c+ojpvCIQQ83Ku8durElNlvgM0Qg=
-github.com/kubescape/k8s-interface v0.0.99/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
+github.com/kubescape/k8s-interface v0.0.103 h1:k/pn1DU1dlEo7e59QqH4c6eI9F/m5nX6XJI8bzqZ/Wg=
+github.com/kubescape/k8s-interface v0.0.103/go.mod h1:McIx729bV395FOL3FWiv8vyT5V0F1TbcbTOCc+LS50A=
 github.com/kubescape/opa-utils v0.0.238 h1:i8uuMOi0T4Lj+svq3OlM056YFrKDt7zGAnxxqbFAnAI=
 github.com/kubescape/opa-utils v0.0.238/go.mod h1:eAZN82Zj4GgpcQlhMox0P6s8iL5YZnWrbX+/az3UWHI=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
@@ -1545,6 +1545,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stripe/stripe-go/v74 v74.8.0 h1:0+3EfQSBhMg8SQ1+w+AP6Gxyko2crWbUG2uXbzYs8SU=
+github.com/stripe/stripe-go/v74 v74.8.0/go.mod h1:5PoXNp30AJ3tGq57ZcFuaMylzNi8KpwlrYAFmO1fHZw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
 	github.com/kubescape/go-logger v0.0.10
-	github.com/kubescape/k8s-interface v0.0.99
+	github.com/kubescape/k8s-interface v0.0.103
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
 	github.com/kubescape/opa-utils v0.0.238
 	github.com/stretchr/testify v1.8.1
@@ -81,7 +81,7 @@ require (
 	github.com/alibabacloud-go/tea-utils v1.4.4 // indirect
 	github.com/alibabacloud-go/tea-xml v1.1.2 // indirect
 	github.com/aliyun/credentials-go v1.2.3 // indirect
-	github.com/armosec/armoapi-go v0.0.151 // indirect
+	github.com/armosec/armoapi-go v0.0.169 // indirect
 	github.com/armosec/utils-k8s-go v0.0.12 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.44.114 // indirect
@@ -284,6 +284,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.1 // indirect
+	github.com/stripe/stripe-go/v74 v74.8.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -279,8 +279,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.151 h1:vyoQVk1y8cb4DHlfRKyFqDtiB1G13w4o5aoG8+YUMq0=
-github.com/armosec/armoapi-go v0.0.151/go.mod h1:5MQAHYUFm1JrTSgb4+EglR5vNsrqUD0krh/5xWm2RdI=
+github.com/armosec/armoapi-go v0.0.169 h1:5X1rpKCwjG3UPTw6TLq2wSk14sfoyOqPDLb55bO7V9Y=
+github.com/armosec/armoapi-go v0.0.169/go.mod h1:xlW8dGq0vVzbuk+kDZqMQIkfU9P/iiiiDavoCIboqgI=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=
@@ -1093,8 +1093,8 @@ github.com/kubescape/go-git-url v0.0.24 h1:+Ryb+bA+6Kx8dBHR7nnoK7ZFvtfWkwI4exYhk
 github.com/kubescape/go-git-url v0.0.24/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kubescape/go-logger v0.0.10 h1:aMciNf1B8wInpFJva4e4gQVsLK51bzRQgaSl+sCGOeQ=
 github.com/kubescape/go-logger v0.0.10/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
-github.com/kubescape/k8s-interface v0.0.99 h1:Bk7P694WkYPORW4c+ojpvCIQQ83Ku8durElNlvgM0Qg=
-github.com/kubescape/k8s-interface v0.0.99/go.mod h1:UO8puAwFZ3XVMlKWJj0GcdFJZI22Q7iwV+5FO6mw5FE=
+github.com/kubescape/k8s-interface v0.0.103 h1:k/pn1DU1dlEo7e59QqH4c6eI9F/m5nX6XJI8bzqZ/Wg=
+github.com/kubescape/k8s-interface v0.0.103/go.mod h1:McIx729bV395FOL3FWiv8vyT5V0F1TbcbTOCc+LS50A=
 github.com/kubescape/opa-utils v0.0.238 h1:i8uuMOi0T4Lj+svq3OlM056YFrKDt7zGAnxxqbFAnAI=
 github.com/kubescape/opa-utils v0.0.238/go.mod h1:eAZN82Zj4GgpcQlhMox0P6s8iL5YZnWrbX+/az3UWHI=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
@@ -1550,6 +1550,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stripe/stripe-go/v74 v74.8.0 h1:0+3EfQSBhMg8SQ1+w+AP6Gxyko2crWbUG2uXbzYs8SU=
+github.com/stripe/stripe-go/v74 v74.8.0/go.mod h1:5PoXNp30AJ3tGq57ZcFuaMylzNi8KpwlrYAFmO1fHZw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=


### PR DESCRIPTION
## Overview
This integration uses the last feature introduced in `k8s-interface` repository that allows to retrieve information about `aws` policies.
Using this functionality, we can have more data available to make logic with rego rules.

## Additional Information
This **PR** can be merged only after this other has been merged: https://github.com/kubescape/k8s-interface/pull/27.
After published the new `k8s-interface`, we have to update the `go.mod` file in `kubescape` in order to point it to the right version.

## How to Test
To test the given PR, you have to clone the `k8s-interface` repository locally:
```
git clone git@github.com:kubescape/k8s-interface.git && cd k8s-interface/
```
Check out to the feature branch:
```
git checkout feat/add-get-policy-version-method
```
add this line to the end of `go.mod` file:
```
replace github.com/kubescape/k8s-interface => /path/to/your/k8s-interface
```
Download the test file (to activate controls for `PolicyVersion` kind): [cis-eks-t1.2.0.txt](https://github.com/kubescape/kubescape/files/10888177/cis-eks-t1.2.0.txt) and put it into a directory:
```
wget https://github.com/kubescape/kubescape/files/10888177/cis-eks-t1.2.0.txt
mkdir test
mv cis-eks-t1.2.0.txt test/cis-eks-t1.2.0
```
Build (from kubescape repo clone) and run **kubescape**:
```
make build && ./kubescape scan framework cis-eks-t1.2.0 --use-artifacts-from test/
```

## Related issues/PRs:

Related to issue: https://cyberarmor-io.atlassian.net/browse/SUB-610
Related to PR: https://github.com/kubescape/k8s-interface/pull/27

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
