### PR TITLE
Refact(test utils): introduce internal/testutils

### DIFF
--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
@@ -159,5 +160,5 @@ func hydrateReleasedPolicyFromMock(t testing.TB, p *DownloadReleasedPolicy) {
 }
 
 func testRegoFile(framework string) string {
-	return filepath.Join(currentDir(), "testdata", fmt.Sprintf("%s.json", framework))
+	return filepath.Join(testutils.CurrentDir(), "testdata", fmt.Sprintf("%s.json", framework))
 }

--- a/core/cautils/getter/kscloudapi_mocks_test.go
+++ b/core/cautils/getter/kscloudapi_mocks_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/stretchr/testify/require"
@@ -279,7 +280,7 @@ func mockLoginResponse() *feLoginResponse {
 }
 
 func mockPostureReport(t testing.TB, reportID, cluster string) *PostureReport {
-	fixture := filepath.Join(currentDir(), "testdata", "mock_posture_report.json")
+	fixture := filepath.Join(testutils.CurrentDir(), "testdata", "mock_posture_report.json")
 
 	buf, err := os.ReadFile(fixture)
 	require.NoError(t, err)

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -387,7 +387,7 @@ func TestLoadPolicy(t *testing.T) {
 }
 
 func testFrameworkFile(framework string) string {
-	return filepath.Join(currentDir(), "testdata", fmt.Sprintf("%s.json", framework))
+	return filepath.Join(testutils.CurrentDir(), "testdata", fmt.Sprintf("%s.json", framework))
 }
 
 func writeTempJSONControlInputs(t testing.TB) (string, map[string][]string) {
@@ -407,10 +407,4 @@ func writeTempJSONControlInputs(t testing.TB) (string, map[string][]string) {
 	require.NoError(t, os.WriteFile(fileName, buf, 0600))
 
 	return fileName, mock
-}
-
-func currentDir() string {
-	_, filename, _, _ := runtime.Caller(1)
-
-	return filepath.Dir(filename)
 }

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -8,6 +8,7 @@ import (
 
 	logger "github.com/kubescape/go-logger"
 	metav1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	"github.com/stretchr/testify/assert"
@@ -172,9 +173,8 @@ func TestApplyFixKeepsFormatting(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.inputFile, func(t *testing.T) {
 			getTestDataPath := func(filename string) string {
-				currentDir, _ := os.Getwd()
 				currentFile := "testdata/" + filename
-				return filepath.Join(currentDir, currentFile)
+				return filepath.Join(testutils.CurrentDir(), currentFile)
 			}
 
 			input, _ := os.ReadFile(getTestDataPath(tc.inputFile))

--- a/core/pkg/hostsensorutils/hostsensordeploy_test.go
+++ b/core/pkg/hostsensorutils/hostsensordeploy_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,7 +190,7 @@ func TestHostSensorHandler(t *testing.T) {
 	t.Run("with manifest from YAML file", func(t *testing.T) {
 		t.Run("should build host sensor", func(t *testing.T) {
 			k8s := NewKubernetesApiMock(WithNode(mockNode1()), WithPod(mockPod1()), WithPod(mockPod2()), WithResponses(mockResponses()))
-			h, err := NewHostSensorHandler(k8s, filepath.Join(currentDir(), "hostsensor.yaml"))
+			h, err := NewHostSensorHandler(k8s, filepath.Join(testutils.CurrentDir(), "hostsensor.yaml"))
 			require.NoError(t, err)
 			require.NotNil(t, h)
 
@@ -223,7 +223,7 @@ func TestHostSensorHandler(t *testing.T) {
 			})
 
 			k8s := NewKubernetesApiMock(WithNode(mockNode1()), WithPod(mockPod1()), WithPod(mockPod2()), WithResponses(mockResponses()))
-			_, err := NewHostSensorHandler(k8s, filepath.Join(currentDir(), invalid))
+			_, err := NewHostSensorHandler(k8s, filepath.Join(testutils.CurrentDir(), invalid))
 			require.Error(t, err)
 		})
 	})
@@ -240,10 +240,4 @@ func TestHostSensorHandler(t *testing.T) {
 	// * explicit TearDown()
 	//
 	// Notice that the package doesn't current pass tests with the race detector enabled.
-}
-
-func currentDir() string {
-	_, filename, _, _ := runtime.Caller(1)
-
-	return filepath.Dir(filename)
 }

--- a/core/pkg/resultshandling/reporter/v2/mockreporter_test.go
+++ b/core/pkg/resultshandling/reporter/v2/mockreporter_test.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/reporter"
+	"github.com/kubescape/kubescape/v2/internal/testutils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
@@ -184,7 +184,7 @@ type (
 
 // mockOPASessionObj builds an OPASessionObj from a JSON fixture.
 func mockOPASessionObj(t testing.TB) *cautils.OPASessionObj {
-	buf, err := os.ReadFile(filepath.Join(currentDir(), "testdata", "mock_opasessionobj.json"))
+	buf, err := os.ReadFile(filepath.Join(testutils.CurrentDir(), "testdata", "mock_opasessionobj.json"))
 	require.NoError(t, err)
 
 	var v mockableOPASessionObj
@@ -348,10 +348,4 @@ func hijackedClient(t testing.TB, srv *testServer) *http.Client {
 	return &http.Client{
 		Transport: newInterceptor(transport, mockURL.Host),
 	}
-}
-
-func currentDir() string {
-	_, filename, _, _ := runtime.Caller(1)
-
-	return filepath.Dir(filename)
 }

--- a/internal/testutils/dir.go
+++ b/internal/testutils/dir.go
@@ -1,0 +1,12 @@
+package testutils
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+func CurrentDir() string {
+	_, filename, _, _ := runtime.Caller(1)
+
+	return filepath.Dir(filename)
+}


### PR DESCRIPTION
## Overview
Introduced an internal package to start factorizing common test utilities.

The first such common function, "CurrentDir()", is used to retrieve test fixtures relative to a go source file, not necessarily the CWD.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
