### PR TITLE
feat: Add the debugging ability for scanning Helm chart

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -58,6 +58,7 @@ type OPASessionObj struct {
 	OmitRawResources      bool                               // omit raw resources from output
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
+	TemplateMapping       map[string]MappingNodes // Map chart obj to template (only for rendering from path)
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo) *OPASessionObj {
@@ -74,6 +75,7 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		SessionID:             scanInfo.ScanID,
 		Metadata:              scanInfoToScanMetadata(ctx, scanInfo),
 		OmitRawResources:      scanInfo.OmitRawResources,
+		TemplateMapping:       make(map[string]MappingNodes),
 	}
 }
 

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -38,7 +38,7 @@ type Chart struct {
 }
 
 // LoadResourcesFromHelmCharts scans a given path (recursively) for helm charts, renders the templates and returns a map of workloads and a map of chart names
-func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, map[string]Chart) {
+func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, map[string]Chart, map[string]MappingNodes) {
 	directories, _ := listDirs(basePath)
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
@@ -49,14 +49,16 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 
 	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
 	sourceToChart := make(map[string]Chart, 0)
+	sourceToNodes := map[string]MappingNodes{}
 	for _, helmDir := range helmDirectories {
 		chart, err := NewHelmChart(helmDir)
 		if err == nil {
-			wls, errs := chart.GetWorkloadsWithDefaultValues()
+			wls, templateToNodes, errs := chart.GetWorkloadsWithDefaultValues()
 			if len(errs) > 0 {
 				logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering of Helm chart template '%s', failed: %v", chart.GetName(), errs))
 				continue
 			}
+			sourceToNodes = templateToNodes
 
 			chartName := chart.GetName()
 			for k, v := range wls {
@@ -66,9 +68,12 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 					Path: helmDir,
 				}
 			}
+			// for k, v := range templateMappings {
+			// 	sourceToNodes[k] = v
+			// }
 		}
 	}
-	return sourceToWorkloads, sourceToChart
+	return sourceToWorkloads, sourceToChart, sourceToNodes
 }
 
 // If the contents at given path is a Kustomize Directory, LoadResourcesFromKustomizeDirectory will

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -45,10 +45,11 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
-	sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath())
+	sourceToWorkloads, sourceToChartName, _ := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath())
 	assert.Equal(t, 6, len(sourceToWorkloads))
 
 	for file, workloads := range sourceToWorkloads {
+
 		assert.Equalf(t, 1, len(workloads), "expected 1 workload in file %s", file)
 
 		w := workloads[0]

--- a/core/cautils/helmchart.go
+++ b/core/cautils/helmchart.go
@@ -3,7 +3,6 @@ package cautils
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -48,15 +47,15 @@ func (hc *HelmChart) GetDefaultValues() map[string]interface{} {
 }
 
 // GetWorkloads renders chart template using the default values and returns a map of source file to its workloads
-func (hc *HelmChart) GetWorkloadsWithDefaultValues() (map[string][]workloadinterface.IMetadata, []error) {
+func (hc *HelmChart) GetWorkloadsWithDefaultValues() (map[string][]workloadinterface.IMetadata, map[string]MappingNodes, []error) {
 	return hc.GetWorkloads(hc.GetDefaultValues())
 }
 
 // GetWorkloads renders chart template using the provided values and returns a map of source (absolute) file path to its workloads
-func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]workloadinterface.IMetadata, []error) {
+func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]workloadinterface.IMetadata, map[string]MappingNodes, []error) {
 	vals, err := helmchartutil.ToRenderValues(hc.chart, values, helmchartutil.ReleaseOptions{}, nil)
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
 	// change the chart to template with comment, only is template(.yaml added otherwise no)
@@ -64,14 +63,14 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 
 	sourceToFile, err := helmengine.Render(hc.chart, vals)
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
 	// get the resouse and analysis and store it to the struct
-	fileMapping := NewFileMapping()
+	fileMapping := make(map[string]MappingNodes)
 	err = GetTemplateMapping(sourceToFile, fileMapping)
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
 	// delete the comment from chart and from sourceToFile
@@ -95,6 +94,11 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 		if firstPathSeparatorIndex := strings.Index(path, string("/")); firstPathSeparatorIndex != -1 {
 			absPath := filepath.Join(hc.path, path[firstPathSeparatorIndex:])
 
+			if nodes, ok := fileMapping[path]; ok {
+				fileMapping[absPath] = nodes
+				delete(fileMapping, path)
+			}
+
 			workloads[absPath] = []workloadinterface.IMetadata{}
 			for i := range wls {
 				lw := localworkload.NewLocalWorkload(wls[i].GetObject())
@@ -103,7 +107,7 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 			}
 		}
 	}
-	return workloads, errs
+	return workloads, fileMapping, errs
 }
 
 func (hc *HelmChart) AddCommentToTemplate() {
@@ -124,7 +128,7 @@ func (hc *HelmChart) AddCommentToTemplate() {
 }
 
 func RemoveComment(sourceToFile map[string]string) {
-	commentRe := regexp.MustCompile(CommentFormat)
+	// commentRe := regexp.MustCompile(CommentFormat)
 	for fileName, file := range sourceToFile {
 		if !IsYaml(strings.ToLower((fileName))) {
 			continue
@@ -133,14 +137,16 @@ func RemoveComment(sourceToFile map[string]string) {
 	}
 }
 
-func GetTemplateMapping(sourceToFile map[string]string, fileMapping *FileMapping) error {
+func GetTemplateMapping(sourceToFile map[string]string, fileMapping map[string]MappingNodes) error {
 	for fileName, fileContent := range sourceToFile {
 		mappingNodes, err := GetMapping(fileName, fileContent)
 		if err != nil {
 			err = fmt.Errorf("GetMapping wrong, err: %s", err.Error())
 			return err
 		}
-		fileMapping.Mapping[fileName] = mappingNodes
+		if len(mappingNodes.Nodes) != 0 {
+			fileMapping[fileName] = *mappingNodes
+		}
 	}
 	return nil
 }

--- a/core/cautils/helmchart_test.go
+++ b/core/cautils/helmchart_test.go
@@ -83,7 +83,7 @@ func (s *HelmChartTestSuite) TestGetWorkloadsWithOverride() {
 	// Override default value
 	values["image"].(map[string]interface{})["pullPolicy"] = "Never"
 
-	fileToWorkloads, errs := chart.GetWorkloads(values)
+	fileToWorkloads, _, errs := chart.GetWorkloads(values)
 	s.Len(errs, 0)
 
 	s.Lenf(fileToWorkloads, len(s.expectedFiles), "Expected %d files", len(s.expectedFiles))
@@ -111,7 +111,7 @@ func (s *HelmChartTestSuite) TestGetWorkloadsMissingValue() {
 	values := chart.GetDefaultValues()
 	delete(values, "image")
 
-	fileToWorkloads, errs := chart.GetWorkloads(values)
+	fileToWorkloads, _, errs := chart.GetWorkloads(values)
 	s.Nil(fileToWorkloads)
 	s.Len(errs, 1, "Expected an error due to missing value")
 

--- a/core/cautils/mappingnode.go
+++ b/core/cautils/mappingnode.go
@@ -14,12 +14,8 @@ type MappingNode struct {
 }
 
 type MappingNodes struct {
-	Nodes            []MappingNode //Map line number of chart to template obj
+	Nodes            map[string]MappingNode //Map line number of chart to template obj map[int]MappingNode
 	TemplateFileName string
-}
-
-type FileMapping struct {
-	Mapping map[string]*MappingNodes
 }
 
 func (node *MappingNode) writeInfoToNode(objectID *ObjectID, path string, lineNumber int, value string, fileName string) {
@@ -31,15 +27,10 @@ func (node *MappingNode) writeInfoToNode(objectID *ObjectID, path string, lineNu
 	return
 }
 
-func NewFileMapping() *FileMapping {
-	fileMapping := new(FileMapping)
-	fileMapping.Mapping = make(map[string]*MappingNodes)
-	return fileMapping
-}
+func NewMappingNodes() *MappingNodes {
+	mappingNodes := new(MappingNodes)
+	mappingNodes.Nodes = make(map[string]MappingNode)
+	mappingNodes.TemplateFileName = ""
+	return mappingNodes
 
-// func NewMappingNodes() *MappingNodes {
-// 	mappingNodes := new(MappingNodes)
-// 	mappingNodes.Nodes = make(map[int]MappingNode)
-// 	mappingNodes.TemplateFileName = ""
-// 	return mappingNodes
-// }
+}

--- a/core/cautils/mappingnode.go
+++ b/core/cautils/mappingnode.go
@@ -1,0 +1,45 @@
+package cautils
+
+type ObjectID struct {
+	apiVersion string
+	kind       string
+}
+
+type MappingNode struct {
+	ObjectID           *ObjectID
+	Field              string
+	Value              string
+	TemplateFileName   string
+	TemplateLineNumber int
+}
+
+type MappingNodes struct {
+	Nodes            []MappingNode //Map line number of chart to template obj
+	TemplateFileName string
+}
+
+type FileMapping struct {
+	Mapping map[string]*MappingNodes
+}
+
+func (node *MappingNode) writeInfoToNode(objectID *ObjectID, path string, lineNumber int, value string, fileName string) {
+	node.Field = path
+	node.TemplateLineNumber = lineNumber
+	node.ObjectID = objectID
+	node.Value = value
+	node.TemplateFileName = fileName
+	return
+}
+
+func NewFileMapping() *FileMapping {
+	fileMapping := new(FileMapping)
+	fileMapping.Mapping = make(map[string]*MappingNodes)
+	return fileMapping
+}
+
+// func NewMappingNodes() *MappingNodes {
+// 	mappingNodes := new(MappingNodes)
+// 	mappingNodes.Nodes = make(map[int]MappingNode)
+// 	mappingNodes.TemplateFileName = ""
+// 	return mappingNodes
+// }

--- a/core/cautils/mappingnode.go
+++ b/core/cautils/mappingnode.go
@@ -24,7 +24,6 @@ func (node *MappingNode) writeInfoToNode(objectID *ObjectID, path string, lineNu
 	node.ObjectID = objectID
 	node.Value = value
 	node.TemplateFileName = fileName
-	return
 }
 
 func NewMappingNodes() *MappingNodes {

--- a/core/cautils/mappingnode.go
+++ b/core/cautils/mappingnode.go
@@ -14,7 +14,7 @@ type MappingNode struct {
 }
 
 type MappingNodes struct {
-	Nodes            map[string]MappingNode //Map line number of chart to template obj map[int]MappingNode
+	Nodes            []map[string]MappingNode //Map line number of chart to template obj map[int]MappingNode
 	TemplateFileName string
 }
 
@@ -28,7 +28,6 @@ func (node *MappingNode) writeInfoToNode(objectID *ObjectID, path string, lineNu
 
 func NewMappingNodes() *MappingNodes {
 	mappingNodes := new(MappingNodes)
-	mappingNodes.Nodes = make(map[string]MappingNode)
 	mappingNodes.TemplateFileName = ""
 	return mappingNodes
 

--- a/core/cautils/parseFile.go
+++ b/core/cautils/parseFile.go
@@ -1,0 +1,217 @@
+package cautils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+)
+
+const (
+	CommentFormat = `#This is the (?P<line>\d*) line`
+)
+
+var apiVersionRe = regexp.MustCompile(`apiVersion: (?P<apiVersion>\S*)`)
+var kindRe = regexp.MustCompile(`kind: (?P<kind>\S*)`)
+var pathRe = regexp.MustCompile(`path: (?P<path>\S*)`)
+var typeRe = regexp.MustCompile(`type: '(?P<type>\S*)'`)
+var valueRe = regexp.MustCompile(`value: (?P<value>\[.+\]|\S*)`)
+var commentRe = regexp.MustCompile(CommentFormat)
+
+// change to use go func
+func GetMapping(fileName string, fileContent string) (*MappingNodes, error) {
+
+	node := new(MappingNode)
+	objectID := new(ObjectID)
+	mappingNodes := new(MappingNodes)
+	// mappingNodes := NewMappingNodes()
+	mappingNodes.TemplateFileName = fileName
+
+	lines := strings.Split(fileContent, "\n")
+
+	lastNumber := -1
+	reducedNumber := -1 // uses to make sure line and line in yq is the same
+
+	isApiVersionEmpty := true
+	isKindEmpty := true
+
+	for i, line := range lines {
+		index := i
+		if apiVersionRe.MatchString(line) {
+			apiVersion := extractParameter(apiVersionRe, line, "$apiVersion")
+			if apiVersion == "" {
+				err := fmt.Errorf("Something wrong when extracting the apiVersion, the line is %s\n", line)
+				return nil, err
+			}
+			objectID.apiVersion = apiVersion
+			isApiVersionEmpty = false
+			if reducedNumber == -1 {
+				reducedNumber = index + reducedNumber
+			}
+			continue
+		} else if kindRe.MatchString(line) {
+			kind := extractParameter(kindRe, line, "$kind")
+			if kind == "" {
+				err := fmt.Errorf("Something wrong when extracting the kind, the line is %s\n", line)
+				return nil, err
+			}
+			objectID.kind = kind
+			isKindEmpty = false
+			continue
+		} else if isApiVersionEmpty == false || isKindEmpty == false {
+			// not sure if it can go to the end
+			index = index - reducedNumber
+			output, err := getYamlLineInfo(index, fileContent)
+			if err != nil {
+				err := fmt.Errorf("getYamlLineInfo wrong, the err is %s\n", err.Error())
+				return nil, err
+			}
+			// fmt.Println(output)
+			path := extractParameter(pathRe, output, "$path")
+			//if path is empty, continue
+			if path != "" && path != "\"\"" {
+				if isApiVersionEmpty == true || isKindEmpty == true {
+					err := fmt.Errorf("There is no enough objectID info")
+					return nil, err
+				}
+				splits := strings.Split(output, "dest")
+				if len(splits) < 2 {
+					err := fmt.Errorf("Something wrong with the length of the splits, which is %d", len(splits))
+					return nil, err
+				} else {
+					// cut the redundant one
+					splits = splits[1:]
+					for _, split := range splits {
+						path := extractParameter(pathRe, split, "$path")
+						pathType := extractParameter(typeRe, split, "$type")
+						mapMatched, err := regexp.MatchString(`!!map`, pathType)
+						if err != nil {
+							err = fmt.Errorf("regexp.MatchString err: %s", err.Error())
+						}
+						if mapMatched {
+							newlastNumber, err := writeNodeInfo(split, lastNumber, path, fileName, node, objectID, true)
+							lastNumber = newlastNumber
+							if err != nil {
+								err = fmt.Errorf("map type: writeNodeInfo wrong err: %s", err.Error())
+								return nil, err
+							}
+							mappingNodes.Nodes = append(mappingNodes.Nodes, *node)
+						} else {
+							newlastNumber, err := writeNodeInfo(split, lastNumber, path, fileName, node, objectID, false)
+							lastNumber = newlastNumber
+							if err != nil {
+								err = fmt.Errorf("not map type: writeNodeInfo wrong err: %s", err.Error())
+								return nil, err
+							}
+							mappingNodes.Nodes = append(mappingNodes.Nodes, *node)
+						}
+
+					}
+				}
+			}
+
+		}
+	}
+	return mappingNodes, nil
+}
+
+func New(MappingNodes MappingNodes) {
+	panic("unimplemented")
+}
+
+func writeNodeInfo(split string, lastNumber int, path string, fileName string, node *MappingNode, objectID *ObjectID, isMapType bool) (int, error) {
+	value, lineNumber, newLastNumber, err := getInfoFromOne(split, lastNumber, isMapType)
+	if err != nil {
+		err = fmt.Errorf("getInfoFromOne wrong err: %s", err.Error())
+		return -1, err
+	}
+	lastNumber = newLastNumber
+	node.writeInfoToNode(objectID, path, lineNumber, value, fileName)
+	return lastNumber, nil
+}
+
+func getInfoFromOne(output string, lastNumber int, isMapType bool) (value string, lineNumber int, newLastNumber int, err error) {
+	if isMapType == true {
+		value = ""
+	} else {
+		value = extractParameter(valueRe, output, "$value")
+	}
+	number := extractParameter(commentRe, output, "$line")
+	if number != "" {
+		lineNumber, err = strconv.Atoi(number)
+		if err != nil {
+			err = fmt.Errorf("strconv.Atoi err: %s", err.Error())
+			return "", -1, -1, err
+		}
+		if isMapType == true {
+			lineNumber = lineNumber - 1
+		}
+		lastNumber = lineNumber
+		// save to structure
+	} else {
+		lineNumber = lastNumber
+		// use the last one number
+	}
+	newLastNumber = lineNumber
+	return value, lineNumber, newLastNumber, nil
+}
+
+func getYamlLineInfo(index int, yamlFile string) (string, error) {
+	expression := `..| select(line == ` + strconv.Itoa(index) + `)| {"destpath": path | join("."),"type": type,"value": .}`
+	out, err := exectuateYq(expression, yamlFile)
+	if err != nil {
+		err = fmt.Errorf("exectuateYq err: %s", err.Error())
+		return "", err
+	}
+	return out, nil
+}
+
+func exectuateYq(expression string, yamlContent string) (string, error) {
+
+	encoder := configureEncoder()
+
+	decoder := configureDecoder(false)
+
+	stringEvaluator := yqlib.NewStringEvaluator()
+
+	out, err := stringEvaluator.Evaluate(expression, yamlContent, encoder, decoder)
+	if err != nil {
+		return "", errors.New("no matches found")
+	}
+	return out, err
+}
+
+func extractParameter(re *regexp.Regexp, line string, keyword string) string {
+	submatch := re.FindStringSubmatchIndex(line)
+	result := []byte{}
+	result = re.ExpandString(result, keyword, line, submatch)
+	parameter := string(result)
+	return parameter
+}
+
+//yqlib configuration
+
+func configurePrinterWriter(out io.Writer) yqlib.PrinterWriter {
+	var printerWriter yqlib.PrinterWriter
+	printerWriter = yqlib.NewSinglePrinterWriter(out)
+
+	return printerWriter
+}
+
+func configureEncoder() yqlib.Encoder {
+	indent := 2
+	colorsEnabled := false
+	yqlibEncoder := yqlib.NewYamlEncoder(indent, colorsEnabled, yqlib.ConfiguredYamlPreferences)
+	return yqlibEncoder
+}
+
+func configureDecoder(evaluateTogether bool) yqlib.Decoder {
+	prefs := yqlib.ConfiguredYamlPreferences
+	prefs.EvaluateTogether = evaluateTogether
+	yqlibDecoder := yqlib.NewYamlDecoder(prefs)
+	return yqlibDecoder
+}

--- a/core/cautils/parseFile.go
+++ b/core/cautils/parseFile.go
@@ -69,18 +69,18 @@ func GetMapping(fileName string, fileContent string) (*MappingNodes, error) {
 			expression := fmt.Sprintf(lineExpression, index)
 			output, err := getYamlLineInfo(expression, fileContent)
 			if err != nil {
-				return nil, fmt.Errorf("getYamlLineInfo wrong, the err is %s\n", err.Error())
+				return nil, fmt.Errorf("getYamlLineInfo wrong, the err is %s", err.Error())
 			}
 
 			path := extractParameter(pathRe, output, "$path")
 			//if path is empty, continue
 			if path != "" && path != "\"\"" {
 				if isApiVersionEmpty || isKindEmpty {
-					return nil, fmt.Errorf("There is no enough objectID info")
+					return nil, fmt.Errorf("there is no enough objectID info")
 				}
 				splits := strings.Split(output, "dest")
 				if len(splits) < 2 {
-					return nil, fmt.Errorf("Something wrong with the length of the splits, which is %d", len(splits))
+					return nil, fmt.Errorf("something wrong with the length of the splits, which is %d", len(splits))
 				} else {
 					// cut the redundant one
 					splits = splits[1:]
@@ -127,7 +127,7 @@ func writeNoteToMapping(split string, lastNumber int, path string, fileName stri
 	if _, ok := mappingNodes.Nodes[path]; !ok {
 		mappingNodes.Nodes[path] = *node
 	} else {
-		return 0, fmt.Errorf("isMapType: %v, %s in mapping.Nodes exists, err: %s", isMapType, path, err.Error())
+		return 0, fmt.Errorf("isMapType: %v, %s in mapping.Nodes exists", isMapType, path)
 	}
 	return newlastNumber, nil
 }
@@ -197,7 +197,7 @@ func exectuateYq(expression string, yamlContent string) (string, error) {
 func extractApiVersion(line string, objectID *ObjectID) (bool, error) {
 	apiVersion := extractParameter(apiVersionRe, line, "$apiVersion")
 	if apiVersion == "" {
-		return true, fmt.Errorf("Something wrong when extracting the apiVersion, the line is %s\n", line)
+		return true, fmt.Errorf("something wrong when extracting the apiVersion, the line is %s", line)
 	}
 	objectID.apiVersion = apiVersion
 	return false, nil
@@ -206,7 +206,7 @@ func extractApiVersion(line string, objectID *ObjectID) (bool, error) {
 func extractKind(line string, objectID *ObjectID) (bool, error) {
 	kind := extractParameter(kindRe, line, "$kind")
 	if kind == "" {
-		return true, fmt.Errorf("Something wrong when extracting the kind, the line is %s\n", line)
+		return true, fmt.Errorf("something wrong when extracting the kind, the line is %s", line)
 	}
 	objectID.kind = kind
 	return false, nil

--- a/core/cautils/parseFile_test.go
+++ b/core/cautils/parseFile_test.go
@@ -1,0 +1,79 @@
+package cautils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	helmchartutil "helm.sh/helm/v3/pkg/chartutil"
+	helmengine "helm.sh/helm/v3/pkg/engine"
+)
+
+type HelmChartGetMappingSuite struct {
+	suite.Suite
+	helmChartPath string
+	expectedFiles []string
+	fileContent   map[string]string
+}
+
+func TestHelmChartGetMappingSuite(t *testing.T) {
+	suite.Run(t, new(HelmChartGetMappingSuite))
+}
+
+func (s *HelmChartGetMappingSuite) SetupSuite() {
+	o, _ := os.Getwd()
+
+	s.helmChartPath = filepath.Join(filepath.Dir(o), "..", "examples", "helm_chart_mapping_node")
+
+	s.expectedFiles = []string{
+		filepath.Join(s.helmChartPath, "templates", "clusterrolebinding.yaml"),
+		filepath.Join(s.helmChartPath, "templates", "clusterrole.yaml"),
+		filepath.Join(s.helmChartPath, "templates", "serviceaccount.yaml"),
+		filepath.Join(s.helmChartPath, "templates", "rolebinding.yaml"),
+		filepath.Join(s.helmChartPath, "templates", "role.yaml"),
+		filepath.Join(s.helmChartPath, "templates", "cronjob.yaml"),
+	}
+
+	s.fileContent = make(map[string]string)
+
+	hc, _ := NewHelmChart(s.helmChartPath)
+
+	values := hc.GetDefaultValues()
+
+	vals, _ := helmchartutil.ToRenderValues(hc.chart, values, helmchartutil.ReleaseOptions{}, nil)
+
+	sourceToFile, _ := helmengine.Render(hc.chart, vals)
+
+	s.fileContent = sourceToFile
+
+}
+
+func (s *HelmChartGetMappingSuite) TestGetMapping() {
+	fileNodes, err := GetMapping("rolebinding.yaml", s.fileContent["kubescape/templates/rolebinding.yaml"])
+	s.NoError(err, "Get Mapping nodes correctly")
+	s.Equal(fileNodes.TemplateFileName, "rolebinding.yaml")
+	s.Len(fileNodes.Nodes, 1)
+	s.Len(fileNodes.Nodes[0], 13)
+}
+
+func (s *HelmChartGetMappingSuite) TestGetMappingFromFileContainsMultipleSubFiles() {
+	fileNodes, err := GetMapping("serviceaccount.yaml", s.fileContent["kubescape/templates/serviceaccount.yaml"])
+	s.NoError(err, "Get Mapping nodes correctly")
+	s.Equal(fileNodes.TemplateFileName, "serviceaccount.yaml")
+	s.Len(fileNodes.Nodes, 2)
+	s.Len(fileNodes.Nodes[0], 8)
+	s.Len(fileNodes.Nodes[1], 2)
+}
+
+func (s *HelmChartGetMappingSuite) TestGetMappingFromFileCWithoutKindOrApiVersion() {
+	fileNodes, err := GetMapping("clusterrole.yaml", s.fileContent["kubescape/templates/clusterrole.yaml"])
+	s.Contains(err.Error(), "there is no enough objectID info")
+	s.Nil(fileNodes)
+}
+
+func (s *HelmChartGetMappingSuite) TestGetMappingFromFileCWithoutApiVersion() {
+	fileNodes, err := GetMapping("clusterrolebinding.yaml", s.fileContent["kubescape/templates/clusterrolebinding.yaml"])
+	s.Contains(err.Error(), "there is no enough objectID info")
+	s.Nil(fileNodes)
+}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -121,8 +121,6 @@ func getWorkloadFromHelmChart(ctx context.Context, helmPath, workloadPath string
 
 	helmSourceToWorkloads, helmSourceToChart, helmSourceToNodes := cautils.LoadResourcesFromHelmCharts(ctx, helmPath)
 
-	fmt.Printf("%s", helmSourceToNodes)
-
 	if clonedRepo != "" {
 		workloadPath = clonedRepo + workloadPath
 	}
@@ -141,15 +139,20 @@ func getWorkloadFromHelmChart(ctx context.Context, helmPath, workloadPath string
 		return nil, nil, nil, fmt.Errorf("helmChart not found for workload %s", workloadPath)
 	}
 
+	templatesNodes, ok := helmSourceToNodes[workloadPath]
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("templatesNodes not found for workload %s", workloadPath)
+	}
+
 	workloadSource := getWorkloadSourceHelmChart(repoRoot, helmPath, gitRepo, helmChart)
 
 	workloadIDToSource := make(map[string]reporthandling.Source, 1)
+	workloadIDToNodes := make(map[string]cautils.MappingNodes, 1)
 	workloadIDToSource[wlSource[0].GetID()] = workloadSource
+	workloadIDToNodes[wlSource[0].GetID()] = templatesNodes
 
 	workloads := []workloadinterface.IMetadata{}
 	workloads = append(workloads, wlSource...)
-
-	var workloadIDToNodes map[string]cautils.MappingNodes
 
 	return workloadIDToSource, workloads, workloadIDToNodes, nil
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -160,14 +160,18 @@ func failedPathsToString(control *resourcesresults.ResourceAssociatedControl) []
 	return paths
 }
 
-func fixPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
+func fixPathsToString(control *resourcesresults.ResourceAssociatedControl, onlyPath bool) []string {
 	var paths []string
 
 	for j := range control.ResourceAssociatedRules {
 		for k := range control.ResourceAssociatedRules[j].Paths {
 			if p := control.ResourceAssociatedRules[j].Paths[k].FixPath.Path; p != "" {
-				v := control.ResourceAssociatedRules[j].Paths[k].FixPath.Value
-				paths = append(paths, fmt.Sprintf("%s=%s", p, v))
+				if onlyPath {
+					paths = append(paths, p)
+				} else {
+					v := control.ResourceAssociatedRules[j].Paths[k].FixPath.Value
+					paths = append(paths, fmt.Sprintf("%s=%s", p, v))
+				}
 			}
 		}
 	}
@@ -201,7 +205,7 @@ func reviewPathsToString(control *resourcesresults.ResourceAssociatedControl) []
 }
 
 func AssistedRemediationPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
-	paths := append(fixPathsToString(control), append(deletePathsToString(control), reviewPathsToString(control)...)...)
+	paths := append(fixPathsToString(control, false), append(deletePathsToString(control), reviewPathsToString(control)...)...)
 	// TODO - deprecate failedPaths once all controls support review/delete paths
 	paths = appendFailedPathsIfNotInPaths(paths, failedPathsToString(control))
 	return paths

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -254,16 +254,16 @@ func TestFixPathsToString(t *testing.T) {
 	}
 
 	// Test case 1: Empty ResourceAssociatedRules
-	actualPaths := fixPathsToString(emptyControl)
+	actualPaths := fixPathsToString(emptyControl, false)
 	assert.Nil(t, actualPaths)
 
 	// Test case 2: Single ResourceAssociatedRule and one ReviewPath
-	actualPaths = fixPathsToString(singleRuleControl)
+	actualPaths = fixPathsToString(singleRuleControl, false)
 	expectedPath := []string{"fix-path1=fix-path-value1"}
 	assert.Equal(t, expectedPath, actualPaths)
 
 	// Test case 3: Multiple ResourceAssociatedRules and multiple ReviewPaths
-	actualPaths = fixPathsToString(multipleRulesControl)
+	actualPaths = fixPathsToString(multipleRulesControl, false)
 	expectedPath = []string{"fix-path2=fix-path-value2", "fix-path3=fix-path-value3"}
 	assert.Equal(t, expectedPath, actualPaths)
 }

--- a/examples/helm_chart_mapping_node/Chart.yaml
+++ b/examples/helm_chart_mapping_node/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: kubescape
+description:
+  Kubescape is the first open-source tool for testing if Kubernetes is deployed securely according to multiple frameworks
+  regulatory, customized company policies and DevSecOps best practices, such as the  [NSA-CISA](https://www.armosec.io/blog/kubernetes-hardening-guidance-summary-by-armo) and the [MITRE ATT&CK®](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/) .
+  Kubescape scans K8s clusters, YAML files, and HELM charts, and detect misconfigurations and software vulnerabilities at early stages of the CI/CD pipeline and provides a risk score instantly and risk trends over time.
+  Kubescape integrates natively with other DevOps tools, including Jenkins, CircleCI and Github workflows.
+
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.0.128"

--- a/examples/helm_chart_mapping_node/templates/_helpers.tpl
+++ b/examples/helm_chart_mapping_node/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubescape.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubescape.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubescape.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubescape.labels" -}}
+helm.sh/chart: {{ include "kubescape.chart" . }}
+{{ include "kubescape.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubescape.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubescape.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubescape.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubescape.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/examples/helm_chart_mapping_node/templates/clusterrole.yaml
+++ b/examples/helm_chart_mapping_node/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubescape.fullname" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "describe"]
+

--- a/examples/helm_chart_mapping_node/templates/clusterrolebinding.yaml
+++ b/examples/helm_chart_mapping_node/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubescape.fullname" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubescape.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubescape.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+
+

--- a/examples/helm_chart_mapping_node/templates/configmap.yaml
+++ b/examples/helm_chart_mapping_node/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configMap.create -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "kubescape.fullname" . }}-configmap
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {
+      "customerGUID": "{{ .Values.configMap.params.customerGUID }}",
+      "clusterName": "{{ .Values.configMap.params.clusterName }}"
+    }
+{{- end }}

--- a/examples/helm_chart_mapping_node/templates/cronjob.yaml
+++ b/examples/helm_chart_mapping_node/templates/cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "kubescape.fullname" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .Chart.Name }}
+            image: "{{ .Values.image.repository }}/{{ .Values.image.imageName }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command: ["/bin/sh", "-c"]
+            args: ["kubescape scan framework nsa --submit"]
+            volumeMounts:
+            - name: kubescape-config-volume
+              mountPath: /root/.kubescape/config.json
+              subPath: config.json
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "kubescape.serviceAccountName" . }}
+          volumes:
+          - name: kubescape-config-volume
+            configMap:
+              name: {{ include "kubescape.fullname" . }}-configmap

--- a/examples/helm_chart_mapping_node/templates/role.yaml
+++ b/examples/helm_chart_mapping_node/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kubescape.fullname" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "describe"]
+

--- a/examples/helm_chart_mapping_node/templates/rolebinding.yaml
+++ b/examples/helm_chart_mapping_node/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubescape.fullname" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubescape.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubescape.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+
+

--- a/examples/helm_chart_mapping_node/templates/serviceaccount.yaml
+++ b/examples/helm_chart_mapping_node/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubescape.serviceAccountName" . }}
+  labels:
+    {{- include "kubescape.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubescape.serviceAccountName" . }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/examples/helm_chart_mapping_node/values.yaml
+++ b/examples/helm_chart_mapping_node/values.yaml
@@ -1,0 +1,74 @@
+# Default values for kubescape.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Frequency of running the scan
+#       ┌────────────── timezone (optional)
+#       |  ┌───────────── minute (0 - 59)
+#       |  │ ┌───────────── hour (0 - 23)
+#       |  │ │ ┌───────────── day of the month (1 - 31)
+#       |  │ │ │ ┌───────────── month (1 - 12)
+#       |  │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+#       |  │ │ │ │ │                         7 is also Sunday on some systems)
+#       |  │ │ │ │ │
+#       |  │ │ │ │ │
+#      UTC * * * * *
+schedule: "* * 1 * *"
+
+# -- Image and version to deploy
+image:
+  repository: quay.io/armosec
+  imageName: kubescape
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Service account that runs the scan and has permissions to view the cluster
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kubescape-discovery"
+
+# -- ARMO customer information
+configMap:
+  create: false
+  params:
+    customerGUID: <MyGUID>
+    clusterName: <MyK8sClusterName>
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Default resources for running the service in cluster
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Mapping struct is defined in. 'mappingnode.go'. Three mapping objects are used, the connection among them is that one MappingNode represents one line in one template, MappingNodes represents one template, FileMapping represents one file, and one file can contain many template.
 GetMapping function in GetWorkLoads function is to call yqlib package to form the FileMapping, which is the most important part.
Adding one more output FileMapping for GetWorkLoads function and change all the related functions which call it.
After that, I connect the Filemappingwith sarif Printer. After connecting, I can use the mapping to generate correct location and fixed object for helm chart.

## Additional Information
 Kubescape can scan helm chart files, however, Helm does not give information about which output line is coming from which input line.
For kubescape, there is no backward connection to the original sources file after the chart was templated.
More than that, Kubescape cannot not produce correct fixes for Helm charts.

## How to Test

I have created the unit tests for filemapping in helmchart.go and sarif report.
In addition, I created a Github-action [repository](https://github.com/MMMMMMorty/github-action) where I change docker image to my branch image, so I could test and use my branch there.

## Examples
Here is the result example, the report format is sarif.
[report.sarif.txt](https://github.com/kubescape/kubescape/files/12144718/report.sarif.txt)
For the helm chart object, it has correct locations and recommended fix objects
<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

--> 
