### PR TITLE
feat(opaprocessor): add CEL rule language dispatch skeleton

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -376,6 +376,8 @@ func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reportha
 	switch rule.RuleLanguage {
 	case reporthandling.RegoLanguage, reporthandling.RegoLanguage2:
 		return opap.runRegoOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
+	case reporthandling.CELLanguage:
+		return opap.runCELOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
 	default:
 		return nil, fmt.Errorf("rule: '%s', language '%v' not supported", rule.Name, rule.RuleLanguage)
 	}
@@ -406,6 +408,10 @@ func (opap *OPAProcessor) runRegoOnK8s(ctx context.Context, rule *reporthandling
 	}
 
 	return results, nil
+}
+
+func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]interface{}, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData) ([]reporthandling.RuleResponse, error) {
+	return nil, fmt.Errorf("rule '%s': CEL rule evaluation not yet implemented", rule.Name)
 }
 
 func (opap *OPAProcessor) Print(ctx opaprint.Context, str string) error {

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -561,3 +561,42 @@ func TestSkipNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestRunOPAOnSingleRule_CELDispatch(t *testing.T) {
+	tests := []struct {
+		name         string
+		ruleLanguage reporthandling.RuleLanguages
+		expectError  bool
+	}{
+		{
+			name:         "CEL language dispatches to runCELOnK8s",
+			ruleLanguage: reporthandling.CELLanguage,
+			expectError:  true,
+		},
+		{
+			name:         "unknown language returns error",
+			ruleLanguage: reporthandling.RuleLanguages("UNKNOWN"),
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opap := &OPAProcessor{}
+			rule := &reporthandling.PolicyRule{
+				PortalBase: armotypes.PortalBase{
+					Name: "test-rule",
+				},
+				RuleLanguage: tt.ruleLanguage,
+			}
+
+			_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, nil, resources.RegoDependenciesData{})
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -563,40 +563,31 @@ func TestSkipNamespace(t *testing.T) {
 }
 
 func TestRunOPAOnSingleRule_CELDispatch(t *testing.T) {
-	tests := []struct {
-		name         string
-		ruleLanguage reporthandling.RuleLanguages
-		expectError  bool
-	}{
-		{
-			name:         "CEL language dispatches to runCELOnK8s",
-			ruleLanguage: reporthandling.CELLanguage,
-			expectError:  true,
-		},
-		{
-			name:         "unknown language returns error",
-			ruleLanguage: reporthandling.RuleLanguages("UNKNOWN"),
-			expectError:  true,
-		},
-	}
+	opap := &OPAProcessor{}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opap := &OPAProcessor{}
-			rule := &reporthandling.PolicyRule{
-				PortalBase: armotypes.PortalBase{
-					Name: "test-rule",
-				},
-				RuleLanguage: tt.ruleLanguage,
-			}
+	t.Run("CEL language dispatches to runCELOnK8s", func(t *testing.T) {
+		rule := &reporthandling.PolicyRule{
+			PortalBase: armotypes.PortalBase{
+				Name: "test-rule",
+			},
+			RuleLanguage: reporthandling.CELLanguage,
+		}
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, nil, resources.RegoDependenciesData{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CEL rule evaluation not yet implemented",
+			"CEL dispatch should route to runCELOnK8s, not the default branch")
+	})
 
-			_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, nil, resources.RegoDependenciesData{})
-
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	t.Run("unknown language returns default branch error", func(t *testing.T) {
+		rule := &reporthandling.PolicyRule{
+			PortalBase: armotypes.PortalBase{
+				Name: "test-rule",
+			},
+			RuleLanguage: reporthandling.RuleLanguages("UNKNOWN"),
+		}
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, nil, resources.RegoDependenciesData{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported",
+			"unknown language should route to default error branch")
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -614,3 +614,5 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
+
+replace github.com/kubescape/opa-utils => github.com/manmathbh/opa-utils v0.0.0-20260502165539-611d593717ae

--- a/go.sum
+++ b/go.sum
@@ -1190,8 +1190,6 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.294 h1:d1nF6BMbiCq1VwqW9KSBQdvbnE3uTc+lBHAq6bHQOZQ=
-github.com/kubescape/opa-utils v0.0.294/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=
@@ -1236,6 +1234,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/manmathbh/opa-utils v0.0.0-20260502165539-611d593717ae h1:aFrSr3b1nna5yleY9yJwENQ2wKmk/SwPEj0byg+ORE8=
+github.com/manmathbh/opa-utils v0.0.0-20260502165539-611d593717ae/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/mark3labs/mcp-go v0.29.0 h1:sH1NBcumKskhxqYzhXfGc201D7P76TVXiT0fGVhabeI=
 github.com/mark3labs/mcp-go v0.29.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=


### PR DESCRIPTION
Adds CEL rule language dispatch support to the OPA processor scanning pipeline.

### Changes
- Add `case reporthandling.CELLanguage:` to `runOPAOnSingleRule()` that dispatches to `runCELOnK8s()`
- Add `runCELOnK8s()` stub method returning a descriptive error (CEL evaluation not yet implemented)
- Add unit test verifying CEL language dispatch and unknown language error paths
- Use `replace` directive for `opa-utils` pointing to the fork with the `CELLanguage` constant (depends on kubescape/opa-utils#167)

### Why
This is the critical extension point for the CEL rule engine support ([#2001](https://github.com/kubescape/kubescape/issues/2001)). Currently the scanning pipeline only supports Rego rules via `runRegoOnK8s()`. Adding the CEL dispatch case prepares the codebase for full CEL-based ValidatingAdmissionPolicy evaluation alongside existing Rego controls.

### Dependencies
- kubescape/opa-utils#167 (CELLanguage constant)

### Test Plan
- `TestRunOPAOnSingleRule_CELDispatch` verifies:
  - `CELLanguage` dispatches to `runCELOnK8s` (returns expected error)
  - Unknown language returns appropriate error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying language dispatch for policy rules, including CEL detection and error reporting.

* **Chores**
  * Updated dependency mapping for tooling compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2022)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->