### PR TITLE
Run binary-build job only for kubescape/kubscape

### DIFF
--- a/.github/workflows/00-pr-scanner.yaml
+++ b/.github/workflows/00-pr-scanner.yaml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   pr-scanner:
+    if: github.repository_owner == 'kubescape'
     permissions:
       actions: read
       checks: read


### PR DESCRIPTION
Added a check before running the binary-build job to ensure that the owner of the repository is kubescape.

Fixes: https://github.com/kubescape/kubescape/issues/1482

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
