### PR TITLE
feat(httphandler): support TLS key configuration via env vars

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -31,7 +31,7 @@ const (
 
 // SetupHTTPListener set up listening http servers
 func SetupHTTPListener() error {
-	keyPair, err := loadTLSKey("", "") // TODO - support key and crt files
+	keyPair, err := loadTLSKey(getCertFile(), getKeyFile())
 	if err != nil {
 		return err
 	}
@@ -99,6 +99,14 @@ func getPort() string {
 		return p
 	}
 	return "8080"
+}
+
+func getCertFile() string {
+	return os.Getenv("KS_CERT_FILE")
+}
+
+func getKeyFile() string {
+	return os.Getenv("KS_KEY_FILE")
 }
 
 func servePprof() {

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -79,8 +79,11 @@ func SetupHTTPListener() error {
 }
 
 func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
-	if keyFile == "" || certFile == "" {
+	switch {
+	case certFile == "" && keyFile == "":
 		return nil, nil
+	case certFile == "" || keyFile == "":
+		return nil, fmt.Errorf("both KS_CERT_FILE and KS_KEY_FILE must be set to enable TLS (got certFile=%q, keyFile=%q)", certFile, keyFile)
 	}
 
 	pair, err := tls.LoadX509KeyPair(certFile, keyFile)


### PR DESCRIPTION
## Overview
This PR resolves a `TODO` in `httphandler/listener/setup.go` by introducing the ability to dynamically configure TLS settings for the HTTP listener via environment variables.

**Current Behavior:** The HTTP listener hardcodes empty strings for the TLS certificate and key file paths, skipping TLS configuration entirely.
**Future Behavior:** The listener will now extract the file paths from the `KS_CERT_FILE` and `KS_KEY_FILE` environment variables, enabling the backend to run securely over HTTPS without requiring hardcoded paths.


## Additional Information
> The approach mimics the existing environment variable pattern already used in the same file for `KS_PORT` and `KS_OFFLINE`.

## How to Test
> 1. Run `go build .` in the root directory to verify the codebase compiles successfully.
> 2. To manually verify the new behavior, generate a test TLS certificate, set the `KS_CERT_FILE` and `KS_KEY_FILE` environment variables to their respective paths, and start the Kubescape backend. Ensure that the listener attempts to serve HTTPS requests on the port defined by `KS_PORT`.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server can enable HTTPS by reading TLS certificate and key file paths from environment variables; when both are provided, HTTPS is used automatically.
  * If neither variable is set, the server falls back to plain HTTP.

* **Bug Fixes**
  * Startup now fails with a clear error when only one of the certificate or key is provided (prevents misconfiguration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->