### PR TITLE
Invoke packaging workflow to update after release

### DIFF
--- a/.github/workflows/03-post-release.yaml
+++ b/.github/workflows/03-post-release.yaml
@@ -17,18 +17,21 @@ jobs:
           file-name: kubescape-release-digests
       - name: Invoke workflow to update packaging
         uses: benc-uk/workflow-dispatch@v1
+        if: github.repository_owner == 'kubescape'
         with:
           workflow: release.yml
           repo: kubescape/packaging
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Invoke workflow to update homebrew tap
         uses: benc-uk/workflow-dispatch@v1
+        if: github.repository_owner == 'kubescape'
         with:
           workflow: release.yml
           repo: kubescape/homebrew-tap
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Invoke workflow to update github action
         uses: benc-uk/workflow-dispatch@v1
+        if: github.repository_owner == 'kubescape'
         with:
           workflow: release.yml
           repo: kubescape/github-action

--- a/.github/workflows/03-post-release.yaml
+++ b/.github/workflows/03-post-release.yaml
@@ -27,3 +27,9 @@ jobs:
           workflow: release.yml
           repo: kubescape/homebrew-tap
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Invoke workflow to update github action
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release.yml
+          repo: kubescape/github-action
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/03-post-release.yaml
+++ b/.github/workflows/03-post-release.yaml
@@ -1,4 +1,4 @@
-name: 03-create_release_digests
+name: 03-post_release
 on:
   release:
     types: [published]
@@ -6,7 +6,7 @@ on:
       - 'master'
       - 'main'
 jobs:
-  create_release_digests:
+  post_release:
     name: Creating digests
     runs-on: ubuntu-latest
     steps:
@@ -15,3 +15,15 @@ jobs:
         with:
           hash-type: sha1
           file-name: kubescape-release-digests
+      - name: Invoke workflow to update packaging
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release.yml
+          repo: kubescape/packaging
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Invoke workflow to update homebrew tap
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release.yml
+          repo: kubescape/homebrew-tap
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Overview
Invoke packaging workflow to update after release.

Wait for:
- Transferring the [packaging repo](https://github.com/HollowMan6/packaging) under kubescape org: https://github.com/kubescape/kubescape/issues/1143#issuecomment-1497306913
- https://github.com/kubescape/homebrew-tap/pull/7 gets merged.
- https://github.com/kubescape/github-action/pull/38 gets merged.
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

Remember to add the **read and write** access to `Actions` for the GitHub Personal Access Token `secrets.GH_PERSONAL_ACCESS_TOKEN` with repo `kubescape/packaging` and `kubescape/homebrew-tap`. 

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
