### PR TITLE
fix: correct typo 'requeued' to 'required' in list error message

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -42,7 +42,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 			supported := strings.Join(core.ListSupportActions(), ",")
 
 			if len(args) < 1 {
-				return fmt.Errorf("policy type requeued, supported: %s", supported)
+				return fmt.Errorf("policy type required, supported: %s", supported)
 			}
 			if !slices.Contains(core.ListSupportActions(), args[0]) {
 				return fmt.Errorf("invalid parameter '%s'. Supported parameters: %s", args[0], supported)

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -25,7 +25,7 @@ func TestGetListCmd(t *testing.T) {
 	supported := strings.Join(core.ListSupportActions(), ",")
 
 	err := listCmd.Args(&cobra.Command{}, []string{})
-	expectedErrorMessage := "policy type requeued, supported: " + supported
+	expectedErrorMessage := "policy type required, supported: " + supported
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = listCmd.Args(&cobra.Command{}, []string{"not-frameworks"})


### PR DESCRIPTION
## Overview
The `kubescape list` command had a typo in its error message when no policy type is provided. "requeued" was used instead of "required". The test file also had the same typo.

**Before:**
Error: policy type requeued, supported: controls,exceptions,frameworks

**After:**
Error: policy type required, supported: controls,exceptions,frameworks

For comparison, `kubescape download` already used the correct word "required" in its error message.

## How to Test
kubescape list
# Expected: Error: policy type required, supported: controls,exceptions,frameworks

## Related issues/PRs
* Fixes #2092

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect error message in the CLI list command. When no policy type argument is provided, the error now correctly states "policy type required" along with supported values, replacing the previously inaccurate wording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2093)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->