### PR TITLE
Issue 1817 fix: Show container name in Assisted remediation

### DIFF
--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -111,7 +111,6 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 
 		rows = append(rows, row)
 	}
-
 	return rows
 }
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -24,7 +24,6 @@ const (
 	resourceColumnPath     = iota
 	_resourceRowLen        = iota
 )
-const regex = `spec\\.containers\\[(\\d+)\\]`
 
 func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASessionObj) {
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -2,13 +2,13 @@ package printer
 
 import (
 	"fmt"
-	"github.com/kubescape/k8s-interface/workloadinterface"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/jwalton/gchalk"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"


### PR DESCRIPTION
## Overview
   As requested in the [issue](https://github.com/kubescape/kubescape/issues/1817), currently we only show the container indexes in AssistedRemediation not the container names during kubescape scan control

##  Additional Information
Implemented a step to add container name along with container indexes in the Assisted remediation

**Existing flow**: 

- Controls are applied for each resource

- For every resource , if there is any assisted remediation against a control, we get it from results

**Changes:**

- Iterate over the assisted remediation path, Check if the path contains container indexes using regex

- Get the index of container

- Get the container name using workloadinterface 


## How to Test

1. Run scan control command
     kubescape scan control C-0013 -v


## Examples/Screenshots

Container name is present in Assisted remediation Path 
<img width="1297" height="558" alt="image" src="https://github.com/user-attachments/assets/f184144d-bbda-404c-be0d-b80009bf7e57" />


## Related issues/PRs:

* Resolved #1817 



## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code

