### PR TITLE
test(resourcehandler): ensure scan integrity by verifying surfaced API pull errors

### DIFF
--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -1,0 +1,162 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type mockDynamicClient struct {
+	dynamic.Interface
+	listFunc func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+}
+
+func (m *mockDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &mockNamespaceableResourceClient{listFunc: m.listFunc}
+}
+
+type mockNamespaceableResourceClient struct {
+	dynamic.NamespaceableResourceInterface
+	listFunc func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+}
+
+func (m *mockNamespaceableResourceClient) Namespace(s string) dynamic.ResourceInterface {
+	return m
+}
+
+func (m *mockNamespaceableResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return m.listFunc(ctx, opts)
+}
+
+func TestPullResources_PartialFailureSurface(t *testing.T) {
+	mockErr := errors.New("simulated API failure")
+	mockClient := &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			if opts.FieldSelector == "metadata.name=fail" {
+				return nil, mockErr
+			}
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata": map[string]interface{}{
+								"name":      "test-pod",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	k8sApi := &k8sinterface.KubernetesApi{
+		DynamicClient: mockClient,
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: k8sApi,
+	}
+
+	queryableResources := QueryableResources{
+		"//v1/configmaps/metadata.name=ok": QueryableResource{
+			GroupVersionResourceTriplet: "//v1/configmaps",
+			FieldSelectors:              "metadata.name=ok",
+		},
+		"//v1/configmaps/metadata.name=fail": QueryableResource{
+			GroupVersionResourceTriplet: "//v1/configmaps",
+			FieldSelectors:              "metadata.name=fail",
+		},
+	}
+
+	k8sResourcesMap, allResources, failedQueries := handler.pullResources(queryableResources, &EmptySelector{})
+
+	// Verify that the successful selector populated the shared raw-GVR bucket.
+	assert.Len(t, allResources, 1)
+	assert.Len(t, k8sResourcesMap["//v1/configmaps"], 1)
+
+	// Verify that the failed selector is retained under its selector-qualified key.
+	assert.Len(t, failedQueries, 1)
+	fq, ok := failedQueries["//v1/configmaps/metadata.name=fail"]
+	assert.True(t, ok, "expected failed query key to include the field selector")
+	assert.Equal(t, "//v1/configmaps", fq.gvr)
+	assert.ErrorContains(t, fq.err, "simulated API failure")
+}
+
+func TestGetResources_SurfacesMissingGVRFailuresInInfoMap(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			if opts.FieldSelector != "" {
+				return nil, errors.New("simulated API failure")
+			}
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Namespace",
+						"metadata": map[string]interface{}{
+							"name": "default",
+						},
+					},
+				}},
+			}, nil
+		},
+	}
+
+	rule := mockRule("rule-a", nil, "")
+	rule.Match = append(rule.Match, mockMatch(6), mockMatch(4))
+	control := mockControl("control-1", nil)
+	control.Rules = append(control.Rules, rule)
+	framework := mockFramework("test", nil)
+	framework.Controls = append(framework.Controls, control)
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.TODO(), nil, nil, scanInfo)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.TODO(), sessionObj, scanInfo)
+	assert.NoError(t, err)
+
+	info, ok := sessionObj.InfoMap["core/v1/secrets"]
+	assert.True(t, ok, "expected missing secrets GVR to be surfaced in InfoMap")
+	assert.Contains(t, info.InnerInfo, "simulated API failure")
+}
+
+func TestGetResources_FailsWhenAllQueriesFail(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return nil, errors.New("simulated API failure")
+		},
+	}
+
+	rule := mockRule("rule-a", nil, "")
+	rule.Match = append(rule.Match, mockMatch(4))
+	control := mockControl("control-1", nil)
+	control.Rules = append(control.Rules, rule)
+	framework := mockFramework("test", nil)
+	framework.Controls = append(framework.Controls, control)
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.TODO(), nil, nil, scanInfo)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.TODO(), sessionObj, scanInfo)
+	assert.ErrorContains(t, err, "failed to pull any Kubernetes resources")
+	assert.ErrorContains(t, err, "simulated API failure")
+}


### PR DESCRIPTION
## Overview
This PR fixes a critical issue where resource pull errors were silently ignored, causing partial Kubernetes scans to be reported as complete.

### Key Changes
- **Error Propagation Refactor:**  
  `pullResources` no longer suppresses errors when partial resources are fetched. Instead, it now returns a `map[string]queryFailure` capturing all per-query failures.

- **Fatal State Handling:**  
  If no resources are fetched and failures exist (`len(allResources) == 0 && len(failedQueries) > 0`), the scan now correctly fails immediately.

- **Partial Failure Visibility:**  
  In partial success scenarios, failures are now surfaced via `OPASessionObj.InfoMap`, ensuring they are reflected in the final scan report as skipped/missing resources rather than being silently ignored.

- **Reliability Improvement:**  
  Prevents false negatives and misleading "successful" scan results when the scanner operates on incomplete data due to API errors or RBAC restrictions.


## Additional Information
Previously, the following logic caused silent error suppression:
```go
if errs != nil && len(allResources) > 0 {
    errs = nil
}
```
This resulted in:

- Incomplete scans being treated as successful
- Security reports missing critical resources without any indication
- CI/CD pipelines falsely passing despite degraded scans

This PR removes that behavior and ensures all failures are either:

- Properly surfaced in the report, or
- Cause the scan to fail (in fatal scenarios)


## How to Test

1. Set up a Kubernetes cluster.

2. Create a ServiceAccount with restricted RBAC permissions:
   - Allow: Pods
   - Deny: Deployments, ConfigMaps, etc.

3. Run:
```bash
kubescape scan --account <account>
```
4. Verify:
   - Scan does not silently succeed with incomplete data
   - Failures are either:
     - Explicitly surfaced in the report, OR
     - Cause the scan to fail (if no resources fetched)


## Examples/Screenshots

N/A (logic-level fix, no UI impact)


## Related issues/PRs:

- This PR provides the regression testing for the logic introduced in #1997 and ensures future stability of the resource collection pipeline.


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes


## Tests Added

### Test: `TestPullResources_PartialFailureSurface`

- File: `core/pkg/resourcehandler/k8sresources_pull_test.go`

#### What it Covers:

- Simulates partial API failures using a mocked dynamic client

- Ensures:
  - Successful resources are still processed
  - Failed queries are not suppressed
  - Errors are correctly captured in `failedQueries`

#### Test Snippet:
```go
func TestPullResources_PartialFailureSurface(t *testing.T) {
    mockErr := errors.New("simulated API failure")
    mockClient := &mockDynamicClient{
        listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
            if opts.FieldSelector == "metadata.name=fail" {
                return nil, mockErr
            }
            // returns success for other objects
        },
    }

    // Initialization and execution
    k8sResourcesMap, allResources, failedQueries := handler.pullResources(queryableResources, &EmptySelector{})

    // Assertions
    assert.Len(t, failedQueries, 1)
    for _, fq := range failedQueries {
        assert.Equal(t, "//v1/configmaps", fq.gvr)
        assert.ErrorContains(t, fq.err, "simulated API failure")
    }
}
```
## Impact

- Ensures scan results are accurate and trustworthy
- Eliminates silent data loss during resource fetching
- Prevents false negatives and misleading posture reports
- Enables CI/CD systems to correctly detect incomplete scans and fail when necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering partial failures when fetching Kubernetes resources, verifying successful items are retained and failures are recorded.
  * Added tests that ensure missing resource mapping failures are surfaced without aborting the overall operation.
  * Added tests that verify an appropriate error is returned when all resource fetches fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->