### PR TITLE
fix: validate severity-threshold flag before running scan

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -56,6 +56,11 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if scanInfo.FailThresholdSeverity != "" {
+				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+					return err
+				}
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -70,6 +70,11 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if scanInfo.FailThresholdSeverity != "" {
+				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+					return err
+				}
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -42,6 +43,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Long:    `The action you want to perform`,
 		Example: scanCmdExamples,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if scanInfo.FailThresholdSeverity != "" {
+				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+					return err
+				}
+			}
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				setSecurityViewScanInfo(args, &scanInfo)
 

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -57,6 +58,11 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if scanInfo.FailThresholdSeverity != "" {
+				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+					return err
+				}
+			}
 			kind, name, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %s", err.Error())


### PR DESCRIPTION
## Overview
Previously, `--severity-threshold` accepted any value and only validated it after the full scan completed, wasting time and giving poor UX.

This fix calls `ValidateSeverity()` early inside `RunE` before the scan starts. If the value is invalid, the command returns immediately with a clear error message.

## How to Test
Run with invalid severity — should exit immediately, no scan:
````kubescape scan --severity-threshold critical123```
Expected: `❌ unknown severity. Supported severities are: Low, Medium, High, Critical`

Run with valid severity — should scan normally:
```kubescape scan --severity-threshold high```
Expected: scan runs and completes normally

## Related issues/PRs
* Resolves #2030

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan commands now validate any configured severity threshold up front and return an error for invalid values, preventing scans from starting with incorrect settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->