### PR TITLE
fix(cmd/scan/framework.go): remove redundant code

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -94,7 +94,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 				}
 				if len(args) > 1 {
-					if len(args[1:]) == 0 || args[1] != "-" {
+					if args[1] != "-" {
 						scanInfo.InputPatterns = args[1:]
 						logger.L().Debug("List of input files", helpers.Interface("patterns", scanInfo.InputPatterns))
 					} else { // store stdin to file - do NOT move to separate function !!
@@ -112,7 +112,6 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				}
 			}
 			scanInfo.SetScanType(cautils.ScanTypeFramework)
-			scanInfo.FrameworkScan = true
 
 			scanInfo.SetPolicyIdentifiers(frameworks, apisv1.KindFramework)
 


### PR DESCRIPTION
## Overview
remove some redundant code

## Additional Information

1. there are two lines of "scanInfo.FrameworkScan = true" in the same level, so remove one.
2. when "len(args) > 1" len(args[1:]) must be > 0, so no need to check, remove it.

## Examples/Screenshots

![image](https://github.com/kubescape/kubescape/assets/73151874/5c41a6f8-8774-4ba7-aed0-e8f1dcc96123)

## Checklist before requesting a review

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x ] New and existing unit tests pass locally with my changes

