### PR TITLE
feat(junit): populate JUnit skip message from StatusInfo

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -231,9 +231,15 @@ func buildSkipMessage(status apis.IStatus) string {
 	if status == nil {
 		return ""
 	}
-	subStatus := string(status.GetSubStatus())
-	if si, ok := status.(*apis.StatusInfo); ok && si.InnerInfo != "" {
-		return fmt.Sprintf("%s: %s", subStatus, si.InnerInfo)
+	subStatus := strings.TrimSpace(string(status.GetSubStatus()))
+	if si, ok := status.(*apis.StatusInfo); ok {
+		info := strings.TrimSpace(si.InnerInfo)
+		if subStatus != "" && info != "" {
+			return fmt.Sprintf("%s: %s", subStatus, info)
+		}
+		if info != "" {
+			return info
+		}
 	}
 	return subStatus
 }

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -216,13 +216,26 @@ func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControls
 			testCase.Failure = &testCaseFailure
 		} else if control.GetStatus().IsSkipped() {
 			testCase.SkipMessage = &JUnitSkipMessage{
-				Message: "", // TODO - fill after statusInfo is supported
+				Message: buildSkipMessage(control.GetStatus()),
 			}
 
 		}
 		testCases = append(testCases, testCase)
 	}
 	return testCases
+}
+
+// buildSkipMessage constructs a human-readable skip reason from StatusInfo.
+// It uses SubStatus (e.g. "configuration", "irrelevant") and appends InnerInfo when available.
+func buildSkipMessage(status apis.IStatus) string {
+	if status == nil {
+		return ""
+	}
+	subStatus := string(status.GetSubStatus())
+	if si, ok := status.(*apis.StatusInfo); ok && si.InnerInfo != "" {
+		return fmt.Sprintf("%s: %s", subStatus, si.InnerInfo)
+	}
+	return subStatus
 }
 
 func resourceToString(resource workloadinterface.IMetadata, sourcePath string) string {

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -237,6 +238,52 @@ func TestSetWriter_Junit(t *testing.T) {
 
 			jp.SetWriter(ctx, tt.outputFile)
 			assert.Equal(t, tt.expected, jp.writer.Name())
+		})
+	}
+}
+
+func TestBuildSkipMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   apis.IStatus
+		expected string
+	}{
+		{
+			name:     "nil status returns empty string",
+			status:   nil,
+			expected: "",
+		},
+		{
+			name:     "configuration substatus with InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusConfiguration, InnerInfo: "control not configured"},
+			expected: "configuration: control not configured",
+		},
+		{
+			name:     "irrelevant substatus no InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusIrrelevant},
+			expected: "irrelevant",
+		},
+		{
+			name:     "manual review substatus with InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusManualReview, InnerInfo: "requires manual check"},
+			expected: "manual review: requires manual check",
+		},
+		{
+			name:     "notEvaluated substatus with InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusNotEvaluated, InnerInfo: "not evaluated"},
+			expected: "notEvaluated: not evaluated",
+		},
+		{
+			name:     "requires review substatus no InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusRequiresReview},
+			expected: "requires review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSkipMessage(tt.status)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -278,6 +278,11 @@ func TestBuildSkipMessage(t *testing.T) {
 			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: apis.SubStatusRequiresReview},
 			expected: "requires review",
 		},
+		{
+			name:     "empty subStatus with InnerInfo returns only InnerInfo",
+			status:   &apis.StatusInfo{InnerStatus: apis.StatusSkipped, SubStatus: "", InnerInfo: "some detail"},
+			expected: "some detail",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview
`JUnitSkipMessage.Message` was always set to `""` with a `// TODO - fill after statusInfo is supported` comment. `StatusInfo` is now fully supported in opa-utils with `GetSubStatus()` and `InnerInfo`.

This change populates the skip message with the actual skip reason so CI/CD tools parsing JUnit XML can distinguish between controls skipped due to configuration, irrelevance, manual review, etc.

**Before:** `<skipped message=""/>`
**After:** `<skipped message="configuration: This control is not applicable"/>`

## How to Test
go test ./core/pkg/resultshandling/printer/v2/ -run "TestBuildSkipMessage" -v

## Related issues/PRs
* Resolved #2089

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JUnit test reports now include descriptive skip reasons for skipped controls instead of empty messages.
* **Tests**
  * Added unit tests covering skip-message formatting for various skipped-status scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2091)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->