### PR TITLE
fix: remove unreachable args check and fix arguements typo

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -31,7 +31,7 @@ func GetCompletionCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// Check if args array is not empty
 			if len(args) == 0 {
-				fmt.Println("No arguements provided.")
+				fmt.Println("No arguments provided.")
 				return
 			}
 

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -33,9 +33,9 @@ func TestGetCompletionCmd_RunExpectedOutputs(t *testing.T) {
 			want: "Invalid arguement unknown",
 		},
 		{
-			name: "Empty arguements",
+			name: "Empty arguments",
 			args: []string{},
-			want: "No arguements provided.\n",
+			want: "No arguments provided.\n",
 		},
 	}
 

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -67,10 +66,6 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 				downloadInfo.Path, downloadInfo.FileName = filepath.Split(downloadInfo.Path)
 			}
 
-			if len(args) == 0 {
-				return fmt.Errorf("no arguements provided")
-			}
-
 			downloadInfo.Target = args[0]
 			if len(args) >= 2 {
 				if args[1] == "" && (args[0] == "framework" || args[0] == "control") {
@@ -79,7 +74,7 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 				downloadInfo.Identifier = args[1]
 			}
 			if err := ks.Download(&downloadInfo); err != nil {
-				logger.L().Fatal(err.Error())
+				return err
 			}
 			return nil
 		},

--- a/cmd/download/download_test.go
+++ b/cmd/download/download_test.go
@@ -39,7 +39,7 @@ func TestGetViewCmd_Args(t *testing.T) {
 	assert.Equal(t, "", downloadCmd.Long)
 	assert.Equal(t, downloadExample, downloadCmd.Example)
 
-	err := downloadCmd.RunE(&cobra.Command{}, []string{"config"})
+	err := downloadCmd.RunE(&cobra.Command{}, []string{"artifacts"})
 	assert.Nil(t, err)
 
 	err = downloadCmd.Args(&cobra.Command{}, []string{})

--- a/cmd/download/download_test.go
+++ b/cmd/download/download_test.go
@@ -39,15 +39,11 @@ func TestGetViewCmd_Args(t *testing.T) {
 	assert.Equal(t, "", downloadCmd.Long)
 	assert.Equal(t, downloadExample, downloadCmd.Example)
 
-	err := downloadCmd.RunE(&cobra.Command{}, []string{})
-	expectedErrorMessage := "no arguements provided"
-	assert.Equal(t, expectedErrorMessage, err.Error())
-
-	err = downloadCmd.RunE(&cobra.Command{}, []string{"config"})
+	err := downloadCmd.RunE(&cobra.Command{}, []string{"config"})
 	assert.Nil(t, err)
 
 	err = downloadCmd.Args(&cobra.Command{}, []string{})
-	expectedErrorMessage = "policy type required, supported: artifacts,attack-tracks,control,controls-inputs,exceptions,framework"
+	expectedErrorMessage := "policy type required, supported: artifacts,attack-tracks,control,controls-inputs,exceptions,framework"
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = downloadCmd.Args(&cobra.Command{}, []string{"invalid"})

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -53,10 +52,6 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 
 			if err := flagValidationList(&listPolicies); err != nil {
 				return err
-			}
-
-			if len(args) < 1 {
-				return errors.New("no arguements provided")
 			}
 
 			listPolicies.Target = args[0]

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -35,10 +35,6 @@ func TestGetListCmd(t *testing.T) {
 	err = listCmd.Args(&cobra.Command{}, []string{"frameworks"})
 	assert.Nil(t, err)
 
-	err = listCmd.RunE(&cobra.Command{}, []string{})
-	expectedErrorMessage = "no arguements provided"
-	assert.Equal(t, expectedErrorMessage, err.Error())
-
 	err = listCmd.RunE(&cobra.Command{}, []string{"some-value"})
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
## Overview
Both `cmd/download/download.go` and `cmd/list/list.go` had a redundant `len(args)` check inside `RunE` that could never be reached — `Args` already validates this before `RunE` runs. Both also contained the typo `"arguements"` instead of `"arguments"`. Same typo was found and fixed in `cmd/completion/completion.go`.

Also replaced `logger.L().Fatal` with `return err` in `download.go` so errors propagate correctly instead of calling os.Exit.

## How to Test
go test ./cmd/download/... ./cmd/list/... ./cmd/completion/...

## Related issues/PRs
* Fixes #2096

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling in user-facing error messages.

* **Improvements**
  * Argument validation now runs earlier in command execution.
  * Improved error propagation to avoid abrupt process termination.

* **Tests**
  * Updated tests to match corrected messages and new argument-validation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2098)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->