### PR TITLE
Fix for Empty Build Number in cmd Version

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -3,7 +3,6 @@ package version
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -18,10 +17,11 @@ func GetVersionCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.TODO()
 			v := cautils.NewIVersionCheckHandler(ctx)
-			v.CheckLatestVersion(ctx, cautils.NewVersionCheckRequest(cautils.BuildNumber, "", "", "version"))
-			fmt.Fprintf(os.Stdout,
+			versionCheckRequest := cautils.NewVersionCheckRequest(cautils.BuildNumber, "", "", "version")
+			v.CheckLatestVersion(ctx, versionCheckRequest)
+			fmt.Fprintf(cmd.OutOrStdout(),
 				"Your current version is: %s\n",
-				cautils.BuildNumber,
+				versionCheckRequest.ClientVersion,
 			)
 			logger.L().Debug(fmt.Sprintf("git enabled in build: %t", isGitEnabled()))
 			return nil

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,45 @@
+package version
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersionCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		buildNumber string
+		want        string
+	}{
+		{
+			name:        "Undefined Build Number",
+			buildNumber: "",
+			want:        "Your current version is: unknown\n",
+		},
+		{
+			name:        "Defined Build Number: v3.0.1",
+			buildNumber: "v3.0.1",
+			want:        "Your current version is: v3.0.1\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cautils.BuildNumber = tt.buildNumber
+
+			if cmd := GetVersionCmd(); cmd != nil {
+				buf := bytes.NewBufferString("")
+				cmd.SetOut(buf)
+				cmd.Execute()
+				out, err := io.ReadAll(buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Equal(t, tt.want, string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR includes two main changes:
- A bug fix for the 'cmd version' command which was not showing any output when the build number was empty. Now, it will display 'unknown' when the build number is not available.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/version/version.go`: Modified the 'RunE' function in the 'GetVersionCmd' command. Instead of directly using 'cautils.BuildNumber', a 'versionCheckRequest' object is created and used. This ensures that even if the 'BuildNumber' is empty, 'unknown' will be displayed as the version.
</details>
