### PR TITLE
support paths from related resources

### DIFF
--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -307,8 +307,10 @@ func TestProcessRule(t *testing.T) {
 					ControlConfigurations: map[string][]string{},
 					Status:                "failed",
 					SubStatus:             "",
-					Paths:                 nil,
-					Exception:             nil,
+					Paths: []armotypes.PosturePaths{
+						{ResourceID: "/v1/default/Service/fake-service-1", FailedPath: "spec.type"},
+					},
+					Exception: nil,
 					RelatedResourcesIDs: []string{
 						"/v1/default/Service/fake-service-1",
 					},

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -331,5 +332,76 @@ func TestProcessRule(t *testing.T) {
 		resources, err := opap.processRule(context.Background(), &tc.rule, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedResult, resources)
+	}
+}
+
+func TestAppendPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		paths       []armotypes.PosturePaths
+		failedPaths []string
+		fixPaths    []armotypes.FixPath
+		fixCommand  string
+		resourceID  string
+		expected    []armotypes.PosturePaths
+	}{
+		{
+			name:        "Only FailedPaths",
+			paths:       []armotypes.PosturePaths{{ResourceID: "1", FailedPath: "path1"}},
+			failedPaths: []string{"path2", "path3"},
+			resourceID:  "2",
+			expected: []armotypes.PosturePaths{
+				{ResourceID: "1", FailedPath: "path1"},
+				{ResourceID: "2", FailedPath: "path2"},
+				{ResourceID: "2", FailedPath: "path3"},
+			},
+		},
+		{
+			name:  "Only FixPaths",
+			paths: []armotypes.PosturePaths{},
+			fixPaths: []armotypes.FixPath{
+				{Path: "path2", Value: "command2"},
+				{Path: "path3", Value: "command3"},
+			},
+			resourceID: "2",
+			expected: []armotypes.PosturePaths{
+				{ResourceID: "2", FixPath: armotypes.FixPath{Path: "path2", Value: "command2"}},
+				{ResourceID: "2", FixPath: armotypes.FixPath{Path: "path3", Value: "command3"}},
+			},
+		},
+		{
+			name:       "Only FixCommand",
+			paths:      []armotypes.PosturePaths{},
+			fixCommand: "fix command",
+			resourceID: "2",
+			expected: []armotypes.PosturePaths{
+				{ResourceID: "2", FixCommand: "fix command"},
+			},
+		},
+		{
+			name:        "All types of paths",
+			paths:       []armotypes.PosturePaths{{ResourceID: "1", FailedPath: "path1"}},
+			failedPaths: []string{"path2"},
+			fixPaths: []armotypes.FixPath{
+				{Path: "path3", Value: "command3"},
+			},
+			fixCommand: "fix command",
+			resourceID: "2",
+			expected: []armotypes.PosturePaths{
+				{ResourceID: "1", FailedPath: "path1"},
+				{ResourceID: "2", FailedPath: "path2"},
+				{ResourceID: "2", FixPath: armotypes.FixPath{Path: "path3", Value: "command3"}},
+				{ResourceID: "2", FixCommand: "fix command"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appendPaths(tt.paths, tt.failedPaths, tt.fixPaths, tt.fixCommand, tt.resourceID)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Add additional support for related objects - resources that are related to the reason that another resource failed for a certain control. For e.g - a secret that is mounted to a deployment, causing the deployment to fail on a control that checks for mounted secrets. 
This PR adds support for showing assisted remediation (fix path, fail path, fix command) connected to a related resource that is not the main resource that's failing
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
