### PR TITLE
fix(httphandler): harden IDOR remediation for /v1/results

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -161,8 +161,19 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.L().Info("requesting results", helpers.String("scanID", resultsQueryParams.ScanID), helpers.String("api", "v1/results"), helpers.String("method", r.Method))
 
+	isLatestFallback := false
 	if resultsQueryParams.ScanID == "" {
-		resultsQueryParams.ScanID = handler.state.getLatestID()
+		if handler.offline {
+			resultsQueryParams.ScanID = handler.state.getLatestID()
+			isLatestFallback = true
+		} else {
+			logger.L().Info("empty scan ID")
+			w.WriteHeader(http.StatusBadRequest)
+			response.Response = "scan ID is required"
+			response.Type = utilsapisv1.ErrorScanResponseType
+			w.Write(responseToBytes(&response))
+			return
+		}
 	}
 
 	if resultsQueryParams.ScanID == "" { // if no scan found
@@ -199,8 +210,12 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 			response.Response = res
 
 			if !resultsQueryParams.KeepResults {
-				logger.L().Info("deleting results", helpers.String("ID", resultsQueryParams.ScanID))
-				defer removeResultsFile(resultsQueryParams.ScanID)
+				if isLatestFallback {
+					logger.L().Info("keeping results for latest scan fallback to prevent unintended deletion", helpers.String("ID", resultsQueryParams.ScanID))
+				} else {
+					logger.L().Info("deleting results", helpers.String("ID", resultsQueryParams.ScanID))
+					defer removeResultsFile(resultsQueryParams.ScanID)
+				}
 			}
 
 		}
@@ -214,6 +229,10 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
+			if isLatestFallback {
+				handler.writeError(w, fmt.Errorf("scan ID must be provided for deletion"), resultsQueryParams.ScanID)
+				return
+			}
 			removeResultsFile(resultsQueryParams.ScanID)
 		}
 		w.WriteHeader(http.StatusOK)

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -161,6 +161,16 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.L().Info("requesting results", helpers.String("scanID", resultsQueryParams.ScanID), helpers.String("api", "v1/results"), helpers.String("method", r.Method))
 
+	if r.Method == http.MethodDelete && resultsQueryParams.AllResults {
+		logger.L().Info("deleting all results")
+		if err := handler.state.removeAllIfIdle(removeResultDirs); err != nil {
+			handler.writeError(w, err, resultsQueryParams.ScanID)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	isLatestFallback := false
 	if resultsQueryParams.ScanID == "" {
 		if handler.offline {
@@ -223,18 +233,11 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		logger.L().Info("deleting results", helpers.String("ID", resultsQueryParams.ScanID))
 
-		if resultsQueryParams.AllResults {
-			if err := handler.state.removeAllIfIdle(removeResultDirs); err != nil {
-				handler.writeError(w, err, resultsQueryParams.ScanID)
-				return
-			}
-		} else {
-			if isLatestFallback {
-				handler.writeError(w, fmt.Errorf("scan ID must be provided for deletion"), resultsQueryParams.ScanID)
-				return
-			}
-			removeResultsFile(resultsQueryParams.ScanID)
+		if isLatestFallback {
+			handler.writeError(w, fmt.Errorf("scan ID must be provided for deletion"), resultsQueryParams.ScanID)
+			return
 		}
+		removeResultsFile(resultsQueryParams.ScanID)
 		w.WriteHeader(http.StatusOK)
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/httphandler/handlerequests/v1/requestshandler_test.go
+++ b/httphandler/handlerequests/v1/requestshandler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -86,3 +87,28 @@ func TestScan(t *testing.T) {
 // 		assert.Equal(t, "aaaaaaaaaa", req.scanRequest.Account)
 // 	}
 // }
+
+func TestResultsDeleteAll(t *testing.T) {
+	h := NewHTTPHandler(false)
+
+	rq := httptest.NewRequest("DELETE", "/results?all=true", nil)
+	w := httptest.NewRecorder()
+
+	h.Results(w, rq)
+	rs := w.Result()
+	
+	if rs.StatusCode != http.StatusOK {
+		t.Errorf("Expected StatusOK (200), got %v", rs.StatusCode)
+	}
+
+	// Also verify that a normal DELETE without all=true and no ScanID fails
+	rq = httptest.NewRequest("DELETE", "/results", nil)
+	w = httptest.NewRecorder()
+
+	h.Results(w, rq)
+	rs = w.Result()
+	
+	if rs.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected StatusBadRequest (400) for missing ScanID, got %v", rs.StatusCode)
+	}
+}

--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -54,33 +54,65 @@ func TestGetScanCommandWithAccessKey(t *testing.T) {
 	assert.False(t, s.Submit)
 }
 
-func TestFindFile_EarlyExit(t *testing.T) {
-	// Create a temp dir with multiple files
+func TestReadResultsFile(t *testing.T) {
 	dir := t.TempDir()
-	// Create target file and extra files
-	targetFile := dir + "/target-abc123.json"
+
+	// Temporarily override OutputDir for tests
+	oldOutputDir := OutputDir
+	OutputDir = dir
+	defer func() { OutputDir = oldOutputDir }()
+
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	targetFile := dir + "/" + validUUID + ".json"
 	otherFile := dir + "/other-xyz.json"
+
 	err := os.WriteFile(targetFile, []byte("{}"), 0644)
 	assert.NoError(t, err)
 	err = os.WriteFile(otherFile, []byte("{}"), 0644)
 	assert.NoError(t, err)
 
-	// findFile should find the target and stop early
-	found, err := findFile(dir, "target-abc123")
+	// readResultsFile should find the target via exact match
+	_, err = readResultsFile(validUUID)
 	assert.NoError(t, err)
-	assert.Contains(t, found, "target-abc123")
+
+	// readResultsFile should not find a non-existent UUID
+	_, err = readResultsFile("111e4567-e89b-12d3-a456-426614174000")
+	assert.ErrorContains(t, err, "file 111e4567-e89b-12d3-a456-426614174000 not found")
+
+	// readResultsFile should reject invalid UUID formats
+	_, err = readResultsFile("invalid-uuid")
+	assert.ErrorContains(t, err, "invalid scan ID format")
+
+	// readResultsFile should prevent path traversal
+	_, err = readResultsFile("../target")
+	assert.ErrorContains(t, err, "invalid scan ID format")
 }
 
-func TestFindFile_NotFound(t *testing.T) {
+func TestRemoveResultsFile(t *testing.T) {
 	dir := t.TempDir()
-	found, err := findFile(dir, "nonexistent-file")
-	assert.NoError(t, err)
-	assert.Equal(t, "", found)
-}
 
-func TestFindFile_MissingDir(t *testing.T) {
-	// WalkDir skips the root error same as per-entry errors; missing dir returns empty string and nil
-	found, err := findFile("/nonexistent/dir", "file")
+	// Temporarily override OutputDir for tests
+	oldOutputDir := OutputDir
+	OutputDir = dir
+	defer func() { OutputDir = oldOutputDir }()
+
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	targetFile := dir + "/" + validUUID + ".json"
+
+	err := os.WriteFile(targetFile, []byte("{}"), 0644)
 	assert.NoError(t, err)
-	assert.Equal(t, "", found)
+
+	// removeResultsFile should succeed
+	err = removeResultsFile(validUUID)
+	assert.NoError(t, err)
+	_, statErr := os.Stat(targetFile)
+	assert.True(t, os.IsNotExist(statErr))
+
+	// removeResultsFile should ignore invalid UUID formats
+	err = removeResultsFile("invalid-uuid")
+	assert.NoError(t, err) // Logs warning, but no error returned
+
+	// removeResultsFile should prevent path traversal
+	err = removeResultsFile("../target")
+	assert.NoError(t, err)
 }

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"io/fs"
 	"path/filepath"
-	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/armosec/utils-go/boolutils"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -108,16 +108,28 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 }
 
 func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
-	if fileName := searchFile(fileID); fileName != "" {
-		f, err := os.ReadFile(fileName)
-		if err != nil {
-			return nil, err
-		}
-		postureReport := &reporthandlingv2.PostureReport{}
-		err = json.Unmarshal(f, postureReport)
-		return postureReport, err
+	parsedUUID, err := uuid.Parse(fileID)
+	if err != nil {
+		logger.L().Warning("invalid scan ID requested", helpers.String("ID", fileID), helpers.Error(err))
+		return nil, fmt.Errorf("invalid scan ID format")
 	}
-	return nil, fmt.Errorf("file %s not found", fileID)
+	cleanID := parsedUUID.String()
+
+	dirs := []string{OutputDir, FailedOutputDir}
+	extensions := []string{"", ".json"}
+
+	for _, dir := range dirs {
+		for _, ext := range extensions {
+			path := filepath.Join(dir, cleanID+ext)
+			f, err := os.ReadFile(path)
+			if err == nil {
+				postureReport := &reporthandlingv2.PostureReport{}
+				err = json.Unmarshal(f, postureReport)
+				return postureReport, err
+			}
+		}
+	}
+	return nil, fmt.Errorf("file %s not found", cleanID)
 }
 
 func removeResultDirs() {
@@ -128,38 +140,28 @@ func removeResultDirs() {
 		logger.L().Error("failed to remove failed output directory", helpers.String("path", FailedOutputDir), helpers.Error(err))
 	}
 }
-func removeResultsFile(fileID string) error {
-	if fileName := searchFile(fileID); fileName != "" {
-		return os.Remove(fileName)
-	}
-	return nil // no files found to delete
-}
-func searchFile(fileID string) string {
-	if fileName, _ := findFile(OutputDir, fileID); fileName != "" {
-		return fileName
-	}
-	if fileName, _ := findFile(FailedOutputDir, fileID); fileName != "" {
-		return fileName
-	}
-	return ""
-}
 
-func findFile(targetDir string, fileName string) (string, error) {
-	var found string
-	err := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip inaccessible entries
-		}
-		if strings.Contains(path, fileName) {
-			found = path
-			return filepath.SkipAll
-		}
-		return nil
-	})
+func removeResultsFile(fileID string) error {
+	parsedUUID, err := uuid.Parse(fileID)
 	if err != nil {
-		return "", err
+		logger.L().Warning("invalid scan ID requested", helpers.String("ID", fileID), helpers.Error(err))
+		return nil // Invalid ID means no file to delete
 	}
-	return found, nil
+	cleanID := parsedUUID.String()
+
+	dirs := []string{OutputDir, FailedOutputDir}
+	extensions := []string{"", ".json"}
+
+	for _, dir := range dirs {
+		for _, ext := range extensions {
+			path := filepath.Join(dir, cleanID+ext)
+			err := os.Remove(path)
+			if err != nil && !os.IsNotExist(err) {
+				logger.L().Warning("failed to remove result file", helpers.String("path", path), helpers.Error(err))
+			}
+		}
+	}
+	return nil
 }
 
 func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *cautils.ScanInfo {
@@ -187,16 +189,16 @@ func defaultScanInfo() *cautils.ScanInfo {
 	scanInfo := &cautils.ScanInfo{}
 	scanInfo.FailThreshold = 100
 	scanInfo.ComplianceThreshold = 0
-	scanInfo.AccountID = envToString("KS_ACCOUNT_ID", config.GetAccount())         // publish results to Kubescape SaaS
-	scanInfo.AccessKey = envToString("KS_ACCESS_KEY", config.GetAccessKey())       // publish results to Kubescape SaaS
-	scanInfo.ExcludedNamespaces = envToString("KS_EXCLUDE_NAMESPACES", "")         // namespaces to exclude
-	scanInfo.IncludeNamespaces = envToString("KS_INCLUDE_NAMESPACES", "")          // namespaces to include
-	scanInfo.HostSensorYamlPath = envToString("KS_HOST_SCAN_YAML", "")  // path to host scan YAML
-	scanInfo.FormatVersion = envToString("KS_FORMAT_VERSION", "v2")    // output format version
-	scanInfo.Format = envToString("KS_FORMAT", "json")                 // default output should be json
-	scanInfo.Submit = envToBool("KS_SUBMIT", false)                    // publish results to Kubescape SaaS
-	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                 // do not publish results to Kubescape SaaS
-	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)       // print rego rules
+	scanInfo.AccountID = envToString("KS_ACCOUNT_ID", config.GetAccount())   // publish results to Kubescape SaaS
+	scanInfo.AccessKey = envToString("KS_ACCESS_KEY", config.GetAccessKey()) // publish results to Kubescape SaaS
+	scanInfo.ExcludedNamespaces = envToString("KS_EXCLUDE_NAMESPACES", "")   // namespaces to exclude
+	scanInfo.IncludeNamespaces = envToString("KS_INCLUDE_NAMESPACES", "")    // namespaces to include
+	scanInfo.HostSensorYamlPath = envToString("KS_HOST_SCAN_YAML", "")       // path to host scan YAML
+	scanInfo.FormatVersion = envToString("KS_FORMAT_VERSION", "v2")          // output format version
+	scanInfo.Format = envToString("KS_FORMAT", "json")                       // default output should be json
+	scanInfo.Submit = envToBool("KS_SUBMIT", false)                          // publish results to Kubescape SaaS
+	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                       // do not publish results to Kubescape SaaS
+	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)             // print rego rules
 	// Only set HostSensorEnabled when explicitly configured; leaving it nil allows
 	// auto-detection of node-agent CRDs in getHostSensorHandler.
 	if val, ok := os.LookupEnv("KS_ENABLE_HOST_SCANNER"); ok {
@@ -224,10 +226,10 @@ func envToString(env string, defaultValue string) string {
 }
 
 func writeScanErrorToFile(err error, scanID string) error {
-	if e := os.MkdirAll(filepath.Dir(FailedOutputDir), os.ModePerm); e != nil {
+	if e := os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to create directory. reason: %s", err.Error(), e.Error())
 	}
-	f, e := os.Create(filepath.Join(filepath.Dir(FailedOutputDir), scanID))
+	f, e := os.Create(filepath.Join(FailedOutputDir, scanID))
 	if e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to open file for writing. reason: %s", err.Error(), e.Error())
 	}


### PR DESCRIPTION
## Summary

This PR performs a hardening pass for Issue #2028 involving IDOR and cross-tenant data leakage in the `/v1/results` endpoint.

While the earlier remediation addressed the insecure `filepath.WalkDir` + `strings.Contains` lookup pattern, additional security review identified remaining production risks around:

* shared `latestID` fallback behavior
* TOCTOU filesystem races
* custom UUID parsing logic

## Changes

### Security Hardening

* Replaced custom UUID validation with `github.com/google/uuid`
* Removed TOCTOU-prone `os.Stat` pre-check flow
* Switched to deterministic exact-match file access
* Restricted `latestID` fallback to offline mode only
* Prevented cross-tenant leakage in shared-service deployments
* Preserved compatibility for local/offline workflows

### Additional Improvements

* Added regression coverage for malformed IDs and traversal attempts
* Simplified result file read/remove logic
* Preserved existing API structure and repository patterns

## Security Impact

This closes remaining confidentiality risks where shared-service callers could retrieve another tenant's latest scan result when `scanID` was omitted.

It also removes race-prone filesystem access patterns and avoids custom identity parsing logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Offline requests now use the latest scan when no scan ID is provided; non-offline requests return 400 if a scan ID is required.
  * DELETE /results?all=true now attempts immediate removal of all result directories and returns 200.
  * Deletions that rely on a latest-scan fallback are rejected to prevent accidental removals.
  * Result file operations enforce UUID validation and block path-traversal inputs.

* **Tests**
  * Added tests covering read/remove result file behavior, UUID validation, path-safety, and DELETE-all handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2109)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->