### PR TITLE
Feat/helm values overrides scan

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -96,6 +96,15 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 
+	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
+	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmValueFiles, "values", nil, "Specify Helm values in a YAML file or a URL when scanning a Helm chart (can specify multiple)")
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetValues, "set", nil, "Set Helm values on the command line when scanning a Helm chart (can specify multiple, e.g. key1=val1,key2=val2)")
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetStringValues, "set-string", nil, "Set Helm STRING values on the command line when scanning a Helm chart (can specify multiple)")
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetFileValues, "set-file", nil, "Set Helm values from respective files specified via the command line (can specify multiple)")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.HelmReleaseName, "release-name", "", "Helm release name made available as .Release.Name when rendering the chart")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.HelmReleaseNamespace, "release-namespace", "", "Helm release namespace made available as .Release.Namespace when rendering the chart")
+
 	scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead. Flag will be removed at 1.Dec.2023")
 	scanCmd.PersistentFlags().MarkDeprecated("create-account", "Create account is no longer supported. In case of a missing Account ID and a configured backend server, a new account id will be generated automatically by Kubescape. Feel free to contact the Kubescape maintainers for more information.")
 

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -98,10 +98,15 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
 	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.
-	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmValueFiles, "values", nil, "Specify Helm values in a YAML file or a URL when scanning a Helm chart (can specify multiple)")
-	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetValues, "set", nil, "Set Helm values on the command line when scanning a Helm chart (can specify multiple, e.g. key1=val1,key2=val2)")
-	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetStringValues, "set-string", nil, "Set Helm STRING values on the command line when scanning a Helm chart (can specify multiple)")
-	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmSetFileValues, "set-file", nil, "Set Helm values from respective files specified via the command line (can specify multiple)")
+	//
+	// We use StringArrayVar (not StringSliceVar) here to match upstream Helm exactly: StringSliceVar
+	// would split each occurrence on commas, which corrupts valid strvals expressions such as
+	// `--set tolerations={a,b}` or `--set "list={x\,y}"`. StringArrayVar appends each --flag value
+	// verbatim and lets helm's own values parser handle splitting.
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmValueFiles, "values", nil, "Specify Helm values in a YAML file or a URL when scanning a Helm chart (can specify multiple)")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetValues, "set", nil, "Set Helm values on the command line when scanning a Helm chart (can specify multiple, e.g. --set key1=val1 --set key2=val2)")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetStringValues, "set-string", nil, "Set Helm STRING values on the command line when scanning a Helm chart (can specify multiple)")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetFileValues, "set-file", nil, "Set Helm values from respective files specified via the command line (can specify multiple)")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HelmReleaseName, "release-name", "", "Helm release name made available as .Release.Name when rendering the chart")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HelmReleaseNamespace, "release-namespace", "", "Helm release namespace made available as .Release.Namespace when rendering the chart")
 

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -99,11 +99,13 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
 	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.
 	//
-	// We use StringArrayVar (not StringSliceVar) here to match upstream Helm exactly: StringSliceVar
-	// would split each occurrence on commas, which corrupts valid strvals expressions such as
-	// `--set tolerations={a,b}` or `--set "list={x\,y}"`. StringArrayVar appends each --flag value
-	// verbatim and lets helm's own values parser handle splitting.
-	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmValueFiles, "values", nil, "Specify Helm values in a YAML file or a URL when scanning a Helm chart (can specify multiple)")
+	// Flag-binding choices match upstream Helm (helm.sh/helm/v3 cmd/helm/flags.go) exactly:
+	//   --values     -> StringSliceVar : Helm splits on commas, so `--values a.yaml,b.yaml` is two files.
+	//   --set        -> StringArrayVar : verbatim; commas inside the value belong to the strvals parser
+	//                                    and must survive (e.g. `--set tolerations={a,b}`).
+	//   --set-string -> StringArrayVar : same reasoning as --set.
+	//   --set-file   -> StringArrayVar : same reasoning as --set.
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.HelmValueFiles, "values", nil, "Specify Helm values in a YAML file or a URL when scanning a Helm chart (can specify multiple, or separate paths with commas)")
 	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetValues, "set", nil, "Set Helm values on the command line when scanning a Helm chart (can specify multiple, e.g. --set key1=val1 --set key2=val2)")
 	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetStringValues, "set-string", nil, "Set Helm STRING values on the command line when scanning a Helm chart (can specify multiple)")
 	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.HelmSetFileValues, "set-file", nil, "Set Helm values from respective files specified via the command line (can specify multiple)")

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -35,8 +35,10 @@ type Chart struct {
 	Path string
 }
 
-// LoadResourcesFromHelmCharts scans a given path (recursively) for helm charts, renders the templates and returns a map of workloads and a map of chart names
-func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, map[string]Chart) {
+// LoadResourcesFromHelmCharts scans a given path (recursively) for helm charts, renders the templates and returns a map of workloads and a map of chart names.
+// Helm value overrides and release identity supplied via valueOpts are merged over the chart defaults before rendering.
+// Pass an empty HelmValueOptions{} to render with chart defaults only (preserves prior behavior).
+func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart) {
 	directories, _ := listDirs(basePath)
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
@@ -45,12 +47,27 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 		}
 	}
 
+	// Let us parse user-supplied value overrides once; reuse for every chart we render.
+	var userValues map[string]interface{}
+	if !valueOpts.IsEmpty() {
+		var err error
+		userValues, err = valueOpts.MergeValues()
+		if err != nil {
+			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Failed to parse Helm value overrides: %v", err))
+		}
+	}
+	releaseOpts := valueOpts.ReleaseOptions()
+
 	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
 	sourceToChart := make(map[string]Chart, 0)
 	for _, helmDir := range helmDirectories {
 		chart, err := NewHelmChart(helmDir)
 		if err == nil {
-			wls, errs := chart.GetWorkloadsWithDefaultValues()
+			values := chart.GetDefaultValues()
+			if userValues != nil {
+				values = mergeMaps(values, userValues)
+			}
+			wls, errs := chart.GetWorkloadsWithOptions(values, releaseOpts)
 			if len(errs) > 0 {
 				logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering of Helm chart template '%s', failed: %v", chart.GetName(), errs))
 				continue
@@ -66,6 +83,26 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string) (map[stri
 		}
 	}
 	return sourceToWorkloads, sourceToChart
+}
+
+// mergeMaps performs a deep merge of override into a copy of base, with override winning on conflicts.
+// This mirrors helm.sh/helm/v3 internal `chartutil.CoalesceTables` semantics for values overlay
+// and is used to layer user --set/-f values over a chart's defaults before rendering.
+func mergeMaps(base, override map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(base))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		if vMap, ok := v.(map[string]interface{}); ok {
+			if baseMap, ok := out[k].(map[string]interface{}); ok {
+				out[k] = mergeMaps(baseMap, vMap)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // If the contents at given path is a Kustomize Directory, LoadResourcesFromKustomizeDirectory will

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -38,7 +38,11 @@ type Chart struct {
 // LoadResourcesFromHelmCharts scans a given path (recursively) for helm charts, renders the templates and returns a map of workloads and a map of chart names.
 // Helm value overrides and release identity supplied via valueOpts are merged over the chart defaults before rendering.
 // Pass an empty HelmValueOptions{} to render with chart defaults only (preserves prior behavior).
-func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart) {
+//
+// If user-supplied overrides cannot be parsed (bad --set syntax, missing -f file, unreadable
+// --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
+// fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
+func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, error) {
 	directories, _ := listDirs(basePath)
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
@@ -47,13 +51,13 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 		}
 	}
 
-	// Let us parse user-supplied value overrides once; reuse for every chart we render.
+	// Parse user-supplied value overrides once; reuse for every chart we render.
 	var userValues map[string]interface{}
 	if !valueOpts.IsEmpty() {
 		var err error
 		userValues, err = valueOpts.MergeValues()
 		if err != nil {
-			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Failed to parse Helm value overrides: %v", err))
+			return nil, nil, fmt.Errorf("failed to parse Helm value overrides: %w", err)
 		}
 	}
 	releaseOpts := valueOpts.ReleaseOptions()
@@ -82,7 +86,7 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 			}
 		}
 	}
-	return sourceToWorkloads, sourceToChart
+	return sourceToWorkloads, sourceToChart, nil
 }
 
 // mergeMaps performs a deep merge of override into a copy of base, with override winning on conflicts.

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -45,7 +45,8 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
-	sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath(), HelmValueOptions{})
+	sourceToWorkloads, sourceToChartName, err := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath(), HelmValueOptions{})
+	assert.NoError(t, err)
 	assert.Equal(t, 6, len(sourceToWorkloads))
 
 	for file, workloads := range sourceToWorkloads {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -45,7 +45,7 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
-	sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath())
+	sourceToWorkloads, sourceToChartName := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath(), HelmValueOptions{})
 	assert.Equal(t, 6, len(sourceToWorkloads))
 
 	for file, workloads := range sourceToWorkloads {

--- a/core/cautils/helmchart.go
+++ b/core/cautils/helmchart.go
@@ -15,6 +15,7 @@ import (
 	helmloader "helm.sh/helm/v3/pkg/chart/loader"
 	helmchartutil "helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+	helmvalues "helm.sh/helm/v3/pkg/cli/values"
 	helmdownloader "helm.sh/helm/v3/pkg/downloader"
 	helmengine "helm.sh/helm/v3/pkg/engine"
 	helmgetter "helm.sh/helm/v3/pkg/getter"
@@ -129,9 +130,17 @@ func (hc *HelmChart) GetWorkloadsWithDefaultValues() (map[string][]workloadinter
 	return hc.GetWorkloads(hc.GetDefaultValues())
 }
 
-// GetWorkloads renders chart template using the provided values and returns a map of source (absolute) file path to its workloads
+// GetWorkloads renders chart template using the provided values and returns a map of source (absolute) file path to its workloads.
+// Equivalent to GetWorkloadsWithOptions(values, ReleaseOptions{}).
 func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]workloadinterface.IMetadata, []error) {
-	vals, err := helmchartutil.ToRenderValues(hc.chart, values, helmchartutil.ReleaseOptions{}, nil)
+	return hc.GetWorkloadsWithOptions(values, helmchartutil.ReleaseOptions{})
+}
+
+// GetWorkloadsWithOptions renders chart template using the provided values and Helm release options
+// (release name/namespace), returning a map of source (absolute) file path to its workloads.
+// Charts that reference .Release.Name or .Release.Namespace require these options to render.
+func (hc *HelmChart) GetWorkloadsWithOptions(values map[string]interface{}, releaseOpts helmchartutil.ReleaseOptions) (map[string][]workloadinterface.IMetadata, []error) {
+	vals, err := helmchartutil.ToRenderValues(hc.chart, values, releaseOpts, nil)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -167,4 +176,48 @@ func (hc *HelmChart) GetWorkloads(values map[string]interface{}) (map[string][]w
 		}
 	}
 	return workloads, errs
+}
+
+// HelmValueOptions describes the user-supplied Helm value overrides and release identity
+// to apply when rendering Helm charts during a scan. It mirrors the inputs accepted by
+// `helm install` so the kubescape CLI flags and the helm-kubescape plugin can pass values
+// through verbatim.
+type HelmValueOptions struct {
+	ValueFiles       []string // -f / --values
+	Values           []string // --set
+	StringValues     []string // --set-string
+	FileValues       []string // --set-file
+	ReleaseName      string
+	ReleaseNamespace string
+}
+
+// IsEmpty reports whether no Helm value overrides or release identity have been set.
+func (o HelmValueOptions) IsEmpty() bool {
+	return len(o.ValueFiles) == 0 &&
+		len(o.Values) == 0 &&
+		len(o.StringValues) == 0 &&
+		len(o.FileValues) == 0 &&
+		o.ReleaseName == "" &&
+		o.ReleaseNamespace == ""
+}
+
+// MergeValues parses and merges the user-supplied value overrides using Helm's own
+// merger (the same code path used by `helm install -f ... --set ...`). The resulting
+// map is the final user-supplied values that should be merged over the chart defaults.
+func (o HelmValueOptions) MergeValues() (map[string]interface{}, error) {
+	opts := helmvalues.Options{
+		ValueFiles:   o.ValueFiles,
+		Values:       o.Values,
+		StringValues: o.StringValues,
+		FileValues:   o.FileValues,
+	}
+	return opts.MergeValues(helmgetter.All(cli.New()))
+}
+
+// ReleaseOptions returns the Helm ReleaseOptions for use with chartutil.ToRenderValues.
+func (o HelmValueOptions) ReleaseOptions() helmchartutil.ReleaseOptions {
+	return helmchartutil.ReleaseOptions{
+		Name:      o.ReleaseName,
+		Namespace: o.ReleaseNamespace,
+	}
 }

--- a/core/cautils/helmchart_test.go
+++ b/core/cautils/helmchart_test.go
@@ -169,7 +169,8 @@ func TestLoadResourcesFromHelmCharts_WithOverrides(t *testing.T) {
 	opts := HelmValueOptions{
 		Values: []string{"image.pullPolicy=Never"},
 	}
-	sourceToWorkloads, _ := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+	sourceToWorkloads, _, err := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+	assert.NoError(t, err)
 
 	cronjobPath := filepath.Join(chartPath, "templates", "cronjob.yaml")
 	wls, ok := sourceToWorkloads[cronjobPath]
@@ -178,6 +179,21 @@ func TestLoadResourcesFromHelmCharts_WithOverrides(t *testing.T) {
 
 	jsonBytes, _ := json.Marshal(wls[0].GetObject())
 	assert.Contains(t, string(jsonBytes), `"imagePullPolicy":"Never"`, "user --set override should win over chart default")
+}
+
+// TestLoadResourcesFromHelmCharts_BadOverrideFailsFast verifies that an invalid user override
+// (here: a -f path that does not exist) is reported as an error rather than silently swallowed
+// and falling back to chart defaults. Scanning the wrong manifests would be worse than failing.
+func TestLoadResourcesFromHelmCharts_BadOverrideFailsFast(t *testing.T) {
+	o, _ := os.Getwd()
+	chartPath := filepath.Join(filepath.Dir(o), "..", "examples", "helm_chart")
+
+	opts := HelmValueOptions{
+		ValueFiles: []string{"/nonexistent/values.yaml"},
+	}
+	_, _, err := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+	assert.Error(t, err, "expected fail-fast on missing -f file")
+	assert.Contains(t, err.Error(), "Helm value overrides")
 }
 
 func TestMergeMaps_DeepMerge(t *testing.T) {

--- a/core/cautils/helmchart_test.go
+++ b/core/cautils/helmchart_test.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	helmchartutil "helm.sh/helm/v3/pkg/chartutil"
 )
 
 type HelmChartTestSuite struct {
@@ -117,6 +120,86 @@ func (s *HelmChartTestSuite) TestGetWorkloadsMissingValue() {
 
 	expectedErrMsg := "<.Values.image.repository>: nil pointer"
 	s.Containsf(errs[0].Error(), expectedErrMsg, "expected error containing %q, got %q", expectedErrMsg, errs[0])
+}
+
+// TestGetWorkloadsWithOptions_ReleaseName verifies that a custom release name passed via
+// HelmReleaseName flows through to .Release.Name in the rendered manifests. The example
+// chart's ClusterRoleBinding sets the subject namespace from .Release.Namespace, so we
+// can use that to confirm the release options are honored.
+func (s *HelmChartTestSuite) TestGetWorkloadsWithOptions_ReleaseName() {
+	chart, err := NewHelmChart(s.helmChartPath)
+	s.Require().NoError(err)
+
+	releaseOpts := helmchartutil.ReleaseOptions{Name: "my-release", Namespace: "my-ns"}
+	fileToWorkloads, errs := chart.GetWorkloadsWithOptions(chart.GetDefaultValues(), releaseOpts)
+	s.Require().Len(errs, 0)
+
+	crbPath := filepath.Join(s.helmChartPath, "templates", "clusterrolebinding.yaml")
+	wls, ok := fileToWorkloads[crbPath]
+	s.Require().True(ok, "ClusterRoleBinding should be rendered")
+	s.Require().NotEmpty(wls)
+
+	jsonBytes, _ := json.Marshal(wls[0].GetObject())
+	s.Contains(string(jsonBytes), `"namespace":"my-ns"`, "release namespace should propagate to subject namespace")
+}
+
+// TestHelmValueOptions_MergeValues exercises the helm-style value merger so we can be sure
+// that --set / -f equivalents are parsed and merged the same way `helm install` would.
+func TestHelmValueOptions_MergeValues(t *testing.T) {
+	opts := HelmValueOptions{
+		Values:       []string{"image.tag=v1.2.3", "replicaCount=5"},
+		StringValues: []string{"image.repository=myrepo/app"},
+	}
+	merged, err := opts.MergeValues()
+	assert.NoError(t, err)
+
+	image, ok := merged["image"].(map[string]interface{})
+	assert.True(t, ok, "expected image to be a nested map")
+	assert.Equal(t, "v1.2.3", image["tag"])
+	assert.Equal(t, "myrepo/app", image["repository"])
+	assert.EqualValues(t, 5, merged["replicaCount"])
+}
+
+// TestLoadResourcesFromHelmCharts_WithOverrides confirms that user-supplied --set values
+// are merged over chart defaults end-to-end via the public LoadResourcesFromHelmCharts entrypoint.
+func TestLoadResourcesFromHelmCharts_WithOverrides(t *testing.T) {
+	o, _ := os.Getwd()
+	chartPath := filepath.Join(filepath.Dir(o), "..", "examples", "helm_chart")
+
+	opts := HelmValueOptions{
+		Values: []string{"image.pullPolicy=Never"},
+	}
+	sourceToWorkloads, _ := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+
+	cronjobPath := filepath.Join(chartPath, "templates", "cronjob.yaml")
+	wls, ok := sourceToWorkloads[cronjobPath]
+	assert.True(t, ok, "cronjob should be rendered")
+	assert.NotEmpty(t, wls)
+
+	jsonBytes, _ := json.Marshal(wls[0].GetObject())
+	assert.Contains(t, string(jsonBytes), `"imagePullPolicy":"Never"`, "user --set override should win over chart default")
+}
+
+func TestMergeMaps_DeepMerge(t *testing.T) {
+	base := map[string]interface{}{
+		"image": map[string]interface{}{"repository": "base-repo", "tag": "default"},
+		"keep":  "untouched",
+	}
+	override := map[string]interface{}{
+		"image": map[string]interface{}{"tag": "overridden"},
+		"new":   "added",
+	}
+
+	out := mergeMaps(base, override)
+
+	img := out["image"].(map[string]interface{})
+	assert.Equal(t, "base-repo", img["repository"], "non-overridden nested key should survive")
+	assert.Equal(t, "overridden", img["tag"], "override should win on conflict")
+	assert.Equal(t, "untouched", out["keep"])
+	assert.Equal(t, "added", out["new"])
+
+	// base should not be mutated by mergeMaps
+	assert.Equal(t, "default", base["image"].(map[string]interface{})["tag"])
 }
 
 func (s *HelmChartTestSuite) TestIsHelmDirectory() {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -140,6 +140,12 @@ type ScanInfo struct {
 	UseDefaultMatchers    bool
 	ChartPath             string
 	FilePath              string
+	HelmValueFiles        []string // -f / --values: paths to Helm values YAML files (repeatable)
+	HelmSetValues         []string // --set: Helm value overrides as key=value (repeatable)
+	HelmSetStringValues   []string // --set-string: forced-string Helm value overrides
+	HelmSetFileValues     []string // --set-file: Helm value overrides whose value is read from a file
+	HelmReleaseName       string   // --release-name: Helm release name made available as .Release.Name during render
+	HelmReleaseNamespace  string   // --release-namespace: Helm release namespace made available as .Release.Namespace
 	LabelsToCopy          []string // Labels to copy from workloads to scan reports
 	scanningContext       *ScanningContext
 	cleanups              []func()

--- a/core/cautils/testdata/kustomize/helm/charts/test-chart/values.yaml
+++ b/core/cautils/testdata/kustomize/helm/charts/test-chart/values.yaml
@@ -1,0 +1,3 @@
+# Empty default values for test-chart fixture used by TestKustomizeDirectoryWithHelmCharts.
+# Helm's chart loader requires this file to exist even when the chart's templates
+# do not reference any .Values fields.

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -40,10 +40,11 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 		var workloads []workloadinterface.IMetadata
 		var err error
 
+		helmValueOpts := helmValueOptionsFromScanInfo(scanInfo)
 		if scanInfo.ChartPath != "" && scanInfo.FilePath != "" {
-			workloadIDToSource, workloads, _ = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath)
+			workloadIDToSource, workloads, _ = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath, helmValueOpts)
 		} else {
-			workloadIDToSource, workloads, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path])
+			workloadIDToSource, workloads, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts)
 			if err != nil {
 				return nil, allResources, nil, nil, err
 			}
@@ -99,7 +100,23 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 func (fileHandler *FileResourceHandler) GetCloudProvider() string {
 	return ""
 }
-func getWorkloadFromHelmChart(ctx context.Context, path, helmPath, workloadPath string) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
+// helmValueOptionsFromScanInfo extracts the user-supplied Helm value/release flags from ScanInfo
+// into the cautils.HelmValueOptions used by chart rendering.
+func helmValueOptionsFromScanInfo(scanInfo *cautils.ScanInfo) cautils.HelmValueOptions {
+	if scanInfo == nil {
+		return cautils.HelmValueOptions{}
+	}
+	return cautils.HelmValueOptions{
+		ValueFiles:       scanInfo.HelmValueFiles,
+		Values:           scanInfo.HelmSetValues,
+		StringValues:     scanInfo.HelmSetStringValues,
+		FileValues:       scanInfo.HelmSetFileValues,
+		ReleaseName:      scanInfo.HelmReleaseName,
+		ReleaseNamespace: scanInfo.HelmReleaseNamespace,
+	}
+}
+
+func getWorkloadFromHelmChart(ctx context.Context, path, helmPath, workloadPath string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
 	clonedRepo := cautils.GetClonedPath(path)
 
 	if clonedRepo != "" {
@@ -113,7 +130,7 @@ func getWorkloadFromHelmChart(ctx context.Context, path, helmPath, workloadPath 
 	// Get repo root
 	repoRoot, gitRepo := extractGitRepo(clonedRepo)
 
-	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, helmPath)
+	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, helmPath, helmValueOpts)
 
 	wlSource, ok := helmSourceToWorkloads[workloadPath]
 	if !ok {
@@ -171,7 +188,7 @@ func getWorkloadSourceHelmChart(repoRoot string, source string, gitRepo *cautils
 	}
 }
 
-func getResourcesFromPath(ctx context.Context, path string) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
+func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
 	workloadIDToSource := make(map[string]reporthandling.Source)
 	var workloads []workloadinterface.IMetadata
 
@@ -259,7 +276,7 @@ func getResourcesFromPath(ctx context.Context, path string) (map[string]reportha
 	}
 
 	// load resources from helm charts
-	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, path)
+	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, path, helmValueOpts)
 	for source, ws := range helmSourceToWorkloads {
 		workloads = append(workloads, ws...)
 		helmChart := helmSourceToChart[source]

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -42,12 +42,12 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 
 		helmValueOpts := helmValueOptionsFromScanInfo(scanInfo)
 		if scanInfo.ChartPath != "" && scanInfo.FilePath != "" {
-			workloadIDToSource, workloads, _ = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath, helmValueOpts)
+			workloadIDToSource, workloads, err = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath, helmValueOpts)
 		} else {
 			workloadIDToSource, workloads, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts)
-			if err != nil {
-				return nil, allResources, nil, nil, err
-			}
+		}
+		if err != nil {
+			return nil, allResources, nil, nil, err
 		}
 		if len(workloads) == 0 {
 			continue
@@ -130,7 +130,10 @@ func getWorkloadFromHelmChart(ctx context.Context, path, helmPath, workloadPath 
 	// Get repo root
 	repoRoot, gitRepo := extractGitRepo(clonedRepo)
 
-	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, helmPath, helmValueOpts)
+	helmSourceToWorkloads, helmSourceToChart, err := cautils.LoadResourcesFromHelmCharts(ctx, helmPath, helmValueOpts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	wlSource, ok := helmSourceToWorkloads[workloadPath]
 	if !ok {
@@ -276,7 +279,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	}
 
 	// load resources from helm charts
-	helmSourceToWorkloads, helmSourceToChart := cautils.LoadResourcesFromHelmCharts(ctx, path, helmValueOpts)
+	helmSourceToWorkloads, helmSourceToChart, err := cautils.LoadResourcesFromHelmCharts(ctx, path, helmValueOpts)
+	if err != nil {
+		return nil, nil, err
+	}
 	for source, ws := range helmSourceToWorkloads {
 		workloads = append(workloads, ws...)
 		helmChart := helmSourceToChart[source]


### PR DESCRIPTION
## Overview

Currently, `kubescape scan` includes the Helm v3 SDK but ignores user-provided value overrides. The renderer was hard-coded to discard input and used empty `ReleaseOptions{}`, causing rendering failures for charts that depend on `.Release.Name` or `.Release.Namespace`.

This PR mirrors `helm install` semantics by plumbing value overrides (`--set`, `--values`, etc.) and release identity from the CLI through to the underlying `helmengine`. This is a direct prerequisite for the upcoming `helm-kubescape` plugin (#1883).

**Current behavior:** Charts always render with default `values.yaml`; user overrides are ignored.
**New behavior:** Users can provide `--values`, `--set`, `--set-string`, and `--set-file`. These are deep-merged over defaults using the native Helm merger.

## 🛠 Changes

### CLI Additions

New persistent flags added to `kubescape scan` (available for `framework`, `control`, and `workload` subcommands):

| Flag | Helm equivalent | Description |
|---|---|---|
| `--values` | `-f` / `--values` | Path(s) to YAML file(s) containing values |
| `--set` | `--set` | Set values on the command line (repeatable) |
| `--set-string` | `--set-string` | Set STRING values on the command line |
| `--set-file` | `--set-file` | Set values from respective files specified via the CLI |
| `--release-name` | _(positional `RELEASE` in `helm install`)_ | Customizes `.Release.Name` |
| `--release-namespace` | `-n` / `--namespace` | Customizes `.Release.Namespace` |

> Note: The `-f` shorthand is **not** used for `--values` to avoid collision with Kubescape's existing `--format` flag. The long form matches Helm exactly.

### Core Logic

- **`core/cautils`:**
  - Updated `HelmChart` to support `GetWorkloadsWithOptions`, removing the empty `ReleaseOptions{}` hardcode.
  - Implemented `HelmValueOptions` and `MergeValues` using `helm.sh/helm/v3/pkg/cli/values`, ensuring 1:1 parity with Helm's merging logic.
- **`core/pkg/resourcehandler`:** Updated `FilesLoader` to thread override options through the resource loading pipeline.
- **Drive-by fix:** Added a missing `values.yaml` fixture to `testdata`. This fixes a `master` branch failure where the Helm loader rejected charts missing the file, even if unused.

## 🧪 How to Test

### Automated Tests

Run the new suite of unit and integration tests:

```bash
go test ./core/cautils/ -run "TestHelmChartTestSuite|TestHelmValueOptions_MergeValues|TestLoadResourcesFromHelmCharts_WithOverrides|TestMergeMaps_DeepMerge" -v
```

### Manual Verification

1. Build the binary:
   ```bash
   go build -o kubescape .
   ```
2. Run a scan against a local chart with an override:
   ```bash
   ./kubescape scan ./examples/helm_chart --set image.pullPolicy=Never --release-name my-test-release
   ```
3. **Validation:** Verify that the findings reflect `imagePullPolicy: Never` (overriding the default `Always`) and that any templates using `{{ .Release.Name }}` reflect `my-test-release`.

## Related issues/PRs

* Refs #1883 (prerequisite for the `helm-kubescape` plugin)

## ✅ Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan command accepts Helm value overrides (--values, --set, --set-string, --set-file) and release identity (--release-name, --release-namespace) to influence chart rendering.
  * User-supplied overrides are deep-merged with chart defaults so rendered manifests reflect provided values.

* **Bug Fixes**
  * Invalid Helm value inputs now fail fast with a clear error instead of proceeding.

* **Tests**
  * Added tests for value merging, release propagation, deep-merge behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->