### PR TITLE
fix(image-scan): normalize vulnerability exceptions across casings

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -135,9 +135,26 @@ func getUniqueVulnerabilitiesAndSeverities(policies []VulnerabilitiesIgnorePolic
 		// Include the exceptions only if the image is one of the targets
 		if isTargetImage(policy.Targets, imageAttributes) {
 			for _, vulnerability := range policy.Vulnerabilities {
-				// Add to slice directly
+				// grype's IgnoreRule matching is case-sensitive and advisory
+				// sources do not share a single casing convention: CVE IDs
+				// are uppercase, while GHSA IDs keep a lowercase suffix
+				// (e.g. "GHSA-jc7w-c686-c4v9"). Emit the trimmed original
+				// casing plus the uppercased and lowercased forms so users
+				// can list the ID in any casing without the filter silently
+				// missing the match (kubescape issue #1870).
+				vulnerability = strings.TrimSpace(vulnerability)
+				if vulnerability == "" {
+					continue
+				}
+				uniqueVulns[vulnerability] = append(uniqueVulns[vulnerability], vulnerability)
 				vulnerabilityUppercase := strings.ToUpper(vulnerability)
-				uniqueVulns[vulnerabilityUppercase] = append(uniqueVulns[vulnerabilityUppercase], vulnerability)
+				if vulnerabilityUppercase != vulnerability {
+					uniqueVulns[vulnerabilityUppercase] = append(uniqueVulns[vulnerabilityUppercase], vulnerability)
+				}
+				vulnerabilityLowercase := strings.ToLower(vulnerability)
+				if vulnerabilityLowercase != vulnerability && vulnerabilityLowercase != vulnerabilityUppercase {
+					uniqueVulns[vulnerabilityLowercase] = append(uniqueVulns[vulnerabilityLowercase], vulnerability)
+				}
 			}
 
 			for _, severity := range policy.Severities {

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -326,7 +326,7 @@ func TestGetVulnerabilitiesAndSeverities(t *testing.T) {
 				},
 			},
 			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
-			expectedVulnerabilities: []string{"CVE-2023-42365"},
+			expectedVulnerabilities: []string{"CVE-2023-42365", "cve-2023-42365"},
 			expectedSeverities:      []string{},
 		},
 		{
@@ -430,8 +430,88 @@ func TestGetVulnerabilitiesAndSeverities(t *testing.T) {
 				},
 			},
 			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
-			expectedVulnerabilities: []string{"CVE-2022-30065", "CVE-2022-28391"},
+			expectedVulnerabilities: []string{"CVE-2022-28391", "CVE-2022-30065", "cve-2022-28391", "cve-2022-30065"},
 			expectedSeverities:      []string{"CRITICAL"},
+		},
+		{
+			// A lowercase-suffix GHSA ID on its own must reach grype in
+			// original, uppercase, and lowercase form, because grype's
+			// IgnoreRule matching is case-sensitive and the advisory is
+			// reported with a mixed casing (see issue #1870).
+			policies: []VulnerabilitiesIgnorePolicy{
+				{
+					Metadata: Metadata{
+						Name: "ghsa-lowercase-only",
+					},
+					Kind: "VulnerabilitiesIgnorePolicy",
+					Targets: []Target{
+						{
+							DesignatorType: "Attributes",
+							Attributes: Attributes{
+								Registry: "quay.io",
+							},
+						},
+					},
+					Vulnerabilities: []string{"GHSA-jc7w-c686-c4v9"},
+					Severities:      []string{},
+				},
+			},
+			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
+			expectedVulnerabilities: []string{"GHSA-JC7W-C686-C4V9", "GHSA-jc7w-c686-c4v9", "ghsa-jc7w-c686-c4v9"},
+			expectedSeverities:      []string{},
+		},
+		{
+			// When users list the same GHSA ID in both cases, each variant
+			// is preserved so the filter still works regardless of how the
+			// advisory is reported.
+			policies: []VulnerabilitiesIgnorePolicy{
+				{
+					Metadata: Metadata{
+						Name: "ghsa-mixed-and-upper",
+					},
+					Kind: "VulnerabilitiesIgnorePolicy",
+					Targets: []Target{
+						{
+							DesignatorType: "Attributes",
+							Attributes: Attributes{
+								Registry: "quay.io",
+							},
+						},
+					},
+					Vulnerabilities: []string{"GHSA-jc7w-c686-c4v9", "GHSA-JC7W-C686-C4V9"},
+					Severities:      []string{},
+				},
+			},
+			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
+			expectedVulnerabilities: []string{"GHSA-JC7W-C686-C4V9", "GHSA-jc7w-c686-c4v9", "ghsa-jc7w-c686-c4v9"},
+			expectedSeverities:      []string{},
+		},
+		{
+			// Empty or whitespace-only entries are skipped so they cannot
+			// produce an empty IgnoreRule that grype would treat as a
+			// match-everything wildcard, and surrounding whitespace from a
+			// hand-edited exceptions file is tolerated.
+			policies: []VulnerabilitiesIgnorePolicy{
+				{
+					Metadata: Metadata{
+						Name: "edge-empty-whitespace",
+					},
+					Kind: "VulnerabilitiesIgnorePolicy",
+					Targets: []Target{
+						{
+							DesignatorType: "Attributes",
+							Attributes: Attributes{
+								Registry: "quay.io",
+							},
+						},
+					},
+					Vulnerabilities: []string{"", "   ", "  CVE-2024-1234  "},
+					Severities:      []string{},
+				},
+			},
+			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
+			expectedVulnerabilities: []string{"CVE-2024-1234", "cve-2024-1234"},
+			expectedSeverities:      []string{},
 		},
 	}
 


### PR DESCRIPTION
## Summary
Closes #1870

grype's \`IgnoreRule\` matching is case-sensitive, and advisory sources do not share a single casing convention. CVE IDs are uppercase; GHSA IDs keep a lowercase suffix (e.g. \`GHSA-jc7w-c686-c4v9\`). The previous logic uppercased every exception entry before passing it to grype, so exceptions containing any lowercase character silently failed to match.

## Change
In \`getUniqueVulnerabilitiesAndSeverities\`, emit **three** forms of each vulnerability ID (deduped via map keys):
1. The trimmed original casing.
2. The uppercased form (for users who list lowercase CVEs).
3. The lowercased form (for users who list uppercase GHSA variants).

Empty / whitespace-only entries are skipped so they can never be passed to grype as an empty \`IgnoreRule.Vulnerability\` string (which would otherwise match every finding). Leading / trailing whitespace is trimmed so hand-edited exception files are tolerant of accidental spacing.

## Why three forms
The issue lists three candidate fixes. Dropping the uppercasing alone breaks users who list lowercase CVEs. Uppercasing alone breaks users who list GHSA IDs in either canonical case. Passing every pure-case variant is the narrowest way to restore the intended suppression behavior without changing the external data contract.

## Test plan
- [x] \`go test ./core/core/ -run TestGetVulnerabilitiesAndSeverities -v\` — 5 subtests pass, covering: existing uppercase CVEs (unchanged semantics), GHSA lowercase-only, GHSA both cases, and empty / whitespace / padded entries.
- [x] \`go vet ./core/core/\`
- [x] \`gofmt -l\` on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability de-duplication: trims and ignores empty/whitespace entries, preserves original ID casing, and only adds uppercase/lowercase variants when they differ—reducing spurious duplicates in scan results.

* **Tests**
  * Expanded test coverage to validate casing variants and trimming behavior, including mixed-case, uppercase, lowercase, and whitespace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->