### PR TITLE
Fix: handle error from `NormalizeImageName` in patch command

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -95,7 +95,7 @@ func validateImagePatchInfo(patchInfo *metav1.PatchInfo) error {
 	// Convert image to canonical format (required by copacetic for patching images)
 	patchInfoImage, err := cautils.NormalizeImageName(patchInfo.Image)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Parse the image full name to get image name and tag


### PR DESCRIPTION
## Overview

This PR fixes an issue where the error returned from `NormalizeImageName` was silently ignored in the patch command.
The error is now properly returned and preventing unexpected behavior.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->


## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image patch validation now properly rejects invalid image names with error messages instead of silently accepting them, ensuring the command fails early with clear feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->