### PR TITLE
Enhancement of 'update' command and addition of tests for version check

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -5,7 +5,9 @@ package update
 //          kubescape update
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -29,12 +31,23 @@ func GetUpdateCmd() *cobra.Command {
 		Long:    ``,
 		Example: updateCmdExamples,
 		RunE: func(_ *cobra.Command, args []string) error {
+			ctx := context.TODO()
+			v := cautils.NewVersionCheckHandler()
+			versionCheckRequest := cautils.NewVersionCheckRequest(cautils.BuildNumber, "", "", "update")
+			v.CheckLatestVersion(ctx, versionCheckRequest)
+
 			//Checking the user's version of kubescape to the latest release
-			if cautils.BuildNumber == cautils.LatestReleaseVersion {
+			if cautils.BuildNumber == "" || strings.Contains(cautils.BuildNumber, "rc") {
+				//your version is unknown
+				fmt.Printf("Nothing to update: you are running the development version\n")
+			} else if cautils.LatestReleaseVersion == "" {
+				//Failed to check for updates
+				logger.L().Info(("Failed to check for updates"))
+			} else if cautils.BuildNumber == cautils.LatestReleaseVersion {
 				//your version == latest version
 				logger.L().Info(("Nothing to update: you are running the latest version"), helpers.String("Version", cautils.BuildNumber))
 			} else {
-				fmt.Printf("Please refer to our installation documentation: %s\n", installationLink)
+				fmt.Printf("Version %s is available. Please refer to our installation documentation: %s\n", cautils.LatestReleaseVersion, installationLink)
 			}
 			return nil
 		},

--- a/core/cautils/versioncheck.go
+++ b/core/cautils/versioncheck.go
@@ -118,7 +118,7 @@ func (v *VersionCheckHandler) CheckLatestVersion(ctx context.Context, versionDat
 		return fmt.Errorf("failed to get latest version")
 	}
 
-	LatestReleaseVersion := latestVersion.ClientUpdate
+	LatestReleaseVersion = latestVersion.ClientUpdate
 
 	if latestVersion.ClientUpdate != "" {
 		if BuildNumber != "" && semver.Compare(BuildNumber, LatestReleaseVersion) == -1 {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This pull request primarily focuses on enhancing the 'update' command in the 'update.go' file and adding tests for the version check functionality in the 'versioncheck_test.go' file. The main changes include:
- In 'update.go', the 'update' command now checks for the latest version of Kubescape and provides more informative messages to the user based on different scenarios.
- In 'versioncheck.go', the 'CheckLatestVersion' function has been updated to assign the latest version to 'LatestReleaseVersion' and not to a new variable.
- New tests have been added in 'versioncheck_test.go' to test the 'CheckLatestVersion' and 'getLatestVersion' functions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/update/update.go`: Enhanced the 'update' command to check for the latest version of Kubescape and provide more informative messages to the user based on different scenarios.
- `core/cautils/versioncheck.go`: Updated the 'CheckLatestVersion' function to assign the latest version to 'LatestReleaseVersion' and not to a new variable.
- `core/cautils/versioncheck_test.go`: Added new tests to test the 'CheckLatestVersion' and 'getLatestVersion' functions.
</details>
