### PR TITLE
Revert "Deprecate kubescape-windows-latest"

### DIFF
--- a/.github/workflows/c-create-release.yaml
+++ b/.github/workflows/c-create-release.yaml
@@ -30,6 +30,11 @@ jobs:
         id: download-artifact
         with:
           path: .
+
+      # TODO: kubescape-windows-latest is deprecated and should be removed
+      - name: Get kubescape.exe from kubescape-windows-latest
+        run: cp ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }} ./kubescape-${{ env.WINDOWS_OS }}/kubescape.exe
+
       - name: Set release token
         run: |
           if [ "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" != "" ]; then
@@ -47,7 +52,9 @@ jobs:
           draft: ${{ inputs.DRAFT }}
           fail_on_unmatched_files: true
           prerelease: false
+          # TODO: kubescape-windows-latest is deprecated and should be removed
           files: |
+            ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.sha256
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.tar.gz

--- a/build.py
+++ b/build.py
@@ -26,7 +26,9 @@ def get_build_dir():
 
 def get_package_name():
     if CURRENT_PLATFORM not in platformSuffixes: raise OSError("Platform %s is not supported!" % (CURRENT_PLATFORM))
-    if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
+
+    # # TODO: kubescape-windows-latest is deprecated and should be removed
+    # if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
 
     package_name = "kubescape-"
     if os.getenv("GOARCH"):


### PR DESCRIPTION
Reverts kubescape/kubescape#1213

We need to release Kubescape immediately, and I suspect this depreciation broke the smoke tests.
I'm reverting this for now, so we can fix it properly.