### PR TITLE
Fix field selector state carryover across resource queries

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -351,7 +351,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		if err != nil {
 			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
 				qr := queryableResources[i]
-			failedQueries[qr.String()] = queryFailure{
+				failedQueries[qr.String()] = queryFailure{
 					gvr: queryableResources[i].GroupVersionResourceTriplet,
 					err: err,
 				}
@@ -397,12 +397,20 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 	}
 }
 
-func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, error) {
+func (k8sHandler *K8sResourceHandler) pullSingleResource(
+	resource *schema.GroupVersionResource,
+	labels map[string]string,
+	fields string,
+	fieldSelector IFieldSelector,
+) ([]unstructured.Unstructured, error) {
+
 	var resourceList []unstructured.Unstructured
-	// set labels
-	listOptions := metav1.ListOptions{}
+
 	fieldSelectors := fieldSelector.GetNamespacesSelectors(resource)
+
 	for i := range fieldSelectors {
+		listOptions := metav1.ListOptions{}
+
 		if fieldSelectors[i] != "" {
 			listOptions.FieldSelector = combineFieldSelectors(fieldSelectors[i], fields)
 		} else if fields != "" {
@@ -414,29 +422,53 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupV
 			listOptions.LabelSelector = set.AsSelector().String()
 		}
 
-		// set dynamic object
 		clientResource := k8sHandler.k8s.DynamicClient.Resource(*resource)
 
-		// list resources
 		lenBefore := len(resourceList)
+
 		if err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return clientResource.List(ctx, opts)
 		}).EachListItem(context.Background(), listOptions, func(obj runtime.Object) error {
+
 			uObject := obj.(*unstructured.Unstructured)
-			if k8sinterface.IsTypeWorkload(uObject.Object) && k8sinterface.WorkloadHasParent(workloadinterface.NewWorkloadObj(uObject.Object)) {
-				logger.L().Debug("Skipping resource with parent", helpers.String("resource", resource.String()), helpers.String("namespace", uObject.GetNamespace()), helpers.String("name", uObject.GetName()))
+
+			if k8sinterface.IsTypeWorkload(uObject.Object) &&
+				k8sinterface.WorkloadHasParent(workloadinterface.NewWorkloadObj(uObject.Object)) {
+
+				logger.L().Debug(
+					"Skipping resource with parent",
+					helpers.String("resource", resource.String()),
+					helpers.String("namespace", uObject.GetNamespace()),
+					helpers.String("name", uObject.GetName()),
+				)
+
 				return nil
 			}
+
 			resourceList = append(resourceList, *obj.(*unstructured.Unstructured))
 			return nil
+
 		}); err != nil {
-			return nil, fmt.Errorf("failed to get resource: %v, labelSelector: %v, fieldSelector: %v, reason: %w", resource, listOptions.LabelSelector, listOptions.FieldSelector, err)
+
+			return nil, fmt.Errorf(
+				"failed to get resource: %v, labelSelector: %v, fieldSelector: %v, reason: %w",
+				resource,
+				listOptions.LabelSelector,
+				listOptions.FieldSelector,
+				err,
+			)
 		}
-		logger.L().Debug("Pulled resources", helpers.String("resource", resource.String()), helpers.String("fieldSelector", listOptions.FieldSelector), helpers.String("labelSelector", listOptions.LabelSelector), helpers.Int("count", len(resourceList)-lenBefore))
+
+		logger.L().Debug(
+			"Pulled resources",
+			helpers.String("resource", resource.String()),
+			helpers.String("fieldSelector", listOptions.FieldSelector),
+			helpers.String("labelSelector", listOptions.LabelSelector),
+			helpers.Int("count", len(resourceList)-lenBefore),
+		)
 	}
 
 	return resourceList, nil
-
 }
 func ConvertMapListToMeta(resourceMap []map[string]interface{}) []workloadinterface.IMetadata {
 	var workloads []workloadinterface.IMetadata

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -19,12 +19,79 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
 
+type staticFieldSelector struct {
+	selectors []string
+}
+
+func (s *staticFieldSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
+	return s.selectors
+}
+func (s *staticFieldSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
+	return false
+}
+func TestPullSingleResource_FieldSelectorDoesNotLeakAcrossIterations(t *testing.T) {
+	var capturedSelectors []string
+
+	podList := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+	}
+
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListAction)
+		require.True(t, ok)
+
+		capturedSelectors = append(
+			capturedSelectors,
+			listAction.GetListRestrictions().Fields.String(),
+		)
+
+		return true, podList, nil
+	})
+
+	resource := &schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+
+	fieldSelector := &staticFieldSelector{
+		selectors: []string{
+			"metadata.namespace=test-ns",
+			"",
+		},
+	}
+
+	_, err := handler.pullSingleResource(
+		resource,
+		nil,
+		"",
+		fieldSelector,
+	)
+
+	require.NoError(t, err)
+
+	require.Len(t, capturedSelectors, 2)
+
+	assert.Equal(t,
+		"metadata.namespace=test-ns",
+		capturedSelectors[0],
+	)
+
+	assert.Equal(t,
+		"",
+		capturedSelectors[1],
+	)
+}
+
 // gvrToListKind registers the GVRs used in these tests so the fake dynamic
 // client doesn't panic when List is called on them.
 var testGVRToListKind = map[schema.GroupVersionResource]string{
 	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
-	{Group: "", Version: "v1", Resource: "pods"}: "PodList",
-	{Group: "", Version: "v1", Resource: "somecrd"}:                                       "SomeCRDList",
+	{Group: "", Version: "v1", Resource: "pods"}:                                         "PodList",
+	{Group: "", Version: "v1", Resource: "somecrd"}:                                      "SomeCRDList",
 }
 
 // newHandlerWithReactor builds a K8sResourceHandler whose dynamic client


### PR DESCRIPTION
## Summary

Fixes stale `FieldSelector` state leakage across iterations in `pullSingleResource`.

`metav1.ListOptions` was initialized outside the namespace selector loop. When one iteration populated `FieldSelector` and a later iteration used an empty selector, the stale selector value persisted into the subsequent Kubernetes API query.

This could unintentionally constrain broad/unscoped queries to the previously queried namespace and silently skip resources during scans.

## Fix

Move `metav1.ListOptions{}` initialization inside the selector iteration loop so each query starts with clean state.

## Testing

Added regression coverage validating that:

* scoped queries preserve their selector
* subsequent empty-selector queries do not inherit stale namespace filters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized resource-pulling logic and formatting for readability while preserving existing behavior; improved debug logging and error reporting that show selector context and pulled counts.

* **Tests**
  * Added a test ensuring field-selector restrictions do not leak between iterations.
  * Added a static field-selector test helper to support selector-specific test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2154)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->