### PR TITLE
Update patch_test.go (Add Test Case for Non-Existent Image in GetPatchCmd)

### DIFF
--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -34,3 +34,19 @@ func TestGetPatchCmd(t *testing.T) {
 	err = cmd.RunE(&cobra.Command{}, []string{"patch", "--image", "docker.io/library/nginx:1.22"})
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
+
+func TestGetPatchCmdWithNonExistentImage(t *testing.T) {
+	// Create a mock Kubescape interface
+	mockKubescape := &mocks.MockIKubescape{}
+
+	// Call the GetPatchCmd function
+	cmd := GetPatchCmd(mockKubescape)
+
+	// Run the command with a non-existent image argument
+	err := cmd.RunE(&cobra.Command{}, []string{"patch", "--image", "non-existent-image"})
+
+	// Check that there is an error and the error message is as expected
+	expectedErrorMessage := "image tag is required"
+	assert.Error(t, err)
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}


### PR DESCRIPTION
Title: Add Test Case for Non-Existent Image in GetPatchCmd

Resolves issue #1530 

**Description:**

This pull request introduces a new test case TestGetPatchCmdWithNonExistentImage in the patch_test.go file. The purpose of this test case is to verify the behavior of the GetPatchCmd function when it's run with a non-existent image argument.

In this test case, we:

- Create a mock Kubescape interface
- Call the GetPatchCmd function with the mock interface
- Run the command with a non-existent image argument
- Check that there is an error and the error message is "image tag is required"

This test case enhances the test coverage of the GetPatchCmd function and ensures that it correctly handles non-existent image arguments.