### PR TITLE
fix: handle error returned by scorewrapper.Calculate() in processorhandler.go

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -81,9 +81,10 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	// edit results
 	opap.updateResults(ctx)
 
-	//TODO: review this location
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
-	_ = scorewrapper.Calculate(score.EPostureReportV2)
+	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
+		logger.L().Warning("failed to calculate score", helpers.Error(err))
+	}
 
 	return processErr
 }
@@ -544,4 +545,3 @@ func (opap *OPAProcessor) getCompiledRule(ctx context.Context, ruleName, ruleDat
 	opap.compiledModules[cacheKey] = compiled
 	return compiled, nil
 }
-

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -83,7 +83,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
-		logger.L().Warning("failed to calculate score", helpers.Error(err))
+		logger.L().Ctx(ctx).Warning("failed to calculate score", helpers.Error(err))
 	}
 
 	return processErr


### PR DESCRIPTION
## Overview
In `core/pkg/opaprocessor/processorhandler.go`, the error returned by `scorewrapper.Calculate()` was being silently discarded with `_`. This fix adds proper error handling by logging a warning when the calculation fails.

## Additional Information
- 1 file changed: `core/pkg/opaprocessor/processorhandler.go`
- Removed the `//TODO: review this location` comment
- No functional changes to the scoring logic itself

## How to Test
Run Kubescape scan and simulate a score calculation failure — a warning log should now appear instead of silent failure.

## Examples/Screenshots
N/A

## Related issues/PRs
Closes #2116

## Checklist before requesting a review
put an [x] in the box to get it checked

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Score calculation failures are now explicitly detected and surfaced via warning logs, improving visibility when scoring cannot be completed and reducing silent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2117)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->