### PR TITLE
Fix downloading arm64 binary for kubescape

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ else
 fi
 
 arch=$(uname -m)
-if [[ $arch == *"aarch64"* ]]; then
+if [[ $arch == *"aarch64"* || $arch == *"arm64"* ]]; then
     arch="-arm64"
 else
     if [[ $arch != *"x86_64"* ]]; then


### PR DESCRIPTION
## Overview
Fix #1237 

Test:
```bash
curl -s https://raw.githubusercontent.com/HollowMan6/kubescape/macm1/install.sh | /bin/bash
```

cc: @craigbox 

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
