### PR TITLE
fix: stuck spinner

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -136,7 +136,9 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 		if gitRepo != nil {
 			commitInfo, err := gitRepo.GetFileLastCommit(source)
 			if err != nil && !warnIssued {
+				cautils.StopSpinner()
 				logger.L().Ctx(ctx).Warning("git scan skipped", helpers.Error(err))
+				cautils.StartSpinner()
 				warnIssued = true // croak only once
 			}
 


### PR DESCRIPTION
## Overview

Occasionally due to certain conditions the spinner on the Kubescape cli binary would get stuck in place even after it would have been expected to disappear.

## Additional Information

The cause for this is mainly the fact that once the spinner starts running if before it stops there is anything else that gets printed to the console like warnings or debug statements, that leads the spinner to skip a frame and re-render on the next line instead of the one it was already running on, leading to a print of the spinner to remain dormant then onwards and doesn't even gets cleaned.
So we stop the spinner just before anything is printed on the console and restart it after that.

## How to Test

```bash
kubescape scan resource.yaml
```

## Examples/Screenshots

Before:
![image](https://github.com/kubescape/kubescape/assets/81813720/04cc5cb2-0500-4fa4-a634-1cb99daa2cbc)

After:
![image](https://github.com/kubescape/kubescape/assets/81813720/01b40e2d-dce4-4e26-a67d-eb4a2c969f18)


## Related issues/PRs:

Resolved #1280 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
