### PR TITLE
Fix for Index Out of Range Error in Malformed Policies Handling

### DIFF
--- a/core/core/list.go
+++ b/core/core/list.go
@@ -164,13 +164,14 @@ func generateControlRows(policies []string) [][]string {
 
 		var id, control, framework string
 
-		if len(idAndControlAndFrameworks) == 0 {
+		switch len(idAndControlAndFrameworks) {
+		case 0:
 			continue
-		} else if len(idAndControlAndFrameworks) == 1 {
+		case 1:
 			id = idAndControlAndFrameworks[0]
-		} else if len(idAndControlAndFrameworks) == 2 {
+		case 2:
 			id, control = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1]
-		} else if len(idAndControlAndFrameworks) > 2 {
+		default:
 			id, control, framework = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1], idAndControlAndFrameworks[2]
 		}
 

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -159,8 +159,20 @@ func generateControlRows(policies []string) [][]string {
 	rows := [][]string{}
 
 	for _, control := range policies {
+
 		idAndControlAndFrameworks := strings.Split(control, "|")
-		id, control, framework := idAndControlAndFrameworks[0], idAndControlAndFrameworks[1], idAndControlAndFrameworks[2]
+
+		var id, control, framework string
+
+		if len(idAndControlAndFrameworks) == 0 {
+			continue
+		} else if len(idAndControlAndFrameworks) == 1 {
+			id = idAndControlAndFrameworks[0]
+		} else if len(idAndControlAndFrameworks) == 2 {
+			id, control = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1]
+		} else if len(idAndControlAndFrameworks) > 2 {
+			id, control, framework = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1], idAndControlAndFrameworks[2]
+		}
 
 		docs := cautils.GetControlLink(id)
 

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -206,15 +206,21 @@ func TestGenerateControlRowsHandlesPoliciesWithEmptyStringOrNoPipesOrOnePipeMiss
 	policies := []string{
 		"",
 		"1",
-		"2|Control 2",
-		"3",
+		"2|Control 2|Framework 2",
+		"3|Control 3|Framework 3|Extra 3",
+		"4||Framework 4",
+		"|",
+		"5|Control 5||Extra 5",
 	}
 
 	expectedRows := [][]string{
 		{"", "", "https://hub.armosec.io/docs/", ""},
 		{"1", "", "https://hub.armosec.io/docs/1", ""},
-		{"2", "Control 2", "https://hub.armosec.io/docs/2", ""},
-		{"3", "", "https://hub.armosec.io/docs/3", ""},
+		{"2", "Control 2", "https://hub.armosec.io/docs/2", "Framework\n2"},
+		{"3", "Control 3", "https://hub.armosec.io/docs/3", "Framework\n3"},
+		{"4", "", "https://hub.armosec.io/docs/4", "Framework\n4"},
+		{"", "", "https://hub.armosec.io/docs/", ""},
+		{"5", "Control 5", "https://hub.armosec.io/docs/5", ""},
 	}
 
 	rows := generateControlRows(policies)
@@ -255,6 +261,56 @@ func TestGenerateTableWithCorrectHeadersAndRows(t *testing.T) {
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
 │          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ Framework  │
 │            │              │                               │          3 │
+└────────────┴──────────────┴───────────────────────────────┴────────────┘
+`
+
+	assert.Equal(t, want, string(got))
+}
+
+func TestGenerateTableWithMalformedPoliciesAndPrettyPrintHeadersAndRows(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	policies := []string{
+		"",
+		"1",
+		"2|Control 2|Framework 2",
+		"3|Control 3|Framework 3|Extra 3",
+		"4||Framework 4",
+		"|",
+		"5|Control 5||Extra 5",
+	}
+
+	// Redirect stdout to a buffer
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	prettyPrintControls(ctx, policies)
+
+	w.Close()
+	got, _ := io.ReadAll(r)
+
+	os.Stdout = rescueStdout
+
+	want := `┌────────────┬──────────────┬───────────────────────────────┬────────────┐
+│ Control ID │ Control name │ Docs                          │ Frameworks │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│            │              │ https://hub.armosec.io/docs/  │            │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│          1 │              │ https://hub.armosec.io/docs/1 │            │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│          2 │ Control 2    │ https://hub.armosec.io/docs/2 │ Framework  │
+│            │              │                               │          2 │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ Framework  │
+│            │              │                               │          3 │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│          4 │              │ https://hub.armosec.io/docs/4 │ Framework  │
+│            │              │                               │          4 │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│            │              │ https://hub.armosec.io/docs/  │            │
+├────────────┼──────────────┼───────────────────────────────┼────────────┤
+│          5 │ Control 5    │ https://hub.armosec.io/docs/5 │            │
 └────────────┴──────────────┴───────────────────────────────┴────────────┘
 `
 

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -201,6 +201,27 @@ func TestGenerateControlRowsWithAllFields(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// Handles policies with no '|' characters in the string
+func TestGenerateControlRowsHandlesPoliciesWithEmptyStringOrNoPipesOrOnePipeMissing(t *testing.T) {
+	policies := []string{
+		"",
+		"1",
+		"2|Control 2",
+		"3",
+	}
+
+	expectedRows := [][]string{
+		{"", "", "https://hub.armosec.io/docs/", ""},
+		{"1", "", "https://hub.armosec.io/docs/1", ""},
+		{"2", "Control 2", "https://hub.armosec.io/docs/2", ""},
+		{"3", "", "https://hub.armosec.io/docs/3", ""},
+	}
+
+	rows := generateControlRows(policies)
+
+	assert.Equal(t, expectedRows, rows)
+}
+
 // The function generates a table with the correct headers and rows based on the input policies.
 func TestGenerateTableWithCorrectHeadersAndRows(t *testing.T) {
 	// Arrange


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug that could cause an index out-of-range error when handling malformed policies. The changes include:
- A more robust handling of edge cases in the `generateControlRows` function to prevent potential errors.
- Addition of a new test case to verify the correct handling of policies with missing or extra '|' characters.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/core/list.go`: The `generateControlRows` function has been updated to handle edge cases where the policy string is malformed. It now checks the length of the `idAndControlAndFrameworks` slice before attempting to access its elements, thus preventing an index out-of-range error.
- `core/core/list_test.go`: A new test case `TestGenerateControlRowsHandlesPoliciesWithEmptyStringOrNoPipesOrOnePipeMissing` has been added. This test verifies the correct handling of policies with missing or extra '|' characters.
</details>
