### PR TITLE
docs: replace placeholder Long description in scan command

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -40,7 +40,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd := &cobra.Command{
 		Use:     "scan",
 		Short:   "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations",
-		Long:    `The action you want to perform`,
+		Long:    `Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.`,
 		Example: scanCmdExamples,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scanInfo.FailThresholdSeverity != "" {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -372,6 +372,6 @@ func TestGetScanCommand(t *testing.T) {
 	// Verify the command name and short description
 	assert.Equal(t, "scan", cmd.Use)
 	assert.Equal(t, "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations", cmd.Short)
-	assert.Equal(t, "The action you want to perform", cmd.Long)
+	assert.Equal(t, "Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.", cmd.Long)
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }


### PR DESCRIPTION
## Overview
The `scan` command had a placeholder text as its Long description:

`The action you want to perform`

This showed when running `kubescape scan --help`. Every other subcommand has a proper description. This PR replaces it with a meaningful description.

## How to Test
kubescape scan --help

Expected: `Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.`

## Related issues/PRs
* Resolves #2045

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the scan command help text to explicitly describe scanning Kubernetes clusters, YAML files, Helm charts, and container images for security misconfigurations and vulnerabilities.

* **Tests**
  * Updated automated tests to verify the help text reflects the new, specific scanning description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->