### PR TITLE
fix: replace os.ReadDir with os.RemoveAll in removeResultDirs

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -209,6 +209,10 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 		logger.L().Info("deleting results", helpers.String("ID", resultsQueryParams.ScanID))
 
 		if resultsQueryParams.AllResults {
+			if handler.state.len() > 0 {
+				handler.writeError(w, fmt.Errorf("cannot delete all results while a scan is in progress"), resultsQueryParams.ScanID)
+				return
+			}
 			removeResultDirs()
 		} else {
 			removeResultsFile(resultsQueryParams.ScanID)

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -209,11 +209,10 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 		logger.L().Info("deleting results", helpers.String("ID", resultsQueryParams.ScanID))
 
 		if resultsQueryParams.AllResults {
-			if handler.state.len() > 0 {
-				handler.writeError(w, fmt.Errorf("cannot delete all results while a scan is in progress"), resultsQueryParams.ScanID)
+			if err := handler.state.removeAllIfIdle(removeResultDirs); err != nil {
+				handler.writeError(w, err, resultsQueryParams.ScanID)
 				return
 			}
-			removeResultDirs()
 		} else {
 			removeResultsFile(resultsQueryParams.ScanID)
 		}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -120,8 +120,8 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 }
 
 func removeResultDirs() {
-	os.ReadDir(OutputDir)
-	os.ReadDir(FailedOutputDir)
+	os.RemoveAll(OutputDir)
+	os.RemoveAll(FailedOutputDir)
 }
 func removeResultsFile(fileID string) error {
 	if fileName := searchFile(fileID); fileName != "" {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -120,8 +120,12 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 }
 
 func removeResultDirs() {
-	os.RemoveAll(OutputDir)
-	os.RemoveAll(FailedOutputDir)
+	if err := os.RemoveAll(OutputDir); err != nil {
+		logger.L().Error("failed to remove output directory", helpers.String("path", OutputDir), helpers.Error(err))
+	}
+	if err := os.RemoveAll(FailedOutputDir); err != nil {
+		logger.L().Error("failed to remove failed output directory", helpers.String("path", FailedOutputDir), helpers.Error(err))
+	}
 }
 func removeResultsFile(fileID string) error {
 	if fileName := searchFile(fileID); fileName != "" {

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -1,6 +1,9 @@
 package v1
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 type serverState struct {
 	statusID map[string]bool
@@ -44,6 +47,16 @@ func (s *serverState) len() int {
 	l := len(s.statusID)
 	s.mtx.RUnlock()
 	return l
+}
+
+func (s *serverState) removeAllIfIdle(removeFn func()) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if len(s.statusID) > 0 {
+		return fmt.Errorf("cannot delete all results while a scan is in progress")
+	}
+	removeFn()
+	return nil
 }
 
 func newServerState() *serverState {


### PR DESCRIPTION
## Overview

`removeResultDirs` called `os.ReadDir` on both output directories and discarded the return values. This made `DELETE /v1/results?all=true` a complete no-op - the API returned 200 OK while leaving all scan results on disk untouched. In long-running in-cluster deployments this causes unbounded disk usage growth.

Replaced `os.ReadDir` with `os.RemoveAll` so both directories and their contents are actually deleted when the endpoint is called.

**Before:** `DELETE /v1/results?all=true` returns 200 OK, nothing deleted.

**After:** Both `OutputDir` and `FailedOutputDir` and their contents are removed on the DELETE call.

## How to Test

1. Run kubescape in operator mode and trigger several scans to populate the results directories.
2. Confirm files exist under `OutputDir` and `FailedOutputDir`.
3. Call `DELETE /v1/results?all=true`.
4. Confirm both directories are now empty.

## Additional Information

Bug confirmed in v4.0.5 and master. The `removeResultDirs` implementation has been a no-op since it was introduced. The fix is a 2-line change - `os.ReadDir` replaced with `os.RemoveAll` on each directory.

## Related issues/PRs

* Resolved #2037

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup now reliably removes both primary and failed-output result directories to prevent leftover files or empty folders.
  * Added a safety guard to block deleting all results while scans are active, preventing accidental data loss during in-progress operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->