### PR TITLE
fix: correct typo 'arguement' to 'argument' in completion files

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -45,7 +45,7 @@ func GetCompletionCmd() *cobra.Command {
 			case "powershell":
 				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 			default:
-				fmt.Printf("Invalid arguement %s", args[0])
+				fmt.Printf("Invalid argument %s", args[0])
 			}
 		},
 	}

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -30,7 +30,7 @@ func TestGetCompletionCmd_RunExpectedOutputs(t *testing.T) {
 		{
 			name: "Unknown completion",
 			args: []string{"unknown"},
-			want: "Invalid arguement unknown",
+			want: "Invalid argument unknown",
 		},
 		{
 			name: "Empty arguments",


### PR DESCRIPTION
## Overview
Fixed a spelling typo in `cmd/completion/completion.go` and `cmd/completion/completion_test.go`.

`arguement` → `argument`

## Additional Information
- `cmd/completion/completion.go` line 48
- `cmd/completion/completion_test.go` line 33
- No functional changes — purely a spelling fix

## Examples/Screenshots
N/A

## Related issues/PRs
N/A

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spelling error in completion command error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->