### PR TITLE
fix(portforwarder): surface ForwardPorts error and unblock waitForPortForwardReadiness

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -24,6 +24,7 @@ type portForward struct {
 	localPort string
 	stopChan  chan struct{}
 	readyChan chan struct{}
+	errChan   chan error
 	out       *bytes.Buffer
 	errOut    *bytes.Buffer
 }
@@ -59,13 +60,22 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 		localPort:     getPortForwardingPort(),
 		stopChan:      stopChan,
 		readyChan:     readyChan,
+		errChan:       make(chan error, 1),
 		out:           out,
 		errOut:        errOut,
 	}, nil
 }
 
-func (p *portForward) waitForPortForwardReadiness() struct{} {
-	return <-p.readyChan
+func (p *portForward) waitForPortForwardReadiness() error {
+	select {
+	case <-p.readyChan:
+		return nil
+	case err := <-p.errChan:
+		if err == nil {
+			err = fmt.Errorf("port-forward exited before becoming ready: %s", strings.TrimSpace(p.errOut.String()))
+		}
+		return err
+	}
 }
 
 func (p *portForward) GetPortForwardLocalhost() string {
@@ -78,9 +88,7 @@ func (p *portForward) StopPortForwarder() {
 
 func (p *portForward) StartPortForwarder() error {
 	go func() {
-		p.ForwardPorts()
+		p.errChan <- p.ForwardPorts()
 	}()
-	p.waitForPortForwardReadiness()
-
-	return nil
+	return p.waitForPortForwardReadiness()
 }


### PR DESCRIPTION
Closes #2014.

`StartPortForwarder` discarded the error returned by `ForwardPorts()` and `waitForPortForwardReadiness` blocked on `readyChan` with no escape:

```go
func (p *portForward) StartPortForwarder() error {
    go func() {
        p.ForwardPorts()  // error discarded
    }()
    p.waitForPortForwardReadiness()  // blocks forever if ForwardPorts errored
    return nil  // always nil despite signature
}
```

So if `ForwardPorts()` returned an error before `readyChan` was signalled (e.g. local port already in use, dialer fails), the caller deadlocked and the operator never saw the real reason.

### Patch

- Add a buffered `errChan` to the `portForward` struct.
- Push the goroutine result into `errChan`.
- Have `waitForPortForwardReadiness` `select` between `readyChan` and `errChan`. If the goroutine returns `nil` before signalling ready (spdy stream closed unexpectedly), surface `p.errOut` so operators see why the forwarder bailed.
- `StartPortForwarder` now returns the error from `waitForPortForwardReadiness` instead of unconditionally returning `nil`.

### Verification

```
go vet ./core/cautils/
go build ./...
```
both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port forwarding now reports readiness and failures correctly: startup errors are surfaced instead of being suppressed, improving reliability and making connectivity issues easier to detect and diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->