### PR TITLE
fix: propagate request context through CallTool to Kubernetes API calls

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -37,7 +37,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(listManifestsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool("list_vulnerability_manifests", request.Params.Arguments.(map[string]interface{}))
+		return ksServer.CallTool(ctx, "list_vulnerability_manifests", request.Params.Arguments.(map[string]interface{}))
 	})
 
 	listVulnerabilitiesTool := mcp.NewTool(
@@ -53,7 +53,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(listVulnerabilitiesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool("list_vulnerabilities_in_manifest", request.Params.Arguments.(map[string]interface{}))
+		return ksServer.CallTool(ctx, "list_vulnerabilities_in_manifest", request.Params.Arguments.(map[string]interface{}))
 	})
 
 	listVulnerabilityMatchesForCVE := mcp.NewTool(
@@ -73,7 +73,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(listVulnerabilityMatchesForCVE, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool("list_vulnerability_matches_for_cve", request.Params.Arguments.(map[string]interface{}))
+		return ksServer.CallTool(ctx, "list_vulnerability_matches_for_cve", request.Params.Arguments.(map[string]interface{}))
 	})
 
 	vulnerabilityManifestTemplate := mcp.NewResourceTemplate(
@@ -98,7 +98,7 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(listConfigsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool("list_configuration_security_scan_manifests", request.Params.Arguments.(map[string]interface{}))
+		return ksServer.CallTool(ctx, "list_configuration_security_scan_manifests", request.Params.Arguments.(map[string]interface{}))
 	})
 
 	getConfigDetailsTool := mcp.NewTool(
@@ -114,7 +114,7 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(getConfigDetailsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool("get_configuration_security_scan_manifest", request.Params.Arguments.(map[string]interface{}))
+		return ksServer.CallTool(ctx, "get_configuration_security_scan_manifest", request.Params.Arguments.(map[string]interface{}))
 	})
 
 	configManifestTemplate := mcp.NewResourceTemplate(
@@ -253,7 +253,7 @@ func (ksServer *KubescapeMcpserver) ReadConfigurationResource(ctx context.Contex
 	}}, nil
 }
 
-func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
+func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	switch name {
 	case "list_vulnerability_manifests":
 		//namespace, ok := arguments["namespace"]
@@ -281,9 +281,9 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		var manifests *v1beta1.VulnerabilityManifestList
 		var err error
 		if labelSelector == "" {
-			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		} else {
-			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{
+			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 				LabelSelector: labelSelector,
 			})
 		}
@@ -348,7 +348,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		if !ok {
 			return nil, fmt.Errorf("manifest_name must be a string")
 		}
-		manifest, err := ksServer.ksClient.VulnerabilityManifests(namespaceStr).Get(context.Background(), manifestNameStr, metav1.GetOptions{})
+		manifest, err := ksServer.ksClient.VulnerabilityManifests(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get vulnerability manifest: %s", err)
 		}
@@ -393,7 +393,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		if !ok {
 			return nil, fmt.Errorf("cve_id must be a string")
 		}
-		manifest, err := ksServer.ksClient.VulnerabilityManifests(namespaceStr).Get(context.Background(), manifestNameStr, metav1.GetOptions{})
+		manifest, err := ksServer.ksClient.VulnerabilityManifests(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get vulnerability manifest: %s", err)
 		}
@@ -424,7 +424,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		if !ok {
 			return nil, fmt.Errorf("namespace must be a string")
 		}
-		manifests, err := ksServer.ksClient.WorkloadConfigurationScans(namespaceStr).List(context.Background(), metav1.ListOptions{})
+		manifests, err := ksServer.ksClient.WorkloadConfigurationScans(namespaceStr).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -475,7 +475,7 @@ func (ksServer *KubescapeMcpserver) CallTool(name string, arguments map[string]i
 		if !ok {
 			return nil, fmt.Errorf("manifest_name must be a string")
 		}
-		manifest, err := ksServer.ksClient.WorkloadConfigurationScans(namespaceStr).Get(context.Background(), manifestNameStr, metav1.GetOptions{})
+		manifest, err := ksServer.ksClient.WorkloadConfigurationScans(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get configuration manifest: %s", err)
 		}


### PR DESCRIPTION
## Overview
`CallTool` did not accept a `context.Context` parameter, so all Kubernetes API calls inside it used `context.Background()`, ignoring the request context passed by the MCP framework. This meant client disconnection or request timeout was never propagated — Kubernetes API calls kept running even after the client had gone away.

By contrast, `ReadResource` and `ReadConfigurationResource` already correctly used the passed `ctx`. This fix makes `CallTool` consistent with them.

Changes:
- Added `ctx context.Context` as first parameter to `CallTool`
- Updated all 5 tool handler callers to pass `ctx`
- Replaced all 6 `context.Background()` calls inside `CallTool` with `ctx`

## How to Test

go test ./cmd/mcpserver/... -v

All tests pass.

## Related issues/PRs
* Resolves #2145

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved how the MCP server handles request timeouts and cancellation for vulnerability manifest operations, CVE matching, and configuration security scans, ensuring operations properly respect timeout signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2146)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->