### PR TITLE
fix: remove unread buildChannel to prevent goroutine leak in patchWithContext

### DIFF
--- a/cmd/operator/vulnerabilitiesscan.go
+++ b/cmd/operator/vulnerabilitiesscan.go
@@ -22,7 +22,7 @@ var operatorScanVulnerabilitiesExamples = fmt.Sprintf(`
 func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:     "vulnerabilities",
-		Short:   "Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components",
+		Short:   "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components",
 		Long:    ``,
 		Example: operatorScanVulnerabilitiesExamples,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/operator/vulnerabilitiesscan_test.go
+++ b/cmd/operator/vulnerabilitiesscan_test.go
@@ -20,7 +20,7 @@ func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
 
 	// Verify the command name and short description
 	assert.Equal(t, "vulnerabilities", cmd.Use)
-	assert.Equal(t, "Vulnerabilities use for scan your cluster vulnerabilities using Kubescape operator in the in cluster components", cmd.Short)
+	assert.Equal(t, "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components", cmd.Short)
 	assert.Equal(t, "", cmd.Long)
 	assert.Equal(t, operatorScanVulnerabilitiesExamples, cmd.Example)
 

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -222,7 +222,6 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 		return fmt.Errorf("copa: error reading source policy :: %w", err)
 	}
 
-	buildChannel := make(chan *client.SolveStatus)
 	_, err = bkClient.Build(ctx, solveOpt, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
 		// Configure buildctl/client for use by package manager
 		config, err := buildkit.InitializeBuildkitConfig(ctx, c, image)
@@ -315,7 +314,7 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 			}
 		}
 		return res, nil
-	}, buildChannel)
+	}, nil)
 
 	return err
 }


### PR DESCRIPTION
## Overview
In `core/core/patch.go`, `patchWithContext` created an unbuffered `chan *client.SolveStatus` and passed it to `bkClient.Build()`, but never read from it anywhere in the code.

Buildkit's internal `solve()` sends `*SolveStatus` progress updates into this channel. Since the channel is unbuffered and has no reader, the goroutine inside buildkit blocks forever on `statusChan <- NewSolveStatus(resp)` — a goroutine leak on every `kubescape patch` call.

Fix: pass `nil` instead. Buildkit checks `if statusChan != nil` before sending, so `nil` safely discards progress updates without blocking any goroutine.

## How to Verify
1. Open `core/core/patch.go` — `buildChannel` no longer exists
2. `bkClient.Build()` now receives `nil` as the status channel
3. Buildkit's `solve()` checks `if statusChan != nil` before sending — so `nil` is safe
4. Check `runtime.NumGoroutine()` before/after patch — no longer grows

## Related issues/PRs
* Resolves #2068
* Similar to #2026 (goroutine leak in copaPatch), fixed in #2027

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the help text for the operator vulnerabilities scanning command with more descriptive and accurate wording, making it clearer what the functionality does.

* **Bug Fixes**
  * Fixed the build status update handling during cluster patching operations to ensure proper stream management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->