### PR TITLE
docs: add PDF output format and fix heading inconsistencies in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,14 +10,14 @@ The best way to get started with Kubescape is to download it to the machine you 
 - [Run your first scan](#run-your-first-scan)
 - [Usage](#usage)
   - [Misconfigurations Scanning](#misconfigurations-scanning)
+    - [Output Formats](#output-formats)
+    - [Compliance Score](#compliance-score)
   - [Image Scanning](#image-scanning)
   - [Auto-Fix Misconfigurations](#auto-fix-misconfigurations)
   - [Image Patching](#image-patching)
   - [Validating Admission Policies (VAP)](#validating-admission-policies-vap)
   - [MCP Server (AI Integration)](#mcp-server-ai-integration)
   - [Configuration Management](#configuration-management)
-    - [Output Formats](#output-formats)
-    - [Compliance Score](#compliance-score)
 - [Offline/Air-gapped Support](#offlineair-gapped-environment-support)
 - [Other Ways to Use Kubescape](#other-ways-to-use-kubescape)
 - [Tutorial Videos](#tutorial-videos)
@@ -261,7 +261,7 @@ We offer two important metrics to assess compliance:
     kubescape scan framework <FRAMEWORK_NAME> --compliance-threshold <SCORE_VALUE[float32]>
     ```
 
-### Output formats
+### Output Formats
 
 #### JSON
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ The best way to get started with Kubescape is to download it to the machine you 
   - [Validating Admission Policies (VAP)](#validating-admission-policies-vap)
   - [MCP Server (AI Integration)](#mcp-server-ai-integration)
   - [Configuration Management](#configuration-management)
+    - [Output Formats](#output-formats)
+    - [Compliance Score](#compliance-score)
 - [Offline/Air-gapped Support](#offlineair-gapped-environment-support)
 - [Other Ways to Use Kubescape](#other-ways-to-use-kubescape)
 - [Tutorial Videos](#tutorial-videos)
@@ -261,18 +263,18 @@ We offer two important metrics to assess compliance:
 
 ### Output formats
 
-#### JSON:
+#### JSON
 
 ```bash
 kubescape scan --format json --output results.json
 ```
 
-#### junit XML: 
+#### JUnit XML
 
 ```bash
 kubescape scan --format junit --output results.xml
 ```
-#### SARIF: 
+#### SARIF
 
 SARIF is a standard format for the output of static analysis tools. It is supported by many tools, including GitHub Code Scanning and Azure DevOps. [Read more about SARIF](https://docs.github.com/en/code-security/secure-coding/sarif-support-for-code-scanning/about-sarif-support-for-code-scanning).
 
@@ -286,6 +288,12 @@ kubescape scan --format sarif --output results.sarif
 
 ```bash
 kubescape scan --format html --output results.html
+```
+
+#### PDF
+
+```bash
+kubescape scan --format pdf --output report.pdf
 ```
 
 ## Offline/air-gapped environment support


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

The `getting-started.md` doc was missing the PDF output format example even though Kubescape already supports it. The Output Formats section also had inconsistent heading styles — some had colons (`JSON:`, `junit XML:`, `SARIF:`) while others didn't, and `junit` was lowercase while everything else was uppercase. On top of that, the Table of Contents was missing entries for `Output Formats` and `Compliance Score` sections which made navigation confusing.

This PR fixes all three of these small but noticeable inconsistencies.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know
-->

The PDF format is already mentioned in the main `README.md` — this just brings `getting-started.md` in sync with it. All other changes are purely formatting fixes with no functional impact.

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

1. Open `docs/getting-started.md`
2. Check the Table of Contents — `Output Formats` and `Compliance Score` should now be listed
3. Scroll to the Output Formats section — headings should now be consistent (`JSON`, `JUnit XML`, `SARIF`, `HTML`, `PDF`) with no extra colons
4. Verify the new `PDF` section appears right after `HTML` with the correct example command

<!--
## Examples/Screenshots

> Here you add related screenshots
-->

Documentation only change — no screenshots needed.

<!--
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>
-->

No related issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured the Getting Started guide’s Output Formats into a clear top-level section with dedicated subsections.
  * Added examples and guidance for JSON, JUnit XML, SARIF (with support note), and a new PDF output format.
  * Updated the Table of Contents to surface Output Formats and Compliance Score for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->