### PR TITLE
fix(core): add warning logs for dropped workloads in local file scans

### DIFF
--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -14,14 +14,14 @@ func addWorkloadsToResourcesMap(allResources map[string][]workloadinterface.IMet
 	for i := range workloads {
 		groupVersionResource, err := k8sinterface.GetGroupVersionResource(workloads[i].GetKind())
 		if err != nil {
-			// TODO - print warning
+			logger.L().Warning("failed to get GroupVersionResource for workload", helpers.String("kind", workloads[i].GetKind()), helpers.Error(err))
 			continue
 		}
 
 		if k8sinterface.IsTypeWorkload(workloads[i].GetObject()) {
 			w := workloadinterface.NewWorkloadObj(workloads[i].GetObject())
 			if groupVersionResource.Group != w.GetGroup() || groupVersionResource.Version != w.GetVersion() {
-				// TODO - print warning
+				logger.L().Warning("workload GroupVersion mismatch", helpers.String("kind", workloads[i].GetKind()), helpers.String("expectedGroup", groupVersionResource.Group), helpers.String("actualGroup", w.GetGroup()), helpers.String("expectedVersion", groupVersionResource.Version), helpers.String("actualVersion", w.GetVersion()))
 				continue
 			}
 		}

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -14,14 +14,14 @@ func addWorkloadsToResourcesMap(allResources map[string][]workloadinterface.IMet
 	for i := range workloads {
 		groupVersionResource, err := k8sinterface.GetGroupVersionResource(workloads[i].GetKind())
 		if err != nil {
-			logger.L().Warning("failed to get GroupVersionResource for workload", helpers.String("kind", workloads[i].GetKind()), helpers.Error(err))
+			logger.L().Warning("unsupported/unmapped object kind", helpers.String("kind", workloads[i].GetKind()), helpers.String("id", workloads[i].GetID()), helpers.Error(err))
 			continue
 		}
 
 		if k8sinterface.IsTypeWorkload(workloads[i].GetObject()) {
 			w := workloadinterface.NewWorkloadObj(workloads[i].GetObject())
 			if groupVersionResource.Group != w.GetGroup() || groupVersionResource.Version != w.GetVersion() {
-				logger.L().Warning("workload GroupVersion mismatch", helpers.String("kind", workloads[i].GetKind()), helpers.String("expectedGroup", groupVersionResource.Group), helpers.String("actualGroup", w.GetGroup()), helpers.String("expectedVersion", groupVersionResource.Version), helpers.String("actualVersion", w.GetVersion()))
+				logger.L().Warning("workload GroupVersion mismatch", helpers.String("id", workloads[i].GetID()), helpers.String("kind", workloads[i].GetKind()), helpers.String("expectedGroup", groupVersionResource.Group), helpers.String("actualGroup", w.GetGroup()), helpers.String("expectedVersion", groupVersionResource.Version), helpers.String("actualVersion", w.GetVersion()))
 				continue
 			}
 		}


### PR DESCRIPTION
## Overview
This PR addresses several `TODO - print warning` comments inside `core/pkg/resourcehandler/filesloaderutils.go`. Previously, when users scanned local directories (YAML/JSON files), Kubescape would silently ignore and drop workloads if their `GroupVersionResource` could not be resolved or if there was a `Group`/`Version` mismatch between the expected schema and the provided workload. 

This silent dropping led to a confusing user experience because users wouldn't know why certain workloads were being skipped from the scan results (e.g., due to typos or invalid apiVersions in their manifests). 

By adding descriptive `logger.L().Warning()` logs, we now proactively inform users about these problematic resources and the underlying reasons for dropping them.

## Additional Information
> These warnings utilize the existing `kubescape/go-logger` package and do not change any of the core parsing logic, they only add visibility to previously swallowed errors.

## How to Test
> 1. Run `go test ./core/pkg/resourcehandler/...` to ensure all existing resource handler tests pass.
> 2. You can also manually test by running a Kubescape scan on a directory containing a malformed Kubernetes YAML file (e.g., with a typo in the `apiVersion`), and you will now see a clear warning printed in the console about the dropped workload instead of it being silently skipped.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning and diagnostic logging during resource mapping and workload processing when mismatches or lookup failures occur, providing clearer context for troubleshooting while preserving existing skip-on-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->