### PR TITLE
fix(opaprocessor): eliminate false negatives when OPA rule evaluation fails

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -231,8 +231,8 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 
 		ruleResponses, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData)
 		if err != nil {
+			logger.L().Ctx(ctx).Warning("failed to evaluate rule, skipping", helpers.String("rule", rule.Name), helpers.Error(err))
 			continue
-			// return resources, allResources, err
 		}
 
 		// Build the set of failed IDs so we can correctly mark the remainder as passed.
@@ -243,6 +243,9 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 		failedIDs := make(map[string]struct{})
 		for _, ruleResponse := range ruleResponses {
 			for _, failedResource := range objectsenvelopes.ListMapToMeta(ruleResponse.GetFailedResources()) {
+				if opap.skipNamespace(failedResource.GetNamespace()) {
+					continue
+				}
 				id := failedResource.GetID()
 				failedIDs[id] = struct{}{}
 				resources[id] = &resourcesresults.ResourceAssociatedRule{

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -222,22 +222,46 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 
 		inputResources = objectsenvelopes.ListMapToMeta(enumeratedData)
 
-		for i, inputResource := range inputResources {
+		for _, inputResource := range inputResources {
 			if opap.skipNamespace(inputResource.GetNamespace()) {
 				continue
 			}
-			resources[inputResource.GetID()] = &resourcesresults.ResourceAssociatedRule{
-				Name:                  rule.Name,
-				ControlConfigurations: ruleRegoDependenciesData.PostureControlInputs,
-				Status:                apis.StatusPassed,
-			}
-			opap.AllResources[inputResource.GetID()] = inputResources[i]
+			opap.AllResources[inputResource.GetID()] = inputResource
 		}
 
 		ruleResponses, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData)
 		if err != nil {
 			continue
 			// return resources, allResources, err
+		}
+
+		// Build the set of failed IDs so we can correctly mark the remainder as passed.
+		// Resources are only written to the result map after a successful OPA evaluation,
+		// preventing stale StatusPassed entries when evaluation fails.
+		// Failed entries are pre-seeded with rule metadata so the loop below can
+		// find them and attach paths/status without losing Name/ControlConfigurations.
+		failedIDs := make(map[string]struct{})
+		for _, ruleResponse := range ruleResponses {
+			for _, failedResource := range objectsenvelopes.ListMapToMeta(ruleResponse.GetFailedResources()) {
+				id := failedResource.GetID()
+				failedIDs[id] = struct{}{}
+				resources[id] = &resourcesresults.ResourceAssociatedRule{
+					Name:                  rule.Name,
+					ControlConfigurations: ruleRegoDependenciesData.PostureControlInputs,
+				}
+			}
+		}
+		for _, inputResource := range inputResources {
+			if opap.skipNamespace(inputResource.GetNamespace()) {
+				continue
+			}
+			if _, failed := failedIDs[inputResource.GetID()]; !failed {
+				resources[inputResource.GetID()] = &resourcesresults.ResourceAssociatedRule{
+					Name:                  rule.Name,
+					ControlConfigurations: ruleRegoDependenciesData.PostureControlInputs,
+					Status:                apis.StatusPassed,
+				}
+			}
 		}
 
 		// ruleResponse to ruleResult
@@ -331,7 +355,7 @@ func (opap *OPAProcessor) runRegoOnK8s(ctx context.Context, rule *reporthandling
 
 	results, err := opap.regoEval(ctx, k8sObjects, compiled, &store)
 	if err != nil {
-		logger.L().Ctx(ctx).Warning(err.Error())
+		return nil, fmt.Errorf("rule '%s': rego eval failed: %w", rule.Name, err)
 	}
 
 	return results, nil


### PR DESCRIPTION
## Overview
  While digging into the OPA evaluation pipeline, I found that processRule was pre-marking all input resources as StatusPassed before actually running OPA on them. If the evaluation failed for any reason , a compilation error, a context timeout, a storage serialization issue ; the code would continue out of the loop, leaving every resource in that rule's scope silently marked as passed. No error surfaced to the user, the scan exited cleanly, and the posture report looked fine. But the resources were never actually evaluated.

There was a second path doing the same thing: inside runRegoOnK8s, if regoEval itself failed at runtime, the error was logged as a warning and then dropped.The function returned nil, nil, so the caller saw a successful evaluation with zero failures , same false negative outcome, different code path.
                                                                                                                                                              
The fix defers all writes to the result map until after OPA returns successfully. I build the set of failed resource IDs from the OPA response first, pre-seed those entries with their rule metadata (so the existing path-attachment loop below can still find them), then mark everything else as passed. If OPA errors out, the continue now leaves the result map clean instead of poisoned with stale StatusPassed entries. I also made regoEval errors propagate properly instead of being swallowed.


## How to Test

  - Run a scan against a cluster using a control whose Rego rule fails to compile (e.g. point regolibrary at a malformed rule). Before this fix, affected resources show as passed. After, they are absent from results and a warning is logged.
  - Existing unit tests in core/pkg/opaprocessor cover the happy path and continue to pass.


## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy evaluation now reports errors reliably instead of proceeding with incomplete results.
  * Resource assessment more accurately marks passed vs. failed resources and preserves failed resource details so rule outcomes reflect actual evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->