### PR TITLE
fix(hostsensorutils): fix indentation of probe attributes

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -56,8 +56,8 @@ spec:
           httpGet:
             path: /kernelVersion
             port: 7888
-            initialDelaySeconds: 1
-            periodSeconds: 1
+          initialDelaySeconds: 1
+          periodSeconds: 1
       terminationGracePeriodSeconds: 120
       dnsPolicy: ClusterFirstWithHostNet
       automountServiceAccountToken: false


### PR DESCRIPTION
## Overview
As described [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request) the definition of probes, in out host-scanner manifest, is not correct.
This create issues when we try to apply the yaml file in this way:
```sh
kubectl apply -f https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/hostsensorutils/hostsensor.yaml
Error from server (BadRequest): error when creating "https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/hostsensorutils/hostsensor.yaml": DaemonSet in version "v1" cannot be handled as a DaemonSet: strict decoding error: unknown field "spec.template.spec.containers[0].readinessProbe.httpGet.initialDelaySeconds", unknown field "spec.template.spec.containers[0].readinessProbe.httpGet.periodSeconds"
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
