### PR TITLE
Validate printer formats and deduplicate output formats

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -27,7 +27,7 @@ var scanCmdExamples = fmt.Sprintf(`
   %[1]s scan --format json --output results.json
 
   # Scan and save the results in multiple format in a single scan
-  %[1]s scan --format json,html,junit ---output result
+  %[1]s scan --format json,html,junit --output result
 
   # Display all resources
   %[1]s scan --verbose

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -26,6 +26,9 @@ var scanCmdExamples = fmt.Sprintf(`
   # Scan and save the results in the JSON format
   %[1]s scan --format json --output results.json
 
+  # Scan and save the results in multiple format in a single scan
+  %[1]s scan --format json,html,junit ---output result
+
   # Display all resources
   %[1]s scan --verbose
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -224,10 +224,24 @@ func (scanInfo *ScanInfo) setUseFrom() {
 func (scanInfo *ScanInfo) Formats() []string {
 	formatString := scanInfo.Format
 	if formatString != "" {
-		return strings.Split(scanInfo.Format, ",")
+		return unique(strings.Split(scanInfo.Format, ","))
 	} else {
 		return []string{}
 	}
+}
+
+func unique(items []string) []string {
+	seen := map[string]bool{}
+	result := []string{}
+
+	for _, item := range items {
+		if !seen[item] {
+			seen[item] = true
+			result = append(result, item)
+		}
+	}
+
+	return result
 }
 
 func (scanInfo *ScanInfo) SetScanType(scanType ScanTypes) {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -113,12 +113,12 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
 	for _, format := range formats {
-		invalidPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
+		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
 			logger.L().Ctx(ctx).Fatal(err.Error())
 		}
 
-		if invalidPrinter && containPrettyPrinter {
+		if usesPrettyPrinter && containPrettyPrinter {
 			continue
 		}
 
@@ -126,7 +126,7 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 		printerHandler.SetWriter(ctx, scanInfo.Output)
 		outputPrinters = append(outputPrinters, printerHandler)
 
-		if invalidPrinter {
+		if usesPrettyPrinter {
 			containPrettyPrinter = true
 		}
 	}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -110,17 +110,27 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 
 func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterName string) []printer.IPrinter {
 	formats := scanInfo.Formats()
-
+	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
 	for _, format := range formats {
-		if err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format); err != nil {
+		invalidPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
+		if err != nil {
 			logger.L().Ctx(ctx).Fatal(err.Error())
+		}
+
+		if invalidPrinter && containPrettyPrinter {
+			continue
 		}
 
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo, clusterName)
 		printerHandler.SetWriter(ctx, scanInfo.Output)
 		outputPrinters = append(outputPrinters, printerHandler)
+
+		if invalidPrinter {
+			containPrettyPrinter = true
+		}
 	}
+
 	return outputPrinters
 }
 

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -121,3 +121,90 @@ func TestIsAirGappedMode(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOutputPrintersDeduplicatesPrettyPrinterFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		scanType    cautils.ScanTypes
+		format      string
+		expectedLen int
+	}{
+		{
+			name:        "cluster scan: pretty-printer and invalid format should create single pretty-printer",
+			scanType:    cautils.ScanTypeCluster,
+			format:      "pretty-printer,abc",
+			expectedLen: 1,
+		},
+		{
+			name:        "cluster scan: multiple invalid formats should create single pretty-printer",
+			scanType:    cautils.ScanTypeCluster,
+			format:      "abc,def,ghi",
+			expectedLen: 1,
+		},
+
+		{
+			name:        "repo scan: pretty-printer and invalid format should create single pretty-printer",
+			scanType:    cautils.ScanTypeRepo,
+			format:      "pretty-printer,abc",
+			expectedLen: 1,
+		},
+		{
+			name:        "repo scan: multiple invalid formats should create single pretty-printer",
+			scanType:    cautils.ScanTypeRepo,
+			format:      "abc,def,ghi",
+			expectedLen: 1,
+		},
+
+		{
+			name:        "framework scan: pretty-printer and invalid format should create single pretty-printer",
+			scanType:    cautils.ScanTypeFramework,
+			format:      "pretty-printer,abc",
+			expectedLen: 1,
+		},
+		{
+			name:        "framework scan: multiple invalid formats should create single pretty-printer",
+			scanType:    cautils.ScanTypeFramework,
+			format:      "abc,def,ghi",
+			expectedLen: 1,
+		},
+
+		{
+			name:        "control scan: pretty-printer and invalid format should create single pretty-printer",
+			scanType:    cautils.ScanTypeControl,
+			format:      "pretty-printer,abc",
+			expectedLen: 1,
+		},
+		{
+			name:        "control scan: multiple invalid formats should create single pretty-printer",
+			scanType:    cautils.ScanTypeControl,
+			format:      "abc,def,ghi",
+			expectedLen: 1,
+		},
+
+		{
+			name:        "workload scan: pretty-printer and invalid format should create single pretty-printer",
+			scanType:    cautils.ScanTypeWorkload,
+			format:      "pretty-printer,abc",
+			expectedLen: 1,
+		},
+		{
+			name:        "workload scan: multiple invalid formats should create single pretty-printer",
+			scanType:    cautils.ScanTypeWorkload,
+			format:      "abc,def,ghi",
+			expectedLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				Format:   tt.format,
+				ScanType: tt.scanType,
+			}
+
+			got := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
+
+			assert.Len(t, got, tt.expectedLen)
+		})
+	}
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -139,7 +139,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		case printer.JsonFormat, printer.PrettyFormat, printer.SARIFFormat:
 			return nil
 		default:
-			return fmt.Errorf("format \"%s\"is not supported for image scanning", printFormat)
+			return fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 		}
 	}
 
@@ -150,6 +150,15 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 			return nil
 		default:
 			return fmt.Errorf("format \"%s\" is only supported when scanning local files", printFormat)
+		}
+	}
+
+	if scanType == cautils.ScanTypeCluster {
+		switch printFormat {
+		case printer.JsonFormat, printer.PrettyFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat:
+			return nil
+		default:
+			return fmt.Errorf("format \"%s\" is not supported when scanning", printFormat)
 		}
 	}
 

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -132,14 +132,14 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 	}
 }
 
-func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningContext, printFormat string) error {
+func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningContext, printFormat string) (bool, error) {
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
 		case printer.JsonFormat, printer.PrettyFormat, printer.SARIFFormat:
-			return nil
+			return false, nil
 		default:
-			return fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
+			return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 		}
 	}
 
@@ -147,20 +147,20 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		// supported types for SARIF
 		switch scanContext {
 		case cautils.ContextDir, cautils.ContextFile, cautils.ContextGitLocal, cautils.ContextGitRemote:
-			return nil
+			return false, nil
 		default:
-			return fmt.Errorf("format \"%s\" is only supported when scanning local files", printFormat)
+			return false, fmt.Errorf("format \"%s\" is only supported when scanning local files", printFormat)
 		}
 	}
 
 	if scanType == cautils.ScanTypeCluster {
 		switch printFormat {
 		case printer.JsonFormat, printer.PrettyFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat:
-			return nil
+			return false, nil
 		default:
-			return fmt.Errorf("format \"%s\" is not supported when scanning", printFormat)
+			return true, nil
 		}
 	}
 
-	return nil
+	return false, nil
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -136,8 +136,10 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
-		case printer.JsonFormat, printer.PrettyFormat, printer.SARIFFormat:
+		case printer.JsonFormat, printer.SARIFFormat:
 			return false, nil
+		case printer.PrettyFormat:
+			return true, nil
 		default:
 			return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 		}
@@ -153,14 +155,10 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		}
 	}
 
-	if scanType == cautils.ScanTypeCluster {
-		switch printFormat {
-		case printer.JsonFormat, printer.PrettyFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat:
-			return false, nil
-		default:
-			return true, nil
-		}
+	switch printFormat {
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat:
+		return false, nil
+	default:
+		return true, nil
 	}
-
-	return false, nil
 }

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -116,7 +116,7 @@ func TestValidatePrinter(t *testing.T) {
 			name:      "junit format for image scan should return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.JunitResultFormat,
-			expectErr: errors.New("format \"junit\"is not supported for image scanning"),
+			expectErr: errors.New("format \"junit\" is not supported for image scanning"),
 		},
 		{
 			name:      "sarif format for image scan should not return error",
@@ -134,13 +134,13 @@ func TestValidatePrinter(t *testing.T) {
 			name:      "html format for image scan should return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.HtmlFormat,
-			expectErr: errors.New("format \"html\"is not supported for image scanning"),
+			expectErr: errors.New("format \"html\" is not supported for image scanning"),
 		},
 		{
 			name:      "prometheus format for image scan should return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PrometheusFormat,
-			expectErr: errors.New("format \"prometheus\"is not supported for image scanning"),
+			expectErr: errors.New("format \"prometheus\" is not supported for image scanning"),
 		},
 		{
 			name:        "sarif format for cluster context should return error",
@@ -165,6 +165,24 @@ func TestValidatePrinter(t *testing.T) {
 			scanContext: cautils.ContextGitLocal,
 			format:      printer.SARIFFormat,
 			expectErr:   nil,
+		},
+		{
+			name:      "invalid format for cluster scan should return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    "invalid",
+			expectErr: errors.New("format \"invalid\" is not supported when scanning"),
+		},
+		{
+			name:      "pdf format for image scan should return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.PdfFormat,
+			expectErr: errors.New("format \"pdf\" is not supported for image scanning"),
+		},
+		{
+			name:      "pdf format for cluster scan should not return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    printer.PdfFormat,
+			expectErr: nil,
 		},
 	}
 

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -167,12 +167,6 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr:   nil,
 		},
 		{
-			name:      "invalid format for cluster scan should return error",
-			scanType:  cautils.ScanTypeCluster,
-			format:    "invalid",
-			expectErr: errors.New("format \"invalid\" is not supported when scanning"),
-		},
-		{
 			name:      "pdf format for image scan should return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PdfFormat,
@@ -188,7 +182,7 @@ func TestValidatePrinter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ValidatePrinter(tt.scanType, tt.scanContext, tt.format)
+			_, got := ValidatePrinter(tt.scanType, tt.scanContext, tt.format)
 
 			assert.Equal(t, tt.expectErr, got)
 		})


### PR DESCRIPTION
## Overview

This PR improves printer/output format handling and avoids creating duplicate printers during scan execution.

Few changes are: 
- Prevents adding duplicate printers for repeated formats in the `--format` flag
- Prevents creating multiple `pretty-printer` instances for multiple invalid formats
- Adds additional printer validation handling
- Extends unit tests for printer validation behavior

## Additional Information

Previously, repeated formats such as: `--format json,json,json` would create multiple identical printers and execute them multiple times.

Additionally, invalid formats such as: `--format abc,xyz,test` would create multiple fallback `pretty-printer` instances since every invalid format was internally mapped to the default pretty printer. This could unnecessarily increase processing and output generation and could also be abused by passing a large number of invalid formats.

### Resolves: #2007 

## How to Test
 `kubescape scan --format json,html,json --output report`
`kubescape scan --format abc,hdfksj,ksdfn --output report`


put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single scan can produce multiple output formats in one invocation; CLI examples updated.

* **Bug Fixes**
  * Deduplicates requested output formats to avoid duplicate processing.
  * Improved validation to enforce format compatibility across scan types and stricter SARIF/local-context rules.
  * Prevents adding multiple "pretty" output handlers when multiple formats request it.

* **Tests**
  * Updated and added unit tests covering validation rules and pretty-printer deduplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2079)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->