### PR TITLE
core(adaptors): Ignore adaptors when credentials are not set

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -66,8 +66,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Credentials.Account, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.CreateAccount, "create-account", false, "Create a Kubescape SaaS account ID account ID is not found in cache. After creating the account, the account ID will be saved in cache. In addition, the scanning results will be uploaded to the Kubescape SaaS")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.Credentials.ClientID, "client-id", "", "", "Kubescape SaaS client ID. Default will load client ID from cache, read more - https://hub.armosec.io/docs/authentication")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.Credentials.SecretKey, "secret-key", "", "", "Kubescape SaaS secret key. Default will load secret key from cache, read more - https://hub.armosec.io/docs/authentication")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.KubeContext, "kube-context", "", "", "Kube context. Default will use the current-context")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
@@ -95,6 +93,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().MarkDeprecated("silent", "use '--logger' flag instead. Flag will be removed at 1.May.2022")
 	scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead. Flag will be removed at 1.Dec.2023")
+
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.Credentials.ClientID, "client-id", "", "", "Kubescape SaaS client ID. Default will load client ID from cache, read more - https://hub.armosec.io/docs/authentication")
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.Credentials.SecretKey, "secret-key", "", "", "Kubescape SaaS secret key. Default will load secret key from cache, read more - https://hub.armosec.io/docs/authentication")
+	scanCmd.PersistentFlags().MarkDeprecated("client-id", "login to Kubescape SaaS will be unsupported, please contact the Kubescape maintainers for more information")
+	scanCmd.PersistentFlags().MarkDeprecated("secret-key", "login to Kubescape SaaS will be unsupported, please contact the Kubescape maintainers for more information")
 
 	// hidden flags
 	scanCmd.PersistentFlags().MarkHidden("host-scan-yaml") // this flag should be used very cautiously. We prefer users will not use it at all unless the DaemonSet can not run pods on the nodes

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -94,7 +94,7 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 
 	if len(scanInfo.InputPatterns) > 0 || k8s == nil {
 		// scanInfo.HostSensor.SetBool(false)
-		return resourcehandler.NewFileResourceHandler(ctx, scanInfo.InputPatterns, registryAdaptors)
+		return resourcehandler.NewFileResourceHandler(ctx, scanInfo.InputPatterns)
 	}
 	getter.GetKSCloudAPIConnector()
 	rbacObjects := getRBACHandler(tenantConfig, k8s, scanInfo.Submit)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -79,11 +79,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 	spanHostScanner.End()
 
 	// ================== setup registry adaptors ======================================
-
-	registryAdaptors, err := resourcehandler.NewRegistryAdaptors()
-	if err != nil {
-		logger.L().Ctx(ctx).Error("failed to initialize registry adaptors", helpers.Error(err))
-	}
+	registryAdaptors, _ := resourcehandler.NewRegistryAdaptors()
 
 	// ================== setup resource collector object ======================================
 

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -20,15 +20,13 @@ import (
 
 // FileResourceHandler handle resources from files and URLs
 type FileResourceHandler struct {
-	inputPatterns    []string
-	registryAdaptors *RegistryAdaptors
+	inputPatterns []string
 }
 
-func NewFileResourceHandler(_ context.Context, inputPatterns []string, registryAdaptors *RegistryAdaptors) *FileResourceHandler {
+func NewFileResourceHandler(_ context.Context, inputPatterns []string) *FileResourceHandler {
 	k8sinterface.InitializeMapResourcesMock() // initialize the resource map
 	return &FileResourceHandler{
-		inputPatterns:    inputPatterns,
-		registryAdaptors: registryAdaptors,
+		inputPatterns: inputPatterns,
 	}
 }
 
@@ -77,11 +75,6 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 		}
 
 	}
-
-	// Should Kubescape scan image related controls when scanning local files?
-	// if err := fileHandler.registryAdaptors.collectImagesVulnerabilities(k8sResources, allResources, ksResources); err != nil {
-	// 	logger.L().Ctx(ctx).Warning("failed to collect images vulnerabilities", helpers.Error(err))
-	// }
 
 	cautils.StopSpinner()
 	logger.L().Success("Done accessing local objects")

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -94,20 +94,19 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	cautils.StopSpinner()
 	logger.L().Success("Accessed to Kubernetes objects")
 
-	imgVulnResources := cautils.MapImageVulnResources(ksResourceMap)
-	// check that controls use image vulnerability resources
-	if len(imgVulnResources) > 0 {
-		logger.L().Info("Requesting images vulnerabilities results")
-		cautils.StartSpinner()
-		if err := k8sHandler.registryAdaptors.collectImagesVulnerabilities(k8sResourcesMap, allResources, ksResourceMap); err != nil {
-			cautils.SetInfoMapForResources(fmt.Sprintf("failed to pull image scanning data: %s. for more information: https://hub.armosec.io/docs/configuration-of-image-vulnerabilities", err.Error()), imgVulnResources, sessionObj.InfoMap)
-		} else {
-			if isEmptyImgVulns(*ksResourceMap) {
-				cautils.SetInfoMapForResources("image scanning is not configured. for more information: https://hub.armosec.io/docs/configuration-of-image-vulnerabilities", imgVulnResources, sessionObj.InfoMap)
+	// backswords compatibility - get image vulnerability resources
+	if k8sHandler.registryAdaptors != nil {
+		imgVulnResources := cautils.MapImageVulnResources(ksResourceMap)
+		// check that controls use image vulnerability resources
+		if len(imgVulnResources) > 0 {
+			logger.L().Info("Requesting images vulnerabilities results")
+			cautils.StartSpinner()
+			if err := k8sHandler.registryAdaptors.collectImagesVulnerabilities(k8sResourcesMap, allResources, ksResourceMap); err != nil {
+				cautils.SetInfoMapForResources(fmt.Sprintf("failed to pull image scanning data: %s. for more information: https://hub.armosec.io/docs/configuration-of-image-vulnerabilities", err.Error()), imgVulnResources, sessionObj.InfoMap)
 			}
+			cautils.StopSpinner()
+			logger.L().Success("Requested images vulnerabilities results")
 		}
-		cautils.StopSpinner()
-		logger.L().Success("Requested images vulnerabilities results")
 	}
 
 	hostResources := cautils.MapHostResources(ksResourceMap)

--- a/core/pkg/resourcehandler/registrydata.go
+++ b/core/pkg/resourcehandler/registrydata.go
@@ -32,6 +32,10 @@ func NewRegistryAdaptors() (*RegistryAdaptors, error) {
 	if err != nil {
 		return registryAdaptors, err
 	}
+	if len(adaptors) == 0 {
+		return nil, nil
+	}
+
 	registryAdaptors.adaptors = adaptors
 	return registryAdaptors, nil
 }


### PR DESCRIPTION
## Overview
As part of the plan of separating between configuration scanning and image scanning, we are removing controls that are dependent on the image scanning results.
The first step is to deprecate the related flags and skip the adaptors when the credentials are not set. This way, new users will not set up the integration.

The full deprecation is introduced in #1263 
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
