### PR TITLE
feat(policyhandler): merge CRD-backed exceptions with primary exceptions

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -1,8 +1,6 @@
 package getter
 
 import (
-	"fmt"
-
 	"github.com/armosec/armoapi-go/armotypes"
 )
 
@@ -25,7 +23,7 @@ func (g *CRDExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.Pos
 	_ = clusterName
 
 	if g == nil {
-		return nil, fmt.Errorf("CRDExceptionsGetter is nil")
+		return []armotypes.PostureExceptionPolicy{}, nil
 	}
 
 	return []armotypes.PostureExceptionPolicy{}, nil

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -1,0 +1,32 @@
+package getter
+
+import (
+	"fmt"
+
+	"github.com/armosec/armoapi-go/armotypes"
+)
+
+var (
+	_ IExceptionsGetter = &CRDExceptionsGetter{}
+)
+
+// CRDExceptionsGetter retrieves posture exceptions from Kubernetes
+// SecurityException and ClusterSecurityException CRDs in the cluster.
+type CRDExceptionsGetter struct {
+}
+
+// NewCRDExceptionsGetter creates a new CRD-based exceptions getter.
+func NewCRDExceptionsGetter() *CRDExceptionsGetter {
+	return &CRDExceptionsGetter{}
+}
+
+// GetExceptions returns posture exception policies from in-cluster CRDs.
+func (g *CRDExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	_ = clusterName
+
+	if g == nil {
+		return nil, fmt.Errorf("CRDExceptionsGetter is nil")
+	}
+
+	return []armotypes.PostureExceptionPolicy{}, nil
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -154,6 +154,7 @@ type ScanInfo struct {
 
 type Getters struct {
 	ExceptionsGetter     getter.IExceptionsGetter
+	CRDExceptionsGetter  getter.IExceptionsGetter
 	ControlsInputsGetter getter.IControlsInputsGetter
 	PolicyGetter         getter.IPolicyGetter
 	AttackTracksGetter   getter.IAttackTracksGetter

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -201,11 +201,21 @@ func (policyHandler *PolicyHandler) getExceptions() ([]armotypes.PostureExceptio
 	}
 
 	exceptions, err := policyHandler.getters.ExceptionsGetter.GetExceptions(policyHandler.clusterName)
-	if err == nil {
-		policyHandler.cachedExceptions.Set(exceptions)
+	if err != nil {
+		return nil, err
 	}
 
-	return exceptions, err
+	if policyHandler.getters.CRDExceptionsGetter != nil {
+		crdExceptions, crdErr := policyHandler.getters.CRDExceptionsGetter.GetExceptions(policyHandler.clusterName)
+		if crdErr != nil {
+			logger.L().Warning("failed to get CRD exceptions", helpers.Error(crdErr))
+		} else {
+			exceptions = append(exceptions, crdExceptions...)
+		}
+	}
+
+	policyHandler.cachedExceptions.Set(exceptions)
+	return exceptions, nil
 }
 
 func (policyHandler *PolicyHandler) getControlInputs() (map[string][]string, error) {

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -209,9 +209,9 @@ func (policyHandler *PolicyHandler) getExceptions() ([]armotypes.PostureExceptio
 		crdExceptions, crdErr := policyHandler.getters.CRDExceptionsGetter.GetExceptions(policyHandler.clusterName)
 		if crdErr != nil {
 			logger.L().Warning("failed to get CRD exceptions", helpers.Error(crdErr))
-		} else {
-			exceptions = append(exceptions, crdExceptions...)
+			return exceptions, nil
 		}
+		exceptions = append(exceptions, crdExceptions...)
 	}
 
 	policyHandler.cachedExceptions.Set(exceptions)

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -238,30 +238,39 @@ func (mock *CRDExceptionsGetterErrorMock) GetExceptions(clusterName string) ([]a
 
 func TestGetExceptions_WithCRDExceptions(t *testing.T) {
 	tests := []struct {
-		name              string
-		crdGetter         getter.IExceptionsGetter
-		wantTotalCount    int
+		name             string
+		crdGetter        getter.IExceptionsGetter
+		wantTotalCount   int
+		expectCacheWrite bool
 	}{
 		{
-			name:           "no CRD getter configured",
-			crdGetter:      nil,
-			wantTotalCount: 1,
+			name:             "no CRD getter configured",
+			crdGetter:        nil,
+			wantTotalCount:   1,
+			expectCacheWrite: true,
 		},
 		{
-			name:           "CRD getter returns exceptions, merged with primary",
-			crdGetter:      &CRDExceptionsGetterMock{},
-			wantTotalCount: 2,
+			name:             "CRD getter returns exceptions, merged with primary",
+			crdGetter:        &CRDExceptionsGetterMock{},
+			wantTotalCount:   2,
+			expectCacheWrite: true,
 		},
 		{
-			name:           "CRD getter returns error, primary exceptions still returned",
-			crdGetter:      &CRDExceptionsGetterErrorMock{},
-			wantTotalCount: 1,
+			name:             "CRD getter returns error, primary exceptions returned without caching",
+			crdGetter:        &CRDExceptionsGetterErrorMock{},
+			wantTotalCount:   1,
+			expectCacheWrite: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			policyHandler := NewPolicyHandler("test-cluster")
+
+			// Set a long TTL so we can observe caching behavior
+			longTTL := NewTimedCache[[]armotypes.PostureExceptionPolicy](999999)
+			policyHandler.cachedExceptions = longTTL
+
 			policyHandler.getters = &cautils.Getters{
 				ExceptionsGetter:    &ExceptionsGetterMock{},
 				CRDExceptionsGetter: tt.crdGetter,
@@ -271,6 +280,10 @@ func TestGetExceptions_WithCRDExceptions(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Len(t, exceptions, tt.wantTotalCount)
+
+			_, cacheHit := policyHandler.cachedExceptions.Get()
+			assert.Equal(t, tt.expectCacheWrite, cacheHit,
+				"cache write expectation mismatch: expected cacheWrite=%v", tt.expectCacheWrite)
 		})
 	}
 }

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
@@ -221,6 +222,57 @@ func TestGetExceptions(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedExceptions, exceptions)
+}
+
+type CRDExceptionsGetterMock struct{}
+
+func (mock *CRDExceptionsGetterMock) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	return []armotypes.PostureExceptionPolicy{*mocks.MockExceptionAllKinds(&armotypes.PosturePolicy{ControlID: "C-0198"})}, nil
+}
+
+type CRDExceptionsGetterErrorMock struct{}
+
+func (mock *CRDExceptionsGetterErrorMock) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	return nil, fmt.Errorf("CRD not available")
+}
+
+func TestGetExceptions_WithCRDExceptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		crdGetter         getter.IExceptionsGetter
+		wantTotalCount    int
+	}{
+		{
+			name:           "no CRD getter configured",
+			crdGetter:      nil,
+			wantTotalCount: 1,
+		},
+		{
+			name:           "CRD getter returns exceptions, merged with primary",
+			crdGetter:      &CRDExceptionsGetterMock{},
+			wantTotalCount: 2,
+		},
+		{
+			name:           "CRD getter returns error, primary exceptions still returned",
+			crdGetter:      &CRDExceptionsGetterErrorMock{},
+			wantTotalCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyHandler := NewPolicyHandler("test-cluster")
+			policyHandler.getters = &cautils.Getters{
+				ExceptionsGetter:    &ExceptionsGetterMock{},
+				CRDExceptionsGetter: tt.crdGetter,
+			}
+
+			exceptions, err := policyHandler.getExceptions()
+
+			assert.NoError(t, err)
+			assert.Len(t, exceptions, tt.wantTotalCount)
+		})
+	}
 }
 
 func TestGetControlInputs(t *testing.T) {


### PR DESCRIPTION
### Problem
The exception retrieval pipeline has no support for in-cluster CRD-based exceptions. The `Getters` struct and `getExceptions()` method only support a single exceptions getter (file-based or release-based), with no way to merge exceptions from multiple sources.

### Solution
1. **Add `CRDExceptionsGetter` skeleton** (`core/cautils/getter/crdexceptionsgetter.go`) — implements `IExceptionsGetter` interface, returns empty slice (ready for full CRD client implementation in [#1982](https://github.com/kubescape/kubescape/issues/1982))

2. **Add `CRDExceptionsGetter` to `Getters` struct** — makes it available throughout the scanning pipeline

3. **Wire into `getExceptions()`** — the policy handler now:
   - Fetches primary exceptions as before
   - If `CRDExceptionsGetter` is non-nil, fetches CRD exceptions and appends them
   - CRD getter errors are logged as warnings (non-fatal) — the scan continues with primary exceptions

### Test Coverage
3 table-driven test cases for CRD merging:
- No CRD getter configured → only primary exceptions returned
- CRD getter returns exceptions → merged with primary  
- CRD getter returns error → primary exceptions still returned, no error propagated

### Why this matters
This is the integration point for the SecurityException CRD project ([#1982](https://github.com/kubescape/kubescape/issues/1982)). Once the full CRD client is implemented, CRD-based exceptions will automatically flow into the scanning pipeline through this wiring.

### Note
This PR branches from `upstream/master` directly (no unrelated commits) — fixing the commit interleaving issue from previous PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for CRD-sourced exceptions so policies can include CRD-provided exception rules.

* **Improvements**
  * Fail-fast on primary exception fetch; if CRD fetch fails the system logs a warning and continues with primary exceptions.
  * Merged exceptions are cached on successful retrievals; cache is not updated when CRD retrieval errors occur.

* **Tests**
  * Added tests for CRD exceptions, error handling, and caching behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2024)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->