### PR TITLE
feat(scan): add hide flag and anonymization pipeline scaffold

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -93,6 +93,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
+    scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide,"hide",false,"Hide sensitive identifiers(name,namespace,image) in results")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -108,6 +108,7 @@ type ScanInfo struct {
 	UseDefault            bool                         // Load framework from cached file (instead of download). Use when running offline
 	UseArtifactsFrom      string                       // Load artifacts from local path. Use when running offline
 	VerboseMode           bool                         // Display all the input resources and not only failed resources
+	Hide                  bool                         // Hide sensitive identifiers (names, namespaces, images) in results
 	View                  string                       //
 	Format                string                       // Format results (table, json, junit ...)
 	Output                string                       // Store results in an output file, Output file name

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubescape/opa-utils/resources"
 	"go.opentelemetry.io/otel"
 	"k8s.io/client-go/kubernetes"
+	"github.com/kubescape/kubescape/v3/core/pkg/anonymizer"
 )
 
 type componentInterfaces struct {
@@ -218,10 +219,19 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)
 
+    /*logger.L().Info("hide flag value", helpers.String("hide", fmt.Sprintf("%v", scanInfo.Hide))) //used for debuging pipeline right now will be removed in suceeding PR */
+
+	if scanInfo.Hide { 
+		/* logger.L().Info("anonymizer hook triggered")  //used for debuging pipeline right now will be removed in suceeding phase */ 
+       if err := anonymizer.Apply(resultsHandling); err != nil {
+        logger.L().Warning("failed to hide sensitive fields", helpers.Error(err))
+       }
+    }
+
 	// if resultsHandling.GetRiskScore() > float32(scanInfo.FailThreshold) {
 	// 	return resultsHandling, fmt.Errorf("scan risk-score %.2f is above permitted threshold %.2f", resultsHandling.GetRiskScore(), scanInfo.FailThreshold)
 	// }
-
+   
 	return resultsHandling, nil
 }
 

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -1,0 +1,8 @@
+package anonymizer
+
+import "github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+
+func Apply(r *resultshandling.ResultsHandler) error {
+    // Phase 1: no-op (just wiring)
+    return nil
+}


### PR DESCRIPTION
Part of #1200
 
### Changes introduced in this PR

- Added `--hide` CLI flag to enable `anonymization` flow
- Extended `ScanInfo` with `Hide bool`
- Introduced initial `anonymizer` package scaffold
- Wired anonymization hook into the scan results pipeline
- Verified end-to-end propagation of the `hide flag`
- Established a dedicated extension point for future `anonymization` phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--hide` flag to mask sensitive identifiers (name, namespace, image) in scan results for enhanced privacy protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->