### PR TITLE
Fix scan command

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -42,7 +42,11 @@ var (
   Run '%[1]s list frameworks' for the list of supported frameworks
 `, cautils.ExecName())
 
-	ErrUnknownSeverity = errors.New("unknown severity")
+	ErrUnknownSeverity          = errors.New("unknown severity")
+	ErrSecurityViewNotSupported = errors.New("security view is not supported for framework scan")
+	ErrBadThreshold             = errors.New("bad argument: out of range threshold")
+	ErrKeepLocalOrSubmit        = errors.New("you can use `keep-local` or `submit`, but not both")
+	ErrOmitRawResourcesOrSubmit = errors.New("you can use `omit-raw-resources` or `submit`, but not both")
 )
 
 func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
@@ -209,20 +213,20 @@ func validateSeverity(severity string) error {
 // validateFrameworkScanInfo validates the scan info struct for the `scan framework` command
 func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if scanInfo.View == string(cautils.SecurityViewType) {
-		return fmt.Errorf("you can use `security` view only when not scanning specific frameworks/controls")
+		return ErrSecurityViewNotSupported
 	}
 
 	if scanInfo.Submit && scanInfo.Local {
-		return fmt.Errorf("you can use `keep-local` or `submit`, but not both")
+		return ErrKeepLocalOrSubmit
 	}
 	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
-		return fmt.Errorf("bad argument: out of range threshold")
+		return ErrBadThreshold
 	}
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
-		return fmt.Errorf("bad argument: out of range threshold")
+		return ErrBadThreshold
 	}
 	if scanInfo.Submit && scanInfo.OmitRawResources {
-		return fmt.Errorf("you can use `omit-raw-resources` or `submit`, but not both")
+		return ErrOmitRawResourcesOrSubmit
 	}
 	severity := scanInfo.FailThresholdSeverity
 	if err := validateSeverity(severity); severity != "" && err != nil {

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -208,6 +208,10 @@ func validateSeverity(severity string) error {
 
 // validateFrameworkScanInfo validates the scan info struct for the `scan framework` command
 func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
+	if scanInfo.View == string(cautils.SecurityViewType) {
+		return fmt.Errorf("you can use `security` view only when not scanning specific frameworks/controls")
+	}
+
 	if scanInfo.Submit && scanInfo.Local {
 		return fmt.Errorf("you can use `keep-local` or `submit`, but not both")
 	}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -41,15 +41,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Short:   "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations",
 		Long:    `The action you want to perform`,
 		Example: scanCmdExamples,
-		Args: func(cmd *cobra.Command, args []string) error {
-			// setting input patterns for framework scan is only relevancy for non-security view
-			if len(args) > 0 && scanInfo.View != string(cautils.SecurityViewType) {
-				if args[0] != "framework" && args[0] != "control" {
-					return getFrameworkCmd(ks, &scanInfo).RunE(cmd, append([]string{strings.Join(getter.NativeFrameworks, ",")}, args...))
-				}
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				setSecurityViewScanInfo(args, &scanInfo)
@@ -57,8 +48,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				return securityScan(scanInfo, ks)
 			}
 
-			if len(args) == 0 {
-				return getFrameworkCmd(ks, &scanInfo).RunE(cmd, []string{strings.Join(getter.NativeFrameworks, ",")})
+			if len(args) == 0 || (args[0] != "framework" && args[0] != "control") {
+				return getFrameworkCmd(ks, &scanInfo).RunE(cmd, append([]string{strings.Join(getter.NativeFrameworks, ",")}, args...))
 			}
 			return nil
 		},

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -68,6 +68,16 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
 			ErrUnknownSeverity,
 		},
+		{
+			"Security view should be invalid for scan info",
+			&cautils.ScanInfo{View: string(cautils.SecurityViewType)},
+			ErrSecurityViewNotSupported,
+		},
+		{
+			"Empty view should be valid for scan info",
+			&cautils.ScanInfo{},
+			nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/kubescape/backend v0.0.2
 	github.com/kubescape/go-git-url v0.0.25
 	github.com/kubescape/go-logger v0.0.20
-	github.com/kubescape/k8s-interface v0.0.141
+	github.com/kubescape/k8s-interface v0.0.142
 	github.com/kubescape/opa-utils v0.0.267
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary v1.0.291-rc.0

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,8 @@ github.com/kubescape/go-git-url v0.0.25 h1:i7SSSC1+1m/Dg+4LV3erp0YklnWj1Z0cVlRxC
 github.com/kubescape/go-git-url v0.0.25/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kubescape/go-logger v0.0.20 h1:ZU3T6Za7maCiChdoTrqpD6TI11DGJwd9xU/TFtRlMOI=
 github.com/kubescape/go-logger v0.0.20/go.mod h1:BAWhQMYc/gnC5wMtPvc9Z4VXFqykFFMaXaPkq0+txBY=
-github.com/kubescape/k8s-interface v0.0.141 h1:CQcK3PZsSeDFVmlvyHya48NJihGe7Qc+3kEWsmc4KnA=
-github.com/kubescape/k8s-interface v0.0.141/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
+github.com/kubescape/k8s-interface v0.0.142 h1:kL8D/2s+GNEZlp50rTNDLe6dhSzHAXMOQweyJdSWkVk=
+github.com/kubescape/k8s-interface v0.0.142/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
 github.com/kubescape/opa-utils v0.0.267 h1:qzINBGsVOTKeLAIj1YfaYdV93FsSRriWdiN0JXJwD/o=
 github.com/kubescape/opa-utils v0.0.267/go.mod h1:95JkuIOfClgLc+DyGb2mDvefRW0STkZe4L2z6AaZJlQ=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/kubescape/backend v0.0.2
 	github.com/kubescape/go-logger v0.0.20
-	github.com/kubescape/k8s-interface v0.0.141
+	github.com/kubescape/k8s-interface v0.0.142
 	github.com/kubescape/kubescape/v2 v2.0.0-00010101000000-000000000000
 	github.com/kubescape/opa-utils v0.0.267
 	github.com/stretchr/testify v1.8.4

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1296,8 +1296,8 @@ github.com/kubescape/go-git-url v0.0.25 h1:i7SSSC1+1m/Dg+4LV3erp0YklnWj1Z0cVlRxC
 github.com/kubescape/go-git-url v0.0.25/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kubescape/go-logger v0.0.20 h1:ZU3T6Za7maCiChdoTrqpD6TI11DGJwd9xU/TFtRlMOI=
 github.com/kubescape/go-logger v0.0.20/go.mod h1:BAWhQMYc/gnC5wMtPvc9Z4VXFqykFFMaXaPkq0+txBY=
-github.com/kubescape/k8s-interface v0.0.141 h1:CQcK3PZsSeDFVmlvyHya48NJihGe7Qc+3kEWsmc4KnA=
-github.com/kubescape/k8s-interface v0.0.141/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
+github.com/kubescape/k8s-interface v0.0.142 h1:kL8D/2s+GNEZlp50rTNDLe6dhSzHAXMOQweyJdSWkVk=
+github.com/kubescape/k8s-interface v0.0.142/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
 github.com/kubescape/opa-utils v0.0.267 h1:qzINBGsVOTKeLAIj1YfaYdV93FsSRriWdiN0JXJwD/o=
 github.com/kubescape/opa-utils v0.0.267/go.mod h1:95JkuIOfClgLc+DyGb2mDvefRW0STkZe4L2z6AaZJlQ=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=


### PR DESCRIPTION
When running `kubescape scan` against any files, kubescape was skipping all the initialization logic (for example, initializing the correct logger).
Root cause: The  `scan ` command was calling the `framework` command inside the `Args` function, which is supposed to do only arguments validation. This caused the entire logic of  the `PersistentPreRun` function inside the `root` command, which perform the initialization, not to be called, since `Args` is called before (it was indeed called but only after the entire scan was performed).

This PR fixes this issue by moving this logic to the right place - inside the actual `RunE` function. It also adds a validation for the `framework` and `control` command, which cannot be used with the `--view=security` flag.



Before:

![image](https://github.com/kubescape/kubescape/assets/84905812/5d98446f-9dd4-43a7-a091-76fbd015ff0f)

After:

![image](https://github.com/kubescape/kubescape/assets/84905812/1d691f7d-b0b3-4cfd-af3f-4be6c2d467aa)
