### PR TITLE
change basic auth username to x-token-auth

### DIFF
--- a/core/pkg/resourcehandler/remotegitutils.go
+++ b/core/pkg/resourcehandler/remotegitutils.go
@@ -80,7 +80,7 @@ func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 			return "", getProviderError(gitURL)
 		}
 		auth = &http.BasicAuth{
-			Username: "anything Except Empty String",
+			Username: "x-token-auth",
 			Password: gitURL.GetToken(),
 		}
 	}


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
In a call with a customer we saw with @yossi77 that the authentication failed with a private BitBucket repo.
After debugging it seems that BitBucket expects a special username `x-token-auth`.
TODO: in the future allow customers to specify a username ?

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
