### PR TITLE
Replace `golang.org/x/exp/slices` with `slices` from stdlib

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -12,7 +13,6 @@ import (
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -12,7 +13,6 @@ import (
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -18,7 +19,6 @@ import (
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -14,7 +15,6 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/kubescape/backend/pkg/versioncheck"
 	"github.com/kubescape/go-logger"
@@ -23,7 +24,6 @@ import (
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/resources"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/slices"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -3,6 +3,7 @@ package opaprocessor
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -23,7 +24,6 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	opaprint "github.com/open-policy-agent/opa/topdown/print"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/slices"
 )
 
 const ScoreConfigPath = "/resources/config"

--- a/core/pkg/opaprocessor/utils.go
+++ b/core/pkg/opaprocessor/utils.go
@@ -2,6 +2,7 @@ package opaprocessor
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -14,7 +15,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown/builtins"
 	"github.com/open-policy-agent/opa/types"
-	"golang.org/x/exp/slices"
 )
 
 // convertFrameworksToPolicies convert list of frameworks to list of policies

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.30.0
 	go.opentelemetry.io/otel/metric v1.30.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.27.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
@@ -471,6 +470,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect


### PR DESCRIPTION
## Overview

The experimental functions in `golang.org/x/exp/slices` are now part of the Go standard library as of Go 1.21.

Reference: https://go.dev/doc/go1.21#slices

## Related issues/PRs:

I have submitted PRs to the following downstream repositories:

1. https://github.com/kubescape/k8s-interface/pull/117
2. https://github.com/kubescape/opa-utils/pull/156
3. https://github.com/kubescape/storage/pull/186

Please review them as well. Thank you :blush: 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
