### PR TITLE
test: add coverage for compliance and risk score accessors in ResultsHandler

### DIFF
--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -2,6 +2,7 @@ package resultshandling
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -258,4 +259,95 @@ func TestNewPrinter(t *testing.T) {
 			assert.NotNil(t, p)
 		})
 	}
+}
+
+func makeResultsHandler(complianceScore, riskScore float32) *ResultsHandler {
+	fakeScanData := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Score:           riskScore,
+				ComplianceScore: complianceScore,
+			},
+		},
+		Metadata: &reporthandlingv2.Metadata{},
+	}
+	rh := NewResultsHandler(&DummyReporter{}, nil, &SpyPrinter{})
+	rh.SetData(fakeScanData)
+	return rh
+}
+
+func TestGetComplianceScore(t *testing.T) {
+	tests := []struct {
+		name            string
+		complianceScore float32
+		want            float32
+	}{
+		{name: "zero score", complianceScore: 0, want: 0},
+		{name: "full score", complianceScore: 100, want: 100},
+		{name: "partial score", complianceScore: 67.5, want: 67.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rh := makeResultsHandler(tt.complianceScore, 0)
+			assert.Equal(t, tt.want, rh.GetComplianceScore())
+		})
+	}
+}
+
+func TestGetRiskScore(t *testing.T) {
+	tests := []struct {
+		name      string
+		riskScore float32
+		want      float32
+	}{
+		{name: "zero risk", riskScore: 0, want: 0},
+		{name: "full risk", riskScore: 100, want: 100},
+		{name: "partial risk", riskScore: 42.0, want: 42.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rh := makeResultsHandler(0, tt.riskScore)
+			assert.Equal(t, tt.want, rh.GetRiskScore())
+		})
+	}
+}
+
+func TestSetDataGetData(t *testing.T) {
+	rh := NewResultsHandler(&DummyReporter{}, nil, &SpyPrinter{})
+	assert.Nil(t, rh.GetData())
+
+	data := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				ComplianceScore: 55.0,
+			},
+		},
+	}
+	rh.SetData(data)
+	assert.Equal(t, data, rh.GetData())
+	assert.Equal(t, float32(55.0), rh.GetComplianceScore())
+}
+
+func TestGetResults(t *testing.T) {
+	rh := makeResultsHandler(80.0, 60.0)
+	results := rh.GetResults()
+	assert.NotNil(t, results)
+}
+
+func TestToJson(t *testing.T) {
+	rh := makeResultsHandler(75.0, 50.0)
+	data, err := rh.ToJson()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	// verify it is valid JSON
+	var out map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &out))
+}
+
+func TestGetComplianceScoreAndRiskScoreAreIndependent(t *testing.T) {
+	rh := makeResultsHandler(80.0, 40.0)
+	assert.Equal(t, float32(80.0), rh.GetComplianceScore())
+	assert.Equal(t, float32(40.0), rh.GetRiskScore())
+	assert.NotEqual(t, rh.GetComplianceScore(), rh.GetRiskScore())
 }


### PR DESCRIPTION
## Overview

`GetComplianceScore`, `GetRiskScore`, `SetData/GetData`, `GetResults`, and `ToJson` in `core/pkg/resultshandling/results.go` had no unit tests despite being the primary interface for reading compliance results after a scan. These functions are what CLI threshold checks, the operator API, and the Prometheus exporter rely on to surface compliance data to users.

Adds table-driven tests covering zero, full, and partial score values, a SetData/GetData round-trip, non-nil report verification from GetResults, valid JSON output from ToJson, and independence of compliance score from risk score.

## How to Test

```bash
go test -v -run "TestGetComplianceScore|TestGetRiskScore|TestSetData|TestGetResults|TestToJson|TestGetComplianceScoreAndRisk" ./core/pkg/resultshandling/...
```

Expected: 11 sub-tests, all passing.

## Additional Information

Tests follow the existing patterns in `results_test.go` using `DummyReporter` and `SpyPrinter`. The `makeResultsHandler` helper is scoped to the test file and builds a minimal but valid `OPASessionObj` including `Metadata` which `FinalizeResults` requires.

## Related issues/PRs

* Resolved #2073

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced unit test coverage for results handling functionality
  * Added validation tests for compliance scoring, risk scoring, data operations, and JSON output serialization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2074)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->