### PR TITLE
Attack chains - support in in-cluster "security" framework scanning

### DIFF
--- a/core/cautils/getter/testdata/MITRE.json
+++ b/core/cautils/getter/testdata/MITRE.json
@@ -6,6 +6,7 @@
   },
   "creationTime": "",
   "description": "Testing MITRE for Kubernetes as suggested by microsoft in https://www.microsoft.com/security/blog/wp-content/uploads/2020/04/k8s-matrix.png",
+  "typeTags": ["compliance"],
   "controls": [
     {
       "guid": "",

--- a/core/cautils/getter/testdata/NSA.json
+++ b/core/cautils/getter/testdata/NSA.json
@@ -6,6 +6,7 @@
   },
   "creationTime": "",
   "description": "Implement NSA security advices for K8s ",
+  "typeTags": ["compliance"],
   "controls": [
     {
       "guid": "",

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -133,6 +133,7 @@ type ScanInfo struct {
 	ScanAll               bool               // true if scan all frameworks
 	OmitRawResources      bool               // true if omit raw resources from the output
 	PrintAttackTree       bool               // true if print attack tree
+	ScanSecurityFramework bool               // true if to scan also "Security" framework, relevant only when FrameworkScan is true
 }
 
 type Getters struct {

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,9 @@ require (
 	github.com/kubescape/go-git-url v0.0.25
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
-	github.com/kubescape/opa-utils v0.0.249
+	github.com/kubescape/opa-utils v0.0.250
 	github.com/kubescape/rbac-utils v0.0.20
-	github.com/kubescape/regolibrary v1.0.250
+	github.com/kubescape/regolibrary v1.0.284-rc.0
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-isatty v0.0.17
 	github.com/mikefarah/yq/v4 v4.29.1

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kubescape/k8s-interface v0.0.116
 	github.com/kubescape/opa-utils v0.0.250
 	github.com/kubescape/rbac-utils v0.0.20
-	github.com/kubescape/regolibrary v1.0.284-rc.0
+	github.com/kubescape/regolibrary v1.0.286-rc.0
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-isatty v0.0.17
 	github.com/mikefarah/yq/v4 v4.29.1

--- a/go.sum
+++ b/go.sum
@@ -1075,8 +1075,8 @@ github.com/kubescape/opa-utils v0.0.250 h1:SpMjtDB3EgyvbwxpCpZXAtQ/TixOeVQAmkcfi
 github.com/kubescape/opa-utils v0.0.250/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
-github.com/kubescape/regolibrary v1.0.284-rc.0 h1:JSVApX6gbalPbw6oQkN+N/l23x80AjZKahVxhAniX44=
-github.com/kubescape/regolibrary v1.0.284-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
+github.com/kubescape/regolibrary v1.0.286-rc.0 h1:OzhtQEx1npAxTbgkbEpMLZvPWg6sh2CmCgQLs0j6pQ4=
+github.com/kubescape/regolibrary v1.0.286-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=

--- a/go.sum
+++ b/go.sum
@@ -1071,12 +1071,12 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.249 h1:04eMB0QZLDoRALv0DTQmGWmvRV0yJuFYGl8oVqSfBRc=
-github.com/kubescape/opa-utils v0.0.249/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
+github.com/kubescape/opa-utils v0.0.250 h1:SpMjtDB3EgyvbwxpCpZXAtQ/TixOeVQAmkcfi+w66KA=
+github.com/kubescape/opa-utils v0.0.250/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
-github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
-github.com/kubescape/regolibrary v1.0.250/go.mod h1:SQkyJbA51qjNji/1nG5jABkC0GfyZtZqDDJJB5Cczn8=
+github.com/kubescape/regolibrary v1.0.284-rc.0 h1:JSVApX6gbalPbw6oQkN+N/l23x80AjZKahVxhAniX44=
+github.com/kubescape/regolibrary v1.0.284-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=

--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -178,3 +178,4 @@ go tool pprof http://localhost:6060/debug/pprof/heap
 * `KS_DOWNLOAD_ARTIFACTS`: Download the artifacts every scan
 * `KS_LOGGER_NAME`: Set logger name
 * `KS_LOGGER_LEVEL`: Set logger level
+* `KS_SCAN_SECURITY_FRAMEWORK`: Enable "security" framework scan on top of any framework scan.

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kubescape/go-logger v0.0.11
 	github.com/kubescape/k8s-interface v0.0.116
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
-	github.com/kubescape/opa-utils v0.0.249
+	github.com/kubescape/opa-utils v0.0.250
 	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.38.0
 	go.opentelemetry.io/otel v1.14.0
@@ -219,7 +219,7 @@ require (
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/kubescape/go-git-url v0.0.25 // indirect
 	github.com/kubescape/rbac-utils v0.0.20 // indirect
-	github.com/kubescape/regolibrary v1.0.250 // indirect
+	github.com/kubescape/regolibrary v1.0.284-rc.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20220929215747-76583552c2be // indirect

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/kubescape/go-git-url v0.0.25 // indirect
 	github.com/kubescape/rbac-utils v0.0.20 // indirect
-	github.com/kubescape/regolibrary v1.0.284-rc.0 // indirect
+	github.com/kubescape/regolibrary v1.0.286-rc.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20220929215747-76583552c2be // indirect

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1080,8 +1080,8 @@ github.com/kubescape/opa-utils v0.0.250 h1:SpMjtDB3EgyvbwxpCpZXAtQ/TixOeVQAmkcfi
 github.com/kubescape/opa-utils v0.0.250/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
-github.com/kubescape/regolibrary v1.0.284-rc.0 h1:JSVApX6gbalPbw6oQkN+N/l23x80AjZKahVxhAniX44=
-github.com/kubescape/regolibrary v1.0.284-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
+github.com/kubescape/regolibrary v1.0.286-rc.0 h1:OzhtQEx1npAxTbgkbEpMLZvPWg6sh2CmCgQLs0j6pQ4=
+github.com/kubescape/regolibrary v1.0.286-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1076,12 +1076,12 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.116 h1:Sn76gsMLAArc5kbHZVoRMS6QlM4mOz9Dolpym9BOul8=
 github.com/kubescape/k8s-interface v0.0.116/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
-github.com/kubescape/opa-utils v0.0.249 h1:04eMB0QZLDoRALv0DTQmGWmvRV0yJuFYGl8oVqSfBRc=
-github.com/kubescape/opa-utils v0.0.249/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
+github.com/kubescape/opa-utils v0.0.250 h1:SpMjtDB3EgyvbwxpCpZXAtQ/TixOeVQAmkcfi+w66KA=
+github.com/kubescape/opa-utils v0.0.250/go.mod h1:SkNqbhUGipSYVE+oAUaHko6aggp8XVVbDChoNg48lao=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
-github.com/kubescape/regolibrary v1.0.250 h1:BKoH89Cex+5rsD+vn1ILxULcJ++aA/KEhV5jJ4Wgp/8=
-github.com/kubescape/regolibrary v1.0.250/go.mod h1:SQkyJbA51qjNji/1nG5jABkC0GfyZtZqDDJJB5Cczn8=
+github.com/kubescape/regolibrary v1.0.284-rc.0 h1:JSVApX6gbalPbw6oQkN+N/l23x80AjZKahVxhAniX44=
+github.com/kubescape/regolibrary v1.0.284-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -11,6 +11,10 @@ import (
 	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 )
 
+const (
+	securityFrameworkName = "security"
+)
+
 func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 	scanInfo := defaultScanInfo()
 
@@ -85,5 +89,13 @@ func setTargetInScanInfo(scanRequest *utilsmetav1.PostScanRequest, scanInfo *cau
 	} else {
 		scanInfo.FrameworkScan = true
 		scanInfo.ScanAll = true
+	}
+
+	// Add "security" framework if not present
+	if scanInfo.FrameworkScan == true && scanInfo.ScanSecurityFramework {
+		if cautils.StringInSlice(scanRequest.TargetNames, securityFrameworkName) == cautils.ValueNotFound {
+			scanRequest.TargetNames = append(scanRequest.TargetNames, securityFrameworkName)
+			scanInfo.SetPolicyIdentifiers(scanRequest.TargetNames, scanRequest.TargetType)
+		}
 	}
 }

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -61,6 +61,72 @@ func TestToScanInfo(t *testing.T) {
 }
 
 func TestSetTargetInScanInfo(t *testing.T) {
+	// framework scan with "security" framework
+	{
+		req := &utilsmetav1.PostScanRequest{
+			TargetType:  apisv1.KindFramework,
+			TargetNames: []string{""},
+		}
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.ScanSecurityFramework = true
+		setTargetInScanInfo(req, scanInfo)
+		assert.True(t, scanInfo.FrameworkScan)
+		assert.True(t, scanInfo.ScanAll)
+		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Contains(t, scanInfo.PolicyIdentifier[0].Identifier, "security")
+	}
+	{
+		req := &utilsmetav1.PostScanRequest{
+			TargetType:  apisv1.KindFramework,
+			TargetNames: []string{},
+		}
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.ScanSecurityFramework = true
+		setTargetInScanInfo(req, scanInfo)
+		assert.True(t, scanInfo.FrameworkScan)
+		assert.True(t, scanInfo.ScanAll)
+		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Contains(t, scanInfo.PolicyIdentifier[0].Identifier, "security")
+	}
+	{
+		req := &utilsmetav1.PostScanRequest{
+			TargetType:  apisv1.KindFramework,
+			TargetNames: []string{"nsa", "mitre"},
+		}
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.ScanSecurityFramework = true
+		setTargetInScanInfo(req, scanInfo)
+		assert.True(t, scanInfo.FrameworkScan)
+		assert.False(t, scanInfo.ScanAll)
+		assert.Equal(t, 3, len(scanInfo.PolicyIdentifier))
+		assert.Contains(t, scanInfo.PolicyIdentifier[2].Identifier, "security")
+
+	}
+	{
+		req := &utilsmetav1.PostScanRequest{
+			TargetType:  apisv1.KindFramework,
+			TargetNames: []string{"all"},
+		}
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.ScanSecurityFramework = true
+		setTargetInScanInfo(req, scanInfo)
+		assert.True(t, scanInfo.FrameworkScan)
+		assert.True(t, scanInfo.ScanAll)
+		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Contains(t, scanInfo.PolicyIdentifier[0].Identifier, "security")
+	}
+	{
+		req := &utilsmetav1.PostScanRequest{}
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.ScanSecurityFramework = true
+		setTargetInScanInfo(req, scanInfo)
+		assert.True(t, scanInfo.FrameworkScan)
+		assert.True(t, scanInfo.ScanAll)
+		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Contains(t, scanInfo.PolicyIdentifier[0].Identifier, "security")
+	}
+
+	// framework scan without "security" framework
 	{
 		req := &utilsmetav1.PostScanRequest{
 			TargetType:  apisv1.KindFramework,
@@ -113,6 +179,8 @@ func TestSetTargetInScanInfo(t *testing.T) {
 		assert.True(t, scanInfo.ScanAll)
 		assert.Equal(t, 0, len(scanInfo.PolicyIdentifier))
 	}
+
+	// control scan
 	{
 		req := &utilsmetav1.PostScanRequest{
 			TargetType:  apisv1.KindControl,

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -173,7 +173,8 @@ func defaultScanInfo() *cautils.ScanInfo {
 	if !envToBool("KS_DOWNLOAD_ARTIFACTS", false) {
 		scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape fom downloading the artifacts every time)
 	}
-	scanInfo.KubeContext = envToString("KS_CONTEXT", "") // publish results to Kubescape SaaS
+	scanInfo.KubeContext = envToString("KS_CONTEXT", "")                            // publish results to Kubescape SaaS
+	scanInfo.ScanSecurityFramework = envToBool("KS_SCAN_SECURITY_FRAMEWORK", false) // enable security framework scan
 
 	return scanInfo
 }


### PR DESCRIPTION
## Overview
Support in in-cluster scanning of "security" framework for attack-chain.
If env var KS_SCAN_SECURITY_FRAMEWORK in the in-cluster kubescape pod is True then "security" framework will be scanned on top of any framework scan (requires updating helm in order to activate).

## Additional Information
### Updating regolibrary (GitRegoStore) to version **v1.0.286-rc.0**:
- version includes a new file _security_frameworks_.
-  _security_frameworks_ is expected to exist only from version **v1.0.286-rc.0** and above for backward compatibility.

### New framework attribute "typeTags":
- a list of framework types, currently can be "compliance" and/or "security".
- for compliance framework, typeTags is ["compliance"]
- for security framework, typeTags is ["security"]
- if no typeTags is configured or is empty, it will be considered as "compliance"


## How to Test
- CLI scan should never scan security framework unless specifically asked for this framework (`kubescape scan framework security`)
- Once helm is updated with the env var as True, any in-cluster framework scan will include also the security framework.


## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


