### PR TITLE
test: add regression tests for cluster-scoped resource namespace filter bug

### DIFF
--- a/core/pkg/opaprocessor/skipnamespace_bug_test.go
+++ b/core/pkg/opaprocessor/skipnamespace_bug_test.go
@@ -1,0 +1,88 @@
+package opaprocessor
+
+import "testing"
+
+func TestSkipNamespace_ClusterScopedResourcesMustNotBeFilteredByIncludeNamespaces(t *testing.T) {
+	tests := []struct {
+		name              string
+		includeNamespaces []string
+		excludeNamespaces []string
+		resourceNS        string
+		wantSkip          bool
+		why               string
+	}{
+		{
+			name:              "cluster-scoped resource with include-namespaces set MUST be evaluated",
+			includeNamespaces: []string{"production"},
+			resourceNS:        "",
+			wantSkip:          false,
+			why:               "C-0035, C-0036, C-0262 all read cluster-scoped input; dropping them yields a green scan on a misconfigured cluster",
+		},
+		{
+			name:              "cluster-scoped resource with exclude-namespaces set MUST be evaluated",
+			excludeNamespaces: []string{"kube-system"},
+			resourceNS:        "",
+			wantSkip:          false,
+			why:               "exclude-namespaces filters namespaced workloads only; cluster-scoped objects have no namespace to match against",
+		},
+		{
+			name:              "namespaced resource in included namespace is kept (control case)",
+			includeNamespaces: []string{"production"},
+			resourceNS:        "production",
+			wantSkip:          false,
+			why:               "sanity: namespaced resources in the include list must still be evaluated",
+		},
+		{
+			name:              "namespaced resource outside include list is correctly skipped (control case)",
+			includeNamespaces: []string{"production"},
+			resourceNS:        "staging",
+			wantSkip:          true,
+			why:               "sanity: the include filter must still apply to genuinely namespaced resources",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opap := &OPAProcessor{
+				includeNamespaces: tc.includeNamespaces,
+				excludeNamespaces: tc.excludeNamespaces,
+			}
+			got := opap.skipNamespace(tc.resourceNS)
+			if got != tc.wantSkip {
+				t.Errorf(
+					"skipNamespace(ns=%q) with include=%v exclude=%v = %v; want %v\n  reason: %s",
+					tc.resourceNS, tc.includeNamespaces, tc.excludeNamespaces,
+					got, tc.wantSkip, tc.why,
+				)
+			}
+		})
+	}
+}
+
+func TestSkipNamespace_ClusterScopedKindMatrix(t *testing.T) {
+	opap := &OPAProcessor{
+		includeNamespaces: []string{"app-prod"},
+	}
+	clusterScopedKinds := []struct {
+		kind            string
+		exampleControls string
+	}{
+		{"ClusterRole", "C-0015, C-0035, C-0185"},
+		{"ClusterRoleBinding", "C-0035, C-0262"},
+		{"ValidatingWebhookConfiguration", "C-0036"},
+		{"MutatingWebhookConfiguration", "C-0036"},
+		{"Node", "C-0066, C-0088"},
+		{"PersistentVolume", "C-0257"},
+		{"StorageClass", "C-0257"},
+		{"CustomResourceDefinition", "framework-wide"},
+		{"APIService", "framework-wide"},
+	}
+	for _, k := range clusterScopedKinds {
+		if opap.skipNamespace("") {
+			t.Errorf(
+				"skipNamespace returned true for cluster-scoped kind %q under --include-namespaces=app-prod: silently drops input for controls %s",
+				k.kind, k.exampleControls,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

The bug was in `skipNamespace` in `core/pkg/opaprocessor/processorhandler.go`. When running a scan with `--include-namespaces=production`, cluster-scoped resources like `ClusterRole`, `ClusterRoleBinding`, `Node`, `ValidatingWebhookConfiguration` etc. were getting silently skipped because their namespace is just `""` and that obviously isn't in the include list.

This meant controls like C-0035 (cluster-admin binding), C-0036 (webhooks), C-0262 (anonymous role bindings) were receiving zero resources as input and just passing. Green scan on a genuinely misconfigured cluster.

The fix itself already landed in # 7b65d417 . This PR adds the regression tests that were missing so this doesn't silently break again.

## What the tests cover

Two tests in `core/pkg/opaprocessor/skipnamespace_bug_test.go`:

- `TestSkipNamespace_ClusterScopedResourcesMustNotBeFilteredByIncludeNamespaces` - table-driven test with four cases: cluster-scoped resource with include-namespaces set (the failing case), cluster-scoped with exclude-namespaces set, namespaced resource in the include list, and one outside it. The last two are sanity checks to make sure normal namespace filtering still works.

- `TestSkipNamespace_ClusterScopedKindMatrix` - goes through 9 real cluster-scoped kinds that actual Kubescape controls depend on and asserts none of them get skipped under `--include-namespaces`. Each failure message names the specific controls affected (C-0015, C-0035, C-0036, C-0066, C-0088, C-0185, C-0257, C-0262) so if this ever regresses it's immediately obvious what broke.

Before the fix these tests fail like this:

```
skipNamespace returned true for cluster-scoped kind "ClusterRole" under --include-namespaces=app-prod: silently drops input for controls C-0015, C-0035, C-0185
skipNamespace returned true for cluster-scoped kind "ClusterRoleBinding" under --include-namespaces=app-prod: silently drops input for controls C-0035, C-0262
...
```