### PR TITLE
Preserve RelatedResourcesIDs in scanned control rules

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -486,8 +486,7 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 
 		controlConfigurations := ruleToControlConfigurations(rule)
 
-		relatedResourceIds := []string{}
-		copy(relatedResourceIds, rule.RelatedResourcesIDs)
+		relatedResourceIds := append([]string(nil), rule.RelatedResourcesIDs...)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -89,6 +89,9 @@ func Test_getControlsMapFromResult(t *testing.T) {
 
 	actual := getControlsMapFromResult(context.Background(), &scanResult, controlSummaries)
 	assert.Len(t, actual, len(scanResult.AssociatedControls))
+	if assert.Len(t, actual["C-002"].Rules, 1) {
+		assert.Equal(t, []string{"resource-1"}, actual["C-002"].Rules[0].RelatedResourcesIDs)
+	}
 }
 
 type FakeMetadata struct {


### PR DESCRIPTION
## Overview

Fix `RelatedResourcesIDs` being silently dropped in `parseScannedControlRules`.

The previous implementation copied into a zero-length slice, causing all related resource IDs to be lost during persistence.

This change replaces it with an idiomatic slice clone and adds focused test coverage validating the parsed rule preserves the related resource IDs.

## How to Test

Run:

```bash id="0f55"
go test ./storage -v
```

from the `httphandler` module.

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added assertion to verify control rules contain correct resource identifiers.

* **Refactor**
  * Simplified internal slice cloning logic for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->