### PR TITLE
fix: remove deprecated endpoint

### DIFF
--- a/core/pkg/hostsensorutils/hostsensor.yaml
+++ b/core/pkg/hostsensorutils/hostsensor.yaml
@@ -32,7 +32,7 @@ spec:
       - operator: Exists
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.59
+        image: quay.io/kubescape/host-scanner:v1.0.61
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/core/pkg/hostsensorutils/hostsensordeploy_test.go
+++ b/core/pkg/hostsensorutils/hostsensordeploy_test.go
@@ -41,7 +41,7 @@ func TestHostSensorHandler(t *testing.T) {
 				envelope, status, err := h.CollectResources(ctx)
 				require.NoError(t, err)
 
-				require.Len(t, envelope, 10*2) // has cloud provider, no control plane requested
+				require.Len(t, envelope, 9*2) // has cloud provider, no control plane requested
 				require.Len(t, status, 0)
 
 				foundControl, foundProvider := false, false
@@ -91,7 +91,7 @@ func TestHostSensorHandler(t *testing.T) {
 				envelope, status, err := h.CollectResources(ctx)
 				require.NoError(t, err)
 
-				require.Len(t, envelope, 11*2) // has empty cloud provider, has control plane info
+				require.Len(t, envelope, 10*2) // has empty cloud provider, has control plane info
 				require.Len(t, status, 0)
 
 				foundControl, foundProvider := false, false

--- a/core/pkg/hostsensorutils/hostsensorgetfrompod.go
+++ b/core/pkg/hostsensorutils/hostsensorgetfrompod.go
@@ -167,27 +167,6 @@ func (hsh *HostSensorHandler) getCloudProviderInfo(ctx context.Context) ([]hosts
 	return hsh.sendAllPodsHTTPGETRequest(ctx, "/cloudProviderInfo", CloudProviderInfo)
 }
 
-// getKubeletCommandLine returns the list of kubelet command lines.
-func (hsh *HostSensorHandler) getKubeletCommandLine(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
-	// loop over pods and port-forward it to each of them
-	resps, err := hsh.sendAllPodsHTTPGETRequest(ctx, "/kubeletCommandLine", KubeletCommandLine)
-	if err != nil {
-		return resps, err
-	}
-
-	for resp := range resps {
-		var data = make(map[string]interface{})
-		data["fullCommand"] = string(resps[resp].Data)
-		resBytesMarshal, err := json.Marshal(data)
-		// TODO catch error
-		if err == nil {
-			resps[resp].Data = stdjson.RawMessage(resBytesMarshal)
-		}
-	}
-
-	return resps, nil
-}
-
 // getCNIInfo returns the list of CNI metadata
 func (hsh *HostSensorHandler) getCNIInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
 	// loop over pods and port-forward it to each of them
@@ -245,10 +224,6 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 		Query    func(context.Context) ([]hostsensor.HostSensorDataEnvelope, error)
 	}{
 		// queries to the deployed host-scanner
-		{
-			Resource: KubeletCommandLine,
-			Query:    hsh.getKubeletCommandLine,
-		},
 		{
 			Resource: OsReleaseFile,
 			Query:    hsh.getOsReleaseFile,


### PR DESCRIPTION
## Overview
`/kubeletcommandline` has been replaced by `/kubeletinfo` endpoint.

## Related issues/PRs:
Related issue: https://github.com/kubescape/host-scanner/pull/46

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes