### PR TITLE
test: add baseline coverage for compliance-critical functions in opaprocessor

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -509,3 +509,144 @@ func TestApplyExceptionsToManualControls(t *testing.T) {
 		assert.Equal(t, apis.StatusSkipped, ctrl.GetStatus().Status())
 	})
 }
+
+// mockCounters implements reportsummary.ICounters for testing
+type mockCounters struct {
+	failed, skipped, passed, excluded int
+}
+
+func (m mockCounters) Failed() int   { return m.failed }
+func (m mockCounters) Skipped() int  { return m.skipped }
+func (m mockCounters) Passed() int   { return m.passed }
+func (m mockCounters) Excluded() int { return m.excluded }
+func (m mockCounters) All() int      { return m.failed + m.skipped + m.passed + m.excluded }
+
+func TestIsEmptyResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		counters mockCounters
+		want     bool
+	}{
+		{
+			name:     "all zero — empty",
+			counters: mockCounters{},
+			want:     true,
+		},
+		{
+			name:     "one failed — not empty",
+			counters: mockCounters{failed: 1},
+			want:     false,
+		},
+		{
+			name:     "one passed — not empty",
+			counters: mockCounters{passed: 1},
+			want:     false,
+		},
+		{
+			name:     "one skipped — not empty",
+			counters: mockCounters{skipped: 1},
+			want:     false,
+		},
+		{
+			name:     "mixed non-zero — not empty",
+			counters: mockCounters{failed: 2, passed: 3, skipped: 1},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isEmptyResources(tt.counters))
+		})
+	}
+}
+
+func TestIsLargeCluster(t *testing.T) {
+	// Reset the global so the default threshold (2500) is used
+	largeClusterSize = -1
+
+	tests := []struct {
+		name        string
+		clusterSize int
+		want        bool
+	}{
+		{
+			name:        "zero nodes — not large",
+			clusterSize: 0,
+			want:        false,
+		},
+		{
+			name:        "below threshold — not large",
+			clusterSize: 100,
+			want:        false,
+		},
+		{
+			name:        "at threshold — not large (exclusive)",
+			clusterSize: 2500,
+			want:        false,
+		},
+		{
+			name:        "above threshold — large",
+			clusterSize: 2501,
+			want:        true,
+		},
+		{
+			name:        "well above threshold — large",
+			clusterSize: 10000,
+			want:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			largeClusterSize = -1 // reset before each sub-test
+			assert.Equal(t, tt.want, isLargeCluster(tt.clusterSize))
+		})
+	}
+}
+
+func TestGetNamespaceName(t *testing.T) {
+	podJSON := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"mypod","namespace":"mynamespace"}}`
+	namespaceJSON := `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"mynamespace"}}`
+	nodeJSON := `{"apiVersion":"v1","kind":"Node","metadata":{"name":"mynode"}}`
+
+	pod, _ := workloadinterface.NewWorkload([]byte(podJSON))
+	ns, _ := workloadinterface.NewWorkload([]byte(namespaceJSON))
+	node, _ := workloadinterface.NewWorkload([]byte(nodeJSON))
+
+	tests := []struct {
+		name        string
+		obj         workloadinterface.IMetadata
+		clusterSize int
+		want        string
+	}{
+		{
+			name:        "small cluster — always clusterScope",
+			obj:         pod,
+			clusterSize: 10,
+			want:        clusterScope,
+		},
+		{
+			name:        "large cluster — namespaced resource returns namespace",
+			obj:         pod,
+			clusterSize: 3000,
+			want:        "mynamespace",
+		},
+		{
+			name:        "large cluster — Namespace kind returns its name",
+			obj:         ns,
+			clusterSize: 3000,
+			want:        "mynamespace",
+		},
+		{
+			name:        "large cluster — cluster-scoped resource returns clusterScope",
+			obj:         node,
+			clusterSize: 3000,
+			want:        clusterScope,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			largeClusterSize = -1
+			assert.Equal(t, tt.want, getNamespaceName(tt.obj, tt.clusterSize))
+		})
+	}
+}

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -548,6 +549,11 @@ func TestIsEmptyResources(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "one excluded — empty (excluded does not count as a result)",
+			counters: mockCounters{excluded: 1},
+			want:     true,
+		},
+		{
 			name:     "mixed non-zero — not empty",
 			counters: mockCounters{failed: 2, passed: 3, skipped: 1},
 			want:     false,
@@ -561,8 +567,9 @@ func TestIsEmptyResources(t *testing.T) {
 }
 
 func TestIsLargeCluster(t *testing.T) {
-	// Reset the global so the default threshold (2500) is used
-	largeClusterSize = -1
+	orig := largeClusterSize
+	t.Cleanup(func() { largeClusterSize = orig })
+	t.Setenv("LARGE_CLUSTER_SIZE", "2500")
 
 	tests := []struct {
 		name        string
@@ -597,20 +604,32 @@ func TestIsLargeCluster(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			largeClusterSize = -1 // reset before each sub-test
+			largeClusterSize = -1
 			assert.Equal(t, tt.want, isLargeCluster(tt.clusterSize))
 		})
 	}
 }
 
 func TestGetNamespaceName(t *testing.T) {
+	orig := largeClusterSize
+	t.Cleanup(func() { largeClusterSize = orig })
+	t.Setenv("LARGE_CLUSTER_SIZE", "2500")
+
 	podJSON := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"mypod","namespace":"mynamespace"}}`
 	namespaceJSON := `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"mynamespace"}}`
 	nodeJSON := `{"apiVersion":"v1","kind":"Node","metadata":{"name":"mynode"}}`
 
-	pod, _ := workloadinterface.NewWorkload([]byte(podJSON))
-	ns, _ := workloadinterface.NewWorkload([]byte(namespaceJSON))
-	node, _ := workloadinterface.NewWorkload([]byte(nodeJSON))
+	pod, err := workloadinterface.NewWorkload([]byte(podJSON))
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+
+	ns, err := workloadinterface.NewWorkload([]byte(namespaceJSON))
+	require.NoError(t, err)
+	require.NotNil(t, ns)
+
+	node, err := workloadinterface.NewWorkload([]byte(nodeJSON))
+	require.NoError(t, err)
+	require.NotNil(t, node)
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Overview

Three functions in `core/pkg/opaprocessor/processorhandlerutils.go` had no test coverage despite sitting directly in the path that determines scan correctness: `isEmptyResources`, `isLargeCluster`, and `getNamespaceName`. These are particularly important to have as a baseline before a second rule engine is introduced, so regressions can be caught by diffing results against the existing OPA engine behaviour.

Adds table-driven unit tests for all three functions. Also adds `mockCounters`, a minimal `ICounters` implementation scoped to the test file.

## How to Test

```bash
go test -v -run "TestIsEmptyResources|TestIsLargeCluster|TestGetNamespaceName" ./core/pkg/opaprocessor/...
```

Expected output: 14 sub-tests, all passing.

## Additional Information

`isLargeCluster` uses a package-level variable (`largeClusterSize`) that is lazily initialised on first call. Each sub-test resets it to -1 before calling the function so the default threshold (2500) is applied consistently regardless of test execution order.

## Related issues/PRs

* Resolved #2052

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test helpers and expanded unit tests for processor utilities, covering empty-resource detection, large-cluster classification at threshold, and namespace-name resolution across small vs. large clusters and cluster- vs. namespaced resources. These tests improve validation of resource logic and cluster-size behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->