### PR TITLE
fix: handle unhandled error from defer f.Close() in writeScanErrorToFile

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -233,7 +233,11 @@ func writeScanErrorToFile(err error, scanID string) error {
 	if e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to open file for writing. reason: %s", err.Error(), e.Error())
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && e == nil {
+			e = fmt.Errorf("failed to close scan error file: %w", cerr)
+		}
+	}()
 
 	if _, e := f.Write([]byte(err.Error())); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to write. reason: %s", err.Error(), e.Error())

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -226,10 +226,11 @@ func envToString(env string, defaultValue string) string {
 }
 
 func writeScanErrorToFile(err error, scanID string) (e error) {
-	if e := os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
+	if e = os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to create directory. reason: %s", err.Error(), e.Error())
 	}
-	f, e := os.Create(filepath.Join(FailedOutputDir, scanID))
+	var f *os.File
+	f, e = os.Create(filepath.Join(FailedOutputDir, scanID))
 	if e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to open file for writing. reason: %s", err.Error(), e.Error())
 	}
@@ -239,7 +240,7 @@ func writeScanErrorToFile(err error, scanID string) (e error) {
 		}
 	}()
 
-	if _, e := f.Write([]byte(err.Error())); e != nil {
+	if _, e = f.Write([]byte(err.Error())); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to write. reason: %s", err.Error(), e.Error())
 	}
 	return fmt.Errorf("failed to scan. reason: '%s'", err.Error())

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -225,7 +225,7 @@ func envToString(env string, defaultValue string) string {
 	return defaultValue
 }
 
-func writeScanErrorToFile(err error, scanID string) error {
+func writeScanErrorToFile(err error, scanID string) (e error) {
 	if e := os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to create directory. reason: %s", err.Error(), e.Error())
 	}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -235,8 +235,8 @@ func writeScanErrorToFile(err error, scanID string) (e error) {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to open file for writing. reason: %s", err.Error(), e.Error())
 	}
 	defer func() {
-		if cerr := f.Close(); cerr != nil && e == nil {
-			e = fmt.Errorf("failed to close scan error file: %w", cerr)
+		if cerr := f.Close(); cerr != nil {
+			e = fmt.Errorf("%w; failed to close scan error file: %w", e, cerr)
 		}
 	}()
 


### PR DESCRIPTION
## Overview
In `httphandler/handlerequests/v1/requestshandlerutils.go`, the `writeScanErrorToFile` function was using a bare `defer f.Close()` which silently discarded any error returned by `Close()`. If closing the file failed (e.g. due to a full disk or I/O error), the error would be lost and the caller would have no way to know the file was not properly closed.

This PR fixes the issue by:
- Changing the function signature to use a named return `(e error)`
- Replacing `defer f.Close()` with a proper error-capturing defer that propagates the close error to the caller

## Additional Information
- No functional changes to the happy path
- Close errors are now properly returned to the caller

## How to Test
Run the existing tests:
`go test ./httphandler/...`

## Examples/Screenshots
N/A

## Related issues/PRs
Closes #2134

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for writing scan errors to disk: file-close failures are now properly captured and reported (only when no prior error exists), preventing previously ignored close errors.
  * This change increases reliability of file-based operations and surfaces close failures that were previously hidden, aiding diagnosis of intermittent write issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2137)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->