### PR TITLE
chore(core/pkg/resultshandling): add control id to pdf output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -14,11 +14,13 @@ import (
 
 const (
 	columnSeverity        = iota
+	columnRef             = iota
 	columnName            = iota
 	columnCounterFailed   = iota
 	columnCounterAll      = iota
 	columnComplianceScore = iota
 	_rowLen               = iota
+	controlNameMaxLength  = 70
 )
 
 func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo []infoStars, verbose bool) []string {
@@ -30,8 +32,8 @@ func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo [
 	}
 
 	row[columnSeverity] = getSeverityColumn(controlSummary)
-	if len(controlSummary.GetName()) > 50 {
-		row[columnName] = controlSummary.GetName()[:50] + "..."
+	if len(controlSummary.GetName()) > controlNameMaxLength {
+		row[columnName] = controlSummary.GetName()[:controlNameMaxLength] + "..."
 	} else {
 		row[columnName] = controlSummary.GetName()
 	}
@@ -62,8 +64,9 @@ func generateRowPdf(controlSummary reportsummary.IControlSummary, infoToPrintInf
 	}
 
 	row[columnSeverity] = apis.ControlSeverityToString(controlSummary.GetScoreFactor())
-	if len(controlSummary.GetName()) > 50 {
-		row[columnName] = controlSummary.GetName()[:50] + "..."
+	row[columnRef] = controlSummary.GetID()
+	if len(controlSummary.GetName()) > controlNameMaxLength {
+		row[columnName] = controlSummary.GetName()[:controlNameMaxLength] + "..."
 	} else {
 		row[columnName] = controlSummary.GetName()
 	}
@@ -144,6 +147,7 @@ func getControlTableHeaders(short bool) []string {
 		headers[0] = "Controls"
 	} else {
 		headers = make([]string, _rowLen)
+		headers[columnRef] = "Control reference"
 		headers[columnName] = "Control name"
 		headers[columnCounterFailed] = "Failed resources"
 		headers[columnCounterAll] = "All resources"

--- a/core/pkg/resultshandling/printer/v2/controltable_test.go
+++ b/core/pkg/resultshandling/printer/v2/controltable_test.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,23 +41,28 @@ func Test_generateRowPdf(t *testing.T) {
 			t.Errorf("got %s, want either of these: %s", c[0], "Low, Medium, High, Critical")
 		}
 
+		// Validating length of control ID
+		if len(c[1]) > 6 {
+			t.Errorf("got %s, want %s", c[1], "less than 7 characters")
+		}
+
 		// Validating length of control name
-		if len(c[1]) > 53 {
-			t.Errorf("got %s, want %s", c[1], "less than 54 characters")
+		if len(c[2]) > controlNameMaxLength {
+			t.Errorf("got %s, want %s", c[1], fmt.Sprintf("less than %d characters", controlNameMaxLength))
 		}
 
 		// Validating numeric fields
-		_, err := strconv.Atoi(c[2])
+		_, err := strconv.Atoi(c[3])
 		if err != nil {
 			t.Errorf("got %s, want an integer %s", c[2], err)
 		}
 
-		_, err = strconv.Atoi(c[3])
+		_, err = strconv.Atoi(c[4])
 		if err != nil {
 			t.Errorf("got %s, want an integer %s", c[3], err)
 		}
 
-		assert.NotEmpty(t, c[4], "expected a non-empty string")
+		assert.NotEmpty(t, c[5], "expected a non-empty string")
 
 	}
 

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -192,18 +192,21 @@ func (pp *PdfPrinter) printTable(m pdf.Maroto, summaryDetails *reportsummary.Sum
 		}
 	}
 
+	size := 6.0
+	gridSize := []uint{1, 1, 6, 1, 1, 2}
+
 	m.TableList(headers, controls, props.TableList{
 		HeaderProp: props.TableListContent{
 			Family:    consts.Arial,
 			Style:     consts.Bold,
-			Size:      6.0,
-			GridSizes: []uint{1, 5, 2, 2, 2},
+			Size:      size,
+			GridSizes: gridSize,
 		},
 		ContentProp: props.TableListContent{
 			Family:                          consts.Courier,
 			Style:                           consts.Normal,
-			Size:                            6.0,
-			GridSizes:                       []uint{1, 5, 2, 2, 2},
+			Size:                            size,
+			GridSizes:                       gridSize,
 			CellTextColorChangerColumnIndex: 0,
 			CellTextColorChangerFunc: func(cellValue string) color.Color {
 				if cellValue == "Critical" {


### PR DESCRIPTION
## Overview

This PR adds a new column in the PDF output to reference each control that has been executed as control ID.
 
## Additional Information

The PDF report is useful, especially for assessment overviews.
As of now a reference to each control, independently of the framework, is missing and only a description.
The description of the control is not enough to reference the documentation of the control, remediation.

Furthermore, this PR increments the control description volume width to 73 characters, from 53.

## How to Test

```shell
kubescape scan -v --format pdf --output test-report.pdf
```

## Examples/Screenshots

![image](https://github.com/kubescape/kubescape/assets/7593929/f8a10bdc-baa5-4a5b-9e01-4e7277433969)

## Related issues/PRs:

#1661 

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
