### PR TITLE
initialize ns in case we don't have one in YAML

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -242,7 +242,7 @@ func NewClusterConfig(k8s *k8sinterface.KubernetesApi, backendAPI getter.IBacken
 		backendAPI:         backendAPI,
 		configObj:          &ConfigObj{},
 		configMapName:      getConfigMapName(),
-		configMapNamespace: getConfigMapNamespace(),
+		configMapNamespace: GetConfigMapNamespace(),
 	}
 
 	// first, load from configMap
@@ -557,7 +557,8 @@ func getConfigMapName() string {
 	return "kubescape"
 }
 
-func getConfigMapNamespace() string {
+// GetConfigMapNamespace returns the namespace of the cluster config, which is the same for all in-cluster components
+func GetConfigMapNamespace() string {
 	if n := os.Getenv("KS_DEFAULT_CONFIGMAP_NAMESPACE"); n != "" {
 		return n
 	}

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -299,3 +299,34 @@ func Test_initializeCloudAPI(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConfigMapNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{
+			name: "no env",
+			want: "default",
+		},
+		{
+			name: "default ns",
+			env:  "kubescape",
+			want: "kubescape",
+		},
+		{
+			name: "custom ns",
+			env:  "my-ns",
+			want: "my-ns",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				_ = os.Setenv("KS_DEFAULT_CONFIGMAP_NAMESPACE", tt.env)
+			}
+			assert.Equalf(t, tt.want, GetConfigMapNamespace(), "GetConfigMapNamespace()")
+		})
+	}
+}

--- a/core/pkg/hostsensorutils/hostsensordeploy.go
+++ b/core/pkg/hostsensorutils/hostsensordeploy.go
@@ -136,7 +136,7 @@ func (hsh *HostSensorHandler) applyYAML(ctx context.Context) error {
 	}
 
 	// Get namespace name
-	namespaceName := ""
+	namespaceName := cautils.GetConfigMapNamespace()
 	for i := range workloads {
 		if workloads[i].GetKind() == "Namespace" {
 			namespaceName = workloads[i].GetName()
@@ -154,6 +154,7 @@ func (hsh *HostSensorHandler) applyYAML(ctx context.Context) error {
 		}
 		// set namespace in all objects
 		if w.GetKind() != "Namespace" {
+			logger.L().Debug("Setting namespace", helpers.String("kind", w.GetKind()), helpers.String("name", w.GetName()), helpers.String("namespace", namespaceName))
 			w.SetNamespace(namespaceName)
 		}
 		// Get container port


### PR DESCRIPTION
@alegrey91 at some point we would like to drop NS from our Helm chart, because anyways we're using the default one - this fix prepares for that