### PR TITLE
Make powershell Windows installation user path available immediately

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -29,8 +29,11 @@ $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if (-not $currentPath.Contains($BASE_DIR)) {
     $confirmation = Read-Host "Add kubescape to user path? (y/n)"
     if ($confirmation -eq 'y') {
-        [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", "User") + ";$BASE_DIR;", "User")
+        $env:Path=[Environment]::GetEnvironmentVariable("Path", "User") + ";$BASE_DIR;"
+        [Environment]::SetEnvironmentVariable("Path", "${env:Path}", "User")
     }
 }
 
-Write-Host "Finished Installation" -ForegroundColor Green 
+Write-Host "Finished Installation.`n" -ForegroundColor Green
+kubescape version
+Write-Host "`nUsage: $ kubescape scan --enable-host-scan" -ForegroundColor Magenta


### PR DESCRIPTION
## Overview
Fix:
![20230502001316](https://user-images.githubusercontent.com/43995067/235533893-ddef707b-9519-4cc2-bf3f-88f1c536e4a2.png)

Test:
```bash
iwr -useb https://raw.githubusercontent.com/HollowMan6/kubescape/install/install.ps1 | iex
```
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
