### PR TITLE
Adding Tests and Refactoring for ruleWithKSOpaDependency Function in cautils

### DIFF
--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -60,7 +60,11 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, version str
 func isRuleKubescapeVersionCompatible(attributes map[string]interface{}, version string) bool {
 	if from, ok := attributes["useFromKubescapeVersion"]; ok && from != nil {
 		if version != "" {
-			if semver.Compare(version, from.(string)) == -1 {
+			if sfrom, ok := from.(string); ok {
+				if semver.Compare(version, sfrom) == -1 {
+					return false
+				}
+			} else {
 				return false
 			}
 		}
@@ -69,7 +73,11 @@ func isRuleKubescapeVersionCompatible(attributes map[string]interface{}, version
 		if version == "" {
 			return false
 		}
-		if semver.Compare(version, until.(string)) >= 0 {
+		if suntil, ok := until.(string); ok {
+			if semver.Compare(version, suntil) >= 0 {
+				return false
+			}
+		} else {
 			return false
 		}
 	}

--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -3,7 +3,6 @@ package cautils
 import (
 	"golang.org/x/mod/semver"
 
-	"github.com/armosec/utils-go/boolutils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
@@ -33,7 +32,7 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, version str
 					}
 				}
 
-				if !ruleWithKSOpaDependency(frameworks[i].Controls[j].Rules[r].Attributes) && isRuleKubescapeVersionCompatible(frameworks[i].Controls[j].Rules[r].Attributes, version) && isControlFitToScanScope(frameworks[i].Controls[j], scanningScope) {
+				if isRuleKubescapeVersionCompatible(frameworks[i].Controls[j].Rules[r].Attributes, version) && isControlFitToScanScope(frameworks[i].Controls[j], scanningScope) {
 					compatibleRules = append(compatibleRules, frameworks[i].Controls[j].Rules[r])
 				}
 			}
@@ -53,18 +52,6 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, version str
 		}
 
 	}
-}
-
-func ruleWithKSOpaDependency(attributes map[string]interface{}) bool {
-	if attributes == nil {
-		return false
-	}
-	if val, ok := attributes["armoOpa"]; ok { // TODO - make global
-		if s, ok := val.(string); ok {
-			return boolutils.StringToBool(s)
-		}
-	}
-	return false
 }
 
 // Checks that kubescape version is in range of use for this rule

--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -59,8 +59,10 @@ func ruleWithKSOpaDependency(attributes map[string]interface{}) bool {
 	if attributes == nil {
 		return false
 	}
-	if s, ok := attributes["armoOpa"]; ok { // TODO - make global
-		return boolutils.StringToBool(s.(string))
+	if val, ok := attributes["armoOpa"]; ok { // TODO - make global
+		if s, ok := val.(string); ok {
+			return boolutils.StringToBool(s)
+		}
 	}
 	return false
 }

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -9,37 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRuleWithKSOpaDependency(t *testing.T) {
-	t.Run("return false when attributes is nil", func(t *testing.T) {
-		result := ruleWithKSOpaDependency(nil)
-		assert.False(t, result)
-	})
-
-	t.Run("returns false when attributes does not contain armoOpa key", func(t *testing.T) {
-		attributes := map[string]interface{}{
-			"key": "value",
-		}
-		result := ruleWithKSOpaDependency(attributes)
-		assert.False(t, result)
-	})
-
-	t.Run("returns false when attributes contain armoOpa key with non bool value", func(t *testing.T) {
-		attributes := map[string]interface{}{
-			"armoOpa": true,
-		}
-		result := ruleWithKSOpaDependency(attributes)
-		assert.False(t, result)
-	})
-
-	t.Run("returns true when attributes contain armoOpa key with value true", func(t *testing.T) {
-		attributes := map[string]interface{}{
-			"armoOpa": "true",
-		}
-		result := ruleWithKSOpaDependency(attributes)
-		assert.True(t, result)
-	})
-}
-
 func TestIsScanningScopeMatchToControlScope(t *testing.T) {
 	tests := []struct {
 		scanScope    reporthandling.ScanningScopeType

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRuleWithKSOpaDependency(t *testing.T) {
+	t.Run("return false when attributes is nil", func(t *testing.T) {
+		result := ruleWithKSOpaDependency(nil)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when attributes does not contain armoOpa key", func(t *testing.T) {
+		attributes := map[string]interface{}{
+			"key": "value",
+		}
+		result := ruleWithKSOpaDependency(attributes)
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when attributes contain armoOpa key with non bool value", func(t *testing.T) {
+		attributes := map[string]interface{}{
+			"armoOpa": true,
+		}
+		result := ruleWithKSOpaDependency(attributes)
+		assert.False(t, result)
+	})
+
+	t.Run("returns true when attributes contain armoOpa key with value true", func(t *testing.T) {
+		attributes := map[string]interface{}{
+			"armoOpa": "true",
+		}
+		result := ruleWithKSOpaDependency(attributes)
+		assert.True(t, result)
+	})
+}
+
 func TestIsScanningScopeMatchToControlScope(t *testing.T) {
 	tests := []struct {
 		scanScope    reporthandling.ScanningScopeType

--- a/core/cautils/versioncheck_test.go
+++ b/core/cautils/versioncheck_test.go
@@ -20,11 +20,20 @@ var rule_v1_0_133 = &reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{
 	Attributes: map[string]interface{}{"useFromKubescapeVersion": "v1.0.133", "useUntilKubescapeVersion": "v1.0.134"}}}
 var rule_v1_0_134 = &reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{
 	Attributes: map[string]interface{}{"useFromKubescapeVersion": "v1.0.134"}}}
+var rule_invalid_from = &reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{
+	Attributes: map[string]interface{}{"useFromKubescapeVersion": 1.0135, "useUntilKubescapeVersion": "v1.0.135"}}}
+var rule_invalid_until = &reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{
+	Attributes: map[string]interface{}{"useFromKubescapeVersion": "v1.0.135", "useUntilKubescapeVersion": 1.0135}}}
 
 func TestIsRuleKubescapeVersionCompatible(t *testing.T) {
 	// local build- no build number
+
+	// should not crash when the value of useUntilKubescapeVersion is not a string
+	buildNumberMock := "v1.0.135"
+	assert.False(t, isRuleKubescapeVersionCompatible(rule_invalid_from.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible(rule_invalid_from.Attributes, buildNumberMock))
 	// should use only rules that don't have "until"
-	buildNumberMock := ""
+	buildNumberMock = ""
 	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
 	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
 	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces the following changes:
- Adds unit tests for the `ruleWithKSOpaDependency` function in `core/cautils/datastructuresmethods_test.go`.
- Refactors the `ruleWithKSOpaDependency` function in `core/cautils/datastructuresmethods.go` to handle type assertion of the "armoOpa" attribute.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/cautils/datastructuresmethods.go`: Refactored the `ruleWithKSOpaDependency` function to handle type assertion of the 'armoOpa' attribute.
- `core/cautils/datastructuresmethods_test.go`: Added unit tests for the `ruleWithKSOpaDependency` function, covering cases when attributes are nil, do not contain 'armoOpa' key, contain 'armoOpa' key with non-boolean value, and contain 'armoOpa' key with value 'true'.
</details>
