### PR TITLE
fix(imagescan): use all targets in exceptions

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -110,7 +110,9 @@ func regexStringMatch(pattern, target string) bool {
 // exception policy.
 func isTargetImage(targets []Target, attributes Attributes) bool {
 	for _, target := range targets {
-		return regexStringMatch(target.Attributes.Registry, attributes.Registry) && regexStringMatch(target.Attributes.Organization, attributes.Organization) && regexStringMatch(target.Attributes.ImageName, attributes.ImageName) && regexStringMatch(target.Attributes.ImageTag, attributes.ImageTag)
+		if regexStringMatch(target.Attributes.Registry, attributes.Registry) && regexStringMatch(target.Attributes.Organization, attributes.Organization) && regexStringMatch(target.Attributes.ImageName, attributes.ImageName) && regexStringMatch(target.Attributes.ImageTag, attributes.ImageTag) {
+			return true
+		}
 	}
 
 	return false

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -241,6 +241,33 @@ func TestIsTargetImage(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			targets: []Target{
+				{
+					Attributes: Attributes{
+						Registry:     "quay.io",
+						Organization: "kubescape",
+						ImageName:    "kubescape*",
+						ImageTag:     "",
+					},
+				},
+				{
+					Attributes: Attributes{
+						Registry:     "docker.io",
+						Organization: "library",
+						ImageName:    "alpine",
+						ImageTag:     "",
+					},
+				},
+			},
+			attributes: Attributes{
+				Registry:     "docker.io",
+				Organization: "library",
+				ImageName:    "alpine",
+				ImageTag:     "latest",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

Previously, kubescape only used the first target in scan image exceptions.

Now it uses all targets.

## How to Test

A test has been added in the commit, so a `go test -v ./core/core` should be enough.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
  **Is it necessary here?**
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
