### PR TITLE
feat: migrate fatih/color to gchalk

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fatih/color"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -74,7 +73,7 @@ func generateCategoryStatusRow(controlSummary reportsummary.IControlSummary, inf
 		rows[0] = controlSummary.GetName()
 	}
 
-	rows[1] = color.New(color.Bold, utils.GetStatusColor(controlSummary.GetStatus().Status())).SprintFunc()(getStatus(status, controlSummary, infoToPrintInfo))
+	rows[1] = utils.GetStatusColor(controlSummary.GetStatus().Status())(getStatus(status, controlSummary, infoToPrintInfo))
 
 	rows[2] = getDocsForControl(controlSummary)
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fatih/color"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
@@ -71,7 +71,7 @@ func (cp *ClusterPrinter) generateCountingCategoryRow(controlSummary reportsumma
 
 	failedResources := controlSummary.NumberOfResources().Failed()
 	if failedResources > 0 {
-		row[1] = string(color.New(color.FgYellow, color.Bold).SprintFunc()(fmt.Sprintf("%d", failedResources)))
+		row[1] = string(gchalk.WithYellow().Bold(fmt.Sprintf("%d", failedResources)))
 	} else {
 		row[1] = fmt.Sprintf("%d", failedResources)
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/reposcan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/reposcan.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -85,7 +85,7 @@ func (rp *RepoPrinter) generateCountingCategoryRow(controlSummary reportsummary.
 
 	failedResources := controlSummary.NumberOfResources().Failed()
 	if failedResources > 0 {
-		rows[1] = string(color.New(color.FgYellow, color.Bold).SprintFunc()(fmt.Sprintf("%d", failedResources)))
+		rows[1] = string(gchalk.WithYellow().Bold(fmt.Sprintf("%d", failedResources)))
 	} else {
 		rows[1] = fmt.Sprintf("%d", failedResources)
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -26,7 +25,7 @@ func ControlCountersForSummary(counters reportsummary.ICounters) string {
 }
 
 func GetSeverityColumn(controlSummary reportsummary.IControlSummary) string {
-	return color.New(utils.GetColor(apis.ControlSeverityToInt(controlSummary.GetScoreFactor())), color.Bold).SprintFunc()(apis.ControlSeverityToString(controlSummary.GetScoreFactor()))
+	return utils.GetColor(apis.ControlSeverityToInt(controlSummary.GetScoreFactor()))(apis.ControlSeverityToString(controlSummary.GetScoreFactor()))
 }
 
 func GetControlTableHeaders(short bool) []string {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
-	"github.com/fatih/color"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/olekukonko/tablewriter"
@@ -47,7 +47,7 @@ func generateRows(summary ImageScanSummary) [][]string {
 
 func generateRow(cve CVE) []string {
 	row := make([]string, 5)
-	row[imageColumnSeverity] = color.New(getColor(cve.Severity), color.Bold).Sprint(cve.Severity)
+	row[imageColumnSeverity] = getColor(cve.Severity)(cve.Severity)
 	row[imageColumnName] = cve.ID
 	row[imageColumnComponent] = cve.Package
 	row[imageColumnVersion] = cve.Version
@@ -77,19 +77,19 @@ func getImageScanningColumnsAlignments() []int {
 	return []int{tablewriter.ALIGN_CENTER, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT}
 }
 
-func getColor(severity string) color.Attribute {
+func getColor(severity string) (func(...string) string) {
 	switch severity {
 	case apis.SeverityCriticalString:
-		return color.FgRed
+		return gchalk.WithAnsi256(1).Bold
 	case apis.SeverityHighString:
-		return color.FgYellow
+		return gchalk.WithAnsi256(196).Bold
 	case apis.SeverityMediumString:
-		return color.FgCyan
+		return gchalk.WithAnsi256(166).Bold
 	case apis.SeverityLowString:
-		return color.FgBlue
+		return gchalk.WithAnsi256(220).Bold
 	case apis.SeverityNegligibleString:
-		return color.FgMagenta
+		return gchalk.WithAnsi256(16).Bold
 	default:
-		return color.FgWhite
+		return gchalk.WithAnsi256(16).Bold
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
-	"github.com/fatih/color"
-	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -160,58 +158,5 @@ func TestGetImageScanningColumnsAlignments(t *testing.T) {
 		if alignments[i] != expectedAlignments[i] {
 			t.Errorf("expected %d, got %d", expectedAlignments[i], alignments[i])
 		}
-	}
-}
-
-func TestGetColor(t *testing.T) {
-	tests := []struct {
-		name     string
-		severity string
-		want     color.Attribute
-	}{
-		{
-			name:     "check color for Critical",
-			severity: apis.SeverityCriticalString,
-			want:     color.FgRed,
-		},
-		{
-			name:     "check color for High",
-			severity: apis.SeverityHighString,
-			want:     color.FgYellow,
-		},
-		{
-			name:     "check color for Medium",
-			severity: apis.SeverityMediumString,
-			want:     color.FgCyan,
-		},
-		{
-			name:     "check color for Low",
-			severity: apis.SeverityLowString,
-			want:     color.FgBlue,
-		},
-		{
-			name:     "check color for Negligible",
-			severity: apis.SeverityNegligibleString,
-			want:     color.FgMagenta,
-		},
-		{
-			name:     "check color for Unknown",
-			severity: apis.SeverityUnknownString,
-			want:     color.FgWhite,
-		},
-		{
-			name:     "check color for Other",
-			severity: "Other",
-			want:     color.FgWhite,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actualColor := getColor(tt.severity)
-			if actualColor != tt.want {
-				t.Errorf("expected %v, got %v", tt.want, actualColor)
-			}
-		})
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/fatih/color"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -55,18 +55,18 @@ func MapInfoToPrintInfo(controls reportsummary.ControlSummaries) []InfoStars {
 	return infoToPrintInfo
 }
 
-func GetColor(severity int) color.Attribute {
+func GetColor(severity int) (func(...string) string) {
 	switch severity {
 	case apis.SeverityCritical:
-		return color.FgRed
+		return gchalk.WithAnsi256(1).Bold
 	case apis.SeverityHigh:
-		return color.FgYellow
+		return gchalk.WithAnsi256(196).Bold
 	case apis.SeverityMedium:
-		return color.FgCyan
+		return gchalk.WithAnsi256(166).Bold
 	case apis.SeverityLow:
-		return color.FgWhite
+		return gchalk.WithAnsi256(220).Bold
 	default:
-		return color.FgWhite
+		return gchalk.WithAnsi256(16).Bold
 	}
 }
 
@@ -112,31 +112,31 @@ func PrintInfo(writer io.Writer, infoToPrintInfo []InfoStars) {
 	}
 }
 
-func GetStatusColor(status apis.ScanningStatus) color.Attribute {
+func GetStatusColor(status apis.ScanningStatus) (func(...string) string) {
 	switch status {
 	case apis.StatusPassed:
-		return color.FgGreen
+		return gchalk.WithGreen().Bold
 	case apis.StatusFailed:
-		return color.FgRed
+		return gchalk.WithRed().Bold
 	case apis.StatusSkipped:
-		return color.FgCyan
+		return gchalk.WithCyan().Bold
 	default:
-		return color.FgWhite
+		return gchalk.WithWhite().Bold
 	}
 }
 
-func getColor(controlSeverity int) color.Attribute {
+func getColor(controlSeverity int) (func(...string) string) {
 	switch controlSeverity {
 	case apis.SeverityCritical:
-		return color.FgRed
+		return gchalk.WithAnsi256(1).Bold
 	case apis.SeverityHigh:
-		return color.FgYellow
+		return gchalk.WithAnsi256(196).Bold
 	case apis.SeverityMedium:
-		return color.FgCyan
+		return gchalk.WithAnsi256(166).Bold
 	case apis.SeverityLow:
-		return color.FgWhite
+		return gchalk.WithAnsi256(220).Bold
 	default:
-		return color.FgWhite
+		return gchalk.WithAnsi256(16).Bold
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
@@ -245,5 +245,5 @@ func printComplianceScore(writer *os.File, frameworks []reportsummary.IFramework
 }
 
 func getCallToActionString(action string) string {
-	return color.New(color.Bold, color.FgHiBlue).SprintFunc()(action)
+	return gchalk.WithBrightBlue().Bold(action)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/enescakir/emoji v1.0.0
-	github.com/fatih/color v1.15.0
 	github.com/francoispqt/gojay v1.2.13
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/google/go-containerregistry v0.15.2
@@ -178,6 +177,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect


### PR DESCRIPTION
## Overview

As mentioned in the issue, we had moved to using the `gchalk` library for all our console output color needs, still some direct remnants of `fatih/color` remained because of which the output colors weren't consistent due to conflict between libraries. This PR removes all direct usage of `fatih/color` from the repo.

## Additional Information

This only removes all direct dependence, some indirect independence still remains, mainly due to the `table` library we use which is built on top of `fatih/color` for it's coloring needs, though it is possible to find a workaround to remove this as well, but that should be on a need to do basis, as currently there is no problem since all direct usage has been removed.

## How to Test

`kubescape scan resource.yaml`

## Related issues/PRs:

Resolved #1339 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
