### PR TITLE
Add github action actor check for binary-build

### DIFF
--- a/.github/workflows/00-pr-scanner.yaml
+++ b/.github/workflows/00-pr-scanner.yaml
@@ -20,7 +20,6 @@ concurrency:
 
 jobs:
   pr-scanner:
-    if: github.repository_owner == 'kubescape'
     permissions:
       actions: read
       checks: read
@@ -42,6 +41,7 @@ jobs:
     secrets: inherit
 
   binary-build:
+    if: ${{ github.actor == 'kubescape' }}
     permissions:
       actions: read
       checks: read


### PR DESCRIPTION
## Overview
Added a check before running the binary-build job to ensure that the owner of the repository is kubescape.

Fixes: https://github.com/kubescape/kubescape/issues/1482
## Additional Information
I tested https://github.com/kubescape/kubescape/pull/1490, it seems it doesn't work properly. Since for the repository_owner, it is the same for internal or external PR, which is kubescape, so it cannot skip the job. More than that, the check is added to pr-scanner instead of binary-build.

Here, I check the actor of the action instead of repository_owner, for me (external PR), it will be MMMMMMorty, instead of kubescape.

I tested this on my other PR https://github.com/kubescape/kubescape/actions/runs/7019483545, it skips the binary-build.

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
