### PR TITLE
Fix Docker Build for Kubescape-CLI

### DIFF
--- a/.github/workflows/d-publish-image.yaml
+++ b/.github/workflows/d-publish-image.yaml
@@ -62,12 +62,14 @@ jobs:
         id: download-artifact
         with:
           path: .
+      - name: mv kubescape amd64 binary
+        run: mv kubescape-ubuntu-latest/kubescape-ubuntu-latest kubescape-amd64-ubuntu-latest
+      - name: mv kubescape arm64 binary
+        run: mv kubescape-ubuntu-latest/kubescape-arm64-ubuntu-latest kubescape-arm64-ubuntu-latest
       - name: chmod +x
-        run: chmod +x -v kubescape-*/kubescape-*
-      - name: Build and push image for linux/amd64
-        run: docker buildx build . --file build/kubescape-cli.Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --build-arg ks_binary=kubescape-ubuntu-latest/kubescape-ubuntu-latest --push --platform linux/amd64
-      - name: Build and push image for linux/arm64
-        run: docker buildx build . --file build/kubescape-cli.Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --build-arg ks_binary=kubescape-arm64-ubuntu-latest/kubescape-arm64-ubuntu-latest --push --platform linux/arm64
+        run: chmod +x -v kubescape-a*
+      - name: Build and push images
+        run: docker buildx build . --file build/kubescape-cli.Dockerfile --tag ${{ inputs.image_name }}:${{ inputs.image_tag }} --tag ${{ inputs.image_name }}:latest --build-arg image_version=${{ inputs.image_tag }} --build-arg client=${{ inputs.client }} --push --platform linux/amd64,linux/arm64
       - name: Install cosign
         uses: sigstore/cosign-installer@4079ad3567a89f68395480299c77e40170430341 # ratchet:sigstore/cosign-installer@main
         with:

--- a/build/kubescape-cli.Dockerfile
+++ b/build/kubescape-cli.Dockerfile
@@ -3,10 +3,10 @@ FROM gcr.io/distroless/base-debian11:debug-nonroot
 USER nonroot
 WORKDIR /home/nonroot/
 
-ARG image_version client ks_binary
+ARG image_version client TARGETARCH
 ENV RELEASE=$image_version CLIENT=$client
 
-COPY $ks_binary /usr/bin/kubescape
+COPY kubescape-${TARGETARCH}-ubuntu-latest /usr/bin/kubescape
 RUN ["kubescape", "download", "artifacts"]
 
 ENTRYPOINT ["kubescape"]


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses issues with the Docker build process for the Kubescape-CLI. The changes include:
- Renaming the kubescape binaries for amd64 and arm64 architectures.
- Changing the chmod command to apply to the renamed binaries.
- Modifying the Docker build and push command to work with the renamed binaries and support multiple platforms.
- Updating the Dockerfile to copy the renamed binary into the image and remove unused arguments.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/d-publish-image.yaml`: The kubescape binaries for amd64 and arm64 are renamed. The chmod command is updated to apply to the renamed binaries. The Docker build and push command is modified to work with the renamed binaries and support multiple platforms.
- `build/kubescape-cli.Dockerfile`: The Dockerfile is updated to copy the renamed binary into the image. The arguments 'image_version', 'client', and 'ks_binary' are replaced with 'image_version', 'client', and 'TARGETARCH'. The 'ks_binary' argument is no longer used.
</details>
