### PR TITLE
added support for exception rules in Scan API ( As a HTTP request)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/google/uuid v1.6.0
+	github.com/johnfercher/go-tree v1.1.0
 	github.com/johnfercher/maroto/v2 v2.2.2
 	github.com/json-iterator/go v1.1.12
 	github.com/jwalton/gchalk v1.3.0
@@ -302,7 +303,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/johnfercher/go-tree v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jung-kurt/gofpdf v1.16.2 // indirect
 	github.com/jwalton/go-supportscolor v1.1.0 // indirect

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -1,8 +1,14 @@
 package v1
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -67,6 +73,10 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 		scanInfo.IsDeletedScanObject = *scanRequest.IsDeletedScanObject
 	}
 
+	if scanRequest.Exceptions != nil {
+		scanInfo.UseExceptions = loadexception(scanRequest)
+
+	}
 	return scanInfo
 }
 
@@ -91,4 +101,27 @@ func setTargetInScanInfo(scanRequest *utilsmetav1.PostScanRequest, scanInfo *cau
 		scanInfo.FrameworkScan = true
 		scanInfo.ScanAll = true
 	}
+}
+
+func loadexception(exceptions *utilsmetav1.PostScanRequest) (path string) {
+	exceptionJSON, err := json.Marshal(exceptions.Exceptions)
+	if err != nil {
+		logger.L().Error("Failed to marshal exceptions", helpers.Error(err))
+	} else {
+		exePath, err := os.Executable()
+		if err != nil {
+			fmt.Printf("Failed to get executable path, reason: %s", err)
+		}
+		exeDir := filepath.Dir(exePath)
+		exdir := filepath.Dir(exeDir)
+		edir := filepath.Dir(exdir)
+		exceptionpath := filepath.Join(edir, ".kubescape", "exceptions.json")
+		if err := os.WriteFile(exceptionpath, exceptionJSON, 0644); err != nil {
+			logger.L().Error("Failed to write exceptions file to disk", helpers.String("path", exceptionpath), helpers.Error(err))
+			return
+		}
+		print(exceptionpath)
+		return exceptionpath // to test
+	}
+	return
 }


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
- Update opa-utils from v0.0.273 to v0.0.275 to add Exception in --data payload
- Added loadexception function which runs when scanRequest or payload contains an Exception  
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->


## Examples/Screenshots
Here is the command to test weather the Exception Payload is load or not 
```
curl --header "Content-Type: application/json"   --request POST   --data '{"Exceptions": [{"name":"exclude-allowed-hostPath-control","policyType":"postureExceptionPolicy","actions":["alertOnly"],"resources":[{"designatorType":"Attributes","attributes":{"kind":".*"}}],"posturePolicies":[{"controlName":"HostPath mount"}]}]}'   http://127.0.0.1:8080/v1/scan

```
I used this Exception example [exclude-allowed-hostPath-control](https://github.com/kubescape/kubescape/blob/master/examples/exceptions/exclude-allowed-hostPath-control.json)
> Here are results screenshots
![Screenshot from 2024-01-21 22-36-52](https://github.com/kubescape/kubescape/assets/92817635/5b3a89f9-1915-4194-8e2e-d09311575554)





## Related issues/PRs:
fixes : #1580 


<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
