### PR TITLE
Ensure context cancellation on command execution failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	}()
 
 	if err := cmd.Execute(ctx); err != nil {
+		stop()
 		logger.L().Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
This PR fixes an issue where the deferred `stop()` (from `signal.NotifyContext`) would not be executed if `logger.L().Fatal(...)` is called due to a command failure. Since `Fatal` internally invokes `os.Exit(1)`, any deferred functions — including `stop()` — are skipped.

To address this, an explicit call to `stop()` is added before `Fatal` to ensure that the context is properly cancelled. This guarantees that any goroutines waiting on `ctx.Done()` can proceed with cleanup or shutdown logic.

### Changes

- Added `stop()` before `logger.L().Fatal(...)` in `main`.

