### PR TITLE
Handle unknown fw

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -150,7 +150,7 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			logger.L().Debug("Downloading framework", helpers.String("framework", rule.Identifier))
 			receivedFramework, err := policyHandler.getters.PolicyGetter.GetFramework(rule.Identifier)
 			if err != nil {
-				return frameworks, policyDownloadError(err)
+				return frameworks, frameworkDownloadError(err, rule.Identifier)
 			}
 			if err := validateFramework(receivedFramework); err != nil {
 				return frameworks, err
@@ -171,7 +171,7 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			logger.L().Debug("Downloading control", helpers.String("control", policy.Identifier))
 			receivedControl, err = policyHandler.getters.PolicyGetter.GetControl(policy.Identifier)
 			if err != nil {
-				return frameworks, policyDownloadError(err)
+				return frameworks, controlDownloadError(err, policy.Identifier)
 			}
 			if receivedControl != nil {
 				f.Controls = append(f.Controls, *receivedControl)

--- a/core/pkg/policyhandler/handlepullpoliciesutils.go
+++ b/core/pkg/policyhandler/handlepullpoliciesutils.go
@@ -17,9 +17,21 @@ func getScanKind(policyIdentifier []cautils.PolicyIdentifier) apisv1.Notificatio
 	}
 	return "unknown"
 }
-func policyDownloadError(err error) error {
+func frameworkDownloadError(err error, fwName string) error {
 	if strings.Contains(err.Error(), "unsupported protocol scheme") {
 		err = fmt.Errorf("failed to download from GitHub release, try running with `--use-default` flag")
+	}
+	if strings.Contains(err.Error(), "not found") {
+		err = fmt.Errorf("framework '%s' not found, run `kubescape list frameworks` for available frameworks", fwName)
+	}
+	return err
+}
+func controlDownloadError(err error, controls string) error {
+	if strings.Contains(err.Error(), "unsupported protocol scheme") {
+		err = fmt.Errorf("failed to download from GitHub release, try running with `--use-default` flag")
+	}
+	if strings.Contains(err.Error(), "not found") {
+		err = fmt.Errorf("control '%s' not found, run `kubescape list controls` for available controls", controls)
 	}
 	return err
 }

--- a/core/pkg/policyhandler/handlepullpoliciesutils_test.go
+++ b/core/pkg/policyhandler/handlepullpoliciesutils_test.go
@@ -89,6 +89,8 @@ func TestPolicyDownloadError(t *testing.T) {
 	tests := []struct {
 		err  error
 		want error
+		name string
+		kind string
 	}{
 		{
 			err:  errors.New("Some error"),
@@ -98,11 +100,31 @@ func TestPolicyDownloadError(t *testing.T) {
 			err:  errors.New("unsupported protocol scheme"),
 			want: fmt.Errorf("failed to download from GitHub release, try running with `--use-default` flag"),
 		},
+		{
+			err:  errors.New("framework 'cis' not found"),
+			want: fmt.Errorf("framework 'cis' not found, run `kubescape list frameworks` for available frameworks"),
+			name: "cis",
+			kind: "framework",
+		},
+		{
+			err:  errors.New("control 'c-0005' not found"),
+			want: fmt.Errorf("control 'c-0005' not found, run `kubescape list controls` for available controls"),
+			name: "c-0005",
+			kind: "control",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, tt.want, policyDownloadError(tt.err))
+			switch tt.kind {
+			case "framework":
+				assert.Equal(t, tt.want, frameworkDownloadError(tt.err, tt.name))
+			case "control":
+				assert.Equal(t, tt.want, controlDownloadError(tt.err, tt.name))
+			default:
+				assert.Equal(t, tt.want, frameworkDownloadError(tt.err, tt.name))
+				assert.Equal(t, tt.want, controlDownloadError(tt.err, tt.name))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Overview
Updating error message in case of unknown framework.

Before:
```
% kubescape scan framework cis
 ✅  Initialized scanner
 ❌  http-error: '400 Bad Request', reason: 'framework 'cis' not found`
```

After:
```
% kubescape scan framework cis
 ✅  Initialized scanner
 ❌  framework 'cis' not found, run `kubescape list frameworks` for available frameworks
```
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
