### PR TITLE
docs: fix misleading Short and Long description in patch command

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -31,8 +31,8 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 
 	patchCmd := &cobra.Command{
 		Use:     "patch --image <image>:<tag> [flags]",
-		Short:   "Patch container images with vulnerabilities",
-		Long:    `Patch command is for automatically patching images with vulnerabilities.`,
+		Short:   "Patch container images to fix known OS-level vulnerabilities",
+		Long:    `Automatically patch container images to remediate known OS-level vulnerabilities using Copa and BuildKit.`,
 		Example: patchCmdExamples,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -18,8 +18,8 @@ func TestGetPatchCmd(t *testing.T) {
 
 	// Verify the command name and short description
 	assert.Equal(t, "patch --image <image>:<tag> [flags]", cmd.Use)
-	assert.Equal(t, "Patch container images with vulnerabilities", cmd.Short)
-	assert.Equal(t, "Patch command is for automatically patching images with vulnerabilities.", cmd.Long)
+	assert.Equal(t, "Patch container images to fix known OS-level vulnerabilities", cmd.Short)
+	assert.Equal(t, "Automatically patch container images to remediate known OS-level vulnerabilities using Copa and BuildKit.", cmd.Long)
 	assert.Equal(t, patchCmdExamples, cmd.Example)
 
 	err := cmd.Args(&cobra.Command{}, []string{})


### PR DESCRIPTION
## Overview
The `patch` command's `Short` and `Long` descriptions said "patch container images with vulnerabilities" which reads as if the command injects vulnerabilities into images rather than fixing them. Updated both descriptions to clearly convey the command's purpose.

## How to Test
```bash
kubescape patch --help
go test ./cmd/patch/... -v
```

## Related issues/PRs
Closes #2149

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Refreshed the patch command's help documentation with improved text and descriptions. The updated documentation now better explains the command's purpose: remediating known OS-level vulnerabilities in container images. It also details the use of Copa and BuildKit technologies for automated vulnerability remediation and container image patching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2150)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->