### PR TITLE
fix: yamlhandler error handling

### DIFF
--- a/core/pkg/fixhandler/yamlhandler.go
+++ b/core/pkg/fixhandler/yamlhandler.go
@@ -23,8 +23,6 @@ func decodeDocumentRoots(yamlAsString string) ([]yaml.Node, error) {
 		var node yaml.Node
 		err := dec.Decode(&node)
 
-		nodes = append(nodes, node)
-
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -32,6 +30,8 @@ func decodeDocumentRoots(yamlAsString string) ([]yaml.Node, error) {
 			return nil, fmt.Errorf("Cannot Decode File as YAML")
 
 		}
+
+		nodes = append(nodes, node)
 	}
 
 	return nodes, nil


### PR DESCRIPTION
## Overview

As mentioned in the issue, yaml nodes were being appended without checking for errors leading to redundant nodes being appended to the slice.

## Additional Information

Not a user facing problem, but helps in ensuring variable safety in the code.

## How to Test

Run `kubescape fix output.json` for a previously generated `output.json` from `kubescape scan` and debug through the code.

## Related issues/PRs:

Resolved #1290 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
