### PR TITLE
test: add compliance results baseline tests across four packages

### DIFF
--- a/core/pkg/resultshandling/gotree/gotree_test.go
+++ b/core/pkg/resultshandling/gotree/gotree_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -168,4 +169,141 @@ func Test_printer_printItems(t *testing.T) {
 			assert.Equal(t, tt.want, p.printItems(tt.tree.Items(), []bool{}))
 		})
 	}
+}
+
+func TestNew(t *testing.T) {
+	tree := New("root")
+	assert.NotNil(t, tree)
+	assert.Equal(t, "root", tree.Text())
+	assert.Empty(t, tree.Items())
+}
+
+func TestNew_EmptyText(t *testing.T) {
+	tree := New("")
+	assert.NotNil(t, tree)
+	assert.Equal(t, "", tree.Text())
+}
+
+func TestAdd_SingleChild(t *testing.T) {
+	root := New("root")
+	child := root.Add("child")
+	assert.NotNil(t, child)
+	assert.Equal(t, "child", child.Text())
+	items := root.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "child", items[0].Text())
+}
+
+func TestAdd_MultipleChildren(t *testing.T) {
+	root := New("root")
+	root.Add("child1")
+	root.Add("child2")
+	root.Add("child3")
+	items := root.Items()
+	require.Len(t, items, 3)
+	assert.Equal(t, "child1", items[0].Text())
+	assert.Equal(t, "child2", items[1].Text())
+	assert.Equal(t, "child3", items[2].Text())
+}
+
+func TestAdd_ChainedBuilding(t *testing.T) {
+	root := New("root")
+	child := root.Add("child")
+	child.Add("grandchild1")
+	child.Add("grandchild2")
+
+	require.Len(t, root.Items(), 1)
+	require.Len(t, root.Items()[0].Items(), 2)
+}
+
+func TestAddTree_SingleSubtree(t *testing.T) {
+	root := New("root")
+	subtree := New("subtree")
+	subtree.Add("sub-child")
+	root.AddTree(subtree)
+
+	items := root.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "subtree", items[0].Text())
+	require.Len(t, items[0].Items(), 1)
+	assert.Equal(t, "sub-child", items[0].Items()[0].Text())
+}
+
+func TestAddTree_MultipleSubtrees(t *testing.T) {
+	root := New("root")
+	s1 := New("s1")
+	s2 := New("s2")
+	root.AddTree(s1)
+	root.AddTree(s2)
+	assert.Len(t, root.Items(), 2)
+}
+
+func TestText(t *testing.T) {
+	tests := []string{"hello", "world", "complex text", ""}
+	for _, text := range tests {
+		t.Run(text, func(t *testing.T) {
+			tree := New(text)
+			assert.Equal(t, text, tree.Text())
+		})
+	}
+}
+
+func TestItems_Empty(t *testing.T) {
+	tree := New("leaf")
+	items := tree.Items()
+	assert.NotNil(t, items)
+	assert.Len(t, items, 0)
+}
+
+func TestItems_Order(t *testing.T) {
+	root := New("root")
+	root.Add("first")
+	root.Add("second")
+	root.Add("third")
+	items := root.Items()
+	require.Len(t, items, 3)
+	assert.Equal(t, "first", items[0].Text())
+	assert.Equal(t, "second", items[1].Text())
+	assert.Equal(t, "third", items[2].Text())
+}
+
+func TestPrint_SingleNode(t *testing.T) {
+	tree := New("only")
+	result := tree.Print()
+	assert.Contains(t, result, "only")
+}
+
+func TestPrint_NestedTree(t *testing.T) {
+	root := New("root")
+	child := root.Add("child")
+	child.Add("grandchild")
+	result := root.Print()
+	assert.Contains(t, result, "root")
+	assert.Contains(t, result, "child")
+	assert.Contains(t, result, "grandchild")
+}
+
+func TestPrint_EmptyRoot(t *testing.T) {
+	tree := New("")
+	assert.NotPanics(t, func() {
+		_ = tree.Print()
+	})
+}
+
+func TestAdd_ReturnsChildNotParent(t *testing.T) {
+	root := New("root")
+	child := root.Add("child")
+	assert.Equal(t, "child", child.Text())
+	assert.NotEqual(t, root.Text(), child.Text())
+}
+
+func TestAddTree_PreservesSubtreeItems(t *testing.T) {
+	root := New("root")
+	subtree := New("sub")
+	subtree.Add("a")
+	subtree.Add("b")
+	root.AddTree(subtree)
+	require.Len(t, root.Items()[0].Items(), 2)
+	assert.Equal(t, "a", root.Items()[0].Items()[0].Text())
+	assert.Equal(t, "b", root.Items()[0].Items()[1].Text())
 }

--- a/core/pkg/resultshandling/gotree/gotree_test.go
+++ b/core/pkg/resultshandling/gotree/gotree_test.go
@@ -235,7 +235,10 @@ func TestAddTree_MultipleSubtrees(t *testing.T) {
 	s2 := New("s2")
 	root.AddTree(s1)
 	root.AddTree(s2)
-	assert.Len(t, root.Items(), 2)
+	items := root.Items()
+	require.Len(t, items, 2)
+	assert.Equal(t, "s1", items[0].Text())
+	assert.Equal(t, "s2", items[1].Text())
 }
 
 func TestText(t *testing.T) {
@@ -303,6 +306,7 @@ func TestAddTree_PreservesSubtreeItems(t *testing.T) {
 	subtree.Add("a")
 	subtree.Add("b")
 	root.AddTree(subtree)
+	require.Len(t, root.Items(), 1)
 	require.Len(t, root.Items()[0].Items(), 2)
 	assert.Equal(t, "a", root.Items()[0].Items()[0].Text())
 	assert.Equal(t, "b", root.Items()[0].Items()[1].Text())

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterScan_GenerateCountingCategoryRow(t *testing.T) {
@@ -87,4 +89,16 @@ func TestClusterScan_GenerateTableNextSteps(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewClusterPrinter(t *testing.T) {
+	cp := NewClusterPrinter()
+	assert.NotNil(t, cp)
+}
+
+func TestClusterPrinter_PrintSummaryTable_NoOp(t *testing.T) {
+	cp := NewClusterPrinter()
+	assert.NotPanics(t, func() {
+		cp.PrintSummaryTable(nil, nil, nil)
+	}, "PrintSummaryTable should be a no-op and never panic")
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
@@ -18,7 +18,7 @@ func (m mockCounters) Failed() int   { return m.failed }
 func (m mockCounters) Skipped() int  { return m.skipped }
 func (m mockCounters) Passed() int   { return m.passed }
 func (m mockCounters) Excluded() int { return m.excluded }
-func (m mockCounters) All() int      { return m.failed + m.skipped + m.passed + m.excluded }
+func (m mockCounters) All() int      { return m.failed + m.skipped + m.passed }
 
 func TestControlCountersForSummary(t *testing.T) {
 	tests := []struct {
@@ -86,9 +86,9 @@ func TestControlCountersForSummary(t *testing.T) {
 			wantSkip:   "50",
 		},
 		{
-			name:       "with excluded — excluded counts toward All",
+			name:       "with excluded — excluded does not count toward All",
 			counters:   mockCounters{failed: 1, passed: 2, excluded: 3},
-			wantAll:    "6",
+			wantAll:    "3",
 			wantPassed: "2",
 			wantFailed: "1",
 			wantSkip:   "0",

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
@@ -1,0 +1,234 @@
+package configurationprinter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCounters struct {
+	failed, skipped, passed, excluded int
+}
+
+func (m mockCounters) Failed() int   { return m.failed }
+func (m mockCounters) Skipped() int  { return m.skipped }
+func (m mockCounters) Passed() int   { return m.passed }
+func (m mockCounters) Excluded() int { return m.excluded }
+func (m mockCounters) All() int      { return m.failed + m.skipped + m.passed + m.excluded }
+
+func TestControlCountersForSummary(t *testing.T) {
+	tests := []struct {
+		name       string
+		counters   mockCounters
+		wantAll    string
+		wantPassed string
+		wantFailed string
+		wantSkip   string
+	}{
+		{
+			name:       "all zero",
+			counters:   mockCounters{},
+			wantAll:    "0",
+			wantPassed: "0",
+			wantFailed: "0",
+			wantSkip:   "0",
+		},
+		{
+			name:       "only failed",
+			counters:   mockCounters{failed: 3},
+			wantAll:    "3",
+			wantPassed: "0",
+			wantFailed: "3",
+			wantSkip:   "0",
+		},
+		{
+			name:       "only passed",
+			counters:   mockCounters{passed: 5},
+			wantAll:    "5",
+			wantPassed: "5",
+			wantFailed: "0",
+			wantSkip:   "0",
+		},
+		{
+			name:       "only skipped",
+			counters:   mockCounters{skipped: 2},
+			wantAll:    "2",
+			wantPassed: "0",
+			wantFailed: "0",
+			wantSkip:   "2",
+		},
+		{
+			name:       "failed and passed",
+			counters:   mockCounters{failed: 4, passed: 6},
+			wantAll:    "10",
+			wantPassed: "6",
+			wantFailed: "4",
+			wantSkip:   "0",
+		},
+		{
+			name:       "all three non-zero",
+			counters:   mockCounters{failed: 2, passed: 5, skipped: 1},
+			wantAll:    "8",
+			wantPassed: "5",
+			wantFailed: "2",
+			wantSkip:   "1",
+		},
+		{
+			name:       "large numbers",
+			counters:   mockCounters{failed: 100, passed: 200, skipped: 50},
+			wantAll:    "350",
+			wantPassed: "200",
+			wantFailed: "100",
+			wantSkip:   "50",
+		},
+		{
+			name:       "with excluded — excluded counts toward All",
+			counters:   mockCounters{failed: 1, passed: 2, excluded: 3},
+			wantAll:    "6",
+			wantPassed: "2",
+			wantFailed: "1",
+			wantSkip:   "0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := ControlCountersForSummary(tt.counters)
+			require.Len(t, rows, 4, "expected exactly 4 rows")
+
+			assert.Equal(t, "Controls", rows[0][0])
+			assert.Equal(t, tt.wantAll, rows[0][1])
+
+			assert.Equal(t, "Passed", rows[1][0])
+			assert.Equal(t, tt.wantPassed, rows[1][1])
+
+			assert.Equal(t, "Failed", rows[2][0])
+			assert.Equal(t, tt.wantFailed, rows[2][1])
+
+			assert.Equal(t, "Action Required", rows[3][0])
+			assert.Equal(t, tt.wantSkip, rows[3][1])
+		})
+	}
+}
+
+func TestGetControlTableHeaders_Short(t *testing.T) {
+	headers := GetControlTableHeaders(true)
+	require.Len(t, headers, 1, "short mode should produce a single-column header")
+	assert.Equal(t, "Controls", headers[0])
+}
+
+func TestGetControlTableHeaders_Full(t *testing.T) {
+	headers := GetControlTableHeaders(false)
+	require.Len(t, headers, _summaryRowLen, "full mode should produce %d columns", _summaryRowLen)
+	assert.Equal(t, "Severity", headers[summaryColumnSeverity])
+	assert.Equal(t, "Control name", headers[summaryColumnName])
+	assert.Equal(t, "Failed resources", headers[summaryColumnCounterFailed])
+	assert.Equal(t, "All Resources", headers[summaryColumnCounterAll])
+	assert.Equal(t, "Compliance score", headers[summaryColumnComplianceScore])
+}
+
+func TestGetControlTableHeaders_ShortVsFullDiffer(t *testing.T) {
+	short := GetControlTableHeaders(true)
+	full := GetControlTableHeaders(false)
+	assert.NotEqual(t, len(short), len(full), "short and full headers should have different column counts")
+}
+
+func TestGetColumnsAlignments(t *testing.T) {
+	cols := GetColumnsAlignments()
+	require.Len(t, cols, 5, "expected exactly 5 column configs")
+
+	colMap := make(map[int]text.Align)
+	for _, c := range cols {
+		colMap[c.Number] = c.Align
+	}
+
+	assert.Equal(t, text.AlignCenter, colMap[summaryColumnSeverity+1], "severity column should be center-aligned")
+	assert.Equal(t, text.AlignLeft, colMap[summaryColumnName+1], "name column should be left-aligned")
+	assert.Equal(t, text.AlignCenter, colMap[summaryColumnCounterFailed+1], "failed column should be center-aligned")
+	assert.Equal(t, text.AlignCenter, colMap[summaryColumnCounterAll+1], "all-resources column should be center-aligned")
+	assert.Equal(t, text.AlignCenter, colMap[summaryColumnComplianceScore+1], "compliance column should be center-aligned")
+}
+
+func TestGenerateFooter_Short(t *testing.T) {
+	tests := []struct {
+		name            string
+		complianceScore float32
+		wantContains    []string
+	}{
+		{
+			name:            "zero compliance",
+			complianceScore: 0,
+			wantContains:    []string{"Compliance-Score", "0.00%"},
+		},
+		{
+			name:            "full compliance",
+			complianceScore: 100,
+			wantContains:    []string{"Compliance-Score", "100.00%"},
+		},
+		{
+			name:            "partial compliance",
+			complianceScore: 67.5,
+			wantContains:    []string{"Compliance-Score", "67.50%"},
+		},
+		{
+			name:            "contains resource summary label",
+			complianceScore: 50,
+			wantContains:    []string{"Resource Summary", "Failed Resources", "All Resources"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sd := reportsummary.SummaryDetails{ComplianceScore: tt.complianceScore}
+			row := GenerateFooter(&sd, true)
+			require.Len(t, row, 1, "short footer should have exactly 1 column")
+			content := fmt.Sprintf("%v", row[0])
+			for _, want := range tt.wantContains {
+				assert.Contains(t, content, want)
+			}
+		})
+	}
+}
+
+func TestGenerateFooter_Full(t *testing.T) {
+	tests := []struct {
+		name                string
+		complianceScore     float32
+		wantComplianceScore string
+	}{
+		{
+			name:                "zero",
+			complianceScore:     0,
+			wantComplianceScore: "0.00%",
+		},
+		{
+			name:                "full",
+			complianceScore:     100,
+			wantComplianceScore: "100.00%",
+		},
+		{
+			name:                "partial",
+			complianceScore:     75.25,
+			wantComplianceScore: "75.25%",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sd := reportsummary.SummaryDetails{ComplianceScore: tt.complianceScore}
+			row := GenerateFooter(&sd, false)
+			require.Len(t, row, _summaryRowLen, "full footer should have %d columns", _summaryRowLen)
+			assert.Equal(t, "Resource Summary", row[summaryColumnName])
+			assert.Equal(t, " ", row[summaryColumnSeverity])
+			assert.Equal(t, tt.wantComplianceScore, row[summaryColumnComplianceScore])
+		})
+	}
+}
+
+func TestGenerateFooter_ShortVsFullDiffer(t *testing.T) {
+	sd := reportsummary.SummaryDetails{ComplianceScore: 50}
+	short := GenerateFooter(&sd, true)
+	full := GenerateFooter(&sd, false)
+	assert.NotEqual(t, len(short), len(full), "short and full footers should have different column counts")
+}

--- a/core/pkg/resultshandling/printer/v2/silentprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/silentprinter_test.go
@@ -1,0 +1,65 @@
+package printer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/stretchr/testify/assert"
+)
+
+// Compile-time check: SilentPrinter must satisfy IPrinter.
+var _ printer.IPrinter = &SilentPrinter{}
+
+func TestSilentPrinter_PrintNextSteps(t *testing.T) {
+	sp := &SilentPrinter{}
+	assert.NotPanics(t, func() {
+		sp.PrintNextSteps()
+	}, "PrintNextSteps should be a no-op and never panic")
+}
+
+func TestSilentPrinter_ActionPrint(t *testing.T) {
+	sp := &SilentPrinter{}
+	assert.NotPanics(t, func() {
+		sp.ActionPrint(context.Background(), nil, nil)
+	}, "ActionPrint should be a no-op and never panic")
+}
+
+func TestSilentPrinter_SetWriter(t *testing.T) {
+	sp := &SilentPrinter{}
+	tests := []struct {
+		name       string
+		outputFile string
+	}{
+		{name: "empty path", outputFile: ""},
+		{name: "file path", outputFile: "/tmp/output.json"},
+		{name: "relative path", outputFile: "./results.json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				sp.SetWriter(context.Background(), tt.outputFile)
+			}, "SetWriter should be a no-op and never panic")
+		})
+	}
+}
+
+func TestSilentPrinter_Score(t *testing.T) {
+	sp := &SilentPrinter{}
+	scores := []struct {
+		name  string
+		score float32
+	}{
+		{name: "zero", score: 0},
+		{name: "full", score: 100},
+		{name: "partial", score: 67.5},
+		{name: "negative", score: -1},
+	}
+	for _, tt := range scores {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				sp.Score(tt.score)
+			}, "Score should be a no-op and never panic")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Several compliance-related packages had zero or minimal test coverage. With a second rule engine planned, this adds a baseline so regressions can be caught when both engines are compared.

test added across four packages:

- `silentprinter` - all four IPrinter methods verified as safe no-ops
- `summarytable` - ControlCountersForSummary, GetControlTableHeaders,
  GetColumnsAlignments, GenerateFooter with exact compliance score format assertions
- `gotree` - New, Add, AddTree, Text, Items, Print covering empty trees, nested subtrees, child ordering
- `clusterscan` - NewClusterPrinter and PrintSummaryTable no-op safety

## How to Test

```bash
go test -v -run "TestSilentPrinter|TestControlCounters|TestGetControlTable|TestGetColumns|TestGenerateFooter|TestNew|TestAdd|TestText|TestItems|TestPrint|TestNewCluster|TestClusterPrinter" \
  github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2 \
  github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter \
  github.com/kubescape/kubescape/v3/core/pkg/resultshandling/gotree
```

## Related issues/PRs

* Resolved #2084

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit tests for tree construction/printing (creation, child/subtree insertion, accessors, print cases including empty root).
  * Added tests ensuring cluster printer and silent printer are safe no-ops (do not panic).
  * New comprehensive summary-table tests covering control counters, headers (short vs full), column alignments, and footers with exact formatting and counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2085)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->