### PR TITLE
fix: surface YAML parse errors instead of silently dropping documents

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -259,33 +259,27 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 	return paths, errs
 }
 
-func readYamlFile(yamlFile []byte) ([]workloadinterface.IMetadata, error) {
+func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, _ error) {
+	yamlObjs = []workloadinterface.IMetadata{}
 	defer func() {
 		if r := recover(); r != nil {
 			logger.L().Warning(fmt.Sprintf("panic during YAML parsing: %v", r))
 		}
 	}()
 
-	yamlObjs := []workloadinterface.IMetadata{}
-
-	// Split into individual documents before parsing.
-	// yaml.v3's streaming decoder does not advance past parse errors —
-	// calling Decode again after an error loops on the same position indefinitely.
-	// Splitting by the document separator and using yaml.Unmarshal per document
-	// gives us clean per-document error isolation.
-	normalized := yamlFile
-	if bytes.HasPrefix(normalized, []byte("---")) {
-		normalized = normalized[3:]
+	normalized := bytes.TrimPrefix(yamlFile, []byte("---\n"))
+	if len(normalized) > 0 && normalized[len(normalized)-1] != '\n' {
+		normalized = append(normalized, '\n')
 	}
 
-	for _, doc := range bytes.Split(normalized, []byte("\n---")) {
+	for i, doc := range bytes.Split(normalized, []byte("\n---\n")) {
 		doc = bytes.TrimSpace(doc)
 		if len(doc) == 0 {
 			continue
 		}
 		var t interface{}
 		if err := yaml.Unmarshal(doc, &t); err != nil {
-			logger.L().Warning(fmt.Sprintf("skipping malformed YAML document: %v", err))
+			logger.L().Warning(fmt.Sprintf("skipping malformed YAML document %d: %v", i+1, err))
 			continue
 		}
 		j := convertYamlToJson(t)
@@ -305,7 +299,7 @@ func readYamlFile(yamlFile []byte) ([]workloadinterface.IMetadata, error) {
 		}
 	}
 
-	return yamlObjs, nil
+	return
 }
 
 func readJsonFile(jsonFile []byte) ([]workloadinterface.IMetadata, error) {

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -267,16 +268,7 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, _ er
 		}
 	}()
 
-	normalized := bytes.TrimPrefix(yamlFile, []byte("---\n"))
-	if len(normalized) > 0 && normalized[len(normalized)-1] != '\n' {
-		normalized = append(normalized, '\n')
-	}
-
-	for i, doc := range bytes.Split(normalized, []byte("\n---\n")) {
-		doc = bytes.TrimSpace(doc)
-		if len(doc) == 0 {
-			continue
-		}
+	for i, doc := range splitYAMLDocuments(yamlFile) {
 		var t interface{}
 		if err := yaml.Unmarshal(doc, &t); err != nil {
 			logger.L().Warning(fmt.Sprintf("skipping malformed YAML document %d: %v", i+1, err))
@@ -300,6 +292,38 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, _ er
 	}
 
 	return
+}
+
+func splitYAMLDocuments(data []byte) [][]byte {
+	var docs [][]byte
+	var current bytes.Buffer
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if isYAMLDocumentSeparator(line) {
+			if doc := bytes.TrimSpace(current.Bytes()); len(doc) > 0 {
+			docs = append(docs, append([]byte{}, doc...))
+			}
+			current.Reset()
+			continue
+		}
+		current.Write(line)
+		current.WriteByte('\n')
+	}
+	if doc := bytes.TrimSpace(current.Bytes()); len(doc) > 0 {
+	docs = append(docs, append([]byte{}, doc...))
+	}
+	return docs
+}
+
+func isYAMLDocumentSeparator(line []byte) bool {
+	line = bytes.TrimRight(line, "\r")
+	if !bytes.HasPrefix(line, []byte("---")) {
+		return false
+	}
+	rest := bytes.TrimLeft(line[3:], " \t")
+	return len(rest) == 0 || rest[0] == '#'
 }
 
 func readJsonFile(jsonFile []byte) ([]workloadinterface.IMetadata, error) {

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -299,11 +299,12 @@ func splitYAMLDocuments(data []byte) [][]byte {
 	var current bytes.Buffer
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), len(data)+1)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if isYAMLDocumentSeparator(line) {
 			if doc := bytes.TrimSpace(current.Bytes()); len(doc) > 0 {
-			docs = append(docs, append([]byte{}, doc...))
+				docs = append(docs, append([]byte{}, doc...))
 			}
 			current.Reset()
 			continue
@@ -311,8 +312,11 @@ func splitYAMLDocuments(data []byte) [][]byte {
 		current.Write(line)
 		current.WriteByte('\n')
 	}
+	if err := scanner.Err(); err != nil {
+		logger.L().Warning(fmt.Sprintf("error scanning YAML input: %v", err))
+	}
 	if doc := bytes.TrimSpace(current.Bytes()); len(doc) > 0 {
-	docs = append(docs, append([]byte{}, doc...))
+		docs = append(docs, append([]byte{}, doc...))
 	}
 	return docs
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -260,14 +260,34 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 }
 
 func readYamlFile(yamlFile []byte) ([]workloadinterface.IMetadata, error) {
-	defer recover()
+	defer func() {
+		if r := recover(); r != nil {
+			logger.L().Warning(fmt.Sprintf("panic during YAML parsing: %v", r))
+		}
+	}()
 
-	r := bytes.NewReader(yamlFile)
-	dec := yaml.NewDecoder(r)
 	yamlObjs := []workloadinterface.IMetadata{}
 
-	var t interface{}
-	for dec.Decode(&t) == nil {
+	// Split into individual documents before parsing.
+	// yaml.v3's streaming decoder does not advance past parse errors —
+	// calling Decode again after an error loops on the same position indefinitely.
+	// Splitting by the document separator and using yaml.Unmarshal per document
+	// gives us clean per-document error isolation.
+	normalized := yamlFile
+	if bytes.HasPrefix(normalized, []byte("---")) {
+		normalized = normalized[3:]
+	}
+
+	for _, doc := range bytes.Split(normalized, []byte("\n---")) {
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+		var t interface{}
+		if err := yaml.Unmarshal(doc, &t); err != nil {
+			logger.L().Warning(fmt.Sprintf("skipping malformed YAML document: %v", err))
+			continue
+		}
 		j := convertYamlToJson(t)
 		if j == nil {
 			continue


### PR DESCRIPTION
## Overview

`readYamlFile` used `for dec.Decode(&t) == nil` to iterate YAML documents.
Any decode error exits the loop, silently dropping every document after the
broken one. The bare `defer recover()` also swallowed panics without
surfacing them. Both issues cause kubescape to report a successful scan
while skipping workloads - a false negative in a security scanner.

Root cause: yaml.v3's streaming decoder does not advance past parse errors.
Calling `Decode` again after an error loops on the same position
indefinitely, making error recovery via `continue` impossible.

The fix splits the input on the YAML document separator and calls
`yaml.Unmarshal` per document. Malformed documents are logged as a warning
and skipped. Valid documents before and after a broken one are scanned
correctly.

**Before:** a 3-document YAML with a malformed middle document scanned 1
resource, dropped 2 silently, exited 0, no warning shown.

**After:** 2 resources scanned, malformed document logged as warning, exit 0.

```
WARNING  skipping malformed YAML document: yaml: line 6: did not find expected ',' or ']'

| Control name        | Resources |
| Non-root containers |     2     |
```

## How to Test

```bash
cat > /tmp/test-bad.yaml << 'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: good-pod
spec:
  containers:
  - name: nginx
    image: nginx
---
apiVersion: v1
kind: Pod
metadata:
  name: bad-pod
spec:
  containers:
  - name: [[[INVALID YAML
    image: nginx
---
apiVersion: v1
kind: Pod
metadata:
  name: third-pod
spec:
  containers:
  - name: nginx
    image: nginx
EOF

kubescape scan /tmp/test-bad.yaml
```

Expected: 2 resources scanned, warning logged for the malformed document,
exit 0.

## Additional Information

The bug was confirmed in v3.0.15, v4.0.5, and master. The `readYamlFile`
implementation is identical across all three. Any multi-document YAML file
with a malformed document would produce incorrect scan results without any
indication to the user.

## Related issues/PRs

* Resolved #2033

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * YAML input now supports multiple documents and processes each independently.
  * Malformed YAML documents are skipped with a logged warning (including document index) instead of aborting the entire operation.
  * Parsing errors and unexpected panics during YAML decoding are caught and logged as warnings to prevent crashes and allow processing to continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->