### PR TITLE
add scan info policy tests

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -222,18 +222,22 @@ func (scanInfo *ScanInfo) setUseFrom() {
 	}
 }
 
-// Formats returns a slice of output formats that have been requested for a given scan
+// Formats returns a slice of output formats that have been requested for a given scan.
+// Empty entries and surrounding whitespace are dropped so that inputs like
+// "json,,pdf" or "json, ,pdf" do not produce blank format strings.
 func (scanInfo *ScanInfo) Formats() []string {
-	formatString := scanInfo.Format
-	if formatString != "" {
-		parts := strings.Split(scanInfo.Format, ",")
-		for i, p := range parts {
-			parts[i] = strings.TrimSpace(p)
-		}
-		return unique(parts)
-	} else {
+	if scanInfo.Format == "" {
 		return []string{}
 	}
+
+	var cleaned []string
+	for _, f := range strings.Split(scanInfo.Format, ",") {
+		if v := strings.TrimSpace(f); v != "" {
+			cleaned = append(cleaned, v)
+		}
+	}
+
+	return unique(cleaned)
 }
 
 func unique(items []string) []string {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -226,7 +226,11 @@ func (scanInfo *ScanInfo) setUseFrom() {
 func (scanInfo *ScanInfo) Formats() []string {
 	formatString := scanInfo.Format
 	if formatString != "" {
-		return unique(strings.Split(scanInfo.Format, ","))
+		parts := strings.Split(scanInfo.Format, ",")
+		for i, p := range parts {
+			parts[i] = strings.TrimSpace(p)
+		}
+		return unique(parts)
 	} else {
 		return []string{}
 	}

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -110,27 +110,34 @@ func TestGetScanningContext(t *testing.T) {
 
 func TestScanInfoFormats(t *testing.T) {
 	testCases := []struct {
+		name  string
 		Input string
 		Want  []string
 	}{
-		{"", []string{}},
-		{"json", []string{"json"}},
-		{"pdf", []string{"pdf"}},
-		{"html", []string{"html"}},
-		{"sarif", []string{"sarif"}},
-		{"html,pdf,sarif", []string{"html", "pdf", "sarif"}},
-		{"pretty-printer,pdf,sarif", []string{"pretty-printer", "pdf", "sarif"}},
+		{"empty string", "", []string{}},
+		{"single json", "json", []string{"json"}},
+		{"single pdf", "pdf", []string{"pdf"}},
+		{"single html", "html", []string{"html"}},
+		{"single sarif", "sarif", []string{"sarif"}},
+		{"multiple formats", "html,pdf,sarif", []string{"html", "pdf", "sarif"}},
+		{"pretty-printer with others", "pretty-printer,pdf,sarif", []string{"pretty-printer", "pdf", "sarif"}},
+		{"consecutive commas", "json,,pdf", []string{"json", "pdf"}},
+		{"whitespace-only entry", "json, ,pdf", []string{"json", "pdf"}},
+		{"trailing comma", "json,pdf,", []string{"json", "pdf"}},
+		{"leading comma", ",json,pdf", []string{"json", "pdf"}},
+		{"only commas", ",,,", []string{}},
+		{"whitespace around formats", " json , pdf ", []string{"json", "pdf"}},
+		{"duplicates preserved order", "json,pdf,json", []string{"json", "pdf"}},
+		{"duplicates with whitespace", "json, json ,pdf", []string{"json", "pdf"}},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Input, func(t *testing.T) {
-			input := tc.Input
-			want := tc.Want
-			scanInfo := &ScanInfo{Format: input}
+		t.Run(tc.name, func(t *testing.T) {
+			scanInfo := &ScanInfo{Format: tc.Input}
 
 			got := scanInfo.Formats()
 
-			assert.Equal(t, want, got)
+			assert.Equal(t, tc.Want, got)
 		})
 	}
 }

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -152,9 +152,9 @@ func TestScanInfoFormatsDeduplicatesInOrder(t *testing.T) {
 			want:   []string{"json", "pdf", "sarif"},
 		},
 		{
-			name:   "preserves whitespace as existing format value",
+			name:   "trims whitespace and deduplicates",
 			format: "json, json,json",
-			want:   []string{"json", " json"},
+			want:   []string{"json"},
 		},
 	}
 

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,6 +131,82 @@ func TestScanInfoFormats(t *testing.T) {
 			got := scanInfo.Formats()
 
 			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestScanInfoFormatsDeduplicatesInOrder(t *testing.T) {
+	testCases := []struct {
+		name   string
+		format string
+		want   []string
+	}{
+		{
+			name:   "duplicate json",
+			format: "json,json",
+			want:   []string{"json"},
+		},
+		{
+			name:   "keeps first occurrence order",
+			format: "json,pdf,json,sarif,pdf",
+			want:   []string{"json", "pdf", "sarif"},
+		},
+		{
+			name:   "preserves whitespace as existing format value",
+			format: "json, json,json",
+			want:   []string{"json", " json"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanInfo := &ScanInfo{Format: tc.format}
+
+			assert.Equal(t, tc.want, scanInfo.Formats())
+		})
+	}
+}
+
+func TestScanInfoSetPolicyIdentifiers(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []PolicyIdentifier
+		policies []string
+		want     []PolicyIdentifier
+	}{
+		{
+			name:     "adds new policies",
+			policies: []string{"nsa", "mitre"},
+			want: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+				{Identifier: "mitre", Kind: apisv1.KindFramework},
+			},
+		},
+		{
+			name: "skips existing policy",
+			existing: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+			},
+			policies: []string{"nsa", "mitre"},
+			want: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+				{Identifier: "mitre", Kind: apisv1.KindFramework},
+			},
+		},
+		{
+			name:     "empty policy list leaves existing values",
+			existing: []PolicyIdentifier{{Identifier: "C-0001", Kind: apisv1.KindControl}},
+			want:     []PolicyIdentifier{{Identifier: "C-0001", Kind: apisv1.KindControl}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &ScanInfo{PolicyIdentifier: tt.existing}
+
+			scanInfo.SetPolicyIdentifiers(tt.policies, apisv1.KindFramework)
+
+			assert.Equal(t, tt.want, scanInfo.PolicyIdentifier)
 		})
 	}
 }


### PR DESCRIPTION
## What changed

Added table-driven tests for `core/cautils/scaninfo.go`.

The new tests cover:

- output format deduplication while preserving order
- duplicate policy identifiers being skipped
- new policy identifiers being added with the expected kind
- empty policy input leaving existing policy identifiers unchanged

## Why

ScanInfo feeds CLI scan metadata and report targeting. These tests protect small but important behavior that affects what formats and policy targets Kubescape records for a scan.

## Validation

```sh
go test ./core/cautils -run 'TestScanInfoFormats|TestScanInfoFormatsDeduplicatesInOrder|TestScanInfoSetPolicyIdentifiers'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of requested formats: commas and surrounding whitespace are handled correctly, duplicates are removed while preserving first-seen order.
  * Fix to policy identifier handling: adding new policies appends missing identifiers, existing identifiers are preserved, and empty updates leave identifiers unchanged.

* **Tests**
  * Added unit tests validating formats parsing/deduplication and policy-identifier update behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2143)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->