### PR TITLE
feat: Define labels to copy from workloads to reports

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -93,6 +93,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 
 	scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead. Flag will be removed at 1.Dec.2023")
 	scanCmd.PersistentFlags().MarkDeprecated("create-account", "Create account is no longer supported. In case of a missing Account ID and a configured backend server, a new account id will be generated automatically by Kubescape. Feel free to contact the Kubescape maintainers for more information.")

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -69,6 +69,7 @@ type OPASessionObj struct {
 	TopWorkloadsByScore   []reporthandling.IResource
 	TemplateMapping       map[string]MappingNodes // Map chart obj to template (only for rendering from path)
 	TriggeredByCLI        bool
+	LabelsToCopy          []string // Labels to copy from workloads to scan reports
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo) *OPASessionObj {
@@ -87,6 +88,7 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		OmitRawResources:      scanInfo.OmitRawResources,
 		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		TemplateMapping:       make(map[string]MappingNodes),
+		LabelsToCopy:          scanInfo.LabelsToCopy,
 	}
 }
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -140,6 +140,7 @@ type ScanInfo struct {
 	UseDefaultMatchers    bool
 	ChartPath             string
 	FilePath              string
+	LabelsToCopy          []string // Labels to copy from workloads to scan reports
 	scanningContext       *ScanningContext
 	cleanups              []func()
 }

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -121,8 +121,9 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 	}
 
 	// Convert to PostureReportWithSeverity to add severity field to controls
+	// and extract specified labels from workloads
 	finalizedReport := FinalizeResults(opaSessionObj)
-	reportWithSeverity := ConvertToPostureReportWithSeverity(finalizedReport)
+	reportWithSeverity := ConvertToPostureReportWithSeverityAndLabels(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources)
 
 	r, err := json.Marshal(reportWithSeverity)
 	_, err = jp.writer.Write(r)


### PR DESCRIPTION
Fixes #1660

## Changes
- Add `--labels-to-copy` CLI flag to specify which workload labels to include in scan reports
- Extract specified labels from scanned workloads and include in JSON output as `resourceLabels` field
- Add unit tests for label extraction functionality

## Usage
```bash
kubescape scan --labels-to-copy=app,team,environment
```

This allows tying scan reports back to app teams/repos by including custom labels from workloads.