### PR TITLE
Fixed issue #1800 : Added parameterNotFoundAction in spec.paramRef while creating policy binding 

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -220,9 +220,11 @@ func createPolicyBinding(bindingName string, policyName string, action string, p
 	}
 
 	policyBinding.Spec.ValidationActions = []admissionv1.ValidationAction{admissionv1.ValidationAction(action)}
+	paramAction := admissionv1.DenyAction
 	if paramRefName != "" {
 		policyBinding.Spec.ParamRef = &admissionv1.ParamRef{
-			Name: paramRefName,
+			Name:                    paramRefName,
+			ParameterNotFoundAction: &paramAction,
 		}
 	}
 	// Marshal the policy binding to YAML


### PR DESCRIPTION
## Overview
As stated in the https://github.com/kubescape/kubescape/issues/1800 , kubescape vap create-policy-binding fails when --parameter-reference flag is passed 

Starting with Kubernetes v1.29+, the field spec.paramRef.parameterNotFoundAction has become mandatory when defining a paramRef in a ValidatingAdmissionPolicyBinding.

## Additional Information

To comply with new requirement , fixed the issue by setting 
policyBinding.spec.paramRef.parameterNotFoundAction = Deny

## How to Test

Create policy binding with parameter reference flag

e.g kubescape vap create-policy-binding --name <policy-name> --policy kubescape-c-0046-deny-resources-with-insecure-capabilities --namespace default --parameter-reference basic-control-configuration | kubectl apply -f -

This command now runs successfully, which otherwise fails as  parameterNotFoundAction was missing 


## Examples/Screenshots

**Before Fix**:
<img width="1820" height="234" alt="image" src="https://github.com/user-attachments/assets/ecf57732-2ec2-42aa-91a9-fddc693138ce" />


**After Fix**:
<img width="1801" height="147" alt="image" src="https://github.com/user-attachments/assets/1f7dd5eb-11a6-4cc6-8b3d-3de84bcf30dc" />


## Related issues/PRs:


e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved https://github.com/kubescape/kubescape/issues/1800




## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

