### PR TITLE
test(resourcehandler): add tests for partial GVR collection failure and InfoMap propagation

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -101,18 +101,8 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	for _, f := range failedQueries {
 		logger.L().Ctx(ctx).Warning("failed to pull resource type",
 			helpers.String("gvr", f.gvr), helpers.Error(f.err))
-		// InfoMap and ResourceToControlsMap are both keyed by raw GVR, not by
-		// query string, so we can only mark controls as skipped when the whole
-		// resource type is absent. If any selector-specific query succeeded and
-		// populated k8sResourcesMap[gvr], the control already has data to
-		// evaluate; marking it skipped via a sibling-query failure would be
-		// incorrect. A follow-up should introduce query-granular control mapping
-		// so partial-collection failures can be surfaced with the right scope.
-		if len(k8sResourcesMap[f.gvr]) > 0 {
-			continue
-		}
-		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, sessionObj.InfoMap)
 	}
+	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, sessionObj.InfoMap)
 
 	// add single resource to k8s resources map (for single resource scan)
 	if !scanInfo.IsDeletedScanObject {
@@ -379,6 +369,24 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 	}
 
 	return k8sResources, allResources, failedQueries
+}
+
+// recordFailedQueryStatuses writes a StatusSkipped entry to infoMap for each
+// failed GVR that has no successfully collected resources in k8sResources.
+// InfoMap and ResourceToControlsMap are both keyed by raw GVR, not by query
+// string, so we can only mark controls as skipped when the whole resource type
+// is absent. If any selector-specific query succeeded and populated
+// k8sResources[gvr], the control already has data to evaluate; marking it
+// skipped via a sibling-query failure would be incorrect. A follow-up should
+// introduce query-granular control mapping so partial-collection failures can
+// be surfaced with the right scope.
+func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResources cautils.K8SResources, infoMap map[string]apis.StatusInfo) {
+	for _, f := range failedQueries {
+		if len(k8sResources[f.gvr]) > 0 {
+			continue
+		}
+		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, infoMap)
+	}
 }
 
 func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, error) {

--- a/core/pkg/resourcehandler/k8sresourcesutils_test.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils_test.go
@@ -3,8 +3,11 @@ package resourcehandler
 import (
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +22,92 @@ func TestSsEmptyImgVulns(t *testing.T) {
 	externalResourcesMap["armo.vuln.images/v1/ImageVulnerabilities"] = []string{}
 	externalResourcesMap["bla"] = []string{"blu"}
 	assert.Equal(t, true, isEmptyImgVulns(externalResourcesMap))
+}
+
+// TestSetComplexKSResourceMap_IncludesRuleMatch verifies that setComplexKSResourceMap
+// populates resourceToControls from rule.Match (regular K8s resources), not only
+// from rule.DynamicMatch. This is required so that when pullResources fails to
+// fetch a GVR, SetInfoMapForResources can link the GVR key back to the controls
+// that depend on it via mapControlToInfo.
+func TestSetComplexKSResourceMap_IncludesRuleMatch(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	controlID := "C-0035"
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{"rbac.authorization.k8s.io"},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"clusterrolebindings"},
+	}
+	rule := reporthandling.PolicyRule{
+		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", "rule-rbac", nil),
+		Match:      []reporthandling.RuleMatchObjects{match},
+	}
+	control := reporthandling.Control{
+		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", "ctrl-rbac", nil),
+		ControlID:  controlID,
+		Rules:      []reporthandling.PolicyRule{rule},
+	}
+	framework := reporthandling.Framework{
+		Controls: []reporthandling.Control{control},
+	}
+
+	resourceToControls := map[string][]string{}
+	setComplexKSResourceMap([]reporthandling.Framework{framework}, resourceToControls)
+
+	// At least one GVR key for clusterrolebindings should map to the control.
+	found := false
+	for _, controlIDs := range resourceToControls {
+		for _, id := range controlIDs {
+			if id == controlID {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "ResourceToControlsMap should contain the control ID for a rule.Match GVR")
+}
+
+// TestSetComplexKSResourceMap_RuleMatchKeyMatchesPullResourcesKey verifies that
+// the GVR keys written into resourceToControls by setComplexKSResourceMap use the
+// same format as the GroupVersionResourceTriplet strings produced by
+// getQueryableResourceMapFromPolicies — the two must match for the InfoMap path
+// to correctly link a failed pull to its affected controls.
+func TestSetComplexKSResourceMap_RuleMatchKeyMatchesPullResourcesKey(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"clusterrolebindings"},
+	}
+	rule := reporthandling.PolicyRule{
+		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", "rule-rbac", nil),
+		Match:      []reporthandling.RuleMatchObjects{match},
+	}
+	control := reporthandling.Control{
+		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", "ctrl-rbac", nil),
+		ControlID:  "C-0035",
+		Rules:      []reporthandling.PolicyRule{rule},
+	}
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{control}}
+
+	// Keys from ResourceToControlsMap (built by setComplexKSResourceMap).
+	resourceToControls := map[string][]string{}
+	setComplexKSResourceMap([]reporthandling.Framework{framework}, resourceToControls)
+
+	// Keys from QueryableResources (built by getQueryableResourceMapFromPolicies).
+	queryable, _ := getQueryableResourceMapFromPolicies(
+		[]reporthandling.Framework{framework},
+		nil,
+		reporthandling.ScopeCluster,
+	)
+
+	// Every QueryableResource GVR that appears in QueryableResources should also
+	// appear in resourceToControls so InfoMap lookups succeed.
+	for qKey := range queryable {
+		_, exists := resourceToControls[qKey]
+		assert.True(t, exists,
+			"GVR %q is in QueryableResources but missing from ResourceToControlsMap", qKey)
+	}
 }
 
 func Test_getWorkloadFromScanObject(t *testing.T) {

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -1,0 +1,196 @@
+package resourcehandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	"k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+// gvrToListKind registers the GVRs used in these tests so the fake dynamic
+// client doesn't panic when List is called on them.
+var testGVRToListKind = map[schema.GroupVersionResource]string{
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+	{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	{Group: "", Version: "v1", Resource: "somecrd"}:                                       "SomeCRDList",
+}
+
+// newHandlerWithReactor builds a K8sResourceHandler whose dynamic client
+// prepends a reactor so tests can inject per-GVR errors.
+func newHandlerWithReactor(t *testing.T, reactor k8stesting.ReactionFunc) *K8sResourceHandler {
+	t.Helper()
+	client := fakeclientset.NewClientset()
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), testGVRToListKind)
+	dynClient.Fake.PrependReactor("list", "*", reactor)
+
+	k8s := &k8sinterface.KubernetesApi{
+		KubernetesClient: client,
+		DynamicClient:    dynClient,
+		DiscoveryClient:  client.Discovery(),
+		Context:          context.Background(),
+	}
+	return NewK8sResourceHandler(k8s, nil, nil, "test-cluster")
+}
+
+// TestPullResources_NonForbiddenErrorRecorded verifies that a non-404 API error
+// (e.g. 403 Forbidden) is recorded in failedQueries so the caller can surface
+// the affected control as skipped rather than falsely passed.
+func TestPullResources_NonForbiddenErrorRecorded(t *testing.T) {
+	forbiddenErr := fmt.Errorf("forbidden: User cannot list clusterrolebindings")
+
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, forbiddenErr
+	})
+
+	qrs := QueryableResources{
+		"rbac.authorization.k8s.io/v1/clusterrolebindings": QueryableResource{
+			GroupVersionResourceTriplet: "rbac.authorization.k8s.io/v1/clusterrolebindings",
+		},
+	}
+
+	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+
+	require.Len(t, failedQueries, 1, "expected one failed query entry")
+	for _, f := range failedQueries {
+		assert.Equal(t, "rbac.authorization.k8s.io/v1/clusterrolebindings", f.gvr)
+		assert.ErrorContains(t, f.err, "forbidden")
+	}
+}
+
+// TestPullResources_NotFoundErrorIgnored verifies that a "server could not find
+// the requested resource" error (CRD not installed) is silently ignored and does
+// NOT appear in failedQueries — this is expected behaviour when a control
+// references an optional CRD that isn't present on the cluster.
+func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("the server could not find the requested resource")
+	})
+
+	qrs := QueryableResources{
+		"/v1/somecrd": QueryableResource{
+			GroupVersionResourceTriplet: "/v1/somecrd",
+		},
+	}
+
+	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+
+	assert.Empty(t, failedQueries, "404-style errors should not be recorded as failures")
+}
+
+// TestPullResources_PartialFailure verifies that when one GVR succeeds and
+// another fails, only the failed GVR appears in failedQueries and allResources
+// is still non-empty (scan continues).
+func TestPullResources_PartialFailure(t *testing.T) {
+	forbiddenGVR := "rbac.authorization.k8s.io/v1/clusterrolebindings"
+
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Resource == "clusterrolebindings" {
+			return true, nil, fmt.Errorf("forbidden: cannot list clusterrolebindings")
+		}
+		// pods succeeds — return empty list
+		return false, nil, nil
+	})
+
+	qrs := QueryableResources{
+		forbiddenGVR: QueryableResource{
+			GroupVersionResourceTriplet: forbiddenGVR,
+		},
+		"/v1/pods": QueryableResource{
+			GroupVersionResourceTriplet: "/v1/pods",
+		},
+	}
+
+	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+
+	assert.Len(t, failedQueries, 1)
+	for _, f := range failedQueries {
+		assert.Equal(t, forbiddenGVR, f.gvr)
+	}
+}
+
+// TestPullResources_TotalFailure verifies that when every query fails,
+// failedQueries contains all of them and allResources is empty.
+func TestPullResources_TotalFailure(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden: no permissions")
+	})
+
+	qrs := QueryableResources{
+		"rbac.authorization.k8s.io/v1/clusterrolebindings": QueryableResource{
+			GroupVersionResourceTriplet: "rbac.authorization.k8s.io/v1/clusterrolebindings",
+		},
+		"/v1/pods": QueryableResource{
+			GroupVersionResourceTriplet: "/v1/pods",
+		},
+	}
+
+	_, allResources, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+
+	assert.Empty(t, allResources, "no resources should be collected when all queries fail")
+	assert.Len(t, failedQueries, 2, "both failed GVRs should be recorded")
+}
+
+// TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent verifies that when a GVR
+// fails and k8sResourcesMap has no data for it, the GVR is written to InfoMap
+// so mapControlToInfo can mark the affected controls as skipped.
+func TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent(t *testing.T) {
+	failedGVR := "rbac.authorization.k8s.io/v1/clusterrolebindings"
+	infoMap := map[string]apis.StatusInfo{}
+
+	// simulate: the GVR failed AND k8sResourcesMap has no entries for it
+	k8sResourcesMap := cautils.K8SResources{
+		failedGVR: []string{}, // empty — no successful pull
+	}
+	failedQueries := map[string]queryFailure{
+		failedGVR: {gvr: failedGVR, err: fmt.Errorf("forbidden")},
+	}
+
+	for _, f := range failedQueries {
+		if len(k8sResourcesMap[f.gvr]) > 0 {
+			continue
+		}
+		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, infoMap)
+	}
+
+	info, ok := infoMap[failedGVR]
+	require.True(t, ok, "InfoMap should have an entry for the failed GVR")
+	assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
+	assert.Contains(t, info.InnerInfo, "forbidden")
+}
+
+// TestGetResources_InfoMapNotWrittenWhenGVRHasData verifies that when a GVR
+// failed for one field-selector query but another query for the same GVR
+// succeeded and populated k8sResourcesMap, InfoMap is NOT written — preventing
+// controls from being incorrectly marked skipped when they do have data.
+func TestGetResources_InfoMapNotWrittenWhenGVRHasData(t *testing.T) {
+	gvr := "/v1/pods"
+	infoMap := map[string]apis.StatusInfo{}
+
+	// One namespace selector succeeded and added a resource ID.
+	k8sResourcesMap := cautils.K8SResources{
+		gvr: []string{"default/pod-abc"},
+	}
+	failedQueries := map[string]queryFailure{
+		gvr + "/metadata.namespace=prod": {gvr: gvr, err: fmt.Errorf("forbidden for prod")},
+	}
+
+	for _, f := range failedQueries {
+		if len(k8sResourcesMap[f.gvr]) > 0 {
+			continue
+		}
+		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, infoMap)
+	}
+
+	assert.Empty(t, infoMap, "InfoMap should NOT be written when k8sResourcesMap already has data for the GVR")
+}

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
@@ -89,16 +90,38 @@ func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
 }
 
 // TestPullResources_PartialFailure verifies that when one GVR succeeds and
-// another fails, only the failed GVR appears in failedQueries and allResources
-// is still non-empty (scan continues).
+// another fails, only the failed GVR appears in failedQueries AND the
+// successful resource still lands in allResources / k8sResources — proving the
+// "scan continues" half of the contract, not just the "error is recorded" half.
 func TestPullResources_PartialFailure(t *testing.T) {
 	forbiddenGVR := "rbac.authorization.k8s.io/v1/clusterrolebindings"
+	podsGVR := "/v1/pods"
+
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "pod-survives",
+				"namespace": "default",
+			},
+		},
+	}
+	podList := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+		Items: []unstructured.Unstructured{*pod},
+	}
 
 	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.GetResource().Resource == "clusterrolebindings" {
 			return true, nil, fmt.Errorf("forbidden: cannot list clusterrolebindings")
 		}
-		// pods succeeds — return empty list
+		if action.GetResource().Resource == "pods" {
+			return true, podList, nil
+		}
 		return false, nil, nil
 	})
 
@@ -106,16 +129,24 @@ func TestPullResources_PartialFailure(t *testing.T) {
 		forbiddenGVR: QueryableResource{
 			GroupVersionResourceTriplet: forbiddenGVR,
 		},
-		"/v1/pods": QueryableResource{
-			GroupVersionResourceTriplet: "/v1/pods",
+		podsGVR: QueryableResource{
+			GroupVersionResourceTriplet: podsGVR,
 		},
 	}
 
-	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+	k8sResources, allResources, failedQueries := handler.pullResources(qrs, &EmptySelector{})
 
+	// failed query is recorded
 	assert.Len(t, failedQueries, 1)
 	for _, f := range failedQueries {
 		assert.Equal(t, forbiddenGVR, f.gvr)
+	}
+
+	// successful pod survives in both maps — this is what "scan continues" means
+	assert.Len(t, allResources, 1, "the successful pod must still be collected")
+	assert.Len(t, k8sResources[podsGVR], 1, "k8sResources[pods] must contain the surviving pod ID")
+	for id := range allResources {
+		assert.Contains(t, id, "pod-survives")
 	}
 }
 
@@ -141,14 +172,14 @@ func TestPullResources_TotalFailure(t *testing.T) {
 	assert.Len(t, failedQueries, 2, "both failed GVRs should be recorded")
 }
 
-// TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent verifies that when a GVR
-// fails and k8sResourcesMap has no data for it, the GVR is written to InfoMap
-// so mapControlToInfo can mark the affected controls as skipped.
-func TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent(t *testing.T) {
+// TestRecordFailedQueryStatuses_WrittenWhenGVRTotallyAbsent verifies that when
+// a GVR fails and k8sResources has no data for it, the helper writes a
+// StatusSkipped entry into infoMap so mapControlToInfo can mark the affected
+// controls as skipped. Drives the real production helper, not an inlined copy.
+func TestRecordFailedQueryStatuses_WrittenWhenGVRTotallyAbsent(t *testing.T) {
 	failedGVR := "rbac.authorization.k8s.io/v1/clusterrolebindings"
 	infoMap := map[string]apis.StatusInfo{}
 
-	// simulate: the GVR failed AND k8sResourcesMap has no entries for it
 	k8sResourcesMap := cautils.K8SResources{
 		failedGVR: []string{}, // empty — no successful pull
 	}
@@ -156,12 +187,7 @@ func TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent(t *testing.T) {
 		failedGVR: {gvr: failedGVR, err: fmt.Errorf("forbidden")},
 	}
 
-	for _, f := range failedQueries {
-		if len(k8sResourcesMap[f.gvr]) > 0 {
-			continue
-		}
-		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, infoMap)
-	}
+	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
 
 	info, ok := infoMap[failedGVR]
 	require.True(t, ok, "InfoMap should have an entry for the failed GVR")
@@ -169,15 +195,15 @@ func TestGetResources_InfoMapWrittenWhenGVRTotallyAbsent(t *testing.T) {
 	assert.Contains(t, info.InnerInfo, "forbidden")
 }
 
-// TestGetResources_InfoMapNotWrittenWhenGVRHasData verifies that when a GVR
-// failed for one field-selector query but another query for the same GVR
-// succeeded and populated k8sResourcesMap, InfoMap is NOT written — preventing
-// controls from being incorrectly marked skipped when they do have data.
-func TestGetResources_InfoMapNotWrittenWhenGVRHasData(t *testing.T) {
+// TestRecordFailedQueryStatuses_NotWrittenWhenGVRHasData verifies that when a
+// GVR failed for one field-selector query but another query for the same GVR
+// succeeded and populated k8sResources, the helper does NOT write to infoMap —
+// preventing controls from being incorrectly marked skipped when they do have
+// data. Drives the real production helper.
+func TestRecordFailedQueryStatuses_NotWrittenWhenGVRHasData(t *testing.T) {
 	gvr := "/v1/pods"
 	infoMap := map[string]apis.StatusInfo{}
 
-	// One namespace selector succeeded and added a resource ID.
 	k8sResourcesMap := cautils.K8SResources{
 		gvr: []string{"default/pod-abc"},
 	}
@@ -185,12 +211,7 @@ func TestGetResources_InfoMapNotWrittenWhenGVRHasData(t *testing.T) {
 		gvr + "/metadata.namespace=prod": {gvr: gvr, err: fmt.Errorf("forbidden for prod")},
 	}
 
-	for _, f := range failedQueries {
-		if len(k8sResourcesMap[f.gvr]) > 0 {
-			continue
-		}
-		cautils.SetInfoMapForResources(f.err.Error(), []string{f.gvr}, infoMap)
-	}
+	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
 
-	assert.Empty(t, infoMap, "InfoMap should NOT be written when k8sResourcesMap already has data for the GVR")
+	assert.Empty(t, infoMap, "InfoMap should NOT be written when k8sResources already has data for the GVR")
 }


### PR DESCRIPTION
## Overview

So the previous PR (#1997) fixed a real bug where kubescape was swallowing errors when it failed to pull certain resource types. That fix landed but the checklist item for tests was left unchecked. This PR adds those tests.

The tests basically verify the three things the fix relies on working correctly. First, that when a GVR pull fails with a real error (like a 403), it actually gets recorded and doesn't just get dropped. Second, that 404-style errors (resource type not installed on the cluster) stay silent like they should. And third, that the InfoMap guard works right, meaning we only mark a control as skipped when we have zero data for that GVR, not when another field selector query for the same GVR already succeeded.

I also added two tests for the `setComplexKSResourceMap` change that was part of that PR. One checks that `rule.Match` GVRs actually end up in `ResourceToControlsMap`, and the other checks that the key format matches what `pullResources` uses, since the whole InfoMap propagation path breaks silently if those keys don't line up.

Honestly the key format one is the test I most wanted to write. That mismatch would be really annoying to debug if someone changed one side without knowing about the other.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for Kubernetes resource handling: validating resource-to-control mapping and GVR key formatting, and covering partial/total query failures and recording of failed query statuses.
* **Refactor**
  * Consolidated per-query failure status handling into a shared helper to centralize how failed resource queries are recorded and surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->