### PR TITLE
fix: validate empty format flag before running scan subcommands

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -61,7 +61,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 					return err
 				}
 			}
-			if scanInfo.Format == "" {
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -61,6 +61,9 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 					return err
 				}
 			}
+			if scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -75,6 +75,9 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 					return err
 				}
 			}
+			if scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -75,7 +75,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 					return err
 				}
 			}
-			if scanInfo.Format == "" {
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -47,7 +47,7 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				return fmt.Errorf("the command takes exactly one image name as an argument")
 			}
 
-			if scanInfo.Format == "" {
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
 			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -47,6 +47,9 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				return fmt.Errorf("the command takes exactly one image name as an argument")
 			}
 
+			if scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
+			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -48,6 +48,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			if scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			}
 			requestedView := scanInfo.View
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {
 				return err

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -48,7 +48,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
-			if scanInfo.Format == "" {
+			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
 			requestedView := scanInfo.View

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -63,6 +63,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 					return err
 				}
 			}
+			if scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			}
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -63,7 +63,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 					return err
 				}
 			}
-			if scanInfo.Format == "" {
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
 			if err := validateThresholdsOnly(scanInfo); err != nil {


### PR DESCRIPTION
## Overview
Passing `--format ""` (empty string) previously caused kubescape to run the full scan silently with no formatted output and no error message. The empty string bypassed all validation because `Formats()` returns an empty slice for empty string, so `GetOutputPrinters` loop never runs and `ValidatePrinter` is never called.

This fix adds early format validation in `RunE` of all scan subcommands before any scanning logic runs.

## How to Test
Run with empty format — should exit immediately, no scan:

kubescape scan --format ""
kubescape scan framework nsa --format ""
kubescape scan control C-0001 --format ""
kubescape scan workload Deployment/test --format ""
kubescape scan image nginx:latest --format ""

Expected: format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif

Run with valid format — should scan normally:

kubescape scan --format json

## Related issues/PRs
* Resolves #2043

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * All scan commands now validate that an output format is provided. If omitted when the format flag is explicitly changed, users receive a clear error listing supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif. This prevents ambiguous runs and ensures users specify a valid output format before scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->