### PR TITLE
Fixed crash when running the scan command

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -135,25 +135,17 @@ func filterCVEsBySeverities(cves []imageprinter.CVE, severities []string) []imag
 
 // getSortPackageScores returns a slice of package names sorted by score
 func getSortPackageScores(pkgScores map[string]*imageprinter.PackageScore) []string {
-	// Create a slice of PackageScore pointers to avoid unnecessary map lookups
-	var pkgScoresPtrs []*imageprinter.PackageScore
-	for _, pkgScore := range pkgScores {
-		pkgScoresPtrs = append(pkgScoresPtrs, pkgScore)
+	sortedSlice := make([]string, 0, len(pkgScores))
+	for pkgName, _ := range pkgScores {
+		sortedSlice = append(sortedSlice, pkgName)
 	}
 
-	// Sort by score. If score is equal, sort by name
-	sort.Slice(pkgScoresPtrs, func(i, j int) bool {
-		if pkgScoresPtrs[i].Score == pkgScoresPtrs[j].Score {
-			return pkgScoresPtrs[i].Name < pkgScoresPtrs[j].Name
+	sort.Slice(sortedSlice, func(i, j int) bool {
+		if pkgScores[sortedSlice[i]].Score == pkgScores[sortedSlice[j]].Score {
+			return pkgScores[sortedSlice[i]].Name < pkgScores[sortedSlice[j]].Name
 		}
-		return pkgScoresPtrs[i].Score > pkgScoresPtrs[j].Score
+		return pkgScores[sortedSlice[i]].Score > pkgScores[sortedSlice[j]].Score
 	})
-
-	// Extract package names from the sorted slice of pointers
-	var sortedSlice []string
-	for _, pkgScorePtr := range pkgScoresPtrs {
-		sortedSlice = append(sortedSlice, pkgScorePtr.Name)
-	}
 
 	return sortedSlice
 }


### PR DESCRIPTION
Updated the `getSortPackageScores` function to fix the crash in the scan command.

Fixes: https://github.com/kubescape/kubescape/issues/1553

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
