### PR TITLE
feat(cautils): populate scanMetadata excluded/include namespaces

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -244,6 +244,22 @@ func (scanInfo *ScanInfo) contains(policyName string) bool {
 	return false
 }
 
+// splitNamespaceList parses a comma-separated namespace list (as accepted by
+// --exclude-namespaces / --include-namespaces) into a clean slice. Empty
+// entries and surrounding whitespace are dropped.
+func splitNamespaceList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo) *reporthandlingv2.Metadata {
 	metadata := &reporthandlingv2.Metadata{}
 
@@ -251,13 +267,12 @@ func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo) *reporthand
 	metadata.ScanMetadata.FormatVersion = scanInfo.FormatVersion
 	metadata.ScanMetadata.Submit = scanInfo.Submit
 
-	// TODO - Add excluded and included namespaces
-	// if len(scanInfo.ExcludedNamespaces) > 1 {
-	// 	opaSessionObj.Metadata.ScanMetadata.ExcludedNamespaces = strings.Split(scanInfo.ExcludedNamespaces[1:], ",")
-	// }
-	// if len(scanInfo.IncludeNamespaces) > 1 {
-	// 	opaSessionObj.Metadata.ScanMetadata.IncludeNamespaces = strings.Split(scanInfo.IncludeNamespaces[1:], ",")
-	// }
+	if ns := splitNamespaceList(scanInfo.ExcludedNamespaces); len(ns) > 0 {
+		metadata.ScanMetadata.ExcludedNamespaces = ns
+	}
+	if ns := splitNamespaceList(scanInfo.IncludeNamespaces); len(ns) > 0 {
+		metadata.ScanMetadata.IncludeNamespaces = ns
+	}
 
 	// scan type
 	if len(scanInfo.PolicyIdentifier) > 0 {

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -133,3 +133,47 @@ func TestScanInfoFormats(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitNamespaceList(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "ns-a", []string{"ns-a"}},
+		{"multiple", "ns-a,ns-b,ns-c", []string{"ns-a", "ns-b", "ns-c"}},
+		{"whitespace", "ns-a, ns-b ,ns-c", []string{"ns-a", "ns-b", "ns-c"}},
+		{"empty entries dropped", "ns-a,,ns-b,", []string{"ns-a", "ns-b"}},
+		{"only commas", ",,,", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitNamespaceList(tc.in))
+		})
+	}
+}
+
+func TestScanInfoToScanMetadataNamespaces(t *testing.T) {
+	t.Run("populates excluded namespaces", func(t *testing.T) {
+		scanInfo := &ScanInfo{ExcludedNamespaces: "kube-system,kube-public"}
+		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		assert.Equal(t, []string{"kube-system", "kube-public"}, md.ScanMetadata.ExcludedNamespaces)
+		assert.Empty(t, md.ScanMetadata.IncludeNamespaces)
+	})
+
+	t.Run("populates included namespaces", func(t *testing.T) {
+		scanInfo := &ScanInfo{IncludeNamespaces: "default,prod"}
+		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		assert.Equal(t, []string{"default", "prod"}, md.ScanMetadata.IncludeNamespaces)
+		assert.Empty(t, md.ScanMetadata.ExcludedNamespaces)
+	})
+
+	t.Run("empty when not set", func(t *testing.T) {
+		scanInfo := &ScanInfo{}
+		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		assert.Empty(t, md.ScanMetadata.ExcludedNamespaces)
+		assert.Empty(t, md.ScanMetadata.IncludeNamespaces)
+	})
+}


### PR DESCRIPTION
## Overview

Right now if I scan with `--exclude-namespaces` or `--include-namespaces`, the report does not actually mention which namespaces I filtered. The flags work, the field selectors get applied, but the `scanMetadata.excludedNamespaces` and `scanMetadata.includeNamespaces` fields in the report stay empty.

The interesting part is these fields already exist in opa-utils (`reporthandling/v2/datastructures.go`), they were just never being filled in on the kubescape side. There was even a `// TODO - Add excluded and included namespaces` block in `scanInfoToScanMetadata` with the old code commented out, so this looks like something that was started a while ago and never finished.

This PR just wires it up.

## What changed

- `core/cautils/scaninfo.go`: replaced the TODO + commented code in `scanInfoToScanMetadata` with the real implementation. Added a small `splitNamespaceList` helper that takes the comma separated string and gives back a clean slice (handles whitespace and drops empty entries so things like `"ns-a, ,ns-b,"` don't end up with junk in the report).
- `core/cautils/scaninfo_test.go`: tests for the helper covering the edge cases (empty input, single, multiple, whitespace, empty entries, only commas) and tests for `scanInfoToScanMetadata` confirming the metadata fields actually get populated.

## Why now

This is part of the scan coverage work in #2010. The bigger feature is reporting which controls were not evaluated due to missing GVRs, but that needs the opa-utils side to land first (kubescape/opa-utils#166 is up for that). This piece is independent so I figured I would split it out and get it in early since it is a small standalone fix that downstream consumers already expect to work.

## Related

- Part of #2010
- Related opa-utils PR: kubescape/opa-utils#166

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan configurations now properly parse and store namespace inclusion and exclusion settings from comma-separated values, with whitespace trimming and empty entry removal.

* **Tests**
  * Added comprehensive test coverage for namespace parsing and scan metadata population to ensure correct handling of various namespace configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->