### PR TITLE
fix panic when submitting report

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -76,7 +76,7 @@ func (report *ReportEventReceiver) Submit(ctx context.Context, opaSessionObj *ca
 	}
 
 	if err := report.prepareReport(opaSessionObj); err != nil {
-		return fmt.Errorf("failed to submit scan results. url: '%s', reason: %s", report.getReportUrl(), err.Error())
+		return fmt.Errorf("failed to submit scan results. reason: %s", err.Error())
 	}
 
 	logger.L().Debug("", helpers.String("account ID", report.GetAccountID()))


### PR DESCRIPTION
## Overview

A continuation of https://github.com/kubescape/kubescape/pull/1640

```
goroutine 1 [running]:
github.com/google/uuid.MustParse({0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/google/uuid@v1.6.0/uuid.go:169 +0x99
github.com/kubescape/backend/pkg/client/v1.GetPostureReportUrl({0xc001896c00?, 0x42824f1?}, {0x0, 0x0}, {0xc0011e6380, 0x31}, {0xc0014bb6b0, 0x24})
	/home/runner/go/pkg/mod/github.com/kubescape/backend@v0.0.19/pkg/client/v1/reporter.go:69 +0x175
github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2.(*ReportEventReceiver).getReportUrl(0xc000e05570)
	/home/runner/work/kubescape/kubescape/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go:121 +0xb1
github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2.(*ReportEventReceiver).Submit(0xc000e05570, {0x4fc9708, 0x756b460}, 0xc00192c800)
	/home/runner/work/kubescape/kubescape/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go:79 +0x70a
```