### PR TITLE
Draft: Added kubescape survery link at the bottom

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -74,7 +74,8 @@ func getReporter(ctx context.Context, tenantConfig cautils.ITenantConfig, report
 		// Add link only when scanning a cluster using a framework
 		return reporterv2.NewReportMock("", "")
 	}
-	var message string
+
+	message := "Please fill a 3 question survey to help the Kubescape project! https://kubescape.io/project/survey/"
 
 	if !fwScan && scanInfo.ScanType != cautils.ScanTypeWorkload {
 		message = "Kubescape does not submit scan results when scanning controls"

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"io"
+	"os"
 	"reflect"
 	"testing"
 
@@ -228,4 +230,28 @@ func TestIsScanTypeForSubmission(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetReporter_MessageSurvey(t *testing.T) {
+	ctx := context.TODO()
+	tenantConfig := cautils.GetTenantConfig("Test", "Fake Access key", "Temp cluster", "", nil)
+	reportID := "your-report-id"
+	submit := false
+	fwScan := false
+	scanInfo := cautils.ScanInfo{ScanType: cautils.ScanTypeWorkload}
+	result := getReporter(ctx, tenantConfig, reportID, submit, fwScan, scanInfo)
+
+	// Redirect stdout to a buffer
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result.DisplayMessage()
+
+	w.Close()
+	got, _ := io.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	want := "Please fill a 3 question survey to help the Kubescape project! https://kubescape.io/project/survey/"
+	assert.Equal(t, want, string(got))
 }


### PR DESCRIPTION
This change will display the kubescape project survery link at the bottom instead of the provider text.

Fixes: https://github.com/kubescape/kubescape/issues/1409

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
