### PR TITLE
Fix/surface partial resource collection errors

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -98,8 +98,18 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 		return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, fmt.Errorf("failed to pull any Kubernetes resources: %s", strings.Join(combined, "; "))
 	}
 	for _, f := range failedQueries {
-		logger.L().Ctx(ctx).Warning("failed to pull resource type; affected controls will be marked skipped",
+		logger.L().Ctx(ctx).Warning("failed to pull resource type",
 			helpers.String("gvr", f.gvr), helpers.Error(f.err))
+		// InfoMap and ResourceToControlsMap are both keyed by raw GVR, not by
+		// query string, so we can only mark controls as skipped when the whole
+		// resource type is absent. If any selector-specific query succeeded and
+		// populated k8sResourcesMap[gvr], the control already has data to
+		// evaluate; marking it skipped via a sibling-query failure would be
+		// incorrect. A follow-up should introduce query-granular control mapping
+		// so partial-collection failures can be surfaced with the right scope.
+		if len(k8sResourcesMap[f.gvr]) > 0 {
+			continue
+		}
 		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, sessionObj.InfoMap)
 	}
 

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -87,23 +87,20 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	sessionObj.ResourceToControlsMap = resourceToControl
 
 	// pull k8s resources
-	k8sResourcesMap, allResources, failedGVRs := k8sHandler.pullResources(queryableResources, globalFieldSelectors)
-	if len(allResources) == 0 && len(failedGVRs) > 0 {
-		// Every resource type failed — nothing was collected; treat as fatal.
+	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(queryableResources, globalFieldSelectors)
+	if len(allResources) == 0 && len(failedQueries) > 0 {
+		// Every query failed — nothing was collected; treat as fatal.
 		var combined []string
-		for gvr, e := range failedGVRs {
-			combined = append(combined, fmt.Sprintf("%s: %s", gvr, e.Error()))
+		for _, f := range failedQueries {
+			combined = append(combined, fmt.Sprintf("%s: %s", f.gvr, f.err.Error()))
 		}
 		cautils.StopSpinner()
 		return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, fmt.Errorf("failed to pull any Kubernetes resources: %s", strings.Join(combined, "; "))
 	}
-	for gvr, e := range failedGVRs {
-		if len(k8sResourcesMap[gvr]) > 0 {
-			continue
-		}
+	for _, f := range failedQueries {
 		logger.L().Ctx(ctx).Warning("failed to pull resource type; affected controls will be marked skipped",
-			helpers.String("gvr", gvr), helpers.Error(e))
-		cautils.SetInfoMapForResources(e.Error(), []string{gvr}, sessionObj.InfoMap)
+			helpers.String("gvr", f.gvr), helpers.Error(f.err))
+		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, sessionObj.InfoMap)
 	}
 
 	// add single resource to k8s resources map (for single resource scan)
@@ -323,18 +320,31 @@ func setMapNamespaceToNumOfResources(ctx context.Context, allResources map[strin
 	sessionObj.SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources)
 }
 
-func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]error) {
+// queryFailure records a failed pull at query granularity (GVR + field selectors).
+type queryFailure struct {
+	gvr string
+	err error
+}
+
+func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
-	failedGVRs := map[string]error{}
+	// keyed by QueryableResource.String() (GVR + field selectors) so a failure on
+	// one selector variant is never suppressed by a success on a different variant
+	// for the same raw GVR.
+	failedQueries := map[string]queryFailure{}
 	for i := range queryableResources {
 		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(queryableResources[i].GroupVersionResourceTriplet)
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 		result, err := k8sHandler.pullSingleResource(&gvr, nil, queryableResources[i].FieldSelectors, globalFieldSelectors)
 		if err != nil {
 			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
-				failedGVRs[queryableResources[i].GroupVersionResourceTriplet] = err
+				qr := queryableResources[i]
+			failedQueries[qr.String()] = queryFailure{
+					gvr: queryableResources[i].GroupVersionResourceTriplet,
+					err: err,
+				}
 			}
 			continue
 		}
@@ -352,7 +362,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		}
 	}
 
-	return k8sResources, allResources, failedGVRs
+	return k8sResources, allResources, failedQueries
 }
 
 func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, error) {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -87,10 +87,20 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	sessionObj.ResourceToControlsMap = resourceToControl
 
 	// pull k8s resources
-	k8sResourcesMap, allResources, err := k8sHandler.pullResources(queryableResources, globalFieldSelectors)
-	if err != nil {
+	k8sResourcesMap, allResources, failedGVRs := k8sHandler.pullResources(queryableResources, globalFieldSelectors)
+	if len(allResources) == 0 && len(failedGVRs) > 0 {
+		// Every resource type failed — nothing was collected; treat as fatal.
+		var combined []string
+		for gvr, e := range failedGVRs {
+			combined = append(combined, fmt.Sprintf("%s: %s", gvr, e.Error()))
+		}
 		cautils.StopSpinner()
-		return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, err
+		return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, fmt.Errorf("failed to pull any Kubernetes resources: %s", strings.Join(combined, "; "))
+	}
+	for gvr, e := range failedGVRs {
+		logger.L().Ctx(ctx).Warning("failed to pull resource type; affected controls will be marked skipped",
+			helpers.String("gvr", gvr), helpers.Error(e))
+		cautils.SetInfoMapForResources(e.Error(), []string{gvr}, sessionObj.InfoMap)
 	}
 
 	// add single resource to k8s resources map (for single resource scan)
@@ -310,24 +320,18 @@ func setMapNamespaceToNumOfResources(ctx context.Context, allResources map[strin
 	sessionObj.SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources)
 }
 
-func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, error) {
+func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]error) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
-	var errs error
+	failedGVRs := map[string]error{}
 	for i := range queryableResources {
 		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(queryableResources[i].GroupVersionResourceTriplet)
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 		result, err := k8sHandler.pullSingleResource(&gvr, nil, queryableResources[i].FieldSelectors, globalFieldSelectors)
 		if err != nil {
 			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
-				logger.L().Warning("failed to pull resource", helpers.String("resource", queryableResources[i].GroupVersionResourceTriplet), helpers.Error(err))
-				// handle error
-				if errs == nil {
-					errs = err
-				} else {
-					errs = fmt.Errorf("%s; %s", errs, err.Error())
-				}
+				failedGVRs[queryableResources[i].GroupVersionResourceTriplet] = err
 			}
 			continue
 		}
@@ -345,13 +349,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		}
 	}
 
-	// we don't want to fail the scan if we failed to pull only some resources
-	// in that case, we return nil error (and errors are logged in the loop above)
-	if errs != nil && len(allResources) > 0 {
-		errs = nil
-	}
-
-	return k8sResources, allResources, errs
+	return k8sResources, allResources, failedGVRs
 }
 
 func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, error) {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -98,6 +98,9 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 		return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, fmt.Errorf("failed to pull any Kubernetes resources: %s", strings.Join(combined, "; "))
 	}
 	for gvr, e := range failedGVRs {
+		if len(k8sResourcesMap[gvr]) > 0 {
+			continue
+		}
 		logger.L().Ctx(ctx).Warning("failed to pull resource type; affected controls will be marked skipped",
 			helpers.String("gvr", gvr), helpers.Error(e))
 		cautils.SetInfoMapForResources(e.Error(), []string{gvr}, sessionObj.InfoMap)

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -87,6 +87,9 @@ func setComplexKSResourceMap(frameworks []reporthandling.Framework, resourceToCo
 	for _, framework := range frameworks {
 		for _, control := range framework.Controls {
 			for _, rule := range control.Rules {
+				for _, match := range rule.Match {
+					insertKSResourcesAndControls(k8sResources, match, resourceToControls, control)
+				}
 				for _, match := range rule.DynamicMatch {
 					insertKSResourcesAndControls(k8sResources, match, resourceToControls, control)
 				}

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -89,6 +89,17 @@ func setComplexKSResourceMap(frameworks []reporthandling.Framework, resourceToCo
 			for _, rule := range control.Rules {
 				for _, match := range rule.Match {
 					insertKSResourcesAndControls(k8sResources, match, resourceToControls, control)
+					for _, apiGroup := range match.APIGroups {
+						for _, apiVersion := range match.APIVersions {
+							for _, resource := range match.Resources {
+								for _, groupResource := range k8sinterface.ResourceGroupToString(apiGroup, apiVersion, resource) {
+									if !slices.Contains(resourceToControls[groupResource], control.ControlID) {
+										resourceToControls[groupResource] = append(resourceToControls[groupResource], control.ControlID)
+									}
+								}
+							}
+						}
+					}
 				}
 				for _, match := range rule.DynamicMatch {
 					insertKSResourcesAndControls(k8sResources, match, resourceToControls, control)


### PR DESCRIPTION
## Overview

So basically I found a bug where kubescape was silently ignoring errors when it failed to fetch certain Kubernetes resource types during a scan. Like if your ServiceAccount didn't have permission to list ClusterRoleBindings, the error would just get swallowed as long as at least one other resource type succeeded. The scan would finish, those RBAC controls would see empty input, and report everything as Passed. Which is bad because a genuinely misconfigured cluster would look clean.

The fix has two parts. First, instead of accumulating all the errors into one string and then throwing it away, I now track which GVRs actually failed in a map. If everything failed (nothing collected at all), it still returns a fatal error like before. But if it's a partial failure, the failing GVRs get passed through SetInfoMapForResources which marks the affected controls as Skipped with the actual error message. That's the same thing the host-scanner and cloud-resource paths already do.

The second part: I noticed that setComplexKSResourceMap was only iterating rule.DynamicMatch (external/host resources) when building ResourceToControlsMap, completely skipping rule.Match (regular K8s resources like ClusterRoleBindings, Pods, etc.). Without this, the InfoMap entries for failing GVRs had nowhere to go , mapControlToInfo couldn't link them to their controls, so the controls still showed as Passed even after the first fix. Adding rule.Match to that loop closes the gap.

The end result is that instead of getting a false "Passed" on controls you couldn't even evaluate, you now see them as Skipped with an explanation. Way more honest.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partial resource-collection failures now emit per-query warnings and no longer suppress partial results; a hard error is returned only when every queried resource type fails.
* **Improvements**
  * Resource matching expanded to include additional rule types, ensuring broader coverage of matched resources and correctly associating controls without duplicating IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->