### PR TITLE
Fix panic when error is returned from SubmitReport

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -249,7 +249,7 @@ func (report *ReportEventReceiver) sendReport(postureReport *reporthandlingv2.Po
 			report.tenantConfig.DeleteCredentials()
 		}
 
-		return fmt.Errorf("%s, %v:%s", report.getReportUrl(), err, strResponse)
+		return fmt.Errorf("%w:%s", err, strResponse)
 	}
 
 	// message is taken only from last report


### PR DESCRIPTION
## Overview

When an error is returned from `SubmitReport`, Kubescape calls `getReportUrl()` (for logging purposes) which causes a panic since it is empty.

```
{"level":"debug","ts":"2024-03-17T04:35:44Z","msg":"sending report","url":"https://report.armo.cloud/k8s/v2/postureReport?clusterName=kind-systets-1f6ac241-7723-4fff-8b5d-2dacdca93e26&contextName=kind-systets-1f6ac241-7723-4fff-8b5d-2dacdca93e26&customerGUID=69bcb204-5b2d-446a-896f-ff68a2312be9&reportGUID=8a8323e8-18aa-416a-bfd3-3a0fa96506b4","account":"69bcb204-5b2d-446a-896f-ff68a2312be9","accessKey length":0,"reportNumber":0}
{"level":"debug","ts":"2024-03-17T04:36:45Z","msg":"updating cached config","configObj":{"clusterName":"kind-systets-1f6ac241-7723-4fff-8b5d-2dacdca93e26","cloudReportURL":"https://report.armo.cloud/","cloudAPIURL":"https://api.armosec.io/"}}
panic: uuid: Parse(): invalid UUID length: 0

goroutine 1 [running]:
github.com/google/uuid.MustParse({0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/google/uuid@v1.6.0/uuid.go:169 +0x99
github.com/kubescape/backend/pkg/client/v1.GetPostureReportUrl({0xc001a23080?, 0x42824d1?}, {0x0, 0x0}, {0xc001a8c700, 0x31}, {0xc00189e150, 0x24})
	/home/runner/go/pkg/mod/github.com/kubescape/backend@v0.0.19/pkg/client/v1/reporter.go:69 +0x175
github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2.(*ReportEventReceiver).getReportUrl(0xc000e22540)
	/home/runner/work/kubescape/kubescape/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go:[121](https://github.com/armosec/sanity-tests/actions/runs/8312978807/job/22748455180#step:7:122) +0xb1
github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2.(*ReportEventReceiver).sendReport(0xc000e22540, 0xc001eb5200, 0x0, 0x1)
	/home/runner/work/kubescape/kubescape/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go:252 +0x336
github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2.(*ReportEventReceiver).sendResources(0xc002e8d870?, 0xc000e49300)
```