### PR TITLE
Adding Test Suite for Prometheus Printer and Handling Invalid Scores

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -37,6 +37,13 @@ func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 }
 
 func (pp *PrometheusPrinter) Score(score float32) {
+	// Handle invalid scores
+	if score > 100 {
+		score = 100
+	} else if score < 0 {
+		score = 0
+	}
+
 	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
 }
 

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -1,0 +1,93 @@
+package printer
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPrometheusPrinter(t *testing.T) {
+	// For verbose mode false
+	verboseMode := false
+	promPrinter := NewPrometheusPrinter(verboseMode)
+	assert.NotNil(t, promPrinter)
+	assert.Equal(t, verboseMode, promPrinter.verboseMode)
+
+	// For verbose mode true
+	verboseMode = true
+	promPrinter = NewPrometheusPrinter(verboseMode)
+	assert.NotNil(t, promPrinter)
+	assert.Equal(t, verboseMode, promPrinter.verboseMode)
+}
+
+func TestSetWriter(t *testing.T) {
+	// Test case 1: Empty outputFile
+	outputFile := ""
+	promPrinter := &PrometheusPrinter{}
+	promPrinter.SetWriter(context.Background(), outputFile)
+	assert.Equal(t, os.Stdout, promPrinter.writer)
+
+	// Test case 2: Valid outputFile
+	outputFile = "/tmp/test.log"
+	promPrinter = &PrometheusPrinter{}
+	promPrinter.SetWriter(context.Background(), outputFile)
+	f, err := os.Open(outputFile)
+	assert.NoError(t, err)
+	defer f.Close()
+	assert.NotNil(t, promPrinter.writer)
+}
+
+func TestScore(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  string
+	}{
+		{
+			name:  "Score less than 0",
+			score: -20.0,
+			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 0\n",
+		},
+		{
+			name:  "Score greater than 100",
+			score: 120.0,
+			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 100\n",
+		},
+		{
+			name:  "Score 50",
+			score: 50.0,
+			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 50\n",
+		},
+		{
+			name:  "Zero Score",
+			score: 0.0,
+			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 0\n",
+		},
+		{
+			name:  "Perfect Score",
+			score: 100,
+			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 100\n",
+		},
+	}
+
+	promPrinter := NewPrometheusPrinter(false)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Redirect stdout to a buffer
+			rescueStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			promPrinter.Score(tt.score)
+
+			w.Close()
+			got, _ := io.ReadAll(r)
+			os.Stdout = rescueStdout
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR introduces the following changes:
- Adds a comprehensive test suite for the Prometheus Printer.
- Implements handling of invalid scores in the `Score` function of the Prometheus Printer.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `core/pkg/resultshandling/printer/v2/prometheus.go`: Added handling for invalid scores in the `Score` function. If the score is greater than 100, it is set to 100. If it is less than 0, it is set to 0.
- `core/pkg/resultshandling/printer/v2/prometheus_test.go`: Introduced a new test suite for the Prometheus Printer. This includes tests for the `NewPrometheusPrinter`, `SetWriter`, and `Score` functions. The `Score` function tests include various scenarios such as scores less than 0, greater than 100, and scores of 0, 50, and 100.
</details>
