### PR TITLE
fix(policyhandler): close load spinners with StopError on failure instead of always StopSuccess

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -86,18 +86,18 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 
 	// get exceptions
 	if exceptions, err = policyHandler.getExceptions(); err != nil {
-		logger.L().Ctx(ctx).Warning("failed to load exceptions", helpers.Error(err))
+		logger.L().Ctx(ctx).StopError("failed to load exceptions", helpers.Error(err))
+	} else {
+		logger.L().StopSuccess("Loaded exceptions")
 	}
-
-	logger.L().StopSuccess("Loaded exceptions")
 	logger.L().Start("Loading account configurations...")
 
 	// get account configuration
 	if controlInputs, err = policyHandler.getControlInputs(); err != nil {
-		logger.L().Ctx(ctx).Warning(err.Error())
+		logger.L().Ctx(ctx).StopError("failed to load account configurations", helpers.Error(err))
+	} else {
+		logger.L().StopSuccess("Loaded account configurations")
 	}
-
-	logger.L().StopSuccess("Loaded account configurations")
 
 	return policies, exceptions, controlInputs, nil
 }


### PR DESCRIPTION
Replaced the unconditional StopSuccess calls in core/pkg/policyhandler/handlepullpolicies.go with an if/else that
   closes the spinner via StopError on failure and StopSuccess on success, for both the "Loading exceptions..." and
   "Loading account configurations..." stages. The previous code always emitted a green ✓ success line even when
  getExceptions/getControlInputs had just failed and logged a warning, producing contradictory output. Since
  StopError itself logs the failure message (with the error detail) and properly terminates the spinner, the
  separate Warning calls were folded into it. Behavior is unchanged otherwise  these failures remain non-fatal and
   the scan continues.

fixes #2065 

Not a big change :smile:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and logging for policy loading operations to provide more precise failure reporting and success confirmation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2077)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->