### PR TITLE
fix(junit): make --format junit output spec-compliant for standard CI parsers

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -40,26 +41,26 @@ type JUnitXML struct {
 // JUnitTestSuites represents the test summary
 type JUnitTestSuites struct {
 	XMLName  xml.Name         `xml:"testsuites"`
-	Suites   []JUnitTestSuite `xml:"testsuite"`     // list of controls
-	Errors   int              `xml:"errors,attr"`   // total number of tests with error result from all testsuites
-	Failures int              `xml:"failures,attr"` // total number of failed tests from all testsuites
-	Tests    int              `xml:"tests,attr"`    // total number of tests from all testsuites. Some software may expect to only see the number of successful tests from all testsuites though
-	Time     string           `xml:"time,attr"`     // time in seconds to execute all test suites
-	Name     string           `xml:"name,attr"`     // ? Add framework names ?
+	Suites   []JUnitTestSuite `xml:"testsuite"`              // list of controls
+	Errors   int              `xml:"errors,attr"`            // total number of tests with error result from all testsuites
+	Failures int              `xml:"failures,attr"`          // total number of failed tests from all testsuites
+	Tests    int              `xml:"tests,attr"`             // total number of tests from all testsuites. Some software may expect to only see the number of successful tests from all testsuites though
+	Time     string           `xml:"time,attr,omitempty"`    // time in seconds to execute all test suites
+	Name     string           `xml:"name,attr,omitempty"`    // ? Add framework names ?
 }
 
 // JUnitTestSuite represents a single control
 type JUnitTestSuite struct {
 	XMLName    xml.Name        `xml:"testsuite"`
-	Tests      int             `xml:"tests,attr"`     // total number of tests from this testsuite. Some software may expect to only see the number of successful tests though
-	Name       string          `xml:"name,attr"`      // Full (class) name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents. Required
-	Errors     int             `xml:"errors,attr"`    // The total number of tests in the suite that errors
-	Failures   int             `xml:"failures,attr"`  // The total number of tests in the suite that failed
-	Hostname   string          `xml:"hostname,attr"`  // Host on which the tests were executed ? cluster name ?
-	ID         int             `xml:"id,attr"`        // Starts at 0 for the first testsuite and is incremented by 1 for each following testsuite
-	Skipped    string          `xml:"skipped,attr"`   // The total number of skipped tests
-	Time       string          `xml:"time,attr"`      // Time taken (in seconds) to execute the tests in the suite
-	Timestamp  string          `xml:"timestamp,attr"` // when the test was executed in ISO 8601 format (2014-01-21T16:17:18)
+	Tests      int             `xml:"tests,attr"`                // total number of tests from this testsuite. Some software may expect to only see the number of successful tests though
+	Name       string          `xml:"name,attr"`                 // Full (class) name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents. Required
+	Errors     int             `xml:"errors,attr"`               // The total number of tests in the suite that errors
+	Failures   int             `xml:"failures,attr"`             // The total number of tests in the suite that failed
+	Hostname   string          `xml:"hostname,attr,omitempty"`   // Host on which the tests were executed ? cluster name ?
+	ID         int             `xml:"id,attr"`                   // Starts at 0 for the first testsuite and is incremented by 1 for each following testsuite
+	Skipped    int             `xml:"skipped,attr"`              // The total number of skipped tests
+	Time       string          `xml:"time,attr,omitempty"`       // Time taken (in seconds) to execute the tests in the suite
+	Timestamp  string          `xml:"timestamp,attr,omitempty"`  // when the test was executed in ISO 8601 format (2014-01-21T16:17:18)
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`
 	TestCases  []JUnitTestCase `xml:"testcase"`
 }
@@ -67,9 +68,9 @@ type JUnitTestSuite struct {
 // JUnitTestCase represents a single resource
 type JUnitTestCase struct {
 	XMLName     xml.Name          `xml:"testcase"`
-	Classname   string            `xml:"classname,attr"` // Full class name for the class the test method is in. required
-	Name        string            `xml:"name,attr"`      // Name of the test method, required
-	Time        string            `xml:"time,attr"`      // Time taken (in seconds) to execute the test. optional
+	Classname   string            `xml:"classname,attr"`      // Full class name for the class the test method is in. required
+	Name        string            `xml:"name,attr"`           // Name of the test method, required
+	Time        string            `xml:"time,attr,omitempty"` // Time taken (in seconds) to execute the test. optional
 	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
 	Failure     *JUnitFailure     `xml:"failure,omitempty"`
 }
@@ -132,11 +133,15 @@ func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 	}
 
 	junitResult := testsSuites(opaSessionObj)
-	postureReportStr, err := xml.Marshal(junitResult)
+	postureReportStr, err := xml.MarshalIndent(junitResult, "", "  ")
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("failed to Marshal xml result object", helpers.Error(err))
 	}
 
+	if _, err := jp.writer.Write([]byte(xml.Header)); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
+		return
+	}
 	if _, err := jp.writer.Write(postureReportStr); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
 		return
@@ -144,23 +149,42 @@ func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 	printer.LogOutputFile(jp.writer.Name())
 }
 
+// iso8601Timestamp returns the report generation time in ISO 8601 format,
+// falling back to the current time when ReportGenerationTime is the zero value.
+func iso8601Timestamp(t time.Time) string {
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
 func testsSuites(results *cautils.OPASessionObj) *JUnitTestSuites {
+	suites := listTestsSuite(results)
+	var tests, failures, errs int
+	for _, s := range suites {
+		tests += s.Tests
+		failures += s.Failures
+		errs += s.Errors
+	}
 	return &JUnitTestSuites{
-		Suites:   listTestsSuite(results),
-		Tests:    results.Report.SummaryDetails.NumberOfControls().All(),
+		Suites:   suites,
+		Tests:    tests,
+		Failures: failures,
+		Errors:   errs,
 		Name:     "Kubescape Scanning",
-		Failures: results.Report.SummaryDetails.NumberOfControls().Failed(),
 	}
 }
 func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 	var testSuites []JUnitTestSuite
+	timestamp := iso8601Timestamp(results.Report.ReportGenerationTime)
 
 	// control scan
 	if len(results.Report.SummaryDetails.ListFrameworks()) == 0 {
 		testSuite := JUnitTestSuite{}
 		testSuite.Tests = results.Report.SummaryDetails.NumberOfControls().All()
 		testSuite.Failures = results.Report.SummaryDetails.NumberOfControls().Failed()
-		testSuite.Timestamp = results.Report.ReportGenerationTime.String()
+		testSuite.Skipped = results.Report.SummaryDetails.NumberOfControls().Skipped()
+		testSuite.Timestamp = timestamp
 		testSuite.ID = 0
 		testSuite.Name = "kubescape"
 		testSuite.Properties = properties(results.Report.SummaryDetails.Score)
@@ -173,7 +197,8 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 		testSuite := JUnitTestSuite{}
 		testSuite.Tests = f.NumberOfControls().All()
 		testSuite.Failures = f.NumberOfControls().Failed()
-		testSuite.Timestamp = results.Report.ReportGenerationTime.String()
+		testSuite.Skipped = f.NumberOfControls().Skipped()
+		testSuite.Timestamp = timestamp
 		testSuite.ID = i
 		testSuite.Name = f.Name
 		testSuite.Properties = properties(f.Score)
@@ -186,7 +211,14 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControlsSummaries, classname string) []JUnitTestCase {
 	var testCases []JUnitTestCase
 
-	for cID := range controls.ListControlsIDs(nil).All() {
+	controlIDs := controls.ListControlsIDs(nil).All()
+	sortedIDs := make([]string, 0, len(controlIDs))
+	for cID := range controlIDs {
+		sortedIDs = append(sortedIDs, cID)
+	}
+	sort.Strings(sortedIDs)
+
+	for _, cID := range sortedIDs {
 		testCase := JUnitTestCase{}
 		control := results.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, cID)
 
@@ -211,7 +243,8 @@ func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControls
 			sort.Strings(resourcesStr)
 			testCaseFailure := JUnitFailure{}
 			testCaseFailure.Type = "Control"
-			testCaseFailure.Message = fmt.Sprintf("Remediation: %s\nMore details: %s\n\n%s", control.GetRemediation(), cautils.GetControlLink(control.GetID()), strings.Join(resourcesStr, "\n"))
+			testCaseFailure.Message = fmt.Sprintf("%s failed on %d resource(s)", control.GetName(), len(resourcesStr))
+			testCaseFailure.Contents = fmt.Sprintf("Remediation: %s\nMore details: %s\n\n%s", control.GetRemediation(), cautils.GetControlLink(control.GetID()), strings.Join(resourcesStr, "\n"))
 
 			testCase.Failure = &testCaseFailure
 		} else if control.GetStatus().IsSkipped() {

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -158,14 +158,21 @@ func iso8601Timestamp(t time.Time) string {
 	return t.UTC().Format("2006-01-02T15:04:05Z")
 }
 
-func testsSuites(results *cautils.OPASessionObj) *JUnitTestSuites {
-	suites := listTestsSuite(results)
-	var tests, failures, errs int
+// aggregateSuiteCounts sums the Tests/Failures/Errors counters across child
+// testsuites. Extracted so the aggregation can be unit-tested directly,
+// independent of the production code path (which never populates child Errors).
+func aggregateSuiteCounts(suites []JUnitTestSuite) (tests, failures, errors int) {
 	for _, s := range suites {
 		tests += s.Tests
 		failures += s.Failures
-		errs += s.Errors
+		errors += s.Errors
 	}
+	return
+}
+
+func testsSuites(results *cautils.OPASessionObj) *JUnitTestSuites {
+	suites := listTestsSuite(results)
+	tests, failures, errs := aggregateSuiteCounts(suites)
 	return &JUnitTestSuites{
 		Suites:   suites,
 		Tests:    tests,

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -536,3 +536,46 @@ func TestJunitMultiFrameworkSharedControl(t *testing.T) {
 	assert.NotEqual(t, session.Report.SummaryDetails.NumberOfControls().All(), suites.Tests,
 		"parent Tests must NOT be the deduplicated SummaryDetails count")
 }
+
+// TestAggregateSuiteCounts covers the Tests/Failures/Errors aggregator
+// directly. The production code path in junit.go never populates child
+// Errors (the printer only emits <failure> and <skipped>), so the multi-
+// framework regression test above cannot exercise the errors branch via
+// testsSuites. This unit test pins the loop itself.
+func TestAggregateSuiteCounts(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		in                                   []JUnitTestSuite
+		wantTests, wantFailures, wantErrors  int
+	}{
+		{
+			name: "empty slice yields zeros",
+		},
+		{
+			name: "errors aggregate across suites independently of failures",
+			in: []JUnitTestSuite{
+				{Tests: 5, Failures: 1, Errors: 2},
+				{Tests: 3, Failures: 0, Errors: 4},
+			},
+			wantTests: 8, wantFailures: 1, wantErrors: 6,
+		},
+		{
+			name: "mixed: errors-only, failures-only, and a clean suite",
+			in: []JUnitTestSuite{
+				{Tests: 4, Errors: 4},
+				{Tests: 2, Failures: 2},
+				{Tests: 7},
+			},
+			wantTests: 13, wantFailures: 2, wantErrors: 4,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTests, gotFailures, gotErrors := aggregateSuiteCounts(tc.in)
+			assert.Equal(t, tc.wantTests, gotTests, "tests")
+			assert.Equal(t, tc.wantFailures, gotFailures, "failures")
+			assert.Equal(t, tc.wantErrors, gotErrors, "errors")
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -1,17 +1,26 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
+	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+var updateGolden = flag.Bool("update-golden", false, "regenerate JUnit golden fixture under testdata/")
 
 func TestJunitPrinter(t *testing.T) {
 	// Verbose mode off
@@ -110,18 +119,26 @@ func TestListTestSuites(t *testing.T) {
 	results := cautils.NewOPASessionObjMock()
 	testsSuites := listTestsSuite(results)
 
+	if assert.Len(t, testsSuites, 1) {
+		// Timestamp is generated from time.Now() when the report has no
+		// generation time set, so just assert it parses as ISO 8601 and zero it
+		// out before comparing the rest of the struct.
+		_, err := time.Parse("2006-01-02T15:04:05Z", testsSuites[0].Timestamp)
+		assert.NoError(t, err, "timestamp should be ISO 8601")
+		testsSuites[0].Timestamp = ""
+	}
+
 	expectedTestSuites := []JUnitTestSuite{
 		{
-			XMLName:   xml.Name{Space: "", Local: ""},
-			Tests:     0,
-			Name:      "kubescape",
-			Errors:    0,
-			Failures:  0,
-			Hostname:  "",
-			ID:        0,
-			Skipped:   "",
-			Time:      "",
-			Timestamp: "0001-01-01 00:00:00 +0000 UTC",
+			XMLName:  xml.Name{Space: "", Local: ""},
+			Tests:    0,
+			Name:     "kubescape",
+			Errors:   0,
+			Failures: 0,
+			Hostname: "",
+			ID:       0,
+			Skipped:  0,
+			Time:     "",
 			Properties: []JUnitProperty{
 				{Name: "complianceScore", Value: "0.00"},
 			},
@@ -291,4 +308,148 @@ func TestBuildSkipMessage(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// TestJunitOutputInvariants is a regression test for the bugs reported in
+// issue #2099: counts mismatch, zero-time timestamps, missing XML prolog,
+// string-typed Skipped attribute, multi-line failure messages, and empty
+// attributes. It exercises the full ActionPrint path against a mock session
+// populated from the shared mock_summaryDetails.json fixture and asserts the
+// invariants standard JUnit parsers depend on.
+func TestJunitOutputInvariants(t *testing.T) {
+	mockSummary, err := mockSummaryDetails()
+	require.NoError(t, err)
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: *mockSummary,
+	}
+
+	tmp, err := os.CreateTemp("", "junit-regression-*.xml")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+
+	jp := NewJunitPrinter(false)
+	jp.writer = tmp
+	jp.ActionPrint(context.Background(), session, nil)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	// 4c — XML prolog present.
+	assert.True(t, bytes.HasPrefix(raw, []byte("<?xml")), "output must start with XML prolog")
+
+	// Round-trip through encoding/xml to ensure the document is well-formed.
+	var got JUnitXML
+	dec := xml.NewDecoder(bytes.NewReader(raw))
+	require.NoError(t, dec.Decode(&got.TestSuites), "output must round-trip through encoding/xml")
+	require.NotEmpty(t, got.TestSuites.Suites, "expected at least one <testsuite>")
+
+	// 4a — Σ(children) == parent for tests, failures, errors.
+	var sumTests, sumFailures, sumErrors int
+	for _, s := range got.TestSuites.Suites {
+		sumTests += s.Tests
+		sumFailures += s.Failures
+		sumErrors += s.Errors
+	}
+	assert.Equal(t, sumTests, got.TestSuites.Tests, "parent tests must equal sum of child tests")
+	assert.Equal(t, sumFailures, got.TestSuites.Failures, "parent failures must equal sum of child failures")
+	assert.Equal(t, sumErrors, got.TestSuites.Errors, "parent errors must equal sum of child errors")
+
+	// 4b — Timestamp is ISO 8601, not Go's default zero time.
+	for _, s := range got.TestSuites.Suites {
+		assert.NotContains(t, s.Timestamp, "0001-01-01", "timestamp must not be Go zero time")
+		_, perr := time.Parse("2006-01-02T15:04:05Z", s.Timestamp)
+		assert.NoError(t, perr, "timestamp %q must be ISO 8601", s.Timestamp)
+	}
+
+	// 4d — Skipped is now typed as int; the marshaller no longer emits skipped="".
+	assert.NotContains(t, string(raw), `skipped=""`, "skipped attribute must not be an empty string")
+
+	// 4e — Failure body lives in chardata, not in a multi-line message attribute.
+	for _, s := range got.TestSuites.Suites {
+		for _, tc := range s.TestCases {
+			if tc.Failure == nil {
+				continue
+			}
+			assert.NotContains(t, tc.Failure.Message, "\n", "failure message attribute must not contain newlines")
+			if strings.Contains(tc.Failure.Contents, "Remediation:") {
+				// remediation detail must live in element body, not the attribute
+				assert.NotContains(t, tc.Failure.Message, "Remediation:", "remediation belongs in the element body")
+			}
+		}
+	}
+
+	// 4f — Optional attributes are omitted when empty.
+	assert.NotContains(t, string(raw), `hostname=""`, "empty hostname attribute should be omitted")
+	assert.NotContains(t, string(raw), `time=""`, "empty time attribute should be omitted")
+
+	// Sanity check: golden testdata fixture still exists alongside this test.
+	_, statErr := os.Stat(filepath.Join("testdata", "mock_summaryDetails.json"))
+	assert.NoError(t, statErr)
+}
+
+// TestJunitGoldenFile pins the marshalled JUnit output byte-for-byte against
+// testdata/junit_golden.xml so future regressions of the issue #2099 fixes are
+// caught at review time. A fixed ReportGenerationTime keeps the output
+// deterministic; run with `go test -update-golden` to regenerate the fixture.
+func TestJunitGoldenFile(t *testing.T) {
+	mockSummary, err := mockSummaryDetails()
+	require.NoError(t, err)
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails:       *mockSummary,
+		ReportGenerationTime: time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC),
+	}
+
+	tmp, err := os.CreateTemp("", "junit-golden-*.xml")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+
+	jp := NewJunitPrinter(false)
+	jp.writer = tmp
+	jp.ActionPrint(context.Background(), session, nil)
+	require.NoError(t, tmp.Close())
+
+	got, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "junit_golden.xml")
+	if *updateGolden {
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "golden fixture missing — run `go test -update-golden`")
+	assert.Equal(t, string(want), string(got), "marshalled JUnit output diverged from testdata/junit_golden.xml")
+
+	// Also round-trip the golden file through encoding/xml and re-check the
+	// invariants on the *stored* fixture so a hand-edited golden that breaks
+	// JUnit semantics still fails the test.
+	var doc JUnitXML
+	require.NoError(t, xml.NewDecoder(bytes.NewReader(want)).Decode(&doc.TestSuites))
+	require.True(t, bytes.HasPrefix(want, []byte("<?xml")), "golden must include XML prolog")
+	var sumTests, sumFailures, sumErrors int
+	for _, s := range doc.TestSuites.Suites {
+		sumTests += s.Tests
+		sumFailures += s.Failures
+		sumErrors += s.Errors
+		assert.NotContains(t, s.Timestamp, "0001-01-01", "golden timestamp must not be Go zero time")
+	}
+	assert.Equal(t, sumTests, doc.TestSuites.Tests, "golden: Σ child tests must equal parent")
+	assert.Equal(t, sumFailures, doc.TestSuites.Failures, "golden: Σ child failures must equal parent")
+	assert.Equal(t, sumErrors, doc.TestSuites.Errors, "golden: Σ child errors must equal parent")
+}
+
+// TestIso8601Timestamp covers the small helper that powers the timestamp fix
+// in 4b — including the fallback when ReportGenerationTime is the zero value.
+func TestIso8601Timestamp(t *testing.T) {
+	fixed := time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC)
+	assert.Equal(t, "2024-03-14T09:15:26Z", iso8601Timestamp(fixed))
+
+	got := iso8601Timestamp(time.Time{})
+	_, err := time.Parse("2006-01-02T15:04:05Z", got)
+	assert.NoError(t, err, "zero time must fall back to a valid ISO 8601 timestamp, got %q", got)
 }

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -346,7 +347,13 @@ func TestJunitOutputInvariants(t *testing.T) {
 	require.NoError(t, dec.Decode(&got.TestSuites), "output must round-trip through encoding/xml")
 	require.NotEmpty(t, got.TestSuites.Suites, "expected at least one <testsuite>")
 
-	// 4a — Σ(children) == parent for tests, failures, errors.
+	// 4a — Σ(children) == parent for tests, failures, errors. This is a
+	// structural invariant any conformant JUnit document must satisfy; on the
+	// single-framework fixture used here it is trivially true even under the
+	// pre-fix code, so the *regression* of the deduplicated-parent bug is
+	// covered by TestJunitMultiFrameworkSharedControl below, which fabricates
+	// two frameworks sharing a control and asserts parent counts are derived
+	// from the child suites rather than SummaryDetails.NumberOfControls().
 	var sumTests, sumFailures, sumErrors int
 	for _, s := range got.TestSuites.Suites {
 		sumTests += s.Tests
@@ -452,4 +459,80 @@ func TestIso8601Timestamp(t *testing.T) {
 	got := iso8601Timestamp(time.Time{})
 	_, err := time.Parse("2006-01-02T15:04:05Z", got)
 	assert.NoError(t, err, "zero time must fall back to a valid ISO 8601 timestamp, got %q", got)
+}
+
+// TestJunitMultiFrameworkSharedControl directly targets the issue #2099/4a
+// regression: when 2+ frameworks share a control, the parent <testsuites>
+// totals must equal Σ(children), not the deduplicated control count.
+//
+// The single-framework fixture used elsewhere cannot exercise this because the
+// deduplicated SummaryDetails count and the per-framework count happen to be
+// equal. Here we build a synthetic posture with two frameworks that both
+// reference the same failed control, then assert:
+//
+//   - Σ child Tests == 2 (each framework contributes one testcase)
+//   - parent.Tests == Σ child Tests (would be 1 under the old, regressed code)
+//   - parent.Tests != SummaryDetails.NumberOfControls().All() (would be 1)
+//
+// If testsSuites ever regresses to sourcing parent counts from
+// SummaryDetails.NumberOfControls() this test fails.
+func TestJunitMultiFrameworkSharedControl(t *testing.T) {
+	sharedID := "C-9999"
+	failed := apis.StatusInfo{InnerStatus: apis.StatusFailed}
+	sharedCtrl := reportsummary.ControlSummary{
+		ControlID:  sharedID,
+		Name:       "Shared failing control",
+		StatusInfo: failed,
+		Status:     apis.StatusFailed,
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			// Top-level Controls map is deduplicated — the shared control
+			// appears here exactly once. SummaryDetails.NumberOfControls().All()
+			// will therefore return 1.
+			Controls: reportsummary.ControlSummaries{sharedID: sharedCtrl},
+			Frameworks: []reportsummary.FrameworkSummary{
+				{
+					Name:     "F1",
+					Controls: reportsummary.ControlSummaries{sharedID: sharedCtrl},
+				},
+				{
+					Name:     "F2",
+					Controls: reportsummary.ControlSummaries{sharedID: sharedCtrl},
+				},
+			},
+		},
+	}
+
+	// Sanity-check the assumption that drives the regression: the
+	// deduplicated parent counter and Σ(per-framework counters) disagree.
+	require.Equal(t, 1, session.Report.SummaryDetails.NumberOfControls().All(),
+		"precondition: dedup'd SummaryDetails counts the shared control once")
+	require.Equal(t, 2,
+		session.Report.SummaryDetails.Frameworks[0].NumberOfControls().All()+
+			session.Report.SummaryDetails.Frameworks[1].NumberOfControls().All(),
+		"precondition: per-framework counts double-count the shared control")
+
+	suites := testsSuites(session)
+
+	// Σ(children) must equal 2 — each framework yields a <testsuite> with one
+	// <testcase>. This is the value parsers will see when summing children.
+	var sumTests, sumFailures int
+	for _, s := range suites.Suites {
+		sumTests += s.Tests
+		sumFailures += s.Failures
+	}
+	require.Equal(t, 2, sumTests, "Σ child tests should be 2 across the two frameworks")
+	require.Equal(t, 2, sumFailures, "Σ child failures should be 2 across the two frameworks")
+
+	// The fix: parent equals Σ(children). The regression: parent would equal
+	// SummaryDetails.NumberOfControls().All() == 1.
+	assert.Equal(t, sumTests, suites.Tests,
+		"parent Tests must equal Σ child Tests (regressed code returns 1)")
+	assert.Equal(t, sumFailures, suites.Failures,
+		"parent Failures must equal Σ child Failures (regressed code returns 1)")
+	assert.NotEqual(t, session.Report.SummaryDetails.NumberOfControls().All(), suites.Tests,
+		"parent Tests must NOT be the deduplicated SummaryDetails count")
 }

--- a/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
+++ b/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites errors="0" failures="16" tests="24" name="Kubescape Scanning">
+  <testsuite tests="24" name="NSA" errors="0" failures="16" id="0" skipped="3" timestamp="2024-03-14T09:15:26Z">
+    <properties>
+      <property name="complianceScore" value="19.65"></property>
+    </properties>
+    <testcase classname="NSA" name="Exec into container">
+      <failure message="Exec into container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0002&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="API server insecure port is enabled"></testcase>
+    <testcase classname="NSA" name="Resource limits">
+      <failure message="Resource limits failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0009&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Applications credentials in configuration files">
+      <skipped message="configuration: Control configurations are empty"></skipped>
+    </testcase>
+    <testcase classname="NSA" name="Non-root containers">
+      <failure message="Non-root containers failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0013&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Allow privilege escalation">
+      <failure message="Allow privilege escalation failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0016&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Immutable container filesystem">
+      <failure message="Immutable container filesystem failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0017&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Ingress and Egress blocked">
+      <failure message="Ingress and Egress blocked failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0030&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Automatic mapping of service account">
+      <failure message="Automatic mapping of service account failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0034&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Cluster-admin binding">
+      <failure message="Cluster-admin binding failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0035&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Host PID/IPC privileges">
+      <failure message="Host PID/IPC privileges failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0038&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="HostNetwork access"></testcase>
+    <testcase classname="NSA" name="Container hostPort"></testcase>
+    <testcase classname="NSA" name="Insecure capabilities">
+      <failure message="Insecure capabilities failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0046&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Cluster internal networking">
+      <failure message="Cluster internal networking failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0054&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Linux hardening">
+      <failure message="Linux hardening failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0055&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Privileged container">
+      <failure message="Privileged container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0057&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="CVE-2021-25741 - Using symlink for arbitrary host file system access."></testcase>
+    <testcase classname="NSA" name="CVE-2021-25742-nginx-ingress-snippet-annotation-vulnerability"></testcase>
+    <testcase classname="NSA" name="Secret/ETCD encryption enabled">
+      <failure message="Secret/ETCD encryption enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0066&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Audit logs enabled">
+      <failure message="Audit logs enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0067&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="PSP enabled">
+      <failure message="PSP enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0068&#xA;&#xA;</failure>
+    </testcase>
+    <testcase classname="NSA" name="Disable anonymous access to Kubelet service">
+      <skipped message="This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator"></skipped>
+    </testcase>
+    <testcase classname="NSA" name="Enforce Kubelet client TLS authentication">
+      <skipped message="This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator"></skipped>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Overview

Fixes the six independent bugs in the `--format junit` output reported in #2099 that combined to make the generated XML unusable for standard CI consumers (Jenkins JUnit plugin, GitLab `junit` report, CircleCI test summary, GitHub Actions `dorny/test-reporter`).

**Current behavior:** kubescape emits JUnit XML where the top-level `<testsuites>` counts disagree with the sum of `<testsuite>` children, timestamps are Go's zero-time string (`0001-01-01 00:00:00 +0000 UTC`), there is no XML prolog, `skipped` is serialized as an empty string instead of an integer, multi-line remediation text is shoved into the `message` attribute (where many parsers truncate at the first newline), and optional attributes like `hostname=""`, `time=""` pollute every element.

**Future behavior:** Output begins with an XML prolog, parent counts equal `Σ(children)`, timestamps are ISO 8601 (`2024-03-14T09:15:26Z`) populated from `ReportGenerationTime` with a `time.Now().UTC()` fallback, `skipped` is an integer, remediation/resource detail lives in the `<failure>` element body (chardata) with a short single-line `message` attribute, and optional attributes use `omitempty`. Output is also deterministic (test cases sorted by control ID), which is friendlier to diff-based CI.

## Additional Information

Root cause locations are in `core/pkg/resultshandling/printer/v2/junit.go`. All six fixes are localized to this single file plus its test:

- **4a — count mismatch:** the parent used `SummaryDetails.NumberOfControls()` (deduplicated across frameworks) while each child used per-framework counts (`f.NumberOfControls()`), so controls present in multiple frameworks were counted in the children but not the parent. Fix: derive the parent totals from the child slice after it is built.
- **4b — Go zero-time string:** `time.Time.String()` does not produce ISO 8601, and `ReportGenerationTime` is never set in the scan path that drives the printer. Fix: new `iso8601Timestamp` helper formats with `2006-01-02T15:04:05Z` and falls back to `time.Now().UTC()` when the field is zero.
- **4c — missing XML prolog:** `xml.Marshal` never writes `<?xml ... ?>`. Fix: write `xml.Header` before the marshalled bytes in `ActionPrint`.
- **4d — `skipped` is a `string`:** the struct field was `Skipped string`, which marshalled as `skipped=""` for every suite. Fix: retype to `int` and populate via `NumberOfControls().Skipped()`.
- **4e — failure body in attribute:** remediation text containing newlines was assigned to `JUnitFailure.Message`, which serializes as an XML attribute. The struct already had a `Contents` chardata field that was never used. Fix: short summary in `Message`, full detail in `Contents`.
- **4f — empty optional attributes:** `hostname`, `time`, `timestamp` lacked `omitempty`. Fix: add the tag.

A bonus change is sorting control IDs in `testsCases` before emitting `<testcase>` elements. The previous code iterated a Go map, which produced non-deterministic ordering. Determinism is required for the new golden-file test and is a real quality-of-life win for anyone diffing CI output across runs.

## How to Test

1. Build: `go build -o /tmp/kubescape ./`
2. Reproduce against an insecure manifest (same fixture as #2099):
   ```sh
   cat > /tmp/deploy.yaml <<'EOF'
   apiVersion: apps/v1
   kind: Deployment
   metadata: { name: insecure-app, namespace: default }
   spec:
     replicas: 1
     selector: { matchLabels: { app: insecure } }
     template:
       metadata: { labels: { app: insecure } }
       spec:
         hostNetwork: true
         hostPID: true
         containers:
         - name: app
           image: nginx:latest
           securityContext: { privileged: true, runAsUser: 0, allowPrivilegeEscalation: true }
   EOF
   /tmp/kubescape scan /tmp/deploy.yaml --format junit --output /tmp/r.xml
   ```
3. Verify each invariant on `/tmp/r.xml`:
   ```sh
   head -1 /tmp/r.xml                    # must be <?xml version="1.0" encoding="UTF-8"?>
   grep -c 'skipped=""' /tmp/r.xml       # must be 0
   grep -c '0001-01-01' /tmp/r.xml       # must be 0
   grep -c 'hostname=""' /tmp/r.xml      # must be 0
   ```
4. Verify `Σ(children) == parent` programmatically:
   ```sh
   python3 -c "
   import xml.etree.ElementTree as ET
   t = ET.parse('/tmp/r.xml').getroot()
   p_t, p_f = int(t.get('tests')), int(t.get('failures'))
   c_t = sum(int(s.get('tests')) for s in t)
   c_f = sum(int(s.get('failures')) for s in t)
   assert p_t == c_t and p_f == c_f, (p_t, c_t, p_f, c_f)
   print('OK', p_t, p_f)
   "
   ```
5. Run the unit + regression tests:
   ```sh
   go test ./core/pkg/resultshandling/printer/v2/...
   ```
   This now includes:
   - `TestJunitGoldenFile` — byte-exact comparison against `testdata/junit_golden.xml`, plus an `encoding/xml` round-trip of the stored fixture that re-checks the invariants (XML prolog, no zero-time, parent counts == Σ children).
   - `TestJunitOutputInvariants` — drives `ActionPrint` end-to-end and asserts the invariants without depending on a stored golden.
   - `TestIso8601Timestamp` — covers the timestamp helper including its zero-time fallback branch.

   The golden fixture is regenerated with `go test ./core/pkg/resultshandling/printer/v2/ -run TestJunitGoldenFile -update-golden`.

## Examples

**Before the fix:**
```xml
<testsuites errors="0" failures="16" tests="48" name="Kubescape Scanning"><testsuite tests="19" name="WorkloadScan" errors="0" failures="10" hostname="" id="0" skipped="" time="" timestamp="0001-01-01 00:00:00 +0000 UTC">
  <testcase classname="WorkloadScan" name="Privileged container" time="">
    <failure message="Remediation: Remove privileged capabilities...
More details: https://hub.armosec.io/docs/c-0057

apiVersion: apps/v1; kind: Deployment; ..." type="Control"></failure>
  </testcase>
  ...
```
- No XML prolog
- Parent `tests="48"` but children sum to 64
- `timestamp="0001-01-01 00:00:00 +0000 UTC"`
- `skipped=""`, `hostname=""`, `time=""`
- Multi-line content inside the `message` attribute (parsers reject or truncate)

**After the fix:**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites errors="0" failures="25" tests="64" name="Kubescape Scanning">
  <testsuite tests="19" name="WorkloadScan" errors="0" failures="10" id="0" skipped="1" timestamp="2026-05-12T11:41:44Z">
    <properties>
      <property name="complianceScore" value="53.91"></property>
    </properties>
    <testcase classname="WorkloadScan" name="Privileged container">
      <failure message="Privileged container failed on 1 resource(s)" type="Control">Remediation: Remove privileged capabilities...
More details: https://hub.armosec.io/docs/c-0057

apiVersion: apps/v1; kind: Deployment; namespace: default; name: insecure-app; sourcePath: deploy.yaml</failure>
    </testcase>
    ...
```
- XML prolog present
- `Σ(children) == parent` (64 tests, 25 failures)
- ISO 8601 timestamp
- `skipped` is an integer; empty optional attributes omitted
- Full failure detail in element body; `message` is a short single-line summary

## Related issues/PRs

* Resolves #2099

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JUnit output now includes XML prolog and indentation, and omits empty attributes
  * Timestamps standardized to ISO-8601 (UTC) with fallback for missing times
  * Deterministic test case ordering; suite totals aggregate Tests/Failures/Errors correctly
  * Skipped counts reported; improved error handling for marshal/write paths
  * Failure messages now summarize control and failing resources; details moved to body

* **Tests**
  * Added end-to-end invariants test and pinned golden XML
  * Introduced update flag for golden regeneration
  * Added unit tests for timestamp fallback, aggregation, and multi-framework scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->