### PR TITLE
fix: clear EnvFrom in removeContainersData to prevent secret name leakage

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -350,6 +350,7 @@ func removeContainersData(containers []corev1.Container) {
 		for j := range containers[i].Env {
 			containers[i].Env[j].Value = "XXXXXX"
 		}
+		containers[i].EnvFrom = nil
 	}
 }
 func removeEphemeralContainersData(containers []corev1.EphemeralContainer) {
@@ -357,6 +358,7 @@ func removeEphemeralContainersData(containers []corev1.EphemeralContainer) {
 		for j := range containers[i].Env {
 			containers[i].Env[j].Value = "XXXXXX"
 		}
+		containers[i].EnvFrom = nil
 	}
 }
 

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -159,6 +159,59 @@ func TestRemoveEphemeralContainersData(t *testing.T) {
 	}
 }
 
+func TestRemoveContainersData_ClearsEnvFrom(t *testing.T) {
+	containers := []corev1.Container{
+		{
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+					},
+				},
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-configmap"},
+					},
+				},
+			},
+		},
+	}
+
+	removeContainersData(containers)
+
+	for _, c := range containers {
+		assert.Nil(t, c.EnvFrom, "EnvFrom must be cleared to prevent secret name leakage")
+	}
+}
+
+func TestRemoveEphemeralContainersData_ClearsEnvFrom(t *testing.T) {
+	containers := []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+						},
+					},
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-configmap"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	removeEphemeralContainersData(containers)
+
+	for _, c := range containers {
+		assert.Nil(t, c.EnvFrom, "EnvFrom must be cleared to prevent secret name leakage")
+	}
+}
+
+
 func TestApplyExceptionsToManualControls(t *testing.T) {
 	processor := exceptions.NewProcessor()
 


### PR DESCRIPTION
## Overview
`removeContainersData` and `removeEphemeralContainersData` masked `env[].value` but left `envFrom` untouched. Workloads using `envFrom.secretRef` would have their secret names sent unmasked during scan submission.

## How to Test
```bash
go test ./core/pkg/opaprocessor/... -run "TestRemoveContainersData_ClearsEnvFrom|TestRemoveEphemeralContainersData_ClearsEnvFrom" -v
```

## Related issues/PRs
Closes #2119

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced container data sanitization to additionally clear environment configuration sources alongside existing field overwriting.

* **Tests**
  * Added unit tests to verify proper clearing of environment configuration from containers and ephemeral containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2120)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->