### PR TITLE
Fix: Empty Frameworks Column when listing controls

### DIFF
--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -78,12 +78,12 @@ func (drp *DownloadReleasedPolicy) ListControls() ([]string, error) {
 	}
 	var controlsFrameworksList [][]string
 	for _, control := range controls {
-		controlsFrameworksList = append(controlsFrameworksList, control.FrameworkNames)
+		controlsFrameworksList = append(controlsFrameworksList, drp.gs.GetOpaFrameworkListByControlID(control.ControlID))
 	}
 	controlsNamesWithIDsandFrameworksList := make([]string, len(controlsIDsList))
 	// by design all slices have the same lengt
 	for i := range controlsIDsList {
-		controlsNamesWithIDsandFrameworksList[i] = fmt.Sprintf("%v|%v|%v", controlsIDsList[i], controlsNamesList[i], strings.Join(controlsFrameworksList[i], ","))
+		controlsNamesWithIDsandFrameworksList[i] = fmt.Sprintf("%v|%v|%v", controlsIDsList[i], controlsNamesList[i], strings.Join(controlsFrameworksList[i], ", "))
 	}
 	return controlsNamesWithIDsandFrameworksList, nil
 }


### PR DESCRIPTION
## Overview
The controls derived from `*DownloadReleasedPolicy.gs.getOPAControls()` do not have their `Frameworks` field filled. 
So, the alternative to get the `FrameworkNames` is by using `gs.GetOpaFrameworkListByControlID()`. Fixes one problem of #1176 .


`list controls` After Changes:
![list controls](https://github.com/suhasgumma/ImagesForGitHub/blob/master/framework%20display.png?raw=true)

