### PR TITLE
fix: return clear error when directory path is passed to `kubescape fix`

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -31,6 +31,9 @@ const unixNewline = "\n"
 const oldMacNewline = "\r"
 
 func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
+	if info, err := os.Stat(fixInfo.ReportFile); err == nil && info.IsDir() {
+		return nil, fmt.Errorf("%q is a directory, not a file. Please provide a JSON report file path", fixInfo.ReportFile)
+	}
 	jsonFile, err := os.Open(fixInfo.ReportFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Overview

Passing a directory path to `kubescape fix` caused a cryptic `unexpected end of JSON input` error with no indication of what went wrong. `os.Open` succeeds on directories, `io.ReadAll` returns empty bytes, and `json.Unmarshal` fails silently.

This fix adds an `os.Stat` + `IsDir()` check in `NewFixHandler` before `os.Open` is called, returning a clear actionable error message. Note: `os.Stat` is already used in the same file at lines 51 and 148 — this follows the existing pattern.

## How to Test

```bash
mkdir -p /tmp/testdir

# Should give clear error — no scan attempt:
kubescape fix /tmp/testdir
# Expected: "/tmp/testdir" is a directory, not a file. Please provide a JSON report file path

# Nonexistent file — should still give original clear error:
kubescape fix /tmp/nonexistent.json
# Expected: open /tmp/nonexistent.json: no such file or directory
```

## Related issues/PRs

- Resolves #2049

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid input file paths. The system now validates that provided report file paths point to files rather than directories, and returns a clear error message if a directory path is supplied instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->