### PR TITLE
Fix bug for no matches of yalib in one file mapping

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -58,7 +58,9 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 				logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering of Helm chart template '%s', failed: %v", chart.GetName(), errs))
 				continue
 			}
-			sourceToNodes = templateToNodes
+			for k, v := range templateToNodes {
+				sourceToNodes[k] = v
+			}
 
 			chartName := chart.GetName()
 			for k, v := range wls {
@@ -68,9 +70,6 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 					Path: helmDir,
 				}
 			}
-			// for k, v := range templateMappings {
-			// 	sourceToNodes[k] = v
-			// }
 		}
 	}
 	return sourceToWorkloads, sourceToChart, sourceToNodes

--- a/core/cautils/helmchart.go
+++ b/core/cautils/helmchart.go
@@ -1,7 +1,6 @@
 package cautils
 
 import (
-	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -68,10 +67,7 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 
 	// get the resouse and analysis and store it to the struct
 	fileMapping := make(map[string]MappingNodes)
-	err = GetTemplateMapping(sourceToFile, fileMapping)
-	if err != nil {
-		return nil, nil, []error{err}
-	}
+	GetTemplateMapping(sourceToFile, fileMapping)
 
 	// delete the comment from chart and from sourceToFile
 	RemoveComment(sourceToFile)
@@ -98,7 +94,6 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 				fileMapping[absPath] = nodes
 				delete(fileMapping, path)
 			}
-
 			workloads[absPath] = []workloadinterface.IMetadata{}
 			for i := range wls {
 				lw := localworkload.NewLocalWorkload(wls[i].GetObject())
@@ -137,16 +132,16 @@ func RemoveComment(sourceToFile map[string]string) {
 	}
 }
 
-func GetTemplateMapping(sourceToFile map[string]string, fileMapping map[string]MappingNodes) error {
+func GetTemplateMapping(sourceToFile map[string]string, fileMapping map[string]MappingNodes) {
 	for fileName, fileContent := range sourceToFile {
 		mappingNodes, err := GetMapping(fileName, fileContent)
 		if err != nil {
-			err = fmt.Errorf("GetMapping wrong, err: %s", err.Error())
-			return err
+			// if one file cannot get mapping nodes, generate error, then ignore it
+			logger.L().Warning("Failed to get File Mapping nodes", helpers.String("file name", fileName), helpers.Error(err))
+			continue
 		}
 		if len(mappingNodes.Nodes) != 0 {
 			fileMapping[fileName] = *mappingNodes
 		}
 	}
-	return nil
 }

--- a/core/cautils/parseFile.go
+++ b/core/cautils/parseFile.go
@@ -1,7 +1,6 @@
 package cautils
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -78,7 +77,7 @@ func GetMapping(fileName string, fileContent string) (*MappingNodes, error) {
 			expression := fmt.Sprintf(lineExpression, index)
 			output, err := getYamlLineInfo(expression, fileContent)
 			if err != nil {
-				return nil, fmt.Errorf("getYamlLineInfo wrong, the err is %s", err.Error())
+				return nil, err
 			}
 
 			path := extractParameter(pathRe, output, "$path")
@@ -184,7 +183,7 @@ func getInfoFromOne(output string, lastNumber int, isMapType bool) (value string
 func getYamlLineInfo(expression string, yamlFile string) (string, error) {
 	out, err := exectuateYq(expression, yamlFile)
 	if err != nil {
-		return "", fmt.Errorf("exectuateYq err: %s", err.Error())
+		return "", fmt.Errorf("exectuate yqlib err: %s", err.Error())
 	}
 	return out, nil
 }
@@ -203,7 +202,7 @@ func exectuateYq(expression string, yamlContent string) (string, error) {
 
 	out, err := stringEvaluator.Evaluate(expression, yamlContent, encoder, decoder)
 	if err != nil {
-		return "", errors.New("no matches found")
+		return "", fmt.Errorf("no matches found")
 	}
 	return out, err
 }

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -283,7 +283,10 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 	for source, ws := range helmSourceToWorkloads {
 		workloads = append(workloads, ws...)
 		helmChart := helmSourceToChart[source]
-		templatesNodes := helmSourceToNodes[source]
+		var templatesNodes cautils.MappingNodes
+		if nodes, ok := helmSourceToNodes[source]; ok {
+			templatesNodes = nodes
+		}
 
 		if clonedRepo != "" {
 			url, err := gitRepo.GetRemoteUrl()
@@ -302,16 +305,11 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 		for i := range ws {
 			workloadIDToSource[ws[i].GetID()] = workloadSource
 			workloadIDToNodes[ws[i].GetID()] = templatesNodes
-			// workloadIDToNodes[ws[i].GetID()].Nodes = templatesNodes.Nodes
-			// workloadIDToNodes[ws[i].GetID()].TemplateFileName = templatesNodes.TemplateFileName
-			// helmSourceToNodes[source]
 		}
 	}
 
 	if len(helmSourceToWorkloads) > 0 { // && len(helmSourceToNodes) > 0
 		logger.L().Debug("helm templates found in local storage", helpers.Int("helmTemplates", len(helmSourceToWorkloads)), helpers.Int("workloads", len(workloads)))
-	} else {
-		workloadIDToNodes = nil
 	}
 
 	//patch, get value from env


### PR DESCRIPTION
## Overview
When executing yqlib, if there is an error, it will return, which causes the crash of Kubescape scanning.
To fix it, instead of generating an error and return, I print a warning log to tell users which files are failing to execute yqlib. Therefore, it will only generate a warning for the files, and scanning will not be stopped.
In this case, in the sarif printer, since the files don't have the file mapping, it will return the default location. The worst case will be all the files fail to execute yqlib, but this is really rare.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->


## Examples/Screenshots
`./kubescape scan framework allcontrols ./demo-bitnami-charts -f sarif -o test1.sarif`
![result](https://github.com/kubescape/kubescape/assets/55234982/94df2ae6-da12-4eb8-b011-35e8bcb9efbb)

## Related issues/PRs:

* Resolved #1625 

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ x] My code follows the style guidelines of this project
- [ x] I have commented on my code, particularly in hard-to-understand areas
- [ x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
