### PR TITLE
move context flag to root

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/cmd/completion"
 	"github.com/kubescape/kubescape/v2/cmd/config"
 	"github.com/kubescape/kubescape/v2/cmd/download"
@@ -49,6 +50,13 @@ func getRootCmd(ks meta.IKubescape) *cobra.Command {
 		Use:     "kubescape",
 		Short:   "Kubescape is a tool for testing Kubernetes security posture. Docs: https://hub.armosec.io/docs",
 		Example: ksExamples,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			k8sinterface.SetClusterContextName(rootInfo.KubeContext)
+			initLogger()
+			initLoggerLevel()
+			initEnvironment()
+			initCacheDir()
+		},
 	}
 
 	if cautils.IsKrewPlugin() {
@@ -76,8 +84,7 @@ func getRootCmd(ks meta.IKubescape) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&rootInfo.DisableColor, "disable-color", "", false, "Disable color output for logging")
 	rootCmd.PersistentFlags().BoolVarP(&rootInfo.EnableColor, "enable-color", "", false, "Force enable color output for logging")
 
-	cobra.OnInitialize(initLogger, initLoggerLevel, initEnvironment, initCacheDir)
-
+	rootCmd.PersistentFlags().StringVarP(&rootInfo.KubeContext, "kube-context", "", "", "Kube context. Default will use the current-context")
 	// Supported commands
 	rootCmd.AddCommand(scan.GetScanCommand(ks))
 	rootCmd.AddCommand(download.GetDownloadCmd(ks))

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/cautils/getter"
 	"github.com/kubescape/kubescape/v2/core/meta"
@@ -63,17 +62,12 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 			}
 			return nil
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
-			k8sinterface.SetClusterContextName(scanInfo.KubeContext)
-
-		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			// TODO - revert context
 		},
 	}
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.KubeContext, "kube-context", "", "", "Kube context. Default will use the current-context")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")

--- a/core/cautils/rootinfo.go
+++ b/core/cautils/rootinfo.go
@@ -13,6 +13,7 @@ type RootInfo struct {
 	DisableColor       bool   // Disable Color
 	EnableColor        bool   // Force enable Color
 	DiscoveryServerURL string // Discovery Server URL  (See https://github.com/kubescape/backend/tree/main/pkg/servicediscovery)
+	KubeContext        string //  context name
 }
 type CloudURLs struct {
 	CloudReportURL string

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -129,7 +129,6 @@ type ScanInfo struct {
 	HostSensorYamlPath    string                       // Path to hostsensor file
 	Local                 bool                         // Do not submit results
 	AccountID             string                       // account ID
-	KubeContext           string                       // context name
 	FrameworkScan         bool                         // false if scanning control
 	ScanAll               bool                         // true if scan all frameworks
 	OmitRawResources      bool                         // true if omit raw resources from the output

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -70,7 +70,6 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string) (*repo
 		trace.WithAttributes(attribute.String("excludedNamespaces", scanInfo.ExcludedNamespaces)),
 		trace.WithAttributes(attribute.String("includeNamespaces", scanInfo.IncludeNamespaces)),
 		trace.WithAttributes(attribute.String("hostSensorYamlPath", scanInfo.HostSensorYamlPath)),
-		trace.WithAttributes(attribute.String("kubeContext", scanInfo.KubeContext)),
 	)
 
 	result, err := ks.Scan(ctx, scanInfo)
@@ -151,8 +150,8 @@ func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *ca
 	scanInfo.Output = filepath.Join(OutputDir, scanID)
 	// *** end ***
 
-	// Set default KubeContext from scanInfo input
-	k8sinterface.SetClusterContextName(scanInfo.KubeContext)
+	// Set default KubeContext from current context
+	k8sinterface.SetClusterContextName(k8sinterface.GetContextName())
 
 	return scanInfo
 }
@@ -173,7 +172,6 @@ func defaultScanInfo() *cautils.ScanInfo {
 	if !envToBool("KS_DOWNLOAD_ARTIFACTS", false) {
 		scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape fom downloading the artifacts every time)
 	}
-	scanInfo.KubeContext = envToString("KS_CONTEXT", "") // publish results to Kubescape SaaS
 
 	return scanInfo
 }


### PR DESCRIPTION
Fix `--kube-context` flag by making it available to the root command, and move all initialization logic to `PreRun`

fixes #1365 