### PR TITLE
fix(cautils): use TrimPrefix to strip URL scheme in CreatePortForwarder

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -35,16 +35,26 @@ func getPortForwardingPort() string {
 	return DefaultPortForwardPortValue
 }
 
-func stripScheme(host string) string {
-	host = strings.TrimPrefix(host, "https://")
-	host = strings.TrimPrefix(host, "http://")
-	return host
+func splitHostAndBasePath(host string) (string, string, error) {
+	if !strings.Contains(host, "://") {
+		return host, "", nil
+	}
+
+	baseURL, err := url.Parse(host)
+	if err != nil {
+		return "", "", err
+	}
+
+	return baseURL.Host, strings.TrimRight(baseURL.Path, "/"), nil
 }
 
 func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, forwardingPort, namespace string) (OperatorConnector, error) {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, pod.Name)
-	hostIP := stripScheme(k8sClient.K8SConfig.Host)
-	serverURL := &url.URL{Scheme: "https", Path: path, Host: hostIP}
+	hostIP, basePath, err := splitHostAndBasePath(k8sClient.K8SConfig.Host)
+	if err != nil {
+		return nil, err
+	}
+	serverURL := &url.URL{Scheme: "https", Path: basePath + path, Host: hostIP}
 
 	roundTripper, upgrader, err := spdy.RoundTripperFor(k8sClient.K8SConfig)
 	if err != nil {

--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -35,9 +35,15 @@ func getPortForwardingPort() string {
 	return DefaultPortForwardPortValue
 }
 
+func stripScheme(host string) string {
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	return host
+}
+
 func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, forwardingPort, namespace string) (OperatorConnector, error) {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, pod.Name)
-	hostIP := strings.TrimLeft(k8sClient.K8SConfig.Host, "htps:/")
+	hostIP := stripScheme(k8sClient.K8SConfig.Host)
 	serverURL := &url.URL{Scheme: "https", Path: path, Host: hostIP}
 
 	roundTripper, upgrader, err := spdy.RoundTripperFor(k8sClient.K8SConfig)

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -21,62 +21,95 @@ type FakeCachedDiscoveryClient struct {
 	Invalidations      int
 }
 
-func Test_stripScheme(t *testing.T) {
+func Test_splitHostAndBasePath(t *testing.T) {
 	testCases := []struct {
-		name string
-		host string
-		want string
+		name         string
+		host         string
+		wantHost     string
+		wantBasePath string
+		wantErr      bool
 	}{
 		{
-			name: "https scheme is stripped",
-			host: "https://1.2.3.4:6443",
-			want: "1.2.3.4:6443",
+			name:     "https scheme is stripped",
+			host:     "https://1.2.3.4:6443",
+			wantHost: "1.2.3.4:6443",
 		},
 		{
-			name: "http scheme is stripped",
-			host: "http://1.2.3.4:6443",
-			want: "1.2.3.4:6443",
+			name:     "http scheme is stripped",
+			host:     "http://1.2.3.4:6443",
+			wantHost: "1.2.3.4:6443",
 		},
 		{
-			name: "host without scheme is returned unchanged",
-			host: "1.2.3.4:6443",
-			want: "1.2.3.4:6443",
+			name:     "host without scheme is returned unchanged",
+			host:     "1.2.3.4:6443",
+			wantHost: "1.2.3.4:6443",
 		},
 		{
-			name: "empty host is returned unchanged",
-			host: "",
-			want: "",
+			name:     "empty host is returned unchanged",
+			host:     "",
+			wantHost: "",
 		},
 		{
-			name: "hostname starting with 'h' is preserved after https scheme",
-			host: "https://hello-cluster.example.com:6443",
-			want: "hello-cluster.example.com:6443",
+			name:     "hostname starting with 'h' is preserved after https scheme",
+			host:     "https://hello-cluster.example.com:6443",
+			wantHost: "hello-cluster.example.com:6443",
 		},
 		{
-			name: "hostname starting with 't' is preserved after https scheme",
-			host: "https://test.example.com:6443",
-			want: "test.example.com:6443",
+			name:     "hostname starting with 't' is preserved after https scheme",
+			host:     "https://test.example.com:6443",
+			wantHost: "test.example.com:6443",
 		},
 		{
-			name: "hostname starting with 'p' is preserved after https scheme",
-			host: "https://prod.example.com",
-			want: "prod.example.com",
+			name:     "hostname starting with 'p' is preserved after https scheme",
+			host:     "https://prod.example.com",
+			wantHost: "prod.example.com",
 		},
 		{
-			name: "hostname starting with 's' is preserved after https scheme",
-			host: "https://staging.example.com",
-			want: "staging.example.com",
+			name:     "hostname starting with 's' is preserved after https scheme",
+			host:     "https://staging.example.com",
+			wantHost: "staging.example.com",
 		},
 		{
-			name: "kubernetes.docker.internal is preserved",
-			host: "https://kubernetes.docker.internal:6443",
-			want: "kubernetes.docker.internal:6443",
+			name:     "kubernetes.docker.internal is preserved",
+			host:     "https://kubernetes.docker.internal:6443",
+			wantHost: "kubernetes.docker.internal:6443",
+		},
+		{
+			name:         "host with base path preserves path",
+			host:         "https://proxy.example.com/k8s",
+			wantHost:     "proxy.example.com",
+			wantBasePath: "/k8s",
+		},
+		{
+			name:         "host with port and base path preserves both",
+			host:         "https://proxy.example.com:6443/k8s",
+			wantHost:     "proxy.example.com:6443",
+			wantBasePath: "/k8s",
+		},
+		{
+			name:         "trailing slash on base path is trimmed",
+			host:         "https://proxy.example.com/k8s/",
+			wantHost:     "proxy.example.com",
+			wantBasePath: "/k8s",
+		},
+		{
+			name:         "multi-segment base path is preserved",
+			host:         "https://proxy.example.com/api/v1/k8s",
+			wantHost:     "proxy.example.com",
+			wantBasePath: "/api/v1/k8s",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, stripScheme(tc.host))
+			gotHost, gotBasePath, err := splitHostAndBasePath(tc.host)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantHost, gotHost)
+			assert.Equal(t, tc.wantBasePath, gotBasePath)
 		})
 	}
 }

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -21,6 +21,66 @@ type FakeCachedDiscoveryClient struct {
 	Invalidations      int
 }
 
+func Test_stripScheme(t *testing.T) {
+	testCases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "https scheme is stripped",
+			host: "https://1.2.3.4:6443",
+			want: "1.2.3.4:6443",
+		},
+		{
+			name: "http scheme is stripped",
+			host: "http://1.2.3.4:6443",
+			want: "1.2.3.4:6443",
+		},
+		{
+			name: "host without scheme is returned unchanged",
+			host: "1.2.3.4:6443",
+			want: "1.2.3.4:6443",
+		},
+		{
+			name: "empty host is returned unchanged",
+			host: "",
+			want: "",
+		},
+		{
+			name: "hostname starting with 'h' is preserved after https scheme",
+			host: "https://hello-cluster.example.com:6443",
+			want: "hello-cluster.example.com:6443",
+		},
+		{
+			name: "hostname starting with 't' is preserved after https scheme",
+			host: "https://test.example.com:6443",
+			want: "test.example.com:6443",
+		},
+		{
+			name: "hostname starting with 'p' is preserved after https scheme",
+			host: "https://prod.example.com",
+			want: "prod.example.com",
+		},
+		{
+			name: "hostname starting with 's' is preserved after https scheme",
+			host: "https://staging.example.com",
+			want: "staging.example.com",
+		},
+		{
+			name: "kubernetes.docker.internal is preserved",
+			host: "https://kubernetes.docker.internal:6443",
+			want: "kubernetes.docker.internal:6443",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripScheme(tc.host))
+		})
+	}
+}
+
 func Test_getPortForwardingPort(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
## Overview

`CreatePortForwarder` in `core/cautils/portforwarder.go` used `strings.TrimLeft(host, "htps:/")` to strip the URL scheme from `K8SConfig.Host`. `TrimLeft` treats its second argument as a character set, so it also strips any leading `h`/`t`/`p`/`s`/`:`/`/` runes from the hostname itself — `https://hello.example.com:6443` became `ello.example.com:6443`, which then becomes the SPDY dialer target for the operator port-forward.

This PR introduces a small `stripScheme` helper that uses `strings.TrimPrefix` for `https://` and `http://`, and adds table-driven tests covering the regression cases (hostnames starting with `h`, `t`, `p`, `s`, plus IPs and `kubernetes.docker.internal`).

## How to Test

```
go test ./core/cautils/ -run Test_stripScheme -v
```

A reproducer for the original bug (no kubescape required):

```go
package main

import (
	"fmt"
	"strings"
)

func main() {
	host := "https://hello-cluster.example.com:6443"
	fmt.Printf("%q\n", strings.TrimLeft(host, "htps:/"))
	// "ello-cluster.example.com:6443"
}
```

## Related issues/PRs:

* Resolved #2017

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port forwarding now correctly normalizes Kubernetes API server addresses, preserving any existing base path and handling URL schemes so connections use the correct server path.

* **Tests**
  * Added unit tests covering scheme and base-path handling in host normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->