### PR TITLE
fix: kubescape list controls

### DIFF
--- a/core/core/list.go
+++ b/core/core/list.go
@@ -112,7 +112,7 @@ func jsonListFormat(_ context.Context, _ string, policies []string) {
 
 func prettyPrintControls(ctx context.Context, policies []string) {
 	controlsTable := tablewriter.NewWriter(printer.GetWriter(ctx, ""))
-	controlsTable.SetAutoWrapText(true)
+	controlsTable.SetAutoWrapText(false)
 	controlsTable.SetHeader([]string{"Control ID", "Control Name", "Docs", "Frameworks"})
 	controlsTable.SetHeaderLine(true)
 	controlsTable.SetRowLine(true)
@@ -134,7 +134,7 @@ func generateControlRows(policies []string) [][]string {
 
 		docs := cautils.GetControlLink(id)
 
-		currentRow := []string{id, control, docs, framework}
+		currentRow := []string{id, control, docs, strings.Replace(framework, " ", "\n", -1)}
 
 		rows = append(rows, currentRow)
 	}


### PR DESCRIPTION
## Overview

As mentioned in the issue, line wrapping didn't utilize all the available space in the corresponding table blocks, this has not been fixed and all the lines will utilize all the space available to them in a block.

## How to Test

`kubescape list controls`

## Examples/Screenshots

Before change:
![image](https://github.com/kubescape/kubescape/assets/81813720/e84e7e02-1ffe-4bb8-82c6-3e846f87eaf1)


After change:
![image](https://github.com/kubescape/kubescape/assets/81813720/acbc2ded-8b54-4e2c-8dd0-636e7b57be53)


## Related issues/PRs:

Resolved #1176 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

