### PR TITLE
fix: Fix stdin restoration in TestUserConfirmed

### DIFF
--- a/core/core/fix_test.go
+++ b/core/core/fix_test.go
@@ -33,10 +33,11 @@ func TestUserConfirmed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.input), func(t *testing.T) {
+			originalStdin := os.Stdin
 			r, w, _ := os.Pipe()
 			os.Stdin = r
 			defer func() {
-				os.Stdin = os.Stdin
+				os.Stdin = originalStdin
 			}()
 
 			go func() {


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->


Fixed an issue in TestUserConfirmed where the standard input wasn't properly restored after test execution. The previous implementation attempted to restore os.Stdin to itself rather than to the original value.

This change saves the original stdin before modifying it and properly restores it in the defer function, ensuring that test cases don't affect each other and that the standard input is correctly reset after tests complete.


<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
