### PR TITLE
fix panic & provide msg

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -117,6 +117,11 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context) []printe
 
 	outputPrinters := make([]printer.IPrinter, 0)
 	for _, format := range formats {
+		if !resultshandling.ValidatePrinter(scanInfo.ScanType, format) {
+			logger.L().Ctx(ctx).Fatal(fmt.Sprintf("Unsupported output format: %s", format))
+			continue
+		}
+
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo.FormatVersion, scanInfo.PrintAttackTree, scanInfo.VerboseMode, cautils.ViewTypes(scanInfo.View))
 		printerHandler.SetWriter(ctx, scanInfo.Output)
 		outputPrinters = append(outputPrinters, printerHandler)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -57,7 +57,7 @@ func (hp *HtmlPrinter) PrintNextSteps() {
 
 func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		logMissingData("html", ctx, opaSessionObj, imageScanData)
+		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -56,6 +56,11 @@ func (hp *HtmlPrinter) PrintNextSteps() {
 }
 
 func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logMissingData("html", ctx, opaSessionObj, imageScanData)
+		return
+	}
+
 	tplFuncMap := template.FuncMap{
 		"sum": func(nums ...int) int {
 			total := 0

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -53,11 +53,11 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	} else if imageScanData != nil {
 		err = jp.PrintImageScan(ctx, imageScanData[0].PresenterConfig)
 	} else {
-		err = fmt.Errorf("failed to write results, no data provided")
+		err = fmt.Errorf("no data provided")
 	}
 
 	if err != nil {
-		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("failed to write results in json format", helpers.Error(err))
 		return
 	}
 
@@ -75,7 +75,15 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, ctx conte
 }
 
 func (jp *JsonPrinter) PrintImageScan(ctx context.Context, scanResults *models.PresenterConfig) error {
-	presenterConfig, _ := presenter.ValidatedConfig("json", "", false)
+	if scanResults == nil {
+		return fmt.Errorf("no image vulnerability data provided")
+	}
+
+	presenterConfig, err := presenter.ValidatedConfig("json", "", false)
+	if err != nil {
+		return err
+	}
+
 	pres := presenter.GetPresenter(presenterConfig, *scanResults)
 
 	return pres.Present(jp.writer)

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -118,7 +118,7 @@ func (jp *JunitPrinter) PrintNextSteps() {
 
 func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		logMissingData("junit", ctx, opaSessionObj, imageScanData)
+		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -117,6 +117,11 @@ func (jp *JunitPrinter) PrintNextSteps() {
 }
 
 func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logMissingData("junit", ctx, opaSessionObj, imageScanData)
+		return
+	}
+
 	junitResult := testsSuites(opaSessionObj)
 	postureReportStr, err := xml.Marshal(junitResult)
 	if err != nil {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -90,6 +90,11 @@ func (pp *PdfPrinter) PrintNextSteps() {
 }
 
 func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logMissingData("pdf", ctx, opaSessionObj, imageScanData)
+		return
+	}
+
 	sortedControlIDs := getSortedControlsIDs(opaSessionObj.Report.SummaryDetails.Controls)
 
 	infoToPrintInfo := mapInfoToPrintInfo(opaSessionObj.Report.SummaryDetails.Controls)

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -91,7 +91,7 @@ func (pp *PdfPrinter) PrintNextSteps() {
 
 func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		logMissingData("pdf", ctx, opaSessionObj, imageScanData)
+		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -56,6 +56,10 @@ func (pp *PrometheusPrinter) PrintImageScan(context.Context, *models.PresenterCo
 }
 
 func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logMissingData("prometheus", ctx, opaSessionObj, imageScanData)
+		return
+	}
 
 	metrics := pp.generatePrometheusFormat(opaSessionObj.AllResources, opaSessionObj.ResourcesResult, &opaSessionObj.Report.SummaryDetails)
 

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -57,7 +57,7 @@ func (pp *PrometheusPrinter) PrintImageScan(context.Context, *models.PresenterCo
 
 func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		logMissingData("prometheus", ctx, opaSessionObj, imageScanData)
+		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -116,7 +116,7 @@ func (sp *SARIFPrinter) printImageScan(scanResults *models.PresenterConfig) erro
 		return fmt.Errorf("no no image vulnerability data provided")
 	}
 
-	presenterConfig, err := presenter.ValidatedConfig("sarif", "", false)
+	presenterConfig, err := presenter.ValidatedConfig(printer.SARIFFormat, "", false)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -142,7 +142,6 @@ func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 		}
 
 	} else {
-
 		report, err := sarif.New(sarif.Version210)
 		if err != nil {
 			panic(err)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -118,6 +118,11 @@ func (sp *SARIFPrinter) PrintNextSteps() {
 }
 
 func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logMissingData("sarif", ctx, opaSessionObj, imageScanData)
+		return
+	}
+
 	report, err := sarif.New(sarif.Version210)
 	if err != nil {
 		panic(err)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -120,6 +120,7 @@ func (sp *SARIFPrinter) PrintImageScan(scanResults *models.PresenterConfig) erro
 	if err != nil {
 		return err
 	}
+
 	pres := presenter.GetPresenter(presenterConfig, *scanResults)
 
 	return pres.Present(sp.writer)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -132,16 +132,16 @@ func (sp *SARIFPrinter) PrintNextSteps() {
 
 func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		// image scan
-		if len(imageScanData) > 0 {
-			if err := sp.printImageScan(imageScanData[0].PresenterConfig); err != nil {
-				logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
-				return
-			}
-		} else {
+		if len(imageScanData) == 0 {
 			logger.L().Ctx(ctx).Fatal("failed to write results in sarif format: no data provided")
+			return
 		}
 
+		// image scan
+		if err := sp.printImageScan(imageScanData[0].PresenterConfig); err != nil {
+			logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
+			return
+		}
 	} else {
 		// configuration scan
 		if err := sp.printConfigurationScan(ctx, opaSessionObj); err != nil {

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,12 +1,8 @@
 package printer
 
 import (
-	"context"
-	"fmt"
-
 	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/presenter/models"
-	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
@@ -142,12 +138,4 @@ func extractCVEs(matches []models.Match) []imageprinter.CVE {
 		CVEs = append(CVEs, cve)
 	}
 	return CVEs
-}
-
-func logMissingData(format string, ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
-	if imageScanData != nil {
-		logger.L().Ctx(ctx).Fatal(fmt.Sprintf("%s format is not supported for image scanning", format))
-	} else {
-		logger.L().Ctx(ctx).Fatal(fmt.Sprintf("failed to write results in %s format: no data provided", format))
-	}
 }

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,8 +1,12 @@
 package printer
 
 import (
+	"context"
+	"fmt"
+
 	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/presenter/models"
+	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
@@ -138,4 +142,12 @@ func extractCVEs(matches []models.Match) []imageprinter.CVE {
 		CVEs = append(CVEs, cve)
 	}
 	return CVEs
+}
+
+func logMissingData(format string, ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if imageScanData != nil {
+		logger.L().Ctx(ctx).Fatal(fmt.Sprintf("%s format is not supported for image scanning", format))
+	} else {
+		logger.L().Ctx(ctx).Fatal(fmt.Sprintf("failed to write results in %s format: no data provided", format))
+	}
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -133,12 +133,19 @@ func NewPrinter(ctx context.Context, printFormat, formatVersion string, verboseM
 }
 
 func ValidatePrinter(scanType cautils.ScanTypes, printFormat string) bool {
-	if scanType == cautils.ScanTypeImage {
-		if printFormat != printer.JsonFormat && printFormat != printer.PrettyFormat {
-			return false
-		}
-
+	if scanType != cautils.ScanTypeImage {
+		return true
 	}
 
-	return true
+	// supported types for image scanning
+	switch printFormat {
+	case printer.JsonFormat:
+		return true
+	case printer.PrettyFormat:
+		return true
+	case printer.SARIFFormat:
+		return true
+	default:
+		return false
+	}
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -131,3 +131,14 @@ func NewPrinter(ctx context.Context, printFormat, formatVersion string, verboseM
 		return printerv2.NewPrettyPrinter(verboseMode, formatVersion, attackTree, viewType, "", nil)
 	}
 }
+
+func ValidatePrinter(scanType cautils.ScanTypes, printFormat string) bool {
+	if scanType == cautils.ScanTypeImage {
+		if printFormat != printer.JsonFormat && printFormat != printer.PrettyFormat {
+			return false
+		}
+
+	}
+
+	return true
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -139,11 +139,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, printFormat string) bool {
 
 	// supported types for image scanning
 	switch printFormat {
-	case printer.JsonFormat:
-		return true
-	case printer.PrettyFormat:
-		return true
-	case printer.SARIFFormat:
+	case printer.JsonFormat, printer.PrettyFormat, printer.SARIFFormat:
 		return true
 	default:
 		return false

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -57,3 +57,96 @@ func TestResultsHandlerHandleResultsPrintsResultsToUI(t *testing.T) {
 		t.Errorf("UI Printer was not called to print. Got calls: %d, want calls: %d", got, want)
 	}
 }
+
+func TestValidatePrinter(t *testing.T) {
+	tests := []struct {
+		name     string
+		scanType cautils.ScanTypes
+		format   string
+		expected bool
+	}{
+		{
+			name:     "json format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.JsonFormat,
+			expected: true,
+		},
+		{
+			name:     "junit format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.JunitResultFormat,
+			expected: true,
+		},
+		{
+			name:     "sarif format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.SARIFFormat,
+			expected: true,
+		},
+		{
+			name:     "pretty format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.PrettyFormat,
+			expected: true,
+		},
+		{
+			name:     "html format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.HtmlFormat,
+			expected: true,
+		},
+		{
+			name:     "prometheus format for cluster scan",
+			scanType: cautils.ScanTypeCluster,
+			format:   printer.PrometheusFormat,
+			expected: true,
+		},
+
+		{
+			name:     "json format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.JsonFormat,
+			expected: true,
+		},
+		{
+			name:     "junit format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.JunitResultFormat,
+			expected: false,
+		},
+		{
+			name:     "sarif format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.SARIFFormat,
+			expected: true,
+		},
+		{
+			name:     "pretty format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.PrettyFormat,
+			expected: true,
+		},
+		{
+			name:     "html format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.HtmlFormat,
+			expected: false,
+		},
+		{
+			name:     "prometheus format for image scan",
+			scanType: cautils.ScanTypeImage,
+			format:   printer.PrometheusFormat,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidatePrinter(tt.scanType, tt.format)
+			if got != tt.expected {
+				t.Errorf("%s failed - got = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Overview
This PR fixes Kubescape panicking for image scanning when using output formats other than pretty printer and JSON (which are the only ones supported).

Previous behavior:
`kubescape scan image nginx --format junit`

![image](https://github.com/kubescape/kubescape/assets/84905812/edc88595-08d4-4144-8fc4-52d43777a1e3)

Behavior with this PR:
`kubescape scan image nginx --format junit`

![image](https://github.com/kubescape/kubescape/assets/84905812/b77eddea-dd99-42f6-aed0-3d06dc910146)


<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
