### PR TITLE
Improve validation and error handling for config set

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
@@ -24,10 +23,7 @@ func getSetCmd(ks meta.IKubescape) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := ks.SetCachedConfig(setConfig); err != nil {
-				logger.L().Fatal(err.Error())
-			}
-			return nil
+			return ks.SetCachedConfig(setConfig)
 		},
 	}
 	return configSetCmd
@@ -55,23 +51,36 @@ func stringKeysToSlice(m map[string]func(*metav1.SetConfig, string)) []string {
 }
 
 func parseSetArgs(args []string) (*metav1.SetConfig, error) {
-	var key string
-	var value string
-	if len(args) == 1 {
-		if keyValue := strings.Split(args[0], "="); len(keyValue) == 2 {
-			key = keyValue[0]
-			value = keyValue[1]
-		}
-	} else if len(args) == 2 {
-		key = args[0]
-		value = args[1]
-	}
-	setConfig := &metav1.SetConfig{}
+	supported := strings.Join(stringKeysToSlice(supportConfigSet), "/")
 
+	var key, value string
+	switch len(args) {
+	case 0:
+		return nil, fmt.Errorf("missing arguments: expected KEY=VALUE or KEY VALUE; supported keys: %s", supported)
+	case 1:
+		parts := strings.SplitN(args[0], "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid argument %q: expected KEY=VALUE or two arguments KEY VALUE; supported keys: %s", args[0], supported)
+		}
+		key = strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, fmt.Errorf("invalid argument %q: key cannot be empty", args[0])
+		}
+		value = parts[1]
+	case 2:
+		key = strings.TrimSpace(args[0])
+		if key == "" {
+			return nil, fmt.Errorf("invalid arguments: key cannot be empty")
+		}
+		value = args[1]
+	default:
+		return nil, fmt.Errorf("too many arguments: expected KEY=VALUE or KEY VALUE; supported keys: %s", supported)
+	}
+
+	setConfig := &metav1.SetConfig{}
 	if setConfigFunc, ok := supportConfigSet[key]; ok {
 		setConfigFunc(setConfig, value)
-	} else {
-		return setConfig, fmt.Errorf("key '%s' unknown . supported: %s", key, strings.Join(stringKeysToSlice(supportConfigSet), "/"))
+		return setConfig, nil
 	}
-	return setConfig, nil
+	return setConfig, fmt.Errorf("key %q unknown; supported: %s", key, supported)
 }

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// setCachedConfigErr implements SetCachedConfig failure for RunE error propagation tests.
+type setCachedConfigErr struct {
+	mocks.MockIKubescape
+}
+
+func (setCachedConfigErr) SetCachedConfig(*metav1.SetConfig) error {
+	return fmt.Errorf("persist failed")
+}
+
 func TestGetSetCmd(t *testing.T) {
 	// Create a mock Kubescape interface
 	mockKubescape := &mocks.MockIKubescape{}
@@ -28,8 +37,14 @@ func TestGetSetCmd(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = configSetCmd.RunE(&cobra.Command{}, []string{})
-	expectedErrorMessage := "key '' unknown . supported: accessKey/accountID/cloudAPIURL/cloudReportURL"
-	assert.Equal(t, expectedErrorMessage, err.Error())
+	assert.ErrorContains(t, err, "missing arguments")
+	assert.ErrorContains(t, err, "supported keys:")
+}
+
+func TestGetSetCmd_SetCachedConfigReturnsError(t *testing.T) {
+	cmd := getSetCmd(&setCachedConfigErr{})
+	err := cmd.RunE(&cobra.Command{}, []string{"accountID=value1"})
+	assert.EqualError(t, err, "persist failed")
 }
 
 // Should return a slice of keys when given a non-empty map
@@ -47,13 +62,10 @@ func TestStringKeysToSlice(t *testing.T) {
 func TestParseSetArgs_InvalidFormat(t *testing.T) {
 	args := []string{"key"}
 	setConfig, err := parseSetArgs(args)
-	assert.Equal(t, "", setConfig.Account)
-	assert.Equal(t, "", setConfig.AccessKey)
-	assert.Equal(t, "", setConfig.CloudReportURL)
-	assert.Equal(t, "", setConfig.CloudAPIURL)
-
-	expectedErrorMessage := fmt.Sprintf("key '' unknown . supported: %s", strings.Join(stringKeysToSlice(supportConfigSet), "/"))
-	assert.Equal(t, expectedErrorMessage, err.Error())
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid argument")
+	assert.ErrorContains(t, err, "key")
+	assert.ErrorContains(t, err, "supported keys:")
 }
 
 func TestParseSetArgs_AccessKey(t *testing.T) {
@@ -77,5 +89,11 @@ func TestParseSetArgs_Single(t *testing.T) {
 func TestParseSetArgs_InvalidKey(t *testing.T) {
 	args := []string{"invalidKey=value1"}
 	_, err := parseSetArgs(args)
-	assert.Equal(t, "key 'invalidKey' unknown . supported: accessKey/accountID/cloudAPIURL/cloudReportURL", err.Error())
+	assert.EqualError(t, err, `key "invalidKey" unknown; supported: accessKey/accountID/cloudAPIURL/cloudReportURL`)
+}
+
+func TestParseSetArgs_TooManyArgs(t *testing.T) {
+	_, err := parseSetArgs([]string{"accountID", "v", "extra"})
+	assert.ErrorContains(t, err, "too many arguments")
+	assert.ErrorContains(t, err, "supported keys:")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			k8sinterface.SetClusterContextName(rootInfo.KubeContext)
 			initLogger()
-			initLoggerLevel()
+			initLoggerLevel(cmd)
 			initEnvironment()
 			initCacheDir()
 		},

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
 )
 
 func initLogger() {
@@ -33,10 +34,23 @@ func initLogger() {
 	logger.InitLogger(rootInfo.LoggerName)
 }
 
-func initLoggerLevel() {
-	if rootInfo.Logger == helpers.InfoLevel.String() {
-	} else if l := os.Getenv("KS_LOGGER"); l != "" {
-		rootInfo.Logger = l
+func initLoggerLevel(cmd *cobra.Command) {
+	loggerExplicit := false
+	if cmd != nil {
+		// Persistent flags are parsed on the root while traversing to the subcommand.
+		// cmd.Flag("logger") on a child can be a merged copy that never gets Changed=true;
+		// the root flag holds the authoritative parse state (see cobra Traverse + ParseFlags).
+		r := cmd.Root()
+		if lf := r.Flag("logger"); lf != nil {
+			loggerExplicit = lf.Changed
+		} else if lf := cmd.Flag("logger"); lf != nil {
+			loggerExplicit = lf.Changed
+		}
+	}
+	if !loggerExplicit && rootInfo.Logger == helpers.InfoLevel.String() {
+		if l := os.Getenv("KS_LOGGER"); l != "" {
+			rootInfo.Logger = l
+		}
 	}
 
 	if err := logger.L().SetLevel(rootInfo.Logger); err != nil {

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/go-logger/zaplogger"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// testCmdWithLoggerFlag mirrors root: logger on PersistentFlags, bound to rootInfo.Logger.
+func testCmdWithLoggerFlag(t *testing.T) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "kubescape-test"}
+	c.PersistentFlags().StringVarP(&rootInfo.Logger, "logger", "l", helpers.InfoLevel.String(), "log level")
+	return c
+}
+
+func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
+	t.Run("KS_LOGGER applies when logger flag not set", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, "debug", rootInfo.Logger)
+	})
+
+	t.Run("explicit non-default logger level wins over KS_LOGGER", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "error")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"-l", helpers.WarningLevel.String()}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, helpers.WarningLevel.String(), rootInfo.Logger)
+	})
+
+	t.Run("explicit -l info wins over KS_LOGGER", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+		cmd := testCmdWithLoggerFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"-l", helpers.InfoLevel.String()}))
+		rootInfo.LoggerName = zaplogger.LoggerName
+
+		initLogger()
+		initLoggerLevel(cmd)
+
+		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+
+	t.Run("explicit --logger on root wins for subcommand path", func(t *testing.T) {
+		prevLogger := rootInfo.Logger
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.Logger = prevLogger
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		t.Setenv("KS_LOGGER", "debug")
+
+		rootCmd := &cobra.Command{Use: "kubescape"}
+		rootCmd.PersistentFlags().StringVarP(&rootInfo.Logger, "logger", "l", helpers.InfoLevel.String(), "log level")
+		versionCmd := &cobra.Command{Use: "version"}
+		rootCmd.AddCommand(versionCmd)
+
+		assert.NoError(t, rootCmd.ParseFlags([]string{"--logger", helpers.InfoLevel.String()}))
+
+		rootInfo.LoggerName = zaplogger.LoggerName
+		initLogger()
+		initLoggerLevel(versionCmd)
+
+		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+}

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -486,8 +486,7 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 
 		controlConfigurations := ruleToControlConfigurations(rule)
 
-		relatedResourceIds := []string{}
-		copy(relatedResourceIds, rule.RelatedResourcesIDs)
+		relatedResourceIds := append([]string(nil), rule.RelatedResourcesIDs...)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -486,7 +486,8 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 
 		controlConfigurations := ruleToControlConfigurations(rule)
 
-		relatedResourceIds := append([]string(nil), rule.RelatedResourcesIDs...)
+		relatedResourceIds := make([]string, len(rule.RelatedResourcesIDs))
+        copy(relatedResourceIds, rule.RelatedResourcesIDs)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -487,7 +487,7 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 		controlConfigurations := ruleToControlConfigurations(rule)
 
 		relatedResourceIds := make([]string, len(rule.RelatedResourcesIDs))
-        copy(relatedResourceIds, rule.RelatedResourcesIDs)
+		copy(relatedResourceIds, rule.RelatedResourcesIDs)
 		rules[i] = v1beta1.ScannedControlRule{
 			Name: rule.GetName(),
 			Status: v1beta1.RuleStatus{

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -89,6 +89,9 @@ func Test_getControlsMapFromResult(t *testing.T) {
 
 	actual := getControlsMapFromResult(context.Background(), &scanResult, controlSummaries)
 	assert.Len(t, actual, len(scanResult.AssociatedControls))
+	if assert.Len(t, actual["C-002"].Rules, 1) {
+		assert.Equal(t, []string{"resource-1"}, actual["C-002"].Rules[0].RelatedResourcesIDs)
+	}
 }
 
 type FakeMetadata struct {


### PR DESCRIPTION
## Overview

Improve validation and error handling for `kubescape config set`.

Changes include:

* clearer validation errors for malformed arguments
* explicit handling for missing and excessive arguments
* improved error messages for invalid `KEY=VALUE` input
* returning persistence errors from `RunE` instead of calling `logger.L().Fatal(...)`

Also adds focused unit tests covering malformed argument handling and persistence failure behavior.

## How to Test

Run:

```bash id="0f263"
go test ./cmd/config -v
```

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Config set command now returns persistence errors instead of suppressing them.
  * Related resource IDs are preserved correctly when parsing control rules.
  * Logger level initialization now respects flag vs. environment precedence.

* **Improvements**
  * Stricter validation and clearer error messages for config set arguments.

* **Tests**
  * Added/updated unit tests covering logger-level precedence, config persistence errors, and control-rule parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->