### PR TITLE
add new line

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -102,10 +102,10 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	hostF.NoOptDefVal = "true"
 	hostF.DefValue = "false, for no TTY in stdin"
 	scanCmd.PersistentFlags().MarkHidden("enable-host-scan")
-	scanCmd.PersistentFlags().MarkDeprecated("enable-host-scan", "To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator. The flag will be removed at 1.Dec.2023")
+	scanCmd.PersistentFlags().MarkDeprecated("enable-host-scan", "To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator. The flag will be removed at 1.Dec.2023")
 
 	scanCmd.PersistentFlags().MarkHidden("host-scan-yaml") // this flag should be used very cautiously. We prefer users will not use it at all unless the DaemonSet can not run pods on the nodes
-	scanCmd.PersistentFlags().MarkDeprecated("host-scan-yaml", "To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator. The flag will be removed at 1.Dec.2023")
+	scanCmd.PersistentFlags().MarkDeprecated("host-scan-yaml", "To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator. The flag will be removed at 1.Dec.2023")
 
 	scanCmd.AddCommand(getControlCmd(ks, &scanInfo))
 	scanCmd.AddCommand(getFrameworkCmd(ks, &scanInfo))

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -34,7 +34,7 @@ func GetUpdateCmd() *cobra.Command {
 				//your version == latest version
 				logger.L().Info(("Nothing to update, you are running the latest version"), helpers.String("Version", cautils.BuildNumber))
 			} else {
-				fmt.Printf("Please refer to our installation docs in the following link: %s", installationLink)
+				fmt.Printf("Please refer to our installation docs in the following link: %s\n", installationLink)
 			}
 			return nil
 		},

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -115,7 +115,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 			cautils.StopSpinner()
 			logger.L().Success("Requested Host scanner data")
 		} else {
-			cautils.SetInfoMapForResources("This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator", hostResources, sessionObj.InfoMap)
+			cautils.SetInfoMapForResources("This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator", hostResources, sessionObj.InfoMap)
 		}
 	}
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -20,7 +20,7 @@ const (
 	configScanVerboseRunText = "Run with '--verbose'/'-v' flag for detailed resources view"
 	imageScanVerboseRunText  = "Run with '--verbose'/'-v' flag for detailed vulnerabilities view"
 	runCommandsText          = "Run one of the suggested commands to learn more about a failed control failure"
-	ksHelmChartLink          = "https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator"
+	ksHelmChartLink          = "https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator"
 	highStakesWlsText        = "High-stakes workloads are defined as those which Kubescape estimates would have the highest impact if they were to be exploited.\n\n"
 )
 


### PR DESCRIPTION
When running the `kubescape update` command with an old version, the output we currently get has an extra '%':
`Please refer to our installation docs in the following link: https://github.com/kubescape/kubescape/blob/master/docs/installation.md%`

This PR fixes that by adding a new line character, since the '%' sign comes from the bash / shell prompt

```
% ./kubescape update
Please refer to our installation docs in the following link: https://github.com/kubescape/kubescape/blob/master/docs/installation.md
%
```