### PR TITLE
fix panic and improve logs

### DIFF
--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/meta"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -70,11 +71,11 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			ctx := context.TODO()
 			results, err := ks.Scan(ctx, scanInfo)
 			if err != nil {
-				return err
+				logger.L().Fatal(err.Error())
 			}
 
 			if err = results.HandleResults(ctx); err != nil {
-				return err
+				logger.L().Fatal(err.Error())
 			}
 
 			return nil

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -112,7 +112,7 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 	if len(wls) == 0 {
 		return nil, fmt.Errorf("k8s resource '%s' not found", getReadableID(resource))
 	} else if len(wls) > 1 {
-		return nil, fmt.Errorf("more than one k8s resource found for '%s'", resource.GetID())
+		return nil, fmt.Errorf("more than one k8s resource found for '%s'", getReadableID(resource))
 	}
 
 	return wls[0], nil

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -62,11 +62,6 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 		return nil, nil, nil, nil, err
 	}
 
-	// we don't scan resources which have a parent
-	if sessionObj.SingleResourceScan != nil && k8sinterface.WorkloadHasParent(sessionObj.SingleResourceScan) {
-		return nil, nil, nil, nil, fmt.Errorf("resource %s has a parent and cannot be scanned", sessionObj.SingleResourceScan.GetID())
-	}
-
 	resourceToControl := make(map[string][]string)
 	// build resources map
 	// map resources based on framework required resources: map["/group/version/kind"][]<k8s workloads ids>
@@ -183,20 +178,24 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(resource *objectsen
 	}
 	result, err := k8sHandler.pullSingleResource(&gvr, nil, fieldSelectors, globalFieldSelector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get resource %s, reason: %v", resource.GetID(), err)
+		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), err)
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("%s was not found", resource.GetID())
-	}
-
-	if len(result) > 1 {
-		return nil, fmt.Errorf("more than one resource found for %s", resource.GetID())
+		return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
 	}
 
 	metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
+	if len(metaObjs) == 0 {
+		return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+	}
+
+	if len(metaObjs) > 1 {
+		return nil, fmt.Errorf("more than one resource found for %s", getReadableID(resource))
+	}
+
 	if !k8sinterface.IsTypeWorkload(metaObjs[0].GetObject()) {
-		return nil, fmt.Errorf("%s is not a valid Kubernetes workload", resource.GetID())
+		return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
 	}
 
 	wl := workloadinterface.NewWorkloadObj(metaObjs[0].GetObject())


### PR DESCRIPTION
## Overview
Kubescape was panicking when scanning a workload which has an owner reference. This PR fixes that by checking for this error and validating list length
## Additional Information
This PR also fix the workload scan logs, making them more readable by using the readable ID, and not printing the entire help message if we encounter an error during the scan.

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
