### PR TITLE
fix(hostsensorutils): reduce periods of readiness probe

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -32,7 +32,7 @@ spec:
       - operator: Exists
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.57
+        image: quay.io/kubescape/host-scanner:v1.0.59
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true
@@ -52,12 +52,17 @@ spec:
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem
-        readinessProbe:
+        startupProbe:
           httpGet:
-            path: /kernelVersion
+            path: /readyz
             port: 7888
-          initialDelaySeconds: 1
+          failureThreshold: 30
           periodSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7888
+          periodSeconds: 10
       terminationGracePeriodSeconds: 120
       dnsPolicy: ClusterFirstWithHostNet
       automountServiceAccountToken: false


### PR DESCRIPTION
## Overview
In order to reduce the number of requests we should decrease the readiness probe periods.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

This PR is related to [SUB-1286](https://cyberarmor-io.atlassian.net/browse/SUB-1286).

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes
