### PR TITLE
fix(resourcehandler): recognize ErrCloudDescribeUnavailable as non-fatal 

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -229,8 +230,13 @@ func (k8sHandler *K8sResourceHandler) collectCloudResources(ctx context.Context,
 		logger.L().Debug("Collecting cloud data ", helpers.String("resourceKind", resourceKind))
 		wl, err := resourceGetter(k8sHandler.clusterName, k8sHandler.cloudProvider)
 		if err != nil {
-			if !strings.Contains(err.Error(), cloudv1.NotSupportedMsg) {
-				// Return error with useful info on how to configure credentials for getting cloud provider info
+			switch {
+			case strings.Contains(err.Error(), cloudv1.NotSupportedMsg):
+				// silently skip unsupported providers
+			case errors.Is(err, cloudsupport.ErrCloudDescribeUnavailable):
+				logger.L().Debug("cloud describe unavailable, continuing scan", helpers.String("resourceKind", resourceKind), helpers.Error(err))
+				cautils.SetInfoMapForResources("cloud-describe-unavailable", cloudResources, sessionObj.InfoMap)
+			default:
 				logger.L().Debug("failed to get cloud data", helpers.String("resourceKind", resourceKind), helpers.Error(err))
 				err = fmt.Errorf("failed to get %s descriptive information. Read more: https://kubescape.io/docs/integrations/kubescape-integration-with-cloud-providers/", strings.ToUpper(k8sHandler.cloudProvider))
 				cautils.SetInfoMapForResources(err.Error(), cloudResources, sessionObj.InfoMap)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/stereoscope v0.1.9
 	github.com/anchore/syft v1.32.0
 	github.com/anubhav06/copa-grype v1.0.3-alpha.1
-	github.com/armosec/armoapi-go v0.0.667
+	github.com/armosec/armoapi-go v0.0.693
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.30
 	github.com/briandowns/spinner v1.23.2
@@ -32,7 +32,7 @@ require (
 	github.com/kubescape/backend v0.0.20
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
-	github.com/kubescape/k8s-interface v0.0.202
+	github.com/kubescape/k8s-interface v0.0.208
 	github.com/kubescape/opa-utils v0.0.288
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.667 h1:LrFowKvthnL676Gx+hjhvqP4pQ2+CjykFO9SdIYDc/c=
-github.com/armosec/armoapi-go v0.0.667/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.693 h1:nVS4OsnvQEZcUj8jdlRiNKo6LoiM+hDB04SCk/ZUD2Q=
+github.com/armosec/armoapi-go v0.0.693/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=
@@ -1188,8 +1188,8 @@ github.com/kubescape/go-git-url v0.0.31 h1:VZnvtdGLVc42cQaR7llQeGZz0PnOxcs+eDig2
 github.com/kubescape/go-git-url v0.0.31/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/k8s-interface v0.0.202 h1:yu9x+07crFQAgrBatFFU2WuuxMJfHUMHVuCzuHE9Q4M=
-github.com/kubescape/k8s-interface v0.0.202/go.mod h1:d4NVhL81bVXe8yEXlkT4ZHrt3iEppEIN39b8N1oXm5s=
+github.com/kubescape/k8s-interface v0.0.208 h1:vmZ2FVAQRsz3XRKNG/6wJAYvZJ12RtMoDTLVxFEktms=
+github.com/kubescape/k8s-interface v0.0.208/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.288 h1:X6kebUaVrM/fZt+XmeRw1mVJYkIrkyBdcbmjBs66gSc=
 github.com/kubescape/opa-utils v0.0.288/go.mod h1:9ZmBd4xni0OLffuvcp4fKMmBo/glvgbwkCY5zggIKSw=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -7,7 +7,7 @@ replace github.com/kubescape/kubescape/v3 => ../
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
 
 require (
-	github.com/armosec/armoapi-go v0.0.667
+	github.com/armosec/armoapi-go v0.0.693
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.30
 	github.com/go-openapi/runtime v0.29.3
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/schema v1.4.1
 	github.com/kubescape/backend v0.0.20
 	github.com/kubescape/go-logger v0.0.28
-	github.com/kubescape/k8s-interface v0.0.202
+	github.com/kubescape/k8s-interface v0.0.208
 	github.com/kubescape/kubescape/v3 v3.0.4
 	github.com/kubescape/opa-utils v0.0.288
 	github.com/kubescape/storage v0.0.184

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -319,8 +319,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.667 h1:LrFowKvthnL676Gx+hjhvqP4pQ2+CjykFO9SdIYDc/c=
-github.com/armosec/armoapi-go v0.0.667/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.693 h1:nVS4OsnvQEZcUj8jdlRiNKo6LoiM+hDB04SCk/ZUD2Q=
+github.com/armosec/armoapi-go v0.0.693/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=
@@ -1194,8 +1194,8 @@ github.com/kubescape/go-git-url v0.0.31 h1:VZnvtdGLVc42cQaR7llQeGZz0PnOxcs+eDig2
 github.com/kubescape/go-git-url v0.0.31/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/k8s-interface v0.0.202 h1:yu9x+07crFQAgrBatFFU2WuuxMJfHUMHVuCzuHE9Q4M=
-github.com/kubescape/k8s-interface v0.0.202/go.mod h1:d4NVhL81bVXe8yEXlkT4ZHrt3iEppEIN39b8N1oXm5s=
+github.com/kubescape/k8s-interface v0.0.208 h1:vmZ2FVAQRsz3XRKNG/6wJAYvZJ12RtMoDTLVxFEktms=
+github.com/kubescape/k8s-interface v0.0.208/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.288 h1:X6kebUaVrM/fZt+XmeRw1mVJYkIrkyBdcbmjBs66gSc=
 github.com/kubescape/opa-utils v0.0.288/go.mod h1:9ZmBd4xni0OLffuvcp4fKMmBo/glvgbwkCY5zggIKSw=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -350,10 +350,10 @@ func getManifestObjectLabelsAndAnnotations(clusterName string, resource workload
 	}
 	labels := make(map[string]string)
 	labels[helpersv1.ApiGroupMetadataKey], labels[helpersv1.ApiVersionMetadataKey] = k8sinterface.SplitApiVersion(resource.GetApiVersion())
-	labels[helpersv1.KindMetadataKey] = resource.GetKind()
-	labels[helpersv1.NameMetadataKey] = resource.GetName()
+	labels[helpersv1.RelatedKindMetadataKey] = resource.GetKind()
+	labels[helpersv1.RelatedNameMetadataKey] = resource.GetName()
 	if k8sinterface.IsResourceInNamespaceScope(resource.GetKind()) {
-		labels[helpersv1.NamespaceMetadataKey] = resource.GetNamespace()
+		labels[helpersv1.RelatedNamespaceMetadataKey] = resource.GetNamespace()
 	}
 
 	if len(relatedObjects) > 0 {


### PR DESCRIPTION
## Summary                                                

  Consumes the new `cloudsupport.ErrCloudDescribeUnavailable` sentinel from                                                                                                      
  [kubescape/k8s-interface#149](https://github.com/kubescape/k8s-interface/pull/149)
  so the scan loop classifies an unavailable cloud-describe as **non-fatal**                                                                                                     
  and continues collecting host-scanner / node-agent data.                                                                                                                       
                                                                                                                                                                                 
  Together with that PR, this completes the fix for                                                                                                                              
  [kubescape/helm-charts#637](https://github.com/kubescape/helm-charts/issues/637)                                                                                               
  (host-scanner reports missing in air-gapped AKS).                                                                                                                              
                                                                                                                                                                                 
  ## Why                                                                                                                                                                         
                                                                                                                                                                                 
  Before this change, `collectCloudResources` had two error arms:                                                                                                                
  - `cloudv1.NotSupportedMsg` → silently skip the resource.
  - everything else → log Debug + add a generic "configure your credentials"                                                                                                     
    string to the scan's `InfoMap`.                                                                                                                                              
                                                                                                                                                                                 
  That second arm misclassifies the new air-gap path. With the upstream                                                                                                          
  `k8s-interface` change, AKS describe failures now return                                                                                                                       
  `ErrCloudDescribeUnavailable`, which is **expected** in offline / air-gapped                                                                                                   
  environments — not a credentials misconfiguration the user needs to fix. The                                                                                                   
  generic message would confuse users who deliberately set                                                                                                                       
  `capabilities.kubescapeOffline=enable`.                                                                                                                                        
                                                                                                                                                                                 
  ## Changes                                                
                                                                                                                                                                                 
  ### `core/pkg/resourcehandler/k8sresources.go`            
  - Added `errors` import.
  - Replaced the single `if !strings.Contains(err.Error(), cloudv1.NotSupportedMsg)`                                                                                             
    branch with a `switch` that recognizes three classes of failure:                                                                                                             
    - `NotSupportedMsg` → skip silently (unchanged behavior).                                                                                                                    
    - `errors.Is(err, cloudsupport.ErrCloudDescribeUnavailable)` → Debug log                                                                                                     
      + `cloud-describe-unavailable` info-map entry. **(new)**                                                                                                                   
    - default → existing user-facing "configure your credentials" message.                                                                                                       
  - The `continue` is preserved across all arms — scan always proceeds.                                                                                                          
                                                                                                                                                                                 
  ### `go.mod` / `go.sum`                                   
  - Bumps `github.com/kubescape/k8s-interface` to the version containing the                                                                                                     
    sentinel (`vX.Y.Z`). I will Replace this once the upstream tag is published.                                                                                                 
                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                   
                                                                                                                                                                                 
  ### Unit                                                  
  - [x] `go test ./core/pkg/resourcehandler/...` — green.
  - [x] `go build ./...` — clean.
                                                                                                                                                                                 
  ### End-to-end (kind, simulated AKS air-gap)
  - [x] 3-node kind cluster with `azure://...` providerIDs set via kubeadm                                                                                                       
        kubelet config, so `cloudsupport.GetCloudProvider` returns AKS.                                                                                                          
  - [x] iptables `OUTPUT -d 169.254.169.254 -j DROP` on every node to simulate                                                                                                   
        AKS-style IMDS unreachability (drop, not reject).                                                                                                                        
  - [x] Helm install with `capabilities.kubescapeOffline=enable` and a custom                                                                                                    
        kubescape image built from this branch.                                                                                                                                  
  - [x] Triggered scan completed in 49s (vs. minutes-long stall on stock build).                                                                                                 
  - [x] Logs show `Downloading cloud resources...` → `Downloaded cloud resources`                                                                                                
        within the same second; **zero `DefaultAzureCredential` traces**.                                                                                                        
  - [x] `cloud-describe-unavailable` propagates into the scan report next to                                                                                                     
        AKS-specific controls (CIS-AKS-1.2.0/1.8.0 RBAC controls, etc.) —                                                                                                        
        proves the new switch arm is the one that fires.                                                                                                                         
  - [x] All 11 frameworks scored normally (security, AllControls, ArmoBest,                                                                                                      
        cis-aks-t1.2.0, cis-aks-t1.8.0, cis-v1.10.0/1.12.0, DevOpsBest, MITRE,                                                                                                   
        NSA, SOC2) — confirms AKS detection still happens and the rest of the                                                                                                    
        scan pipeline is unaffected.                                                                                                                                             
                                                                                                                                                                                 
  ## Risk / compatibility                                   
                                                                                                                                                                                 
  - The default arm of the new `switch` matches the previous behavior exactly,                                                                                                   
    so users not running in air-gap see no change.
  - No public API changes. No schema changes.                                                                                                                                    
  - Depends on a new tagged release of `k8s-interface`; CI will fail until that                                                                                                  
    release is available.                                                                                                                                                        
                                                                                                                                                                                 
  ## Related                                                                                                                                                                     
                                                            
  - Upstream sentinel: kubescape/k8s-interface#149                                                                                                                         
  - Symptom report: kubescape/helm-charts#637               
  - Operator companion (deps bump only) - This will be done once both the PRs get merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for cloud provider resource discovery to better distinguish between unsupported providers and unavailable operations, enabling more accurate diagnostics and continued scanning.

* **Chores**
  * Updated module dependencies for improved compatibility and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->