### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -65,7 +64,7 @@ func unzipAllResourcesTestDataAndSetVar(zipFilePath, destFilePath string) error 
 	if err != nil {
 		panic(err)
 	}
-	allResourcesMockData, err = ioutil.ReadAll(file)
+	allResourcesMockData, err = io.ReadAll(file)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Overview
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

## Additional Information

## How to Test


## Examples/Screenshots

## Related issues/PRs:

Here you add related issues and PRs.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


