### PR TITLE
feat(file scanning): Submit untracked files

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -337,14 +337,23 @@ func setContextMetadata(ctx context.Context, contextMetadata *reporthandlingv2.C
 		}
 		contextMetadata.RepoContextMetadata = context
 	case ContextDir:
-		contextMetadata.DirectoryContextMetadata = &reporthandlingv2.DirectoryContextMetadata{
-			BasePath: getAbsPath(input),
-			HostName: getHostname(),
+		contextMetadata.RepoContextMetadata = &reporthandlingv2.RepoContextMetadata{
+			Provider:      "none",
+			Repo:          fmt.Sprintf("path@%s", getAbsPath(input)),
+			Owner:         getHostname(),
+			Branch:        "none",
+			DefaultBranch: "none",
+			LocalRootPath: getAbsPath(input),
 		}
+
 	case ContextFile:
-		contextMetadata.FileContextMetadata = &reporthandlingv2.FileContextMetadata{
-			FilePath: getAbsPath(input),
-			HostName: getHostname(),
+		contextMetadata.RepoContextMetadata = &reporthandlingv2.RepoContextMetadata{
+			Provider:      "none",
+			Repo:          fmt.Sprintf("file@%s", getAbsPath(input)),
+			Owner:         getHostname(),
+			Branch:        "none",
+			DefaultBranch: "none",
+			LocalRootPath: getAbsPath(input),
 		}
 	case ContextGitLocal:
 		// local

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -183,12 +183,6 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 		return
 	}
 
-	scanningContext := scanInfo.GetScanningContext()
-	if scanningContext == cautils.ContextFile || scanningContext == cautils.ContextDir {
-		scanInfo.Submit = false
-		return
-	}
-
 	if scanInfo.Local {
 		scanInfo.Submit = false
 		return


### PR DESCRIPTION
## Overview
Until now, kubescape will submit the results of cluster scanning and repo scanning.
Once this PR is released, Kubescape will submit also untracked files.
## Examples/Screenshots
![image](https://github.com/kubescape/kubescape/assets/64066841/e8fb6f73-870d-464f-85f8-759161efc15e)

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
