### PR TITLE
refactor: replace log.Printf with logger.L().Info() in mcpserver.go

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -292,7 +291,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 			return nil, err
 		}
 
-		log.Printf("Found %d manifests", len(manifests.Items))
+		logger.L().Info(fmt.Sprintf("Found %d manifests", len(manifests.Items)))
 
 		vulnerabilityManifests := []map[string]interface{}{}
 		for _, manifest := range manifests.Items {
@@ -429,7 +428,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		if err != nil {
 			return nil, err
 		}
-		log.Printf("Found %d configuration manifests", len(manifests.Items))
+		logger.L().Info(fmt.Sprintf("Found %d configuration manifests", len(manifests.Items)))
 		configManifests := []map[string]interface{}{}
 		for _, manifest := range manifests.Items {
 			item := map[string]interface{}{


### PR DESCRIPTION
## Overview
Two instances of `log.Printf` in `cmd/mcpserver/mcpserver.go` were replaced with the project's standard structured logger `logger.L().Info()`. The unused `"log"` import was also removed.

## Additional Information
- Line 295: `log.Printf("Found %d manifests", ...)` → `logger.L().Info(...)`
- Line 432: `log.Printf("Found %d configuration manifests", ...)` → `logger.L().Info(...)`
- Removed unused `"log"` import
- No functional changes — purely a consistency improvement

## How to Test
Run the MCP server and verify that manifest listing logs appear in the structured logger output instead of standard log output.

## Examples/Screenshots
N/A

## Related issues/PRs
Closes #2128

## Checklist before requesting a review
put an [x] in the box to get it checked

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging system for manifest discovery reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->