### PR TITLE
feat: add ControlInput CRD for in-cluster control configuration

### DIFF
--- a/core/cautils/getter/crdcontrolinputs.go
+++ b/core/cautils/getter/crdcontrolinputs.go
@@ -38,10 +38,6 @@ func NewCRDControlInputs() (*CRDControlInputs, error) {
 		return nil, fmt.Errorf("failed to get k8s config")
 	}
 
-	// force GRPC for performance
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
-
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)

--- a/core/cautils/getter/crdcontrolinputs.go
+++ b/core/cautils/getter/crdcontrolinputs.go
@@ -1,0 +1,109 @@
+package getter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	controlInputGroup    = "kubescape.io"
+	controlInputVersion  = "v1"
+	controlInputResource = "controlinputs"
+)
+
+var _ IControlsInputsGetter = &CRDControlInputs{}
+
+// CRDControlInputs retrieves control configuration inputs from the ControlInput CRD in-cluster.
+type CRDControlInputs struct {
+	client dynamic.Interface
+}
+
+// NewCRDControlInputs creates a new CRDControlInputs getter.
+// Returns an error if not connected to a cluster or if the dynamic client cannot be created.
+func NewCRDControlInputs() (*CRDControlInputs, error) {
+	if !k8sinterface.IsConnectedToCluster() {
+		return nil, fmt.Errorf("not connected to a Kubernetes cluster")
+	}
+
+	config := k8sinterface.GetK8sConfig()
+	if config == nil {
+		return nil, fmt.Errorf("failed to get k8s config")
+	}
+
+	// force GRPC for performance
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &CRDControlInputs{
+		client: dynamicClient,
+	}, nil
+}
+
+// GetControlsInputs retrieves control inputs from the ControlInput CRD.
+// It looks for a ControlInput resource named "default" in the cluster scope.
+func (c *CRDControlInputs) GetControlsInputs(clusterName string) (map[string][]string, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    controlInputGroup,
+		Version:  controlInputVersion,
+		Resource: controlInputResource,
+	}
+
+	obj, err := c.client.Resource(gvr).Get(context.Background(), "default", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ControlInput CRD 'default': %w", err)
+	}
+
+	return extractControlsInputs(obj)
+}
+
+// extractControlsInputs parses the controls map from an unstructured ControlInput object.
+func extractControlsInputs(obj *unstructured.Unstructured) (map[string][]string, error) {
+	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ControlInput spec: %w", err)
+	}
+	if !found {
+		logger.L().Debug("ControlInput resource has no spec")
+		return map[string][]string{}, nil
+	}
+
+	controlsRaw, found, err := unstructured.NestedMap(spec, "controls")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ControlInput spec.controls: %w", err)
+	}
+	if !found {
+		logger.L().Debug("ControlInput resource has no spec.controls")
+		return map[string][]string{}, nil
+	}
+
+	controls := make(map[string][]string, len(controlsRaw))
+	for key, val := range controlsRaw {
+		arr, ok := val.([]interface{})
+		if !ok {
+			logger.L().Warning("unexpected type for control input, skipping",
+				helpers.String("key", key))
+			continue
+		}
+
+		strArr := make([]string, 0, len(arr))
+		for _, item := range arr {
+			strArr = append(strArr, fmt.Sprintf("%v", item))
+		}
+		controls[key] = strArr
+	}
+
+	return controls, nil
+}

--- a/core/cautils/getter/crdcontrolinputs_test.go
+++ b/core/cautils/getter/crdcontrolinputs_test.go
@@ -1,0 +1,104 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractControlsInputs_EmptyObject(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_NoSpec(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_WithControls(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"c-0001": []interface{}{"val1", "val2"},
+					"c-0004": []interface{}{"val3"},
+					"c-0050": []interface{}{"0.5", "5"},
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, []string{"val1", "val2"}, result["c-0001"])
+	assert.Equal(t, []string{"val3"}, result["c-0004"])
+	assert.Equal(t, []string{"0.5", "5"}, result["c-0050"])
+}
+
+func TestExtractControlsInputs_NumericValues(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"maxCriticalVulnerabilities": []interface{}{int64(5)},
+					"cpuLimitMin":                []interface{}{float64(0.5)},
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []string{"5"}, result["maxCriticalVulnerabilities"])
+	assert.Equal(t, []string{"0.5"}, result["cpuLimitMin"])
+}
+
+func TestExtractControlsInputs_EmptyControls(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtractControlsInputs_InvalidTypeSkipped(t *testing.T) {
+	// Non-array values (like a bare string) should be skipped gracefully
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"controls": map[string]interface{}{
+					"validKey":         []interface{}{"val1"},
+					"invalidStringKey": "not-an-array",
+					"invalidIntKey":    int64(42),
+				},
+			},
+		},
+	}
+
+	result, err := extractControlsInputs(obj)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []string{"val1"}, result["validKey"])
+}

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -100,7 +100,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	controlsInputsGetter := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil)
+	controlsInputsGetter := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false)
 	controlInputs, err := controlsInputsGetter.GetControlsInputs(tenant.GetContextName())
 	if err != nil {
 		return err

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -221,7 +221,11 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 
 }
 
-// setConfigInputsGetter sets the config input getter - local file/github release/Kubescape Cloud API
+// setConfigInputsGetter sets the config input getter with the following precedence:
+//  1. Local file (--controls-config flag)
+//  2. Kubescape Cloud API (if accountID configured)
+//  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
+//  4. Defaults from regolibrary GitHub releases
 func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IControlsInputsGetter {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs})
@@ -230,6 +234,13 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
 		return g
 	}
+
+	// Try to read control inputs from the ControlInput CRD in-cluster
+	if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
+		logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
+		return crdInputs
+	}
+
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -226,7 +226,7 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 //  2. Kubescape Cloud API (if accountID configured)
 //  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
 //  4. Defaults from regolibrary GitHub releases
-func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IControlsInputsGetter {
+func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool) getter.IControlsInputsGetter {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs})
 	}
@@ -235,13 +235,15 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		return g
 	}
 
-	// Try to read control inputs from the ControlInput CRD in-cluster
-	if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
-		if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
-			logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
-			return crdInputs
+	// Try to read control inputs from the ControlInput CRD in-cluster (live cluster scans only)
+	if useCRD {
+		if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
+			if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
+				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
+				return crdInputs
+			}
+			logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 		}
-		logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 	}
 
 	if downloadReleasedPolicy == nil {

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -237,8 +237,11 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 
 	// Try to read control inputs from the ControlInput CRD in-cluster
 	if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
-		logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
-		return crdInputs
+		if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
+			logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
+			return crdInputs
+		}
+		logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 	}
 
 	if downloadReleasedPolicy == nil {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -147,7 +147,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 
 	// set policy getter only after setting the customerGUID
 	scanInfo.PolicyGetter = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy)
-	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
+	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, !isAirGappedMode(scanInfo))
 	scanInfo.ExceptionsGetter = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
 	scanInfo.AttackTracksGetter = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -147,7 +147,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 
 	// set policy getter only after setting the customerGUID
 	scanInfo.PolicyGetter = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy)
-	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, !isAirGappedMode(scanInfo))
+	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster)
 	scanInfo.ExceptionsGetter = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
 	scanInfo.AttackTracksGetter = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
 

--- a/examples/controlinput-crd.yaml
+++ b/examples/controlinput-crd.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: controlinputs.kubescape.io
+  labels:
+    app.kubernetes.io/name: kubescape
+    app.kubernetes.io/component: operator
+spec:
+  group: kubescape.io
+  scope: Cluster
+  names:
+    plural: controlinputs
+    singular: controlinput
+    kind: ControlInput
+    shortNames:
+      - ci
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                controls:
+                  type: object
+                  description: "Map of control IDs to their configuration values. Keys are control IDs (e.g., 'c-0001'), values are arrays of configuration strings."
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+              required:
+                - controls

--- a/examples/default-controlinput.yaml
+++ b/examples/default-controlinput.yaml
@@ -1,0 +1,155 @@
+apiVersion: kubescape.io/v1
+kind: ControlInput
+metadata:
+  name: default
+  labels:
+    app.kubernetes.io/name: kubescape
+    app.kubernetes.io/component: operator
+spec:
+  controls:
+    unclassified_cipher:
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      - TLS_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_RSA_WITH_AES_256_CBC_SHA256
+      - TLS_RSA_WITH_AES_128_CBC_SHA256
+    sensitiveKeyNames:
+      - aws_access_key_id
+      - aws_secret_access_key
+      - azure_batchai_storage_account
+      - azure_batchai_storage_key
+      - azure_batch_account
+      - azure_batch_key
+      - secret
+      - key
+      - password
+      - pwd
+      - token
+      - jwt
+      - bearer
+      - credential
+    sensitiveValues:
+      - BEGIN \w+ PRIVATE KEY
+      - PRIVATE KEY
+      - eyJhbGciO
+      - JWT
+      - Bearer
+      - _key_
+      - _secret_
+    insecureCapabilities:
+      - SETPCAP
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_MODULE
+      - SYS_RAWIO
+      - SYS_PTRACE
+      - SYS_ADMIN
+      - SYS_BOOT
+      - MAC_OVERRIDE
+      - MAC_ADMIN
+      - PERFMON
+      - ALL
+      - BPF
+    untrustedRegistries:
+      - docker.io
+      - gcr.io
+      - quay.io
+      - registry.hub.docker.com
+    imageRepositoryAllowList:
+      - gcr.io
+    publicRegistries:
+      - docker.io
+      - gcr.io
+      - quay.io
+      - registry.hub.docker.com
+    recommendedLabels:
+      - app
+      - tier
+      - phase
+      - version
+      - owner
+      - env
+    k8sRecommendedLabels:
+      - app.kubernetes.io/name
+      - app.kubernetes.io/instance
+      - app.kubernetes.io/version
+      - app.kubernetes.io/component
+      - app.kubernetes.io/part-of
+      - app.kubernetes.io/managed-by
+      - app.kubernetes.io/created-by
+    listOfDangerousArtifacts:
+      - bin/bash
+      - sbin/sh
+      - bin/ksh
+      - bin/tcsh
+      - bin/zsh
+      - usr/bin/scsh
+      - bin/csh
+      - bin/busybox
+      - usr/bin/busybox
+    servicesNames:
+      - nifi-service
+      - argo-server
+      - minio
+      - postgres
+      - workflow-controller-metrics
+      - weave-scope-app
+      - kubernetes-dashboard
+    wlKnownNames:
+      - coredns
+      - kube-proxy
+      - event-exporter-gke
+      - kube-dns
+      - 17-default-backend
+      - metrics-server
+      - ca-audit
+      - ca-dashboard-aggregator
+      - ca-notification-server
+      - ca-ocimage
+      - ca-oracle
+      - ca-posture
+      - ca-rbac
+      - ca-vuln-scan
+      - ca-webhook
+      - ca-websocket
+      - clair-clair
+    sensitiveInterfaces:
+      - nifi
+      - argo-server
+      - weave-scope-app
+      - kubeflow
+      - kubernetes-dashboard
+      - jenkins
+      - prometheus-deployment
+    cpuLimitMin:
+      - "0.5"
+    cpuLimitMax:
+      - "5"
+    cpuRequestMin:
+      - "0.1"
+    cpuRequestMax:
+      - "5"
+    memoryLimitMin:
+      - 0.25Gi
+    memoryLimitMax:
+      - 4Gi
+    memoryRequestMin:
+      - 0.125Gi
+    memoryRequestMax:
+      - 4Gi
+    maxCriticalVulnerabilities:
+      - "5"
+    maxHighVulnerabilities:
+      - "10"
+    cloudProvider:
+      - ""
+    sensitiveKeyNamesAllowed: []
+    sensitiveValuesAllowed:
+      - ''


### PR DESCRIPTION
## Summary

Adds a `ControlInput` CRD (`kubescape.io/v1`, cluster-scoped) for storing control configuration parameters in-cluster, enabling operator and air-gapped users to configure controls without external services.

Fixes: #1725

## Problem

The Kubescape operator currently has no in-cluster mechanism for control configuration parameters. Operator users (not ARMO/vendor users) cannot configure controls without external services, blocking air-gapped and self-hosted deployments.

## Solution

Following the methodology from #1982:

1. Defines a `ControlInput` CRD with a `spec.controls` map matching the existing `map[string][]string` format used by OPA/Rego
2. Implements `CRDControlInputs` getter using the K8s dynamic client
3. Integrates into scan flow with precedence: local file > cloud API > CRD > defaults

## Files Changed

| File | Change |
|------|--------|
| `core/cautils/getter/crdcontrolinputs.go` | New getter implementing `IControlsInputsGetter` |
| `core/cautils/getter/crdcontrolinputs_test.go` | Unit tests (6 test cases) |
| `core/core/initutils.go` | Added CRD case to `getConfigInputsGetter` |
| `examples/controlinput-crd.yaml` | CRD definition |
| `examples/default-controlinput.yaml` | Default CR instance with sensible defaults |

## Deployment

```bash
kubectl apply -f examples/controlinput-crd.yaml
kubectl apply -f examples/default-controlinput.yaml
```

The operator automatically detects the CRD and uses it when no local file or cloud account is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read control inputs from a new in-cluster ControlInput CRD with example manifests and a default ControlInput provided.
  * Control-input sourcing now follows a deterministic precedence and will conditionally use cluster CRDs when scanning clusters.

* **Tests**
  * Added unit tests covering CRD parsing, empty/missing specs, numeric values, and invalid types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->