### PR TITLE
feat: add GCP and Azure support for DescribeRepositories and ListEntitiesForPolicies

### DIFF
--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -48,8 +48,8 @@ var (
 		ImageVulnerabilities: {"armo.vuln.images/v1", "image.vulnscan.com/v1"}}
 	MapResourceToApiGroupCloud = map[string][]string{
 		ClusterDescribe:         {"container.googleapis.com/v1", "eks.amazonaws.com/v1", "management.azure.com/v1"},
-		DescribeRepositories:    {"eks.amazonaws.com/v1"}, //TODO - add google and azure when they are supported
-		ListEntitiesForPolicies: {"eks.amazonaws.com/v1"}, //TODO - add google and azure when they are supported
+		DescribeRepositories:    {"container.googleapis.com/v1", "eks.amazonaws.com/v1", "management.azure.com/v1"},
+		ListEntitiesForPolicies: {"container.googleapis.com/v1", "eks.amazonaws.com/v1", "management.azure.com/v1"},
 	}
 )
 


### PR DESCRIPTION
## Overview
Currently, `DescribeRepositories` and `ListEntitiesForPolicies` in `MapResourceToApiGroupCloud` only support AWS EKS. This PR adds GCP (`container.googleapis.com/v1`) and Azure (`management.azure.com/v1`) support to match the existing `ClusterDescribe` behavior.

## Additional Information
- 2 entries updated in `core/pkg/resourcehandler/k8sresourcesutils.go`
- No functional changes to existing AWS EKS behavior
- Resolves the TODO comments present in the code

## How to Test
Run Kubescape on a GCP or Azure cluster and verify that repository and policy data is returned correctly.

## Examples/Screenshots
N/A

## Related issues/PRs
Closes #2110

## Checklist before requesting a review
put an [x] in the box to get it checked

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended repository and policy entity operations to support Google Cloud and Azure cloud platforms in addition to AWS.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->