### PR TITLE
add attack track printer tests

### DIFF
--- a/core/pkg/resultshandling/printer/v2/attacktracks_test.go
+++ b/core/pkg/resultshandling/printer/v2/attacktracks_test.go
@@ -1,0 +1,50 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrettyPrinterCreateFailedControlList(t *testing.T) {
+	tests := []struct {
+		name     string
+		controls []v1alpha1.IAttackTrackControl
+		expected string
+	}{
+		{
+			name:     "no controls",
+			controls: nil,
+			expected: "",
+		},
+		{
+			name: "single control",
+			controls: []v1alpha1.IAttackTrackControl{
+				&v1alpha1.AttackTrackControlMock{ControlId: "C-001"},
+			},
+			expected: "C-001",
+		},
+		{
+			name: "multiple controls preserve order",
+			controls: []v1alpha1.IAttackTrackControl{
+				&v1alpha1.AttackTrackControlMock{ControlId: "C-001"},
+				&v1alpha1.AttackTrackControlMock{ControlId: "C-002"},
+				&v1alpha1.AttackTrackControlMock{ControlId: "C-003"},
+			},
+			expected: "C-001, C-002, C-003",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pp := &PrettyPrinter{}
+			step := v1alpha1.AttackTrackStepMock{
+				Name:     "attack step",
+				Controls: tt.controls,
+			}
+
+			assert.Equal(t, tt.expected, pp.createFailedControlList(step))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Added a table-driven unit test for `core/pkg/resultshandling/printer/v2/attacktracks.go`.

The new test covers:

- attack-track steps with no failed controls
- attack-track steps with one failed control
- attack-track steps with multiple failed controls while preserving display order

## Why

Attack-track output is used to explain prioritized risk paths. The failed-control list is small but user-visible, so this adds a guardrail around the exact text users see in that output.

## Validation

```sh
go test ./core/pkg/resultshandling/printer/v2 -run TestPrettyPrinterCreateFailedControlList
go test ./core/pkg/resultshandling/printer/v2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for control list formatting functionality to improve code reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2142)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->