### PR TITLE
fix(resourcehandler): dedup workloads emitted by both helm and plain-YAML loaders

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -325,7 +325,104 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 		}
 	}
 
+	workloads, workloadIDToSource = dedupWorkloadsBySource(workloads, workloadIDToSource)
+
 	return workloadIDToSource, workloads, nil
+}
+
+// dedupWorkloadsBySource collapses workloads that point to the same logical
+// resource (RelativePath + apiVersion + kind + namespace + name) when emitted
+// by *different* loaders. The plain YAML walker, the helm renderer, and the
+// kustomize renderer are each recursive over the input directory; a helm
+// chart whose templates happen to be valid plain YAML (no `{{ }}` placeholders)
+// is otherwise picked up twice — once as a raw YAML file and once as a
+// rendered chart resource. Downstream consumers that aggregate by file path
+// then see the same file with conflicting Source.HelmChartName values, which
+// breaks any per-file invariant (Armo's BE childCount vs. file_summary
+// mismatch on `armosec/kubescape@master`'s test-chart fixture is the
+// user-visible symptom).
+//
+// Precedence keeps the most specific attribution: HelmChart > Kustomize > YAML/JSON.
+//
+// Multi-document YAML files where the *same* resource identity legitimately
+// appears more than once within a single file (used heavily under
+// core/pkg/fixhandler/testdata/) are preserved, because they share a
+// FileType and so don't trip the cross-loader collapse.
+func dedupWorkloadsBySource(workloads []workloadinterface.IMetadata, workloadIDToSource map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
+	if len(workloads) == 0 {
+		return workloads, workloadIDToSource
+	}
+
+	priority := func(fileType string) int {
+		switch fileType {
+		case reporthandling.SourceTypeHelmChart:
+			return 3
+		case reporthandling.SourceTypeKustomizeDirectory:
+			return 2
+		case reporthandling.SourceTypeYaml, reporthandling.SourceTypeJson:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	idToWorkload := make(map[string]workloadinterface.IMetadata, len(workloads))
+	for _, w := range workloads {
+		idToWorkload[w.GetID()] = w
+	}
+
+	type entry struct {
+		id       string
+		fileType string
+	}
+	groups := make(map[string][]entry, len(workloads))
+	keep := make(map[string]struct{}, len(workloads))
+
+	for id, src := range workloadIDToSource {
+		w, ok := idToWorkload[id]
+		if !ok || src.RelativePath == "" {
+			// Workloads without source attribution are kept untouched —
+			// they cannot collide with file-anchored emissions.
+			keep[id] = struct{}{}
+			continue
+		}
+		key := strings.Join([]string{src.RelativePath, w.GetApiVersion(), w.GetKind(), w.GetNamespace(), w.GetName()}, "\x00")
+		groups[key] = append(groups[key], entry{id: id, fileType: src.FileType})
+	}
+
+	for _, group := range groups {
+		bestRank := -1
+		for _, e := range group {
+			if r := priority(e.fileType); r > bestRank {
+				bestRank = r
+			}
+		}
+		// Preserve every workload whose loader matches the highest-rank
+		// FileType in the group: this keeps multi-document repetition
+		// while collapsing duplicates that came from less-specific loaders.
+		for _, e := range group {
+			if priority(e.fileType) == bestRank {
+				keep[e.id] = struct{}{}
+			}
+		}
+	}
+
+	if len(keep) == len(workloadIDToSource) {
+		return workloads, workloadIDToSource
+	}
+
+	dedupedWorkloads := make([]workloadinterface.IMetadata, 0, len(keep))
+	for _, w := range workloads {
+		if _, ok := keep[w.GetID()]; ok {
+			dedupedWorkloads = append(dedupedWorkloads, w)
+		}
+	}
+	for id := range workloadIDToSource {
+		if _, ok := keep[id]; !ok {
+			delete(workloadIDToSource, id)
+		}
+	}
+	return dedupedWorkloads, workloadIDToSource
 }
 
 func extractGitRepo(path string) (string, *cautils.LocalGitRepository) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -330,99 +330,80 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 	return workloadIDToSource, workloads, nil
 }
 
+// fileTypeRank ranks Source.FileType when the same logical resource is
+// emitted by more than one loader. Higher rank wins. Helm beats kustomize
+// because the chart name is more specific attribution; both beat plain
+// YAML/JSON.
+var fileTypeRank = map[string]int{
+	reporthandling.SourceTypeHelmChart:          3,
+	reporthandling.SourceTypeKustomizeDirectory: 2,
+	reporthandling.SourceTypeYaml:               1,
+	reporthandling.SourceTypeJson:               1,
+}
+
 // dedupWorkloadsBySource collapses workloads that point to the same logical
 // resource (RelativePath + apiVersion + kind + namespace + name) when emitted
 // by *different* loaders. The plain YAML walker, the helm renderer, and the
-// kustomize renderer are each recursive over the input directory; a helm
-// chart whose templates happen to be valid plain YAML (no `{{ }}` placeholders)
-// is otherwise picked up twice — once as a raw YAML file and once as a
-// rendered chart resource. Downstream consumers that aggregate by file path
-// then see the same file with conflicting Source.HelmChartName values, which
-// breaks any per-file invariant (Armo's BE childCount vs. file_summary
-// mismatch on `armosec/kubescape@master`'s test-chart fixture is the
-// user-visible symptom).
+// kustomize renderer each scan the input recursively, so a chart whose
+// templates are valid plain YAML (no `{{ }}` placeholders) would otherwise
+// surface twice — once with FileType=YAML and once with FileType=Helm Chart.
 //
-// Precedence keeps the most specific attribution: HelmChart > Kustomize > YAML/JSON.
-//
-// Multi-document YAML files where the *same* resource identity legitimately
-// appears more than once within a single file (used heavily under
-// core/pkg/fixhandler/testdata/) are preserved, because they share a
-// FileType and so don't trip the cross-loader collapse.
-func dedupWorkloadsBySource(workloads []workloadinterface.IMetadata, workloadIDToSource map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
-	if len(workloads) == 0 {
-		return workloads, workloadIDToSource
-	}
-
-	priority := func(fileType string) int {
-		switch fileType {
-		case reporthandling.SourceTypeHelmChart:
-			return 3
-		case reporthandling.SourceTypeKustomizeDirectory:
-			return 2
-		case reporthandling.SourceTypeYaml, reporthandling.SourceTypeJson:
-			return 1
-		default:
-			return 0
-		}
-	}
-
-	idToWorkload := make(map[string]workloadinterface.IMetadata, len(workloads))
-	for _, w := range workloads {
-		idToWorkload[w.GetID()] = w
+// Multi-document YAML files where the same resource identity legitimately
+// repeats within one file are preserved: their entries share a FileType and
+// therefore tie at the highest rank.
+func dedupWorkloadsBySource(workloads []workloadinterface.IMetadata, sources map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
+	if len(workloads) < 2 {
+		return workloads, sources
 	}
 
 	type entry struct {
-		id       string
-		fileType string
+		id   string
+		rank int
 	}
 	groups := make(map[string][]entry, len(workloads))
 	keep := make(map[string]struct{}, len(workloads))
 
-	for id, src := range workloadIDToSource {
-		w, ok := idToWorkload[id]
+	for _, w := range workloads {
+		id := w.GetID()
+		src, ok := sources[id]
 		if !ok || src.RelativePath == "" {
-			// Workloads without source attribution are kept untouched —
-			// they cannot collide with file-anchored emissions.
 			keep[id] = struct{}{}
 			continue
 		}
-		key := strings.Join([]string{src.RelativePath, w.GetApiVersion(), w.GetKind(), w.GetNamespace(), w.GetName()}, "\x00")
-		groups[key] = append(groups[key], entry{id: id, fileType: src.FileType})
+		key := src.RelativePath + "\x00" + w.GetApiVersion() + "\x00" + w.GetKind() + "\x00" + w.GetNamespace() + "\x00" + w.GetName()
+		groups[key] = append(groups[key], entry{id: id, rank: fileTypeRank[src.FileType]})
 	}
 
-	for _, group := range groups {
-		bestRank := -1
-		for _, e := range group {
-			if r := priority(e.fileType); r > bestRank {
-				bestRank = r
+	for _, g := range groups {
+		best := g[0].rank
+		for _, e := range g[1:] {
+			if e.rank > best {
+				best = e.rank
 			}
 		}
-		// Preserve every workload whose loader matches the highest-rank
-		// FileType in the group: this keeps multi-document repetition
-		// while collapsing duplicates that came from less-specific loaders.
-		for _, e := range group {
-			if priority(e.fileType) == bestRank {
+		for _, e := range g {
+			if e.rank == best {
 				keep[e.id] = struct{}{}
 			}
 		}
 	}
 
-	if len(keep) == len(workloadIDToSource) {
-		return workloads, workloadIDToSource
+	if len(keep) == len(workloads) {
+		return workloads, sources
 	}
 
-	dedupedWorkloads := make([]workloadinterface.IMetadata, 0, len(keep))
+	deduped := make([]workloadinterface.IMetadata, 0, len(keep))
 	for _, w := range workloads {
 		if _, ok := keep[w.GetID()]; ok {
-			dedupedWorkloads = append(dedupedWorkloads, w)
+			deduped = append(deduped, w)
 		}
 	}
-	for id := range workloadIDToSource {
+	for id := range sources {
 		if _, ok := keep[id]; !ok {
-			delete(workloadIDToSource, id)
+			delete(sources, id)
 		}
 	}
-	return dedupedWorkloads, workloadIDToSource
+	return deduped, sources
 }
 
 func extractGitRepo(path string) (string, *cautils.LocalGitRepository) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -341,6 +341,54 @@ var fileTypeRank = map[string]int{
 	reporthandling.SourceTypeJson:               1,
 }
 
+// dedupByRank collapses items that share a key, keeping every item whose
+// rank ties for the maximum within the group. Items for which keyRankOf
+// returns hasKey=false are passed through untouched (no group membership,
+// no collapse).
+//
+// Stable: the relative order of kept items mirrors their order in `items`.
+func dedupByRank[T any](items []T, keyRankOf func(T) (key string, rank int, hasKey bool)) []T {
+	if len(items) < 2 {
+		return items
+	}
+	type entry struct {
+		idx, rank int
+	}
+	groups := make(map[string][]entry, len(items))
+	keep := make(map[int]struct{}, len(items))
+	for i, it := range items {
+		key, rank, ok := keyRankOf(it)
+		if !ok {
+			keep[i] = struct{}{}
+			continue
+		}
+		groups[key] = append(groups[key], entry{idx: i, rank: rank})
+	}
+	for _, g := range groups {
+		best := g[0].rank
+		for _, e := range g[1:] {
+			if e.rank > best {
+				best = e.rank
+			}
+		}
+		for _, e := range g {
+			if e.rank == best {
+				keep[e.idx] = struct{}{}
+			}
+		}
+	}
+	if len(keep) == len(items) {
+		return items
+	}
+	out := make([]T, 0, len(keep))
+	for i, it := range items {
+		if _, ok := keep[i]; ok {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // dedupWorkloadsBySource collapses workloads that point to the same logical
 // resource (RelativePath + apiVersion + kind + namespace + name) when emitted
 // by *different* loaders. The plain YAML walker, the helm renderer, and the
@@ -352,54 +400,23 @@ var fileTypeRank = map[string]int{
 // repeats within one file are preserved: their entries share a FileType and
 // therefore tie at the highest rank.
 func dedupWorkloadsBySource(workloads []workloadinterface.IMetadata, sources map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
-	if len(workloads) < 2 {
-		return workloads, sources
-	}
-
-	type entry struct {
-		id   string
-		rank int
-	}
-	groups := make(map[string][]entry, len(workloads))
-	keep := make(map[string]struct{}, len(workloads))
-
-	for _, w := range workloads {
-		id := w.GetID()
-		src, ok := sources[id]
+	deduped := dedupByRank(workloads, func(w workloadinterface.IMetadata) (string, int, bool) {
+		src, ok := sources[w.GetID()]
 		if !ok || src.RelativePath == "" {
-			keep[id] = struct{}{}
-			continue
+			return "", 0, false
 		}
 		key := src.RelativePath + "\x00" + w.GetApiVersion() + "\x00" + w.GetKind() + "\x00" + w.GetNamespace() + "\x00" + w.GetName()
-		groups[key] = append(groups[key], entry{id: id, rank: fileTypeRank[src.FileType]})
-	}
-
-	for _, g := range groups {
-		best := g[0].rank
-		for _, e := range g[1:] {
-			if e.rank > best {
-				best = e.rank
-			}
-		}
-		for _, e := range g {
-			if e.rank == best {
-				keep[e.id] = struct{}{}
-			}
-		}
-	}
-
-	if len(keep) == len(workloads) {
+		return key, fileTypeRank[src.FileType], true
+	})
+	if len(deduped) == len(workloads) {
 		return workloads, sources
 	}
-
-	deduped := make([]workloadinterface.IMetadata, 0, len(keep))
-	for _, w := range workloads {
-		if _, ok := keep[w.GetID()]; ok {
-			deduped = append(deduped, w)
-		}
+	survivors := make(map[string]struct{}, len(deduped))
+	for _, w := range deduped {
+		survivors[w.GetID()] = struct{}{}
 	}
 	for id := range sources {
-		if _, ok := keep[id]; !ok {
+		if _, ok := survivors[id]; !ok {
 			delete(sources, id)
 		}
 	}

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -151,6 +151,32 @@ func TestDedupWorkloadsBySource_MultiDocCollapsesAcrossLoaders(t *testing.T) {
 	}
 }
 
+// A workload present in `workloads` but absent from the source map must
+// survive dedup, even when other groups collapse.
+func TestDedupWorkloadsBySource_OrphanWorkloadKept(t *testing.T) {
+	const cm = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-config","namespace":""}}`
+	const path = "templates/configmap.yaml"
+	wOrphan := newLocalWorkload(t, `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"orphan"}}`, "orphan.yaml")
+	wYaml := newLocalWorkload(t, cm, path)
+	wHelm := newLocalWorkload(t, cm, "helm:"+path)
+	workloads := []workloadinterface.IMetadata{wOrphan, wYaml, wHelm}
+	src := map[string]reporthandling.Source{
+		// wOrphan intentionally absent from the source map.
+		wYaml.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		wHelm.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeHelmChart, HelmChartName: "x"},
+	}
+
+	gotW, _ := dedupWorkloadsBySource(workloads, src)
+
+	gotIDs := map[string]struct{}{}
+	for _, w := range gotW {
+		gotIDs[w.GetID()] = struct{}{}
+	}
+	assert.Contains(t, gotIDs, wOrphan.GetID(), "orphan workload (no source entry) must be preserved")
+	assert.Contains(t, gotIDs, wHelm.GetID())
+	assert.NotContains(t, gotIDs, wYaml.GetID())
+}
+
 func TestDedupWorkloadsBySource_NoSourceAttributionLeftAlone(t *testing.T) {
 	wA := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a"}}`, "a.yaml")
 	workloads := []workloadinterface.IMetadata{wA}

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -177,6 +177,83 @@ func TestDedupWorkloadsBySource_OrphanWorkloadKept(t *testing.T) {
 	assert.NotContains(t, gotIDs, wYaml.GetID())
 }
 
+// Direct coverage for the generic helper, independent of the kubescape
+// types it's wrapped in.
+func TestDedupByRank(t *testing.T) {
+	type item struct {
+		key  string
+		rank int
+		// hasKey false → opts out of grouping (kept as-is)
+		hasKey bool
+		tag    string
+	}
+	keyRankOf := func(it item) (string, int, bool) { return it.key, it.rank, it.hasKey }
+	tagsOf := func(items []item) []string {
+		out := make([]string, len(items))
+		for i, it := range items {
+			out[i] = it.tag
+		}
+		return out
+	}
+
+	cases := []struct {
+		name string
+		in   []item
+		want []string
+	}{
+		{
+			name: "single key wins",
+			in: []item{
+				{key: "p", rank: 1, hasKey: true, tag: "yaml"},
+				{key: "p", rank: 3, hasKey: true, tag: "helm"},
+			},
+			want: []string{"helm"},
+		},
+		{
+			name: "ties at the top survive together",
+			in: []item{
+				{key: "p", rank: 1, hasKey: true, tag: "yaml-a"},
+				{key: "p", rank: 3, hasKey: true, tag: "helm-a"},
+				{key: "p", rank: 3, hasKey: true, tag: "helm-b"},
+			},
+			want: []string{"helm-a", "helm-b"},
+		},
+		{
+			name: "items without a key are passed through",
+			in: []item{
+				{tag: "orphan"},
+				{key: "p", rank: 1, hasKey: true, tag: "yaml"},
+				{key: "p", rank: 3, hasKey: true, tag: "helm"},
+			},
+			want: []string{"orphan", "helm"},
+		},
+		{
+			name: "different keys are independent",
+			in: []item{
+				{key: "p", rank: 1, hasKey: true, tag: "p-yaml"},
+				{key: "q", rank: 1, hasKey: true, tag: "q-yaml"},
+			},
+			want: []string{"p-yaml", "q-yaml"},
+		},
+		{
+			name: "stable order",
+			in: []item{
+				{key: "p", rank: 3, hasKey: true, tag: "first"},
+				{key: "p", rank: 1, hasKey: true, tag: "drop-me"},
+				{key: "p", rank: 3, hasKey: true, tag: "second"},
+			},
+			want: []string{"first", "second"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupByRank(tc.in, keyRankOf)
+			assert.Equal(t, tc.want, tagsOf(got))
+		})
+	}
+}
+
 func TestDedupWorkloadsBySource_NoSourceAttributionLeftAlone(t *testing.T) {
 	wA := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a"}}`, "a.yaml")
 	workloads := []workloadinterface.IMetadata{wA}

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -1,8 +1,12 @@
 package resourcehandler
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,4 +14,152 @@ import (
 func TestNewFileResourceHandler_InitializesNewInstance(t *testing.T) {
 	fileHandler := NewFileResourceHandler()
 	assert.NotNil(t, fileHandler)
+}
+
+// newLocalWorkload builds a LocalWorkload (with a sourcePath that distinguishes
+// otherwise-identical resources, mirroring how the file/helm/kustomize loaders
+// produce different IDs for the same logical resource).
+func newLocalWorkload(t *testing.T, raw, sourcePath string) workloadinterface.IMetadata {
+	t.Helper()
+	var obj map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(raw), &obj))
+	w := localworkload.NewLocalWorkload(obj)
+	w.SetPath(sourcePath)
+	return w
+}
+
+func TestDedupWorkloadsBySource_NoOverlapKeepsAll(t *testing.T) {
+	w1 := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a","namespace":"default"}}`, "a.yaml")
+	w2 := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"b","namespace":"default"}}`, "b.yaml")
+	workloads := []workloadinterface.IMetadata{w1, w2}
+	src := map[string]reporthandling.Source{
+		w1.GetID(): {RelativePath: "a.yaml", FileType: reporthandling.SourceTypeYaml},
+		w2.GetID(): {RelativePath: "b.yaml", FileType: reporthandling.SourceTypeYaml},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 2)
+	assert.Len(t, gotS, 2)
+}
+
+// TestDedupWorkloadsBySource_HelmBeatsPlainYaml exercises the regression that
+// shipped with kubescape's kustomize+helm test fixture: a chart template that
+// happens to be valid plain YAML is picked up both by the plain YAML walker
+// (FileType=YAML, no chart name) and by the helm renderer (FileType=Helm
+// Chart, helmChartName set). After dedup only the helm-attributed copy
+// survives.
+func TestDedupWorkloadsBySource_HelmBeatsPlainYaml(t *testing.T) {
+	const cm = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-config","namespace":""}}`
+	const path = "core/cautils/testdata/kustomize/helm/charts/test-chart/templates/configmap.yaml"
+	// Plain YAML and Helm renderers tag the same logical resource with different
+	// sourcePath values, so their IDs differ even though apiVersion+kind+name match.
+	wYaml := newLocalWorkload(t, cm, path)
+	wHelm := newLocalWorkload(t, cm, "helm-rendered:"+path)
+	assert.NotEqual(t, wYaml.GetID(), wHelm.GetID())
+	workloads := []workloadinterface.IMetadata{wYaml, wHelm}
+	src := map[string]reporthandling.Source{
+		wYaml.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		wHelm.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeHelmChart, HelmChartName: "test-chart"},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 1, "expected helm-attributed workload to win the dedup")
+	assert.Equal(t, wHelm.GetID(), gotW[0].GetID())
+	assert.Len(t, gotS, 1)
+	assert.Equal(t, "test-chart", gotS[wHelm.GetID()].HelmChartName)
+}
+
+func TestDedupWorkloadsBySource_KustomizeBeatsPlainYaml(t *testing.T) {
+	const cm = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"only-here","namespace":""}}`
+	const path = "manifests/configmap.yaml"
+	wYaml := newLocalWorkload(t, cm, path)
+	wKustomize := newLocalWorkload(t, cm, "kustomize-rendered:"+path)
+	workloads := []workloadinterface.IMetadata{wYaml, wKustomize}
+	src := map[string]reporthandling.Source{
+		wYaml.GetID():      {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		wKustomize.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeKustomizeDirectory, KustomizeDirectoryName: "manifests"},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 1)
+	assert.Equal(t, wKustomize.GetID(), gotW[0].GetID())
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, gotS[wKustomize.GetID()].FileType)
+}
+
+func TestDedupWorkloadsBySource_DifferentResourcesInSameFileKept(t *testing.T) {
+	wA := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a","namespace":""}}`, "multi.yaml")
+	wB := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"b","namespace":""}}`, "multi.yaml")
+	workloads := []workloadinterface.IMetadata{wA, wB}
+	src := map[string]reporthandling.Source{
+		wA.GetID(): {RelativePath: "multi.yaml", FileType: reporthandling.SourceTypeYaml},
+		wB.GetID(): {RelativePath: "multi.yaml", FileType: reporthandling.SourceTypeYaml},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 2, "multi-document YAML must keep both resources")
+	assert.Len(t, gotS, 2)
+}
+
+// TestDedupWorkloadsBySource_MultiDocSameIdentityKept locks in that
+// multi-document YAML files which legitimately reuse the same resource
+// identity (e.g. fixhandler test fixtures pairing input + expected Pods)
+// are preserved when only one loader is involved. Cross-loader collapse
+// must not eat them.
+func TestDedupWorkloadsBySource_MultiDocSameIdentityKept(t *testing.T) {
+	const pod = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"remove_example","namespace":""}}`
+	const path = "core/pkg/fixhandler/testdata/removals/tc-04-00-input.yaml"
+	w1 := newLocalWorkload(t, pod, path+"#0")
+	w2 := newLocalWorkload(t, pod, path+"#1")
+	workloads := []workloadinterface.IMetadata{w1, w2}
+	src := map[string]reporthandling.Source{
+		w1.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		w2.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 2, "two YAML docs sharing identity must both survive")
+	assert.Len(t, gotS, 2)
+}
+
+func TestDedupWorkloadsBySource_MultiDocCollapsesAcrossLoaders(t *testing.T) {
+	// Same file rendered twice by helm and twice as plain YAML — keep both
+	// helm copies, drop both plain-YAML copies.
+	const pod = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"dup-pod","namespace":""}}`
+	const path = "charts/x/templates/multi.yaml"
+	wYaml1 := newLocalWorkload(t, pod, path+"#yaml-0")
+	wYaml2 := newLocalWorkload(t, pod, path+"#yaml-1")
+	wHelm1 := newLocalWorkload(t, pod, path+"#helm-0")
+	wHelm2 := newLocalWorkload(t, pod, path+"#helm-1")
+	workloads := []workloadinterface.IMetadata{wYaml1, wYaml2, wHelm1, wHelm2}
+	src := map[string]reporthandling.Source{
+		wYaml1.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		wYaml2.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeYaml},
+		wHelm1.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeHelmChart, HelmChartName: "x"},
+		wHelm2.GetID(): {RelativePath: path, FileType: reporthandling.SourceTypeHelmChart, HelmChartName: "x"},
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 2, "expected only the two helm-attributed copies to survive")
+	for _, w := range gotW {
+		assert.Equal(t, reporthandling.SourceTypeHelmChart, gotS[w.GetID()].FileType)
+	}
+}
+
+func TestDedupWorkloadsBySource_NoSourceAttributionLeftAlone(t *testing.T) {
+	wA := newLocalWorkload(t, `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a"}}`, "a.yaml")
+	workloads := []workloadinterface.IMetadata{wA}
+	src := map[string]reporthandling.Source{
+		wA.GetID(): {}, // no RelativePath
+	}
+
+	gotW, gotS := dedupWorkloadsBySource(workloads, src)
+
+	assert.Len(t, gotW, 1)
+	assert.Len(t, gotS, 1)
 }


### PR DESCRIPTION
## Problem

`getResourcesFromPath` ([core/pkg/resourcehandler/filesloader.go](https://github.com/kubescape/kubescape/blob/master/core/pkg/resourcehandler/filesloader.go)) runs three loaders sequentially over the input directory: the plain YAML/JSON walker, the helm renderer, and the kustomize renderer. A helm chart whose templates happen to be valid plain YAML — i.e. no `{{ }}` placeholders — is picked up **twice**: once with `Source.FileType=YAML` (no chart name) and once with `Source.FileType=Helm Chart` and the chart name set. Each gets a distinct workload ID, so both end up in `workloadIDToSource` and `workloads`.

The fixture `core/cautils/testdata/kustomize/helm/charts/test-chart/templates/configmap.yaml` added by [`649e9b7e`](https://github.com/kubescape/kubescape/commit/649e9b7e) is exactly this shape — pure YAML, no placeholders. Scanning `armosec/kubescape@master` (which mirrors upstream) reports the same `relativePath` twice with conflicting `helmChartName` values:

```
$ kubescape scan framework AllControls https://github.com/armosec/kubescape -f json -o /tmp/scan.json
$ jq -r '.resources[]?.source? | select(.) | "\(.relativePath)|\(.helmChartName // "")"' /tmp/scan.json | sort -u | awk -F'|' '{c[$1]++; v[$1]=v[$1]","$2} END {for (k in c) if (c[k]>1) print k " => " v[k]}'
core/cautils/testdata/kustomize/helm/charts/test-chart/templates/configmap.yaml => ,,test-chart
```

Downstream consumers that aggregate by file path then see the same file with conflicting attribution. The user-visible regression is on the Armo backend side: the system test `scan_git_repository_and_submit_to_backend` fails on every CD release that scans `armosec/kubescape@master` because the per-file aggregation (which groups by `file_path, helm_chart_name, …`) returns 72 rows while the repo-level `COUNT(DISTINCT file_path)` is 71.

## Fix

Add a final dedup step at the end of `getResourcesFromPath`, keyed by `(RelativePath, apiVersion, kind, namespace, name)`. For each group, keep every workload whose loader matches the highest-rank `FileType` in the group:

> Helm Chart > Kustomize Directory > YAML/JSON

Workloads without source attribution and groups that are uniformly emitted by a single loader are untouched. That preserves multi-document YAML files which legitimately reuse the same resource identity (the `core/pkg/fixhandler/testdata/` fixtures pair input + expected Pods named `remove_example` / `insert_to_mapping_node_1`, all under one loader).

## Verified

End-to-end scan of `armosec/kubescape@master` (which tracks upstream):

| | resources | unique relativePath | distinct (path, helmChartName) |
|---|---|---|---|
| before | 84 | 68 | 69 |
| after | 83 | 68 | 68 |

The single duplicate on `core/cautils/testdata/kustomize/helm/charts/test-chart/templates/configmap.yaml` collapses; multi-document fixhandler fixtures retain both Pods each.

## Tests

`core/pkg/resourcehandler/filesloader_test.go` — 7 unit tests for `dedupWorkloadsBySource`:

- `_NoOverlapKeepsAll` — distinct resources untouched.
- `_HelmBeatsPlainYaml` — the kustomize/helm fixture shape; helm wins.
- `_KustomizeBeatsPlainYaml` — same shape with kustomize as the higher-rank loader.
- `_DifferentResourcesInSameFileKept` — multi-doc YAML with distinct (kind, name) survives.
- `_MultiDocSameIdentityKept` — multi-doc YAML reusing the *same* identity (fixhandler fixtures) survives.
- `_MultiDocCollapsesAcrossLoaders` — same shape but mixed loaders → collapses to highest-rank loader, preserving its multiplicity.
- `_NoSourceAttributionLeftAlone` — workloads without `Source.RelativePath` aren't touched.

All `core/pkg/...` and `core/core/...` tests pass. `TestKustomizeDirectoryWithHelmCharts` in `core/cautils/` requires the `helm` CLI on the host and fails the same way without this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved resource deduplication across multiple configuration sources (Helm, Kustomize, YAML/JSON). Identical Kubernetes resources are consolidated by source precedence so the highest-priority source is retained; items without a valid source path remain unchanged. Stable ordering preserved for retained items.
* **Tests**
  * Expanded unit tests covering precedence rules, tie handling, multi-document YAML, orphaned entries, missing-path cases, and stable ordering across keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->