### PR TITLE
fix: prevent nil map assignment panic in APIServerStore

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -195,8 +195,8 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResult(ctx context.Contex
 				return getErr
 			}
 			// update the workload configuration scan manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = mergeWorkloadConfigurationScanSpec(result.Spec, manifest.Spec)
 			// try to send the updated workload configuration scan manifest
 			_, updateErr := a.StorageClient.WorkloadConfigurationScans(namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -294,8 +294,8 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResultSummary(ctx context
 				return getErr
 			}
 			// update the manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = mergeWorkloadConfigurationScanSummarySpec(result.Spec, manifest.Spec)
 			// try to send the updated manifest
 			_, updateErr := a.StorageClient.WorkloadConfigurationScanSummaries(namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -540,8 +540,12 @@ func parseWorkloadScanRelatedObjectList(relatedObjects []workloadinterface.IMeta
 }
 
 // mergeMaps merges new into existing, overwriting existing keys with new values
-func mergeMaps(existing, new map[string]string) {
+func mergeMaps(existing, new map[string]string) map[string]string {
+	if existing == nil {
+		existing = make(map[string]string)
+	}
 	for k, v := range new {
 		existing[k] = v
 	}
+	return existing
 }

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -523,12 +523,24 @@ func TestMergeMaps(t *testing.T) {
 			new:      map[string]string{},
 			expected: map[string]string{},
 		},
+		{
+			name:     "merge with nil existing map",
+			existing: nil,
+			new:      map[string]string{"key1": "value1"},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name:     "merge with both maps nil",
+			existing: nil,
+			new:      nil,
+			expected: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mergeMaps(tt.existing, tt.new)
-			assert.Equal(t, tt.expected, tt.existing)
+			result := mergeMaps(tt.existing, tt.new)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
## Overview
This PR fixes a runtime panic in the APIServer storage layer caused by unsafe handling of nil maps when merging Kubernetes metadata (annotations and labels).

### Current Behavior
When updating an existing `WorkloadConfigurationScan` CRD, the storage layer attempts to merge annotations/labels using a helper function. However, due to Kubernetes deserialization behavior (`omitempty` in `ObjectMeta`), these maps can be `nil`. Writing to a nil map results in a panic:

panic: assignment to entry in nil map

This leads to:
- CrashLoopBackOff in the httphandler component
- Broken continuous scanning
- Silent failure in result aggregation

### Updated Behavior
- `mergeMaps` now safely initializes the map if it is nil and returns it.
- All callers now reassign the returned map.
- The system no longer crashes when annotations/labels are missing.

### Key Changes
- Updated `mergeMaps` to return a map and handle nil safely
- Fixed callers in:
  - `StoreWorkloadConfigurationScanResult`
  - `StoreWorkloadConfigurationScanResultSummary`
- Added/updated unit tests for nil map scenarios

---

## Additional Information
Kubernetes may deserialize `annotations` and `labels` as `nil` if they are not explicitly set. The previous implementation assumed these maps were always initialized, which is incorrect and unsafe.

This fix ensures robustness against:
- Manually modified CRDs
- GitOps sync behavior
- Admission webhooks mutating metadata

---

## How to Test
1. Deploy a Kubernetes cluster with Kubescape operator and continuous scanning enabled.
2. Run an initial scan to generate a `WorkloadConfigurationScan` CRD.
3. Manually remove:
   - `metadata.annotations`
   - `metadata.labels`
4. Trigger another scan.
5. Verify:
   - No panic occurs
   - Scan completes successfully
   - Metadata is correctly re-populated

### Unit Tests
Run:
go test ./httphandler/storage/...

Verify:
- Tests cover nil map scenarios
- All tests pass

---

## Examples/Screenshots
N/A (backend fix, no UI impact)

---

## Related issues/PRs:
* Resolved #1998 

---

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for map merging functionality with additional edge-case scenarios.

* **Refactor**
  * Improved internal code reliability through defensive initialization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->