### PR TITLE
fix: remove outdated enpoints

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -32,7 +32,7 @@ spec:
       - operator: Exists
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.54
+        image: quay.io/kubescape/host-scanner:v1.0.57
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true


### PR DESCRIPTION
## Overview
Since we removed the `/kubeletconfigurations` endpoint from **host-scanner**, we need to remove it also from **kubescape**.
Here's the PR for **host-scanner**: https://github.com/kubescape/host-scanner/pull/41

## Related issues/PRs:
Fix https://github.com/kubescape/kubescape/issues/1198

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes 
