### PR TITLE
docs: add Git-repository and Kustomize-directory to scan Long description

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -40,7 +40,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd := &cobra.Command{
 		Use:     "scan",
 		Short:   "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations",
-		Long:    `Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.`,
+		Long:    `Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.`,
 		Example: scanCmdExamples,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scanInfo.FailThresholdSeverity != "" {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -372,6 +372,6 @@ func TestGetScanCommand(t *testing.T) {
 	// Verify the command name and short description
 	assert.Equal(t, "scan", cmd.Use)
 	assert.Equal(t, "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations", cmd.Short)
-	assert.Equal(t, "Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.", cmd.Long)
+	assert.Equal(t, "Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.", cmd.Long)
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }


### PR DESCRIPTION
## Overview
The `scan` command Long description was missing Git-repository and Kustomize-directory as supported scan targets. Both are documented in `getting-started.md` and work correctly, but were absent from the `--help` text.

Before:
Scan a Kubernetes cluster, YAML files, Helm charts, or container images for security misconfigurations and vulnerabilities.

After:
Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.

## How to Test
kubescape scan --help

## Related issues/PRs
* Resolves #2047
* Follow-up from #2046 as suggested by @matthyx

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the scan command's help text to reflect additional supported input sources, including Kustomize directories and Git repositories alongside existing Helm charts and container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->