### PR TITLE
refactor: replace context.TODO() with context.Background() in initutils_test.go

### DIFF
--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -81,7 +81,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 		{
 			name: "Test GetExceptionsGetter all empty",
 			args: args{
-				ctx:                    context.TODO(),
+				ctx:                    context.Background(),
 				useExceptions:          "",
 				accountID:              "",
 				downloadReleasedPolicy: nil,
@@ -91,7 +91,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 		{
 			name: "Test GetExceptionsGetter empty useExceptions",
 			args: args{
-				ctx:                    context.TODO(),
+				ctx:                    context.Background(),
 				useExceptions:          "",
 				accountID:              "",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
@@ -101,7 +101,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 		{
 			name: "Test GetExceptionsGetter with useExceptions and empty accountID",
 			args: args{
-				ctx:                    context.TODO(),
+				ctx:                    context.Background(),
 				useExceptions:          "true",
 				accountID:              "",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
@@ -111,7 +111,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 		{
 			name: "Test GetExceptionsGetter with useExceptions and filled accountID",
 			args: args{
-				ctx:                    context.TODO(),
+				ctx:                    context.Background(),
 				useExceptions:          "true",
 				accountID:              "123456789012",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
@@ -121,7 +121,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 		{
 			name: "Test GetExceptionsGetter with accountID",
 			args: args{
-				ctx:                    context.TODO(),
+				ctx:                    context.Background(),
 				useExceptions:          "",
 				accountID:              "123456789012",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
@@ -211,7 +211,7 @@ func Test_getUIPrinter(t *testing.T) {
 		{
 			name: "Test getUIPrinter PrettyPrinter",
 			args: args{
-				ctx:           context.TODO(),
+				ctx:           context.Background(),
 				verboseMode:   scanInfo.VerboseMode,
 				formatVersion: scanInfo.FormatVersion,
 				printAttack:   scanInfo.PrintAttackTree,
@@ -229,7 +229,7 @@ func Test_getUIPrinter(t *testing.T) {
 		{
 			name: "Test getUIPrinter SilentPrinter",
 			args: args{
-				ctx:           context.TODO(),
+				ctx:           context.Background(),
 				verboseMode:   scanInfo.VerboseMode,
 				formatVersion: scanInfo.FormatVersion,
 				printAttack:   scanInfo.PrintAttackTree,


### PR DESCRIPTION
Closes #2102

## Overview
Replace `context.TODO()` with `context.Background()` in `core/core/initutils_test.go`.

`context.TODO()` is a placeholder used when the correct context is unclear during development. In test files, `context.Background()` is the appropriate choice as these contexts have no specific cancellation or deadline requirements.

## Additional Information
- 7 occurrences replaced across lines 84, 94, 104, 114, 124, 214, 232
- No functional changes — purely a code quality improvement

## How to Test
Run the existing tests:
`go test ./core/core/...`
All tests should pass without any changes.

## Examples/Screenshots
N/A

## Related issues/PRs
Resolved #2102

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use standard context patterns, ensuring consistency across the test suite.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->