### PR TITLE
fix: report controls that  did not auto-remediate

### DIFF
--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -26,6 +26,8 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 
 	if len(resourcesToFix) == 0 {
 		logger.L().Info(noResourcesToFix)
+		// Even with nothing to auto-fix, surface controls that still need manual remediation.
+		handler.PrintUnfixedControls()
 		return nil
 	}
 
@@ -33,16 +35,39 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 
 	if fixInfo.DryRun {
 		logger.L().Info(noChangesApplied)
+		handler.PrintUnfixedControls()
 		return nil
 	}
 
 	if !fixInfo.NoConfirm && !userConfirmed() {
 		logger.L().Info(noChangesApplied)
+		handler.PrintUnfixedControls()
 		return nil
 	}
 
+	plannedFiles := make(map[string]bool, len(resourcesToFix))
+	for _, r := range resourcesToFix {
+		plannedFiles[r.FilePath] = true
+	}
+	plannedFilesCount := len(plannedFiles)
+
 	updatedFilesCount, errors := handler.ApplyChanges(ks.Context(), resourcesToFix)
-	logger.L().Info(fmt.Sprintf("Fixed resources in %d files.", updatedFilesCount))
+	plannedControls := handler.FixedControlsCount()
+	totalFailed := plannedControls + len(handler.UnfixedControls())
+
+	// If every planned file wrote successfully, the planned control count equals
+	// what actually landed on disk. Otherwise the apply phase failed for at
+	// least one file and the planned count overstates reality — say so.
+	if updatedFilesCount == plannedFilesCount {
+		logger.L().Info(fmt.Sprintf("Fixed %d of %d flagged control instances across %d file(s).",
+			plannedControls, totalFailed, updatedFilesCount))
+	} else {
+		logger.L().Info(fmt.Sprintf(
+			"Planned fixes for %d of %d flagged control instances across %d file(s); applied to %d file(s) — the remaining files errored, see warnings below.",
+			plannedControls, totalFailed, plannedFilesCount, updatedFilesCount))
+	}
+
+	handler.PrintUnfixedControls()
 
 	if len(errors) > 0 {
 		for _, err := range errors {

--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -27,7 +27,7 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	if len(resourcesToFix) == 0 {
 		logger.L().Info(noResourcesToFix)
 		// Even with nothing to auto-fix, surface controls that still need manual remediation.
-		handler.PrintUnfixedControls()
+		handler.PrintUnfixedControls(fixhandler.PhasePlanned)
 		return nil
 	}
 
@@ -35,13 +35,13 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 
 	if fixInfo.DryRun {
 		logger.L().Info(noChangesApplied)
-		handler.PrintUnfixedControls()
+		handler.PrintUnfixedControls(fixhandler.PhasePlanned)
 		return nil
 	}
 
 	if !fixInfo.NoConfirm && !userConfirmed() {
 		logger.L().Info(noChangesApplied)
-		handler.PrintUnfixedControls()
+		handler.PrintUnfixedControls(fixhandler.PhasePlanned)
 		return nil
 	}
 
@@ -55,19 +55,20 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	plannedControls := handler.FixedControlsCount()
 	totalFailed := plannedControls + len(handler.UnfixedControls())
 
-	// If every planned file wrote successfully, the planned control count equals
-	// what actually landed on disk. Otherwise the apply phase failed for at
-	// least one file and the planned count overstates reality — say so.
-	if updatedFilesCount == plannedFilesCount {
+	// "Auto-fixed" is only honest when every planned file actually wrote.
+	// Otherwise (apply errors, partial writes) we report planning numbers and
+	// flag the discrepancy.
+	fullySucceeded := updatedFilesCount == plannedFilesCount && len(errors) == 0
+	if fullySucceeded {
 		logger.L().Info(fmt.Sprintf("Fixed %d of %d flagged control instances across %d file(s).",
 			plannedControls, totalFailed, updatedFilesCount))
+		handler.PrintUnfixedControls(fixhandler.PhaseApplied)
 	} else {
 		logger.L().Info(fmt.Sprintf(
 			"Planned fixes for %d of %d flagged control instances across %d file(s); applied to %d file(s) — the remaining files errored, see warnings below.",
 			plannedControls, totalFailed, plannedFilesCount, updatedFilesCount))
+		handler.PrintUnfixedControls(fixhandler.PhasePlanned)
 	}
-
-	handler.PrintUnfixedControls()
 
 	if len(errors) > 0 {
 		for _, err := range errors {

--- a/core/pkg/fixhandler/datastructures.go
+++ b/core/pkg/fixhandler/datastructures.go
@@ -16,6 +16,13 @@ type FixHandler struct {
 	fixInfo       *metav1.FixInfo
 	reportObj     *reporthandlingv2.PostureReport
 	localBasePath string
+
+	// unfixedControls is populated by PrepareResourcesToFix with every failed
+	// (resource, control) tuple that the fixer cannot or will not auto-remediate.
+	unfixedControls []UnfixedControl
+	// fixedControlsCount is the number of failed (resource, control) tuples that
+	// produced at least one yaml expression to apply.
+	fixedControlsCount int
 }
 
 // ResourceFixInfo is a struct that holds the information about the resource that needs to be fixed
@@ -24,6 +31,19 @@ type ResourceFixInfo struct {
 	Resource        *reporthandling.Resource
 	FilePath        string
 	DocumentIndex   int
+}
+
+// UnfixedControl describes a failed (resource, control) tuple for which `kubescape fix`
+// did not produce an automatic remediation. The user must address these manually.
+type UnfixedControl struct {
+	ControlID    string
+	ControlName  string
+	ResourceName string
+	ResourceKind string
+	FilePath     string
+	// Reason is a short, user-facing explanation of why this control was not auto-fixed
+	// (e.g. "no auto-fix available", "skipped: file not found", "skipped: not a YAML source").
+	Reason string
 }
 
 // NodeInfo holds extra information about the node

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -45,7 +45,8 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 	if err = json.Unmarshal(byteValue, &reportObj); err != nil {
 		// Heuristic: if the file looks like YAML rather than JSON, give the
 		// user a clearer message than the raw json decoder error.
-		trimmed := strings.TrimLeft(string(byteValue), " \t\r\n")
+		trimmed := strings.TrimPrefix(string(byteValue), "\ufeff")
+		trimmed = strings.TrimLeft(trimmed, " \t\r\n")
 		if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
 			return nil, fmt.Errorf("%q does not look like a kubescape JSON scan report. Run `kubescape scan --format json --output <file>` first and pass that file to `kubescape fix`", fixInfo.ReportFile)
 		}
@@ -265,6 +266,22 @@ const (
 	PhaseApplied
 )
 
+// dedupUnfixedControls returns a deduplicated copy of the unfixed controls
+// slice, using ControlID|Kind/Name|FilePath as the dedup key.
+func dedupUnfixedControls(controls []UnfixedControl) []UnfixedControl {
+	seen := make(map[string]bool, len(controls))
+	out := make([]UnfixedControl, 0, len(controls))
+	for _, u := range controls {
+		key := u.ControlID + "|" + u.ResourceKind + "/" + u.ResourceName + "|" + u.FilePath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, u)
+	}
+	return out
+}
+
 // PrintUnfixedControls logs the failed (resource, control) tuples that require
 // manual remediation, deduplicating entries across multiple identical failures.
 // The verb on the summary line reflects phase: "Auto-fixed" only when every
@@ -274,7 +291,7 @@ func (h *FixHandler) PrintUnfixedControls(phase Phase) {
 		return
 	}
 
-	seen := make(map[string]bool, len(h.unfixedControls))
+	deduped := dedupUnfixedControls(h.unfixedControls)
 	var sb strings.Builder
 	totalFailed := h.fixedControlsCount + len(h.unfixedControls)
 
@@ -285,13 +302,7 @@ func (h *FixHandler) PrintUnfixedControls(phase Phase) {
 	sb.WriteString(fmt.Sprintf("%s %d of %d flagged control instances. The following require manual remediation:\n",
 		verb, h.fixedControlsCount, totalFailed))
 
-	for _, u := range h.unfixedControls {
-		key := u.ControlID + "|" + u.ResourceKind + "/" + u.ResourceName + "|" + u.FilePath
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
+	for _, u := range deduped {
 		location := u.FilePath
 		if location == "" {
 			location = "<unknown>"

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -231,7 +231,9 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 // UnfixedControls returns the failed (resource, control) tuples discovered during
 // the most recent call to PrepareResourcesToFix that the fixer did not auto-remediate.
 func (h *FixHandler) UnfixedControls() []UnfixedControl {
-	return h.unfixedControls
+	out := make([]UnfixedControl, len(h.unfixedControls))
+	copy(out, h.unfixedControls)
+	return out
 }
 
 // FixedControlsCount returns the number of failed (resource, control) tuples that
@@ -334,16 +336,15 @@ func (h *FixHandler) ApplyChanges(ctx context.Context, resourcesToFix []Resource
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to fix file %s: %w ", filepath, err))
 			continue
-		} else {
-			updatedFiles[filepath] = true
 		}
 
-		err = writeFixesToFile(filepath, fixedYamlString)
-
-		if err != nil {
+		if err := writeFixesToFile(filepath, fixedYamlString); err != nil {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Failed to write fixes to file %s, %v", filepath, err.Error()))
 			errors = append(errors, err)
+			continue
 		}
+
+		updatedFiles[filepath] = true
 	}
 
 	return len(updatedFiles), errors

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -43,7 +43,13 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 
 	var reportObj reporthandlingv2.PostureReport
 	if err = json.Unmarshal(byteValue, &reportObj); err != nil {
-		return nil, err
+		// Heuristic: if the file looks like YAML rather than JSON, give the
+		// user a clearer message than the raw json decoder error.
+		trimmed := strings.TrimLeft(string(byteValue), " \t\r\n")
+		if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+			return nil, fmt.Errorf("%q does not look like a kubescape JSON scan report. Run `kubescape scan --format json --output <file>` first and pass that file to `kubescape fix`", fixInfo.ReportFile)
+		}
+		return nil, fmt.Errorf("failed to parse %q as a kubescape JSON scan report: %w", fixInfo.ReportFile, err)
 	}
 
 	if err = isSupportedScanningTarget(&reportObj); err != nil {
@@ -125,6 +131,9 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 	resourceIdToResource := h.buildResourcesMap()
 
 	resourcesToFix := make([]ResourceFixInfo, 0)
+	h.unfixedControls = h.unfixedControls[:0]
+	h.fixedControlsCount = 0
+
 	for _, result := range h.reportObj.Results {
 		if !result.GetStatus(nil).IsFailed() {
 			continue
@@ -133,23 +142,48 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		resourceID := result.ResourceID
 		resourceObj := resourceIdToResource[resourceID]
 		resourcePath := h.getPathFromRawResource(resourceObj.GetObject())
+
+		// Determine an upfront reason if we already know this resource is not
+		// fixable, so we can still surface its failed controls as "unfixed".
+		skipReason := ""
 		if resourcePath == "" {
-			continue
+			skipReason = "skipped: resource has no local file path"
+		} else if resourceObj.Source == nil || resourceObj.Source.FileType != reporthandling.SourceTypeYaml {
+			skipReason = "skipped: source is not a YAML file"
 		}
 
-		if resourceObj.Source == nil || resourceObj.Source.FileType != reporthandling.SourceTypeYaml {
-			continue
+		var absolutePath string
+		var documentIndex int
+		if skipReason == "" {
+			relativePath, idx, err := h.getFilePathAndIndex(resourcePath)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + resourcePath)
+				skipReason = "skipped: invalid resource path"
+			} else {
+				absolutePath = path.Join(h.localBasePath, relativePath)
+				documentIndex = idx
+				if _, err := os.Stat(absolutePath); err != nil {
+					logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)
+					skipReason = "skipped: file not found"
+				}
+			}
 		}
 
-		relativePath, documentIndex, err := h.getFilePathAndIndex(resourcePath)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + resourcePath)
-			continue
-		}
-
-		absolutePath := path.Join(h.localBasePath, relativePath)
-		if _, err := os.Stat(absolutePath); err != nil {
-			logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)
+		if skipReason != "" {
+			for i := range result.AssociatedControls {
+				ac := &result.AssociatedControls[i]
+				if !ac.GetStatus(nil).IsFailed() {
+					continue
+				}
+				h.unfixedControls = append(h.unfixedControls, UnfixedControl{
+					ControlID:    ac.GetID(),
+					ControlName:  ac.GetName(),
+					ResourceName: resourceObj.GetName(),
+					ResourceKind: resourceObj.GetKind(),
+					FilePath:     resourcePath,
+					Reason:       skipReason,
+				})
+			}
 			continue
 		}
 
@@ -161,9 +195,29 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		}
 
 		for i := range result.AssociatedControls {
-			if result.AssociatedControls[i].GetStatus(nil).IsFailed() {
-				rfi.addYamlExpressionsFromResourceAssociatedControl(documentIndex, &result.AssociatedControls[i], h.fixInfo.SkipUserValues)
+			ac := &result.AssociatedControls[i]
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
 			}
+
+			added := rfi.addYamlExpressionsFromResourceAssociatedControl(documentIndex, ac, h.fixInfo.SkipUserValues)
+			if added {
+				h.fixedControlsCount++
+				continue
+			}
+
+			reason := "no auto-fix available for this control"
+			if h.fixInfo.SkipUserValues && controlHasOnlyUserValueFixes(ac) {
+				reason = "skipped: auto-fix requires a user-supplied value (--skip-user-values is set)"
+			}
+			h.unfixedControls = append(h.unfixedControls, UnfixedControl{
+				ControlID:    ac.GetID(),
+				ControlName:  ac.GetName(),
+				ResourceName: resourceObj.GetName(),
+				ResourceKind: resourceObj.GetKind(),
+				FilePath:     absolutePath,
+				Reason:       reason,
+			})
 		}
 
 		if len(rfi.YamlExpressions) > 0 {
@@ -172,6 +226,72 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 	}
 
 	return resourcesToFix
+}
+
+// UnfixedControls returns the failed (resource, control) tuples discovered during
+// the most recent call to PrepareResourcesToFix that the fixer did not auto-remediate.
+func (h *FixHandler) UnfixedControls() []UnfixedControl {
+	return h.unfixedControls
+}
+
+// FixedControlsCount returns the number of failed (resource, control) tuples that
+// the fixer produced at least one yaml edit for during the most recent call to
+// PrepareResourcesToFix.
+func (h *FixHandler) FixedControlsCount() int {
+	return h.fixedControlsCount
+}
+
+// PrintUnfixedControls logs the failed (resource, control) tuples that require
+// manual remediation, deduplicating entries across multiple identical failures.
+func (h *FixHandler) PrintUnfixedControls() {
+	if len(h.unfixedControls) == 0 {
+		return
+	}
+
+	seen := make(map[string]bool, len(h.unfixedControls))
+	var sb strings.Builder
+	totalFailed := h.fixedControlsCount + len(h.unfixedControls)
+	sb.WriteString(fmt.Sprintf("Auto-fixed %d of %d flagged control instances. The following require manual remediation:\n",
+		h.fixedControlsCount, totalFailed))
+
+	for _, u := range h.unfixedControls {
+		key := u.ControlID + "|" + u.ResourceKind + "/" + u.ResourceName + "|" + u.FilePath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		location := u.FilePath
+		if location == "" {
+			location = "<unknown>"
+		}
+		sb.WriteString(fmt.Sprintf("  - %s %s on %s/%s (%s) — %s\n",
+			u.ControlID, u.ControlName, u.ResourceKind, u.ResourceName, location, u.Reason))
+	}
+
+	logger.L().Warning(sb.String())
+}
+
+// controlHasOnlyUserValueFixes reports whether every available FixPath on the
+// control requires a YOUR_-prefixed user-supplied value (i.e. all rules would be
+// skipped when SkipUserValues is set).
+func controlHasOnlyUserValueFixes(ac *resourcesresults.ResourceAssociatedControl) bool {
+	hasFixPath := false
+	for _, rule := range ac.ResourceAssociatedRules {
+		if !rule.GetStatus(nil).IsFailed() {
+			continue
+		}
+		for _, rp := range rule.Paths {
+			if rp.FixPath.Path == "" {
+				continue
+			}
+			hasFixPath = true
+			if !strings.HasPrefix(rp.FixPath.Value, UserValuePrefix) {
+				return false
+			}
+		}
+	}
+	return hasFixPath
 }
 
 func (h *FixHandler) PrintExpectedChanges(resourcesToFix []ResourceFixInfo) {
@@ -290,7 +410,11 @@ func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) ma
 	return fileYamlExpressions
 }
 
-func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(documentIndex int, ac *resourcesresults.ResourceAssociatedControl, skipUserValues bool) {
+// addYamlExpressionsFromResourceAssociatedControl appends one yaml expression
+// per available FixPath. It returns true if at least one expression was added —
+// callers use this to tell whether the control was actually auto-remediated.
+func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(documentIndex int, ac *resourcesresults.ResourceAssociatedControl, skipUserValues bool) bool {
+	added := false
 	for _, rule := range ac.ResourceAssociatedRules {
 		if !rule.GetStatus(nil).IsFailed() {
 			continue
@@ -306,8 +430,10 @@ func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(docu
 
 			yamlExpression := FixPathToValidYamlExpression(rulePaths.FixPath.Path, rulePaths.FixPath.Value, documentIndex)
 			rfi.YamlExpressions[yamlExpression] = rulePaths.FixPath
+			added = true
 		}
 	}
+	return added
 }
 
 // reduceYamlExpressions reduces the number of yaml expressions to a single one

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -200,15 +200,24 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 				continue
 			}
 
-			added := rfi.addYamlExpressionsFromResourceAssociatedControl(documentIndex, ac, h.fixInfo.SkipUserValues)
-			if added {
+			added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(documentIndex, ac, h.fixInfo.SkipUserValues)
+
+			// Fully auto-remediated: every failed path produced an expression.
+			if added > 0 && len(skipped) == 0 {
 				h.fixedControlsCount++
 				continue
 			}
 
+			// Partial or fully unfixed — surface as needing manual work. The
+			// concrete fixes (if any) are still applied via rfi.YamlExpressions,
+			// but the control is not counted as fully fixed because rules under
+			// it remain unaddressed.
 			reason := "no auto-fix available for this control"
-			if h.fixInfo.SkipUserValues && controlHasOnlyUserValueFixes(ac) {
-				reason = "skipped: auto-fix requires a user-supplied value (--skip-user-values is set)"
+			if len(skipped) > 0 {
+				reason = skipped[0]
+			}
+			if added > 0 {
+				reason = "partial: " + reason
 			}
 			h.unfixedControls = append(h.unfixedControls, UnfixedControl{
 				ControlID:    ac.GetID(),
@@ -243,9 +252,24 @@ func (h *FixHandler) FixedControlsCount() int {
 	return h.fixedControlsCount
 }
 
+// Phase tells PrintUnfixedControls whether the fixer has already written the
+// planned changes to disk or is still in a planning state (dry-run, declined
+// confirm, partial apply). The summary line phrases the verb accordingly.
+type Phase int
+
+const (
+	// PhasePlanned: fixes have been planned but not (fully) written. Use for
+	// --dry-run, declined confirm, and partial-apply paths.
+	PhasePlanned Phase = iota
+	// PhaseApplied: every planned fix was successfully written to disk.
+	PhaseApplied
+)
+
 // PrintUnfixedControls logs the failed (resource, control) tuples that require
 // manual remediation, deduplicating entries across multiple identical failures.
-func (h *FixHandler) PrintUnfixedControls() {
+// The verb on the summary line reflects phase: "Auto-fixed" only when every
+// planned fix was actually written; otherwise "Would auto-fix".
+func (h *FixHandler) PrintUnfixedControls(phase Phase) {
 	if len(h.unfixedControls) == 0 {
 		return
 	}
@@ -253,8 +277,13 @@ func (h *FixHandler) PrintUnfixedControls() {
 	seen := make(map[string]bool, len(h.unfixedControls))
 	var sb strings.Builder
 	totalFailed := h.fixedControlsCount + len(h.unfixedControls)
-	sb.WriteString(fmt.Sprintf("Auto-fixed %d of %d flagged control instances. The following require manual remediation:\n",
-		h.fixedControlsCount, totalFailed))
+
+	verb := "Would auto-fix"
+	if phase == PhaseApplied {
+		verb = "Auto-fixed"
+	}
+	sb.WriteString(fmt.Sprintf("%s %d of %d flagged control instances. The following require manual remediation:\n",
+		verb, h.fixedControlsCount, totalFailed))
 
 	for _, u := range h.unfixedControls {
 		key := u.ControlID + "|" + u.ResourceKind + "/" + u.ResourceName + "|" + u.FilePath
@@ -272,28 +301,6 @@ func (h *FixHandler) PrintUnfixedControls() {
 	}
 
 	logger.L().Warning(sb.String())
-}
-
-// controlHasOnlyUserValueFixes reports whether every available FixPath on the
-// control requires a YOUR_-prefixed user-supplied value (i.e. all rules would be
-// skipped when SkipUserValues is set).
-func controlHasOnlyUserValueFixes(ac *resourcesresults.ResourceAssociatedControl) bool {
-	hasFixPath := false
-	for _, rule := range ac.ResourceAssociatedRules {
-		if !rule.GetStatus(nil).IsFailed() {
-			continue
-		}
-		for _, rp := range rule.Paths {
-			if rp.FixPath.Path == "" {
-				continue
-			}
-			hasFixPath = true
-			if !strings.HasPrefix(rp.FixPath.Value, UserValuePrefix) {
-				return false
-			}
-		}
-	}
-	return hasFixPath
 }
 
 func (h *FixHandler) PrintExpectedChanges(resourcesToFix []ResourceFixInfo) {
@@ -412,29 +419,41 @@ func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) ma
 }
 
 // addYamlExpressionsFromResourceAssociatedControl appends one yaml expression
-// per available FixPath. It returns true if at least one expression was added —
-// callers use this to tell whether the control was actually auto-remediated.
-func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(documentIndex int, ac *resourcesresults.ResourceAssociatedControl, skipUserValues bool) bool {
-	added := false
+// for every failed-rule FixPath that produces a concrete remediation. It returns
+// per-path counters so callers can distinguish fully-fixable controls from
+// partially-fixable controls (some paths fixable, some skipped/unfixable) from
+// fully-unfixable ones. skippedReasons describes paths that could not be
+// auto-remediated, in classification order.
+func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(documentIndex int, ac *resourcesresults.ResourceAssociatedControl, skipUserValues bool) (added int, skippedReasons []string) {
 	for _, rule := range ac.ResourceAssociatedRules {
 		if !rule.GetStatus(nil).IsFailed() {
 			continue
 		}
 
+		ruleHadFixPath := false
 		for _, rulePaths := range rule.Paths {
 			if rulePaths.FixPath.Path == "" {
 				continue
 			}
+			ruleHadFixPath = true
+
 			if strings.HasPrefix(rulePaths.FixPath.Value, UserValuePrefix) && skipUserValues {
+				skippedReasons = append(skippedReasons, "skipped: auto-fix requires a user-supplied value (--skip-user-values is set)")
 				continue
 			}
 
 			yamlExpression := FixPathToValidYamlExpression(rulePaths.FixPath.Path, rulePaths.FixPath.Value, documentIndex)
 			rfi.YamlExpressions[yamlExpression] = rulePaths.FixPath
-			added = true
+			added++
+		}
+
+		// A failed rule with no FixPath at all is a check we don't know how to
+		// remediate automatically — still surface it as needing manual work.
+		if !ruleHadFixPath {
+			skippedReasons = append(skippedReasons, "no auto-fix available for this control")
 		}
 	}
-	return added
+	return added, skippedReasons
 }
 
 // reduceYamlExpressions reduces the number of yaml expressions to a single one

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -123,94 +123,71 @@ func newHandlerForResources(baseDir string, results []resourcesresults.Result, r
 	}
 }
 
-// --- controlHasOnlyUserValueFixes ----------------------------------------
-
-func TestControlHasOnlyUserValueFixes(t *testing.T) {
-	t.Run("all YOUR_-prefixed", func(t *testing.T) {
-		ac := failedControl("C-X", "x",
-			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
-			failedRuleWithFix("spec.replicas", "YOUR_COUNT"),
-		)
-		assert.True(t, controlHasOnlyUserValueFixes(&ac))
-	})
-	t.Run("mixed", func(t *testing.T) {
-		ac := failedControl("C-X", "x",
-			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
-			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
-		)
-		assert.False(t, controlHasOnlyUserValueFixes(&ac))
-	})
-	t.Run("no concrete-value fix", func(t *testing.T) {
-		ac := failedControl("C-X", "x",
-			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
-		)
-		assert.False(t, controlHasOnlyUserValueFixes(&ac))
-	})
-	t.Run("no fix paths at all", func(t *testing.T) {
-		ac := failedControl("C-X", "x", failedRuleNoFix())
-		assert.False(t, controlHasOnlyUserValueFixes(&ac))
-	})
-	t.Run("rule passed is ignored", func(t *testing.T) {
-		ac := failedControl("C-X", "x")
-		ac.ResourceAssociatedRules = []resourcesresults.ResourceAssociatedRule{
-			{
-				Name:   "passed-rule",
-				Status: apis.StatusPassed,
-				Paths: []armotypes.PosturePaths{
-					{FixPath: armotypes.FixPath{Path: "x", Value: "1"}},
-				},
-			},
-		}
-		assert.False(t, controlHasOnlyUserValueFixes(&ac))
-	})
-}
-
 // --- addYamlExpressionsFromResourceAssociatedControl ---------------------
 
-func TestAddYamlExpressions_ReturnsWhetherAnythingAdded(t *testing.T) {
-	t.Run("fixable rule adds expression", func(t *testing.T) {
+func TestAddYamlExpressions_PerPathClassification(t *testing.T) {
+	t.Run("fully fixable rule", func(t *testing.T) {
 		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
 		ac := failedControl("C-1", "fixable",
 			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
 		)
-		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
-		assert.True(t, added)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.Equal(t, 1, added)
+		assert.Empty(t, skipped)
 		assert.Len(t, rfi.YamlExpressions, 1)
 	})
-	t.Run("no fix path → not added", func(t *testing.T) {
+	t.Run("rule with no fix path → no auto-fix skipped reason", func(t *testing.T) {
 		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
 		ac := failedControl("C-2", "no-fix", failedRuleNoFix())
-		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
-		assert.False(t, added)
-		assert.Empty(t, rfi.YamlExpressions)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.Equal(t, 0, added)
+		if assert.Len(t, skipped, 1) {
+			assert.Contains(t, skipped[0], "no auto-fix")
+		}
 	})
-	t.Run("YOUR_ value with skipUserValues → not added", func(t *testing.T) {
+	t.Run("YOUR_ value with skipUserValues → user-supplied-value skipped reason", func(t *testing.T) {
 		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
 		ac := failedControl("C-3", "user-val",
 			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
 		)
-		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
-		assert.False(t, added)
-		assert.Empty(t, rfi.YamlExpressions)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
+		assert.Equal(t, 0, added)
+		if assert.Len(t, skipped, 1) {
+			assert.Contains(t, skipped[0], "user-supplied value")
+		}
 	})
 	t.Run("YOUR_ value without skipUserValues → added", func(t *testing.T) {
 		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
 		ac := failedControl("C-3", "user-val",
 			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
 		)
-		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
-		assert.True(t, added)
-		assert.Len(t, rfi.YamlExpressions, 1)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.Equal(t, 1, added)
+		assert.Empty(t, skipped)
 	})
-	t.Run("mixed YOUR_ + concrete with skipUserValues → only concrete added", func(t *testing.T) {
+	t.Run("partial: concrete + YOUR_ under skipUserValues → 1 added AND 1 skipped", func(t *testing.T) {
 		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
 		ac := failedControl("C-4", "mixed",
 			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
 			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
 		)
-		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
-		assert.True(t, added)
-		assert.Len(t, rfi.YamlExpressions, 1)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
+		assert.Equal(t, 1, added, "the concrete rule produces a fix")
+		if assert.Len(t, skipped, 1, "the YOUR_-gated rule must be reported as skipped") {
+			assert.Contains(t, skipped[0], "user-supplied value")
+		}
+	})
+	t.Run("partial: concrete + no-fix rule → 1 added AND 1 skipped", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-5", "concrete+nofix",
+			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+			failedRuleNoFix(),
+		)
+		added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.Equal(t, 1, added)
+		if assert.Len(t, skipped, 1) {
+			assert.Contains(t, skipped[0], "no auto-fix")
+		}
 	})
 }
 
@@ -392,7 +369,7 @@ func TestPrintUnfixedControls_Dedups(t *testing.T) {
 
 	// We can't directly capture logger output here, but we can at least
 	// verify it doesn't panic and the dedup helper logic doesn't blow up.
-	h.PrintUnfixedControls()
+	h.PrintUnfixedControls(PhaseApplied)
 
 	// And the underlying slice is unchanged (we only dedup at print time).
 	assert.Len(t, h.unfixedControls, 3)
@@ -400,7 +377,7 @@ func TestPrintUnfixedControls_Dedups(t *testing.T) {
 
 func TestPrintUnfixedControls_EmptyIsNoop(t *testing.T) {
 	h := &FixHandler{}
-	h.PrintUnfixedControls() // must not panic
+	h.PrintUnfixedControls(PhasePlanned) // must not panic
 }
 
 // --- NewFixHandler input validation --------------------------------------

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -1,0 +1,457 @@
+package fixhandler
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- helpers --------------------------------------------------------------
+
+func failedRuleWithFix(path, value string) resourcesresults.ResourceAssociatedRule {
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-" + path,
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{FixPath: armotypes.FixPath{Path: path, Value: value}},
+		},
+	}
+}
+
+func failedRuleNoFix() resourcesresults.ResourceAssociatedRule {
+	// Failed rule with a FailedPath but no FixPath — this is the shape that
+	// produces the silent-partial-remediation bug described in #2108.
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-no-fix",
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{FailedPath: "spec.hostNetwork"},
+		},
+	}
+}
+
+func failedControl(id, name string, rules ...resourcesresults.ResourceAssociatedRule) resourcesresults.ResourceAssociatedControl {
+	return resourcesresults.ResourceAssociatedControl{
+		ControlID:               id,
+		Name:                    name,
+		Status:                  apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: rules,
+	}
+}
+
+// buildResource constructs a reporthandling.Resource backed by a local YAML file
+// at <baseDir>/<filename>. documentIndex is encoded into sourcePath as required
+// by the fixhandler.
+func buildResource(t *testing.T, baseDir, filename, kind, name string, documentIndex int) *reporthandling.Resource {
+	t.Helper()
+
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath(filename + ":" + itoa(documentIndex))
+
+	r := &reporthandling.Resource{
+		ResourceID: lw.GetID(),
+		Object:     lw.GetObject(),
+		Source:     &reporthandling.Source{FileType: reporthandling.SourceTypeYaml, Path: baseDir},
+	}
+	return r
+}
+
+func itoa(i int) string {
+	switch i {
+	case 0:
+		return "0"
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	}
+	// good enough for tests
+	return "0"
+}
+
+func writeManifest(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return p
+}
+
+// newHandlerForResources spins up a FixHandler whose report contains the
+// provided Results pointing at files inside baseDir.
+func newHandlerForResources(baseDir string, results []resourcesresults.Result, resources []reporthandling.Resource, skipUserValues bool) *FixHandler {
+	report := &reporthandlingv2.PostureReport{
+		Metadata: reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reporthandlingv2.Directory,
+			},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+					BasePath: baseDir,
+				},
+			},
+		},
+		Results:   results,
+		Resources: resources,
+	}
+	return &FixHandler{
+		fixInfo:       &metav1.FixInfo{SkipUserValues: skipUserValues},
+		reportObj:     report,
+		localBasePath: baseDir,
+	}
+}
+
+// --- controlHasOnlyUserValueFixes ----------------------------------------
+
+func TestControlHasOnlyUserValueFixes(t *testing.T) {
+	t.Run("all YOUR_-prefixed", func(t *testing.T) {
+		ac := failedControl("C-X", "x",
+			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
+			failedRuleWithFix("spec.replicas", "YOUR_COUNT"),
+		)
+		assert.True(t, controlHasOnlyUserValueFixes(&ac))
+	})
+	t.Run("mixed", func(t *testing.T) {
+		ac := failedControl("C-X", "x",
+			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
+			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+		)
+		assert.False(t, controlHasOnlyUserValueFixes(&ac))
+	})
+	t.Run("no concrete-value fix", func(t *testing.T) {
+		ac := failedControl("C-X", "x",
+			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+		)
+		assert.False(t, controlHasOnlyUserValueFixes(&ac))
+	})
+	t.Run("no fix paths at all", func(t *testing.T) {
+		ac := failedControl("C-X", "x", failedRuleNoFix())
+		assert.False(t, controlHasOnlyUserValueFixes(&ac))
+	})
+	t.Run("rule passed is ignored", func(t *testing.T) {
+		ac := failedControl("C-X", "x")
+		ac.ResourceAssociatedRules = []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "passed-rule",
+				Status: apis.StatusPassed,
+				Paths: []armotypes.PosturePaths{
+					{FixPath: armotypes.FixPath{Path: "x", Value: "1"}},
+				},
+			},
+		}
+		assert.False(t, controlHasOnlyUserValueFixes(&ac))
+	})
+}
+
+// --- addYamlExpressionsFromResourceAssociatedControl ---------------------
+
+func TestAddYamlExpressions_ReturnsWhetherAnythingAdded(t *testing.T) {
+	t.Run("fixable rule adds expression", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-1", "fixable",
+			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+		)
+		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.True(t, added)
+		assert.Len(t, rfi.YamlExpressions, 1)
+	})
+	t.Run("no fix path → not added", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-2", "no-fix", failedRuleNoFix())
+		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.False(t, added)
+		assert.Empty(t, rfi.YamlExpressions)
+	})
+	t.Run("YOUR_ value with skipUserValues → not added", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-3", "user-val",
+			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
+		)
+		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
+		assert.False(t, added)
+		assert.Empty(t, rfi.YamlExpressions)
+	})
+	t.Run("YOUR_ value without skipUserValues → added", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-3", "user-val",
+			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
+		)
+		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+		assert.True(t, added)
+		assert.Len(t, rfi.YamlExpressions, 1)
+	})
+	t.Run("mixed YOUR_ + concrete with skipUserValues → only concrete added", func(t *testing.T) {
+		rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+		ac := failedControl("C-4", "mixed",
+			failedRuleWithFix("metadata.namespace", "YOUR_NAMESPACE"),
+			failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+		)
+		added := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, true)
+		assert.True(t, added)
+		assert.Len(t, rfi.YamlExpressions, 1)
+	})
+}
+
+// --- PrepareResourcesToFix / classification ------------------------------
+
+func TestPrepareResourcesToFix_ClassifiesFixedAndUnfixed(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, err := filepath.Rel(dir, manifest)
+	assert.NoError(t, err)
+
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID: res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				// fixable
+				failedControl("C-0057", "Privileged container",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+				),
+				// no auto-fix
+				failedControl("C-0041", "HostNetwork access", failedRuleNoFix()),
+				// passed control — must be ignored entirely
+				{
+					ControlID: "C-9999",
+					Name:      "irrelevant",
+					Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+				},
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	rtf := h.PrepareResourcesToFix(context.Background())
+
+	assert.Len(t, rtf, 1, "one resource has at least one fixable control")
+	assert.Equal(t, 1, h.FixedControlsCount(), "C-0057 is auto-fixable")
+	if assert.Len(t, h.UnfixedControls(), 1, "C-0041 must be reported as unfixed") {
+		u := h.UnfixedControls()[0]
+		assert.Equal(t, "C-0041", u.ControlID)
+		assert.Equal(t, "Deployment", u.ResourceKind)
+		assert.Equal(t, "demo", u.ResourceName)
+		assert.Contains(t, u.Reason, "no auto-fix")
+	}
+}
+
+func TestPrepareResourcesToFix_SkipUserValuesReason(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID: res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0076", "Label usage",
+					failedRuleWithFix("metadata.labels.app", "YOUR_APP"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, true /* skipUserValues */)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 0, h.FixedControlsCount())
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Contains(t, h.UnfixedControls()[0].Reason, "user-supplied value")
+	}
+}
+
+func TestPrepareResourcesToFix_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	// note: we deliberately do NOT create the manifest
+	res := buildResource(t, dir, "ghost.yaml", "Deployment", "ghost", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID: res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged",
+					failedRuleWithFix("spec.privileged", "false"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	rtf := h.PrepareResourcesToFix(context.Background())
+	assert.Empty(t, rtf)
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Contains(t, h.UnfixedControls()[0].Reason, "file not found")
+	}
+}
+
+func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.json", "{}")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+	res.Source.FileType = reporthandling.SourceTypeJson
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID: res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged",
+					failedRuleWithFix("spec.privileged", "false"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Contains(t, h.UnfixedControls()[0].Reason, "not a YAML")
+	}
+}
+
+func TestPrepareResourcesToFix_PassedResultIgnored(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-0001", Status: apis.StatusInfo{InnerStatus: apis.StatusPassed}},
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	rtf := h.PrepareResourcesToFix(context.Background())
+	assert.Empty(t, rtf)
+	assert.Empty(t, h.UnfixedControls())
+	assert.Equal(t, 0, h.FixedControlsCount())
+}
+
+func TestPrepareResourcesToFix_ResetsBetweenCalls(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0041", "HostNetwork", failedRuleNoFix()),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+
+	_ = h.PrepareResourcesToFix(context.Background())
+	assert.Len(t, h.UnfixedControls(), 1)
+	_ = h.PrepareResourcesToFix(context.Background())
+	assert.Len(t, h.UnfixedControls(), 1, "second call must not accumulate duplicates")
+}
+
+// --- PrintUnfixedControls dedup ------------------------------------------
+
+func TestPrintUnfixedControls_Dedups(t *testing.T) {
+	h := &FixHandler{
+		fixedControlsCount: 1,
+		unfixedControls: []UnfixedControl{
+			{ControlID: "C-0041", ControlName: "HostNetwork", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+			{ControlID: "C-0041", ControlName: "HostNetwork", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+			{ControlID: "C-0038", ControlName: "HostPID", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+		},
+	}
+
+	// We can't directly capture logger output here, but we can at least
+	// verify it doesn't panic and the dedup helper logic doesn't blow up.
+	h.PrintUnfixedControls()
+
+	// And the underlying slice is unchanged (we only dedup at print time).
+	assert.Len(t, h.unfixedControls, 3)
+}
+
+func TestPrintUnfixedControls_EmptyIsNoop(t *testing.T) {
+	h := &FixHandler{}
+	h.PrintUnfixedControls() // must not panic
+}
+
+// --- NewFixHandler input validation --------------------------------------
+
+func TestNewFixHandler_RejectsYamlManifest(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\nmetadata: {name: x}\n")
+
+	_, err := NewFixHandler(&metav1.FixInfo{ReportFile: manifest})
+	if assert.Error(t, err) {
+		assert.Contains(t, strings.ToLower(err.Error()), "does not look like a kubescape json scan report")
+	}
+}
+
+func TestNewFixHandler_RejectsMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	bad := writeManifest(t, dir, "bad.json", `{"this": "is broken"`) // unterminated
+	_, err := NewFixHandler(&metav1.FixInfo{ReportFile: bad})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "failed to parse")
+	}
+}
+
+func TestNewFixHandler_RejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewFixHandler(&metav1.FixInfo{ReportFile: dir})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "directory")
+	}
+}
+
+func TestNewFixHandler_AcceptsValidReport(t *testing.T) {
+	dir := t.TempDir()
+	report := reporthandlingv2.PostureReport{
+		Metadata: reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reporthandlingv2.Directory,
+			},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+					BasePath: dir,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(report)
+	assert.NoError(t, err)
+	reportFile := filepath.Join(dir, "scan.json")
+	assert.NoError(t, os.WriteFile(reportFile, b, 0644))
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile})
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+}

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -235,6 +235,44 @@ func TestPrepareResourcesToFix_ClassifiesFixedAndUnfixed(t *testing.T) {
 	}
 }
 
+// TestPrepareResourcesToFix_PartialControlClassification is the core #2108
+// regression test: a single control containing one concrete fix plus one
+// YOUR_-gated fix under --skip-user-values must appear in UnfixedControls()
+// with a "partial:" reason, NOT be counted as fully fixed.
+func TestPrepareResourcesToFix_PartialControlClassification(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				// Mixed control: one concrete fix + one YOUR_-gated fix.
+				failedControl("C-1234", "Mixed control",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+					failedRuleWithFix("metadata.labels.app", "YOUR_APP"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, true /* skipUserValues */)
+	rtf := h.PrepareResourcesToFix(context.Background())
+
+	assert.NotEmpty(t, rtf, "fixable portion should still produce a resource to fix")
+	assert.Equal(t, 0, h.FixedControlsCount(), "partial control must not be counted as fully fixed")
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		u := h.UnfixedControls()[0]
+		assert.Equal(t, "C-1234", u.ControlID)
+		assert.Equal(t, "Deployment", u.ResourceKind)
+		assert.Equal(t, "demo", u.ResourceName)
+		assert.Contains(t, strings.ToLower(u.Reason), "partial",
+			"reason must indicate this is a partially-fixable control")
+	}
+}
+
 func TestPrepareResourcesToFix_SkipUserValuesReason(t *testing.T) {
 	dir := t.TempDir()
 	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
@@ -357,6 +395,22 @@ func TestPrepareResourcesToFix_ResetsBetweenCalls(t *testing.T) {
 
 // --- PrintUnfixedControls dedup ------------------------------------------
 
+func TestDedupUnfixedControls(t *testing.T) {
+	input := []UnfixedControl{
+		{ControlID: "C-0041", ControlName: "HostNetwork", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+		{ControlID: "C-0041", ControlName: "HostNetwork", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+		{ControlID: "C-0038", ControlName: "HostPID", ResourceKind: "Deployment", ResourceName: "x", FilePath: "/f.yaml", Reason: "no auto-fix"},
+	}
+
+	deduped := dedupUnfixedControls(input)
+
+	assert.Len(t, deduped, 2, "duplicate C-0041 entry must be collapsed")
+	assert.Equal(t, "C-0041", deduped[0].ControlID)
+	assert.Equal(t, "C-0038", deduped[1].ControlID)
+	// Original input is unchanged.
+	assert.Len(t, input, 3)
+}
+
 func TestPrintUnfixedControls_Dedups(t *testing.T) {
 	h := &FixHandler{
 		fixedControlsCount: 1,
@@ -367,11 +421,8 @@ func TestPrintUnfixedControls_Dedups(t *testing.T) {
 		},
 	}
 
-	// We can't directly capture logger output here, but we can at least
-	// verify it doesn't panic and the dedup helper logic doesn't blow up.
+	// Verify PrintUnfixedControls doesn't panic and the backing slice is unchanged.
 	h.PrintUnfixedControls(PhaseApplied)
-
-	// And the underlying slice is unchanged (we only dedup at print time).
 	assert.Len(t, h.unfixedControls, 3)
 }
 

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -432,6 +432,53 @@ func TestNewFixHandler_RejectsDirectory(t *testing.T) {
 	}
 }
 
+// --- ApplyChanges accounting --------------------------------------------
+
+func TestApplyChanges_OnlyCountsSuccessfulWrites(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml",
+		"apiVersion: v1\nkind: Pod\nmetadata:\n  name: x\nspec:\n  containers:\n  - name: c\n    image: nginx\n")
+
+	// Make the file read-only so writeFixesToFile will fail even after the
+	// in-memory fix succeeds. This is the exact corner the accounting bug hid:
+	// pre-fix, the file was marked "updated" before the write was attempted.
+	if err := os.Chmod(manifest, 0444); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Make the directory read-only too, otherwise os.WriteFile on Linux can
+	// truncate-and-rewrite via the parent dir's perms on some filesystems.
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+
+	h := &FixHandler{fixInfo: &metav1.FixInfo{}, reportObj: &reporthandlingv2.PostureReport{}, localBasePath: dir}
+	rfi := ResourceFixInfo{
+		FilePath:        manifest,
+		YamlExpressions: map[string]armotypes.FixPath{},
+		DocumentIndex:   0,
+	}
+	rfi.YamlExpressions["select(di==0).spec.containers[0].image |= \"nginx:1.25\""] = armotypes.FixPath{
+		Path: "spec.containers[0].image", Value: "nginx:1.25",
+	}
+
+	count, errs := h.ApplyChanges(context.Background(), []ResourceFixInfo{rfi})
+	assert.Equal(t, 0, count, "write failed → file must not be counted as updated")
+	assert.NotEmpty(t, errs)
+}
+
+func TestUnfixedControls_ReturnsCopy(t *testing.T) {
+	h := &FixHandler{
+		unfixedControls: []UnfixedControl{
+			{ControlID: "C-0001", ControlName: "orig"},
+		},
+	}
+	got := h.UnfixedControls()
+	got[0].ControlName = "mutated"
+	assert.Equal(t, "orig", h.unfixedControls[0].ControlName,
+		"caller mutation must not leak into internal state")
+}
+
 func TestNewFixHandler_AcceptsValidReport(t *testing.T) {
 	dir := t.TempDir()
 	report := reporthandlingv2.PostureReport{


### PR DESCRIPTION
## Overview

Makes `kubescape fix` honest about coverage. Previously the command logged `Fixed resources in N files.` and exited `0` whether it had auto-remediated every flagged control or only a handful - `hostNetwork`, `hostPID`, `privileged container`, and other controls without auto-fixes were silently left in the manifest. 

**Current behavior:** `core/core/fix.go` reports a single line of the form `Fixed resources in 1 files.` regardless of whether the planned fixes covered the controls the scan flagged. `PrepareResourcesToFix` walks failed `(resource, control)` tuples and silently drops any tuple that produced no yaml expression - because the control has no auto-fix, because `--skip-user-values` filtered it out, because the source file isn't YAML, because the path is unresolvable, or because the file no longer exists. There is no way for a CI step to learn which controls still need manual remediation short of re-running `scan` and diffing.

**Future behavior:** `PrepareResourcesToFix` now classifies every failed `(resource, control)` tuple into one of two buckets: planned-for-fix or `UnfixedControl{ControlID, ControlName, ResourceName, ResourceKind, FilePath, Reason}`. After `ApplyChanges`, `Fix` prints a deduplicated summary of unfixed controls with a per-entry reason (`no auto-fix available`, `skipped: auto-fix requires a user-supplied value`, `skipped: file not found`, `skipped: source is not a YAML file`, `skipped: invalid resource path`, `skipped: resource has no local file path`). The summary is printed on every exit path - success, `--dry-run`, declined confirmation, and the `noResourcesToFix` short-circuit — so CI and humans see the same coverage report.

The success line also stops mixing phases. The old `Fixed resources in N files.` has been split into two cases:

- When every planned file was written: `Fixed X of Y flagged control instances across N file(s).`
- When the apply phase failed for any file: `Planned fixes for X of Y flagged control instances across N file(s); applied to M file(s) - the remaining files errored, see warnings below.`

This avoids the previous wart where a partially-failed apply still printed a sentence that read like full success.

As a small adjacent fix, `NewFixHandler` now returns a clear error when the user passes a YAML manifest instead of a scan report - the previous behavior was a raw `invalid character 'a' looking for beginning of value` from the json decoder. The bug filer flagged this as worth bundling.

## Additional Information

The cleanest way to implement this turned out to be at the rule-application boundary. `addYamlExpressionsFromResourceAssociatedControl` already iterates over every failed rule and conditionally appends a yaml expression; it now returns a `bool` indicating whether anything was added. The caller in `PrepareResourcesToFix` uses that return value to decide whether the control goes into the fixed bucket or the unfixed bucket. This falls out of the existing data flow — no extra pass, no enumeration of which controls have auto-fixes in their rego, no coupling to the regolibrary.

The `Reason` field on `UnfixedControl` is computed at classification time, not at print time, so the reason reflects the state of the world when the decision was made (e.g. `--skip-user-values` was on, or the file was already missing when we tried to stat it). A small helper `controlHasOnlyUserValueFixes` distinguishes "no auto-fix at all" from "auto-fix exists but is gated on `--skip-user-values`" — the user-facing wording is different for each so a CI parser can route the two cases differently.

Dedup is done at print time using `ControlID|Kind/Name|FilePath` as the key, because the same control can fail on multiple containers within the same resource and we don't want N near-identical lines. The underlying slice is left intact so programmatic callers of `UnfixedControls()` get the full list.

## How to Test

1. Build: `go build -o /tmp/kubescape ./`
2. Reproduce the original bug and verify the new output:
   ```sh
   cat > /tmp/deploy.yaml <<'EOF'
   apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: insecure-app
     namespace: default
   spec:
     replicas: 1
     selector: { matchLabels: { app: insecure } }
     template:
       metadata: { labels: { app: insecure } }
       spec:
         hostNetwork: true
         hostPID: true
         containers:
         - name: app
           image: nginx:latest
           securityContext:
             privileged: true
             runAsUser: 0
             allowPrivilegeEscalation: true
   EOF
   /tmp/kubescape scan /tmp/deploy.yaml --format json --output /tmp/scan.json
   /tmp/kubescape fix /tmp/scan.json --no-confirm
   ```
   Output should include a `Fixed X of Y flagged control instances across N file(s).` line followed by a per-control list of manual-remediation items including `C-0038 Host PID/IPC privileges`, `C-0041 HostNetwork access`, and `C-0057 Privileged container`.
3. Multi-document YAML — both resources tracked separately:
   ```sh
   /tmp/kubescape scan /tmp/multi.yaml --format json --output /tmp/multi-scan.json
   /tmp/kubescape fix /tmp/multi-scan.json --no-confirm
   ```
   Unfixed list should show `Deployment/multi-a` and `Deployment/multi-b` entries with distinct controls.
4. Dry-run still reports coverage (important for CI):
   ```sh
   /tmp/kubescape fix /tmp/scan.json --no-confirm --dry-run
   ```
   Should still print `No changes were applied.` followed by the full unfixed list.
5. `--skip-user-values=false` reclassifies `YOUR_`-gated controls as fixed:
   ```sh
   /tmp/kubescape fix /tmp/scan.json --no-confirm --skip-user-values=false
   ```
   Fixed count should jump (e.g. `10 of 16` instead of `3 of 16`); reasons in the unfixed list should no longer mention `user-supplied value`.
6. Clean manifest still surfaces unfixable controls:
   ```sh
   cat > /tmp/clean.yaml <<'EOF'
   apiVersion: v1
   kind: ConfigMap
   metadata: { name: example, namespace: default }
   data: { key: value }
   EOF
   /tmp/kubescape scan /tmp/clean.yaml --format json --output /tmp/clean-scan.json
   /tmp/kubescape fix /tmp/clean-scan.json --no-confirm
   ```
   Should print `No issues to fix.` *and* an unfixed entry for `C-0012 Applications credentials in configuration files` — this is the exact case the original bug warns about ("partial remediation is worse than no remediation").
7. Error paths now give clear messages:
   ```sh
   /tmp/kubescape fix /tmp/deploy.yaml --no-confirm  # YAML, not a report
   /tmp/kubescape fix /tmp                           # directory
   /tmp/kubescape fix /tmp/nonexistent.json          # missing
   ```
   Each should produce a one-line `[fatal]` with a human-readable explanation, not a raw json decoder error.
8. Unit tests:
   ```sh
   go test -race -count=1 ./core/pkg/fixhandler/... ./core/core/...
   ```
   All pass. `unfixed_test.go` covers `controlHasOnlyUserValueFixes`, the new `bool` return on `addYamlExpressionsFromResourceAssociatedControl`, classification across every skip-reason in `PrepareResourcesToFix`, dedup in `PrintUnfixedControls`, and the four `NewFixHandler` input-validation paths.

## Examples

**Before the fix:**
```
$ kubescape fix /tmp/scan.json --no-confirm
{"level":"info","msg":"Reading report file..."}
{"level":"info","msg":"The following changes will be applied: ..."}
{"level":"info","msg":"Fixed resources in 1 files."}
```
A subsequent `scan` still flags `C-0038`, `C-0041`, `C-0057` — the user has no way of knowing from the `fix` output that those controls were never attempted.

**After the fix:**
```
$ kubescape fix /tmp/scan.json --no-confirm
{"level":"info","msg":"Reading report file..."}
{"level":"info","msg":"The following changes will be applied: ..."}
{"level":"info","msg":"Fixed 3 of 16 flagged control instances across 1 file(s)."}
{"level":"warn","msg":"Auto-fixed 3 of 16 flagged control instances. The following require manual remediation:
  - C-0038 Host PID/IPC privileges on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0041 HostNetwork access on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0057 Privileged container on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0061 Pods in default namespace on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0030 Ingress and Egress blocked on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0260 Missing network policy on Deployment/insecure-app (/tmp/deploy.yaml) — no auto-fix available for this control
  - C-0018 Configured readiness probe on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0055 Linux hardening on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0056 Configured liveness probe on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0076 Label usage for resources on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0077 K8s common labels usage on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0270 Ensure CPU limits are set on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
  - C-0271 Ensure memory limits are set on Deployment/insecure-app (/tmp/deploy.yaml) — skipped: auto-fix requires a user-supplied value (--skip-user-values is set)
"}
```

**Apply-failure path (no longer overstates success):**
```
$ kubescape fix /tmp/scan.json --no-confirm --skip-user-values=false
{"level":"info","msg":"Planned fixes for 10 of 16 flagged control instances across 1 file(s); applied to 0 file(s) — the remaining files errored, see warnings below."}
...
```

**YAML passed instead of a JSON report (previously an opaque decoder error):**
```
$ kubescape fix /tmp/deploy.yaml --no-confirm
Error: "/tmp/deploy.yaml" does not look like a kubescape JSON scan report. Run `kubescape scan --format json --output <file>` first and pass that file to `kubescape fix`
```

Closes #2108.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks and displays per-item unfixed controls with user-facing reasons and a count of successfully auto-fixed controls.
  * Distinguishes planned vs applied phases and reports clearer file-level planned vs applied summaries.

* **Bug Fixes**
  * Clearer errors for invalid input formats and malformed reports.
  * Write failures now terminate per-file updates and are reflected in overall results.

* **Tests**
  * Expanded tests for unfixed-control logic, input validation, write-counting, and end-to-end fix flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2121)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->