### PR TITLE
add account id validation tests

### DIFF
--- a/core/cautils/rootinfo_test.go
+++ b/core/cautils/rootinfo_test.go
@@ -1,36 +1,47 @@
 package cautils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestValidateAccountID(t *testing.T) {
-	type fields struct {
-		Account string
-	}
 	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
+		name          string
+		accountID     string
+		expectedError string
 	}{
 		{
-			name: "valid account ID",
-			fields: fields{
-				Account: "22019933-feac-4012-a8eb-e81461ba6655",
-			},
-			wantErr: false,
+			name:      "valid account ID",
+			accountID: "22019933-feac-4012-a8eb-e81461ba6655",
 		},
 		{
-			name: "invalid account ID",
-			fields: fields{
-				Account: "22019933-feac-4012-a8eb-e81461ba665",
-			},
-			wantErr: true,
+			name:      "empty account ID is allowed",
+			accountID: "",
+		},
+		{
+			name:          "too short account ID",
+			accountID:     "22019933-feac-4012-a8eb-e81461ba665",
+			expectedError: "bad argument: accound ID must be a valid UUID",
+		},
+		{
+			name:          "non uuid account ID",
+			accountID:     "not-a-uuid",
+			expectedError: "bad argument: accound ID must be a valid UUID",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateAccountID(tt.fields.Account); (err != nil) != tt.wantErr {
-				t.Errorf("ValidateAccountID() error = %v, wantErr %v", err, tt.wantErr)
+			err := ValidateAccountID(tt.accountID)
+
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				return
 			}
+
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## What changed

Expanded the table-driven tests for `ValidateAccountID` in `core/cautils/rootinfo.go`.

The updated tests cover:

- valid UUID account IDs
- empty account IDs being allowed
- too-short UUID-like values
- non-UUID values
- the exact validation error returned for invalid IDs

## Why

Account ID validation sits on an important configuration path. This keeps the accepted empty value behavior explicit while guarding invalid account IDs from slipping through.

## Validation

```sh
go test ./core/cautils -run TestValidateAccountID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test structure for account ID validation logic with improved assertions and expanded test coverage scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2144)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->