### PR TITLE
fix: negative compliance score

### DIFF
--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -37,6 +37,9 @@ func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo [
 	row[columnCounterFailed] = fmt.Sprintf("%d", controlSummary.NumberOfResources().Failed())
 	row[columnCounterAll] = fmt.Sprintf("%d", controlSummary.NumberOfResources().All())
 	row[columnComplianceScore] = getComplianceScoreColumn(controlSummary, infoToPrintInfo)
+	if row[columnComplianceScore] == "-1%" {
+		row[columnComplianceScore] = "N/A"
+	}
 
 	return row
 }


### PR DESCRIPTION
## Overview

As mentioned in the issue, the compliance score would be returned as `-1%` in case no resources were passed, it would be better to have this set to `N/A` which make more sense from a percentage and score point of view.

## Additional Information

More context regarding the same can be found [here](https://github.com/kubescape/opa-utils/pull/117).

## How to Test

Create an empty `resource.yaml` then:

```bash
./kubescape scan resource.yaml
```

## Examples/Screenshots

Before change:

![image](https://github.com/kubescape/opa-utils/assets/81813720/fe0cd807-ed07-42af-8dfe-840dbb897ed5)

After change:

![image](https://github.com/kubescape/kubescape/assets/81813720/c4071029-eed0-40c7-8d17-1c400a3bc562)

## Related issues/PRs:

Resolved #1282 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes