### PR TITLE
fix: anonymize labels-to-copy values when --hide flag is set

### DIFF
--- a/core/pkg/anonymizer/anonymizer_test.go
+++ b/core/pkg/anonymizer/anonymizer_test.go
@@ -225,3 +225,75 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 	_, inAttackTracks := session.ResourceAttackTracks[newID]
 	assert.True(t, inAttackTracks, "ResourceAttackTracks must use remapped ID as key")
 }
+
+func TestAnonymizeSession_LabelsToCopyAreAnonymized(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "my-pod",
+			"namespace": "default",
+			"labels": map[string]interface{}{
+				"team": "payments",
+				"env":  "production",
+			},
+		},
+	})
+
+	oldID := pod.GetID()
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		LabelsToCopy:         []string{"team", "env"},
+	}
+
+	m := NewMapping()
+	anonymizeSession(session, m)
+
+	for _, r := range session.AllResources {
+		wl, ok := r.(workloadinterface.IWorkload)
+		assert.True(t, ok)
+		labels := wl.GetLabels()
+		assert.NotEqual(t, "payments", labels["team"], "label value team must be anonymized")
+		assert.NotEqual(t, "production", labels["env"], "label value env must be anonymized")
+		assert.NotEmpty(t, labels["team"], "label key must still exist")
+		assert.NotEmpty(t, labels["env"], "label key must still exist")
+	}
+}
+
+func TestAnonymizeSession_EmptyLabelsToCopy_LabelsUnchanged(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "my-pod",
+			"namespace": "default",
+			"labels": map[string]interface{}{
+				"team": "payments",
+			},
+		},
+	})
+
+	oldID := pod.GetID()
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		LabelsToCopy:         []string{},
+	}
+
+	m := NewMapping()
+	anonymizeSession(session, m)
+
+	for _, r := range session.AllResources {
+		wl, ok := r.(workloadinterface.IWorkload)
+		assert.True(t, ok)
+		labels := wl.GetLabels()
+		assert.Equal(t, "payments", labels["team"], "label must be unchanged when LabelsToCopy is empty")
+	}
+}

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -28,6 +28,10 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 		}
 		anonymizeContainerMetadata(resource, mapping)
 
+		if len(session.LabelsToCopy) > 0 {
+			anonymizeResourceLabels(resource, session.LabelsToCopy, mapping)
+		}
+
 		newID := resource.GetID()
 		idMapping[oldID] = newID
 		newAllResources[newID] = resource
@@ -120,4 +124,20 @@ func resolveMappedID(mapping *Mapping, idMapping map[string]string, originalID, 
 	}
 
 	return mapping.GetOrCreate(prefix, originalID)
+}
+
+func anonymizeResourceLabels(resource workloadinterface.IMetadata, labelsToCopy []string, mapping *Mapping) {
+	bw, ok := resource.(workloadinterface.IWorkload)
+	if !ok {
+		return
+	}
+	labels := bw.GetLabels()
+	if len(labels) == 0 {
+		return
+	}
+	for _, key := range labelsToCopy {
+		if val, exists := labels[key]; exists && val != "" {
+			bw.SetLabel(key, mapping.GetOrCreate("lbl", val))
+		}
+	}
 }


### PR DESCRIPTION
## Overview
When `--hide` is used together with `--labels-to-copy`, label values copied from workloads into the JSON scan output were not anonymized. The anonymizer handled names, namespaces, container names, and images — but never touched `resourceLabels`. Labels like `team=payments` or `env=production` appeared in plain text in the output despite `--hide` being set.

This fix adds `anonymizeResourceLabels` to `session.go` which anonymizes label values for any labels specified in `LabelsToCopy`, using the same `Mapping.GetOrCreate` mechanism used for names and namespaces. Label keys are preserved so the output structure remains intact.

## How to Test
```bash
go test ./core/pkg/anonymizer/... -v
```

All 12 tests pass.

## Related issues/PRs
Closes #2147

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced label anonymization: Workload labels can now be selectively anonymized based on configuration. When specific labels are designated for processing, their values are anonymized while retaining the label keys. When no labels are designated, values remain unchanged.

* **Tests**
  * Added comprehensive test coverage for label anonymization behavior in different configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->