### PR TITLE
fix: validate compliance-threshold and fail-threshold in scan and sca…

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -225,6 +225,9 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 }
 
 // validateThresholdsOnly validates only the numeric threshold ranges
+// (compliance-threshold and fail-threshold must be between 0 and 100).
+// Unlike validateFrameworkScanInfo, this function does not mutate scanInfo
+// or enforce unrelated constraints.
 func validateThresholdsOnly(scanInfo *cautils.ScanInfo) error {
 	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
 		return ErrBadThreshold

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -223,3 +223,14 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	// Validate the user's credentials
 	return cautils.ValidateAccountID(scanInfo.AccountID)
 }
+
+// validateThresholdsOnly validates only the numeric threshold ranges
+func validateThresholdsOnly(scanInfo *cautils.ScanInfo) error {
+	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
+		return ErrBadThreshold
+	}
+	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
+		return ErrBadThreshold
+	}
+	return nil
+}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -48,6 +48,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			if err := validateFrameworkScanInfo(&scanInfo); err != nil {
+				return err
+			}
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				setSecurityViewScanInfo(args, &scanInfo)
 

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -48,9 +48,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			requestedView := scanInfo.View
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {
 				return err
 			}
+			scanInfo.View = requestedView
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				setSecurityViewScanInfo(args, &scanInfo)
 

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -63,7 +63,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 					return err
 				}
 			}
-			if err := validateFrameworkScanInfo(scanInfo); err != nil {
+			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}
 			kind, name, err := parseWorkloadIdentifierString(args[0])

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -63,6 +63,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 					return err
 				}
 			}
+			if err := validateFrameworkScanInfo(scanInfo); err != nil {
+				return err
+			}
 			kind, name, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %s", err.Error())


### PR DESCRIPTION
## Overview

`--compliance-threshold` and `--fail-threshold` accepted out-of-range values (e.g. `150`, `-5`) in `scan` and `scan workload` subcommands without error. Scanner initialized and ran fully — invalid threshold never caught.

`validateFrameworkScanInfo()` existed in `cmd/scan/framework.go`, validates both thresholds (0–100). Was called in `scan control` and `scan framework` — **not** in `scan` or `scan workload`.

Fix: call `validateFrameworkScanInfo()` early in `RunE` for both missing subcommands — same pattern already used in `scan control`.

## How to Test

Invalid threshold → should error immediately, no scan:
```
kubescape scan --compliance-threshold 150 <yaml-file>
# Expected: Error: bad argument: out of range threshold

kubescape scan workload --compliance-threshold 150 Deployment/test
# Expected: Error: bad argument: out of range threshold

kubescape scan --fail-threshold -5 <yaml-file>
# Expected: Error: bad argument: out of range threshold
```

Valid threshold → should scan normally:
```
kubescape scan --compliance-threshold 50 <yaml-file>
# Expected: scan runs and completes normally
```

## Related issues/PRs

* Resolves #2039
* Similar to #2030, fixed in #2031

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-flight validation to scan operations to catch configuration issues before processing.
  * Added numeric range checks for compliance and fail thresholds (0–100) to prevent invalid threshold values.
  * Validation now halts scans on error and restores prior state to avoid partial processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->