### PR TITLE
fix: --format sarif logs as expected

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -199,7 +199,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 			filepath := resourceSource.RelativePath
 
 			// Github Code Scanning considers results not associated to a file path meaningless and invalid when uploading
-			if filepath == "" || basePath == "" {
+			if filepath == "" && basePath == "" {
 				continue
 			}
 


### PR DESCRIPTION
## Overview
`kubescape scan ./kubescape-test/bad-deployment --verbose --format sarif` was not printing as expected. This PR solves the issue by changing the code. Now this is printing as expected.

#Related issues/PRs:  #1858 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
