### PR TITLE
Make a second sigint terminate kubescape immediately

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ func main() {
 		<-ctx.Done()
 		// Perform cleanup or graceful shutdown here
 		logger.L().StopError("Received interrupt signal, exiting...")
+		// Clear the signal handler so that a second interrupt signal shuts down immediately
+		stop()
 	}()
 
 	if err := cmd.Execute(ctx); err != nil {


### PR DESCRIPTION
## Overview

Right now, sending a sigint will start a graceful shutdown, which can take quite a while. Trying to Ctrl+C in this state does nothing, and you have to kill the process by opening a new terminal and sending a kill signal.

By calling stop() in the signal handler it unregisters the sigint handler so that a subsequent sigint received during a graceful shutdown will kill the process immediately.

## Additional Information

Ideally we should also figure out why graceful shutdown takes so long, but there are some other things I need to work on first.

## How to Test

Start a scan, send a sigint with ctrl+c, then send a second sigint with ctrl+c again.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. - _I guess technically true, since it's not a core feature?_
- [x] New and existing unit tests pass locally with my changes

