### PR TITLE
feat: add log coupling for hostsensorutils

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorgetfrompod.go
+++ b/core/pkg/hostsensorutils/hostsensorgetfrompod.go
@@ -84,12 +84,17 @@ func (hsh *HostSensorHandler) sendAllPodsHTTPGETRequest(ctx context.Context, pat
 	podList := hsh.getPodList()
 	res := make([]hostsensor.HostSensorDataEnvelope, 0, len(podList))
 	var wg sync.WaitGroup
+
 	// initialization of the channels
 	hsh.workerPool.init(len(podList))
 
+	// log is used to avoid log duplication
+	// coming from the different host-scanner instances
+	log := NewLogCoupling()
+
 	hsh.workerPool.hostSensorApplyJobs(podList, path, requestKind)
 	hsh.workerPool.hostSensorGetResults(&res)
-	hsh.workerPool.createWorkerPool(ctx, hsh, &wg)
+	hsh.workerPool.createWorkerPool(ctx, hsh, &wg, log)
 	hsh.workerPool.waitForDone(&wg)
 
 	return res, nil

--- a/core/pkg/hostsensorutils/log_coupling.go
+++ b/core/pkg/hostsensorutils/log_coupling.go
@@ -1,0 +1,51 @@
+package hostsensorutils
+
+import "sync"
+
+type LogsMap struct {
+	// use sync.Mutex to avoid read/write
+	// access issues in multi-thread environments.
+	sync.Mutex
+	usedLogs map[string]int
+}
+
+// NewLogCoupling return an empty LogsMap struct ready to be used.
+func NewLogCoupling() *LogsMap {
+	return &LogsMap{
+		usedLogs: make(map[string]int),
+	}
+}
+
+// update add the logContent to the internal map
+// and set the occurrencty to 1 (if it has never been used before),
+// increment its values otherwise.
+func (lm *LogsMap) update(logContent string) {
+	lm.Lock()
+	_, ok := lm.usedLogs[logContent]
+	if !ok {
+		lm.usedLogs[logContent] = 1
+	} else {
+		lm.usedLogs[logContent]++
+	}
+	lm.Unlock()
+}
+
+// isDuplicated check if logContent is already present inside the internal map.
+// Return true in case logContent already exists, false otherwise.
+func (lm *LogsMap) isDuplicated(logContent string) bool {
+	lm.Lock()
+	_, ok := lm.usedLogs[logContent]
+	lm.Unlock()
+	return ok
+}
+
+// GgtOccurrence retrieve the number of occurrences logContent has been used.
+func (lm *LogsMap) getOccurrence(logContent string) int {
+	lm.Lock()
+	occurrence, ok := lm.usedLogs[logContent]
+	lm.Unlock()
+	if !ok {
+		return 0
+	}
+	return occurrence
+}

--- a/core/pkg/hostsensorutils/log_coupling_test.go
+++ b/core/pkg/hostsensorutils/log_coupling_test.go
@@ -1,0 +1,100 @@
+package hostsensorutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogsMap_Update(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		logs        []string
+		expectedLog string
+		expected    int
+	}{
+		{
+			name: "test_1",
+			logs: []string{
+				"log_1",
+				"log_1",
+				"log_1",
+			},
+			expectedLog: "log_1",
+			expected:    3,
+		},
+		{
+			name:        "test_2",
+			logs:        []string{},
+			expectedLog: "log_2",
+			expected:    0,
+		},
+		{
+			name: "test_3",
+			logs: []string{
+				"log_3",
+			},
+			expectedLog: "log_3",
+			expected:    1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lm := NewLogCoupling()
+			for _, log := range tt.logs {
+				lm.update(log)
+			}
+			if !assert.Equal(t, lm.getOccurrence(tt.expectedLog), tt.expected) {
+				t.Log("log occurrences are different")
+			}
+		})
+	}
+}
+
+func TestLogsMap_IsDuplicated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		logs        []string
+		expectedLog string
+		expected    bool
+	}{
+		{
+			name: "test_1",
+			logs: []string{
+				"log_1",
+				"log_1",
+				"log_1",
+			},
+			expectedLog: "log_1",
+			expected:    true,
+		},
+		{
+			name: "test_2",
+			logs: []string{
+				"log_1",
+				"log_1",
+			},
+			expectedLog: "log_2",
+			expected:    false,
+		},
+		{
+			name:        "test_3",
+			logs:        []string{},
+			expectedLog: "log_3",
+			expected:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lm := NewLogCoupling()
+			for _, log := range tt.logs {
+				lm.update(log)
+			}
+			if !assert.Equal(t, lm.isDuplicated(tt.expectedLog), tt.expected) {
+				t.Log("duplication value differ from expected")
+			}
+		})
+	}
+}

--- a/core/pkg/hostsensorutils/logging_messages.go
+++ b/core/pkg/hostsensorutils/logging_messages.go
@@ -1,0 +1,10 @@
+package hostsensorutils
+
+// messages used for warnings
+var (
+	failedToGetData                     = "failed to get data"
+	failedToTeardownNamespace           = "failed to teardown Namespace"
+	oneHostSensorPodIsUnabledToSchedule = "One host-sensor pod is unable to schedule on node. We will fail to collect the data from this node"
+	failedToWatchOverDaemonSetPods      = "failed to watch over DaemonSet pods"
+	failedToValidateHostSensorPodStatus = "failed to validate host-scanner pods status"
+)


### PR DESCRIPTION
## Overview
This PR add the possibility to couple logs coming from different nodes for the `host-scanner`.
To avoid logs duplication, we store them temporary in struct to keep track of them and check if they have already been used during the program execution.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test
To test this feature we need to force some kind of error/warning from the host-scanner.
To do so, I created an AKS cluster with 3 nodes (every kind of cluster is fine, but we need more than 1 nodes).
I updated the host-scanner version in the manifest to install it.
Here's the updated file:
```
apiVersion: v1
kind: Namespace
metadata:
  labels:
    app: kubescape-host-scanner
    k8s-app: kubescape-host-scanner
    kubernetes.io/metadata.name: kubescape-host-scanner
    tier: kubescape-host-scanner-control-plane
  name: kubescape-host-scanner
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: host-scanner
  namespace: kubescape-host-scanner
  labels:
    app: host-scanner
    k8s-app: kubescape-host-scanner
    otel: enabled
spec:
  selector:
    matchLabels:
      name: host-scanner
  template:
    metadata:
      labels:
        name: host-scanner
    spec:
      tolerations:
      # this toleration is to have the DaemonDet runnable on all nodes (including masters)
      # remove it if your masters can't run pods
      - operator: Exists
      containers:
      - name: host-sensor
        image: quay.io/kubescape/host-scanner:v1.0.57
        securityContext:
          allowPrivilegeEscalation: true
          privileged: true
          readOnlyRootFilesystem: true
          procMount: Unmasked
        ports:
          - name: scanner # Do not change port name
            containerPort: 7888
            protocol: TCP
        resources:
          limits:
            cpu: 0.1m
            memory: 200Mi
          requests:
            cpu: 1m
            memory: 200Mi
        volumeMounts:
        - mountPath: /host_fs
          name: host-filesystem
        readinessProbe:
          httpGet:
            path: /kernelVersion
            port: 7888
            initialDelaySeconds: 1
            periodSeconds: 1
      terminationGracePeriodSeconds: 120
      dnsPolicy: ClusterFirstWithHostNet
      automountServiceAccountToken: false
      volumes:
      - hostPath:
          path: /
          type: Directory
        name: host-filesystem
      hostPID: true
      hostIPC: true
```
This file has the latest version of `host-scanner`, that removed the `/kubeletconfigurations` endpoint,
so with the current version of **kubescape** (that still search for that endpoint) we can trigger a warning.
The result will be that instead of having 3 warnings, we are going to have just one.

## Related issues/PRs:
Closes https://cyberarmor-io.atlassian.net/browse/SUB-847

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

