### PR TITLE
feat(getter): add CRDExceptionsGetter skeleton for in-cluster SecurityException CRD support

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -1,0 +1,56 @@
+package getter
+
+import (
+	"fmt"
+
+	"github.com/armosec/armoapi-go/armotypes"
+)
+
+var (
+	_ IExceptionsGetter = &CRDExceptionsGetter{}
+)
+
+// CRDExceptionsGetter retrieves posture exceptions from Kubernetes
+// SecurityException and ClusterSecurityException CRDs in the cluster.
+//
+// This getter currently acts as a structural skeleton. The full implementation
+// will use a Kubernetes dynamic client to list and convert CRD instances into
+// PostureExceptionPolicy objects when the SecurityException CRD has been
+// defined and registered (kubescape/kubescape#1982).
+type CRDExceptionsGetter struct {
+	// client holds the Kubernetes dynamic client for querying
+	// SecurityException / ClusterSecurityException CRDs.
+	//
+	// TODO(kubescape/kubescape#1982): populate with a live dynamic.Interface
+	// when the CRD has been defined in the Helm chart.
+}
+
+// NewCRDExceptionsGetter creates a new CRD-based exceptions getter.
+func NewCRDExceptionsGetter() *CRDExceptionsGetter {
+	return &CRDExceptionsGetter{}
+}
+
+// GetExceptions returns posture exception policies from in-cluster CRDs.
+//
+// Currently returns an empty slice because the SecurityException CRD has not
+// yet been registered. Once the CRD is available, this method will:
+//  1. List SecurityException resources (namespaced) and map them to
+//     armotypes.PostureExceptionPolicy.
+//  2. List ClusterSecurityException resources (cluster-scoped) and map them
+//     to armotypes.PostureExceptionPolicy.
+//  3. Evaluate expiresAt at scan time and skip expired entries.
+//  4. Emit Kubernetes Events on matched SecurityException resources.
+//
+// TODO(kubescape/kubescape#1982): implement CRD listing and conversion
+func (g *CRDExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	// Placeholder: returns an empty slice. The CRD-powered implementation
+	// will use a dynamic client to list SecurityException and
+	// ClusterSecurityException resources from the cluster.
+	_ = clusterName // reserved for future use (e.g., filtering by cluster label)
+
+	if g == nil {
+		return nil, fmt.Errorf("CRDExceptionsGetter is nil")
+	}
+
+	return []armotypes.PostureExceptionPolicy{}, nil
+}

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -10,13 +10,13 @@ var (
 	_ IExceptionsGetter = &CRDExceptionsGetter{}
 )
 
-// CRDExceptionsGetter retrieves posture exceptions from Kubernetes
+// CRDExceptionsGetter will retrieve posture exceptions from Kubernetes
 // SecurityException and ClusterSecurityException CRDs in the cluster.
 //
-// This getter currently acts as a structural skeleton. The full implementation
-// will use a Kubernetes dynamic client to list and convert CRD instances into
-// PostureExceptionPolicy objects when the SecurityException CRD has been
-// defined and registered (kubescape/kubescape#1982).
+// Currently a structural skeleton that always returns an empty slice.
+// The full implementation will use a Kubernetes dynamic client to list
+// and convert CRD instances into PostureExceptionPolicy objects when the
+// SecurityException CRD has been defined (kubescape/kubescape#1982).
 type CRDExceptionsGetter struct {
 	// client holds the Kubernetes dynamic client for querying
 	// SecurityException / ClusterSecurityException CRDs.

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -1,0 +1,50 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRDExceptionsGetter_ImplementsInterface(t *testing.T) {
+	// Verify that CRDExceptionsGetter satisfies IExceptionsGetter at compile time.
+	// The package-level var check (var _ IExceptionsGetter = &CRDExceptionsGetter{})
+	// enforces this, but this test serves as documentation and runtime verification.
+	getter := NewCRDExceptionsGetter()
+	require.NotNil(t, getter)
+
+	// Verify through type assertion
+	var ig IExceptionsGetter = getter
+	assert.NotNil(t, ig)
+}
+
+func TestCRDExceptionsGetter_GetExceptions_ReturnsEmpty(t *testing.T) {
+	getter := NewCRDExceptionsGetter()
+	require.NotNil(t, getter)
+
+	exceptions, err := getter.GetExceptions("test-cluster")
+	require.NoError(t, err)
+	assert.NotNil(t, exceptions)
+	assert.Empty(t, exceptions, "expected empty exceptions until CRD implementation is completed")
+}
+
+func TestCRDExceptionsGetter_NilReceiver(t *testing.T) {
+	var getter *CRDExceptionsGetter
+
+	exceptions, err := getter.GetExceptions("test-cluster")
+	require.Error(t, err)
+	assert.Nil(t, exceptions)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestCRDExceptionsGetter_MultipleCalls(t *testing.T) {
+	getter := NewCRDExceptionsGetter()
+
+	// Multiple calls should be idempotent
+	for i := range 3 {
+		exceptions, err := getter.GetExceptions("test-cluster")
+		require.NoError(t, err, "call %d should not error", i)
+		assert.Empty(t, exceptions, "call %d should return empty", i)
+	}
+}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -38,6 +38,11 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		// download exceptions from Kubescape Cloud backend
 		return getter.GetKSCloudAPIConnector()
 	}
+	// TODO(kubescape/kubescape#1982): add CRD-based exception source.
+	// When running in-cluster, query SecurityException / ClusterSecurityException
+	// CRDs and merge results with the downloaded/cloud exceptions.
+	// E.g.: if isConnectedToCluster() { getter.NewCRDExceptionsGetter(dynClient).GetExceptions(clusterName) }
+	//
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -41,7 +41,7 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	// TODO(kubescape/kubescape#1982): add CRD-based exception source.
 	// When running in-cluster, query SecurityException / ClusterSecurityException
 	// CRDs and merge results with the downloaded/cloud exceptions.
-	// E.g.: if isConnectedToCluster() { getter.NewCRDExceptionsGetter(dynClient).GetExceptions(clusterName) }
+	// See CRDExceptionsGetter.GetExceptions() for the planned implementation.
 	//
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {


### PR DESCRIPTION
Adds a structural skeleton for the CRD-based exceptions getter, implementing the `IExceptionsGetter` interface.

## What's included
- `CRDExceptionsGetter` struct in `core/cautils/getter/crdexceptionsgetter.go`
- Stub `GetExceptions()` returning empty slice — will query `SecurityException` / `ClusterSecurityException` CRDs once defined
- Nil-receiver guard
- Compile-time interface check (`var _ IExceptionsGetter = &CRDExceptionsGetter{}`)
- 4 unit tests: interface compliance, empty return, nil receiver, idempotency
- TODO wiring comment in `getExceptionsGetter()` in `initutils.go`

## Related
- LFX Mentorship issue: kubescape/kubescape#1982
- `go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added foundational support for reading exception policies from cluster resources to enable CRD-based exception management.

* **Tests**
  * Added tests validating the new CRD-based exceptions getter: interface conformance, proper error handling for nil receivers, empty-result behavior, and consistency across repeated calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2020)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->