### PR TITLE
speedup golangci-lint-action by skipping caches

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -71,11 +71,13 @@ jobs:
 
       - name: golangci-lint
         continue-on-error: false
-        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # ratchet:golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout 10m --build-tags=static
+          args: --timeout 10m
           only-new-issues: true
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   scanners:
     env:

--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -147,11 +147,13 @@ jobs:
 
       - name: golangci-lint
         continue-on-error: true
-        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # ratchet:golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout 10m --build-tags=static
+          args: --timeout 10m
           only-new-issues: true
+          skip-pkg-cache: true
+          skip-build-cache: true
 
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # ratchet:actions/upload-artifact@v3.1.1
         name: Upload artifacts


### PR DESCRIPTION
https://github.com/golangci/golangci-lint-action/issues/703