### PR TITLE
fix: krew publishing broken since krew-release-bot v0.0.46

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -107,7 +107,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || inputs.skip_publish != true
         uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47
         with:
-          krew_template_file: .krew.yaml
+          krew_template_file: dist/krew/kubescape.yaml
 
       - name: List collected system-test results (debug)
         if: always()

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -136,6 +136,9 @@ krews:
     homepage: https://kubescape.io/
     description: It includes risk analysis, security compliance, and misconfiguration scanning with an easy-to-use CLI interface, flexible output formats, and automated scanning capabilities.
     short_description: Scan resources and cluster configs against security frameworks.
+    caveats: |
+      Requires kubectl and basic knowledge of Kubernetes.
+      Run 'kubescape scan' to scan your Kubernetes cluster or manifests.
 
 release:
   draft: false


### PR DESCRIPTION
## Overview

krew publishing has been broken since we bumped krew-release-bot to v0.0.47. Tracked it down to a breaking change in v0.0.46 — `addURIAndSha` dropped from 4 args to 2, but `.krew.yaml` still uses the old signature.

goreleaser already generates a pre-rendered krew manifest at `dist/krew/kubescape.yaml` during the release job (we have `skip_upload: true`), and that step runs before krew-release-bot anyway. Pointing `krew_template_file` at the generated file fixes the issue without changing anything else about the release.

Also moved `caveats` into `.goreleaser.yaml` since it was only in `.krew.yaml` and would have been lost otherwise.

## Related issues/PRs

* Resolved #1712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation caveats and prerequisites shown during Krew installation (requires kubectl and basic Kubernetes knowledge) and guidance to run the scan command.

* **Chores**
  * Updated release workflow to use the new Krew template location.
  * Enhanced release distribution configuration for improved Krew package integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2106)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->