### PR TITLE
chore(deps): bump k8s-interface to v0.0.209 for multi-group fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/kubescape/backend v0.0.40
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
-	github.com/kubescape/k8s-interface v0.0.208
-	github.com/kubescape/opa-utils v0.0.293
+	github.com/kubescape/k8s-interface v0.0.209
+	github.com/kubescape/opa-utils v0.0.294
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1188,10 +1188,10 @@ github.com/kubescape/go-git-url v0.0.31 h1:VZnvtdGLVc42cQaR7llQeGZz0PnOxcs+eDig2
 github.com/kubescape/go-git-url v0.0.31/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/k8s-interface v0.0.208 h1:vmZ2FVAQRsz3XRKNG/6wJAYvZJ12RtMoDTLVxFEktms=
-github.com/kubescape/k8s-interface v0.0.208/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.293 h1:jpHWHhi8GM3OHCUSPsVifhBxKt6jShFGnK2kcCxs1TA=
-github.com/kubescape/opa-utils v0.0.293/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
+github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
+github.com/kubescape/opa-utils v0.0.294 h1:d1nF6BMbiCq1VwqW9KSBQdvbnE3uTc+lBHAq6bHQOZQ=
+github.com/kubescape/opa-utils v0.0.294/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview
I found a bug in `k8s-interface` (kubescape/k8s-interface#150). The `resourceGroupMapping` was a `map[string]string`, so it only kept one API group per resource name. There was a guard in `setMapResources` that explicitly skipped any group that came in after the first one for a given resource. That means resources served under multiple groups like `ingresses` in both `networking.k8s.io/v1` and `extensions/v1beta1` would silently lose all but the first group, with no error or warning anywhere. Everything downstream that called `ResourceGroupToString` only ever saw one group and had no idea the others existed. I changed the map to `map[string][]string`, dropped the skip guard, and updated `getResourceTriplets` to emit one triplet per
  group in the wildcard branches. Old single-group helpers still work as before so nothing else breaks. Merged in kubescape/k8s-interface#151, dep bumped in this PR.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core system dependencies to their latest versions for enhanced stability, performance, and security. These updates ensure the platform continues to function reliably while maintaining full backward compatibility with all existing features and workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2078)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->