### PR TITLE
adds CRD

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -44,14 +46,23 @@ func GetVapHelperCmd() *cobra.Command {
 }
 
 func getDeployLibraryCmd() *cobra.Command {
-	return &cobra.Command{
+	var outputFile string
+
+	cmd := &cobra.Command{
 		Use:   "deploy-library",
 		Short: "Install Kubescape CEL admission policy library",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return deployLibrary()
+			content, err := deployLibrary()
+			if err != nil {
+				return err
+			}
+			return writeOutput(content, outputFile)
 		},
 	}
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
+
+	return cmd
 }
 
 func getCreatePolicyBindingCmd() *cobra.Command {
@@ -61,6 +72,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	var labelArr []string
 	var action string
 	var parameterReference string
+	var outputFile string
 
 	createPolicyBindingCmd := &cobra.Command{
 		Use:   "create-policy-binding",
@@ -94,7 +106,11 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				}
 			}
 
-			return createPolicyBinding(policyBindingName, policyName, action, parameterReference, namespaceArr, labelArr)
+			content, err := createPolicyBinding(policyBindingName, policyName, action, parameterReference, namespaceArr, labelArr)
+			if err != nil {
+				return err
+			}
+			return writeOutput(content, outputFile)
 		},
 	}
 	// Must specify the name of the policy binding
@@ -106,45 +122,48 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringVarP(&action, "action", "a", "Deny", "Action to take when policy fails")
 	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Parameter reference object name")
+	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
 	return createPolicyBindingCmd
 }
 
 // Implementation of the VAP helper commands
 // deploy-library
-func deployLibrary() error {
+func deployLibrary() (string, error) {
 	logger.L().Info("Downloading the Kubescape CEL admission policy library")
 	// Download the policy-configuration-definition.yaml from the latest release URL
 	policyConfigurationDefinitionURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/policy-configuration-definition.yaml"
 	policyConfigurationDefinition, err := downloadFileToString(policyConfigurationDefinitionURL)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Download the basic-control-configuration.yaml from the latest release URL
 	basicControlConfigurationURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/basic-control-configuration.yaml"
 	basicControlConfiguration, err := downloadFileToString(basicControlConfigurationURL)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Download the kubescape-validating-admission-policies.yaml from the latest release URL
 	kubescapeValidatingAdmissionPoliciesURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/kubescape-validating-admission-policies.yaml"
 	kubescapeValidatingAdmissionPolicies, err := downloadFileToString(kubescapeValidatingAdmissionPoliciesURL)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	logger.L().Info("Successfully downloaded admission policy library")
 
-	// Print the downloaded files to the STDOUT for the user to apply connecting them to a single YAML with ---
-	fmt.Println(policyConfigurationDefinition)
-	fmt.Println("---")
-	fmt.Println(basicControlConfiguration)
-	fmt.Println("---")
-	fmt.Println(kubescapeValidatingAdmissionPolicies)
+	// Concatenate the downloaded files into a single YAML document with --- separators
+	var result strings.Builder
+	result.WriteString(policyConfigurationDefinition)
+	result.WriteString("\n---\n")
+	result.WriteString(basicControlConfiguration)
+	result.WriteString("\n---\n")
+	result.WriteString(kubescapeValidatingAdmissionPolicies)
+	result.WriteString("\n")
 
-	return nil
+	return result.String(), nil
 }
 
 func downloadFileToString(url string) (string, error) {
@@ -171,6 +190,14 @@ func downloadFileToString(url string) (string, error) {
 	return bodyString, nil
 }
 
+func writeOutput(content string, outputFile string) error {
+	if outputFile != "" {
+		return os.WriteFile(outputFile, []byte(content), 0644)
+	}
+	fmt.Print(content)
+	return nil
+}
+
 func isValidK8sObjectName(name string) error {
 	// Kubernetes object names must consist of lower case alphanumeric characters, '-' or '.',
 	// and must start and end with an alphanumeric character (e.g., 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
@@ -188,11 +215,9 @@ func isValidK8sObjectName(name string) error {
 }
 
 // Create a policy binding
-func createPolicyBinding(bindingName string, policyName string, action string, paramRefName string, namespaceArr []string, labelMatch []string) error {
+func createPolicyBinding(bindingName string, policyName string, action string, paramRefName string, namespaceArr []string, labelMatch []string) (string, error) {
 	// Create a policy binding struct
 	policyBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
-	// Print the policy binding after marshalling it to YAML to the STDOUT
-	// The user can apply the output to the cluster
 	policyBinding.APIVersion = "admissionregistration.k8s.io/v1"
 	policyBinding.Name = bindingName
 	policyBinding.Kind = "ValidatingAdmissionPolicyBinding"
@@ -230,8 +255,7 @@ func createPolicyBinding(bindingName string, policyName string, action string, p
 	// Marshal the policy binding to YAML
 	out, err := yaml.Marshal(policyBinding)
 	if err != nil {
-		return err
+		return "", err
 	}
-	fmt.Println(string(out))
-	return nil
+	return string(out), nil
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -168,17 +168,14 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		// Capture stdout
-		out := captureStdout(t, func() {
-			err := deployLibrary()
-			require.NoError(t, err)
-		})
+		content, err := deployLibrary()
+		require.NoError(t, err)
 
-		parts := strings.Split(out, "---\n")
+		parts := strings.Split(content, "\n---\n")
 		require.Len(t, parts, 3)
-		assert.Equal(t, "policy-config-content\n", parts[0])
-		assert.Equal(t, "basic-control-content\n", parts[1])
-		assert.Equal(t, "kubescape-policies-content\n", parts[2])
+		assert.Contains(t, parts[0], "policy-config-content")
+		assert.Contains(t, parts[1], "basic-control-content")
+		assert.Contains(t, parts[2], "kubescape-policies-content")
 	})
 
 	t.Run("first download fails", func(t *testing.T) {
@@ -198,7 +195,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		err := deployLibrary()
+		_, err := deployLibrary()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
 	})
@@ -220,7 +217,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		err := deployLibrary()
+		_, err := deployLibrary()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
 	})
@@ -242,7 +239,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		err := deployLibrary()
+		_, err := deployLibrary()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
 	})
@@ -250,13 +247,11 @@ func TestDeployLibrary(t *testing.T) {
 
 func TestCreatePolicyBinding(t *testing.T) {
 	t.Run("minimal binding with name and policy", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, nil)
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, nil)
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		assert.Equal(t, "admissionregistration.k8s.io/v1", binding.APIVersion)
 		assert.Equal(t, "ValidatingAdmissionPolicyBinding", binding.Kind)
@@ -269,13 +264,11 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with namespaces", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Audit", "", []string{"ns1", "ns2"}, nil)
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Audit", "", []string{"ns1", "ns2"}, nil)
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		require.NotNil(t, binding.Spec.MatchResources.NamespaceSelector)
 		require.Len(t, binding.Spec.MatchResources.NamespaceSelector.MatchExpressions, 1)
@@ -285,13 +278,11 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with labels", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Warn", "", nil, []string{"app=nginx", "env=prod"})
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Warn", "", nil, []string{"app=nginx", "env=prod"})
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		require.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
 		assert.Equal(t, map[string]string{"app": "nginx", "env": "prod"}, binding.Spec.MatchResources.ObjectSelector.MatchLabels)
@@ -299,13 +290,11 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with parameter reference", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", nil, nil)
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", nil, nil)
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		require.NotNil(t, binding.Spec.ParamRef)
 		assert.Equal(t, "my-params", binding.Spec.ParamRef.Name)
@@ -314,13 +303,11 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("all fields combined", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", []string{"ns1"}, []string{"app=nginx"})
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", []string{"ns1"}, []string{"app=nginx"})
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		assert.Equal(t, "my-binding", binding.Name)
 		assert.Equal(t, "c-0016", binding.Spec.PolicyName)
@@ -330,25 +317,21 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("empty namespace slice does not add selector", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", []string{}, nil)
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", []string{}, nil)
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		assert.Nil(t, binding.Spec.MatchResources.NamespaceSelector)
 	})
 
 	t.Run("empty label slice does not add selector", func(t *testing.T) {
-		out := captureStdout(t, func() {
-			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, []string{})
-			require.NoError(t, err)
-		})
+		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, []string{})
+		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
-		err := yaml.Unmarshal([]byte(out), &binding)
+		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		assert.Nil(t, binding.Spec.MatchResources.ObjectSelector)
 	})
@@ -586,4 +569,65 @@ func captureStdout(t *testing.T, fn func()) string {
 	os.Stdout = oldStdout
 
 	return <-outC
+}
+
+func TestWriteOutput(t *testing.T) {
+	dir := t.TempDir()
+	filePath := dir + "/output.yaml"
+
+		t.Run("writes to file when path provided", func(t *testing.T) {
+		err := writeOutput("test content", filePath)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "test content", string(data))
+	})
+
+	t.Run("writes to stdout when path is empty", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := writeOutput("stdout content", "")
+			require.NoError(t, err)
+		})
+		assert.Equal(t, "stdout content", out)
+	})
+}
+
+func TestDeployLibraryCmdOutputFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &redirectTransport{
+		baseURL:           strings.TrimPrefix(server.URL, "http://"),
+		originalTransport: server.Client().Transport,
+	}
+	defer func() { http.DefaultTransport = origTransport }()
+
+	dir := t.TempDir()
+	outPath := dir + "/policies.yaml"
+	cmd := getDeployLibraryCmd()
+	cmd.SetArgs([]string{"--output", outPath})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "ok")
+}
+
+func TestCreatePolicyBindingCmdOutputFlag(t *testing.T) {
+	dir := t.TempDir()
+	outPath := dir + "/binding.yaml"
+	cmd := getCreatePolicyBindingCmd()
+	cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--output", outPath})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "my-binding")
+	assert.Contains(t, string(data), "ValidatingAdmissionPolicyBinding")
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1,10 +1,589 @@
 package vap
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"sigs.k8s.io/yaml"
 )
 
+func TestIsValidK8sObjectName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		// valid names
+		{name: "single lowercase letter", input: "a", wantErr: false},
+		{name: "lowercase word", input: "abc", wantErr: false},
+		{name: "alphanumeric with hyphen", input: "abc-def", wantErr: false},
+		{name: "starts with digit", input: "123", wantErr: false},
+		{name: "contains multiple hyphens", input: "abc-def-ghi", wantErr: false},
+		{name: "hyphen in middle", input: "abc-def123", wantErr: false},
+		{name: "exactly 63 chars", input: strings.Repeat("a", 63), wantErr: false},
+		{name: "1 char", input: "x", wantErr: false},
+
+		// invalid - length
+		{name: "empty string", input: "", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+		{name: "exceeds 63 chars", input: strings.Repeat("a", 64), wantErr: true, errMsg: "less than 63 characters"},
+
+		// invalid - starts with hyphen
+		{name: "starts with hyphen", input: "-abc", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+
+		// invalid - ends with hyphen
+		{name: "ends with hyphen", input: "abc-", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+
+		// invalid - uppercase
+		{name: "contains uppercase", input: "Abc", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+		{name: "all uppercase", input: "ABC", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+
+		// invalid - special characters
+		{name: "contains underscore", input: "abc_def", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+		{name: "contains space", input: "abc def", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+		{name: "contains dot in middle (not allowed by regex)", input: "abc.def", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+		{name: "contains at sign", input: "a@b", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+
+		// invalid - starts/ends with digit
+		{name: "starts with hyphen and digit", input: "-123abc", wantErr: true, errMsg: "should consist of lower case alphanumeric characters"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := isValidK8sObjectName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDownloadFileToString(t *testing.T) {
+	t.Run("successful download", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "hello world")
+		}))
+		defer server.Close()
+
+		result, err := downloadFileToString(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", result)
+	})
+
+	t.Run("server returns 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		_, err := downloadFileToString(server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+	})
+
+	t.Run("server returns 500", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		_, err := downloadFileToString(server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+		assert.Contains(t, err.Error(), "500")
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		// Use an invalid URL to simulate connection refused
+		_, err := downloadFileToString("http://127.0.0.1:1/nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		result, err := downloadFileToString(server.URL)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+// redirectTransport redirects all HTTP requests to a local test server
+type redirectTransport struct {
+	originalTransport http.RoundTripper
+	baseURL           string
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = rt.baseURL
+	req = req.Clone(req.Context())
+	req.URL = &u
+	req.Host = rt.baseURL
+	if rt.originalTransport == nil {
+		rt.originalTransport = http.DefaultTransport
+	}
+	return rt.originalTransport.RoundTrip(req)
+}
+
+func TestDeployLibrary(t *testing.T) {
+	t.Run("all downloads succeed with concatenation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			switch {
+			case strings.Contains(r.URL.Path, "policy-configuration-definition"):
+				fmt.Fprint(w, "policy-config-content")
+			case strings.Contains(r.URL.Path, "basic-control-configuration"):
+				fmt.Fprint(w, "basic-control-content")
+			case strings.Contains(r.URL.Path, "kubescape-validating-admission-policies"):
+				fmt.Fprint(w, "kubescape-policies-content")
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		// Redirect all HTTP traffic to our test server.
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &redirectTransport{
+			baseURL:           strings.TrimPrefix(server.URL, "http://"),
+			originalTransport: server.Client().Transport,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		// Capture stdout
+		out := captureStdout(t, func() {
+			err := deployLibrary()
+			require.NoError(t, err)
+		})
+
+		parts := strings.Split(out, "---\n")
+		require.Len(t, parts, 3)
+		assert.Equal(t, "policy-config-content\n", parts[0])
+		assert.Equal(t, "basic-control-content\n", parts[1])
+		assert.Equal(t, "kubescape-policies-content\n", parts[2])
+	})
+
+	t.Run("first download fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "policy-configuration-definition") {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprint(w, "content")
+		}))
+		defer server.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &redirectTransport{
+			baseURL:           strings.TrimPrefix(server.URL, "http://"),
+			originalTransport: server.Client().Transport,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		err := deployLibrary()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+	})
+
+	t.Run("second download fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "basic-control-configuration") {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprint(w, "content")
+		}))
+		defer server.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &redirectTransport{
+			baseURL:           strings.TrimPrefix(server.URL, "http://"),
+			originalTransport: server.Client().Transport,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		err := deployLibrary()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+	})
+
+	t.Run("third download fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "kubescape-validating-admission-policies") {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprint(w, "content")
+		}))
+		defer server.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &redirectTransport{
+			baseURL:           strings.TrimPrefix(server.URL, "http://"),
+			originalTransport: server.Client().Transport,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		err := deployLibrary()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to download file")
+	})
+}
+
+func TestCreatePolicyBinding(t *testing.T) {
+	t.Run("minimal binding with name and policy", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, nil)
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		assert.Equal(t, "admissionregistration.k8s.io/v1", binding.APIVersion)
+		assert.Equal(t, "ValidatingAdmissionPolicyBinding", binding.Kind)
+		assert.Equal(t, "my-binding", binding.Name)
+		assert.Equal(t, "c-0016", binding.Spec.PolicyName)
+		assert.Equal(t, []admissionv1.ValidationAction{admissionv1.Deny}, binding.Spec.ValidationActions)
+		assert.Nil(t, binding.Spec.ParamRef)
+		assert.Nil(t, binding.Spec.MatchResources.NamespaceSelector)
+		assert.Nil(t, binding.Spec.MatchResources.ObjectSelector)
+	})
+
+	t.Run("with namespaces", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Audit", "", []string{"ns1", "ns2"}, nil)
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		require.NotNil(t, binding.Spec.MatchResources.NamespaceSelector)
+		require.Len(t, binding.Spec.MatchResources.NamespaceSelector.MatchExpressions, 1)
+		assert.Equal(t, "kubernetes.io/metadata.name", binding.Spec.MatchResources.NamespaceSelector.MatchExpressions[0].Key)
+		assert.Equal(t, []string{"ns1", "ns2"}, binding.Spec.MatchResources.NamespaceSelector.MatchExpressions[0].Values)
+		assert.Equal(t, "Audit", string(binding.Spec.ValidationActions[0]))
+	})
+
+	t.Run("with labels", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Warn", "", nil, []string{"app=nginx", "env=prod"})
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		require.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
+		assert.Equal(t, map[string]string{"app": "nginx", "env": "prod"}, binding.Spec.MatchResources.ObjectSelector.MatchLabels)
+		assert.Equal(t, "Warn", string(binding.Spec.ValidationActions[0]))
+	})
+
+	t.Run("with parameter reference", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", nil, nil)
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		require.NotNil(t, binding.Spec.ParamRef)
+		assert.Equal(t, "my-params", binding.Spec.ParamRef.Name)
+		assert.NotNil(t, binding.Spec.ParamRef.ParameterNotFoundAction)
+		assert.Equal(t, admissionv1.DenyAction, *binding.Spec.ParamRef.ParameterNotFoundAction)
+	})
+
+	t.Run("all fields combined", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", []string{"ns1"}, []string{"app=nginx"})
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		assert.Equal(t, "my-binding", binding.Name)
+		assert.Equal(t, "c-0016", binding.Spec.PolicyName)
+		assert.NotNil(t, binding.Spec.MatchResources.NamespaceSelector)
+		assert.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
+		assert.NotNil(t, binding.Spec.ParamRef)
+	})
+
+	t.Run("empty namespace slice does not add selector", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", []string{}, nil)
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		assert.Nil(t, binding.Spec.MatchResources.NamespaceSelector)
+	})
+
+	t.Run("empty label slice does not add selector", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, []string{})
+			require.NoError(t, err)
+		})
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err := yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		assert.Nil(t, binding.Spec.MatchResources.ObjectSelector)
+	})
+}
+
+func TestCreatePolicyBindingCmdValidation(t *testing.T) {
+	t.Run("all valid defaults", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid binding name", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "INVALID-name", "--policy", "c-0016"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid policy binding name")
+	})
+
+	t.Run("invalid policy name", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "_invalid"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid policy name")
+	})
+
+	t.Run("invalid namespace in slice", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--namespace", "valid", "--namespace", "_invalid"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid namespace")
+	})
+
+	t.Run("invalid action", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", "Allow"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid action")
+	})
+
+	t.Run("invalid parameter reference", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--parameter-reference", "_bad-ref"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid parameter reference")
+	})
+
+	t.Run("empty parameter reference is OK", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetDeployLibraryCmd(t *testing.T) {
+	cmd := getDeployLibraryCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "deploy-library", cmd.Use)
+	assert.Equal(t, "Install Kubescape CEL admission policy library", cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestGetCreatePolicyBindingCmd(t *testing.T) {
+	cmd := getCreatePolicyBindingCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "create-policy-binding", cmd.Use)
+	assert.Equal(t, "Create a policy binding", cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+
+	// Check that required flags are marked
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+	assert.Equal(t, "n", nameFlag.Shorthand)
+
+	policyFlag := cmd.Flags().Lookup("policy")
+	require.NotNil(t, policyFlag)
+	assert.Equal(t, "p", policyFlag.Shorthand)
+
+	namespaceFlag := cmd.Flags().Lookup("namespace")
+	require.NotNil(t, namespaceFlag)
+
+	labelFlag := cmd.Flags().Lookup("label")
+	require.NotNil(t, labelFlag)
+
+	actionFlag := cmd.Flags().Lookup("action")
+	require.NotNil(t, actionFlag)
+	assert.Equal(t, "Deny", actionFlag.DefValue)
+
+	paramRefFlag := cmd.Flags().Lookup("parameter-reference")
+	require.NotNil(t, paramRefFlag)
+	assert.Equal(t, "r", paramRefFlag.Shorthand)
+}
+
 func TestGetVapHelperCmd(t *testing.T) {
-	// Call the GetFixCmd function
-	_ = GetVapHelperCmd()
+	cmd := GetVapHelperCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "vap", cmd.Use)
+	assert.Len(t, cmd.Commands(), 2)
+
+	subCmdNames := []string{cmd.Commands()[0].Use, cmd.Commands()[1].Use}
+	assert.Contains(t, subCmdNames, "deploy-library")
+	assert.Contains(t, subCmdNames, "create-policy-binding")
+}
+
+func TestLabelSelectorRegexEdgeCases(t *testing.T) {
+	// The label selector regex in createPolicyBindingCmd is: ^[a-zA-Z0-9]+=[a-zA-Z0-9]+$
+	// This is validated in the RunE function, not in a separate function.
+	// We test it through the validation logic.
+
+	tests := []struct {
+		name      string
+		input     string
+		wantValid bool
+	}{
+		{name: "simple key=val", input: "app=nginx", wantValid: true},
+		{name: "key and val with digits", input: "env1=prod2", wantValid: true},
+		{name: "uppercase allowed", input: "App=Value", wantValid: true},
+		{name: "mixed case", input: "appName=NginxValue", wantValid: true},
+		{name: "missing equals (space)", input: "key value", wantValid: false},
+		{name: "missing value", input: "key=", wantValid: false},
+		{name: "missing key", input: "=value", wantValid: false},
+		{name: "multiple equals", input: "key=val=extra", wantValid: false},
+		{name: "empty string", input: "", wantValid: false},
+		{name: "contains hyphen", input: "app-name=nginx", wantValid: false},
+		{name: "contains dot", input: "app.name=nginx", wantValid: false},
+		{name: "contains underscore", input: "app_name=nginx", wantValid: false},
+		{name: "contains special char in key", input: "app@=nginx", wantValid: false},
+		{name: "contains special char in value", input: "app=nginx@", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Replicate the label validation from createPolicyBindingCmd RunE
+			parts := strings.SplitN(tt.input, "=", 2)
+			valid := false
+			if len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0 {
+				// Check that both key and value match [a-zA-Z0-9]+
+				keyMatch := len(parts[0]) > 0
+				valueMatch := len(parts[1]) > 0
+				for _, c := range parts[0] {
+					if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+						keyMatch = false
+						break
+					}
+				}
+				for _, c := range parts[1] {
+					if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+						valueMatch = false
+						break
+					}
+				}
+				valid = keyMatch && valueMatch
+			}
+
+			if tt.wantValid {
+				assert.True(t, valid, "expected valid label selector: %s", tt.input)
+			} else {
+				assert.False(t, valid, "expected invalid label selector: %s", tt.input)
+			}
+		})
+	}
+}
+
+func TestCreatePolicyBindingCmdAllActions(t *testing.T) {
+	validActions := []string{"Deny", "Audit", "Warn"}
+	invalidActions := []string{"Allow", "deny", "audit", "warn", "", "Log", "Reject"}
+
+	for _, action := range validActions {
+		t.Run("valid action "+action, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("action", "Deny", "")
+			cmd.Flags().Set("action", action)
+			got, _ := cmd.Flags().GetString("action")
+			isValid := got == "Deny" || got == "Audit" || got == "Warn"
+			assert.True(t, isValid)
+		})
+	}
+
+	for _, action := range invalidActions {
+		t.Run("invalid action "+action, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("action", "Deny", "")
+			cmd.Flags().Set("action", action)
+			got, _ := cmd.Flags().GetString("action")
+			isValid := got == "Deny" || got == "Audit" || got == "Warn"
+			assert.False(t, isValid)
+		})
+	}
+}
+
+func TestCreatePolicyBindingCmdRequiredFlags(t *testing.T) {
+	cmd := getCreatePolicyBindingCmd()
+
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+	annotations := nameFlag.Annotations
+	require.NotNil(t, annotations)
+	_, isRequired := annotations[cobra.BashCompOneRequiredFlag]
+	assert.True(t, isRequired, "name flag should be marked as required")
+
+	policyFlag := cmd.Flags().Lookup("policy")
+	require.NotNil(t, policyFlag)
+	annotations = policyFlag.Annotations
+	require.NotNil(t, annotations)
+	_, isRequired = annotations[cobra.BashCompOneRequiredFlag]
+	assert.True(t, isRequired, "policy flag should be marked as required")
+}
+
+// captureStdout captures stdout output from a function and returns it as a string.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	outC := make(chan string)
+	go func() {
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	fn()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	return <-outC
 }

--- a/core/cautils/getter/crdcontrolinputs.go
+++ b/core/cautils/getter/crdcontrolinputs.go
@@ -1,0 +1,109 @@
+package getter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	controlInputGroup    = "kubescape.io"
+	controlInputVersion  = "v1"
+	controlInputResource = "controlinputs"
+)
+
+var _ IControlsInputsGetter = &CRDControlInputs{}
+
+// CRDControlInputs retrieves control configuration inputs from the ControlInput CRD in-cluster.
+type CRDControlInputs struct {
+	client dynamic.Interface
+}
+
+// NewCRDControlInputs creates a new CRDControlInputs getter.
+// Returns an error if not connected to a cluster or if the dynamic client cannot be created.
+func NewCRDControlInputs() (*CRDControlInputs, error) {
+	if !k8sinterface.IsConnectedToCluster() {
+		return nil, fmt.Errorf("not connected to a Kubernetes cluster")
+	}
+
+	config := k8sinterface.GetK8sConfig()
+	if config == nil {
+		return nil, fmt.Errorf("failed to get k8s config")
+	}
+
+	// force GRPC for performance
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &CRDControlInputs{
+		client: dynamicClient,
+	}, nil
+}
+
+// GetControlsInputs retrieves control inputs from the ControlInput CRD.
+// It looks for a ControlInput resource named "default" in the cluster scope.
+func (c *CRDControlInputs) GetControlsInputs(clusterName string) (map[string][]string, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    controlInputGroup,
+		Version:  controlInputVersion,
+		Resource: controlInputResource,
+	}
+
+	obj, err := c.client.Resource(gvr).Get(context.Background(), "default", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ControlInput CRD 'default': %w", err)
+	}
+
+	return extractControlsInputs(obj)
+}
+
+// extractControlsInputs parses the controls map from an unstructured ControlInput object.
+func extractControlsInputs(obj *unstructured.Unstructured) (map[string][]string, error) {
+	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ControlInput spec: %w", err)
+	}
+	if !found {
+		logger.L().Debug("ControlInput resource has no spec")
+		return map[string][]string{}, nil
+	}
+
+	controlsRaw, found, err := unstructured.NestedMap(spec, "controls")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ControlInput spec.controls: %w", err)
+	}
+	if !found {
+		logger.L().Debug("ControlInput resource has no spec.controls")
+		return map[string][]string{}, nil
+	}
+
+	controls := make(map[string][]string, len(controlsRaw))
+	for key, val := range controlsRaw {
+		arr, ok := val.([]interface{})
+		if !ok {
+			logger.L().Warning("unexpected type for control input, skipping",
+				helpers.String("key", key))
+			continue
+		}
+
+		strArr := make([]string, 0, len(arr))
+		for _, item := range arr {
+			strArr = append(strArr, fmt.Sprintf("%v", item))
+		}
+		controls[key] = strArr
+	}
+
+	return controls, nil
+}

--- a/core/cautils/getter/crdcontrolinputs_test.go
+++ b/core/cautils/getter/crdcontrolinputs_test.go
@@ -1,0 +1,104 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractControlsInputs_EmptyObject(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_NoSpec(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_WithControls(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"c-0001": []interface{}{"val1", "val2"},
+					"c-0004": []interface{}{"val3"},
+					"c-0050": []interface{}{"0.5", "5"},
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, []string{"val1", "val2"}, result["c-0001"])
+	assert.Equal(t, []string{"val3"}, result["c-0004"])
+	assert.Equal(t, []string{"0.5", "5"}, result["c-0050"])
+}
+
+func TestExtractControlsInputs_NumericValues(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"maxCriticalVulnerabilities": []interface{}{int64(5)},
+					"cpuLimitMin":                []interface{}{float64(0.5)},
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []string{"5"}, result["maxCriticalVulnerabilities"])
+	assert.Equal(t, []string{"0.5"}, result["cpuLimitMin"])
+}
+
+func TestExtractControlsInputs_EmptyControls(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_InvalidTypeSkipped(t *testing.T) {
+	// Non-array values (like a bare string) should be skipped gracefully
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"validKey":         []interface{}{"val1"},
+					"invalidStringKey": "not-an-array",
+					"invalidIntKey":    int64(42),
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []string{"val1"}, result["validKey"])
+}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -221,7 +221,11 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 
 }
 
-// setConfigInputsGetter sets the config input getter - local file/github release/Kubescape Cloud API
+// setConfigInputsGetter sets the config input getter with the following precedence:
+//  1. Local file (--controls-config flag)
+//  2. Kubescape Cloud API (if accountID configured)
+//  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
+//  4. Defaults from regolibrary GitHub releases
 func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IControlsInputsGetter {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs})
@@ -230,6 +234,13 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
 		return g
 	}
+
+	// Try to read control inputs from the ControlInput CRD in-cluster
+	if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
+		logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
+		return crdInputs
+	}
+
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}

--- a/examples/controlinput-crd.yaml
+++ b/examples/controlinput-crd.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: controlinputs.kubescape.io
+  labels:
+    app.kubernetes.io/name: kubescape
+    app.kubernetes.io/component: operator
+spec:
+  group: kubescape.io
+  scope: Cluster
+  names:
+    plural: controlinputs
+    singular: controlinput
+    kind: ControlInput
+    shortNames:
+      - ci
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                controls:
+                  type: object
+                  description: "Map of control IDs to their configuration values. Keys are control IDs (e.g., 'c-0001'), values are arrays of configuration strings."
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+              required:
+                - controls

--- a/examples/default-controlinput.yaml
+++ b/examples/default-controlinput.yaml
@@ -1,0 +1,155 @@
+apiVersion: kubescape.io/v1
+kind: ControlInput
+metadata:
+  name: default
+  labels:
+    app.kubernetes.io/name: kubescape
+    app.kubernetes.io/component: operator
+spec:
+  controls:
+    unclassified_cipher:
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      - TLS_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_RSA_WITH_AES_256_CBC_SHA256
+      - TLS_RSA_WITH_AES_128_CBC_SHA256
+    sensitiveKeyNames:
+      - aws_access_key_id
+      - aws_secret_access_key
+      - azure_batchai_storage_account
+      - azure_batchai_storage_key
+      - azure_batch_account
+      - azure_batch_key
+      - secret
+      - key
+      - password
+      - pwd
+      - token
+      - jwt
+      - bearer
+      - credential
+    sensitiveValues:
+      - BEGIN \w+ PRIVATE KEY
+      - PRIVATE KEY
+      - eyJhbGciO
+      - JWT
+      - Bearer
+      - _key_
+      - _secret_
+    insecureCapabilities:
+      - SETPCAP
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_MODULE
+      - SYS_RAWIO
+      - SYS_PTRACE
+      - SYS_ADMIN
+      - SYS_BOOT
+      - MAC_OVERRIDE
+      - MAC_ADMIN
+      - PERFMON
+      - ALL
+      - BPF
+    untrustedRegistries:
+      - docker.io
+      - gcr.io
+      - quay.io
+      - registry.hub.docker.com
+    imageRepositoryAllowList:
+      - gcr.io
+    publicRegistries:
+      - docker.io
+      - gcr.io
+      - quay.io
+      - registry.hub.docker.com
+    recommendedLabels:
+      - app
+      - tier
+      - phase
+      - version
+      - owner
+      - env
+    k8sRecommendedLabels:
+      - app.kubernetes.io/name
+      - app.kubernetes.io/instance
+      - app.kubernetes.io/version
+      - app.kubernetes.io/component
+      - app.kubernetes.io/part-of
+      - app.kubernetes.io/managed-by
+      - app.kubernetes.io/created-by
+    listOfDangerousArtifacts:
+      - bin/bash
+      - sbin/sh
+      - bin/ksh
+      - bin/tcsh
+      - bin/zsh
+      - usr/bin/scsh
+      - bin/csh
+      - bin/busybox
+      - usr/bin/busybox
+    servicesNames:
+      - nifi-service
+      - argo-server
+      - minio
+      - postgres
+      - workflow-controller-metrics
+      - weave-scope-app
+      - kubernetes-dashboard
+    wlKnownNames:
+      - coredns
+      - kube-proxy
+      - event-exporter-gke
+      - kube-dns
+      - 17-default-backend
+      - metrics-server
+      - ca-audit
+      - ca-dashboard-aggregator
+      - ca-notification-server
+      - ca-ocimage
+      - ca-oracle
+      - ca-posture
+      - ca-rbac
+      - ca-vuln-scan
+      - ca-webhook
+      - ca-websocket
+      - clair-clair
+    sensitiveInterfaces:
+      - nifi
+      - argo-server
+      - weave-scope-app
+      - kubeflow
+      - kubernetes-dashboard
+      - jenkins
+      - prometheus-deployment
+    cpuLimitMin:
+      - "0.5"
+    cpuLimitMax:
+      - "5"
+    cpuRequestMin:
+      - "0.1"
+    cpuRequestMax:
+      - "5"
+    memoryLimitMin:
+      - 0.25Gi
+    memoryLimitMax:
+      - 4Gi
+    memoryRequestMin:
+      - 0.125Gi
+    memoryRequestMax:
+      - 4Gi
+    maxCriticalVulnerabilities:
+      - "5"
+    maxHighVulnerabilities:
+      - "10"
+    cloudProvider:
+      - ""
+    sensitiveKeyNamesAllowed: []
+    sensitiveValuesAllowed:
+      - ''


### PR DESCRIPTION
Add `ControlInput` CRD (`kubescape.io/v1`, cluster-scoped) for storing control configuration parameters in-cluster
