### PR TITLE
fix: use JSON marshal/unmarshal in anonymizeContainerList to replace broken type assertion

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -1,6 +1,8 @@
 package anonymizer
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -48,8 +50,13 @@ func anonymizeContainerList(
 		return
 	}
 
-	containers, ok := rawContainers.([]corev1.Container)
-	if !ok {
+	data, err := json.Marshal(rawContainers)
+	if err != nil {
+		return
+	}
+
+	var containers []corev1.Container
+	if err := json.Unmarshal(data, &containers); err != nil {
 		return
 	}
 
@@ -57,7 +64,6 @@ func anonymizeContainerList(
 		if containers[i].Name != "" {
 			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
 		}
-
 		if containers[i].Image != "" {
 			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
 		}
@@ -76,8 +82,13 @@ func anonymizeEphemeralContainerList(
 		return
 	}
 
-	containers, ok := rawContainers.([]corev1.EphemeralContainer)
-	if !ok {
+	data, err := json.Marshal(rawContainers)
+	if err != nil {
+		return
+	}
+
+	var containers []corev1.EphemeralContainer
+	if err := json.Unmarshal(data, &containers); err != nil {
 		return
 	}
 
@@ -85,7 +96,6 @@ func anonymizeEphemeralContainerList(
 		if containers[i].Name != "" {
 			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
 		}
-
 		if containers[i].Image != "" {
 			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
 		}

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -1,0 +1,81 @@
+package anonymizer
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	corev1 "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnonymizeContainerList_AnonymizesNamesAndImages(t *testing.T) {
+	obj := map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":  "my-secret-app",
+				"image": "private.registry.io/app:v1",
+			},
+			map[string]interface{}{
+				"name":  "sidecar",
+				"image": "private.registry.io/sidecar:v1",
+			},
+		},
+	}
+
+	m := NewMapping()
+	anonymizeContainerList(obj, "containers", m)
+
+	containers, ok := obj["containers"].([]corev1.Container)
+	assert.True(t, ok, "after fix, containers must be []corev1.Container")
+	assert.Len(t, containers, 2)
+	assert.NotEqual(t, "my-secret-app", containers[0].Name)
+	assert.NotEqual(t, "private.registry.io/app:v1", containers[0].Image)
+	assert.NotEqual(t, "sidecar", containers[1].Name)
+	assert.NotEqual(t, "private.registry.io/sidecar:v1", containers[1].Image)
+	assert.Contains(t, containers[0].Name, "ctr-")
+	assert.Contains(t, containers[0].Image, "img-")
+}
+
+func TestAnonymizeContainerMetadata_AnonymizesContainerNamesAndImages(t *testing.T) {
+	resource := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "my-pod",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "secret-container",
+					"image": "private.io/app:v1",
+				},
+			},
+		},
+	})
+
+	m := NewMapping()
+	anonymizeContainerMetadata(resource, m)
+
+	obj := resource.GetObject()
+	spec := obj["spec"].(map[string]interface{})
+	containers, ok := spec["containers"].([]corev1.Container)
+	assert.True(t, ok)
+	assert.Len(t, containers, 1)
+	assert.NotEqual(t, "secret-container", containers[0].Name)
+	assert.NotEqual(t, "private.io/app:v1", containers[0].Image)
+	assert.Contains(t, containers[0].Name, "ctr-")
+	assert.Contains(t, containers[0].Image, "img-")
+}
+
+func TestAnonymizeContainerList_MissingKey(t *testing.T) {
+	obj := map[string]interface{}{}
+	m := NewMapping()
+	anonymizeContainerList(obj, "containers", m)
+}
+
+func TestAnonymizeContainerList_NilValue(t *testing.T) {
+	obj := map[string]interface{}{"containers": nil}
+	m := NewMapping()
+	anonymizeContainerList(obj, "containers", m)
+}

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -79,3 +79,26 @@ func TestAnonymizeContainerList_NilValue(t *testing.T) {
 	m := NewMapping()
 	anonymizeContainerList(obj, "containers", m)
 }
+
+func TestAnonymizeEphemeralContainerList_AnonymizesNamesAndImages(t *testing.T) {
+	// Simulate runtime shape: []interface{} with map[string]interface{} items
+	obj := map[string]interface{}{
+		"ephemeralContainers": []interface{}{
+			map[string]interface{}{
+				"name":  "debug-container",
+				"image": "private.registry.io/debug:v1",
+			},
+		},
+	}
+
+	m := NewMapping()
+	anonymizeEphemeralContainerList(obj, "ephemeralContainers", m)
+
+	containers, ok := obj["ephemeralContainers"].([]corev1.EphemeralContainer)
+	assert.True(t, ok, "after fix, ephemeral containers must be []corev1.EphemeralContainer")
+	assert.Len(t, containers, 1)
+	assert.NotEqual(t, "debug-container", containers[0].Name)
+	assert.NotEqual(t, "private.registry.io/debug:v1", containers[0].Image)
+	assert.Contains(t, containers[0].Name, "ctr-")
+	assert.Contains(t, containers[0].Image, "img-")
+}


### PR DESCRIPTION
## Overview
`anonymizeContainerList` and `anonymizeEphemeralContainerList` in `core/pkg/anonymizer/container.go` contained a type assertion that always fails at runtime:

```go
containers, ok := rawContainers.([]corev1.Container)
if !ok {
    return  // always returns — container names and images never anonymized
}
```

`resource.GetObject()` returns `map[string]interface{}` where containers are stored as `[]interface{}` (JSON-decoded), never as `[]corev1.Container`. This meant the `--hide` flag silently did nothing for container names and images.

This fix replaces the broken type assertion with JSON marshal/unmarshal — the same approach used by `workloadinterface.GetContainers()` — so containers are correctly deserialized and their names and images are properly anonymized.

## How to Test

go test ./core/pkg/anonymizer/... -v -run "TestAnonymizeContainer"

All 4 new tests pass, covering the real runtime path with `[]interface{}` input.

## Related issues/PRs
* Resolves #2132
* Follow-up to #2129

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for container and ephemeral container anonymization, covering name/image transformations and edge cases (missing or nil fields).

* **Bug Fixes**
  * Improved anonymization reliability by changing how container lists are processed to ensure names and images are consistently anonymized for standard and ephemeral containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->