### PR TITLE
Adding Unit Tests for cmd/shared Package

### DIFF
--- a/cmd/shared/image_scan_test.go
+++ b/cmd/shared/image_scan_test.go
@@ -1,0 +1,61 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+)
+
+// Validate a scanInfo struct with a valid fail threshold severity
+func TestValidateImageScanInfo(t *testing.T) {
+	testCases := []struct {
+		Description string
+		ScanInfo    *cautils.ScanInfo
+		Want        error
+	}{
+		{
+			"Empty scanInfo is valid",
+			&cautils.ScanInfo{},
+			nil,
+		},
+		{
+			"Empty severity is valid",
+			&cautils.ScanInfo{FailThresholdSeverity: ""},
+			nil,
+		},
+		{
+			"High severity is valid",
+			&cautils.ScanInfo{FailThresholdSeverity: "High"},
+			nil,
+		},
+		{
+			"HIGH severity is valid",
+			&cautils.ScanInfo{FailThresholdSeverity: "HIGH"},
+			nil,
+		},
+		{
+			"high severity is valid",
+			&cautils.ScanInfo{FailThresholdSeverity: "high"},
+			nil,
+		},
+		{
+			"Unknown severity is invalid",
+			&cautils.ScanInfo{FailThresholdSeverity: "unknown"},
+			ErrUnknownSeverity,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.Description,
+			func(t *testing.T) {
+				var want error = tc.Want
+
+				got := ValidateImageScanInfo(tc.ScanInfo)
+
+				assert.Equal(t, want, got)
+			},
+		)
+	}
+}


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces unit tests for the `cmd/shared` package. The tests are focused on validating the `ScanInfo` struct, particularly the `FailThresholdSeverity` field. Different scenarios are tested including valid and invalid severity levels.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/shared/image_scan_test.go`: Added a new test file for the `shared` package. The file contains a test function `TestValidateImageScanInfo` which tests the validation of a `ScanInfo` struct with different `FailThresholdSeverity` values.
</details>
