### PR TITLE
Color headers

### DIFF
--- a/core/core/list.go
+++ b/core/core/list.go
@@ -100,6 +100,13 @@ func prettyPrintListFormat(ctx context.Context, targetPolicy string, policies []
 	data := v2.Matrix{}
 
 	controlRows := generatePolicyRows(policies)
+
+	var headerColors []tablewriter.Colors
+	for range controlRows[0] {
+		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+	}
+	policyTable.SetHeaderColor(headerColors...)
+
 	data = append(data, controlRows...)
 
 	policyTable.AppendBulk(data)
@@ -130,6 +137,11 @@ func prettyPrintControls(ctx context.Context, policies []string) {
 	} else {
 		controlsTable.SetHeader([]string{"Control ID", "Control Name", "Docs", "Frameworks"})
 	}
+	var headerColors []tablewriter.Colors
+	for range controlRows[0] {
+		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+	}
+	controlsTable.SetHeaderColor(headerColors...)
 
 	data := v2.Matrix{}
 	data = append(data, controlRows...)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
@@ -97,6 +97,11 @@ func getCategoryTableWriter(writer io.Writer, headers []string, columnAligments 
 	table.SetColumnAlignment(columnAligments)
 	table.SetAutoWrapText(false)
 	table.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	var headerColors []tablewriter.Colors
+	for range headers {
+		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+	}
+	table.SetHeaderColor(headerColors...)
 	return table
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/frameworkscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/frameworkscan.go
@@ -70,6 +70,12 @@ func (fp *FrameworkPrinter) PrintSummaryTable(writer io.Writer, summaryDetails *
 	summaryTable.SetHeader(GetControlTableHeaders(short))
 	summaryTable.SetFooter(GenerateFooter(summaryDetails, short))
 
+	var headerColors []tablewriter.Colors
+	for range dataRows[0] {
+		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+	}
+	summaryTable.SetHeaderColor(headerColors...)
+
 	summaryTable.AppendBulk(dataRows)
 	summaryTable.Render()
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
@@ -19,6 +19,12 @@ func renderTable(writer io.Writer, headers []string, columnAlignments []int, row
 	table.SetColumnAlignment(columnAlignments)
 	table.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
 
+	var headerColors []tablewriter.Colors
+	for range rows[0] {
+		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+	}
+	table.SetHeaderColor(headerColors...)
+
 	table.AppendBulk(rows)
 
 	table.Render()

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -65,6 +65,12 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 		}
 		summaryTable.SetHeader(generateResourceHeader(short))
 
+		var headerColors []tablewriter.Colors
+		for range resourceRows[0] {
+			headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+		}
+		summaryTable.SetHeaderColor(headerColors...)
+
 		data := Matrix{}
 		data = append(data, resourceRows...)
 		// For control scan framework will be nil


### PR DESCRIPTION
## Overview

*NOTE: DO NOT MERGE RIGHT NOW, INCLUDES SOME BREAKING CHANGES*

This PR aims to add the ability to color the table headers based off of the changes made in #1316. Hence that needs to be merged first before approaching this one, as a matter of fact, it'd be better to merge all the table related PRs first then move to this one.

## Additional Information

The table library we are using supports colors internally using the `fatih/color` library which is the recommended method by them, I've used the `gchalk` library instead which leads to some table breaks here and there, but some of the other PRs if merged will be able to fix those issues.

## How to Test

Run any one of:
1) `kubescape list controls/frameworks/exceptions`
2) `kubescape scan resource.yaml`

## Examples/Screenshots

![image](https://github.com/kubescape/kubescape/assets/81813720/caaa6836-5171-4411-98a8-88d2b4e859ed)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
