### PR TITLE
fix(adaptors) Check response size

### DIFF
--- a/core/cautils/getter/utils.go
+++ b/core/cautils/getter/utils.go
@@ -67,6 +67,12 @@ func errAuth(resp *http.Response) error {
 }
 
 func readString(rdr io.Reader, sizeHint int64) (string, error) {
+
+	// if the response is empty, return an empty string
+	if sizeHint < 0 {
+		return "", nil
+	}
+
 	var b strings.Builder
 
 	b.Grow(int(sizeHint))

--- a/core/cautils/getter/utils_test.go
+++ b/core/cautils/getter/utils_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,4 +43,57 @@ func TestIsNativeFramework(t *testing.T) {
 
 	require.Truef(t, isNativeFramework("nSa"), "expected nsa to be native (case insensitive)")
 	require.Falsef(t, isNativeFramework("foo"), "expected framework to be custom")
+}
+
+func Test_readString(t *testing.T) {
+	type args struct {
+		rdr      io.Reader
+		sizeHint int64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "should return empty string if sizeHint is negative",
+			args: args{
+				rdr:      nil,
+				sizeHint: -1,
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "should return empty string if sizeHint is zero",
+			args: args{
+				rdr:      &io.LimitedReader{},
+				sizeHint: 0,
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "should return empty string if sizeHint is positive",
+			args: args{
+				rdr:      &io.LimitedReader{},
+				sizeHint: 1,
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readString(tt.args.rdr, tt.args.sizeHint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("readString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Overview
Kubescape panics when the clientID and secretKey are set.
This happens when the response is empty, but no error was returned.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
