### PR TITLE
fix(cautils): return error on git URL parse  failure and handle unmarshal error

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -258,7 +258,9 @@ func (c *ClusterConfig) GetContextName() string {
 func (c *ClusterConfig) ToMapString() map[string]interface{} {
 	m := map[string]interface{}{}
 	if bc, err := json.Marshal(c.configObj); err == nil {
-		json.Unmarshal(bc, &m)
+		if err := json.Unmarshal(bc, &m); err != nil {
+			logger.L().Error("failed to unmarshal config", helpers.Error(err))
+		}
 	}
 	return m
 }

--- a/core/cautils/remotegitutils.go
+++ b/core/cautils/remotegitutils.go
@@ -155,7 +155,7 @@ func CloneGitRepo(path *string) (string, error) {
 
 	gitURL, err := giturl.NewGitAPI(*path)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	// Clone git repository if needed


### PR DESCRIPTION
## Bug Fix: Unhandled errors in cautils

Fixes #2035

---

### Changes

**1. `core/cautils/remotegitutils.go` — line 158**

The `CloneGitRepo` function was returning `""`, `nil` when Git URL parsing failed, silently swallowing the error. This caused the failure to propagate invisibly downstream and could trigger a panic in the logger.

```go
// Before
if err != nil {
    return "", nil
}

// After
if err != nil {
    return "", err
}
```

**2. `core/cautils/customerloader.go` — lines 261-263**

The return value of `json.Unmarshal` in `ToMapString()` was completely ignored. If unmarshaling failed, the failure was invisible to both the caller and the logs.

```go
// Before
if bc, err := json.Marshal(c.configObj); err == nil {
    json.Unmarshal(bc, &m)
}

// After
if bc, err := json.Marshal(c.configObj); err == nil {
    if err := json.Unmarshal(bc, &m); err != nil {
        logger.L().Error("failed to unmarshal config", helpers.Error(err))
    }
}
```

---

### Impact

- Git URL parse errors now propagate correctly to the caller instead of causing silent downstream failures
- Config unmarshal failures are now logged with proper context using the project's existing logger pattern
- No behavior change on success paths
- No new dependencies introduced

---

### Testing

- Existing tests pass
- Error paths now propagate and log correctly
- Changes are consistent with error handling patterns used elsewhere in the codebase