### PR TITLE
fix: Don't run scan in installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,5 +96,6 @@ if ! kubectl get nodes &> /dev/null; then
 fi
 
 echo -e "\033[0;37;40m"
-echo -e "\033[0;37;32mExecuting Kubescape."
-$KUBESCAPE_EXEC scan
+echo -e "\033[0;37;32mFinished Installation.\n"
+$KUBESCAPE_EXEC version
+echo -e "\033[0;37;35m\nUsage: $ kubescape scan"


### PR DESCRIPTION
## Overview

### Current behavior

The installation script runs a scan at the end.

### New behavior

It follows the same script ending as the PowerShell version; it prints the version and usage:

https://github.com/kubescape/kubescape/blob/7ebf078d0c986566e4795b15a829eb789df68436/install.ps1#L37-L39

## Related issues/PRs:

Resolves #1874 

