### PR TITLE
Fix nil metadata map merge in httphandler storage

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -195,8 +195,8 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResult(ctx context.Contex
 				return getErr
 			}
 			// update the workload configuration scan manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = mergeWorkloadConfigurationScanSpec(result.Spec, manifest.Spec)
 			// try to send the updated workload configuration scan manifest
 			_, updateErr := a.StorageClient.WorkloadConfigurationScans(namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -294,8 +294,8 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResultSummary(ctx context
 				return getErr
 			}
 			// update the manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = mergeWorkloadConfigurationScanSummarySpec(result.Spec, manifest.Spec)
 			// try to send the updated manifest
 			_, updateErr := a.StorageClient.WorkloadConfigurationScanSummaries(namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -539,9 +539,14 @@ func parseWorkloadScanRelatedObjectList(relatedObjects []workloadinterface.IMeta
 	return r
 }
 
-// mergeMaps merges new into existing, overwriting existing keys with new values
-func mergeMaps(existing, new map[string]string) {
+// mergeMaps merges new into existing, overwriting existing keys with new values.
+// It returns the merged map so callers can safely handle nil destinations.
+func mergeMaps(existing, new map[string]string) map[string]string {
+	if existing == nil && new != nil {
+		existing = make(map[string]string, len(new))
+	}
 	for k, v := range new {
 		existing[k] = v
 	}
+	return existing
 }

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewFakeAPIServerStorage(namespace string) *APIServerStore {
@@ -486,6 +487,52 @@ func Test_RoleBindingResourceTripletToSlug(t *testing.T) {
 	}
 }
 
+func TestStoreWorkloadConfigurationScanResult_MergesNilMetadataMaps(t *testing.T) {
+	ctx := context.Background()
+	store := NewFakeAPIServerStorage("test-namespace")
+
+	existing := &v1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scan",
+			Namespace: "test-namespace",
+		},
+	}
+	_, err := store.StorageClient.WorkloadConfigurationScans("test-namespace").Create(ctx, existing, metav1.CreateOptions{})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	manifest := &v1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-scan",
+			Namespace:   "test-namespace",
+			Annotations: map[string]string{"kubescape.io/wlid": "wlid://cluster-minikube/namespace-test-namespace/pod-test-pod"},
+			Labels:      map[string]string{"kubescape.io/workload-name": "test-pod"},
+		},
+		Spec: v1beta1.WorkloadConfigurationScanSpec{
+			Controls: map[string]v1beta1.ScannedControl{
+				"control-1": {},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		err = store.StoreWorkloadConfigurationScanResult(ctx, manifest)
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	stored, err := store.StorageClient.WorkloadConfigurationScans("test-namespace").Get(ctx, manifest.Name, metav1.GetOptions{})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, manifest.Annotations, stored.Annotations)
+	assert.Equal(t, manifest.Labels, stored.Labels)
+	assert.Contains(t, stored.Spec.Controls, "control-1")
+}
+
 func TestMergeMaps(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -523,12 +570,23 @@ func TestMergeMaps(t *testing.T) {
 			new:      map[string]string{},
 			expected: map[string]string{},
 		},
+		{
+			name:     "merge with nil existing map",
+			existing: nil,
+			new:      map[string]string{"key1": "value1"},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name:     "merge with nil maps",
+			existing: nil,
+			new:      nil,
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mergeMaps(tt.existing, tt.new)
-			assert.Equal(t, tt.expected, tt.existing)
+			assert.Equal(t, tt.expected, mergeMaps(tt.existing, tt.new))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- make metadata map merging nil-safe when updating existing workload configuration scans
- apply the same nil-safe merge path to workload configuration scan summaries
- add a regression test for updating a scan whose stored annotations and labels are nil

Fixes #1998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of annotation and label merging during configuration scan result updates, preventing panics when metadata fields are initially nil or empty.

* **Tests**
  * Enhanced test coverage for annotation and label merge scenarios, including edge cases where metadata fields are nil, ensuring proper data preservation during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->