### PR TITLE
Adding tests for core/core/initutils and fixing potential bug

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -167,7 +167,7 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 		return
 	}
 
-	if getter.GetKSCloudAPIConnector().GetCloudReportURL() == "" {
+	if tenantConfig.GetCloudReportURL() == "" {
 		scanInfo.Submit = false
 		return
 	}

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -10,10 +10,177 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type TenantConfigMock struct {
+	clusterName    string
+	accountID      string
+	accessKey      string
+	cloudReportURL string
+}
+
+func (tcm *TenantConfigMock) UpdateCachedConfig() error {
+	return nil
+}
+func (tcm *TenantConfigMock) DeleteCachedConfig(ctx context.Context) error {
+	return nil
+}
+func (tcm *TenantConfigMock) GetContextName() string {
+	return tcm.clusterName
+}
+func (tcm *TenantConfigMock) GetAccountID() string {
+	return tcm.accountID
+}
+func (tcm *TenantConfigMock) IsStorageEnabled() bool {
+	return true
+}
+func (tcm *TenantConfigMock) GetConfigObj() *cautils.ConfigObj {
+	return &cautils.ConfigObj{
+		AccountID:   tcm.accountID,
+		ClusterName: tcm.clusterName,
+	}
+}
+func (tcm *TenantConfigMock) GetCloudReportURL() string {
+	return tcm.cloudReportURL
+}
+func (tcm *TenantConfigMock) GetCloudAPIURL() string {
+	return ""
+}
+
+func (tcm *TenantConfigMock) GenerateAccountID() (string, error) {
+	//tcm.accountID = "6a1ff233-5297-4193-bb51-5d67bc841cbf"
+	return tcm.accountID, nil
+}
+
+func (tcm *TenantConfigMock) DeleteCredentials() error {
+	tcm.accountID = ""
+	tcm.accessKey = ""
+	return nil
+}
+
+func (tcm *TenantConfigMock) GetAccessKey() string {
+	return tcm.accessKey
+}
+
+func TestGetExceptionsGetter(t *testing.T) {
+	type args struct {
+		ctx                    context.Context
+		useExceptions          string
+		accountID              string
+		downloadReleasedPolicy *getter.DownloadReleasedPolicy
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test GetExceptionsGetter all empty",
+			args: args{
+				ctx:                    context.TODO(),
+				useExceptions:          "",
+				accountID:              "",
+				downloadReleasedPolicy: nil,
+			},
+			want: "*getter.DownloadReleasedPolicy",
+		},
+		{
+			name: "Test GetExceptionsGetter empty useExceptions",
+			args: args{
+				ctx:                    context.TODO(),
+				useExceptions:          "",
+				accountID:              "",
+				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
+			},
+			want: "*getter.DownloadReleasedPolicy",
+		},
+		{
+			name: "Test GetExceptionsGetter with useExceptions and empty accountID",
+			args: args{
+				ctx:                    context.TODO(),
+				useExceptions:          "true",
+				accountID:              "",
+				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
+			},
+			want: "*getter.LoadPolicy",
+		},
+		{
+			name: "Test GetExceptionsGetter with useExceptions and filled accountID",
+			args: args{
+				ctx:                    context.TODO(),
+				useExceptions:          "true",
+				accountID:              "123456789012",
+				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
+			},
+			want: "*getter.LoadPolicy",
+		},
+		{
+			name: "Test GetExceptionsGetter with accountID",
+			args: args{
+				ctx:                    context.TODO(),
+				useExceptions:          "",
+				accountID:              "123456789012",
+				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
+			},
+			want: "*v1.KSCloudAPI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy)
+			assert.Equal(t, tt.want, reflect.TypeOf(got).String())
+		})
+	}
+}
+
+func TestPolicyIdentifierIdentities(t *testing.T) {
+	type args struct {
+		pi []cautils.PolicyIdentifier
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test PolicyIdentifierIdentities",
+			args: args{
+				pi: []cautils.PolicyIdentifier{
+					{Identifier: "policy1"},
+					{Identifier: "policy2"},
+					{Identifier: "policy3"},
+				},
+			},
+			want: "policy1,policy2,policy3",
+		},
+		{
+			name: "Test PolicyIdentifierIdentities Empty",
+			args: args{
+				pi: []cautils.PolicyIdentifier{},
+			},
+			want: "all",
+		},
+		{
+			name: "Test PolicyIdentifierIdentities nil",
+			args: args{
+				pi: nil,
+			},
+			want: "all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policyIdentifierIdentities(tt.args.pi)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func Test_getUIPrinter(t *testing.T) {
 	scanInfo := &cautils.ScanInfo{
@@ -185,6 +352,154 @@ func TestGetSensorHandler(t *testing.T) {
 	// TODO(fredbi): need to share the k8s client mock to test a happy path / deployment failure path
 }
 
+func TestSetSubmitBehavior(t *testing.T) {
+	type args struct {
+		scanInfo                *cautils.ScanInfo
+		tenantConfig            *TenantConfigMock
+		isScanTypeForSubmission bool
+		isLocal                 bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test SetSubmitBehavior !setSubmitBehavior and keep-local",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeControl,
+					Local:    true,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName: "test",
+					accountID:   "",
+					accessKey:   "",
+				},
+				isScanTypeForSubmission: false,
+				isLocal:                 true,
+			},
+			want: false,
+		},
+		{
+			name: "Test SetSubmitBehavior !setSubmitBehavior and !keep-local",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeControl,
+					Local:    false,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName: "test",
+					accountID:   "",
+					accessKey:   "",
+				},
+				isScanTypeForSubmission: false,
+				isLocal:                 false,
+			},
+			want: false,
+		},
+		{
+			name: "Test SetSubmitBehavior setSubmitBehavior and keep-local",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeCluster,
+					Local:    true,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName: "test",
+					accountID:   "",
+					accessKey:   "",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 true,
+			},
+			want: false,
+		},
+		{
+			name: "Test SetSubmitBehavior !keep-local and setSubmitBehavior",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName: "test",
+					accountID:   "",
+					accessKey:   "",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: false,
+		}, // TODO: Add test "If CloudReportURL is set"
+		{
+			name: "Test SetSubmitBehavior CloudReportURL is set, no AccountID",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName:    "test",
+					accountID:      "",
+					accessKey:      "",
+					cloudReportURL: "https://example.kubescape.com",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: true,
+		},
+		{
+			name: "Test SetSubmitBehavior CloudReportURL is set, Invalid AccountID",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName:    "test",
+					accountID:      "123456789012",
+					accessKey:      "",
+					cloudReportURL: "https://example.kubescape.com",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: false,
+		},
+		{
+			name: "Test SetSubmitBehavior CloudReportURL is set, Valid AccountID",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName:    "test",
+					accountID:      "6a1ff233-5297-4193-bb51-5d67bc841cbf",
+					accessKey:      "",
+					cloudReportURL: "https://example.kubescape.com",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.args.isScanTypeForSubmission, isScanTypeForSubmission(tt.args.scanInfo.ScanType))
+			require.Equal(t, tt.args.isLocal, tt.args.scanInfo.Local)
+
+			setSubmitBehavior(tt.args.scanInfo, tt.args.tenantConfig)
+
+			assert.Equal(t, tt.want, tt.args.scanInfo.Submit)
+		})
+	}
+}
+
 func TestIsScanTypeForSubmission(t *testing.T) {
 	test := []struct {
 		name     string
@@ -239,4 +554,16 @@ func TestGetDefaultFrameworksPaths(t *testing.T) {
 		assert.NotEmpty(t, path)
 		assert.True(t, strings.HasSuffix(path, ".json"))
 	}
+}
+
+// getDownloadReleasedPolicy should always have a non-nil result
+func TestGetDownloadReleasedPolicy(t *testing.T) {
+	ctx := context.Background()
+	downloadReleasedPolicy := getter.NewDownloadReleasedPolicy()
+
+	require.NoError(t, downloadReleasedPolicy.SetRegoObjects())
+
+	result := getDownloadReleasedPolicy(ctx, downloadReleasedPolicy)
+
+	assert.NotNil(t, result)
 }


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR includes the following changes:
- Added comprehensive unit tests for the functions in the `core/core/initutils.go` file.
- Fixed a potential bug in the `setSubmitBehavior` function in `core/core/initutils.go` by replacing `getter.GetKSCloudAPIConnector().GetCloudReportURL()` with `tenantConfig.GetCloudReportURL()`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/core/initutils.go`: Replaced `getter.GetKSCloudAPIConnector().GetCloudReportURL()` with `tenantConfig.GetCloudReportURL()` in the `setSubmitBehavior` function to fix a potential bug.
- `core/core/initutils_test.go`: Added comprehensive unit tests for the functions in the `core/core/initutils.go` file. This includes tests for `getExceptionsGetter`, `policyIdentifierIdentities`, `getUIPrinter`, `GetSensorHandler`, `setSubmitBehavior`, `isScanTypeForSubmission`, `GetDefaultFrameworksPaths`, and `getDownloadReleasedPolicy`.
</details>
