### PR TITLE
Fix scanning unsupported clouds

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -322,7 +322,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		result, err := k8sHandler.pullSingleResource(&gvr, nil, queryableResources[i].FieldSelectors, globalFieldSelectors)
 		if err != nil {
 			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
-				logger.L().Error("failed to pull resource", helpers.String("resource", queryableResources[i].GroupVersionResourceTriplet), helpers.Error(err))
+				logger.L().Warning("failed to pull resource", helpers.String("resource", queryableResources[i].GroupVersionResourceTriplet), helpers.Error(err))
 				// handle error
 				if errs == nil {
 					errs = err

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/kubescape/backend v0.0.20
 	github.com/kubescape/go-git-url v0.0.30
 	github.com/kubescape/go-logger v0.0.22
-	github.com/kubescape/k8s-interface v0.0.166
+	github.com/kubescape/k8s-interface v0.0.168
 	github.com/kubescape/opa-utils v0.0.281
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1152,8 +1152,8 @@ github.com/kubescape/go-git-url v0.0.30 h1:PIbg86ae0ftee/p/Tu/6CA1ju6VoJ51G3sQWN
 github.com/kubescape/go-git-url v0.0.30/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil6JXHE=
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
-github.com/kubescape/k8s-interface v0.0.166 h1:n9rG8vUvHw7UMh+/PZHadfK4Mcj++WAaj+rvNc8kbJY=
-github.com/kubescape/k8s-interface v0.0.166/go.mod h1:oF+Yxug3Kpfu9Yr2j63wy7gwswrKXpiqI0mLk/7gF/s=
+github.com/kubescape/k8s-interface v0.0.168 h1:VUCd0k4N4CCzAj6dPPRRlmcgqyGwKhF+dphEuHlSwyY=
+github.com/kubescape/k8s-interface v0.0.168/go.mod h1:oF+Yxug3Kpfu9Yr2j63wy7gwswrKXpiqI0mLk/7gF/s=
 github.com/kubescape/opa-utils v0.0.281 h1:NwAjvsriu+xm5L9C+XQwOqb5ttVJz6OVmFCv8mlB1tc=
 github.com/kubescape/opa-utils v0.0.281/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/kubescape/backend v0.0.20
 	github.com/kubescape/go-logger v0.0.22
-	github.com/kubescape/k8s-interface v0.0.166
+	github.com/kubescape/k8s-interface v0.0.168
 	github.com/kubescape/kubescape/v3 v3.0.4
 	github.com/kubescape/opa-utils v0.0.281
 	github.com/kubescape/storage v0.0.20

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1158,8 +1158,8 @@ github.com/kubescape/go-git-url v0.0.30 h1:PIbg86ae0ftee/p/Tu/6CA1ju6VoJ51G3sQWN
 github.com/kubescape/go-git-url v0.0.30/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil6JXHE=
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
-github.com/kubescape/k8s-interface v0.0.166 h1:n9rG8vUvHw7UMh+/PZHadfK4Mcj++WAaj+rvNc8kbJY=
-github.com/kubescape/k8s-interface v0.0.166/go.mod h1:oF+Yxug3Kpfu9Yr2j63wy7gwswrKXpiqI0mLk/7gF/s=
+github.com/kubescape/k8s-interface v0.0.168 h1:VUCd0k4N4CCzAj6dPPRRlmcgqyGwKhF+dphEuHlSwyY=
+github.com/kubescape/k8s-interface v0.0.168/go.mod h1:oF+Yxug3Kpfu9Yr2j63wy7gwswrKXpiqI0mLk/7gF/s=
 github.com/kubescape/opa-utils v0.0.281 h1:NwAjvsriu+xm5L9C+XQwOqb5ttVJz6OVmFCv8mlB1tc=
 github.com/kubescape/opa-utils v0.0.281/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=


### PR DESCRIPTION
## Overview
This PR fixes the panic we get when scanning unsupported clouds.

I scanned a cluster running on DigitalOcean and I got the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d6a7c2]

goroutine 10 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:405 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc000ff8300, {0x0, 0x0, 0xbad95c8cf62385b4?})
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:443 +0xa3b
panic({0x3c48160?, 0x75a9ca0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:405 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc001a6e300, {0x0, 0x0, 0x47d0ea?})
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:443 +0xa3b
panic({0x3c48160?, 0x75a9ca0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/kubescape/k8s-interface/cloudsupport/v1.(*CloudProviderDescribe).GetApiVersion(...)
	/go/pkg/mod/github.com/kubescape/k8s-interface@v0.0.166/cloudsupport/v1/methods.go:84
github.com/kubescape/k8s-interface/cloudsupport/v1.(*CloudProviderDescribe).GetID(0x0)
	/go/pkg/mod/github.com/kubescape/k8s-interface@v0.0.166/cloudsupport/v1/methods.go:127 +0x22
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.(*K8sResourceHandler).collectCloudResources(0xc001b36fc0, {0x5059de0, 0xc0010109f0}, 0xc000f6d600, 0x7?, 0xc000f75600?, {0xc00262d980, 0x3, 0x3bc1740?}, {0x5050b70, ...})
	/work/core/pkg/resourcehandler/k8sresources.go:243 +0x822
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.(*K8sResourceHandler).GetResources(0xc001b36fc0, {0x5059de0, 0xc0010109f0}, 0xc000f6d600, {0x5050b70, 0xc0014e9650}, 0xc000ffad80)
	/work/core/pkg/resourcehandler/k8sresources.go:148 +0xbd5
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.CollectResources({0x5059de0, 0xc0010109c0}, {0x5050ae0, 0xc001b36fc0}, {0x0?, 0xc00158cd01?, 0xc001020438?}, 0xc000f6d600, {0x5050b70, 0xc0014e9650}, ...)
	/work/core/pkg/resourcehandler/handlerpullresources.go:29 +0x1b5
github.com/kubescape/kubescape/v3/core/core.(*Kubescape).Scan(0xc000f80840?, {0x5059de0?, 0xc000fad110}, 0xc000ffad80)
	/work/core/core/scan.go:172 +0x865
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.scan({0x5059de0, 0xc000face70}, 0xc000ffad80, {0xc000198a20, 0x24})
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:77 +0xf85
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.(*HTTPHandler).executeScan(0xc0001acb88, 0xc000fac5d0)
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:32 +0x16a
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.(*HTTPHandler).watchForScan(0xc0001acb88)
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:57 +0x53
created by github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.NewHTTPHandler in goroutine 1
	/work/httphandler/handlerequests/v1/requestshandler.go:44 +0x12f
```

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
