### PR TITLE
Simplify the concurrency in http handler for scan.

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/google/uuid"
@@ -35,18 +36,16 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		},
 		scanInfo: scanInfo,
 		scanID:   scanID,
+		ctx:      trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(r.Context())),
+		resp:     make(chan *utilsmetav1.Response, 1),
 	}
-	scanParams.ctx = trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(r.Context()))
-
-	handler.scanResponseChan.set(scanID) // add scan to channel
-	defer handler.scanResponseChan.delete(scanID)
 
 	// send to scan queue
 	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/metrics"))
 	handler.scanRequestChan <- scanParams
 
 	// wait for scan to complete
-	results := <-handler.scanResponseChan.get(scanID)
+	results := <-scanParams.resp
 	defer removeResultsFile(scanID) // remove json format results file
 	defer os.Remove(resultsFile)    // remove prometheus format results file
 

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -15,47 +14,6 @@ import (
 
 	"github.com/gorilla/schema"
 )
-
-type scanResponseChan struct {
-	scanResponseChan map[string]chan *utilsmetav1.Response
-	mtx              sync.RWMutex
-}
-
-// get response object chan
-func (resChan *scanResponseChan) get(key string) chan *utilsmetav1.Response {
-	resChan.mtx.RLock()
-	defer resChan.mtx.RUnlock()
-	return resChan.scanResponseChan[key]
-}
-
-// set chan for response object
-func (resChan *scanResponseChan) set(key string) {
-	resChan.mtx.Lock()
-	defer resChan.mtx.Unlock()
-	resChan.scanResponseChan[key] = make(chan *utilsmetav1.Response)
-}
-
-// push response object to chan
-func (resChan *scanResponseChan) push(key string, resp *utilsmetav1.Response) {
-	resChan.mtx.Lock()
-	defer resChan.mtx.Unlock()
-	if _, ok := resChan.scanResponseChan[key]; ok {
-		resChan.scanResponseChan[key] <- resp
-	}
-}
-
-// delete channel
-func (resChan *scanResponseChan) delete(key string) {
-	resChan.mtx.Lock()
-	defer resChan.mtx.Unlock()
-	delete(resChan.scanResponseChan, key)
-}
-func newScanResponseChan() *scanResponseChan {
-	return &scanResponseChan{
-		scanResponseChan: make(map[string]chan *utilsmetav1.Response),
-		mtx:              sync.RWMutex{},
-	}
-}
 
 type ScanQueryParams struct {
 	// Wait for scanning to complete (synchronous request)
@@ -106,6 +64,7 @@ type scanRequestParams struct {
 	scanQueryParams *ScanQueryParams  // request as received from api
 	scanID          string            // generated scan ID
 	ctx             context.Context
+	resp            chan *utilsmetav1.Response // Respose chan; nil if not interested.
 }
 
 // swagger:parameters triggerScan
@@ -119,31 +78,30 @@ type ScanRequest struct {
 func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParams, error) {
 	defer r.Body.Close()
 
-	scanRequestParams := &scanRequestParams{}
-
-	scanQueryParams := &ScanQueryParams{}
-	if err := schema.NewDecoder().Decode(scanQueryParams, r.URL.Query()); err != nil {
-		return scanRequestParams, fmt.Errorf("failed to parse query params, reason: %s", err.Error())
-	}
-
-	readBuffer, err := io.ReadAll(r.Body)
-	if err != nil {
-		// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %s", err.Error()), scanID)
-		return scanRequestParams, fmt.Errorf("failed to read request body, reason: %s", err.Error())
-	}
-
-	logger.L().Info("REST API received scan request", helpers.String("body", string(readBuffer)))
-
 	scanRequest := &utilsmetav1.PostScanRequest{}
-	if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {
-		return scanRequestParams, fmt.Errorf("failed to parse request payload, reason: %s", err.Error())
+	{
+		readBuffer, err := io.ReadAll(r.Body)
+		if err != nil {
+			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %s", err.Error()), scanID)
+			return nil, fmt.Errorf("failed to read request body, reason: %s", err.Error())
+		}
+		logger.L().Info("REST API received scan request", helpers.String("body", string(readBuffer)))
+		if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {
+			return nil, fmt.Errorf("failed to parse request payload, reason: %s", err.Error())
+		}
 	}
 
-	scanInfo := getScanCommand(scanRequest, scanID)
+	p := &scanRequestParams{
+		scanID:          scanID,
+		scanQueryParams: &ScanQueryParams{},
+		scanInfo:        getScanCommand(scanRequest, scanID),
+	}
+	if err := schema.NewDecoder().Decode(p.scanQueryParams, r.URL.Query()); err != nil {
+		return p, fmt.Errorf("failed to parse query params, reason: %s", err.Error())
+	}
+	if p.scanQueryParams.ReturnResults {
+		p.resp = make(chan *utilsmetav1.Response, 1)
+	}
 
-	scanRequestParams.scanID = scanID
-	scanRequestParams.scanQueryParams = scanQueryParams
-	scanRequestParams.scanInfo = scanInfo
-
-	return scanRequestParams, nil
+	return p, nil
 }

--- a/httphandler/handlerequests/v1/requestshandler_test.go
+++ b/httphandler/handlerequests/v1/requestshandler_test.go
@@ -1,5 +1,61 @@
 package v1
 
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+func testBody(t *testing.T) io.Reader {
+	t.Helper()
+	b, err := json.Marshal(utilsmetav1.PostScanRequest{Account: "fakeFoobar"})
+	if err != nil {
+		t.Fatal("Can not marshal")
+	}
+	return bytes.NewReader(b)
+}
+
+type scanner func(_ context.Context, _ *cautils.ScanInfo, _ string) (*reporthandlingv2.PostureReport, error)
+
+// TestScan tests that the scan handler passes the scan requests correctly to the underlying scan engine.
+func TestScan(t *testing.T) {
+
+	// Our scanner is not setting up the k8s connection; the test is covering the rest of the wiring
+	// that the signaling from the http handler goes all the way to the scanner implementation.
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(context.Context, *cautils.ScanInfo, string) (*reporthandlingv2.PostureReport, error) {
+		return nil, nil
+	}
+
+	var (
+		h  = NewHTTPHandler()
+		rq = httptest.NewRequest("POST", "/scan?wait=true", testBody(t))
+		w  = httptest.NewRecorder()
+	)
+	h.Scan(w, rq)
+	rs := w.Result()
+	body, _ := io.ReadAll(rs.Body)
+
+	type out struct {
+		code  int
+		ctype string
+		body  string
+	}
+	want := out{200, "application/json", `{"id":"","type":"v1results"}`}
+	got := out{rs.StatusCode, rs.Header.Get("Content-type"), string(body)}
+
+	if got != want {
+		t.Errorf("Scan result: %v,  want %v", got, want)
+	}
+}
+
 // ============================================== STATUS ========================================================
 // Status API
 // func TestStatus(t *testing.T) {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -25,11 +25,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var scanImpl = scan // Override for testing
 func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	response := &utilsmetav1.Response{}
 
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
-	_, err := scan(scanReq.ctx, scanReq.scanInfo, scanReq.scanID)
+	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID)
 	if err != nil {
 		logger.L().Ctx(scanReq.ctx).Error("scanning failed", helpers.String("ID", scanReq.scanID), helpers.Error(err))
 		if scanReq.scanQueryParams.ReturnResults {
@@ -39,6 +40,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	} else {
 		logger.L().Ctx(scanReq.ctx).Success("done scanning", helpers.String("ID", scanReq.scanID))
 		if scanReq.scanQueryParams.ReturnResults {
+			//TODO(ttimonen) should we actually pass the PostureReport here somehow?
 			response.Type = utilsapisv1.ResultsV1ScanResponseType
 		}
 	}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -47,8 +47,11 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 
 	handler.state.setNotBusy(scanReq.scanID)
 
-	// return results
-	handler.scanResponseChan.push(scanReq.scanID, response)
+	// return results, if someone's waiting for them; never block.
+	select {
+	case scanReq.resp <- response:
+	default:
+	}
 }
 
 // executeScan execute the scan request passed in the channel


### PR DESCRIPTION
## Overview
refactor(handler) Simplify the scan http handler concurrency.

This is basically a cleanup, with some minor performance benefits but most importantly benefits on reasoning about the code.
    
## Details
In particular,
    Replace scanResponseChan struct with a reply channel in req.
   This removes one chokepoint with tracking a map of channel with a mutex wrapping by not sharing data across different requests and makes it easier to reason about the correctness of the behavior.
    
Other changes are mostly cosmetic to group your operations related to
the primitives you are operating on, reducing the average lifetime of
a local variable (matters mostly for humans; compilers are very good at this nowadays).

And oh, now there's rudimentary unit-test exposing the handlers and the logic around them to something.
Of course they could be better with drilling deeper, covering handlers more widely and starting from a front door,
but one thing at the time.
    
Also the logic-side (non-tests) is net benefical by reducing LOCs by 45 or so.

## How to Test
Unit-tests included in the first commit.