### PR TITLE
improve cli output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
-	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
@@ -37,8 +36,7 @@ func (ip *ImagePrinter) PrintImageScanning(summary *imageprinter.ImageScanSummar
 
 func (ip *ImagePrinter) PrintImageScanningTable(summary imageprinter.ImageScanSummary) {
 	if !ip.verboseMode {
-		// filter out vulnerabilities with severity lower than High
-		summary.CVEs = filterCVEsBySeverities(summary.CVEs, []string{apis.SeverityCriticalString, apis.SeverityHighString})
+		summary.CVEs = getFilteredCVEs(summary.CVEs)
 	}
 
 	ip.imageTablePrinter.PrintImageScanningTable(ip.writer, summary)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
@@ -77,7 +77,7 @@ func getImageScanningColumnsAlignments() []int {
 	return []int{tablewriter.ALIGN_CENTER, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT}
 }
 
-func getColor(severity string) (func(...string) string) {
+func getColor(severity string) func(...string) string {
 	switch severity {
 	case apis.SeverityCriticalString:
 		return gchalk.WithAnsi256(1).Bold
@@ -88,8 +88,8 @@ func getColor(severity string) (func(...string) string) {
 	case apis.SeverityLowString:
 		return gchalk.WithAnsi256(220).Bold
 	case apis.SeverityNegligibleString:
-		return gchalk.WithAnsi256(16).Bold
+		return gchalk.WithAnsi256(39).Bold
 	default:
-		return gchalk.WithAnsi256(16).Bold
+		return gchalk.WithAnsi256(30).Bold
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -102,6 +102,19 @@ func addEmptySeverities(mapSeverityTSummary map[string]*imageprinter.SeveritySum
 	}
 }
 
+// getFilteredCVEs returns a list of CVEs to show in the table. If there are no vulnerabilities with severity Critical or High, it will return vulnerabilities with severity Medium. Otherwise it will return vulnerabilities with severity Critical or High
+func getFilteredCVEs(cves []imageprinter.CVE) []imageprinter.CVE {
+	// filter out vulnerabilities with severity lower than High
+	filteredCVEs := filterCVEsBySeverities(cves, []string{apis.SeverityCriticalString, apis.SeverityHighString})
+
+	// if there are no vulnerabilities with severity Critical or High, add vulnerabilities with severity Medium
+	if len(filteredCVEs) == 0 {
+		filteredCVEs = filterCVEsBySeverities(cves, []string{apis.SeverityMediumString})
+	}
+
+	return filteredCVEs
+}
+
 // filterCVEsBySeverities returns a list of CVEs only with the severities that are in the severities list
 func filterCVEsBySeverities(cves []imageprinter.CVE, severities []string) []imageprinter.CVE {
 	var filteredCVEs []imageprinter.CVE

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
@@ -535,3 +535,104 @@ func TestGetSortedCVEsBySeverity(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFilteredCVEs(t *testing.T) {
+	tests := []struct {
+		name         string
+		cves         []imageprinter.CVE
+		expectedCVEs []imageprinter.CVE
+	}{
+		{
+			name: "High and Critical",
+			cves: []imageprinter.CVE{
+				{
+					Severity: "High",
+				},
+				{
+					Severity: "Critical",
+				},
+				{
+					Severity: "Medium",
+				},
+				{
+					Severity: "Low",
+				},
+				{
+					Severity: "Negligible",
+				},
+			},
+			expectedCVEs: []imageprinter.CVE{
+				{
+					Severity: "High",
+				},
+				{
+					Severity: "Critical",
+				},
+			},
+		},
+		{
+			name: "Only High",
+			cves: []imageprinter.CVE{
+				{
+					Severity: "High",
+				},
+				{
+					Severity: "Medium",
+				}},
+			expectedCVEs: []imageprinter.CVE{
+				{
+					Severity: "High",
+				},
+			},
+		},
+		{
+			name: "Only Critical",
+			cves: []imageprinter.CVE{
+				{
+					Severity: "Critical",
+				},
+				{
+					Severity: "Medium",
+				}},
+			expectedCVEs: []imageprinter.CVE{
+				{
+					Severity: "Critical",
+				},
+			},
+		},
+		{
+			name: "No High or Critical",
+			cves: []imageprinter.CVE{
+				{
+					Severity: "Low",
+				},
+				{
+					Severity: "Medium",
+				}},
+
+			expectedCVEs: []imageprinter.CVE{
+				{
+					Severity: "Medium",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filteredCVEs := getFilteredCVEs(tc.cves)
+			for _, cve := range filteredCVEs {
+				found := false
+				for _, expectedCVE := range tc.expectedCVEs {
+					if cve.Severity == expectedCVE.Severity {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected: %v, Got: %v", tc.expectedCVEs, filteredCVEs)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview
This PR improves the `scan image` command by:

1. Making colors of  "Negligible" and "Unknown" vulnerabilities similar to the ones in ARMO platform (before they were mostly not visible)
2. If no "High" and "Critical" vulnerabilities were found, the table will show "Medium" severity vulnerabilities (as opposed to not showing the table at all)

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->


## Examples/Screenshots
![image](https://github.com/kubescape/kubescape/assets/84905812/9e093625-5506-4b83-bc70-ee0d3b95ed0f)
![image](https://github.com/kubescape/kubescape/assets/84905812/b17e8cc6-f475-4979-ac29-833faf0c8407)

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
