### PR TITLE
fix: strip URI prefix before splitting in ReadResource

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -128,30 +128,62 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 	ksServer.s.AddResourceTemplate(configManifestTemplate, ksServer.ReadConfigurationResource)
 }
 
+// vulnManifestURI holds the parsed components of a vulnerability manifest resource URI.
+type vulnManifestURI struct {
+	namespace    string
+	manifestName string
+	cveID        string // empty for cve_list requests
+}
+
+// parseVulnManifestURI parses a kubescape://vulnerability-manifests/... URI into its components.
+// Valid forms:
+//
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_list
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_details/{cve_id}
+func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
+	const prefix = "kubescape://vulnerability-manifests/"
+	if !strings.HasPrefix(uri, prefix) {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	parts := strings.Split(uri[len(prefix):], "/")
+	// cve_list:    {namespace}/{manifest_name}/cve_list          -> 3 parts
+	// cve_details: {namespace}/{manifest_name}/cve_details/{id}  -> 4 parts
+	if len(parts) != 3 && len(parts) != 4 {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	namespace := parts[0]
+	manifestName := parts[1]
+	if namespace == "" || manifestName == "" {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	action := parts[2]
+	parsed := &vulnManifestURI{namespace: namespace, manifestName: manifestName}
+	switch {
+	case len(parts) == 3 && action == "cve_list":
+		// no cveID needed
+	case len(parts) == 4 && action == "cve_details" && parts[3] != "":
+		parsed.cveID = parts[3]
+	default:
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	return parsed, nil
+}
+
 func (ksServer *KubescapeMcpserver) ReadResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 	uri := request.Params.URI
-	// Validate the URI and check if it starts with kubescape://vulnerability-manifests/
-	if !strings.HasPrefix(uri, "kubescape://vulnerability-manifests/") {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
+
+	parsed, err := parseVulnManifestURI(uri)
+	if err != nil {
+		return nil, err
 	}
 
-	// Verify that the URI is either the CVE list or CVE details
-	if !strings.HasSuffix(uri, "/cve_list") && !strings.Contains(uri, "/cve_details/") {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
-	}
-
-	// Split the URI into namespace and manifest name
-	parts := strings.Split(uri, "/")
-	if len(parts) != 4 && len(parts) != 5 {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
-	}
-
-	namespace := parts[1]
-	manifestName := parts[2]
-	cveID := ""
-	if len(parts) == 5 {
-		cveID = parts[3]
-	}
+	namespace := parsed.namespace
+	manifestName := parsed.manifestName
+	cveID := parsed.cveID
 
 	// Get the vulnerability manifest
 	manifest, err := ksServer.ksClient.VulnerabilityManifests(namespace).Get(ctx, manifestName, metav1.GetOptions{})

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -138,6 +138,7 @@ type vulnManifestURI struct {
 // parseVulnManifestURI parses a kubescape://vulnerability-manifests/... URI into its components.
 // Valid forms:
 //
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}                          (defaults to cve_list)
 //	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_list
 //	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_details/{cve_id}
 func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
@@ -147,9 +148,10 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 	}
 
 	parts := strings.Split(uri[len(prefix):], "/")
+	// base:        {namespace}/{manifest_name}                   -> 2 parts (defaults to cve_list)
 	// cve_list:    {namespace}/{manifest_name}/cve_list          -> 3 parts
 	// cve_details: {namespace}/{manifest_name}/cve_details/{id}  -> 4 parts
-	if len(parts) != 3 && len(parts) != 4 {
+	if len(parts) < 2 || len(parts) > 4 {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 
@@ -159,8 +161,13 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 
-	action := parts[2]
 	parsed := &vulnManifestURI{namespace: namespace, manifestName: manifestName}
+	if len(parts) == 2 {
+		// Base URI defaults to cve_list behavior
+		return parsed, nil
+	}
+
+	action := parts[2]
 	switch {
 	case len(parts) == 3 && action == "cve_list":
 		// no cveID needed

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -1,0 +1,164 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestParseVulnManifestURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      string // substring expected in error; empty = expect success
+		wantNS       string
+		wantManifest string
+		wantCVE      string
+	}{
+		{
+			name:    "wrong scheme",
+			uri:     "other://vulnerability-manifests/ns/manifest/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "missing action suffix",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest",
+			wantErr: "invalid URI",
+		},
+		{
+			name:         "valid cve_list URI",
+			uri:          "kubescape://vulnerability-manifests/default/my-manifest/cve_list",
+			wantNS:       "default",
+			wantManifest: "my-manifest",
+		},
+		{
+			name:         "valid cve_details URI",
+			uri:          "kubescape://vulnerability-manifests/default/my-manifest/cve_details/CVE-2024-1234",
+			wantNS:       "default",
+			wantManifest: "my-manifest",
+			wantCVE:      "CVE-2024-1234",
+		},
+		{
+			name:    "too few parts after prefix",
+			uri:     "kubescape://vulnerability-manifests/ns/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "too many parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/cve_details/CVE-1/extra",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "wrong action with 3 parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/not_cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "wrong action with 4 parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/not_cve_details/CVE-1",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty namespace",
+			uri:     "kubescape://vulnerability-manifests//manifest/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty manifest name",
+			uri:     "kubescape://vulnerability-manifests/ns//cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty CVE ID",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/cve_details/",
+			wantErr: "invalid URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parseVulnManifestURI(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parsed.namespace != tt.wantNS {
+				t.Errorf("namespace = %q, want %q", parsed.namespace, tt.wantNS)
+			}
+			if parsed.manifestName != tt.wantManifest {
+				t.Errorf("manifestName = %q, want %q", parsed.manifestName, tt.wantManifest)
+			}
+			if parsed.cveID != tt.wantCVE {
+				t.Errorf("cveID = %q, want %q", parsed.cveID, tt.wantCVE)
+			}
+		})
+	}
+}
+
+func TestReadConfigurationResource_URIParsing(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	tests := []struct {
+		name      string
+		uri       string
+		wantErr   string
+		passParse bool
+	}{
+		{
+			name:    "wrong scheme",
+			uri:     "other://configuration-manifests/ns/manifest",
+			wantErr: "invalid URI",
+		},
+		{
+			name:      "valid URI",
+			uri:       "kubescape://configuration-manifests/default/my-config",
+			passParse: true,
+		},
+		{
+			name:    "too few parts",
+			uri:     "kubescape://configuration-manifests/ns",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "too many parts",
+			uri:     "kubescape://configuration-manifests/ns/manifest/extra",
+			wantErr: "invalid URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mcp.ReadResourceRequest{}
+			req.Params.URI = tt.uri
+
+			if tt.passParse {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Fatal("expected panic from nil ksClient after successful URI parse, got none")
+					}
+				}()
+				_, _ = ksServer.ReadConfigurationResource(context.Background(), req)
+				t.Fatal("expected panic, but call returned normally")
+			} else {
+				_, err := ksServer.ReadConfigurationResource(context.Background(), req)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -23,9 +23,10 @@ func TestParseVulnManifestURI(t *testing.T) {
 			wantErr: "invalid URI",
 		},
 		{
-			name:    "missing action suffix",
-			uri:     "kubescape://vulnerability-manifests/ns/manifest",
-			wantErr: "invalid URI",
+			name:         "base URI defaults to cve_list",
+			uri:          "kubescape://vulnerability-manifests/ns/manifest",
+			wantNS:       "ns",
+			wantManifest: "manifest",
 		},
 		{
 			name:         "valid cve_list URI",
@@ -41,8 +42,8 @@ func TestParseVulnManifestURI(t *testing.T) {
 			wantCVE:      "CVE-2024-1234",
 		},
 		{
-			name:    "too few parts after prefix",
-			uri:     "kubescape://vulnerability-manifests/ns/cve_list",
+			name:    "only namespace (too few parts)",
+			uri:     "kubescape://vulnerability-manifests/ns",
 			wantErr: "invalid URI",
 		},
 		{

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -86,15 +86,16 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 
 	// get exceptions
 	if exceptions, err = policyHandler.getExceptions(); err != nil {
-		logger.L().Ctx(ctx).StopError("failed to load exceptions", helpers.Error(err))
+		logger.L().Ctx(ctx).StopError("Failed to load exceptions", helpers.Error(err))
 	} else {
 		logger.L().StopSuccess("Loaded exceptions")
 	}
+
 	logger.L().Start("Loading account configurations...")
 
 	// get account configuration
 	if controlInputs, err = policyHandler.getControlInputs(); err != nil {
-		logger.L().Ctx(ctx).StopError("failed to load account configurations", helpers.Error(err))
+		logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
 	} else {
 		logger.L().StopSuccess("Loaded account configurations")
 	}


### PR DESCRIPTION
## Overview

`ReadResource` splits the full `kubescape://vulnerability-manifests/...` URI on `/`, which produces 6 parts (scheme, empty, authority, namespace, manifest, action) instead of the expected 4-5. Every valid vulnerability manifest resource request gets rejected as "invalid URI."

This extracts a `parseVulnManifestURI` helper that strips the `kubescape://vulnerability-manifests/` prefix before splitting -- matching the approach already used in `ReadConfigurationResource`. The parser validates action segments explicitly and rejects empty namespace, manifest, or CVE ID segments.

## How to Test

```bash
go test -v -run TestParseVulnManifestURI ./cmd/mcpserver/...
go test -v -run TestReadConfigurationResource_URIParsing ./cmd/mcpserver/...
```

## Related issues/PRs

* Resolved #2075

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stricter validation for vulnerability-manifest URIs: malformed request shapes are rejected with clearer errors and only supported URI forms are accepted.
  * Improved logging around policy and exception loading: failures are reported explicitly and successes are logged appropriately.

* **Tests**
  * Added unit tests for URI parsing and resource-request handling to improve reliability and prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2076)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->