### PR TITLE
docs: add missing supported format values for patch --format flag

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -256,7 +256,7 @@ kubescape patch [flags]
 | `--ignore-errors` | Continue on errors | `false` |
 | `-u, --username <user>` | Registry username | - |
 | `-p, --password <pass>` | Registry password | - |
-| `-f, --format <format>` | Output format | - |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `sarif` | - |
 | `-o, --output <path>` | Output file | stdout |
 | `-v, --verbose` | Verbose output | `false` |
 


### PR DESCRIPTION
## Overview
`docs/cli-reference.md` was missing the supported format values for the `kubescape patch --format` flag. The description only said "Output format" with no values listed, while the actual command supports `pretty-printer`, `json`, and `sarif`.

**Before:**
| `-f, --format <format>` | Output format | - |

**After:**
| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `sarif` | - |

## How to Test
Run `kubescape patch --help` and compare the `--format` flag description with `docs/cli-reference.md`.

## Related issues/PRs
* Resolved #2087

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference documentation for the `patch` command to specify supported output formats (`pretty-printer`, `json`, `sarif`) in the `--format` flag description.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2088)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->