### PR TITLE
feat(scan): anonymize container names and images for --hide

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -111,7 +111,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
-	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers(name,namespace) in results")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers (namespace, resource names, container names, images) in results")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -1,0 +1,95 @@
+package anonymizer
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+)
+
+func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *Mapping) {
+	if resource == nil {
+		return
+	}
+
+	obj := resource.GetObject()
+	if obj == nil {
+		return
+	}
+
+	anonymizePodSpecs(obj, mapping)
+	resource.SetObject(obj)
+}
+
+func anonymizePodSpecs(node interface{}, mapping *Mapping) {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		anonymizeContainerList(v, "containers", mapping)
+		anonymizeContainerList(v, "initContainers", mapping)
+		anonymizeEphemeralContainerList(v, "ephemeralContainers", mapping)
+
+		for _, child := range v {
+			anonymizePodSpecs(child, mapping)
+		}
+
+	case []interface{}:
+		for _, item := range v {
+			anonymizePodSpecs(item, mapping)
+		}
+	}
+}
+
+func anonymizeContainerList(
+	obj map[string]interface{},
+	key string,
+	mapping *Mapping,
+) {
+	rawContainers, ok := obj[key]
+	if !ok || rawContainers == nil {
+		return
+	}
+
+	containers, ok := rawContainers.([]corev1.Container)
+	if !ok {
+		return
+	}
+
+	for i := range containers {
+		if containers[i].Name != "" {
+			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+		}
+
+		if containers[i].Image != "" {
+			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+		}
+	}
+
+	obj[key] = containers
+}
+
+func anonymizeEphemeralContainerList(
+	obj map[string]interface{},
+	key string,
+	mapping *Mapping,
+) {
+	rawContainers, ok := obj[key]
+	if !ok || rawContainers == nil {
+		return
+	}
+
+	containers, ok := rawContainers.([]corev1.EphemeralContainer)
+	if !ok {
+		return
+	}
+
+	for i := range containers {
+		if containers[i].Name != "" {
+			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+		}
+
+		if containers[i].Image != "" {
+			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+		}
+	}
+
+	obj[key] = containers
+}

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -26,6 +26,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 		if namespace := resource.GetNamespace(); namespace != "" {
 			resource.SetNamespace(mapping.GetOrCreate("ns", namespace))
 		}
+		anonymizeContainerMetadata(resource, mapping)
 
 		newID := resource.GetID()
 		idMapping[oldID] = newID


### PR DESCRIPTION
Part of #1200

Changes introduced in this PR:

* Added anonymization for `container names` and `container image` references when `--hide` is enabled
* Introduced container metadata traversal across pod spec structures (`containers`, `initContainers`, `ephemeralContainers`)
* Integrated container metadata anonymization into the existing session anonymization flow
* Updated scan output behavior so assisted remediation and `JSON` reports consistently use anonymized `container metadata`
* Updated `--hide` flag description to reflect expanded anonymization coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the scan command’s --hide flag help text and expanded its behavior to hide additional sensitive identifiers (namespace, resource names, container names, and images).
  * Anonymization now also processes container-related metadata across all session resources so container names and images are consistently anonymized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2129)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->