### PR TITLE
feat(opaprocessor): filter expired exceptions before applying results

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -2,6 +2,7 @@ package opaprocessor
 
 import (
 	"context"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
@@ -43,6 +44,9 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	}
 
 	processor := exceptions.NewProcessor()
+
+	// filter expired exceptions before applying them
+	opap.Exceptions = filterExpiredExceptions(opap.Exceptions)
 
 	// set exceptions
 	for i := range opap.ResourcesResult {
@@ -135,6 +139,22 @@ func requiresResourceMatch(designator identifiers.PortalDesignator) bool {
 		designator.GetPath() != "" ||
 		designator.GetResourceID() != "" ||
 		len(designator.GetLabels()) != 0
+}
+
+// filterExpiredExceptions removes exception policies whose ExpirationDate has passed.
+// Policies with a nil ExpirationDate (no expiration) are kept.
+func filterExpiredExceptions(exceptions []armotypes.PostureExceptionPolicy) []armotypes.PostureExceptionPolicy {
+	if len(exceptions) == 0 {
+		return exceptions
+	}
+	now := time.Now()
+	var valid []armotypes.PostureExceptionPolicy
+	for _, e := range exceptions {
+		if e.ExpirationDate == nil || e.ExpirationDate.After(now) {
+			valid = append(valid, e)
+		}
+	}
+	return valid
 }
 
 // hasExplicitControlException reports whether an exception policy targets controlID

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -2,6 +2,7 @@ package opaprocessor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
@@ -666,6 +667,89 @@ func TestGetNamespaceName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			largeClusterSize = -1
 			assert.Equal(t, tt.want, getNamespaceName(tt.obj, tt.clusterSize))
+		})
+	}
+}
+
+func TestFilterExpiredExceptions(t *testing.T) {
+	past := time.Now().Add(-24 * time.Hour)
+	future := time.Now().Add(24 * time.Hour)
+
+	makePolicy := func(expiration *time.Time) armotypes.PostureExceptionPolicy {
+		return armotypes.PostureExceptionPolicy{
+			ExpirationDate: expiration,
+			PosturePolicies: []armotypes.PosturePolicy{
+				{ControlID: "C-0001"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		exceptions []armotypes.PostureExceptionPolicy
+		wantLen    int
+	}{
+		{
+			name:       "nil slice is returned as is",
+			exceptions: nil,
+			wantLen:    0,
+		},
+		{
+			name:       "empty slice is returned as is",
+			exceptions: []armotypes.PostureExceptionPolicy{},
+			wantLen:    0,
+		},
+		{
+			name: "nil expiration date is kept",
+			exceptions: []armotypes.PostureExceptionPolicy{
+				makePolicy(nil),
+			},
+			wantLen: 1,
+		},
+		{
+			name: "future expiration date is kept",
+			exceptions: []armotypes.PostureExceptionPolicy{
+				makePolicy(&future),
+			},
+			wantLen: 1,
+		},
+		{
+			name: "past expiration date is filtered out",
+			exceptions: []armotypes.PostureExceptionPolicy{
+				makePolicy(&past),
+			},
+			wantLen: 0,
+		},
+		{
+			name: "mixed nil, future, and past — only past is filtered",
+			exceptions: []armotypes.PostureExceptionPolicy{
+				makePolicy(nil),
+				makePolicy(&future),
+				makePolicy(&past),
+			},
+			wantLen: 2,
+		},
+		{
+			name: "all expired are filtered out",
+			exceptions: []armotypes.PostureExceptionPolicy{
+				makePolicy(&past),
+				makePolicy(&past),
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterExpiredExceptions(tt.exceptions)
+			assert.Len(t, got, tt.wantLen)
+
+			for _, e := range got {
+				if e.ExpirationDate != nil {
+					assert.True(t, e.ExpirationDate.After(time.Now()),
+						"filtered exceptions must have future ExpirationDate")
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Problem
The `PostureExceptionPolicy` struct has had an `ExpirationDate` field since its introduction, but it was **never evaluated** at scan time. Time-bound exceptions would continue to apply indefinitely after their expiration, defeating the purpose of setting an expiration.

### Solution
Add `filterExpiredExceptions()` that removes exception policies whose `ExpirationDate` has passed before they are applied to scan results. Policies with a `nil` ExpirationDate (no expiration set) are retained.

The filter is called in `updateResults()` before both:
1. The resource exception loop (`SetExceptions()`)
2. The manual controls exception application (`applyExceptionsToManualControls()`)

### Test Coverage
8 table-driven test cases covering:
- nil slice / empty slice
- nil ExpirationDate (kept)
- Future ExpirationDate (kept)
- Past ExpirationDate (filtered out)
- Mixed nil/future/past (only past filtered)
- All expired (all filtered)
- Post-filter invariant: all remaining exceptions have future or nil ExpirationDate

### Why this matters
This is directly relevant to the SecurityException CRD project ([#1982](https://github.com/kubescape/kubescape/issues/1982)) — CRD-based exceptions will need time-bound expiration, and the scan-time evaluation should respect it. The existing field was essentially dead code until now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Expired exception policies are now automatically filtered out before being applied, ensuring only valid policies are used.

* **Tests**
  * Added comprehensive test coverage for exception filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->