### PR TITLE
initialize context in Prometheus handler

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -32,6 +32,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		scanInfo: scanInfo,
 		scanID:   scanID,
 	}
+	scanParams.ctx = r.Context()
 
 	handler.scanResponseChan.set(scanID) // add scan to channel
 	defer handler.scanResponseChan.delete(scanID)


### PR DESCRIPTION
## Overview
Initialize `scanRequestParams.ctx` with parent context to prevent panic when we reuse it to create otel spans.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:
* Resolved SUB-696

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
