### PR TITLE
fix(list): correct missing policy type error

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -42,7 +42,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 			supported := strings.Join(core.ListSupportActions(), ",")
 
 			if len(args) < 1 {
-				return fmt.Errorf("policy type requeued, supported: %s", supported)
+				return fmt.Errorf("policy type required, supported: %s", supported)
 			}
 			if !slices.Contains(core.ListSupportActions(), args[0]) {
 				return fmt.Errorf("invalid parameter '%s'. Supported parameters: %s", args[0], supported)

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -25,7 +25,7 @@ func TestGetListCmd(t *testing.T) {
 	supported := strings.Join(core.ListSupportActions(), ",")
 
 	err := listCmd.Args(&cobra.Command{}, []string{})
-	expectedErrorMessage := "policy type requeued, supported: " + supported
+	expectedErrorMessage := "policy type required, supported: " + supported
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = listCmd.Args(&cobra.Command{}, []string{"not-frameworks"})


### PR DESCRIPTION
## Summary

- correct the missing policy type error from `requeued` to `required`
- update the list command unit test expectation to match the corrected wording

## Tests

- `git diff --check HEAD~1..HEAD`
- `go test ./cmd/list -run TestGetListCmd -count=1` (not completed locally: command timed out on this Windows environment without test failure output)
- `go test ./cmd/download -run TestGetDownloadCmd -count=1` (not completed locally: command timed out on this Windows environment without test failure output)

Fixes #2092.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in the validation error shown when the policy type argument is missing so the message correctly indicates the policy type is required.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2095)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->