### PR TITLE
suppress spurious interrupt signal log on graceful exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,21 +22,27 @@ func main() {
 	// Set the global build number for version checking
 	versioncheck.BuildNumber = version
 
-	// Capture interrupt signal
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	// Capture interrupt signal on a dedicated channel so the watcher can
+	// distinguish a real signal from a normal cancel() on graceful exit.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	// Handle interrupt signal
 	go func() {
-		<-ctx.Done()
-		// Perform cleanup or graceful shutdown here
-		logger.L().StopError("Received interrupt signal, exiting...")
-		// Clear the signal handler so that a second interrupt signal shuts down immediately
-		stop()
+		select {
+		case <-sigCh:
+			logger.L().StopError("Received interrupt signal, exiting...")
+			// Clear the signal handler so a second signal terminates immediately.
+			signal.Stop(sigCh)
+			cancel()
+		case <-ctx.Done():
+			// Normal shutdown — no log line.
+		}
 	}()
 
 	if err := cmd.Execute(ctx, version, commit, date); err != nil {
-		stop()
+		cancel()
 		logger.L().Fatal(err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	// distinguish a real signal from a normal cancel() on graceful exit.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
## Overview

Suppresses the spurious `Received interrupt signal, exiting...` log line that was printed on every graceful exit of the kubescape CLI.

**Current behavior:** `signal.NotifyContext` cancels its context on **both** signal arrival and `stop()` invocation. Because `main.go` called `defer stop()` on normal return and an explicit `stop()` on the error path, the watcher goroutine could not distinguish a real `SIGINT`/`SIGTERM` from a normal cancel. As a result, commands like `kubescape --help`, `kubescape version`, `kubescape list frameworks`, and even `kubescape <unknown-command>` raced to print `Received interrupt signal, exiting...` to stderr / JSON logs — appearing **before** the real `[fatal]` line on the error path.

**Future behavior:** The signal is observed on a dedicated `chan os.Signal`, with a plain `context.WithCancel` driving the rest of the program. The watcher only logs when `sigCh` actually fires; normal `cancel()` paths exit silently. `signal.Stop(sigCh)` after the first signal preserves the previous "second signal terminates immediately" behavior.

## Additional Information

Root cause is at `main.go:21-42`. The Go stdlib documents this for `signal.NotifyContext`:

> The stop function ... unregisters the signal behavior, which, like signal.Reset, may restore the default behavior for a given signal. ... The returned context's Done channel is closed when one of the listed signals arrives, when the stop function is called, or when the parent context's Done channel is closed, whichever happens first.

The original code conflated those three cases. The fix separates "signal arrived" from "we're shutting down".

The bug was also racy on fast-exit commands (the watcher goroutine raced against process termination), so the same command emitted the line on some runs and not others — worse for log-based alerting than a deterministic bug.

## How to Test

1. Build: `go build -o /tmp/kubescape ./`
2. Verify clean exits no longer log the spurious message:
   ```sh
   for i in 1 2 3 4 5; do /tmp/kubescape version 2>&1 | grep -i interrupt; done
   /tmp/kubescape --help 2>&1 | grep -i interrupt
   /tmp/kubescape list frameworks 2>&1 | grep -i interrupt
   KS_LOGGER=debug /tmp/kubescape version 2>&1 | grep -i interrupt
   ```
   All should produce **no output**.
3. Verify the error path is clean (no fake interrupt line before `[fatal]`):
   ```sh
   /tmp/kubescape nonexistentcmd
   ```
   Output should end with only `[fatal] unknown command "nonexistentcmd" for "kubescape"`.
4. Verify a real signal still logs correctly:
   ```sh
   /tmp/kubescape download framework nsa -o /tmp/nsa.json &
   PID=$!; sleep 0.3; kill -INT $PID
   ```
   Should print `Received interrupt signal, exiting...`.

## Examples

**Before the fix:**
```
$ kubescape version
Your current version is: dev
Build commit: none
Build date: unknown
{"level":"info","ts":"...","msg":"Received interrupt signal, exiting..."}

$ kubescape --help
... usage text ...
[error] Received interrupt signal, exiting...

$ kubescape nonexistentcmd
Error: unknown command "nonexistentcmd" for "kubescape"
Run 'kubescape --help' for usage.
[error] Received interrupt signal, exiting...
[fatal] unknown command "nonexistentcmd" for "kubescape"
```

**After the fix:**
```
$ kubescape version
Your current version is: dev
Build commit: none
Build date: unknown

$ kubescape --help
... usage text ...

$ kubescape nonexistentcmd
Error: unknown command "nonexistentcmd" for "kubescape"
Run 'kubescape --help' for usage.
[fatal] unknown command "nonexistentcmd" for "kubescape"
```

Real SIGINT still works:
```
$ kubescape download framework nsa &
$ kill -INT %1
{"level":"info","ts":"...","msg":"Received interrupt signal, exiting..."}
```

## Related issues/PRs

* Resolved #2059

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved shutdown handling: added dedicated interrupt processing with buffered signal handling and context cancellation. Interrupts are logged and further signal delivery is disabled; command errors now trigger immediate cancellation to ensure cleanup and more reliable graceful shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->