### PR TITLE
Refactor: propagate context from main to avoid redundant context creation

### DIFF
--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"context"
-
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -15,7 +13,7 @@ func getDeleteCmd(ks meta.IKubescape) *cobra.Command {
 		Short: "Delete cached configurations",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := ks.DeleteCachedConfig(context.TODO(), &v1.DeleteConfig{}); err != nil {
+			if err := ks.DeleteCachedConfig(&v1.DeleteConfig{}); err != nil {
 				logger.L().Fatal(err.Error())
 			}
 		},

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -1,7 +1,6 @@
 package download
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -78,7 +77,7 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 				downloadInfo.Identifier = args[1]
 
 			}
-			if err := ks.Download(context.TODO(), &downloadInfo); err != nil {
+			if err := ks.Download(&downloadInfo); err != nil {
 				logger.L().Fatal(err.Error())
 			}
 			return nil

--- a/cmd/fix/fix.go
+++ b/cmd/fix/fix.go
@@ -1,7 +1,6 @@
 package fix
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -35,7 +34,7 @@ func GetFixCmd(ks meta.IKubescape) *cobra.Command {
 			}
 			fixInfo.ReportFile = args[0]
 
-			return ks.Fix(context.TODO(), &fixInfo)
+			return ks.Fix(&fixInfo)
 		},
 	}
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -62,7 +61,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 
 			listPolicies.Target = args[0]
 
-			if err := ks.List(context.TODO(), &listPolicies); err != nil {
+			if err := ks.List(&listPolicies); err != nil {
 				logger.L().Fatal(err.Error())
 			}
 			return nil

--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -1,7 +1,6 @@
 package patch
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -50,7 +49,7 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 				return err
 			}
 
-			results, err := ks.Patch(context.Background(), &patchInfo, &scanInfo)
+			results, err := ks.Patch(&patchInfo, &scanInfo)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -42,8 +43,8 @@ var ksExamples = fmt.Sprintf(`
   %[1]s config view
 `, cautils.ExecName())
 
-func NewDefaultKubescapeCommand() *cobra.Command {
-	ks := core.NewKubescape()
+func NewDefaultKubescapeCommand(ctx context.Context) *cobra.Command {
+	ks := core.NewKubescape(ctx)
 	return getRootCmd(ks)
 }
 
@@ -93,7 +94,7 @@ func getRootCmd(ks meta.IKubescape) *cobra.Command {
 	rootCmd.AddCommand(download.GetDownloadCmd(ks))
 	rootCmd.AddCommand(list.GetListCmd(ks))
 	rootCmd.AddCommand(completion.GetCompletionCmd())
-	rootCmd.AddCommand(version.GetVersionCmd())
+	rootCmd.AddCommand(version.GetVersionCmd(ks))
 	rootCmd.AddCommand(config.GetConfigCmd(ks))
 	rootCmd.AddCommand(update.GetUpdateCmd())
 	rootCmd.AddCommand(fix.GetFixCmd(ks))
@@ -115,7 +116,7 @@ func getRootCmd(ks meta.IKubescape) *cobra.Command {
 	return rootCmd
 }
 
-func Execute() error {
-	ks := NewDefaultKubescapeCommand()
+func Execute(ctx context.Context) error {
+	ks := NewDefaultKubescapeCommand(ctx)
 	return ks.Execute()
 }

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -1,7 +1,6 @@
 package scan
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -95,13 +94,12 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			if err := validateControlScanInfo(scanInfo); err != nil {
 				return err
 			}
-
-			ctx := context.TODO()
-			results, err := ks.Scan(ctx, scanInfo)
+			
+			results, err := ks.Scan(scanInfo)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}
-			if err := results.HandleResults(ctx); err != nil {
+			if err := results.HandleResults(ks.Context()); err != nil {
 				logger.L().Fatal(err.Error())
 			}
 			if !scanInfo.VerboseMode {

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -114,7 +114,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			scanInfo.SetPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
 			ctx := context.TODO()
-			results, err := ks.Scan(ctx, scanInfo)
+			results, err := ks.Scan(scanInfo)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -1,7 +1,6 @@
 package scan
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/kubescape/go-logger"
@@ -61,7 +60,7 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				Exceptions: exceptions,
 			}
 
-			results, err := ks.ScanImage(context.Background(), imgScanInfo, scanInfo)
+			results, err := ks.ScanImage(imgScanInfo, scanInfo)
 			if err != nil {
 				return err
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -138,7 +138,7 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
 
 	ctx := context.TODO()
 
-	results, err := ks.Scan(ctx, &scanInfo)
+	results, err := ks.Scan(&scanInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -67,7 +67,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 
 			// todo: add api version if provided
 			ctx := context.TODO()
-			results, err := ks.Scan(ctx, scanInfo)
+			results, err := ks.Scan(scanInfo)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,23 +1,22 @@
 package version
 
 import (
-	"context"
 	"fmt"
+	"github.com/kubescape/kubescape/v3/core/meta"
 
 	"github.com/kubescape/backend/pkg/versioncheck"
 	"github.com/spf13/cobra"
 )
 
-func GetVersionCmd() *cobra.Command {
+func GetVersionCmd(ks meta.IKubescape) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Get current version",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.TODO()
-			v := versioncheck.NewIVersionCheckHandler(ctx)
+			v := versioncheck.NewIVersionCheckHandler(ks.Context())
 			versionCheckRequest := versioncheck.NewVersionCheckRequest("", versioncheck.BuildNumber, "", "", "version", nil)
-			v.CheckLatestVersion(ctx, versionCheckRequest)
+			v.CheckLatestVersion(ks.Context(), versionCheckRequest)
 			fmt.Fprintf(cmd.OutOrStdout(),
 				"Your current version is: %s\n",
 				versionCheckRequest.ClientVersion,

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -2,6 +2,8 @@ package version
 
 import (
 	"bytes"
+	"context"
+	"github.com/kubescape/kubescape/v3/core/core"
 	"io"
 	"testing"
 
@@ -30,7 +32,8 @@ func TestGetVersionCmd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			versioncheck.BuildNumber = tt.buildNumber
 
-			if cmd := GetVersionCmd(); cmd != nil {
+			ks := core.NewKubescape(context.TODO())
+			if cmd := GetVersionCmd(ks); cmd != nil {
 				buf := bytes.NewBufferString("")
 				cmd.SetOut(buf)
 				cmd.Execute()

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -35,8 +34,8 @@ func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
 	return nil
 }
 
-func (ks *Kubescape) DeleteCachedConfig(ctx context.Context, deleteConfig *metav1.DeleteConfig) error {
+func (ks *Kubescape) DeleteCachedConfig(deleteConfig *metav1.DeleteConfig) error {
 
 	tenant := cautils.GetTenantConfig("", "", "", "", nil) // change k8sinterface
-	return tenant.DeleteCachedConfig(ctx)
+	return tenant.DeleteCachedConfig(ks.Context())
 }

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -44,12 +44,12 @@ func DownloadSupportCommands() []string {
 	return commands
 }
 
-func (ks *Kubescape) Download(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) error {
 	setPathAndFilename(downloadInfo)
 	if err := os.MkdirAll(downloadInfo.Path, os.ModePerm); err != nil {
 		return err
 	}
-	if err := downloadArtifact(ctx, downloadInfo, downloadFunc); err != nil {
+	if err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc); err != nil {
 		return err
 	}
 	return nil

--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -16,14 +15,14 @@ const (
 	confirmationQuestion = "Would you like to apply the changes to the files above? [y|n]: "
 )
 
-func (ks *Kubescape) Fix(ctx context.Context, fixInfo *metav1.FixInfo) error {
+func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	logger.L().Info("Reading report file...")
 	handler, err := fixhandler.NewFixHandler(fixInfo)
 	if err != nil {
 		return err
 	}
 
-	resourcesToFix := handler.PrepareResourcesToFix(ctx)
+	resourcesToFix := handler.PrepareResourcesToFix(ks.Context())
 
 	if len(resourcesToFix) == 0 {
 		logger.L().Info(noResourcesToFix)
@@ -42,12 +41,12 @@ func (ks *Kubescape) Fix(ctx context.Context, fixInfo *metav1.FixInfo) error {
 		return nil
 	}
 
-	updatedFilesCount, errors := handler.ApplyChanges(ctx, resourcesToFix)
+	updatedFilesCount, errors := handler.ApplyChanges(ks.Context(), resourcesToFix)
 	logger.L().Info(fmt.Sprintf("Fixed resources in %d files.", updatedFilesCount))
 
 	if len(errors) > 0 {
 		for _, err := range errors {
-			logger.L().Ctx(ctx).Warning(err.Error())
+			logger.L().Ctx(ks.Context()).Warning(err.Error())
 		}
 		return fmt.Errorf("Failed to fix some resources, check the logs for more details")
 	}

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -162,7 +161,7 @@ func getUniqueVulnerabilitiesAndSeverities(policies []VulnerabilitiesIgnorePolic
 	return uniqueVulnsList, uniqueSeversList
 }
 
-func (ks *Kubescape) ScanImage(ctx context.Context, imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
+func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
 	logger.L().Start(fmt.Sprintf("Scanning image %s...", imgScanInfo.Image))
 
 	dbCfg, _ := imagescan.NewDefaultDBConfig()
@@ -185,7 +184,7 @@ func (ks *Kubescape) ScanImage(ctx context.Context, imgScanInfo *ksmetav1.ImageS
 		vulnerabilityExceptions, severityExceptions = getUniqueVulnerabilitiesAndSeverities(exceptionPolicies, imgScanInfo.Image)
 	}
 
-	scanResults, err := svc.Scan(ctx, imgScanInfo.Image, creds, vulnerabilityExceptions, severityExceptions)
+	scanResults, err := svc.Scan(ks.Context(), imgScanInfo.Image, creds, vulnerabilityExceptions, severityExceptions)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Failed to scan image: %s", imgScanInfo.Image))
 		return nil, err
@@ -195,9 +194,9 @@ func (ks *Kubescape) ScanImage(ctx context.Context, imgScanInfo *ksmetav1.ImageS
 
 	scanInfo.SetScanType(cautils.ScanTypeImage)
 
-	outputPrinters := GetOutputPrinters(scanInfo, ctx, "")
+	outputPrinters := GetOutputPrinters(scanInfo, ks.Context(), "")
 
-	uiPrinter := GetUIPrinter(ctx, scanInfo, "")
+	uiPrinter := GetUIPrinter(ks.Context(), scanInfo, "")
 
 	resultsHandler := resultshandling.NewResultsHandler(nil, outputPrinters, uiPrinter)
 
@@ -208,5 +207,5 @@ func (ks *Kubescape) ScanImage(ctx context.Context, imgScanInfo *ksmetav1.ImageS
 		},
 	}
 
-	return scanResults, resultsHandler.HandleResults(ctx)
+	return scanResults, resultsHandler.HandleResults(ks.Context())
 }

--- a/core/core/kscore.go
+++ b/core/core/kscore.go
@@ -1,7 +1,17 @@
 package core
 
-type Kubescape struct{}
+import (
+	"context"
+)
 
-func NewKubescape() *Kubescape {
-	return &Kubescape{}
+type Kubescape struct {
+	Ctx context.Context
+}
+
+func (ks *Kubescape) Context() context.Context {
+	return ks.Ctx
+}
+
+func NewKubescape(ctx context.Context) *Kubescape {
+	return &Kubescape{Ctx: ctx}
 }

--- a/core/core/kscore_test.go
+++ b/core/core/kscore_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,8 @@ import (
 
 // The function should return a non-nil pointer.
 func TestNewKubescape_ReturnsNonNilPointer(t *testing.T) {
-	k := NewKubescape()
+	ctx := context.TODO()
+	k := NewKubescape(ctx)
 	assert.NotNil(t, k)
 }
 
@@ -19,5 +21,6 @@ func TestNewKubescape_DoesNotPanic(t *testing.T) {
 			t.Errorf("Function panicked: %v", r)
 		}
 	}()
-	NewKubescape()
+	ctx := context.TODO()
+	NewKubescape(ctx)
 }

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -38,16 +38,16 @@ func ListSupportActions() []string {
 	sort.Strings(commands)
 	return commands
 }
-func (ks *Kubescape) List(ctx context.Context, listPolicies *metav1.ListPolicies) error {
+func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) error {
 	if policyListerFunc, ok := listFunc[listPolicies.Target]; ok {
-		policies, err := policyListerFunc(ctx, listPolicies)
+		policies, err := policyListerFunc(ks.Context(), listPolicies)
 		if err != nil {
 			return err
 		}
 		policies = naturalSortPolicies(policies)
 
 		if listFormatFunction, ok := listFormatFunc[listPolicies.Format]; ok {
-			listFormatFunction(ctx, listPolicies.Target, policies)
+			listFormatFunction(ks.Context(), listPolicies.Target, policies)
 		} else {
 			return fmt.Errorf("Invalid format \"%s\", Supported formats: 'pretty-print'/'json' ", listPolicies.Format)
 		}

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"context"
-
 	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -10,23 +9,25 @@ import (
 )
 
 type IKubescape interface {
-	Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
+	Context() context.Context
+
+	Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
 
 	// policies
-	List(ctx context.Context, listPolicies *metav1.ListPolicies) error     // TODO - return list response
-	Download(ctx context.Context, downloadInfo *metav1.DownloadInfo) error // TODO - return downloaded policies
+	List(listPolicies *metav1.ListPolicies) error     // TODO - return list response
+	Download(downloadInfo *metav1.DownloadInfo) error // TODO - return downloaded policies
 
 	// config
 	SetCachedConfig(setConfig *metav1.SetConfig) error
 	ViewCachedConfig(viewConfig *metav1.ViewConfig) error
-	DeleteCachedConfig(ctx context.Context, deleteConfig *metav1.DeleteConfig) error
+	DeleteCachedConfig(deleteConfig *metav1.DeleteConfig) error
 
 	// fix
-	Fix(ctx context.Context, fixInfo *metav1.FixInfo) error
+	Fix(fixInfo *metav1.FixInfo) error
 
 	// patch
-	Patch(ctx context.Context, patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error)
+	Patch(patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error)
 
 	// scan image
-	ScanImage(ctx context.Context, imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error)
+	ScanImage(imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error)
 }

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -11,15 +11,19 @@ import (
 
 type MockIKubescape struct{}
 
-func (m *MockIKubescape) Scan(ctx context.Context, scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
+func (m *MockIKubescape) Context() context.Context {
+	return context.TODO()
+}
+
+func (m *MockIKubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
 	return nil, nil
 }
 
-func (m *MockIKubescape) List(ctx context.Context, listPolicies *metav1.ListPolicies) error {
+func (m *MockIKubescape) List(listPolicies *metav1.ListPolicies) error {
 	return nil
 }
 
-func (m *MockIKubescape) Download(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func (m *MockIKubescape) Download(downloadInfo *metav1.DownloadInfo) error {
 	return nil
 }
 
@@ -31,18 +35,18 @@ func (m *MockIKubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
 	return nil
 }
 
-func (m *MockIKubescape) DeleteCachedConfig(ctx context.Context, deleteConfig *metav1.DeleteConfig) error {
+func (m *MockIKubescape) DeleteCachedConfig(deleteConfig *metav1.DeleteConfig) error {
 	return nil
 }
 
-func (m *MockIKubescape) Fix(ctx context.Context, fixInfo *metav1.FixInfo) error {
+func (m *MockIKubescape) Fix(fixInfo *metav1.FixInfo) error {
 	return nil
 }
 
-func (m *MockIKubescape) Patch(ctx context.Context, patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
+func (m *MockIKubescape) Patch(patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
 	return nil, nil
 }
 
-func (m *MockIKubescape) ScanImage(ctx context.Context, imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
+func (m *MockIKubescape) ScanImage(imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (*models.PresenterConfig, error) {
 	return nil, nil
 }

--- a/downloader/main.go
+++ b/downloader/main.go
@@ -10,13 +10,14 @@ import (
 )
 
 func main() {
-	ks := core.NewKubescape()
+	ctx := context.TODO()
+	ks := core.NewKubescape(ctx)
 	downloads := []metav1.DownloadInfo{
 		{Target: "artifacts"},                         // download all artifacts
 		{Target: "framework", Identifier: "security"}, // force add the "security" framework
 	}
 	for _, download := range downloads {
-		if err := ks.Download(context.Background(), &download); err != nil {
+		if err := ks.Download(&download); err != nil {
 			logger.L().Error("failed to download artifact", helpers.Error(err), helpers.String("target", download.Target))
 		}
 	}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -66,7 +66,7 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string) (*repo
 	ctx, spanScan := otel.Tracer("").Start(ctx, "kubescape.scan")
 	defer spanScan.End()
 
-	ks := core.NewKubescape()
+	ks := core.NewKubescape(ctx)
 
 	spanScan.AddEvent("scanning metadata",
 		trace.WithAttributes(attribute.String("version", versioncheck.BuildNumber)),
@@ -79,7 +79,7 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string) (*repo
 		trace.WithAttributes(attribute.String("hostSensorYamlPath", scanInfo.HostSensorYamlPath)),
 	)
 
-	result, err := ks.Scan(ctx, scanInfo)
+	result, err := ks.Scan(scanInfo)
 	if err != nil {
 		return nil, writeScanErrorToFile(err, scanID)
 	}


### PR DESCRIPTION
### Description:
This PR refactors the program to centralize context management by using a single context propagated throughout the application. The context is created in the `main()` function, where it listens for interrupt signals (os.Interrupt, syscall.SIGTERM), and is then passed to the rest of the program.

### Changes:
- Created the context in `main()` to handle interrupt signals.
- Replaced redundant context creation in multiple functions with the propagated context.
- Improved graceful shutdown handling by utilizing a single context.
- Ensured the program consistently reacts to shutdown signals across all components.

### Benefits:
- Improved readability and maintainability by eliminating context duplication.
- Ensured that all components share the same context, allowing for easier management of timeouts, cancellations, and signal handling.
- Simplified shutdown logic by having a single point of context management.

This change makes the program more scalable, cleaner, and easier to extend with future features.


- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
