### PR TITLE
Enhancement of Test Suite for cmd Packages

### DIFF
--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -1,0 +1,19 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Generates autocompletion script for valid shell types
+func TestGetCompletionCmd(t *testing.T) {
+	// Arrange
+	completionCmd := GetCompletionCmd()
+	assert.Equal(t, "completion [bash|zsh|fish|powershell]", completionCmd.Use)
+	assert.Equal(t, "Generate autocompletion script", completionCmd.Short)
+	assert.Equal(t, "To load completions", completionCmd.Long)
+	assert.Equal(t, completionCmdExamples, completionCmd.Example)
+	assert.Equal(t, true, completionCmd.DisableFlagsInUseLine)
+	assert.Equal(t, []string{"bash", "zsh", "fish", "powershell"}, completionCmd.ValidArgs)
+}

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	// Call the GetConfigCmd function
+	configCmd := GetConfigCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "config", configCmd.Use)
+	assert.Equal(t, "Handle cached configurations", configCmd.Short)
+	assert.Equal(t, configExample, configCmd.Example)
+
+	// Verify that the subcommands are added correctly
+	assert.Equal(t, 3, len(configCmd.Commands()))
+
+	for _, subcmd := range configCmd.Commands() {
+		switch subcmd.Name() {
+		case "delete":
+			// Verify that the delete subcommand is added correctly
+			assert.Equal(t, "delete", subcmd.Use)
+			assert.Equal(t, "Delete cached configurations", subcmd.Short)
+		case "set":
+			// Verify that the set subcommand is added correctly
+			assert.Equal(t, "set", subcmd.Use)
+			assert.Equal(t, "Set configurations, supported: "+strings.Join(stringKeysToSlice(supportConfigSet), "/"), subcmd.Short)
+		case "view":
+			// Verify that the view subcommand is added correctly
+			assert.Equal(t, "view", subcmd.Use)
+			assert.Equal(t, "View cached configurations", subcmd.Short)
+		default:
+			t.Errorf("Unexpected subcommand name: %s", subcmd.Name())
+		}
+	}
+}

--- a/cmd/config/delete_test.go
+++ b/cmd/config/delete_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDeleteCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	// Call the GetConfigCmd function
+	configCmd := getDeleteCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "delete", configCmd.Use)
+	assert.Equal(t, "Delete cached configurations", configCmd.Short)
+	assert.Equal(t, "", configCmd.Long)
+}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	logger "github.com/kubescape/go-logger"
@@ -40,10 +41,16 @@ var supportConfigSet = map[string]func(*metav1.SetConfig, string){
 }
 
 func stringKeysToSlice(m map[string]func(*metav1.SetConfig, string)) []string {
-	l := []string{}
-	for i := range m {
-		l = append(l, i)
+	keys := []string{}
+	for key := range m {
+		keys = append(keys, key)
 	}
+
+	// Sort the keys of the map
+	sort.Strings(keys)
+
+	l := []string{}
+	l = append(l, keys...)
 	return l
 }
 

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSetCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	// Call the GetConfigCmd function
+	configCmd := getSetCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "set", configCmd.Use)
+	assert.Equal(t, "Set configurations, supported: "+strings.Join(stringKeysToSlice(supportConfigSet), "/"), configCmd.Short)
+	assert.Equal(t, setConfigExample, configCmd.Example)
+	assert.Equal(t, stringKeysToSlice(supportConfigSet), configCmd.ValidArgs)
+}
+
+// Should return a slice of keys when given a non-empty map
+func TestStringKeysToSlice(t *testing.T) {
+	m := map[string]func(*metav1.SetConfig, string){
+		"key1": nil,
+		"key2": nil,
+		"key3": nil,
+	}
+	result := stringKeysToSlice(m)
+	expected := []string{"key1", "key2", "key3"}
+	assert.ElementsMatch(t, expected, result)
+}
+
+func TestParseSetArgs_InvalidFormat(t *testing.T) {
+	args := []string{"key"}
+	setConfig, err := parseSetArgs(args)
+	assert.Equal(t, "", setConfig.Account)
+	assert.Equal(t, "", setConfig.AccessKey)
+	assert.Equal(t, "", setConfig.CloudReportURL)
+	assert.Equal(t, "", setConfig.CloudAPIURL)
+
+	expectedErrorMessage := fmt.Sprintf("key '' unknown . supported: %s", strings.Join(stringKeysToSlice(supportConfigSet), "/"))
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}
+
+func TestParseSetArgs_AccessKey(t *testing.T) {
+	args := []string{"accessKey", "value1"}
+	setConfig, _ := parseSetArgs(args)
+	assert.Equal(t, "", setConfig.Account)
+	assert.Equal(t, "value1", setConfig.AccessKey)
+	assert.Equal(t, "", setConfig.CloudReportURL)
+	assert.Equal(t, "", setConfig.CloudAPIURL)
+}
+
+func TestParseSetArgs_Single(t *testing.T) {
+	args := []string{"accountID=value1"}
+	setConfig, _ := parseSetArgs(args)
+	assert.Equal(t, "value1", setConfig.Account)
+	assert.Equal(t, "", setConfig.AccessKey)
+	assert.Equal(t, "", setConfig.CloudReportURL)
+	assert.Equal(t, "", setConfig.CloudAPIURL)
+}

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetViewCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	// Call the GetConfigCmd function
+	configCmd := getViewCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "view", configCmd.Use)
+	assert.Equal(t, "View cached configurations", configCmd.Short)
+	assert.Equal(t, "", configCmd.Long)
+}

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+)
+
+type MockIKubescape struct{}
+
+func (m *MockIKubescape) Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
+	return nil, nil
+}
+
+func (m *MockIKubescape) List(ctx context.Context, listPolicies *metav1.ListPolicies) error {
+	return nil
+}
+
+func (m *MockIKubescape) Download(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+	return nil
+}
+
+func (m *MockIKubescape) SetCachedConfig(setConfig *metav1.SetConfig) error {
+	return nil
+}
+
+func (m *MockIKubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
+	return nil
+}
+
+func (m *MockIKubescape) DeleteCachedConfig(ctx context.Context, deleteConfig *metav1.DeleteConfig) error {
+	return nil
+}
+
+func (m *MockIKubescape) Fix(ctx context.Context, fixInfo *metav1.FixInfo) error {
+	return nil
+}
+
+func (m *MockIKubescape) Patch(ctx context.Context, patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
+	return nil, nil
+}
+
+func (m *MockIKubescape) ScanImage(ctx context.Context, imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces a comprehensive test suite for the `cmd` package, specifically targeting the `completion` and `config` sub-packages. The main changes include:
- Addition of new test cases for the `completion` package to validate the generation of autocompletion scripts for valid shell types.
- Addition of new test cases for the `config` package, including tests for the `delete`, `set`, and `view` subcommands.
- Enhancement of the `stringKeysToSlice` function in the `config` package to return the final string slice in sorted order of keys.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/completion/completion_test.go`: Added new tests for the `completion` package, checking the properties of the generated autocompletion command.
- `cmd/config/config_test.go`: Introduced new tests for the `config` package, verifying the properties of the main config command and its subcommands.
- `cmd/config/delete_test.go`: Added tests for the `delete` subcommand of the `config` package.
- `cmd/config/set.go`: Updated the `stringKeysToSlice` function to return the keys in sorted order.
- `cmd/config/set_test.go`: Introduced tests for the `set` subcommand of the `config` package, including a test for the updated `stringKeysToSlice` function.
- `cmd/config/view_test.go`: Added tests for the `view` subcommand of the `config` package.
</details>
