### PR TITLE
Fix markdown syntax error

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ _Some documentation on using Kubescape is yet to move here from the [ARMO Platfo
     kubescape scan *.yaml
     ```
 
-    Take a look at the demonstration](https://youtu.be/Ox6DaR7_4ZI).
+    [Take a look at the demonstration](https://youtu.be/Ox6DaR7_4ZI).
 
 * Scan Kubernetes manifest files from a Git repository:
 


### PR DESCRIPTION
## Overview
Just fixed a markdown syntax error
![image](https://github.com/kubescape/kubescape/assets/40382980/d671d233-9b03-4f88-ba4c-b0e7cd1347a1)