### PR TITLE
Change installation path to ~/.kubescape/bin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,33 +35,23 @@ DOWNLOAD_URL="https://github.com/kubescape/kubescape/releases/${RELEASE}/kubesca
 
 curl --progress-bar -L $DOWNLOAD_URL -o $OUTPUT
 
-# Checking if SUDO needed/exists 
-SUDO=
-if [ "$(id -u)" -ne 0 ] && [ -n "$(which sudo)" ]; then
-    SUDO=sudo
-fi
-
-
 # Find install dir
-install_dir=/usr/local/bin #default
-for pdir in ${PATH//:/ }; do
-    edir="${pdir/#\~/$HOME}"
-    if [[ $edir == $HOME/* ]]; then
-        install_dir=$edir
-        mkdir -p $install_dir 2>/dev/null || true
-        SUDO=
-        break
-    fi
-done
+install_dir=/usr/local/bin # default if running as root
+if [ "$(id -u)" -ne 0 ]; then
+  install_dir=$BASE_DIR/bin # if not running as root, install to user dir
+  export PATH=$PATH:$BASE_DIR/bin
+fi
 
 # Create install dir if it does not exist
 if [ ! -d "$install_dir" ]; then
-  $SUDO mkdir -p $install_dir
+  mkdir -p $install_dir
 fi
 
-chmod +x $OUTPUT 2>/dev/null 
-$SUDO rm -f /usr/local/bin/$KUBESCAPE_EXEC 2>/dev/null || true # clearning up old install
-$SUDO cp $OUTPUT $install_dir/$KUBESCAPE_EXEC 
+chmod +x $OUTPUT 2>/dev/null
+# clearning up old install
+rm -f /usr/local/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+rm -f $BASE_DIR/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+cp $OUTPUT $install_dir/$KUBESCAPE_EXEC 
 rm -rf $OUTPUT
 
 echo
@@ -72,5 +62,10 @@ $KUBESCAPE_EXEC version
 echo
 
 echo -e "\033[35mUsage: $ $KUBESCAPE_EXEC scan --enable-host-scan"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo -e "\nRemember to add the Kubescape CLI to your path with:"
+  echo -e "  export PATH=\$PATH:$BASE_DIR/bin"
+fi
 
 echo -e "\033[0m"

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ chmod +x $OUTPUT 2>/dev/null
 
 # cleaning up old install
 SUDO=
-if [ "$(id -u)" -ne 0 ] && [ -n "$(which sudo)" ] && [ -f /usr/local/bin/$KUBESCAPE_EXEC ]; then
+if [ "$(id -u)" -ne 0 ] && [ -n "$(which sudo)" ] && [ "$KUBESCAPE_EXEC" != "" ] && [ -f /usr/local/bin/$KUBESCAPE_EXEC ]; then
     SUDO=sudo
     echo -e "\n\033[33mOld installation as root found, do you want to remove it? [\033[0my\033[33m/n]:"
     read -n 1 -r
@@ -67,14 +67,20 @@ if [ "$(id -u)" -ne 0 ] && [ -n "$(which sudo)" ] && [ -f /usr/local/bin/$KUBESC
     fi
 fi
 
-rm -f /home/${SUDO_USER:-$USER}/.kubescape/bin/$KUBESCAPE_EXEC 2>/dev/null || true
-rm -f $BASE_DIR/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+if [ "$KUBESCAPE_EXEC" != "" ]; then
+    if [ "${SUDO_USER:-$USER}" != "" ]; then
+        rm -f /home/${SUDO_USER:-$USER}/.kubescape/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+    fi
+    if [ "$BASE_DIR" != "" ]; then
+        rm -f $BASE_DIR/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+    fi
+fi
 
 # Old install location, clean all those things up
 for pdir in ${PATH//:/ }; do
     edir="${pdir/#\~/$HOME}"
     if [[ $edir == $HOME/* ]] && [[ -f $edir/$KUBESCAPE_EXEC ]]; then
-        echo -e "\n\033[33mOld installation found at $edir/, do you want to remove it? [\033[0my\033[33m/n]:"
+        echo -e "\n\033[33mOld installation found at $edir/$KUBESCAPE_EXEC, do you want to remove it? [\033[0my\033[33m/n]:"
         read -n 1 -r
         if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ "$REPLY" != "" ]]; then
             continue
@@ -88,7 +94,7 @@ for pdir in ${PATH//:/ }; do
 done
 
 cp $OUTPUT $install_dir/$KUBESCAPE_EXEC
-rm -rf $OUTPUT
+rm -f $OUTPUT
 
 echo
 echo -e "\033[32mFinished Installation."

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,11 @@ while getopts v: option
 do
     case ${option} in
         v) RELEASE="download/${OPTARG}";;
+        *) ;;
     esac
 done
 
-if [ -z ${RELEASE} ]; then
+if [ -z "${RELEASE}" ]; then
     RELEASE="latest/download"
 fi
 
@@ -17,7 +18,6 @@ echo
 
 BASE_DIR=~/.kubescape
 KUBESCAPE_EXEC=kubescape
-KUBESCAPE_ZIP=kubescape.zip
 
 osName=$(uname -s)
 if [[ $osName == *"MINGW"* ]]; then
@@ -69,7 +69,7 @@ fi
 
 if [ "$KUBESCAPE_EXEC" != "" ]; then
     if [ "${SUDO_USER:-$USER}" != "" ]; then
-        rm -f /home/${SUDO_USER:-$USER}/.kubescape/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+        rm -f /home/"${SUDO_USER:-$USER}"/.kubescape/bin/$KUBESCAPE_EXEC 2>/dev/null || true
     fi
     if [ "$BASE_DIR" != "" ]; then
         rm -f $BASE_DIR/bin/$KUBESCAPE_EXEC 2>/dev/null || true
@@ -85,7 +85,7 @@ for pdir in ${PATH//:/ }; do
         if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ "$REPLY" != "" ]]; then
             continue
         fi
-        if rm -f $edir/$KUBESCAPE_EXEC 2>/dev/null; then
+        if rm -f "$edir"/$KUBESCAPE_EXEC 2>/dev/null; then
             echo -e "\n\033[32mRemoved old installation at $edir/$KUBESCAPE_EXEC"
         else
             echo -e "\n\033[31mFailed to remove old installation as root at $edir/$KUBESCAPE_EXEC, please remove it manually."

--- a/install.sh
+++ b/install.sh
@@ -48,9 +48,16 @@ if [ ! -d "$install_dir" ]; then
 fi
 
 chmod +x $OUTPUT 2>/dev/null
-# clearning up old install
-rm -f /usr/local/bin/$KUBESCAPE_EXEC 2>/dev/null || true
-rm -f $BASE_DIR/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+
+# cleaning up old install
+SUDO=
+if [ "$(id -u)" -ne 0 ] && [ -n "$(which sudo)" ] && [ -f /usr/local/bin/$KUBESCAPE_EXEC ]; then
+    SUDO=sudo
+    echo -e "\n\033[33mOld installation as root found. We need the root access to uninstall the old kubescape CLI."
+fi
+$SUDO rm -f /usr/local/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+rm -f /home/${SUDO_USER:-$USER}/.kubescape/bin/$KUBESCAPE_EXEC 2>/dev/null || true
+
 cp $OUTPUT $install_dir/$KUBESCAPE_EXEC 
 rm -rf $OUTPUT
 


### PR DESCRIPTION
Resolve #1015 

## Overview
The installation behavior now changes into the follows:
- If the user tries to start the script with root access, then kubescape will be installed into `/usr/local/bin/`.
- If without root access, then kubescape will be installed into `~/.kubescape/bin`, and a message will be shown to user asking them to put that directory into PATH manually.
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
