### PR TITLE
Edge-case Handling and Test Enhancements in yamlhelper

### DIFF
--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -49,20 +49,15 @@ func matchNodes(nodeOne, nodeTwo *yaml.Node) NodeRelation {
 func adjustContentLines(contentToAdd *[]contentToAdd, linesSlice *[]string) {
 	for contentIdx, content := range *contentToAdd {
 		line := content.line
-
 		// Adjust line numbers such that there are no "empty lines or comment lines of next nodes" before them
 		for idx := line - 1; idx >= 0; idx-- {
-
 			// If idx is exceeding the length of linesSlice, skip it
-
-			if idx >= len(*linesSlice) {
-				continue
-			}
-
-			if isEmptyLineOrComment((*linesSlice)[idx]) {
-				(*contentToAdd)[contentIdx].line -= 1
-			} else {
-				break
+			if idx < len(*linesSlice) {
+				if isEmptyLineOrComment((*linesSlice)[idx]) {
+					(*contentToAdd)[contentIdx].line -= 1
+				} else {
+					break
+				}
 			}
 		}
 	}
@@ -70,7 +65,7 @@ func adjustContentLines(contentToAdd *[]contentToAdd, linesSlice *[]string) {
 
 func adjustFixedListLines(originalList, fixedList *[]nodeInfo) {
 
-	if len(*originalList) == 0 || len(*fixedList) == 0 {
+	if originalList == nil || fixedList == nil || len(*originalList) == 0 || len(*fixedList) == 0 {
 		return // Check for empty slices to avoid index out of range errors
 	}
 
@@ -91,7 +86,7 @@ func adjustFixedListLines(originalList, fixedList *[]nodeInfo) {
 func enocodeIntoYaml(parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) (string, error) {
 
 	if tracker < 0 || tracker >= len(*nodeList) {
-		return "", fmt.Errorf("Index out of range for nodeList")
+		return "", fmt.Errorf("Index out of range for nodeList: tracker=%d, length=%d", tracker, len(*nodeList))
 	}
 
 	content := make([]*yaml.Node, 0)
@@ -140,6 +135,10 @@ func getContent(ctx context.Context, parentNode *yaml.Node, nodeList *[]nodeInfo
 }
 
 func indentContent(content string, indentationSpaces int) string {
+
+	if content == "" {
+		return ""
+	}
 
 	indentedContent := ""
 

--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -52,6 +52,13 @@ func adjustContentLines(contentToAdd *[]contentToAdd, linesSlice *[]string) {
 
 		// Adjust line numbers such that there are no "empty lines or comment lines of next nodes" before them
 		for idx := line - 1; idx >= 0; idx-- {
+
+			// If idx is exceeding the length of linesSlice, skip it
+
+			if idx >= len(*linesSlice) {
+				continue
+			}
+
 			if isEmptyLineOrComment((*linesSlice)[idx]) {
 				(*contentToAdd)[contentIdx].line -= 1
 			} else {
@@ -62,6 +69,11 @@ func adjustContentLines(contentToAdd *[]contentToAdd, linesSlice *[]string) {
 }
 
 func adjustFixedListLines(originalList, fixedList *[]nodeInfo) {
+
+	if len(*originalList) == 0 || len(*fixedList) == 0 {
+		return // Check for empty slices to avoid index out of range errors
+	}
+
 	differenceAtTop := (*originalList)[0].node.Line - (*fixedList)[0].node.Line
 
 	if differenceAtTop <= 0 {
@@ -77,6 +89,11 @@ func adjustFixedListLines(originalList, fixedList *[]nodeInfo) {
 }
 
 func enocodeIntoYaml(parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) (string, error) {
+
+	if tracker < 0 || tracker >= len(*nodeList) {
+		return "", fmt.Errorf("Index out of range for nodeList")
+	}
+
 	content := make([]*yaml.Node, 0)
 	currentNode := (*nodeList)[tracker].node
 	content = append(content, currentNode)
@@ -123,7 +140,13 @@ func getContent(ctx context.Context, parentNode *yaml.Node, nodeList *[]nodeInfo
 }
 
 func indentContent(content string, indentationSpaces int) string {
+
 	indentedContent := ""
+
+	if indentationSpaces < 0 {
+		indentationSpaces = 0
+	}
+
 	indentSpaces := strings.Repeat(" ", indentationSpaces)
 
 	scanner := bufio.NewScanner(strings.NewReader(content))
@@ -198,7 +221,7 @@ func getLastLineOfResource(linesSlice *[]string, currentLine int) (int, error) {
 }
 
 func getNodeLine(nodeList *[]nodeInfo, tracker int) int {
-	if tracker < len(*nodeList) {
+	if tracker >= 0 && tracker < len(*nodeList) {
 		return (*nodeList)[tracker].node.Line
 	} else {
 		return -1
@@ -253,6 +276,9 @@ func isOneLineSequenceNode(list *[]nodeInfo, currentTracker int) (bool, int) {
 
 // Checks if nodes are of same kind, value, line and column
 func isSameNode(nodeOne, nodeTwo *yaml.Node) bool {
+	if nodeOne == nil || nodeTwo == nil {
+		return false // Ensure neither node is nil to prevent runtime errors
+	}
 	sameLines := nodeOne.Line == nodeTwo.Line
 	sameColumns := nodeOne.Column == nodeTwo.Column
 	sameKinds := nodeOne.Kind == nodeTwo.Kind
@@ -339,15 +365,15 @@ func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMeta
 
 // Returns the first node in the given line that is not mapping node
 func getFirstNodeInLine(list *[]nodeInfo, line int) int {
-	tracker := 0
-
-	currentNode := (*list)[tracker].node
-	for currentNode.Line != line || currentNode.Kind == yaml.MappingNode {
-		tracker += 1
-		currentNode = (*list)[tracker].node
+	for tracker := 0; tracker < len(*list); tracker++ {
+		currentNode := (*list)[tracker].node
+		if currentNode.Line == line && currentNode.Kind != yaml.MappingNode {
+			return tracker
+		}
 	}
 
-	return tracker
+	// Return -1 to indicate that the node with the specified line was not found
+	return -1
 }
 
 // To not mess with the line number while inserting, removed lines are not deleted but replaced with "*"
@@ -356,6 +382,10 @@ func removeLines(linesToRemove *[]linesToRemove, linesSlice *[]string) {
 	for _, lineToRemove := range *linesToRemove {
 		startLine = lineToRemove.startLine - 1
 		endLine = lineToRemove.endLine - 1
+
+		if startLine < 0 || endLine >= len(*linesSlice) {
+			continue // Skip if the indices are out of bounds
+		}
 
 		for line := startLine; line <= endLine; line++ {
 			lineContent := (*linesSlice)[line]


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR focuses on improving the robustness of the `yamlhelper` package by handling edge cases that could lead to index out of range errors or other unexpected behaviors. It also adds several edge-case tests to ensure the correctness of these changes. The main changes include:
- Adding checks to prevent index out of range errors in various functions.
- Modifying some functions to handle edge cases such as negative indices or empty slices.
- Adding new test cases to `yamlhelper_test.go` to verify the correct handling of these edge cases.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/pkg/fixhandler/yamlhelper.go`: Added checks to prevent index out of range errors in functions like `adjustContentLines`, `adjustFixedListLines`, `enocodeIntoYaml`, `indentContent`, `getNodeLine`, `getFirstNodeInLine`, and `removeLines`. Also, modified the `getFirstNodeInLine` function to return -1 when the given line is not found in the list.
- `core/pkg/fixhandler/yamlhelper_test.go`: Added new test cases to verify the correct handling of edge cases in `adjustContentLines`, `adjustFixedListLines`, `enocodeIntoYaml`, `indentContent`, `getNodeLine`, `isSameNode`, `getFirstNodeInLine`, and `removeLines`. These tests ensure that the changes made in `yamlhelper.go` work as expected.
</details>
