### PR TITLE
Add Test Suite for cmd Packages and Fix Potential Crash in Image Subcommand

### DIFF
--- a/cmd/operator/configscan_test.go
+++ b/cmd/operator/configscan_test.go
@@ -1,0 +1,32 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOperatorScanConfigCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	operatorInfo := cautils.OperatorInfo{
+		Namespace: "namespace",
+	}
+
+	cmd := getOperatorScanConfigCmd(mockKubescape, operatorInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "configurations", cmd.Use)
+	assert.Equal(t, "Trigger configuration scanning from the Kubescape Operator microservice", cmd.Short)
+	assert.Equal(t, "", cmd.Long)
+	assert.Equal(t, operatorScanConfigExamples, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	assert.Nil(t, err)
+
+	err = cmd.Args(&cobra.Command{}, []string{"configurations"})
+	assert.Nil(t, err)
+}

--- a/cmd/operator/operator_test.go
+++ b/cmd/operator/operator_test.go
@@ -1,0 +1,42 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOperatorCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	cmd := GetOperatorCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "operator", cmd.Use)
+	assert.Equal(t, "The operator is used to communicate with the Kubescape Operator within the cluster components.", cmd.Short)
+	assert.Equal(t, "", cmd.Long)
+	assert.Equal(t, operatorExamples, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "For the operator sub-command, you need to provide at least one additional sub-command. Refer to the examples above."
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"scan", "configurations"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{"scan", "configurations"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{"scan"})
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{"random-subcommand", "random-config"})
+	expectedErrorMessage = "For the operator sub-command, only " + scanSubCommand + " is supported. Refer to the examples above."
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/operator/scan_test.go
+++ b/cmd/operator/scan_test.go
@@ -1,0 +1,46 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOperatorScanCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	operatorInfo := cautils.OperatorInfo{
+		Namespace: "namespace",
+	}
+
+	cmd := getOperatorScanCmd(mockKubescape, operatorInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "scan", cmd.Use)
+	assert.Equal(t, "Scan your cluster using the Kubescape-operator within the cluster components", cmd.Short)
+	assert.Equal(t, "", cmd.Long)
+	assert.Equal(t, operatorExamples, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "for operator scan sub command, you must pass at least 1 more sub commands, see above examples"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"operator"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{"configurations"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{"vulnerabilities"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{"random"})
+	expectedErrorMessage = "For the operator sub-command, only " + vulnerabilitiesSubCommand + " and " + configurationsSubCommand + " are supported. Refer to the examples above."
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/operator/vulnerabilitiesscan_test.go
+++ b/cmd/operator/vulnerabilitiesscan_test.go
@@ -1,0 +1,29 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	operatorInfo := cautils.OperatorInfo{
+		Namespace: "namespace",
+	}
+
+	cmd := getOperatorScanVulnerabilitiesCmd(mockKubescape, operatorInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "vulnerabilities", cmd.Use)
+	assert.Equal(t, "Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components", cmd.Short)
+	assert.Equal(t, "", cmd.Long)
+	assert.Equal(t, operatorScanVulnerabilitiesExamples, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{"random-arg"})
+	assert.Nil(t, err)
+}

--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -35,7 +35,7 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 
 	patchCmd := &cobra.Command{
 		Use:     "patch --image <image>:<tag> [flags]",
-		Short:   "Patch container images with vulnerabilities ",
+		Short:   "Patch container images with vulnerabilities",
 		Long:    `Patch command is for automatically patching images with vulnerabilities.`,
 		Example: patchCmdExamples,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -1,0 +1,36 @@
+package patch
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPatchCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	cmd := GetPatchCmd(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "patch --image <image>:<tag> [flags]", cmd.Use)
+	assert.Equal(t, "Patch container images with vulnerabilities", cmd.Short)
+	assert.Equal(t, "Patch command is for automatically patching images with vulnerabilities.", cmd.Long)
+	assert.Equal(t, patchCmdExamples, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	assert.Nil(t, err)
+
+	err = cmd.Args(&cobra.Command{}, []string{"test"})
+	expectedErrorMessage := "the command takes no arguments"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	expectedErrorMessage = "image tag is required"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{"patch", "--image", "docker.io/library/nginx:1.22"})
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/scan/control_test.go
+++ b/cmd/scan/control_test.go
@@ -1,0 +1,41 @@
+package scan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetControlCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{
+		AccountID: "new",
+	}
+
+	cmd := getControlCmd(mockKubescape, &scanInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "control <control names list>/<control ids list>", cmd.Use)
+	assert.Equal(t, fmt.Sprintf("The controls you wish to use. Run '%[1]s list controls' for the list of supported controls", cautils.ExecName()), cmd.Short)
+	assert.Equal(t, controlExample, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "requires at least one control name"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"C-0001,C-0002"})
+	assert.Nil(t, err)
+
+	err = cmd.Args(&cobra.Command{}, []string{"C-0001,C-0002,"})
+	expectedErrorMessage = "usage: <control-0>,<control-1>"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	expectedErrorMessage = "bad argument: accound ID must be a valid UUID"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/scan/framework_test.go
+++ b/cmd/scan/framework_test.go
@@ -1,0 +1,41 @@
+package scan
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFrameworkCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{
+		AccountID: "new",
+	}
+
+	cmd := getFrameworkCmd(mockKubescape, &scanInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "framework <framework names list> [`<glob pattern>`/`-`] [flags]", cmd.Use)
+	assert.Equal(t, fmt.Sprintf("The framework you wish to use. Run '%[1]s list frameworks' for the list of supported frameworks", cautils.ExecName()), cmd.Short)
+	assert.Equal(t, frameworkExample, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "requires at least one framework name"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"nsa,mitre"})
+	assert.Nil(t, err)
+
+	err = cmd.Args(&cobra.Command{}, []string{"nsa,mitre,"})
+	expectedErrorMessage = "usage: <framework-0>,<framework-1>"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	expectedErrorMessage = "bad argument: accound ID must be a valid UUID"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -42,6 +42,10 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("the command takes exactly one image name as an argument")
+			}
+
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -1,0 +1,35 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetImageCmd(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{
+		AccountID: "new",
+	}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "image <image>:<tag> [flags]", cmd.Use)
+	assert.Equal(t, "Scan an image for vulnerabilities", cmd.Short)
+	assert.Equal(t, imageExample, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "the command takes exactly one image name as an argument"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"nginx"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(&cobra.Command{}, []string{})
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -361,4 +363,17 @@ func TestSetSecurityViewScanInfo(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetScanCommand(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	cmd := GetScanCommand(mockKubescape)
+
+	// Verify the command name and short description
+	assert.Equal(t, "scan", cmd.Use)
+	assert.Equal(t, "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations", cmd.Short)
+	assert.Equal(t, "The action you want to perform", cmd.Long)
+	assert.Equal(t, scanCmdExamples, cmd.Example)
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -50,6 +50,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return fmt.Errorf("usage: <kind>/<name> [`<glob pattern>`/`-`] [flags]")
 			}
 
+			// Looks strange, a bug maybe????
 			if scanInfo.ChartPath != "" && scanInfo.FilePath == "" {
 				return fmt.Errorf("usage: --chart-path <chart path> --file-path <file path>")
 			}

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetWorkloadScanInfo(t *testing.T) {
@@ -66,4 +69,28 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestGetWorkloadCmd_ChartPathAndFilePathEmpty(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{
+		ChartPath: "temp",
+		FilePath:  "",
+	}
+
+	cmd := getWorkloadCmd(mockKubescape, &scanInfo)
+
+	// Verify the command name and short description
+	assert.Equal(t, "workload <kind>/<name> [`<glob pattern>`/`-`] [flags]", cmd.Use)
+	assert.Equal(t, "Scan a workload for misconfigurations and image vulnerabilities", cmd.Short)
+	assert.Equal(t, workloadExample, cmd.Example)
+
+	err := cmd.Args(&cobra.Command{}, []string{})
+	expectedErrorMessage := "usage: <kind>/<name> [`<glob pattern>`/`-`] [flags]"
+	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	err = cmd.Args(&cobra.Command{}, []string{"nginx"})
+	expectedErrorMessage = "invalid workload identifier"
+	assert.Equal(t, expectedErrorMessage, err.Error())
 }


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces a comprehensive test suite for the 'cmd' packages in the Go codebase. It also includes a fix for a potential crash in the 'image' subcommand within the 'scan' package. The main changes are:
- Addition of new test cases for the 'operator', 'patch', and 'scan' packages.
- Modification of the 'image' subcommand in the 'scan' package to prevent potential crashes.
- Minor adjustments in the 'patch' package to improve code readability.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/operator/configscan_test.go`: Added a new test suite for the 'configscan' subpackage in the 'operator' package.
- `cmd/operator/operator_test.go`: Introduced a new test suite for the 'operator' package.
- `cmd/operator/scan_test.go`: Added a new test suite for the 'scan' subpackage in the 'operator' package.
- `cmd/operator/vulnerabilitiesscan_test.go`: Introduced a new test suite for the 'vulnerabilitiesscan' subpackage in the 'operator' package.
- `cmd/patch/patch.go`: Minor adjustment in the 'patch' command description for better readability.
- `cmd/patch/patch_test.go`: Added a new test suite for the 'patch' package.
- `cmd/scan/control_test.go`: Introduced a new test suite for the 'control' subpackage in the 'scan' package.
- `cmd/scan/framework_test.go`: Added a new test suite for the 'framework' subpackage in the 'scan' package.
- `cmd/scan/image.go`: Added a check to ensure the 'image' command receives exactly one argument, preventing potential crashes.
- `cmd/scan/image_test.go`: Introduced a new test suite for the 'image' subpackage in the 'scan' package.
</details>
