### PR TITLE
Respect CLI logger flag precedence over KS_LOGGER

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			k8sinterface.SetClusterContextName(rootInfo.KubeContext)
 			initLogger()
-			initLoggerLevel()
+			initLoggerLevel(cmd)
 			initEnvironment()
 			initCacheDir()
 		},

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
 )
 
 func initLogger() {
@@ -33,10 +34,23 @@ func initLogger() {
 	logger.InitLogger(rootInfo.LoggerName)
 }
 
-func initLoggerLevel() {
-	if rootInfo.Logger == helpers.InfoLevel.String() {
-	} else if l := os.Getenv("KS_LOGGER"); l != "" {
-		rootInfo.Logger = l
+func initLoggerLevel(cmd *cobra.Command) {
+	loggerExplicit := false
+	if cmd != nil {
+		// Persistent flags are parsed on the root while traversing to the subcommand.
+		// cmd.Flag("logger") on a child can be a merged copy that never gets Changed=true;
+		// the root flag holds the authoritative parse state (see cobra Traverse + ParseFlags).
+		r := cmd.Root()
+		if lf := r.Flag("logger"); lf != nil {
+			loggerExplicit = lf.Changed
+		} else if lf := cmd.Flag("logger"); lf != nil {
+			loggerExplicit = lf.Changed
+		}
+	}
+	if !loggerExplicit && rootInfo.Logger == helpers.InfoLevel.String() {
+		if l := os.Getenv("KS_LOGGER"); l != "" {
+			rootInfo.Logger = l
+		}
 	}
 
 	if err := logger.L().SetLevel(rootInfo.Logger); err != nil {

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/go-logger/zaplogger"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// testCmdWithLoggerFlag mirrors root: logger on PersistentFlags, bound to rootInfo.Logger.
+func testCmdWithLoggerFlag(t *testing.T) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "kubescape-test"}
+	c.PersistentFlags().StringVarP(&rootInfo.Logger, "logger", "l", helpers.InfoLevel.String(), "log level")
+	return c
+}
+
+func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
+	t.Run("KS_LOGGER applies when logger flag not set", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, "debug", rootInfo.Logger)
+	})
+
+	t.Run("explicit non-default logger level wins over KS_LOGGER", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "error")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"-l", helpers.WarningLevel.String()}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, helpers.WarningLevel.String(), rootInfo.Logger)
+	})
+
+	t.Run("explicit -l info wins over KS_LOGGER", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"-l", helpers.InfoLevel.String()}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+
+	t.Run("explicit --logger on root wins for subcommand path", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+
+		rootCmd := &cobra.Command{Use: "kubescape"}
+		rootCmd.PersistentFlags().StringVarP(&rootInfo.Logger, "logger", "l", helpers.InfoLevel.String(), "log level")
+		versionCmd := &cobra.Command{Use: "version"}
+		rootCmd.AddCommand(versionCmd)
+
+		assert.NoError(t, rootCmd.ParseFlags([]string{"--logger", helpers.InfoLevel.String()}))
+
+		rootInfo.LoggerName = zaplogger.LoggerName
+		initLogger()
+		initLoggerLevel(versionCmd)
+
+		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+}

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -486,8 +486,7 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 
 		controlConfigurations := ruleToControlConfigurations(rule)
 
-		relatedResourceIds := []string{}
-		copy(relatedResourceIds, rule.RelatedResourcesIDs)
+		relatedResourceIds := append([]string(nil), rule.RelatedResourcesIDs...)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -486,7 +486,8 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 
 		controlConfigurations := ruleToControlConfigurations(rule)
 
-		relatedResourceIds := append([]string(nil), rule.RelatedResourcesIDs...)
+		relatedResourceIds := make([]string, len(rule.RelatedResourcesIDs))
+        copy(relatedResourceIds, rule.RelatedResourcesIDs)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -89,6 +89,9 @@ func Test_getControlsMapFromResult(t *testing.T) {
 
 	actual := getControlsMapFromResult(context.Background(), &scanResult, controlSummaries)
 	assert.Len(t, actual, len(scanResult.AssociatedControls))
+	if assert.Len(t, actual["C-002"].Rules, 1) {
+		assert.Equal(t, []string{"resource-1"}, actual["C-002"].Rules[0].RelatedResourcesIDs)
+	}
 }
 
 type FakeMetadata struct {


### PR DESCRIPTION
## Overview

Fix `KS_LOGGER` precedence handling in `initLoggerLevel`.

Previously:

* `KS_LOGGER` was ignored when the logger remained at the default `info` level
* `KS_LOGGER` could override an explicitly provided `-l/--logger` flag

This change updates the behavior so:

* `KS_LOGGER` is applied only when the logger is still at the default level
* explicit CLI logger flags always take precedence over the environment variable

Also adds focused unit tests covering both precedence cases.

## How to Test

Run:

```bash id="0f94"
go test -count=1 ./cmd -run TestInitLoggerLevel_KSLoggerPrecedence -v
```

Optionally run the full cmd package tests:

```bash id="0f95"
go test ./cmd -v
```

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logger configuration now respects explicit CLI logger settings and environment variable behavior across commands.

* **Bug Fixes**
  * Corrected related-resource ID handling so control rule results return the expected resource lists.

* **Tests**
  * Added and expanded tests covering logger precedence and related-resource mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2123)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->