### PR TITLE
Adding project security and governance as per maintainer decision

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,23 @@
+# Adopters
+
+# Well-known companies
+Well-known companies who are using and/or contributing to Kubescape are (in alphabetical order):
+* Accenture
+* Amazon.com
+* IBM
+* Intel
+* Meetup
+* RedHat
+* Scaleway
+
+# Users
+
+If you want to be listed here and share with others your experience, open a PR and add the bellow table:
+
+
+| Name | Company | Use case | Contact for questions (optional) |
+| ---- | ------- | -------- | -------------------------------- |
+| Yonathan Amzallag | ARMO | Vulnerability monitoring | yonatana@armosec.io |
+
+
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Governance of Kubescape
+
+## Overview
+
+The Kubescape project is an open-source initiative dedicated to improve security and best practices in Kubernetes environments. This document outlines the governance structure of the Kubescape project and provides guidance for its community contributors.
+
+## Decision Making
+
+### Maintainers
+
+- Maintainers are responsible for the smooth operation of the project.
+- They review and merge pull requests, manage releases, and ensure the quality and stability of the codebase.
+- Maintainers are chosen based on their ongoing contributions and their demonstrated commitment to the project.
+- Everyone who had at least 5 code contribution in the last 12 month can submit her/himself for joining the maintainer team
+- Maintainers who are not taken part in the project work (code, reviews, discussions) for 12 month are automaticaly removed from the maintainer team
+
+
+### Committers
+
+- Committers are contributors who have made significant and consistent contributions to the project.
+- They have the ability to merge minor pull requests if assigned by maintainers.
+- A contributor can be proposed as a committer by any existing maintainer. The proposal will be reviewed and voted on by the existing maintainers.
+
+### Community Members
+
+- Anyone can become a community member by contributing to the project. This can be in the form of code contributions, documentation, or any other form of project support.
+
+## Processes
+
+### Proposing Changes
+
+1. Open an issue on the project repository to discuss the proposed change.
+2. Once there is consensus around the proposed change, create a pull request.
+3. Pull requests will be reviewed by committers and/or maintainers.
+4. Once the pull request has received approval, it can be merged into the main codebase.
+
+### Conflict Resolution
+
+1. In case of any conflicts, it is primarily the responsibility of the parties involved to resolve it.
+2. If the conflict cannot be resolved, it will be escalated to the maintainers for resolution.
+3. Maintainers' decision will be final in case of unresolved conflicts.
+
+## Roles and Responsibilities
+
+### Maintainers
+
+- Ensure the quality and stability of the project.
+- Resolve conflicts.
+- Provide direction and set priorities for the project.
+
+### Committers
+
+- Review and merge minor pull requests.
+- Assist maintainers in project tasks.
+- Promote best practices within the community.
+
+### Community Members
+
+- Contribute to the project in any form.
+- Participate in discussions and provide feedback.
+- Respect the code of conduct and governance of the project.
+
+## Changes to the Governance Document
+
+Proposed changes to this governance document should follow the same process as any other code change to the Kubescape project (see "Proposing Changes").

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,11 +1,12 @@
 # Maintainers
 
-The following table lists the Kubescape project maintainers:
+The following table lists the Kubescape project core maintainers:
 
 | Name | GitHub | Organization | Added/Renewed On |
 | --- | --- | --- | --- |
+| [Matthias Bertschy](https://www.linkedin.com/in/matthias-bertschy-b427b815/) | [@matthyx](https://github.com/matthyx) | [ARMO](https://www.armosec.io/) | 2023-01-01 |
+| [Craig Box](https://www.linkedin.com/in/crbnz/) | [@craigbox](https://github.com/craigbox) | [ARMO](https://www.armosec.io/) | 2022-10-31 |
 | [Ben Hirschberg](https://www.linkedin.com/in/benyamin-ben-hirschberg-66141890) | [@slashben](https://github.com/slashben) | [ARMO](https://www.armosec.io/) | 2021-09-01 |
 | [Rotem Refael](https://www.linkedin.com/in/rotem-refael) | [@rotemamsa](https://github.com/rotemamsa) | [ARMO](https://www.armosec.io/) | 2021-10-11 |
 | [David Wertenteil](https://www.linkedin.com/in/david-wertenteil-0ba277b9) | [@dwertent](https://github.com/dwertent) | [ARMO](https://www.armosec.io/) | 2021-09-01 |
-| [Bezalel Brandwine](https://www.linkedin.com/in/bezalel-brandwine) | [@Bezbran](https://github.com/Bezbran) | [ARMO](https://www.armosec.io/) | 2021-09-01 |
-| [Craig Box](https://www.linkedin.com/in/crbnz/) | [@craigbox](https://github.com/craigbox) | [ARMO](https://www.armosec.io/) | 2022-10-31 |
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ We hold [community meetings](https://zoom.us/j/95174063585) on Zoom, on the firs
 
 The Kubescape project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
-## Contributions 
+### Adopters
+
+See [here](ADOPTERS.md) a list of adopters.
+
+## Contributions
 
 Thanks to all our contributors!  Check out our [CONTRIBUTING](CONTRIBUTING.md) file to learn how to join them.
 
@@ -83,6 +87,10 @@ Thanks to all our contributors!  Check out our [CONTRIBUTING](CONTRIBUTING.md) f
 <a href = "https://github.com/kubescape/kubescape/graphs/contributors">
   <img src = "https://contrib.rocks/image?repo=kubescape/kubescape"/>
 </a>
+
+## Changes
+
+Kubescape changes are tracked on the [release](https://github.com/kubescape/kubescape/releases) page
 
 ## License
 

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,45 @@
+header:
+  schema-version: 1.0.0
+  last-updated: '2023-10-12'
+  last-reviewed: '2023-10-12'
+  expiration-date: '2024-10-12T01:00:00.000Z'
+  project-url: https://github.com/kubescape/kubescape/
+  project-release: '1.0.0'
+project-lifecycle:
+  stage: active
+  bug-fixes-only: false
+  core-maintainers:
+  - github:slashben
+  - github:craigbox
+  - github:matthyx
+  - github:dwertent
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: false
+  code-of-conduct: https://github.com/kubescape/kubescape/blob/master/CODE_OF_CONDUCT.md
+documentation:
+- https://github.com/kubescape/kubescape/tree/master/docs
+distribution-points:
+- https://github.com/kubescape/kubescape/
+security-artifacts:
+  threat-model:
+    threat-model-created: false
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: true
+  comment: |
+    Dependabot is enabled for this repo.
+security-contacts:
+- type: email
+  value: cncf-kubescape-maintainers@lists.cncf.io
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  security-policy: https://github.com/kubescape/kubescape/security/policy
+  email-contact: cncf-kubescape-maintainers@lists.cncf.io
+  comment: |
+    The first and best way to report a vulnerability is by using private security issues in GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+To report a security issue or vulnerability, submit a [private vulnerability report via GitHub](https://github.com/kubescape/kubescape/security/advisories/new) to the repository maintainers with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The maintainers will respond within 7 working days of your report. If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it. This project follows a 90 day disclosure timeline.
+
+Other contacts: cncf-kubescape-maintainers@lists.cncf.io


### PR DESCRIPTION
## Overview
Implementing the following policy documents in the repo:
* Governance
* Security reports
* Security insights
* Change log

and updating the maintainers doc
