### PR TITLE
Add SkipPersistence flag to MetricsQueryParams in metrics endpoint

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -25,6 +25,10 @@ type MetricsQueryParams struct {
 	// Example: "nsa,mitre,cis-v1.10.0"
 	// If not provided, all available frameworks will be scanned
 	Frameworks string `schema:"frameworks" json:"frameworks"`
+
+	// Do not persist data after scanning
+	// default: false
+	SkipPersistence bool `schema:"skipPersistence" json:"skipPersistence"`
 }
 
 // Metrics http listener for prometheus support


### PR DESCRIPTION
## Overview
Added the missing parameter for the URL decoding check in the `metrics` endpoint.
Would've loved to add a test for this, but as I'm just starting to learn go and I couldn't find examples in this repo for similar scenarios, I skipped them for now.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

Call the `metrics` endpoint using the `?skipPersistence=true` flag

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

Resolved #1891 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

