### PR TITLE
add trigger by indication in posture report

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -64,6 +64,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		},
 	}
 
+	scanInfo.TriggeredByCLI = true
+
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -59,6 +59,7 @@ type OPASessionObj struct {
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
 	TemplateMapping       map[string]MappingNodes // Map chart obj to template (only for rendering from path)
+	TriggeredByCLI        bool
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo) *OPASessionObj {
@@ -75,6 +76,7 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		SessionID:             scanInfo.ScanID,
 		Metadata:              scanInfoToScanMetadata(ctx, scanInfo),
 		OmitRawResources:      scanInfo.OmitRawResources,
+		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		TemplateMapping:       make(map[string]MappingNodes),
 	}
 }

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -134,6 +134,7 @@ type ScanInfo struct {
 	EnableRegoPrint       bool                         // true if print rego
 	ScanObject            *objectsenvelopes.ScanObject // identifies a single resource (k8s object) to be scanned
 	IsDeletedScanObject   bool                         // indicates whether the ScanObject is a deleted K8S resource
+	TriggeredByCLI        bool                         // indicates whether the scan was triggered by the CLI
 	ScanType              ScanTypes
 	ScanImages            bool
 	ChartPath             string

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -15,6 +15,7 @@ func (report *ReportEventReceiver) setSubReport(opaSessionObj *cautils.OPASessio
 		Attributes:            opaSessionObj.Report.Attributes,
 		ClusterAPIServerInfo:  opaSessionObj.Report.ClusterAPIServerInfo,
 		CustomerGUIDGenerated: report.accountIdGenerated,
+		TriggeredByCLI:        opaSessionObj.TriggeredByCLI,
 	}
 	if opaSessionObj.Metadata != nil {
 		reportObj.Metadata = *opaSessionObj.Metadata

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.30
 	github.com/kubescape/go-logger v0.0.23
 	github.com/kubescape/k8s-interface v0.0.174
-	github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63
+	github.com/kubescape/opa-utils v0.0.284
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/maruel/natural v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.30
 	github.com/kubescape/go-logger v0.0.23
 	github.com/kubescape/k8s-interface v0.0.174
-	github.com/kubescape/opa-utils v0.0.282
+	github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/maruel/natural v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
 github.com/kubescape/k8s-interface v0.0.174 h1:I62Dc0RZmdESJrZLhtv2ZDqvf35XQ8g19T1LQPLARsk=
 github.com/kubescape/k8s-interface v0.0.174/go.mod h1:PAJHWlN7v+VI3jx4v2xH2VqvbN+4bcy7paqXd5/tQ4I=
-github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63 h1:LA59CKn2slQfE+Dq7za90R/Z9Q4D1ygkpTiagBaJsFc=
-github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
+github.com/kubescape/opa-utils v0.0.284 h1:I7wLXzRjeSCLrAVrktxr0/2cFHRQ3P9SCjh/nkJGrwo=
+github.com/kubescape/opa-utils v0.0.284/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
 github.com/kubescape/k8s-interface v0.0.174 h1:I62Dc0RZmdESJrZLhtv2ZDqvf35XQ8g19T1LQPLARsk=
 github.com/kubescape/k8s-interface v0.0.174/go.mod h1:PAJHWlN7v+VI3jx4v2xH2VqvbN+4bcy7paqXd5/tQ4I=
-github.com/kubescape/opa-utils v0.0.282 h1:cE6EwRqQOLPWYlr1/simUmlr3tWA8UMzhj1nn3y8Dqs=
-github.com/kubescape/opa-utils v0.0.282/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
+github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63 h1:LA59CKn2slQfE+Dq7za90R/Z9Q4D1ygkpTiagBaJsFc=
+github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.23
 	github.com/kubescape/k8s-interface v0.0.174
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.282
+	github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63
 	github.com/kubescape/storage v0.0.111
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.23
 	github.com/kubescape/k8s-interface v0.0.174
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63
+	github.com/kubescape/opa-utils v0.0.284
 	github.com/kubescape/storage v0.0.111
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1181,8 +1181,8 @@ github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
 github.com/kubescape/k8s-interface v0.0.174 h1:I62Dc0RZmdESJrZLhtv2ZDqvf35XQ8g19T1LQPLARsk=
 github.com/kubescape/k8s-interface v0.0.174/go.mod h1:PAJHWlN7v+VI3jx4v2xH2VqvbN+4bcy7paqXd5/tQ4I=
-github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63 h1:LA59CKn2slQfE+Dq7za90R/Z9Q4D1ygkpTiagBaJsFc=
-github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
+github.com/kubescape/opa-utils v0.0.284 h1:I7wLXzRjeSCLrAVrktxr0/2cFHRQ3P9SCjh/nkJGrwo=
+github.com/kubescape/opa-utils v0.0.284/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1181,8 +1181,8 @@ github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
 github.com/kubescape/k8s-interface v0.0.174 h1:I62Dc0RZmdESJrZLhtv2ZDqvf35XQ8g19T1LQPLARsk=
 github.com/kubescape/k8s-interface v0.0.174/go.mod h1:PAJHWlN7v+VI3jx4v2xH2VqvbN+4bcy7paqXd5/tQ4I=
-github.com/kubescape/opa-utils v0.0.282 h1:cE6EwRqQOLPWYlr1/simUmlr3tWA8UMzhj1nn3y8Dqs=
-github.com/kubescape/opa-utils v0.0.282/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
+github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63 h1:LA59CKn2slQfE+Dq7za90R/Z9Q4D1ygkpTiagBaJsFc=
+github.com/kubescape/opa-utils v0.0.284-0.20250109140355-aaa4cef27c63/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview
A new field in the posture report to indicate whether the scan was triggered by CLI (or http handler).
We set the `TriggeredByCLI` to `true` only when ScanInfo is initialized in the command package, in all other places it will be false by default.

### Related PR: 
* https://github.com/kubescape/opa-utils/pull/155