### PR TITLE
upgrade opa-utils and armo-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/containeranalysis v0.6.0
-	github.com/armosec/armoapi-go v0.0.169
+	github.com/armosec/armoapi-go v0.0.173
 	github.com/armosec/utils-go v0.0.12
 	github.com/armosec/utils-k8s-go v0.0.12
 	github.com/briandowns/spinner v1.18.1
@@ -19,7 +19,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.24
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.103
-	github.com/kubescape/opa-utils v0.0.238
+	github.com/kubescape/opa-utils v0.0.242
 	github.com/kubescape/rbac-utils v0.0.20
 	github.com/kubescape/regolibrary v1.0.250
 	github.com/libgit2/git2go/v33 v33.0.9

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.169 h1:5X1rpKCwjG3UPTw6TLq2wSk14sfoyOqPDLb55bO7V9Y=
-github.com/armosec/armoapi-go v0.0.169/go.mod h1:xlW8dGq0vVzbuk+kDZqMQIkfU9P/iiiiDavoCIboqgI=
+github.com/armosec/armoapi-go v0.0.173 h1:TwNxmTxx9ATJPZBlld/53s/WvSVUfoF4gxgHT6UbFng=
+github.com/armosec/armoapi-go v0.0.173/go.mod h1:xlW8dGq0vVzbuk+kDZqMQIkfU9P/iiiiDavoCIboqgI=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=
@@ -1090,8 +1090,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.103 h1:k/pn1DU1dlEo7e59QqH4c6eI9F/m5nX6XJI8bzqZ/Wg=
 github.com/kubescape/k8s-interface v0.0.103/go.mod h1:McIx729bV395FOL3FWiv8vyT5V0F1TbcbTOCc+LS50A=
-github.com/kubescape/opa-utils v0.0.238 h1:i8uuMOi0T4Lj+svq3OlM056YFrKDt7zGAnxxqbFAnAI=
-github.com/kubescape/opa-utils v0.0.238/go.mod h1:eAZN82Zj4GgpcQlhMox0P6s8iL5YZnWrbX+/az3UWHI=
+github.com/kubescape/opa-utils v0.0.242 h1:dxXjkUHIwIqlLpnAOfyREH8pWl8wUOHIW9oigKHl6wg=
+github.com/kubescape/opa-utils v0.0.242/go.mod h1:aaAPHjaIJDoAK6RvAcUDXrXkja0ZTy0qSfnoxkE9z34=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Upgrade opa-utils version to support exceptions using resourceID


## How to Test
Add exception with attributes designator with cluster and resourceID 
Scan and expect the resource to be ignored 
## Examples/Screenshots
Exception example 
```json
{
        "name": "exclude my resource by id",
        "policyType": "postureExceptionPolicy",
        "actions": [
            "alertOnly"
        ],
        "resources": [
            {
                "designatorType": "Attributes",
                "attributes": {
                    "cluster": "cluster3",
                    "resourceID": "v1/core/default/ConfigMap/test"     
                }
            }
        ],
        "posturePolicies": [
            {
                "frameworkName": "NSA",
                "controlName": "Allowed hostPath"
            }
        ]
    }
```



## Related issues/PRs:
https://github.com/kubescape/opa-utils/pull/101
https://github.com/armosec/armoapi-go/pull/74

## Checklist before requesting a review

- [x ] My code follows the style guidelines of this project
- [ x] I have commented on my code, particularly in hard-to-understand areas
- [ x] I have performed a self-review of my code
- [ x] If it is a core feature, I have added thorough tests.
- [ x] New and existing unit tests pass locally with my changes


