### PR TITLE
Addition of Tests for the PrettyPrinter Package

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan_test.go
@@ -1,6 +1,12 @@
 package prettyprinter
 
-import "testing"
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestClusterScan_getNextSteps(t *testing.T) {
 	clusterPrinter := &ClusterPrinter{}
@@ -31,5 +37,98 @@ func TestClusterScan_getWorkloadScanCommand(t *testing.T) {
 
 	if command != "$ kubescape scan workload kind/name --namespace ns" {
 		t.Errorf("Expected $ kubescape scan workload kind/name --namespace ns, got %s", command)
+	}
+}
+
+func TestNewClusterPrinter(t *testing.T) {
+	// Test case 1: Valid writer
+	cp := NewClusterPrinter(os.Stdout)
+	assert.NotNil(t, cp)
+	assert.Equal(t, os.Stdout, cp.writer)
+	assert.NotNil(t, cp.categoriesTablePrinter)
+
+	// Test case 2: Nil writer
+	var writer *os.File
+	cp = NewClusterPrinter(writer)
+	assert.NotNil(t, cp)
+	assert.Nil(t, cp.writer)
+	assert.NotNil(t, cp.categoriesTablePrinter)
+}
+
+func TestPrintNextSteps(t *testing.T) {
+	// Create a temporary file to capture output
+	f, err := os.CreateTemp("", "print-next-steps")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	cp := NewClusterPrinter(f)
+
+	// Redirect stderr to the temporary file
+	oldStderr := os.Stderr
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	os.Stderr = f
+
+	// Print the score using the `Score` function
+	cp.PrintNextSteps()
+
+	// Read the contents of the temporary file
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	want := "\nWhat now?\n─────────\n\n* Run one of the suggested commands to learn more about a failed control failure\n* Scan a workload with '$ kubescape scan workload' to see vulnerability information\n* Install Kubescape in your cluster for continuous monitoring and a full vulnerability report: https://kubescape.io/docs/install-operator/\n\n"
+
+	assert.Equal(t, want, string(got))
+}
+
+func TestGetWorkloadScanCommand(t *testing.T) {
+	cp := NewClusterPrinter(os.Stdout)
+	assert.NotNil(t, cp)
+	assert.Equal(t, os.Stdout, cp.writer)
+	assert.NotNil(t, cp.categoriesTablePrinter)
+
+	tests := []struct {
+		name      string
+		namespace string
+		kind      string
+		want      string
+	}{
+		{
+			name:      "Empty",
+			namespace: "",
+			kind:      "",
+			want:      "$ kubescape scan workload /Empty --namespace ",
+		},
+		{
+			name:      "Empty Namespace",
+			namespace: "",
+			kind:      "Kind",
+			want:      "$ kubescape scan workload Kind/Empty Namespace --namespace ",
+		},
+		{
+			name:      "Empty Kind",
+			namespace: "Namespace",
+			kind:      "",
+			want:      "$ kubescape scan workload /Empty Kind --namespace Namespace",
+		},
+		{
+			name:      "Name",
+			namespace: "Namespace",
+			kind:      "Kind",
+			want:      "$ kubescape scan workload Kind/Name --namespace Namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cp.getWorkloadScanCommand(tt.namespace, tt.kind, tt.name)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/frameworkscan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/frameworkscan_test.go
@@ -1,0 +1,74 @@
+package prettyprinter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSummaryPrinter(t *testing.T) {
+	// Test case 1: Valid writer and verbose mode
+	verbose := true
+	printer := NewSummaryPrinter(os.Stdout, verbose)
+	assert.NotNil(t, printer)
+	assert.Equal(t, os.Stdout, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.summaryTablePrinter)
+
+	// Test case 2: Valid writer and non-verbose mode
+	verbose = false
+	printer = NewSummaryPrinter(os.Stdout, verbose)
+	assert.NotNil(t, printer)
+	assert.Equal(t, os.Stdout, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.summaryTablePrinter)
+
+	// Test case 3: Nil writer and verbose mode
+	var writer *os.File
+	verbose = true
+	printer = NewSummaryPrinter(writer, verbose)
+	assert.NotNil(t, printer)
+	assert.Nil(t, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.summaryTablePrinter)
+
+	// Test case 4: Nil writer and non-verbose mode
+	verbose = false
+	printer = NewSummaryPrinter(writer, verbose)
+	assert.NotNil(t, printer)
+	assert.Nil(t, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.summaryTablePrinter)
+}
+
+func TestGetVerboseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		printer *SummaryPrinter
+		want    bool
+	}{
+		{
+			name: "Verbose mode on",
+			printer: &SummaryPrinter{
+				writer:      os.Stdout,
+				verboseMode: true,
+			},
+			want: true,
+		},
+		{
+			name: "Verbose mode off",
+			printer: &SummaryPrinter{
+				writer:      os.Stdout,
+				verboseMode: false,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.printer.getVerboseMode())
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
@@ -1,0 +1,95 @@
+package prettyprinter
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewImagePrinter(t *testing.T) {
+	// Test case 1: Valid writer and verbose mode
+	verbose := true
+	printer := NewImagePrinter(os.Stdout, verbose)
+	assert.NotNil(t, printer)
+	assert.Equal(t, os.Stdout, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.imageTablePrinter)
+
+	// Test case 2: Valid writer and non-verbose mode
+	verbose = false
+	printer = NewImagePrinter(os.Stdout, verbose)
+	assert.NotNil(t, printer)
+	assert.Equal(t, os.Stdout, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.imageTablePrinter)
+
+	// Test case 3: Nil writer and verbose mode
+	var writer *os.File
+	verbose = true
+	printer = NewImagePrinter(writer, verbose)
+	assert.NotNil(t, printer)
+	assert.Nil(t, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.imageTablePrinter)
+
+	// Test case 4: Nil writer and non-verbose mode
+	verbose = false
+	printer = NewImagePrinter(writer, verbose)
+	assert.NotNil(t, printer)
+	assert.Nil(t, printer.writer)
+	assert.Equal(t, verbose, printer.verboseMode)
+	assert.NotNil(t, printer.imageTablePrinter)
+}
+
+func TestPrintNextSteps_ImageScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		verbose bool
+		want    string
+	}{
+		{
+			name:    "Verbose mode on",
+			verbose: true,
+			want:    "\nWhat now?\n─────────\n\n* Install Kubescape in your cluster for continuous monitoring and a full vulnerability report: https://kubescape.io/docs/install-operator/\n\n",
+		},
+		{
+			name:    "Verbose mode off",
+			verbose: false,
+			want:    "\nWhat now?\n─────────\n\n* Run with '--verbose'/'-v' flag for detailed vulnerabilities view\n* Install Kubescape in your cluster for continuous monitoring and a full vulnerability report: https://kubescape.io/docs/install-operator/\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary file to capture output
+			f, err := os.CreateTemp("", "print-next-steps")
+			if err != nil {
+				panic(err)
+			}
+			defer f.Close()
+
+			ip := NewImagePrinter(f, tt.verbose)
+
+			// Redirect stderr to the temporary file
+			oldStderr := os.Stderr
+			defer func() {
+				os.Stderr = oldStderr
+			}()
+			os.Stderr = f
+
+			// Print the score using the `Score` function
+			ip.PrintNextSteps()
+
+			// Read the contents of the temporary file
+			f.Seek(0, 0)
+			got, err := io.ReadAll(f)
+			if err != nil {
+				panic(err)
+			}
+
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## type:
Tests

___
## description:
This PR focuses on enhancing the test coverage for the `prettyprinter` package. The following changes have been made:
- Added tests for the `clusterscan_test.go` file. The tests cover the `TestClusterScan_getNextSteps`, `TestNewClusterPrinter`, `TestPrintNextSteps`, and `TestGetWorkloadScanCommand` functions.
- Added tests for the `frameworkscan_test.go` file. The tests cover the `TestNewSummaryPrinter` and `TestGetVerboseMode` functions.
- Added tests for the `imagescan_test.go` file. The tests cover the `TestNewImagePrinter` and `TestPrintNextSteps_ImageScan` functions.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan_test.go`: Added tests for the `TestClusterScan_getNextSteps`, `TestNewClusterPrinter`, `TestPrintNextSteps`, and `TestGetWorkloadScanCommand` functions.
- `core/pkg/resultshandling/printer/v2/prettyprinter/frameworkscan_test.go`: Added tests for the `TestNewSummaryPrinter` and `TestGetVerboseMode` functions.
- `core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go`: Added tests for the `TestNewImagePrinter` and `TestPrintNextSteps_ImageScan` functions.
</details>
