### PR TITLE
fix: prevent goroutine leak in copaPatch on timeout

### DIFF
--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -149,7 +149,7 @@ func copaPatch(ctx context.Context, timeout time.Duration, buildkitAddr, image, 
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	go func() {
 		ch <- patchWithContext(timeoutCtx, buildkitAddr, image, reportFile, patchedImageName, workingFolder, ignoreError, bkOpts)
 	}()


### PR DESCRIPTION
## Overview

When `copaPatch` times out before `patchWithContext` completes, the background goroutine leaks. The root cause is an unbuffered channel (`make(chan error)`): after the `select` returns via the timeout path, no receiver remains on `ch`, 
so the goroutine blocks forever on `ch <-`.

**Before:** goroutine blocks indefinitely after timeout - leaked.  
**After:** `make(chan error, 1)` lets the goroutine complete its send and exit cleanly, even when no receiver is waiting.

## How to Test

The fix is a single-character change to channel buffer size. Correctness can be verified by code inspection:

1. Open `core/core/patch.go`, find the `copaPatch` function.
2. Confirm `ch := make(chan error, 1)` - the buffer of 1 ensures the goroutine can always send without blocking.
3. Trace both paths in the `select`:
   - **Normal path** (`<-ch`): unchanged - receives the error as before.
   - **Timeout path** (`<-timeoutCtx.Done()`): the goroutine eventually finishes `patchWithContext`, sends to the buffered channel (non-blocking), and exits. Previously it would block here forever.

To verify at runtime: call `copaPatch` with a very short timeout on a slow image patch, then check `runtime.NumGoroutine()` after the timeout returns - it should return to baseline instead of growing by 1.

## Related issues/PRs:

* Resolved #2026

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling in patching operations to prevent goroutine blocking when a timeout occurs during the patching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->