### PR TITLE
feat(getter): add SecurityException CRD posture entry conversion helper

### DIFF
--- a/core/cautils/getter/crdexceptions_conversion.go
+++ b/core/cautils/getter/crdexceptions_conversion.go
@@ -1,0 +1,82 @@
+package getter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+)
+
+// convertSecurityExceptionToPosturePolicy converts a single posture entry from a
+// SecurityException or ClusterSecurityException CRD spec into an
+// armotypes.PostureExceptionPolicy that the existing scan-time exception flow
+// (opaprocessor.updateResults) can consume without modification.
+//
+// This is part of the in-cluster SecurityException CRD support (kubescape/kubescape#1982).
+func convertSecurityExceptionToPosturePolicy(
+	name string,
+	controlID string,
+	frameworkName string,
+	action string,
+	expiresAt string,
+	reason string,
+	resources []map[string]string,
+) (armotypes.PostureExceptionPolicy, error) {
+
+	// map CRD action → armotypes action
+	var actions []armotypes.PostureExceptionPolicyActions
+	switch action {
+	case "ignore":
+		actions = []armotypes.PostureExceptionPolicyActions{armotypes.Disable}
+	case "alert_only", "":
+		actions = []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly}
+	default:
+		return armotypes.PostureExceptionPolicy{}, fmt.Errorf("unknown action %q: must be ignore or alert_only", action)
+	}
+
+	// parse expiresAt → ExpirationDate
+	var expirationDate *time.Time
+	if expiresAt != "" {
+		t, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil {
+			return armotypes.PostureExceptionPolicy{}, fmt.Errorf("invalid expiresAt %q: %w", expiresAt, err)
+		}
+		expirationDate = &t
+	}
+
+	// build resource designators
+	var designators []identifiers.PortalDesignator
+	for _, res := range resources {
+		if len(res) == 0 {
+			continue
+		}
+		designators = append(designators, identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
+			Attributes:     res,
+		})
+	}
+
+	// optional reason
+	var reasonPtr *string
+	if reason != "" {
+		reasonPtr = &reason
+	}
+
+	policy := armotypes.PostureExceptionPolicy{
+		PolicyType: string(armotypes.PostureExceptionPolicyType),
+		Actions:    actions,
+		Resources:  designators,
+		PosturePolicies: []armotypes.PosturePolicy{
+			{
+				ControlID:     controlID,
+				FrameworkName: frameworkName,
+			},
+		},
+		ExpirationDate: expirationDate,
+		Reason:         reasonPtr,
+	}
+	policy.Name = fmt.Sprintf("%s/%s", name, controlID)
+
+	return policy, nil
+}

--- a/core/cautils/getter/crdexceptions_conversion_test.go
+++ b/core/cautils/getter/crdexceptions_conversion_test.go
@@ -1,0 +1,86 @@
+package getter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertSecurityExceptionToPosturePolicy_AlertOnly(t *testing.T) {
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "NSA", "alert_only", "", "known issue", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "C-0034", policy.PosturePolicies[0].ControlID)
+	assert.Equal(t, "NSA", policy.PosturePolicies[0].FrameworkName)
+	assert.True(t, policy.IsAlertOnly())
+	assert.Equal(t, "my-exception/C-0034", policy.Name)
+	require.NotNil(t, policy.Reason)
+	assert.Equal(t, "known issue", *policy.Reason)
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_Ignore(t *testing.T) {
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0017", "", "ignore", "", "", nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, policy.IsDisable())
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_EmptyActionDefaultsToAlertOnly(t *testing.T) {
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "", "", "", nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, policy.IsAlertOnly())
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_UnknownActionErrors(t *testing.T) {
+	_, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "invalid-action", "", "", nil,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown action")
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_ExpiresAt(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "alert_only", future, "", nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, policy.ExpirationDate)
+	assert.True(t, policy.ExpirationDate.After(time.Now()))
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_InvalidExpiresAt(t *testing.T) {
+	_, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "alert_only", "not-a-date", "", nil,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid expiresAt")
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_ResourceDesignators(t *testing.T) {
+	resources := []map[string]string{
+		{"kind": "Deployment", "name": "nginx"},
+	}
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "alert_only", "", "", resources,
+	)
+	require.NoError(t, err)
+	require.Len(t, policy.Resources, 1)
+	assert.Equal(t, "Deployment", policy.Resources[0].Attributes["kind"])
+	assert.Equal(t, "nginx", policy.Resources[0].Attributes["name"])
+}
+
+func TestConvertSecurityExceptionToPosturePolicy_PolicyType(t *testing.T) {
+	policy, err := convertSecurityExceptionToPosturePolicy(
+		"my-exception", "C-0034", "", "alert_only", "", "", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, string(armotypes.PostureExceptionPolicyType), policy.PolicyType)
+}


### PR DESCRIPTION
## Overview

Adds `convertSecurityExceptionToPosturePolicy()` — a conversion helper that maps a single posture entry from a `SecurityException` or `ClusterSecurityException` CRD spec into an `armotypes.PostureExceptionPolicy` that the existing scan-time exception flow (`opaprocessor.updateResults`) can consume without modification.

This is a focused building block for the in-cluster SecurityException CRD support described in #1982.

## What this does

- Maps `action: ignore` → `Disable`, `action: alert_only` → `AlertOnly`
- Parses `expiresAt` (RFC3339) → `ExpirationDate` — works directly with `filterExpiredExceptions()` added in #2023
- Converts `spec.match.resources` entries → `PortalDesignator` with `Attributes` (kind, name)
- Maps `reason` → `PostureExceptionPolicy.Reason`
- Returns a typed error for unknown actions and malformed `expiresAt` values

## How to Test

```bash
go test ./core/cautils/getter/... -run "TestConvertSecurity" -v
```

All 8 tests pass covering: alert_only, ignore, empty action default, unknown action error, valid expiresAt, invalid expiresAt, resource designators, policy type.

## Related issues/PRs
* Part of #1982
* Works with `filterExpiredExceptions()` from #2023

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering security-exception conversion scenarios: action mapping, expiration parsing/validation, resource designator conversion, and policy typing.

* **Chores**
  * Improved handling of security exceptions: supports ignore vs. alert-only actions (with sensible default), validates optional expiration dates, maps resource designators, and populates policy metadata for downstream use.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2080)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->