### PR TITLE
Update set_test.go

### DIFF
--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -73,3 +73,9 @@ func TestParseSetArgs_Single(t *testing.T) {
 	assert.Equal(t, "", setConfig.CloudReportURL)
 	assert.Equal(t, "", setConfig.CloudAPIURL)
 }
+
+func TestParseSetArgs_InvalidKey(t *testing.T) {
+	args := []string{"invalidKey=value1"}
+	_, err := parseSetArgs(args)
+	assert.Equal(t, "key 'invalidKey' unknown . supported: accessKey/accountID/cloudAPIURL/cloudReportURL", err.Error())
+}


### PR DESCRIPTION
Resolves issue #1523 

Pull Request Description:

**Changes Made**
Added a new test case TestParseSetArgs_InvalidKey in the config package to cover scenarios where an invalid key is provided in the set command arguments.

**Test Case Details**

- Function Tested: TestParseSetArgs_InvalidKey
- Test Objective: Ensures that the parseSetArgs function correctly handles the scenario where an invalid key is provided, returning an appropriate error message.
- Test Input: Command arguments with an invalid key, e.g., invalidKey=value1.
- Expected Output: The function should return an error message indicating that the provided key is unknown, along with the list of supported keys.

**Motivation**
This new test case enhances the test coverage for the parseSetArgs function, ensuring robust handling of invalid keys during the configuration setting process. By validating that the function produces the expected error message for such cases, we contribute to the overall reliability of the codebase. This addition further strengthens the testing suite for the config package, promoting code quality and correctness.