### PR TITLE
force docker-build in absence of release label

### DIFF
--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -306,6 +306,7 @@ jobs:
               ]'
       COSIGN: true
       HELM_E2E_TEST: true
+      FORCE: true
     secrets: inherit
 
   run-tests:


### PR DESCRIPTION
fixes missing image in kubescape release:
![image](https://github.com/kubescape/kubescape/assets/20683409/e1e88425-5f47-41ab-b271-b2cb842507a8)
