### PR TITLE
feat: darken table borders

### DIFF
--- a/core/core/list.go
+++ b/core/core/list.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	metav1 "github.com/kubescape/kubescape/v2/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer"
@@ -96,7 +97,7 @@ func prettyPrintListFormat(ctx context.Context, targetPolicy string, policies []
 	policyTable.SetHeaderLine(true)
 	policyTable.SetRowLine(true)
 	policyTable.SetAlignment(tablewriter.ALIGN_CENTER)
-	policyTable.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	policyTable.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 	data := v2.Matrix{}
 
 	controlRows := generatePolicyRows(policies)
@@ -125,7 +126,7 @@ func prettyPrintControls(ctx context.Context, policies []string) {
 	controlsTable.SetAutoWrapText(false)
 	controlsTable.SetHeaderLine(true)
 	controlsTable.SetRowLine(true)
-	controlsTable.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	controlsTable.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 
 	controlRows := generateControlRows(policies)
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
@@ -3,6 +3,7 @@ package configurationprinter
 import (
 	"io"
 
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -85,7 +86,7 @@ func getCategoryTableWriter(writer io.Writer, headers []string, columnAligments 
 	table.SetHeaderLine(true)
 	table.SetColumnAlignment(columnAligments)
 	table.SetAutoWrapText(false)
-	table.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	table.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 	var headerColors []tablewriter.Colors
 	for range headers {
 		headerColors = append(headerColors, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/frameworkscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/frameworkscan.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -40,7 +41,7 @@ func (fp *FrameworkPrinter) PrintSummaryTable(writer io.Writer, summaryDetails *
 	summaryTable.SetAutoWrapText(false)
 	summaryTable.SetHeaderLine(true)
 	summaryTable.SetColumnAlignment(GetColumnsAlignments())
-	summaryTable.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	summaryTable.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 
 	printAll := fp.getVerboseMode()
 	if summaryDetails.NumberOfResources().Failed() == 0 {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/olekukonko/tablewriter"
 )
@@ -15,7 +16,7 @@ func renderTable(writer io.Writer, headers []string, columnAlignments []int, row
 	table.SetHeader(headers)
 	table.SetHeaderLine(true)
 	table.SetColumnAlignment(columnAlignments)
-	table.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+	table.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 
 	var headerColors []tablewriter.Colors
 	for range rows[0] {

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v2/core/cautils"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter"
 	"github.com/kubescape/kubescape/v2/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
@@ -50,7 +51,7 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 		summaryTable.SetAutoMergeCells(true)
 		summaryTable.SetHeaderLine(true)
 		summaryTable.SetRowLine(true)
-		summaryTable.SetUnicodeHV(tablewriter.Regular, tablewriter.Regular)
+		summaryTable.SetUnicodeHVC(tablewriter.Regular, tablewriter.Regular, gchalk.Ansi256(238))
 
 		resourceRows := [][]string{}
 		if raw := generateResourceRows(result.ListControls(), &opaSessionObj.Report.SummaryDetails); len(raw) > 0 {
@@ -125,7 +126,7 @@ func generateResourceHeader(short bool) []string {
 func shortFormatResource(resourceRows [][]string) [][]string {
 	rows := [][]string{}
 	for _, resourceRow := range resourceRows {
-		rows = append(rows, []string{fmt.Sprintf("Severity"+strings.Repeat(" ", 13)+": %+v\nControl Name"+strings.Repeat(" ", 9)+": %+v\nDocs"+strings.Repeat(" ", 17)+": %+v\nAssisted Remediation"+strings.Repeat(" ", 1)+": %+v", resourceRow[resourceColumnSeverity], resourceRow[resourceColumnName], resourceRow[resourceColumnURL], strings.Replace(resourceRow[resourceColumnPath], "\n", "\n" + strings.Repeat(" ", 23), -1))})
+		rows = append(rows, []string{fmt.Sprintf("Severity"+strings.Repeat(" ", 13)+": %+v\nControl Name"+strings.Repeat(" ", 9)+": %+v\nDocs"+strings.Repeat(" ", 17)+": %+v\nAssisted Remediation"+strings.Repeat(" ", 1)+": %+v", resourceRow[resourceColumnSeverity], resourceRow[resourceColumnName], resourceRow[resourceColumnURL], strings.Replace(resourceRow[resourceColumnPath], "\n", "\n"+strings.Repeat(" ", 23), -1))})
 	}
 	return rows
 }

--- a/go.mod
+++ b/go.mod
@@ -414,6 +414,9 @@ require (
 replace github.com/libgit2/git2go/v33 => ./git2go
 
 replace (
+
+	// Using the forked version of tablewriter
+	github.com/olekukonko/tablewriter => github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6
 	// TODO(vladklokun): Since later versions (e.g. v0.40.0) that get used without the pin introduce weird packaging issues probably due to package renames, pin to last known good.
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 

--- a/go.sum
+++ b/go.sum
@@ -1300,6 +1300,8 @@ github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary v1.0.291-rc.0 h1:DztPS3NSKfiltO1wZvxRjuu5c99c6+dEgfTs6DcsVa8=
 github.com/kubescape/regolibrary v1.0.291-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
+github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6 h1:lUPN6vNOahuAs9Vd5IhoOndYja0zdF90VfcuB5XXkzQ=
+github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6/go.mod h1:g5pGEwPUwL4fTRUODq3fWP41Kn9IoBQrZni/kA1gxq4=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -1426,8 +1428,6 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.6-0.20230417144759-edd1a71a5576 h1:V9mPAyDD3S448NMuNKE3GbGSx8vDk8KW5CXPhW4SU/g=
-github.com/olekukonko/tablewriter v0.0.6-0.20230417144759-edd1a71a5576/go.mod h1:8Hf+pH6thup1sPZPD+NLg7d6vbpsdilu9CPIeikvgMQ=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -423,6 +423,9 @@ require (
 replace github.com/libgit2/git2go/v33 => ../git2go
 
 replace (
+
+	// Using the forked version of tablewriter
+	github.com/olekukonko/tablewriter => github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6
 	// TODO(vladklokun): Since later versions (e.g. v0.40.0) that get used without the pin introduce weird packaging issues probably due to package renames, pin to last known good.
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1304,6 +1304,8 @@ github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary v1.0.291-rc.0 h1:DztPS3NSKfiltO1wZvxRjuu5c99c6+dEgfTs6DcsVa8=
 github.com/kubescape/regolibrary v1.0.291-rc.0/go.mod h1:2j47Snl7jbbR0GenKlnbIQ+dk1J3XpX3x5T/SWY3OJ0=
+github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6 h1:lUPN6vNOahuAs9Vd5IhoOndYja0zdF90VfcuB5XXkzQ=
+github.com/kubescape/tablewriter v0.0.6-0.20230907094812-c8c737a432a6/go.mod h1:g5pGEwPUwL4fTRUODq3fWP41Kn9IoBQrZni/kA1gxq4=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -1430,8 +1432,6 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.6-0.20230417144759-edd1a71a5576 h1:V9mPAyDD3S448NMuNKE3GbGSx8vDk8KW5CXPhW4SU/g=
-github.com/olekukonko/tablewriter v0.0.6-0.20230417144759-edd1a71a5576/go.mod h1:8Hf+pH6thup1sPZPD+NLg7d6vbpsdilu9CPIeikvgMQ=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=


### PR DESCRIPTION
## Overview

As stated in the issue, the table borders now can be colored by passing in a `gchalk` color function.

## Additional Information

To accomplish this changes have been made to the forked upstream table library.

## How to Test

`kubescape list controls`

## Examples/Screenshots

Before:

![image](https://github.com/kubescape/kubescape/assets/81813720/78689296-e878-47bb-9647-e77fefb73d60)

After:

![image](https://github.com/kubescape/kubescape/assets/81813720/1cf002b4-ee05-4e3c-9b3a-81c5b40df0c7)

## Related issues/PRs:

Resolved #1380 
Resolved #1375 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
