### PR TITLE
fix: move host-scanner namespace

### DIFF
--- a/core/cautils/getter/testdata/policy.json
+++ b/core/cautils/getter/testdata/policy.json
@@ -25789,7 +25789,7 @@
     },
     {
       "guid": "",
-      "name": "exclude-kubescape-host-scanner-resources",
+      "name": "exclude-host-scanner-resources",
       "attributes": {
         "systemException": true
       },
@@ -25804,7 +25804,7 @@
           "attributes": {
             "kind": "DaemonSet",
             "name": "host-scanner",
-            "namespace": "kubescape-host-scanner"
+            "namespace": "kubescape"
           }
         }
       ],

--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -6,13 +6,13 @@ metadata:
     k8s-app: kubescape-host-scanner
     kubernetes.io/metadata.name: kubescape-host-scanner
     tier: kubescape-host-scanner-control-plane
-  name: kubescape-host-scanner
+  name: kubescape
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: host-scanner
-  namespace: kubescape-host-scanner
+  namespace: kubescape
   labels:
     app: host-scanner
     k8s-app: kubescape-host-scanner

--- a/core/pkg/hostsensorutils/hostsensordeploy_test.go
+++ b/core/pkg/hostsensorutils/hostsensordeploy_test.go
@@ -34,7 +34,7 @@ func TestHostSensorHandler(t *testing.T) {
 			})
 
 			t.Run("should return namespace", func(t *testing.T) {
-				require.Equal(t, "kubescape-host-scanner", h.GetNamespace())
+				require.Equal(t, "kubescape", h.GetNamespace())
 			})
 
 			t.Run("should collect resources from pods - happy path", func(t *testing.T) {

--- a/core/pkg/resultshandling/reporter/v2/testdata/mock_opasessionobj.json
+++ b/core/pkg/resultshandling/reporter/v2/testdata/mock_opasessionobj.json
@@ -62743,7 +62743,7 @@
         },
         {
             "guid": "",
-            "name": "exclude-kubescape-host-scanner-resources",
+            "name": "exclude-host-scanner-resources",
             "attributes": {
                 "systemException": true
             },
@@ -62758,7 +62758,7 @@
                     "attributes": {
                         "kind": "DaemonSet",
                         "name": "host-scanner",
-                        "namespace": "kubescape-host-scanner"
+                        "namespace": "kubescape"
                     }
                 }
             ],


### PR DESCRIPTION
## Overview
In this PR we are moving the previous dedicated **host-scanner**'s namespace (`kubescape-host-scanner`), to the current in use for **kubescape** operator (`kubescape`).
 
## Additional Information
This is useful to avoid communication issues between namespaces when a policy engine is installed on the cluster.

## How to Test
Build **kubescape** by your own from this branch and run it against a cluster with the following command: `./kubescape scan --enable-host-scan`.
Check if **host-scanner** is deployed in `kubescape` namespace.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
