### PR TITLE
Remove ARMO server url

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func getRootCmd(ks meta.IKubescape) *cobra.Command {
 		rootCmd.SetUsageTemplate(newUsageTemplate)
 	}
 
-	rootCmd.PersistentFlags().StringVar(&rootInfo.DiscoveryServerURL, "server", "api.armosec.io", "Backend discovery server URL") // TODO: remove default value
+	rootCmd.PersistentFlags().StringVar(&rootInfo.DiscoveryServerURL, "server", "", "Backend discovery server URL")
 
 	rootCmd.PersistentFlags().MarkDeprecated("environment", "'environment' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")
 	rootCmd.PersistentFlags().MarkDeprecated("env", "'env' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")


### PR DESCRIPTION
## Overview

Remove the default value of the `server` argument

Related PRs:
- https://github.com/kubescape/helm-charts/pull/283/files