### PR TITLE
fix(results): Fixed results path

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -337,6 +337,11 @@ func setContextMetadata(ctx context.Context, contextMetadata *reporthandlingv2.C
 		}
 		contextMetadata.RepoContextMetadata = context
 	case ContextDir:
+		contextMetadata.DirectoryContextMetadata = &reporthandlingv2.DirectoryContextMetadata{
+			BasePath: getAbsPath(input),
+			HostName: getHostname(),
+		}
+		// add repo context for submitting
 		contextMetadata.RepoContextMetadata = &reporthandlingv2.RepoContextMetadata{
 			Provider:      "none",
 			Repo:          fmt.Sprintf("path@%s", getAbsPath(input)),
@@ -347,6 +352,11 @@ func setContextMetadata(ctx context.Context, contextMetadata *reporthandlingv2.C
 		}
 
 	case ContextFile:
+		contextMetadata.FileContextMetadata = &reporthandlingv2.FileContextMetadata{
+			FilePath: getAbsPath(input),
+			HostName: getHostname(),
+		}
+		// add repo context for submitting
 		contextMetadata.RepoContextMetadata = &reporthandlingv2.RepoContextMetadata{
 			Provider:      "none",
 			Repo:          fmt.Sprintf("file@%s", getAbsPath(input)),

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -73,19 +73,17 @@ func isSupportedScanningTarget(report *reporthandlingv2.PostureReport) error {
 }
 
 func getLocalPath(report *reporthandlingv2.PostureReport) string {
-	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.GitLocal {
+
+	switch report.Metadata.ScanMetadata.ScanningTarget {
+	case reporthandlingv2.GitLocal:
 		return report.Metadata.ContextMetadata.RepoContextMetadata.LocalRootPath
-	}
-
-	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.Directory {
+	case reporthandlingv2.Directory:
 		return report.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath
-	}
-
-	if report.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.File {
+	case reporthandlingv2.File:
 		return filepath.Dir(report.Metadata.ContextMetadata.FileContextMetadata.FilePath)
+	default:
+		return ""
 	}
-
-	return ""
 }
 
 func (h *FixHandler) buildResourcesMap() map[string]*reporthandling.Resource {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -327,15 +327,14 @@ func getDocIndex(opaSessionObj *cautils.OPASessionObj, resourceID string) (int, 
 }
 
 func getBasePathFromMetadata(opaSessionObj cautils.OPASessionObj) string {
-	if opaSessionObj.Metadata.ScanMetadata.ScanningTarget == v2.GitLocal {
+	switch opaSessionObj.Metadata.ScanMetadata.ScanningTarget {
+	case v2.GitLocal:
 		return opaSessionObj.Metadata.ContextMetadata.RepoContextMetadata.LocalRootPath
-	}
-
-	if opaSessionObj.Metadata.ScanMetadata.ScanningTarget == v2.Directory {
+	case v2.Directory:
 		return opaSessionObj.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath
+	default:
+		return ""
 	}
-
-	return ""
 }
 
 // generateRemediationMessage generates a remediation message for the given control summary

--- a/smoke_testing/test_scan.py
+++ b/smoke_testing/test_scan.py
@@ -36,6 +36,30 @@ def scan_all(kubescape_exec: str):
     return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files])
 
 
+def scan_all_format_sarif(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "sarif", "--output", "results"])
+
+
+def scan_all_format_json(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "json", "--output", "results"])
+
+
+def scan_all_format_junit(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "junit", "--output", "results"])
+
+
+def scan_all_format_pretty_printer(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "pretty-printer", "--output", "results"])
+
+
+def scan_all_format_html(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "html", "--output", "results"])
+
+
+def scan_all_format_pdf(kubescape_exec: str):
+    return smoke_utils.run_command(command=[kubescape_exec, "scan", all_files, "--format", "pdf", "--output", "results"])
+
+
 def scan_from_stdin(kubescape_exec: str):
     return smoke_utils.run_command(command=["cat", single_file, "|", kubescape_exec, "scan", "framework", "nsa", "-"])
 
@@ -67,6 +91,33 @@ def run(kubescape_exec: str):
 
     print("Testing scan all")
     msg = scan_all(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+
+    print("Testing scan_all_format_json")
+    msg = scan_all_format_json(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+    print("Testing scan_all_format_sarif")
+    msg = scan_all_format_sarif(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+    print("Testing scan_all_format_junit")
+    msg = scan_all_format_junit(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+    print("Testing scan_all_format_pretty_printer")
+    msg = scan_all_format_pretty_printer(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+
+    print("Testing scan_all_format_html")
+    msg = scan_all_format_html(kubescape_exec=kubescape_exec)
+    smoke_utils.assertion(msg)
+
+
+    print("Testing scan_all_format_pdf")
+    msg = scan_all_format_pdf(kubescape_exec=kubescape_exec)
     smoke_utils.assertion(msg)
 
     # TODO - fix test


### PR DESCRIPTION
## Overview
When scanning a file/dir we change the scanning context so the data can be submitted similarly to repository scanning.
This caused the sarif handler and the fix command to panic in some cases.
In this PR I fixed the panic by saving the context of files/directories and a git.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
