### PR TITLE
fix: post release action does not take tag from GITHUB_REF env var

### DIFF
--- a/.github/workflows/e-post-release.yaml
+++ b/.github/workflows/e-post-release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: rajatjindal/krew-release-bot@v0.0.47
         if: github.repository_owner == 'kubescape'
         env:
-          GITHUB_REF: ${{ inputs.TAG }}
+          GITHUB_REF: refs/tags/${{ inputs.TAG }}
       - name: Invoke workflow to update packaging
         uses: benc-uk/workflow-dispatch@v1
         if: github.repository_owner == 'kubescape'


### PR DESCRIPTION
## Overview

Post release job is not taking properly the tag passed via GITHUB_REF env var.
Can be seen here: https://github.com/kubescape/kubescape/actions/runs/17795795208/job/50587625231#step:4:6

According to the logic of the action, passing a tag requires a `refs/tags` prefix 

https://github.com/rajatjindal/krew-release-bot/blob/e2d6f27e6d51bdc2a0a92c1347810134c903c273/pkg/cicd/github/actions.go#L50

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
