### PR TITLE
refactor: replace context.TODO() with context.Background() in downloader/main.go

### DIFF
--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetUpdateCmd(t *testing.T) {
-	ks := core.NewKubescape(context.TODO())
+	ks := core.NewKubescape(context.Background())
 	cmd := GetUpdateCmd(ks)
 	assert.NotNil(t, cmd)
 

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -33,7 +33,7 @@ func TestGetVersionCmd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			versioncheck.BuildNumber = tt.buildNumber
 
-			ks := core.NewKubescape(context.TODO())
+			ks := core.NewKubescape(context.Background())
 			if cmd := GetVersionCmd(ks, tt.buildNumber, "", ""); cmd != nil {
 				buf := bytes.NewBufferString("")
 				cmd.SetOut(buf)

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -31,7 +31,7 @@ func TestListFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromFiles(t *testing.T) {
-	workloads := LoadResourcesFromFiles(context.TODO(), onlineBoutiquePath(), "")
+	workloads := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "")
 	assert.Equal(t, 12, len(workloads))
 
 	for i, w := range workloads {
@@ -45,7 +45,7 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
-	sourceToWorkloads, sourceToChartName, err := LoadResourcesFromHelmCharts(context.TODO(), helmChartPath(), HelmValueOptions{})
+	sourceToWorkloads, sourceToChartName, err := LoadResourcesFromHelmCharts(context.Background(), helmChartPath(), HelmValueOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 6, len(sourceToWorkloads))
 

--- a/core/cautils/helmchart_test.go
+++ b/core/cautils/helmchart_test.go
@@ -169,7 +169,7 @@ func TestLoadResourcesFromHelmCharts_WithOverrides(t *testing.T) {
 	opts := HelmValueOptions{
 		Values: []string{"image.pullPolicy=Never"},
 	}
-	sourceToWorkloads, _, err := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+	sourceToWorkloads, _, err := LoadResourcesFromHelmCharts(context.Background(), chartPath, opts)
 	assert.NoError(t, err)
 
 	cronjobPath := filepath.Join(chartPath, "templates", "cronjob.yaml")
@@ -191,7 +191,7 @@ func TestLoadResourcesFromHelmCharts_BadOverrideFailsFast(t *testing.T) {
 	opts := HelmValueOptions{
 		ValueFiles: []string{"/nonexistent/values.yaml"},
 	}
-	_, _, err := LoadResourcesFromHelmCharts(context.TODO(), chartPath, opts)
+	_, _, err := LoadResourcesFromHelmCharts(context.Background(), chartPath, opts)
 	assert.Error(t, err, "expected fail-fast on missing -f file")
 	assert.Contains(t, err.Error(), "Helm value overrides")
 }

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -161,7 +161,7 @@ func Test_CreatePortForwarder(t *testing.T) {
 				K8SConfig: &rest.Config{
 					Host: "any",
 				},
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 
 			operatorPod := v1.Pod{
@@ -202,7 +202,7 @@ func Test_GetPortForwardLocalhost(t *testing.T) {
 				K8SConfig: &rest.Config{
 					Host: "any",
 				},
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 
 			operatorPod := v1.Pod{

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -15,7 +15,7 @@ func TestSetContextMetadata(t *testing.T) {
 	{
 		ctx := reporthandlingv2.ContextMetadata{}
 		scanInfo := &ScanInfo{}
-		scanInfo.setContextMetadata(context.TODO(), &ctx)
+		scanInfo.setContextMetadata(context.Background(), &ctx)
 
 		assert.NotNil(t, ctx.ClusterContextMetadata)
 		assert.Nil(t, ctx.DirectoryContextMetadata)

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -43,7 +43,7 @@ func Test_getOperatorPod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			k8sClient := k8sinterface.KubernetesApi{
 				KubernetesClient: fake.NewClientset(),
-				Context:          context.TODO(),
+				Context:          context.Background(),
 			}
 
 			var createdOperatorPod *v1.Pod

--- a/core/core/kscore_test.go
+++ b/core/core/kscore_test.go
@@ -9,7 +9,7 @@ import (
 
 // The function should return a non-nil pointer.
 func TestNewKubescape_ReturnsNonNilPointer(t *testing.T) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	k := NewKubescape(ctx)
 	assert.NotNil(t, k)
 }
@@ -21,6 +21,6 @@ func TestNewKubescape_DoesNotPanic(t *testing.T) {
 			t.Errorf("Function panicked: %v", r)
 		}
 	}()
-	ctx := context.TODO()
+	ctx := context.Background()
 	NewKubescape(ctx)
 }

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -11,7 +11,7 @@ import (
 type MockIKubescape struct{}
 
 func (m *MockIKubescape) Context() context.Context {
-	return context.TODO()
+	return context.Background()
 }
 
 func (m *MockIKubescape) Scan(_ *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -205,7 +205,7 @@ func TestApplyFixKeepsFormatting(t *testing.T) {
 			expression := tc.yamlExpression
 
 			fileAsString := string(input)
-			got, _ := ApplyFixToContent(context.TODO(), fileAsString, expression)
+			got, _ := ApplyFixToContent(context.Background(), fileAsString, expression)
 
 			assert.Equalf(
 				t, want, got,

--- a/core/pkg/opaprocessor/cosign_verify.go
+++ b/core/pkg/opaprocessor/cosign_verify.go
@@ -72,7 +72,7 @@ func verify(img string, key string) (bool, error) {
 		return false, fmt.Errorf("getting Rekor public keys: %w", err)
 	}
 
-	_, _, err = cosign.VerifyImageSignatures(context.TODO(), ref, co)
+	_, _, err = cosign.VerifyImageSignatures(context.Background(), ref, co)
 	if err != nil {
 		return false, fmt.Errorf("verifying signature: %w", err)
 	}

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -203,7 +203,7 @@ func TestProcessResourcesResult(t *testing.T) {
 
 	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false)
 	opap.AllPolicies = policies
-	opap.Process(context.TODO(), policies, nil)
+	opap.Process(context.Background(), policies, nil)
 
 	assert.Equal(t, 1, len(opaSessionObj.ResourcesResult))
 	res := opaSessionObj.ResourcesResult[deployment.GetID()]
@@ -214,7 +214,7 @@ func TestProcessResourcesResult(t *testing.T) {
 	assert.False(t, res.GetStatus(nil).IsPassed())
 	assert.Equal(t, deployment.GetID(), opaSessionObj.ResourcesResult[deployment.GetID()].ResourceID)
 
-	opap.updateResults(context.TODO())
+	opap.updateResults(context.Background())
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
 	assert.Equal(t, 2, res.ListControlsIDs(nil).Len())
 	assert.Equal(t, 1, res.ListControlsIDs(nil).Failed())
@@ -244,7 +244,7 @@ func TestProcessResourcesResult(t *testing.T) {
 	assert.True(t, summaryDetails.GetStatus().IsFailed())
 
 	opaSessionObj.Exceptions = []armotypes.PostureExceptionPolicy{*mocks.MockExceptionAllKinds(&armotypes.PosturePolicy{FrameworkName: frameworks[0].Name})}
-	opap.updateResults(context.TODO())
+	opap.updateResults(context.Background())
 
 	res = opaSessionObj.ResourcesResult[deployment.GetID()]
 	assert.Equal(t, 2, res.ListControlsIDs(nil).Len())

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -111,7 +111,7 @@ func TestCollectPolicies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := context.Background()
 			tc.policyHandler.getters = &cautils.Getters{
 				PolicyGetter:         &PolicyGetterMock{},
 				ExceptionsGetter:     &ExceptionsGetterMock{},
@@ -196,7 +196,7 @@ func TestDownloadScanPolicies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := context.Background()
 			tc.policyHandler.getters = &cautils.Getters{
 				PolicyGetter:         &PolicyGetterMock{},
 				ExceptionsGetter:     &ExceptionsGetterMock{},

--- a/core/pkg/resourcehandler/handlepullresources_test.go
+++ b/core/pkg/resourcehandler/handlepullresources_test.go
@@ -85,12 +85,12 @@ func Test_CollectResources(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		CollectResources(context.TODO(), resourceHandler, objSession, &cautils.ScanInfo{})
+		CollectResources(context.Background(), resourceHandler, objSession, &cautils.ScanInfo{})
 	}, "Cluster named .*eks.* without a cloud config panics on cluster scan !")
 
 	assert.NotPanics(t, func() {
 		objSession.Metadata.ScanMetadata.ScanningTarget = reportv2.File
-		CollectResources(context.TODO(), resourceHandler, objSession, &cautils.ScanInfo{})
+		CollectResources(context.Background(), resourceHandler, objSession, &cautils.ScanInfo{})
 	}, "Cluster named .*eks.* without a cloud config panics on non-cluster scan !")
 
 }

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -495,7 +495,7 @@ func (k8sHandler *K8sResourceHandler) collectRbacResources(allResources map[stri
 }
 
 func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber() (int, error) {
-	nodesList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodesList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	scheduableNodes := v1.NodeList{}
 	if nodesList != nil {
 		for _, node := range nodesList.Items {

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -124,10 +124,10 @@ func TestGetResources_SurfacesMissingGVRFailuresInInfoMap(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.TODO(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
-	_, _, _, _, err := handler.GetResources(context.TODO(), sessionObj, scanInfo)
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
 	assert.NoError(t, err)
 
 	info, ok := sessionObj.InfoMap["core/v1/secrets"]
@@ -153,10 +153,10 @@ func TestGetResources_FailsWhenAllQueriesFail(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.TODO(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
-	_, _, _, _, err := handler.GetResources(context.TODO(), sessionObj, scanInfo)
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
 	assert.ErrorContains(t, err, "failed to pull any Kubernetes resources")
 	assert.ErrorContains(t, err, "simulated API failure")
 }

--- a/core/pkg/resourcehandler/k8sresources_test.go
+++ b/core/pkg/resourcehandler/k8sresources_test.go
@@ -608,7 +608,7 @@ func TestSetMapNamespaceToNumOfResources(t *testing.T) {
 	}
 
 	sessionObj := cautils.NewOPASessionObjMock()
-	setMapNamespaceToNumOfResources(context.TODO(), allResources, sessionObj)
+	setMapNamespaceToNumOfResources(context.Background(), allResources, sessionObj)
 	expected := map[string]int{
 		"kube-system": 1,
 		"armo-system": 3,

--- a/core/pkg/resourcesprioritization/prioritizationhandler_test.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler_test.go
@@ -104,7 +104,7 @@ func ResourceAssociatedControlMock(controlID string, status apis.ScanningStatus)
 }
 
 func TestNewResourcesPrioritizationHandler(t *testing.T) {
-	handler, err := NewResourcesPrioritizationHandler(context.TODO(), &AttackTracksGetterMock{}, false)
+	handler, err := NewResourcesPrioritizationHandler(context.Background(), &AttackTracksGetterMock{}, false)
 	assert.NoError(t, err)
 	assert.Len(t, handler.attackTracks, 3)
 	assert.Equal(t, handler.attackTracks[0].GetName(), "TestAttackTrack")
@@ -190,7 +190,7 @@ func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler, _ := NewResourcesPrioritizationHandler(context.TODO(), &AttackTracksGetterMock{}, false)
+			handler, _ := NewResourcesPrioritizationHandler(context.Background(), &AttackTracksGetterMock{}, false)
 			sessionObj := OPASessionObjMock(tt.allPoliciesControls, tt.results, tt.controls, tt.resources)
 			err := handler.PrioritizeResources(sessionObj)
 			assert.NoError(t, err, "expected to have no errors in PrioritizeResources()")

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -51,7 +51,7 @@ func TestResultsHandlerHandleResultsPrintsResultsToUI(t *testing.T) {
 	rh := NewResultsHandler(reporter, printers, uiPrinter)
 	rh.SetData(fakeScanData)
 
-	err := rh.HandleResults(context.TODO(), &cautils.ScanInfo{})
+	err := rh.HandleResults(context.Background(), &cautils.ScanInfo{})
 	assert.NoError(t, err)
 
 	want := 1

--- a/downloader/main.go
+++ b/downloader/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	ctx := context.TODO()
+	ctx := context.Background()
 	ks := core.NewKubescape(ctx)
 	downloads := []metav1.DownloadInfo{
 		{Target: "artifacts"},                         // download all artifacts

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -87,7 +87,7 @@ func Test_getControlsMapFromResult(t *testing.T) {
 		},
 	}
 
-	actual := getControlsMapFromResult(context.TODO(), &scanResult, controlSummaries)
+	actual := getControlsMapFromResult(context.Background(), &scanResult, controlSummaries)
 	assert.Len(t, actual, len(scanResult.AssociatedControls))
 }
 


### PR DESCRIPTION
Closes #2104

## Overview
Replace `context.TODO()` with `context.Background()` in `downloader/main.go`.

`context.TODO()` is a placeholder used when the correct context is unclear during development. In a `main()` function, `context.Background()` is the appropriate root context as it is the top-level context with no parent, cancellation, or deadline.

## Additional Information
- 1 occurrence replaced at line 13
- No functional changes — purely a code quality improvement

## How to Test
Run the downloader:
`go build ./downloader/...`
Build should succeed without any changes.

## Related issues/PRs
Resolved #2104

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized internal context initialization across the application and tests, replacing provisional contexts with a consistent background context to improve reliability and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->