### PR TITLE
fix references to kubectl in completion help

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -15,8 +15,8 @@ var completionCmdExamples = fmt.Sprintf(`
   $ echo 'source <(%[1]s completion bash)' >> ~/.bashrc
 
   # Enable ZSH shell autocompletion
-  $ source <(kubectl completion zsh)
-  $ echo 'source <(kubectl completion zsh)' >> "${fpath[1]}/_kubectl"
+  $ source <(%[1]s completion zsh)
+  $ echo 'source <(%[1]s completion zsh)' >> "${fpath[1]}/_%[1]s"
 `, cautils.ExecName())
 
 func GetCompletionCmd() *cobra.Command {


### PR DESCRIPTION
## Overview
Fixed help for completion; replaced references to `kubectl` with the executable name.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->


## How to Test

```sh
❯ kubescape completion
Error: accepts 1 arg(s), received 0
Usage:
  kubescape completion [bash|zsh|fish|powershell]

Examples:

  # Enable BASH shell autocompletion
  $ source <(kubescape completion bash)
  $ echo 'source <(kubescape completion bash)' >> ~/.bashrc

  # Enable ZSH shell autocompletion
  $ source <(kubescape completion zsh)
  $ echo 'source <(kubescape completion zsh)' >> "${fpath[1]}/_kubescape"

...
```

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
