### PR TITLE
test(image-scan): add all-lowercase CVE ID test case

### DIFF
--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -513,6 +513,32 @@ func TestGetVulnerabilitiesAndSeverities(t *testing.T) {
 			expectedVulnerabilities: []string{"CVE-2024-1234", "cve-2024-1234"},
 			expectedSeverities:      []string{},
 		},
+		{
+			// An all-lowercase CVE ID must produce exactly two forms (original
+			// + uppercase), not three — the lowercase variant equals the
+			// original so it must not be re-added as a duplicate key.
+			policies: []VulnerabilitiesIgnorePolicy{
+				{
+					Metadata: Metadata{
+						Name: "lowercase-cve",
+					},
+					Kind: "VulnerabilitiesIgnorePolicy",
+					Targets: []Target{
+						{
+							DesignatorType: "Attributes",
+							Attributes: Attributes{
+								Registry: "quay.io",
+							},
+						},
+					},
+					Vulnerabilities: []string{"cve-2023-1234"},
+					Severities:      []string{},
+				},
+			},
+			image:                   "quay.io/kubescape/kubescape-cli:v3.0.0",
+			expectedVulnerabilities: []string{"CVE-2023-1234", "cve-2023-1234"},
+			expectedSeverities:      []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #1979.

Adds a test case for an all-lowercase CVE ID input (e.g. `"cve-2023-1234"`) to verify it produces exactly two `IgnoreRule` forms — original + uppercase — and not three, since the lowercase variant equals the original and must not be re-added as a duplicate map key.

This completes the coverage matrix introduced in #1979.

## Test plan
- [x] `go test ./core/core/ -run TestGetVulnerabilitiesAndSeverities -v` — all 6 subtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for CVE ID case-variant handling to ensure proper de-duplication and prevent duplicate entries when processing different case formats of the same identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->