### PR TITLE
fix: harden vulnerability manifest URI parsing and error logging

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -128,30 +128,62 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 	ksServer.s.AddResourceTemplate(configManifestTemplate, ksServer.ReadConfigurationResource)
 }
 
+// vulnManifestURI holds the parsed components of a vulnerability manifest resource URI.
+type vulnManifestURI struct {
+	namespace    string
+	manifestName string
+	cveID        string // empty for cve_list requests
+}
+
+// parseVulnManifestURI parses a kubescape://vulnerability-manifests/... URI into its components.
+// Valid forms:
+//
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_list
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_details/{cve_id}
+func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
+	const prefix = "kubescape://vulnerability-manifests/"
+	if !strings.HasPrefix(uri, prefix) {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	parts := strings.Split(uri[len(prefix):], "/")
+	// cve_list:    {namespace}/{manifest_name}/cve_list          -> 3 parts
+	// cve_details: {namespace}/{manifest_name}/cve_details/{id}  -> 4 parts
+	if len(parts) != 3 && len(parts) != 4 {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	namespace := parts[0]
+	manifestName := parts[1]
+	if namespace == "" || manifestName == "" {
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	action := parts[2]
+	parsed := &vulnManifestURI{namespace: namespace, manifestName: manifestName}
+	switch {
+	case len(parts) == 3 && action == "cve_list":
+		// no cveID needed
+	case len(parts) == 4 && action == "cve_details" && parts[3] != "":
+		parsed.cveID = parts[3]
+	default:
+		return nil, fmt.Errorf("invalid URI: %s", uri)
+	}
+
+	return parsed, nil
+}
+
 func (ksServer *KubescapeMcpserver) ReadResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 	uri := request.Params.URI
-	// Validate the URI and check if it starts with kubescape://vulnerability-manifests/
-	if !strings.HasPrefix(uri, "kubescape://vulnerability-manifests/") {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
+
+	parsed, err := parseVulnManifestURI(uri)
+	if err != nil {
+		return nil, err
 	}
 
-	// Verify that the URI is either the CVE list or CVE details
-	if !strings.HasSuffix(uri, "/cve_list") && !strings.Contains(uri, "/cve_details/") {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
-	}
-
-	// Split the URI into namespace and manifest name
-	parts := strings.Split(uri, "/")
-	if len(parts) != 4 && len(parts) != 5 {
-		return nil, fmt.Errorf("invalid URI: %s", uri)
-	}
-
-	namespace := parts[1]
-	manifestName := parts[2]
-	cveID := ""
-	if len(parts) == 5 {
-		cveID = parts[3]
-	}
+	namespace := parsed.namespace
+	manifestName := parsed.manifestName
+	cveID := parsed.cveID
 
 	// Get the vulnerability manifest
 	manifest, err := ksServer.ksClient.VulnerabilityManifests(namespace).Get(ctx, manifestName, metav1.GetOptions{})

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -138,6 +138,7 @@ type vulnManifestURI struct {
 // parseVulnManifestURI parses a kubescape://vulnerability-manifests/... URI into its components.
 // Valid forms:
 //
+//	kubescape://vulnerability-manifests/{namespace}/{manifest_name}                          (defaults to cve_list)
 //	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_list
 //	kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_details/{cve_id}
 func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
@@ -147,9 +148,10 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 	}
 
 	parts := strings.Split(uri[len(prefix):], "/")
+	// base:        {namespace}/{manifest_name}                   -> 2 parts (defaults to cve_list)
 	// cve_list:    {namespace}/{manifest_name}/cve_list          -> 3 parts
 	// cve_details: {namespace}/{manifest_name}/cve_details/{id}  -> 4 parts
-	if len(parts) != 3 && len(parts) != 4 {
+	if len(parts) < 2 || len(parts) > 4 {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 
@@ -159,8 +161,13 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 
-	action := parts[2]
 	parsed := &vulnManifestURI{namespace: namespace, manifestName: manifestName}
+	if len(parts) == 2 {
+		// Base URI defaults to cve_list behavior
+		return parsed, nil
+	}
+
+	action := parts[2]
 	switch {
 	case len(parts) == 3 && action == "cve_list":
 		// no cveID needed

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -1,0 +1,164 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestParseVulnManifestURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantErr      string // substring expected in error; empty = expect success
+		wantNS       string
+		wantManifest string
+		wantCVE      string
+	}{
+		{
+			name:    "wrong scheme",
+			uri:     "other://vulnerability-manifests/ns/manifest/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "missing action suffix",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest",
+			wantErr: "invalid URI",
+		},
+		{
+			name:         "valid cve_list URI",
+			uri:          "kubescape://vulnerability-manifests/default/my-manifest/cve_list",
+			wantNS:       "default",
+			wantManifest: "my-manifest",
+		},
+		{
+			name:         "valid cve_details URI",
+			uri:          "kubescape://vulnerability-manifests/default/my-manifest/cve_details/CVE-2024-1234",
+			wantNS:       "default",
+			wantManifest: "my-manifest",
+			wantCVE:      "CVE-2024-1234",
+		},
+		{
+			name:    "too few parts after prefix",
+			uri:     "kubescape://vulnerability-manifests/ns/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "too many parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/cve_details/CVE-1/extra",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "wrong action with 3 parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/not_cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "wrong action with 4 parts",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/not_cve_details/CVE-1",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty namespace",
+			uri:     "kubescape://vulnerability-manifests//manifest/cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty manifest name",
+			uri:     "kubescape://vulnerability-manifests/ns//cve_list",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty CVE ID",
+			uri:     "kubescape://vulnerability-manifests/ns/manifest/cve_details/",
+			wantErr: "invalid URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parseVulnManifestURI(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parsed.namespace != tt.wantNS {
+				t.Errorf("namespace = %q, want %q", parsed.namespace, tt.wantNS)
+			}
+			if parsed.manifestName != tt.wantManifest {
+				t.Errorf("manifestName = %q, want %q", parsed.manifestName, tt.wantManifest)
+			}
+			if parsed.cveID != tt.wantCVE {
+				t.Errorf("cveID = %q, want %q", parsed.cveID, tt.wantCVE)
+			}
+		})
+	}
+}
+
+func TestReadConfigurationResource_URIParsing(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	tests := []struct {
+		name      string
+		uri       string
+		wantErr   string
+		passParse bool
+	}{
+		{
+			name:    "wrong scheme",
+			uri:     "other://configuration-manifests/ns/manifest",
+			wantErr: "invalid URI",
+		},
+		{
+			name:      "valid URI",
+			uri:       "kubescape://configuration-manifests/default/my-config",
+			passParse: true,
+		},
+		{
+			name:    "too few parts",
+			uri:     "kubescape://configuration-manifests/ns",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "too many parts",
+			uri:     "kubescape://configuration-manifests/ns/manifest/extra",
+			wantErr: "invalid URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mcp.ReadResourceRequest{}
+			req.Params.URI = tt.uri
+
+			if tt.passParse {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Fatal("expected panic from nil ksClient after successful URI parse, got none")
+					}
+				}()
+				_, _ = ksServer.ReadConfigurationResource(context.Background(), req)
+				t.Fatal("expected panic, but call returned normally")
+			} else {
+				_, err := ksServer.ReadConfigurationResource(context.Background(), req)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -23,9 +23,10 @@ func TestParseVulnManifestURI(t *testing.T) {
 			wantErr: "invalid URI",
 		},
 		{
-			name:    "missing action suffix",
-			uri:     "kubescape://vulnerability-manifests/ns/manifest",
-			wantErr: "invalid URI",
+			name:         "base URI defaults to cve_list",
+			uri:          "kubescape://vulnerability-manifests/ns/manifest",
+			wantNS:       "ns",
+			wantManifest: "manifest",
 		},
 		{
 			name:         "valid cve_list URI",
@@ -41,8 +42,8 @@ func TestParseVulnManifestURI(t *testing.T) {
 			wantCVE:      "CVE-2024-1234",
 		},
 		{
-			name:    "too few parts after prefix",
-			uri:     "kubescape://vulnerability-manifests/ns/cve_list",
+			name:    "only namespace (too few parts)",
+			uri:     "kubescape://vulnerability-manifests/ns",
 			wantErr: "invalid URI",
 		},
 		{

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -86,18 +86,19 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 
 	// get exceptions
 	if exceptions, err = policyHandler.getExceptions(); err != nil {
-		logger.L().Ctx(ctx).Warning("failed to load exceptions", helpers.Error(err))
+		logger.L().Ctx(ctx).StopError("Failed to load exceptions", helpers.Error(err))
+	} else {
+		logger.L().StopSuccess("Loaded exceptions")
 	}
 
-	logger.L().StopSuccess("Loaded exceptions")
 	logger.L().Start("Loading account configurations...")
 
 	// get account configuration
 	if controlInputs, err = policyHandler.getControlInputs(); err != nil {
-		logger.L().Ctx(ctx).Warning(err.Error())
+		logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
+	} else {
+		logger.L().StopSuccess("Loaded account configurations")
 	}
-
-	logger.L().StopSuccess("Loaded account configurations")
 
 	return policies, exceptions, controlInputs, nil
 }


### PR DESCRIPTION
## Summary

- The MCP server's `ReadResource` handler split URIs by `/` against the full string including the `kubescape://vulnerability-manifests/` prefix, producing off-by-one index errors when the advertised URI format omitted the trailing `/cve_list` segment.
- Extracted URI parsing into a dedicated `parseVulnManifestURI` function that strips the prefix first, validates part count (2-4), and handles the base URI as an implicit `cve_list` request.
- Fixed `StopSuccess` logging in the policy handler so it only runs on the success path, not after errors.

## Test plan

- Added `TestParseVulnManifestURI` with 11 test cases covering valid URIs (base, cve_list, cve_details), wrong scheme, empty components, and too-few/too-many parts
- `go test ./... -short` passes all packages
- Policy handler logging changes validated by existing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite validating URI format parsing with coverage for valid URIs, invalid schemes, malformed segments, and empty components

* **Chores**
  * Enhanced operational logging with structured error tracking and success indicators for resource and policy loading operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2097)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->