### PR TITLE
Implementing capability to print out the "print" statements of the rego

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -15,12 +15,12 @@ import (
 )
 
 var scanCmdExamples = fmt.Sprintf(`
-  Scan command is for scanning an existing cluster or kubernetes manifest files based on pre-defined frameworks 
-  
+  Scan command is for scanning an existing cluster or kubernetes manifest files based on pre-defined frameworks
+
   # Scan current cluster
   %[1]s scan
 
-  # Scan kubernetes manifest files 
+  # Scan kubernetes manifest files
   %[1]s scan .
 
   # Scan and save the results in the JSON format
@@ -29,7 +29,7 @@ var scanCmdExamples = fmt.Sprintf(`
   # Display all resources
   %[1]s scan --verbose
 
-  # Scan different clusters from the kubectl context 
+  # Scan different clusters from the kubectl context
   %[1]s scan --kube-context <kubernetes context>
 `, cautils.ExecName())
 
@@ -89,6 +89,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Submit, "submit", "", false, "Submit the scan results to Kubescape SaaS where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.OmitRawResources, "omit-raw-resources", "", false, "Omit raw resources from the output. By default the raw resources are included in the output")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.PrintAttackTree, "print-attack-tree", "", false, "Print attack tree")
+	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 
 	scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead. Flag will be removed at 1.Dec.2023")

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -132,6 +132,7 @@ type ScanInfo struct {
 	ScanAll               bool                         // true if scan all frameworks
 	OmitRawResources      bool                         // true if omit raw resources from the output
 	PrintAttackTree       bool                         // true if print attack tree
+	EnableRegoPrint       bool                         // true if print rego
 	ScanObject            *objectsenvelopes.ScanObject // identifies a single resource (k8s object) to be scanned
 	IsDeletedScanObject   bool                         // indicates whether the ScanObject is a deleted K8S resource
 	ScanType              ScanTypes

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -182,7 +182,7 @@ func (ks *Kubescape) Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*res
 	defer spanOpa.End()
 
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
-	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces)
+	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint)
 	if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
 		// TODO - do something
 		return resultsHandling, fmt.Errorf("%w", err)

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -197,7 +197,7 @@ func TestProcessResourcesResult(t *testing.T) {
 	opaSessionObj.K8SResources = k8sResources
 	opaSessionObj.AllResources[deployment.GetID()] = deployment
 
-	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "")
+	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false)
 	opap.AllPolicies = policies
 	opap.Process(context.TODO(), policies, nil)
 

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -184,6 +184,7 @@ func defaultScanInfo() *cautils.ScanInfo {
 	scanInfo.Format = envToString("KS_FORMAT", "json")                             // default output should be json
 	scanInfo.Submit = envToBool("KS_SUBMIT", false)                                // publish results to Kubescape SaaS
 	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                             // do not publish results to Kubescape SaaS
+	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)                   // print rego rules
 	scanInfo.HostSensorEnabled.SetBool(envToBool("KS_ENABLE_HOST_SCANNER", false)) // enable host scanner
 	if !envToBool("KS_DOWNLOAD_ARTIFACTS", false) {
 		scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape fom downloading the artifacts every time)


### PR DESCRIPTION
## Overview
This is a long overdue feature: implementing the option to send `print()` statements in rego/OPA to the Kubescape log output.
Note: to use it you need both `-l debug` and `--enable-rego-prints` flags in the CLI and `KS_REGO_PRINT=true` and debug log level in the microservice