### PR TITLE
feat: add progress bar during cloud resources download

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -158,7 +158,7 @@ func (ks *Kubescape) Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*res
 	// ===================== policies & resources =====================
 	ctxPolicies, spanPolicies := otel.Tracer("").Start(ctxInit, "policies & resources")
 	policyHandler := policyhandler.NewPolicyHandler(interfaces.resourceHandler)
-	scanData, err := policyHandler.CollectResources(ctxPolicies, scanInfo.PolicyIdentifier, scanInfo)
+	scanData, err := policyHandler.CollectResources(ctxPolicies, scanInfo.PolicyIdentifier, scanInfo, cautils.NewProgressHandler(""))
 	if err != nil {
 		spanInit.End()
 		return resultsHandling, err

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -153,7 +153,7 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 	// processes rules for all controls in parallel
 	for _, controlToPin := range policies.Controls {
 		if progressListener != nil {
-			progressListener.ProgressJob(1, fmt.Sprintf("Control %s", controlToPin.ControlID))
+			progressListener.ProgressJob(1, fmt.Sprintf("Control: %s", controlToPin.ControlID))
 		}
 
 		control := controlToPin

--- a/core/pkg/policyhandler/handlenotification_test.go
+++ b/core/pkg/policyhandler/handlenotification_test.go
@@ -249,12 +249,12 @@ func Test_getResources(t *testing.T) {
 	policyIdentifier := []cautils.PolicyIdentifier{{}}
 
 	assert.NotPanics(t, func() {
-		policyHandler.getResources(context.TODO(), policyIdentifier, objSession)
+		policyHandler.getResources(context.TODO(), policyIdentifier, objSession, cautils.NewProgressHandler(""))
 	}, "Cluster named .*eks.* without a cloud config panics on cluster scan !")
 
 	assert.NotPanics(t, func() {
 		objSession.Metadata.ScanMetadata.ScanningTarget = reportv2.File
-		policyHandler.getResources(context.TODO(), policyIdentifier, objSession)
+		policyHandler.getResources(context.TODO(), policyIdentifier, objSession, cautils.NewProgressHandler(""))
 	}, "Cluster named .*eks.* without a cloud config panics on non-cluster scan !")
 
 }

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/pkg/opaprocessor"
 )
 
 // FileResourceHandler handle resources from files and URLs
@@ -31,7 +32,7 @@ func NewFileResourceHandler(_ context.Context, inputPatterns []string, registryA
 	}
 }
 
-func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessionObj *cautils.OPASessionObj, _ *armotypes.PortalDesignator) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error) {
+func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessionObj *cautils.OPASessionObj, _ *armotypes.PortalDesignator, progressListener opaprocessor.IJobProgressNotificationClient) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error) {
 
 	//
 	// build resources map

--- a/core/pkg/resourcehandler/resourceshandler.go
+++ b/core/pkg/resourcehandler/resourceshandler.go
@@ -6,10 +6,11 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
+	"github.com/kubescape/kubescape/v2/core/pkg/opaprocessor"
 	"k8s.io/apimachinery/pkg/version"
 )
 
 type IResourceHandler interface {
-	GetResources(context.Context, *cautils.OPASessionObj, *armotypes.PortalDesignator) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error)
+	GetResources(context.Context, *cautils.OPASessionObj, *armotypes.PortalDesignator, opaprocessor.IJobProgressNotificationClient) (*cautils.K8SResources, map[string]workloadinterface.IMetadata, *cautils.KSResources, error)
 	GetClusterAPIServerInfo(ctx context.Context) *version.Info
 }


### PR DESCRIPTION
## Overview
The PR add a progress bar during cloud resource download in order to return a feedback to the user, since this process can take a while.

## Additional Information
As alternative, we can use the already existing spinner, but it doesn't not return a real feedback to the user.

## How to Test
Test it against an **EKS** cluster, since currently it is the provider where we retrive more information.
 
## Related issues/PRs:

Here you add related issues and PRs.
* https://github.com/kubescape/kubescape/issues/1145

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
