### PR TITLE
fix(httphandler): use unique temp file for per-request exceptions

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -167,6 +167,10 @@ func (scanInfo *ScanInfo) Cleanup() {
 	}
 }
 
+func (scanInfo *ScanInfo) AddCleanup(cleanup func()) {
+	scanInfo.cleanups = append(scanInfo.cleanups, cleanup)
+}
+
 func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 	if scanInfo.UseArtifactsFrom == "" {
 		return

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.208
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.288
+	github.com/kubescape/opa-utils v0.0.293
 	github.com/kubescape/storage v0.0.184
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1196,8 +1196,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.208 h1:vmZ2FVAQRsz3XRKNG/6wJAYvZJ12RtMoDTLVxFEktms=
 github.com/kubescape/k8s-interface v0.0.208/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.288 h1:X6kebUaVrM/fZt+XmeRw1mVJYkIrkyBdcbmjBs66gSc=
-github.com/kubescape/opa-utils v0.0.288/go.mod h1:9ZmBd4xni0OLffuvcp4fKMmBo/glvgbwkCY5zggIKSw=
+github.com/kubescape/opa-utils v0.0.293 h1:jpHWHhi8GM3OHCUSPsVifhBxKt6jShFGnK2kcCxs1TA=
+github.com/kubescape/opa-utils v0.0.293/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -79,6 +79,7 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 			logger.L().Warning("failed to save exceptions, scanning without them", helpers.Error(err))
 		} else {
 			scanInfo.UseExceptions = path
+			scanInfo.AddCleanup(func() { _ = os.Remove(path) })
 		}
 	}
 

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -114,9 +113,18 @@ func saveExceptions(exceptions []armotypes.PostureExceptionPolicy) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal exceptions: %w", err)
 	}
-	exceptionsPath := filepath.Join("/tmp", "exceptions.json") // FIXME potential race condition
-	if err := os.WriteFile(exceptionsPath, exceptionsJSON, 0644); err != nil {
+	f, err := os.CreateTemp("", "kubescape-exceptions-*.json")
+	if err != nil {
+		return "", fmt.Errorf("failed to create exceptions file: %w", err)
+	}
+	if _, err := f.Write(exceptionsJSON); err != nil {
+		f.Close()
+		os.Remove(f.Name())
 		return "", fmt.Errorf("failed to write exceptions file to disk: %w", err)
 	}
-	return exceptionsPath, nil
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to close exceptions file: %w", err)
+	}
+	return f.Name(), nil
 }

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -118,6 +118,7 @@ func TestSaveExceptionsConcurrent(t *testing.T) {
 	const goroutines = 32
 	var wg sync.WaitGroup
 	var mu sync.Mutex
+	errs := make(chan error, goroutines*3)
 	paths := make(map[string]struct{}, goroutines)
 	wg.Add(goroutines)
 
@@ -128,13 +129,22 @@ func TestSaveExceptionsConcurrent(t *testing.T) {
 				{PortalBase: armotypes.PortalBase{Name: "ex-" + string(rune('A'+id))}},
 			}
 			path, err := saveExceptions(exceptions)
-			require.NoError(t, err)
+			if err != nil {
+				errs <- err
+				return
+			}
 			defer os.Remove(path)
 
 			buf, err := os.ReadFile(path)
-			require.NoError(t, err)
+			if err != nil {
+				errs <- err
+				return
+			}
 			var got []armotypes.PostureExceptionPolicy
-			require.NoError(t, json.Unmarshal(buf, &got))
+			if err := json.Unmarshal(buf, &got); err != nil {
+				errs <- err
+				return
+			}
 			assert.Equal(t, exceptions, got)
 
 			mu.Lock()
@@ -143,6 +153,10 @@ func TestSaveExceptionsConcurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 	assert.Equal(t, goroutines, len(paths))
 }
 

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -12,6 +12,7 @@ import (
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	objectsenvelopes "github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToScanInfo(t *testing.T) {
@@ -90,23 +91,23 @@ func TestSaveExceptions(t *testing.T) {
 			{PolicyType: "postureExceptionPolicy", PortalBase: armotypes.PortalBase{Name: "ex-A"}},
 		}
 		path, err := saveExceptions(exceptions)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer os.Remove(path)
 
 		buf, err := os.ReadFile(path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		var got []armotypes.PostureExceptionPolicy
-		assert.NoError(t, json.Unmarshal(buf, &got))
+		require.NoError(t, json.Unmarshal(buf, &got))
 		assert.Equal(t, exceptions, got)
 	}
 	{
 		exceptions := []armotypes.PostureExceptionPolicy{{PortalBase: armotypes.PortalBase{Name: "ex"}}}
 		p1, err := saveExceptions(exceptions)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer os.Remove(p1)
 
 		p2, err := saveExceptions(exceptions)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer os.Remove(p2)
 
 		assert.NotEqual(t, p1, p2)
@@ -127,13 +128,13 @@ func TestSaveExceptionsConcurrent(t *testing.T) {
 				{PortalBase: armotypes.PortalBase{Name: "ex-" + string(rune('A'+id))}},
 			}
 			path, err := saveExceptions(exceptions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer os.Remove(path)
 
 			buf, err := os.ReadFile(path)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			var got []armotypes.PostureExceptionPolicy
-			assert.NoError(t, json.Unmarshal(buf, &got))
+			require.NoError(t, json.Unmarshal(buf, &got))
 			assert.Equal(t, exceptions, got)
 
 			mu.Lock()

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -1,8 +1,12 @@
 package v1
 
 import (
+	"encoding/json"
+	"os"
+	"sync"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
@@ -78,6 +82,67 @@ func TestToScanInfo(t *testing.T) {
 		assert.Equal(t, "nginx", s.ScanObject.GetName())
 		assert.Equal(t, "ns1", s.ScanObject.GetNamespace())
 	}
+}
+
+func TestSaveExceptions(t *testing.T) {
+	{
+		exceptions := []armotypes.PostureExceptionPolicy{
+			{PolicyType: "postureExceptionPolicy", PortalBase: armotypes.PortalBase{Name: "ex-A"}},
+		}
+		path, err := saveExceptions(exceptions)
+		assert.NoError(t, err)
+		defer os.Remove(path)
+
+		buf, err := os.ReadFile(path)
+		assert.NoError(t, err)
+		var got []armotypes.PostureExceptionPolicy
+		assert.NoError(t, json.Unmarshal(buf, &got))
+		assert.Equal(t, exceptions, got)
+	}
+	{
+		exceptions := []armotypes.PostureExceptionPolicy{{PortalBase: armotypes.PortalBase{Name: "ex"}}}
+		p1, err := saveExceptions(exceptions)
+		assert.NoError(t, err)
+		defer os.Remove(p1)
+
+		p2, err := saveExceptions(exceptions)
+		assert.NoError(t, err)
+		defer os.Remove(p2)
+
+		assert.NotEqual(t, p1, p2)
+	}
+}
+
+func TestSaveExceptionsConcurrent(t *testing.T) {
+	const goroutines = 32
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	paths := make(map[string]struct{}, goroutines)
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			exceptions := []armotypes.PostureExceptionPolicy{
+				{PortalBase: armotypes.PortalBase{Name: "ex-" + string(rune('A'+id))}},
+			}
+			path, err := saveExceptions(exceptions)
+			assert.NoError(t, err)
+			defer os.Remove(path)
+
+			buf, err := os.ReadFile(path)
+			assert.NoError(t, err)
+			var got []armotypes.PostureExceptionPolicy
+			assert.NoError(t, json.Unmarshal(buf, &got))
+			assert.Equal(t, exceptions, got)
+
+			mu.Lock()
+			paths[path] = struct{}{}
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, goroutines, len(paths))
 }
 
 func TestSetTargetInScanInfo(t *testing.T) {

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -85,6 +85,22 @@ func TestToScanInfo(t *testing.T) {
 	}
 }
 
+func TestToScanInfoExceptionsCleanup(t *testing.T) {
+	req := &utilsmetav1.PostScanRequest{
+		Exceptions: []armotypes.PostureExceptionPolicy{
+			{PortalBase: armotypes.PortalBase{Name: "ex"}},
+		},
+	}
+	s := ToScanInfo(req)
+	require.NotEmpty(t, s.UseExceptions)
+	_, err := os.Stat(s.UseExceptions)
+	require.NoError(t, err)
+
+	s.Cleanup()
+	_, err = os.Stat(s.UseExceptions)
+	assert.True(t, os.IsNotExist(err), "expected exceptions temp file to be removed by Cleanup, got err=%v", err)
+}
+
 func TestSaveExceptions(t *testing.T) {
 	{
 		exceptions := []armotypes.PostureExceptionPolicy{


### PR DESCRIPTION
## Overview 
                                                                                   
  `saveExceptions` in the HTTP scan handler wrote every request's exceptions       
  to a single hardcoded path, `/tmp/exceptions.json`. Concurrent                 
  `POST /v1/scan` handlers race on that path: the queued-but-not-yet-executing     
  scan ends up reading the latest writer's payload and applies the wrong           
  exceptions silently. A mid-write read can also fail JSON unmarshal, in           
  which case `core/pkg/policyhandler/handlepullpolicies.go:88-90` catches          
  the error, logs `Warning("failed to load exceptions")`, and the scan             
  proceeds with no exceptions at all. The author flagged this with                 
  `// FIXME potential race condition` when the feature landed in 2024 and          
  it has not been addressed since.                                                 
                                                                                   
  This PR replaces the hardcoded path with `os.CreateTemp("", "kubescape-exceptions-*.json")`                                                  
  inside `saveExceptions`, so every request gets a unique file with mode           
  `0600`. The race is eliminated because no two requests share a path. The         
  FIXME comment and the unused `path/filepath` import are removed.                 
                                                                                   
  **Current behavior:** two scans submitted with different exception lists         
  can apply each other's exceptions, depending on which write lands second.        
                                                                                   
  **New behavior:** each request writes to its own temp file; concurrent           
  requests cannot interfere with one another's exception filtering.                
                                                                                   
  ## Additional Information                                    
                                                                                   
  - The `httphandler/go.mod` and `httphandler/go.sum` bump                         
    (`opa-utils v0.0.288 → v0.0.293`) is a side-effect of `go mod tidy`,
    which is required for the submodule to build cleanly — the parent              
    module already pins `opa-utils v0.0.293` and the local                         
    `replace ../` made the older submodule pin inconsistent.                       
  - Cleanup of the temp file (so it does not leak in the OS temp dir for           
    the lifetime of the kubescape server) is intentionally **out of scope          
    here**. Proper cleanup needs to span the async scan goroutine that             
    consumes `scanInfo.UseExceptions` later in the pipeline                        
    (`core/core/scan.go:151`), and is best handled in a dedicated                  
    follow-up PR.                                                                  
                                                                                   
  ## How to Test                                                                   
                                                               
  From the `httphandler/` submodule:                                               
   
  ```bash                                                                          
  # unit tests for the changed function                        
  go test -v -run TestSaveExceptions ./handlerequests/v1/
                                                                                   
  # race detector
  go test -race -run TestSaveExceptions ./handlerequests/v1/                       
                                                                                   
  # whole submodule
  go test ./...  

```                                                                  
                                                               
  The new tests cover three properties:                                            
  1. saveExceptions writes the marshalled payload to the returned path
  and the file unmarshals back to the original input.                              
  2. Successive calls return distinct paths.                   
  3. 32 concurrent goroutines each receive a unique path and find their            
  own payload intact when reading back, this would deterministically              
  fail against the previous hardcoded-path implementation.                         
                                                                                   
  End-to-end, the bug also reproduces against a running kubescape server           
  by issuing two POST /v1/scan requests in quick succession with                   
  different exceptions arrays — pre-fix, one scan reads the other's                
  payload; post-fix, each scan reads its own.                                      
                                                                                   
  Related issues/PRs                                                               
                                                               
  - Resolves #2008                                                          
   
  Checklist before requesting a review                                             
                                                               
  - My code follows the style guidelines of this project
  - I have commented on my code, particularly in hard-to-understand areas
  - I have performed a self-review of my code                                      
  - If it is a core feature, I have added thorough tests.
  - New and existing unit tests pass locally with my changes   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Exception persistence now writes to per-call temporary files for improved reliability and concurrent safety.
  * Scan objects can now register additional cleanup callbacks for better resource management.

* **Chores**
  * Updated a Go module dependency to a newer stable version.

* **Tests**
  * Added tests for exception persistence, including concurrent stress tests, uniqueness checks, JSON round-trip verification, and cleanup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->