### PR TITLE
Enhancement of TimedCache with Bug Fixes and Test Suite

### DIFF
--- a/core/pkg/policyhandler/cache_test.go
+++ b/core/pkg/policyhandler/cache_test.go
@@ -73,3 +73,69 @@ func TestTimedCache(t *testing.T) {
 		})
 	}
 }
+
+func TestCache_SetAndGet(t *testing.T) {
+	cache := NewTimedCache[int](time.Second * 2)
+
+	cache.Set(42)
+
+	value, exists := cache.Get()
+	if !exists || value != 42 {
+		t.Errorf("Expected value: %v, Got: %v, Exists: %v", 42, value, exists)
+	}
+}
+
+func TestCache_Expiration(t *testing.T) {
+	cache := NewTimedCache[int](time.Millisecond * 500)
+
+	cache.Set(42)
+
+	time.Sleep(time.Millisecond * 1000) // Wait for expiration
+
+	value, exists := cache.Get()
+	if exists {
+		t.Errorf("Expected cache to be expired, but got value: %v", value)
+	}
+}
+
+func TestCache_WithZeroTTL(t *testing.T) {
+	cache := NewTimedCache[string](0)
+
+	cache.Set("hello")
+
+	value, exists := cache.Get()
+	if exists {
+		t.Errorf("Expected cache to be disabled, but got value: %v", value)
+	}
+}
+
+func TestCache_Invalidate(t *testing.T) {
+	cache := NewTimedCache[string](time.Second * 2)
+
+	cache.Set("initial value")
+
+	cache.Invalidate()
+
+	value, exists := cache.Get()
+	if exists {
+		t.Errorf("Expected cache to be invalidated, but got value: %v", value)
+	}
+}
+
+func TestCache_ConcurrentAccess(t *testing.T) {
+	cache := NewTimedCache[int](time.Second * 1)
+
+	go func() {
+		cache.Set(42)
+	}()
+
+	go func() {
+		time.Sleep(time.Millisecond * 500)
+		value, exists := cache.Get()
+		if !exists || value != 42 {
+			t.Errorf("Expected value: %v, Got: %v, Exists: %v", 42, value, exists)
+		}
+	}()
+
+	time.Sleep(time.Second)
+}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR introduces several enhancements and bug fixes to the `TimedCache` in the `core/pkg/policyhandler/cache.go` file. The main changes include:
- Replacing the `expiration` field's type from `int64` to `time.Time` to simplify expiration checks.
- Adding a `stopChan` field and a `Stop` method to properly stop the `invalidateTask` goroutine, preventing direct value changes.
- Using a `Ticker` in `invalidateTask` for periodic expiration checks.
- Implementing a leak prevention mechanism: the `invalidateTask()` loop now checks the TTL value before continuing. If the TTL is zero, the goroutine exits gracefully, preventing a potential memory leak.
- Adding a comprehensive test suite for the `TimedCache` in the `core/pkg/policyhandler/cache_test.go` file.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/pkg/policyhandler/cache.go`: The `expiration` field's type has been changed from `int64` to `time.Time`. A `stopChan` field and a `Stop` method have been added to control the `invalidateTask` goroutine. The `invalidateTask` now uses a `Ticker` for periodic expiration checks. A leak prevention mechanism has been implemented.
- `core/pkg/policyhandler/cache_test.go`: A comprehensive test suite has been added for the `TimedCache`. The tests cover various scenarios including setting and getting values, cache expiration, cache with zero TTL, cache invalidation, and concurrent access to the cache.
</details>
