### PR TITLE
stop logging raw scan request bodies

### DIFF
--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -87,10 +87,10 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %s", err.Error()), scanID)
 			return nil, fmt.Errorf("failed to read request body, reason: %s", err.Error())
 		}
-		logger.L().Info("REST API received scan request", helpers.String("body", string(readBuffer)))
 		if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {
 			return nil, fmt.Errorf("failed to parse request payload, reason: %s", err.Error())
 		}
+		logger.L().Info("REST API received scan request", helpers.String("scanID", scanID), helpers.String("format", scanRequest.Format))
 	}
 
 	p := &scanRequestParams{

--- a/httphandler/handlerequests/v1/requestparser_test.go
+++ b/httphandler/handlerequests/v1/requestparser_test.go
@@ -3,11 +3,14 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/armosec/utils-go/boolutils"
+	logger "github.com/kubescape/go-logger"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,4 +76,46 @@ func TestGetScanParamsFromRequest(t *testing.T) {
 		assert.False(t, req.scanInfo.Submit)
 		assert.Equal(t, "aaaaaaaaaa", req.scanInfo.AccountID)
 	}
+}
+
+// TestNoSecretsInLogs ensures that sensitive fields (accessKey, account) sent in
+// a scan request body are never written to the application log stream.
+func TestNoSecretsInLogs(t *testing.T) {
+	const (
+		secretAccessKey = "s3cr3t-access-key-value"
+		secretAccount   = "secret-account-id-12345"
+	)
+
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldWriter := logger.L().GetWriter()
+	logger.L().SetWriter(wPipe)
+	t.Cleanup(func() { logger.L().SetWriter(oldWriter) })
+
+	body := utilsmetav1.PostScanRequest{
+		Account:   secretAccount,
+		AccessKey: secretAccessKey,
+	}
+	jsonBytes, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	u := url.URL{Scheme: "http", Host: "test", Path: "/v1/scan"}
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(jsonBytes))
+	assert.NoError(t, err)
+
+	_, err = getScanParamsFromRequest(req, "test-scan-id")
+	assert.NoError(t, err)
+
+	wPipe.Close()
+	logOutput, err := io.ReadAll(rPipe)
+	assert.NoError(t, err)
+	rPipe.Close()
+
+	// Sanity-check that the logger output was actually captured.
+	assert.Contains(t, string(logOutput), "test-scan-id", "expected scan log line was not captured")
+	assert.NotContains(t, string(logOutput), secretAccessKey, "accessKey must not appear in logs")
+	assert.NotContains(t, string(logOutput), secretAccount, "account must not appear in logs")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved logging to remove raw request bodies from logs and emit only essential scan metadata (e.g., scan identifier and format), reducing exposure of request content.

* **Tests**
  * Added a unit test that verifies sensitive fields are not present in log output, ensuring logs contain identifiers but not secret values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->