### PR TITLE
feat(scan): add --fail-coverage-below flag for CI coverage gate

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -120,6 +120,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance score", fmt.Sprintf("%.2f", results.GetComplianceScore())), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
 			}
 			enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
+			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo)
 
 			return nil
 		},

--- a/cmd/scan/control_test.go
+++ b/cmd/scan/control_test.go
@@ -58,3 +58,15 @@ func TestGetControlCmdWithNonExistentControl(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
+
+// TestControlCmdHasCoverageFlag ensures scan control registers --fail-coverage-below
+// so the flag is not silently ignored when passed to this subcommand.
+func TestControlCmdHasCoverageFlag(t *testing.T) {
+	scanInfo := cautils.ScanInfo{}
+	scanCmd := GetScanCommand(&mocks.MockIKubescape{})
+	// add control as a subcommand the same way the real CLI does
+	scanCmd.AddCommand(getControlCmd(&mocks.MockIKubescape{}, &scanInfo))
+
+	flag := scanCmd.PersistentFlags().Lookup("fail-coverage-below")
+	assert.NotNil(t, flag, "scan control should inherit --fail-coverage-below from scan persistent flags")
+}

--- a/cmd/scan/control_test.go
+++ b/cmd/scan/control_test.go
@@ -64,9 +64,9 @@ func TestGetControlCmdWithNonExistentControl(t *testing.T) {
 func TestControlCmdHasCoverageFlag(t *testing.T) {
 	scanInfo := cautils.ScanInfo{}
 	scanCmd := GetScanCommand(&mocks.MockIKubescape{})
-	// add control as a subcommand the same way the real CLI does
-	scanCmd.AddCommand(getControlCmd(&mocks.MockIKubescape{}, &scanInfo))
+	controlCmd := getControlCmd(&mocks.MockIKubescape{}, &scanInfo)
+	scanCmd.AddCommand(controlCmd)
 
-	flag := scanCmd.PersistentFlags().Lookup("fail-coverage-below")
+	flag := controlCmd.InheritedFlags().Lookup("fail-coverage-below")
 	assert.NotNil(t, flag, "scan control should inherit --fail-coverage-below from scan persistent flags")
 }

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -236,6 +236,9 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
 		return ErrBadThreshold
 	}
+	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
+		return ErrBadThreshold
+	}
 	if scanInfo.Submit && scanInfo.OmitRawResources {
 		return ErrOmitRawResourcesOrSubmit
 	}
@@ -257,6 +260,9 @@ func validateThresholdsOnly(scanInfo *cautils.ScanInfo) error {
 		return ErrBadThreshold
 	}
 	if 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
+		return ErrBadThreshold
+	}
+	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
 		return ErrBadThreshold
 	}
 	return nil

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -137,6 +137,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			}
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
+			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo)
 			return nil
 		},
 	}
@@ -182,6 +183,26 @@ func countersExceedSeverityThreshold(severityCounters reportsummary.ISeverityCou
 // terminateOnExceedingSeverity terminates the application on exceeding severity
 func terminateOnExceedingSeverity(scanInfo *cautils.ScanInfo, l helpers.ILogger) {
 	l.Fatal("compliance result exceeds severity threshold", helpers.String("set severity threshold", scanInfo.FailThresholdSeverity))
+}
+
+// enforceCoverageThreshold fails the scan if the percentage of evaluated controls
+// is below scanInfo.FailCoverageThreshold. Coverage = (total - notEvaluated) / total * 100.
+// A threshold of 0 disables the check.
+func enforceCoverageThreshold(coverage cautils.ScanCoverage, totalControls int, scanInfo *cautils.ScanInfo) {
+	if scanInfo.FailCoverageThreshold <= 0 {
+		return
+	}
+	if totalControls == 0 {
+		return
+	}
+	notEvaluated := len(coverage.NotEvaluatedControls)
+	coveragePct := float32(totalControls-notEvaluated) / float32(totalControls) * 100
+	if coveragePct < scanInfo.FailCoverageThreshold {
+		logger.L().Fatal("scan coverage is below permitted threshold",
+			helpers.String("coverage", fmt.Sprintf("%.2f%%", coveragePct)),
+			helpers.String("fail-coverage-below", fmt.Sprintf("%.2f%%", scanInfo.FailCoverageThreshold)),
+		)
+	}
 }
 
 // enforceSeverityThresholds ensures that the scan results are below the defined severity threshold

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -88,6 +88,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.ComplianceThreshold, "compliance-threshold", "", 0, "Compliance threshold is the percent below which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().Float32Var(&scanInfo.FailCoverageThreshold, "fail-coverage-below", 0, "Minimum percentage of controls that must be evaluated (0 to disable). If coverage drops below this threshold the command returns exit code 1")
 
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"`)
@@ -177,6 +178,7 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
 	}
 
 	enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), &scanInfo, terminateOnExceedingSeverity)
+	enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), &scanInfo)
 
 	return nil
 }

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -375,3 +375,35 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, "Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.", cmd.Long)
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
+
+// coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we
+// can test it without triggering os.Exit.
+func coverageWouldFail(notEvaluated, totalControls int, threshold float32) bool {
+	if threshold <= 0 || totalControls == 0 {
+		return false
+	}
+	pct := float32(totalControls-notEvaluated) / float32(totalControls) * 100
+	return pct < threshold
+}
+
+func Test_enforceCoverageThreshold(t *testing.T) {
+	tests := []struct {
+		name          string
+		notEvaluated  int
+		totalControls int
+		threshold     float32
+		wantFail      bool
+	}{
+		{"threshold disabled (0) never fails", 10, 10, 0, false},
+		{"all controls evaluated passes", 0, 10, 80, false},
+		{"coverage exactly at threshold passes", 2, 10, 80, false},
+		{"coverage below threshold fails", 5, 10, 80, true},
+		{"zero total controls never fails", 0, 0, 50, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantFail, coverageWouldFail(tt.notEvaluated, tt.totalControls, tt.threshold))
+		})
+	}
+}

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -97,6 +97,29 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 	}
 }
 
+func Test_validateCoverageThreshold(t *testing.T) {
+	testCases := []struct {
+		Description string
+		ScanInfo    *cautils.ScanInfo
+		Want        error
+	}{
+		{"0 disables the check and is valid", &cautils.ScanInfo{FailCoverageThreshold: 0}, nil},
+		{"50 is a valid threshold", &cautils.ScanInfo{FailCoverageThreshold: 50}, nil},
+		{"100 is a valid threshold", &cautils.ScanInfo{FailCoverageThreshold: 100}, nil},
+		{"101 is out of range", &cautils.ScanInfo{FailCoverageThreshold: 101}, ErrBadThreshold},
+		{"negative value is out of range", &cautils.ScanInfo{FailCoverageThreshold: -1}, ErrBadThreshold},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got := validateThresholdsOnly(tc.ScanInfo)
+			if got != tc.Want {
+				t.Errorf("got: %v, want: %v", got, tc.Want)
+			}
+		})
+	}
+}
+
 func Test_validateWorkloadIdentifier(t *testing.T) {
 	testCases := []struct {
 		Description string

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -87,6 +87,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			}
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
+			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo)
 
 			return nil
 		},

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -120,6 +120,7 @@ type ScanInfo struct {
 	FailThreshold         float32                      // DEPRECATED - Failure score threshold
 	ComplianceThreshold   float32                      // Compliance score threshold
 	FailThresholdSeverity string                       // Severity at and above which the command should fail
+	FailCoverageThreshold float32                      // Coverage threshold below which the command fails (0 = disabled)
 	Submit                bool                         // Submit results to Kubescape Cloud BE
 	ScanID                string                       // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag                  // Deploy Kubescape K8s host scanner to collect data from certain controls


### PR DESCRIPTION
## Overview

This is the last part for #2010.
  
Quick context on what was done before this: PR 1 (kubescape/opa-utils#166) in opa-utils added the notEvaluated substatus, PR 2 (#2064 or whichever number) fixed namespace metadata, and PR 3 (#2069) did the main work of detecting which GVRs failed to pull and surfacing that as ScanCoverage in the output.

###  What this PR does

Adds --fail-coverage-below=N flag. After a scan finishes, it checks what percentage of controls actually got evaluated. If it's below N, the command exits with code 1.

The math is simple: (total controls - not-evaluated controls) / total controls * 100. The notEvaluatedControls list comes from ScanCoverage which was built in PR 3 (#2069).

The check runs in all three scan paths (scan, framework scan, workload scan) right after the existing severity/compliance threshold checks, so the behavior is consistent with how those flags already work.

Default value is 0 which disables the check completely, so nothing breaks for existing users or CI setups.

Useful if you want CI to catch situations where RBAC restrictions are silently reducing scan coverage without you knowing.

## How to Test

  Run the unit tests first:

  ```bash
  go test ./cmd/scan/... ./core/cautils/...
  
  To test the flag manually, run a scan with the flag disabled first to make sure nothing changed:

  kubescape scan --fail-coverage-below=0

  Then test the actual gate. If you have a cluster where some GVRs fail to pull (or just want to simulate it), set a high threshold and it should exit with code 1:

  kubescape scan --fail-coverage-below=95

  Check the exit code right after:

  echo $?

  If coverage is below 95% you'll see scan coverage is below permitted threshold in the logs and exit code 1. If coverage is fine, scan completes normally.
  ```

## Checklist

-  [x] My code follows the style guidelines of this project
-  [x] I have commented on my code, particularly in hard-to-understand areas
-  [x] I have performed a self-review of my code
-  [x] If it is a core feature, I have added thorough tests.
-  [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--fail-coverage-below` option and scan config to require minimum evaluated-controls coverage; framework, workload, and control scans now fail if coverage is below the configured percentage.
  * Validation now enforces the coverage threshold range (0–100).

* **Tests**
  * Added tests covering threshold validation, enforcement scenarios, and flag registration for subcommands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->