### PR TITLE
Deprecate kubescape-windows-latest

### DIFF
--- a/.github/workflows/c-create-release.yaml
+++ b/.github/workflows/c-create-release.yaml
@@ -30,11 +30,6 @@ jobs:
         id: download-artifact
         with:
           path: .
-
-      # TODO: kubescape-windows-latest is deprecated and should be removed
-      - name: Get kubescape.exe from kubescape-windows-latest
-        run: cp ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }} ./kubescape-${{ env.WINDOWS_OS }}/kubescape.exe
-
       - name: Set release token
         run: |
           if [ "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" != "" ]; then
@@ -52,9 +47,7 @@ jobs:
           draft: ${{ inputs.DRAFT }}
           fail_on_unmatched_files: true
           prerelease: false
-          # TODO: kubescape-windows-latest is deprecated and should be removed
           files: |
-            ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.sha256
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.tar.gz

--- a/build.py
+++ b/build.py
@@ -26,9 +26,7 @@ def get_build_dir():
 
 def get_package_name():
     if CURRENT_PLATFORM not in platformSuffixes: raise OSError("Platform %s is not supported!" % (CURRENT_PLATFORM))
-
-    # # TODO: kubescape-windows-latest is deprecated and should be removed
-    # if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
+    if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
 
     package_name = "kubescape-"
     if os.getenv("GOARCH"):


### PR DESCRIPTION
## Overview

As promised in https://github.com/kubescape/kubescape/pull/1169#issuecomment-1515931241 , You can choose to deprecate `kubescape-windows-latest` whenever you feel ready.
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
