### PR TITLE
bump opa-utils version for memory optimizations

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
+	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
@@ -54,10 +55,8 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 		crv1.Remediation = crv2.Remediation
 
 		rulesv1 := map[string]reporthandling.RuleReport{}
-
-		iter := crv2.ListResourcesIDs().All()
-		for iter.HasNext() {
-			resourceID := iter.Next()
+		l := helpersv1.GetAllListsFromPool()
+		for resourceID := range crv2.ListResourcesIDs(l).All() {
 			if result, ok := opaSessionObj.ResourcesResult[resourceID]; ok {
 				for _, rulev2 := range result.ListRulesOfControl(crv2.GetID(), "") {
 
@@ -104,6 +103,7 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 				}
 			}
 		}
+		helpersv1.PutAllListsToPool(l)
 		if len(rulesv1) > 0 {
 			for i := range rulesv1 {
 				crv1.RuleReports = append(crv1.RuleReports, rulesv1[i])

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -178,13 +178,15 @@ func (ks *Kubescape) Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*res
 	}
 
 	// ======================== prioritization ===================
-	_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
-	if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, scanInfo.Getters.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
-		logger.L().Ctx(ctx).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
-	} else if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
-		return resultsHandling, fmt.Errorf("%w", err)
+	if scanInfo.PrintAttackTree {
+		_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
+		if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, scanInfo.Getters.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
+		} else if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
+			return resultsHandling, fmt.Errorf("%w", err)
+		}
+		spanPrioritization.End()
 	}
-	spanPrioritization.End()
 
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -193,18 +193,18 @@ func TestProcessResourcesResult(t *testing.T) {
 
 	assert.Equal(t, 1, len(opaSessionObj.ResourcesResult))
 	res := opaSessionObj.ResourcesResult[deployment.GetID()]
-	assert.Equal(t, 2, res.ListControlsIDs(nil).All().Len())
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Failed()))
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Passed()))
+	assert.Equal(t, 2, res.ListControlsIDs(nil).Len())
+	assert.Equal(t, 1, res.ListControlsIDs(nil).Failed())
+	assert.Equal(t, 1, res.ListControlsIDs(nil).Passed())
 	assert.True(t, res.GetStatus(nil).IsFailed())
 	assert.False(t, res.GetStatus(nil).IsPassed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
 
 	opap.updateResults(context.TODO())
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
-	assert.Equal(t, 2, res.ListControlsIDs(nil).All().Len())
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Failed()))
-	assert.Equal(t, 1, len(res.ListControlsIDs(nil).Passed()))
+	assert.Equal(t, 2, res.ListControlsIDs(nil).Len())
+	assert.Equal(t, 1, res.ListControlsIDs(nil).Failed())
+	assert.Equal(t, 1, res.ListControlsIDs(nil).Passed())
 	assert.True(t, res.GetStatus(nil).IsFailed())
 	assert.False(t, res.GetStatus(nil).IsPassed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
@@ -217,32 +217,32 @@ func TestProcessResourcesResult(t *testing.T) {
 	assert.Equal(t, 0, summaryDetails.NumberOfResources().Skipped())
 
 	// test resource listing
-	assert.Equal(t, 1, summaryDetails.ListResourcesIDs().All().Len())
-	assert.Equal(t, 1, len(summaryDetails.ListResourcesIDs().Failed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Passed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Skipped()))
+	assert.Equal(t, 1, summaryDetails.ListResourcesIDs(nil).Len())
+	assert.Equal(t, 1, summaryDetails.ListResourcesIDs(nil).Failed())
+	assert.Equal(t, 0, summaryDetails.ListResourcesIDs(nil).Passed())
+	assert.Equal(t, 0, summaryDetails.ListResourcesIDs(nil).Skipped())
 
 	// test control listing
-	assert.Equal(t, res.ListControlsIDs(nil).All().Len(), summaryDetails.NumberOfControls().All())
-	assert.Equal(t, len(res.ListControlsIDs(nil).Passed()), summaryDetails.NumberOfControls().Passed())
-	assert.Equal(t, len(res.ListControlsIDs(nil).Skipped()), summaryDetails.NumberOfControls().Skipped())
-	assert.Equal(t, len(res.ListControlsIDs(nil).Failed()), summaryDetails.NumberOfControls().Failed())
+	assert.Equal(t, res.ListControlsIDs(nil).Len(), summaryDetails.NumberOfControls().All())
+	assert.Equal(t, res.ListControlsIDs(nil).Passed(), summaryDetails.NumberOfControls().Passed())
+	assert.Equal(t, res.ListControlsIDs(nil).Skipped(), summaryDetails.NumberOfControls().Skipped())
+	assert.Equal(t, res.ListControlsIDs(nil).Failed(), summaryDetails.NumberOfControls().Failed())
 	assert.True(t, summaryDetails.GetStatus().IsFailed())
 
 	opaSessionObj.Exceptions = []armotypes.PostureExceptionPolicy{*mocks.MockExceptionAllKinds(&armotypes.PosturePolicy{FrameworkName: frameworks[0].Name})}
 	opap.updateResults(context.TODO())
 
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
-	assert.Equal(t, 2, res.ListControlsIDs(nil).All().Len())
-	assert.Equal(t, 2, len(res.ListControlsIDs(nil).Passed()))
+	assert.Equal(t, 2, res.ListControlsIDs(nil).Len())
+	assert.Equal(t, 2, res.ListControlsIDs(nil).Passed())
 	assert.True(t, res.GetStatus(nil).IsPassed())
 	assert.False(t, res.GetStatus(nil).IsFailed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
 
 	// test resource listing
 	summaryDetails = opaSessionObj.Report.SummaryDetails
-	assert.Equal(t, 1, summaryDetails.ListResourcesIDs().All().Len())
-	assert.Equal(t, 1, len(summaryDetails.ListResourcesIDs().Failed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Passed()))
-	assert.Equal(t, 0, len(summaryDetails.ListResourcesIDs().Skipped()))
+	assert.Equal(t, 1, summaryDetails.ListResourcesIDs(nil).Len())
+	assert.Equal(t, 1, summaryDetails.ListResourcesIDs(nil).Failed())
+	assert.Equal(t, 0, summaryDetails.ListResourcesIDs(nil).Passed())
+	assert.Equal(t, 0, summaryDetails.ListResourcesIDs(nil).Skipped())
 }

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/cautils/getter"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
 )
@@ -77,9 +78,9 @@ func (handler *ResourcesPrioritizationHandler) PrioritizeResources(sessionObj *c
 
 		if workload != nil && handler.isSupportedKind(workload) {
 			// build a map of attack track categories to a list of failed controls for the specific resource
-			failedControls := result.ListControlsIDs(nil).Failed()
-			if len(failedControls) > 0 {
-
+			controlsIds := result.ListControlsIDs(nil)
+			if controlsIds.Failed() > 0 {
+				failedControls := controlsIds.GetItems(apis.StatusFailed)
 				controlsLookup := v1alpha1.NewAttackTrackControlsLookup(handler.attackTracks, failedControls, allControls)
 				replicaCount := workload.GetReplicas()
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -297,7 +297,7 @@ func controlCountersForSummary(counters reportsummary.ICounters) string {
 }
 
 func controlCountersForResource(l *helpersv1.AllLists) string {
-	return fmt.Sprintf("Controls: %d (Failed: %d, action required: %d)", l.All().Len(), len(l.Failed()), len(l.Skipped()))
+	return fmt.Sprintf("Controls: %d (Failed: %d, action required: %d)", l.Len(), l.Failed(), l.Skipped())
 }
 func getSeparator(sep string) string {
 	s := ""

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.24
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
-	github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036
+	github.com/kubescape/opa-utils v0.0.247
 	github.com/kubescape/rbac-utils v0.0.20
 	github.com/kubescape/regolibrary v1.0.250
 	github.com/libgit2/git2go/v33 v33.0.9

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.24
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
-	github.com/kubescape/opa-utils v0.0.246
+	github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036
 	github.com/kubescape/rbac-utils v0.0.20
 	github.com/kubescape/regolibrary v1.0.250
 	github.com/libgit2/git2go/v33 v33.0.9
@@ -32,7 +32,7 @@ require (
 	github.com/sergi/go-diff v1.2.0
 	github.com/sigstore/cosign v1.13.1
 	github.com/spf13/cobra v1.7.0
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.3
 	github.com/whilp/git-urls v1.0.0
 	go.opentelemetry.io/otel v1.14.0
 	golang.org/x/mod v0.8.0
@@ -336,7 +336,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20230116083435-1de6713980de // indirect
+	golang.org/x/exp v0.0.0-20230519143937-03e91628a987 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1100,8 +1100,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.246 h1:WCCtkOD9ar8nSh7dUAGwuBsm+zOcVBbYE1jLQeo6wvo=
-github.com/kubescape/opa-utils v0.0.246/go.mod h1:aaAPHjaIJDoAK6RvAcUDXrXkja0ZTy0qSfnoxkE9z34=
+github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036 h1:v1Wu8KtRozunF5r1lj8DrU2GiwHoP8rORVbZ0xxywdM=
+github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
@@ -1556,8 +1556,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stripe/stripe-go/v74 v74.8.0 h1:0+3EfQSBhMg8SQ1+w+AP6Gxyko2crWbUG2uXbzYs8SU=
 github.com/stripe/stripe-go/v74 v74.8.0/go.mod h1:5PoXNp30AJ3tGq57ZcFuaMylzNi8KpwlrYAFmO1fHZw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -1868,8 +1868,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de h1:DBWn//IJw30uYCgERoxCg84hWtA97F4wMiKOIh00Uf0=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230519143937-03e91628a987 h1:3xJIFvzUFbu4ls0BTBYcgbCGhA63eAOEMxIHugyXJqA=
+golang.org/x/exp v0.0.0-20230519143937-03e91628a987/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/go.sum
+++ b/go.sum
@@ -1100,8 +1100,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036 h1:v1Wu8KtRozunF5r1lj8DrU2GiwHoP8rORVbZ0xxywdM=
-github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
+github.com/kubescape/opa-utils v0.0.247 h1:uDnA+CKfxL9K8o23W4Gp3t75y5Z+avDucAtRpnFRqWE=
+github.com/kubescape/opa-utils v0.0.247/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
-	github.com/kubescape/opa-utils v0.0.246
-	github.com/stretchr/testify v1.8.2
+	github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036
+	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.38.0
 	go.opentelemetry.io/otel v1.14.0
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
@@ -26,7 +26,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20230116083435-1de6713980de // indirect
+	golang.org/x/exp v0.0.0-20230519143937-03e91628a987 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
-	github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036
+	github.com/kubescape/opa-utils v0.0.247
 	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.38.0
 	go.opentelemetry.io/otel v1.14.0

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1105,8 +1105,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.246 h1:WCCtkOD9ar8nSh7dUAGwuBsm+zOcVBbYE1jLQeo6wvo=
-github.com/kubescape/opa-utils v0.0.246/go.mod h1:aaAPHjaIJDoAK6RvAcUDXrXkja0ZTy0qSfnoxkE9z34=
+github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036 h1:v1Wu8KtRozunF5r1lj8DrU2GiwHoP8rORVbZ0xxywdM=
+github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
@@ -1561,8 +1561,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stripe/stripe-go/v74 v74.8.0 h1:0+3EfQSBhMg8SQ1+w+AP6Gxyko2crWbUG2uXbzYs8SU=
 github.com/stripe/stripe-go/v74 v74.8.0/go.mod h1:5PoXNp30AJ3tGq57ZcFuaMylzNi8KpwlrYAFmO1fHZw=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -1875,8 +1875,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de h1:DBWn//IJw30uYCgERoxCg84hWtA97F4wMiKOIh00Uf0=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230519143937-03e91628a987 h1:3xJIFvzUFbu4ls0BTBYcgbCGhA63eAOEMxIHugyXJqA=
+golang.org/x/exp v0.0.0-20230519143937-03e91628a987/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1105,8 +1105,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036 h1:v1Wu8KtRozunF5r1lj8DrU2GiwHoP8rORVbZ0xxywdM=
-github.com/kubescape/opa-utils v0.0.247-0.20230522133540-5f7866f7d036/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
+github.com/kubescape/opa-utils v0.0.247 h1:uDnA+CKfxL9K8o23W4Gp3t75y5Z+avDucAtRpnFRqWE=
+github.com/kubescape/opa-utils v0.0.247/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=


### PR DESCRIPTION
## Overview

Changes: 
- This PR bumps opa-utils version in order to support the new AllLists datastructure - mainly for memory optimizations.
Details on the above changes can be found in https://github.com/kubescape/opa-utils/pull/107
- Attack chains are now calculated only when flag is provided

## Related issues/PRs:

-  https://github.com/kubescape/opa-utils/pull/107
