### PR TITLE
Addition of new tests for junit printer, version check and PDF printer

### DIFF
--- a/core/cautils/versioncheck_test.go
+++ b/core/cautils/versioncheck_test.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -178,4 +179,15 @@ func TestVersionCheckHandler_getLatestVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetTriggerSource(t *testing.T) {
+	// Running in github actions pipeline
+	os.Setenv("GITHUB_ACTIONS", "true")
+	source := getTriggerSource()
+	assert.Equal(t, "pipeline", source)
+
+	os.Args[0] = "ksserver"
+	source = getTriggerSource()
+	assert.Equal(t, "microservice", source)
 }

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -1,14 +1,18 @@
 package printer
 
 import (
-	"io/ioutil"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
 	"os"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJunitPdfPrinter(t *testing.T) {
+func TestJunitPrinter(t *testing.T) {
 	// Verbose mode off
 	jp := NewJunitPrinter(false)
 	assert.NotNil(t, jp)
@@ -81,11 +85,158 @@ func TestScore_Junit(t *testing.T) {
 
 			// Read the contents of the temporary file
 			f.Seek(0, 0)
-			got, err := ioutil.ReadAll(f)
+			got, err := io.ReadAll(f)
 			if err != nil {
 				panic(err)
 			}
 			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestTestSuites(t *testing.T) {
+	results := cautils.NewOPASessionObjMock()
+	junitTestSuites := testsSuites(results)
+
+	assert.NotNil(t, junitTestSuites)
+	assert.Equal(t, listTestsSuite(results), junitTestSuites.Suites)
+	assert.Equal(t, results.Report.SummaryDetails.NumberOfControls().All(), junitTestSuites.Tests)
+	assert.Equal(t, "Kubescape Scanning", junitTestSuites.Name)
+}
+
+func TestListTestSuites(t *testing.T) {
+	// Non empty OPASessionObj
+	results := cautils.NewOPASessionObjMock()
+	testsSuites := listTestsSuite(results)
+
+	expectedTestSuites := []JUnitTestSuite{
+		{
+			XMLName:   xml.Name{Space: "", Local: ""},
+			Tests:     0,
+			Name:      "kubescape",
+			Errors:    0,
+			Failures:  0,
+			Hostname:  "",
+			ID:        0,
+			Skipped:   "",
+			Time:      "",
+			Timestamp: "0001-01-01 00:00:00 +0000 UTC",
+			Properties: []JUnitProperty{
+				{Name: "complianceScore", Value: "0.00"},
+			},
+			TestCases: []JUnitTestCase(nil),
+		},
+	}
+
+	assert.Equal(t, expectedTestSuites, testsSuites)
+}
+
+func TestProperties(t *testing.T) {
+	tests := []struct {
+		name             string
+		score            float32
+		expectedProperty []JUnitProperty
+	}{
+		{
+			name:  "Score not an integer",
+			score: 20.7,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", 20.7),
+				},
+			},
+		},
+		{
+			name:  "Score less than 0",
+			score: -20.0,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", -20.0),
+				},
+			},
+		},
+		{
+			name:  "Score greater than 100",
+			score: 120.0,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", 120.0),
+				},
+			},
+		},
+		{
+			name:  "Score 50",
+			score: 50.0,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", 50.0),
+				},
+			},
+		},
+		{
+			name:  "Zero Score",
+			score: 0.0,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", 0.0),
+				},
+			},
+		},
+		{
+			name:  "Perfect Score",
+			score: 100,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: fmt.Sprintf("%.2f", 100.0),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedProperty, properties(tt.score))
+		})
+	}
+}
+
+func TestSetWriter_Junit(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		expected   string
+	}{
+		{
+			name:       "Output file name contains doesn't contain any extension",
+			outputFile: "customFilename",
+			expected:   "customFilename.xml",
+		},
+		{
+			name:       "Output file name contains .xml",
+			outputFile: "customFilename.xml",
+			expected:   "customFilename.xml",
+		},
+		{
+			name:       "Output file name is empty",
+			outputFile: "",
+			expected:   "/dev/stdout",
+		},
+	}
+
+	jp := NewJunitPrinter(false)
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			jp.SetWriter(ctx, tt.outputFile)
+			assert.Equal(t, tt.expected, jp.writer.Name())
 		})
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -80,6 +81,41 @@ func TestScore_Pdf(t *testing.T) {
 				panic(err)
 			}
 			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestSetWriter_Pdf(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		expected   string
+	}{
+		{
+			name:       "Output file name contains doesn't contain any extension",
+			outputFile: "customFilename",
+			expected:   "customFilename.pdf",
+		},
+		{
+			name:       "Output file name contains .pdf",
+			outputFile: "customFilename.pdf",
+			expected:   "customFilename.pdf",
+		},
+		{
+			name:       "Output file name is empty",
+			outputFile: "",
+			expected:   "/dev/stdout",
+		},
+	}
+
+	pp := NewPdfPrinter()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			pp.SetWriter(ctx, tt.outputFile)
+			assert.Equal(t, tt.expected, pp.writer.Name())
 		})
 	}
 }


### PR DESCRIPTION
## type:
Tests

___
## description:
This PR introduces new tests for the junit printer, version check and PDF printer functionalities. The main changes include:
- Addition of tests for the `listTestsSuite`, `testsSuites`, `properties`, and `SetWriter` functions in the junit printer.
- Addition of tests for `getTriggerSource` function in version check.
- Addition of tests for `SetWriter` function in PDF printer.
- The tests cover various scenarios and edge cases, ensuring the robustness of the code.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `core/cautils/versioncheck_test.go`: A new test has been added for the `getTriggerSource` function in the version check. The test verifies the function's behavior when running in a GitHub Actions pipeline and when the first argument is "ksserver".
- `core/pkg/resultshandling/printer/v2/junit_test.go`: New tests have been added for the junit printer. These tests cover the `listTestsSuite`, `testsSuites`, `properties`, and `SetWriter` functions. The tests ensure that the functions behave as expected under various conditions.
- `core/pkg/resultshandling/printer/v2/pdf_test.go`: A new test has been added for the `SetWriter` function in the PDF printer. The test verifies the function's behavior when the output file name doesn't contain any extension, contains .pdf, and is empty.
</details>
