### PR TITLE
fix: handle json.Marshal errors in mcpserver CallTool

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -320,7 +320,10 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 			"vulnerability_manifest_cve_details": "kubescape://vulnerability-manifests/{namespace}/{manifest_name}/cve_details/{cve_id}",
 		}
 
-		content, _ := json.Marshal(result)
+		content, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal result: %s", err)
+		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				mcp.TextContent{
@@ -444,7 +447,10 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 				"configuration_manifest_details": "kubescape://configuration-manifests/{namespace}/{manifest_name}",
 			},
 		}
-		content, _ := json.Marshal(result)
+		content, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal result: %s", err)
+		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				mcp.TextContent{


### PR DESCRIPTION
## Overview
In `cmd/mcpserver/mcpserver.go`, two `json.Marshal` calls silently discarded their errors using `_`:

- `list_vulnerability_manifests` case
- `list_configuration_security_scan_manifests` case

Every other `json.Marshal` call in the same file properly checks and returns the error. A silent marshal failure causes the MCP tool to return an empty response to the client with no error surfaced — a hidden failure that is impossible to debug.

This fix handles both errors consistently with the rest of the file.

## How to Test

go test ./cmd/mcpserver/... -v

All tests pass.

## Related issues/PRs
* Resolves #2111

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to ensure data processing failures are properly reported, preventing the system from proceeding with invalid or incomplete results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->