### PR TITLE
docs: clarify how Kubescape detects Helm vs Kustomize directories

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,23 +208,29 @@ Objects with exceptions will be presented as `exclude` and not `fail`.
 
 [See more examples about exceptions.](/examples/exceptions/README.md)
 
-#### Scan Helm charts 
+#### Scan Helm charts
 
-```bash
-kubescape scan </path/to/directory>
-```
+Kubescape automatically detects a Helm chart directory by the 
+presence of a `Chart.yaml` file.
 
-> **Note**  
-> Kubescape will load the default VALUES file.
-
-#### Scan a Kustomize directory 
-
-```bash
-kubescape scan </path/to/directory>
-```
+    kubescape scan /path/to/helm/chart/directory
 
 > **Note**  
-> Kubescape will generate Kubernetes YAML objects using a `kustomize` file and scan them for security.
+> Kubescape will load the default `values.yaml` file. To use a 
+> custom values file, use the `--helm-values` flag.
+
+#### Scan a Kustomize directory
+
+Kubescape automatically detects a Kustomize directory by the 
+presence of a `kustomization.yaml` file.
+
+    kubescape scan /path/to/kustomize/directory
+
+> **Note**  
+> Kubescape will generate Kubernetes YAML objects using the 
+> `kustomization.yaml` file and scan them for security.
+> If a directory contains both `Chart.yaml` and 
+> `kustomization.yaml`, Kubescape will treat it as a Helm chart.
 
 #### Trigger in cluster components for scanning your cluster
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,9 +212,9 @@ Objects with exceptions will be presented as `exclude` and not `fail`.
 
 Kubescape automatically detects a Helm chart directory by the 
 presence of a `Chart.yaml` file.
-
+ ```bash
     kubescape scan /path/to/helm/chart/directory
-
+ ```
 > **Note**  
 > Kubescape will load the default `values.yaml` file. To use a 
 > custom values file, use the `--helm-values` flag.
@@ -222,10 +222,10 @@ presence of a `Chart.yaml` file.
 #### Scan a Kustomize directory
 
 Kubescape automatically detects a Kustomize directory by the 
-presence of a `kustomization.yaml` file.
-
-    kubescape scan /path/to/kustomize/directory
-
+presence of a `kustomization.yaml`, `kustomization.yml`, or `kustomization` file.
+```bash
+kubescape scan /path/to/kustomize/directory
+```
 > **Note**  
 > Kubescape will generate Kubernetes YAML objects using the 
 > `kustomization.yaml` file and scan them for security.


### PR DESCRIPTION
 ## Overview
Both the Helm chart scan and Kustomize scan sections in 
`docs/getting-started.md` showed identical commands 
(`kubescape scan </path/to/directory>`) with no explanation 
of how Kubescape differentiates between them.

This PR clarifies that:
- Helm chart directories are detected via `Chart.yaml`
- Kustomize directories are detected via `kustomization.yaml`
- When both files exist, Kubescape treats it as a Helm chart

## Additional Information
This is a documentation-only change. No code was modified.
Identified this gap while reading the docs as part of 
exploring the Kubescape codebase for LFX mentorship.

## How to Test
Read the updated sections in `docs/getting-started.md` 
and verify the explanations match actual Kubescape behavior.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added automatic detection of Helm and Kustomize directories based on their standard manifest files.
  * Updated examples to use chart- and kustomize-specific paths and clarified that Helm scans load values.yaml by default with a new --helm-values option for custom values.
  * Clarified that directories containing both Helm and Kustomize indicators are treated as Helm charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->