### PR TITLE
test(junit): add test for skip message wiring in testsCases

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -225,6 +225,78 @@ func TestProperties(t *testing.T) {
 	}
 }
 
+func TestTestCases_SkipMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		subStatus apis.ScanningSubStatus
+		innerInfo string
+		wantMsg   string
+	}{
+		{
+			name:      "not evaluated",
+			subStatus: apis.SubStatusNotEvaluated,
+			innerInfo: string(apis.SubStatusNotEvaluatedInfo),
+			wantMsg:   "notEvaluated: " + string(apis.SubStatusNotEvaluatedInfo),
+		},
+		{
+			name:      "configuration",
+			subStatus: apis.SubStatusConfiguration,
+			innerInfo: string(apis.SubStatusConfigurationInfo),
+			wantMsg:   "configuration: " + string(apis.SubStatusConfigurationInfo),
+		},
+		{
+			name:      "manual review",
+			subStatus: apis.SubStatusManualReview,
+			innerInfo: string(apis.SubStatusManualReviewInfo),
+			wantMsg:   "manual review: " + string(apis.SubStatusManualReviewInfo),
+		},
+		{
+			name:      "requires review",
+			subStatus: apis.SubStatusRequiresReview,
+			innerInfo: string(apis.SubStatusRequiresReviewInfo),
+			wantMsg:   "requires review: " + string(apis.SubStatusRequiresReviewInfo),
+		},
+		{
+			name:      "unknown substatus no info",
+			subStatus: apis.SubStatusUnknown,
+			innerInfo: "",
+			wantMsg:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := cautils.NewOPASessionObjMock()
+			results.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+				"C-0001": reportsummary.ControlSummary{
+					ControlID: "C-0001",
+					Name:      "test-control",
+					StatusInfo: apis.StatusInfo{
+						InnerStatus: apis.StatusSkipped,
+						SubStatus:   tt.subStatus,
+						InnerInfo:   tt.innerInfo,
+					},
+				},
+			}
+
+			cases := testsCases(results, &results.Report.SummaryDetails.Controls, "TestSuite")
+
+			if assert.Len(t, cases, 1) {
+				if tt.wantMsg == "" {
+					if cases[0].SkipMessage != nil {
+						assert.Equal(t, tt.wantMsg, cases[0].SkipMessage.Message)
+					}
+				} else {
+					if assert.NotNil(t, cases[0].SkipMessage) {
+						assert.Equal(t, tt.wantMsg, cases[0].SkipMessage.Message)
+					}
+				}
+				assert.Nil(t, cases[0].Failure)
+			}
+		})
+	}
+}
+
 func TestSetWriter_Junit(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Overview

While looking at the JUnit printer I noticed `testsCases` sets a skip message but there was no test actually checking it gets populated. Added `TestTestCases_SkipMessage` which builds a session with a skipped control and verifies the message comes through correctly.

## Related issues/PRs

Adds test coverage for the `buildSkipMessage` wiring in `testsCases`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a table-driven unit test that verifies skipped controls produce the expected skip message (derived from substatus and inner info) in generated test results, and that failure remains unset.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2107)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->