### PR TITLE
fix: replace filepath.Walk with filepath.WalkDir and stop early in findFile

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"os"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/httphandler/config"
@@ -51,4 +52,35 @@ func TestGetScanCommandWithAccessKey(t *testing.T) {
 	assert.False(t, s.HostSensorEnabled.GetBool())
 	assert.False(t, s.Local)
 	assert.False(t, s.Submit)
+}
+
+func TestFindFile_EarlyExit(t *testing.T) {
+	// Create a temp dir with multiple files
+	dir := t.TempDir()
+	// Create target file and extra files
+	targetFile := dir + "/target-abc123.json"
+	otherFile := dir + "/other-xyz.json"
+	err := os.WriteFile(targetFile, []byte("{}"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(otherFile, []byte("{}"), 0644)
+	assert.NoError(t, err)
+
+	// findFile should find the target and stop early
+	found, err := findFile(dir, "target-abc123")
+	assert.NoError(t, err)
+	assert.Contains(t, found, "target-abc123")
+}
+
+func TestFindFile_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	found, err := findFile(dir, "nonexistent-file")
+	assert.NoError(t, err)
+	assert.Equal(t, "", found)
+}
+
+func TestFindFile_MissingDir(t *testing.T) {
+	// WalkDir skips the root error same as per-entry errors; missing dir returns empty string and nil
+	found, err := findFile("/nonexistent/dir", "file")
+	assert.NoError(t, err)
+	assert.Equal(t, "", found)
 }

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -144,20 +145,21 @@ func searchFile(fileID string) string {
 }
 
 func findFile(targetDir string, fileName string) (string, error) {
-	var files []string
-	err := filepath.Walk(targetDir, func(path string, info os.FileInfo, err error) error {
-		files = append(files, path)
+	var found string
+	err := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible entries
+		}
+		if strings.Contains(path, fileName) {
+			found = path
+			return filepath.SkipAll
+		}
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
-	for i := range files {
-		if strings.Contains(files[i], fileName) {
-			return files[i], nil
-		}
-	}
-	return "", nil
+	return found, nil
 }
 
 func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *cautils.ScanInfo {


### PR DESCRIPTION
## Overview
`findFile` in `httphandler/handlerequests/v1/requestshandlerutils.go` used `filepath.Walk` with a callback that silently ignored per-entry errors and collected all paths into a slice before searching — even after a match was already found.

Two problems:
1. Per-entry errors (e.g. permission denied on a subdirectory) were swallowed — the walk callback always returned `nil`, so inaccessible entries were appended as empty paths and errors were lost.
2. No early exit — the entire directory tree was always walked even when a match was found on the first entry.

This fix replaces `filepath.Walk` with `filepath.WalkDir` (which passes `fs.DirEntry` instead of `os.FileInfo`, avoiding a `Stat` call per entry), handles per-entry errors explicitly by skipping them, and returns `filepath.SkipAll` immediately on first match.

## How to Test
```bash
cd httphandler
go test ./... 
```
All tests pass.

## Related issues/PRs
* Resolves #2071

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal file-search logic for faster, more robust handling of inaccessible entries and earlier termination once a match is found.
* **Tests**
  * Added unit tests to validate search behavior for matching, non-matching, and missing-directory cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2072)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->