### PR TITLE
fix: clear Env[].ValueFrom in removeContainersData and removeEphemeralContainersData

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -349,6 +349,7 @@ func removeContainersData(containers []corev1.Container) {
 	for i := range containers {
 		for j := range containers[i].Env {
 			containers[i].Env[j].Value = "XXXXXX"
+			containers[i].Env[j].ValueFrom = nil
 		}
 		containers[i].EnvFrom = nil
 	}
@@ -357,6 +358,7 @@ func removeEphemeralContainersData(containers []corev1.EphemeralContainer) {
 	for i := range containers {
 		for j := range containers[i].Env {
 			containers[i].Env[j].Value = "XXXXXX"
+			containers[i].Env[j].ValueFrom = nil
 		}
 		containers[i].EnvFrom = nil
 	}

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -212,6 +212,74 @@ func TestRemoveEphemeralContainersData_ClearsEnvFrom(t *testing.T) {
 }
 
 
+
+func TestRemoveContainersData_ClearsValueFrom(t *testing.T) {
+	containers := []corev1.Container{
+		{
+			Env: []corev1.EnvVar{
+				{
+					Name: "SECRET_KEY",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							Key:                  "password",
+						},
+					},
+				},
+				{
+					Name: "CONFIG_KEY",
+					ValueFrom: &corev1.EnvVarSource{
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-configmap"},
+							Key:                  "config-key",
+						},
+					},
+				},
+			},
+		},
+	}
+	removeContainersData(containers)
+	for _, c := range containers {
+		for _, env := range c.Env {
+			assert.Nil(t, env.ValueFrom, "ValueFrom must be cleared to prevent secret and configmap name leakage")
+		}
+	}
+}
+
+func TestRemoveEphemeralContainersData_ClearsValueFrom(t *testing.T) {
+	containers := []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Env: []corev1.EnvVar{
+					{
+						Name: "SECRET_KEY",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "password",
+							},
+						},
+					},
+					{
+						Name: "CONFIG_KEY",
+						ValueFrom: &corev1.EnvVarSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-configmap"},
+								Key:                  "config-key",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	removeEphemeralContainersData(containers)
+	for _, c := range containers {
+		for _, env := range c.Env {
+			assert.Nil(t, env.ValueFrom, "ValueFrom must be cleared to prevent secret and configmap name leakage")
+		}
+	}
+}
 func TestApplyExceptionsToManualControls(t *testing.T) {
 	processor := exceptions.NewProcessor()
 


### PR DESCRIPTION
## Overview
`removeContainersData` and `removeEphemeralContainersData` cleared `Env[j].Value` and `EnvFrom` but did not clear `Env[j].ValueFrom`. This left `SecretKeyRef.Name` and `ConfigMapKeyRef.Name` present in scan output, leaking Secret and ConfigMap names referenced via `valueFrom` in container env vars.

This fix sets `Env[j].ValueFrom = nil` in both functions, consistent with how `Value` and `EnvFrom` are already handled. `EnvFrom` was fixed in #2120 — this closes the remaining gap.

## How to Test

go test ./core/pkg/opaprocessor/... -run "TestRemoveContainersData_ClearsValueFrom|TestRemoveEphemeralContainersData_ClearsValueFrom" -v

Both tests pass. Full suite passes.

## Related issues/PRs
* Resolves #2131
* Related to #2120 (fixed EnvFrom)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment variable data sanitization for Kubernetes Pods to remove all sources, including indirect references to secrets and ConfigMaps through both regular and ephemeral containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->