### PR TITLE
Deprecate kubescape-windows-latest and fix CI

### DIFF
--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -162,12 +162,19 @@ jobs:
           CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
         run: ${{ env.DOCKER_CMD }} python3 --version && ${{ env.DOCKER_CMD }} python3 build.py
 
-      - name: Smoke Testing (Windows / MacOS)
+      - name: Smoke Testing (Windows)
+        env:
+          RELEASE: ${{ inputs.RELEASE }}
+          KUBESCAPE_SKIP_UPDATE_CHECK: "true"
+        run: python3 smoke_testing/init.py ${PWD}/build/kubescape.exe
+        if: startsWith(github.ref, 'refs/tags') && matrix.os == 'windows-latest' && matrix.arch == ''
+
+      - name: Smoke Testing (MacOS)
         env:
           RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"
         run: python3 smoke_testing/init.py ${PWD}/build/kubescape-${{ matrix.os }}
-        if: startsWith(github.ref, 'refs/tags') && matrix.os != 'ubuntu-20.04' && matrix.arch == ''
+        if: startsWith(github.ref, 'refs/tags') && matrix.os == 'macos-latest' && matrix.arch == ''
 
       - name: Smoke Testing (Linux amd64)
         env:

--- a/.github/workflows/c-create-release.yaml
+++ b/.github/workflows/c-create-release.yaml
@@ -30,11 +30,6 @@ jobs:
         id: download-artifact
         with:
           path: .
-
-      # TODO: kubescape-windows-latest is deprecated and should be removed
-      - name: Get kubescape.exe from kubescape-windows-latest
-        run: cp ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }} ./kubescape-${{ env.WINDOWS_OS }}/kubescape.exe
-
       - name: Set release token
         run: |
           if [ "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" != "" ]; then
@@ -52,9 +47,7 @@ jobs:
           draft: ${{ inputs.DRAFT }}
           fail_on_unmatched_files: true
           prerelease: false
-          # TODO: kubescape-windows-latest is deprecated and should be removed
           files: |
-            ./kubescape-${{ env.WINDOWS_OS }}/kubescape-${{ env.WINDOWS_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.sha256
             ./kubescape-${{ env.MAC_OS }}/kubescape-${{ env.MAC_OS }}.tar.gz

--- a/build.py
+++ b/build.py
@@ -26,9 +26,7 @@ def get_build_dir():
 
 def get_package_name():
     if CURRENT_PLATFORM not in platformSuffixes: raise OSError("Platform %s is not supported!" % (CURRENT_PLATFORM))
-
-    # # TODO: kubescape-windows-latest is deprecated and should be removed
-    # if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
+    if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
 
     package_name = "kubescape-"
     if os.getenv("GOARCH"):

--- a/build.py
+++ b/build.py
@@ -26,7 +26,6 @@ def get_build_dir():
 
 def get_package_name():
     if CURRENT_PLATFORM not in platformSuffixes: raise OSError("Platform %s is not supported!" % (CURRENT_PLATFORM))
-    if CURRENT_PLATFORM == "Windows": return "kubescape.exe"
 
     package_name = "kubescape-"
     if os.getenv("GOARCH"):
@@ -51,6 +50,7 @@ def main():
     ks_file = os.path.join(build_dir, package_name)
     hash_file = ks_file + ".sha256"
     tar_file = ks_file + ".tar.gz"
+    if CURRENT_PLATFORM == "Windows": ks_file = os.path.join(build_dir, "kubescape.exe")
 
     if not os.path.isdir(build_dir):
         os.makedirs(build_dir)


### PR DESCRIPTION
## Overview
Fix #1235 

I have triggered a release test in my fork:
https://github.com/HollowMan6/kubescape/actions/runs/4989131099

You can merge this once the workflow passed in my fork.

cc @dwertent 

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
