### PR TITLE
bump actions/checkout to v4

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -10,7 +10,7 @@ jobs:
       NEW_TAG: ${{ steps.tag-calculator.outputs.NEW_TAG }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: tag-calculator
         uses: ./.github/actions/tag-action
         with:

--- a/.github/workflows/04-publish-krew-plugin.yaml
+++ b/.github/workflows/04-publish-krew-plugin.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'kubescape'
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Update new version in krew-index

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/b-binary-build-and-e2e-tests.yaml
+++ b/.github/workflows/b-binary-build-and-e2e-tests.yaml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -216,7 +216,7 @@ jobs:
         run: chmod +x -R ${{steps.download-artifact.outputs.download-path}}/kubescape-ubuntu-latest
 
       - name: Checkout systests repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: armosec/system-tests
           path: .

--- a/.github/workflows/d-publish-image.yaml
+++ b/.github/workflows/d-publish-image.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Build image and upload to registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up QEMU

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 


### PR DESCRIPTION
[Scorecard analysis](https://github.com/kubescape/node-agent/actions/runs/8413161701/job/23034977535)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.