### PR TITLE
docs: fix grammatically incorrect Short description in operator vulnerabilities scan command

### DIFF
--- a/cmd/operator/vulnerabilitiesscan.go
+++ b/cmd/operator/vulnerabilitiesscan.go
@@ -22,7 +22,7 @@ var operatorScanVulnerabilitiesExamples = fmt.Sprintf(`
 func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:     "vulnerabilities",
-		Short:   "Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components",
+		Short:   "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components",
 		Long:    ``,
 		Example: operatorScanVulnerabilitiesExamples,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/operator/vulnerabilitiesscan_test.go
+++ b/cmd/operator/vulnerabilitiesscan_test.go
@@ -20,7 +20,7 @@ func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
 
 	// Verify the command name and short description
 	assert.Equal(t, "vulnerabilities", cmd.Use)
-	assert.Equal(t, "Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components", cmd.Short)
+	assert.Equal(t, "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components", cmd.Short)
 	assert.Equal(t, "", cmd.Long)
 	assert.Equal(t, operatorScanVulnerabilitiesExamples, cmd.Example)
 


### PR DESCRIPTION
## Overview
The `kubescape operator scan vulnerabilities` command had a grammatically incorrect Short description:

Before: `Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components`

Two issues:
1. "use for scan" — grammatically incorrect
2. "in the in cluster" — duplicate word

After: `Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components`

## How to Test
kubescape operator scan vulnerabilities --help

Expected: `Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components`

## Related issues/PRs
* Resolves #2066

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help text for the vulnerabilities scan command to accurately describe scanning your cluster for vulnerabilities using the Kubescape Operator in-cluster components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->