### PR TITLE
fix(anonymizer): support unstructured container metadata anonymization

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -1,7 +1,6 @@
 package anonymizer
 
 import (
-	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -40,6 +39,16 @@ func anonymizePodSpecs(node interface{}, mapping *Mapping) {
 	}
 }
 
+func anonymizeContainerFields(container map[string]interface{}, mapping *Mapping) {
+	if name, ok := container["name"].(string); ok && name != "" {
+		container["name"] = mapping.GetOrCreate("ctr", name)
+	}
+
+	if image, ok := container["image"].(string); ok && image != "" {
+		container["image"] = mapping.GetOrCreate("img", image)
+	}
+}
+
 func anonymizeContainerList(
 	obj map[string]interface{},
 	key string,
@@ -50,26 +59,33 @@ func anonymizeContainerList(
 		return
 	}
 
-	data, err := json.Marshal(rawContainers)
-	if err != nil {
+	if containers, ok := rawContainers.([]corev1.Container); ok {
+		for i := range containers {
+			if containers[i].Name != "" {
+				containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+			}
+
+			if containers[i].Image != "" {
+				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+			}
+		}
+
+		obj[key] = containers
 		return
 	}
 
-	var containers []corev1.Container
-	if err := json.Unmarshal(data, &containers); err != nil {
-		return
-	}
+	if containers, ok := rawContainers.([]interface{}); ok {
+		for _, item := range containers {
+			container, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
-	for i := range containers {
-		if containers[i].Name != "" {
-			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+			anonymizeContainerFields(container, mapping)
 		}
-		if containers[i].Image != "" {
-			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
-		}
-	}
 
-	obj[key] = containers
+		obj[key] = containers
+	}
 }
 
 func anonymizeEphemeralContainerList(
@@ -82,24 +98,31 @@ func anonymizeEphemeralContainerList(
 		return
 	}
 
-	data, err := json.Marshal(rawContainers)
-	if err != nil {
+	if containers, ok := rawContainers.([]corev1.EphemeralContainer); ok {
+		for i := range containers {
+			if containers[i].Name != "" {
+				containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+			}
+
+			if containers[i].Image != "" {
+				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+			}
+		}
+
+		obj[key] = containers
 		return
 	}
 
-	var containers []corev1.EphemeralContainer
-	if err := json.Unmarshal(data, &containers); err != nil {
-		return
-	}
+	if containers, ok := rawContainers.([]interface{}); ok {
+		for _, item := range containers {
+			container, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
-	for i := range containers {
-		if containers[i].Name != "" {
-			containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+			anonymizeContainerFields(container, mapping)
 		}
-		if containers[i].Image != "" {
-			containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
-		}
-	}
 
-	obj[key] = containers
+		obj[key] = containers
+	}
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -4,101 +4,183 @@ import (
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
-	corev1 "k8s.io/api/core/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func TestAnonymizeContainerList_AnonymizesNamesAndImages(t *testing.T) {
-	obj := map[string]interface{}{
-		"containers": []interface{}{
-			map[string]interface{}{
-				"name":  "my-secret-app",
-				"image": "private.registry.io/app:v1",
+func TestAnonymizeContainerMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   map[string]interface{}
+		validate func(t *testing.T, spec map[string]interface{})
+	}{
+		{
+			name: "typed containers should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []corev1.Container{
+						{
+							Name:  "payment-api",
+							Image: "nginx:latest",
+						},
+					},
+				},
 			},
-			map[string]interface{}{
-				"name":  "sidecar",
-				"image": "private.registry.io/sidecar:v1",
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]corev1.Container)
+				assert.True(t, ok, "expected typed containers")
+				assert.Len(t, containers, 1)
+
+				assert.NotEqual(t, "payment-api", containers[0].Name)
+				assert.NotEqual(t, "nginx:latest", containers[0].Image)
+				assert.Contains(t, containers[0].Name, "ctr-")
+				assert.Contains(t, containers[0].Image, "img-")
+			},
+		},
+		{
+			name: "unstructured containers should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "payment-api",
+							"image": "nginx:latest",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]interface{})
+				assert.True(t, ok, "expected unstructured containers")
+				assert.Len(t, containers, 1)
+
+				container, ok := containers[0].(map[string]interface{})
+				assert.True(t, ok, "expected unstructured container map")
+
+				assert.NotEqual(t, "payment-api", container["name"])
+				assert.NotEqual(t, "nginx:latest", container["image"])
+				assert.Contains(t, container["name"], "ctr-")
+				assert.Contains(t, container["image"], "img-")
+			},
+		},
+		{
+			name: "typed init containers should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"initContainers": []corev1.Container{
+						{
+							Name:  "init-db",
+							Image: "postgres:latest",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["initContainers"].([]corev1.Container)
+				assert.True(t, ok, "expected typed init containers")
+				assert.Len(t, containers, 1)
+
+				assert.NotEqual(t, "init-db", containers[0].Name)
+				assert.NotEqual(t, "postgres:latest", containers[0].Image)
+				assert.Contains(t, containers[0].Name, "ctr-")
+				assert.Contains(t, containers[0].Image, "img-")
+			},
+		},
+		{
+			name: "typed ephemeral containers should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"ephemeralContainers": []corev1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name:  "debug-shell",
+								Image: "busybox:latest",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["ephemeralContainers"].([]corev1.EphemeralContainer)
+				assert.True(t, ok, "expected typed ephemeral containers")
+				assert.Len(t, containers, 1)
+
+				assert.NotEqual(t, "debug-shell", containers[0].Name)
+				assert.NotEqual(t, "busybox:latest", containers[0].Image)
+				assert.Contains(t, containers[0].Name, "ctr-")
+				assert.Contains(t, containers[0].Image, "img-")
+			},
+		},
+		{
+			name: "unstructured ephemeral containers should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"ephemeralContainers": []interface{}{
+						map[string]interface{}{
+							"name":  "debug-shell",
+							"image": "busybox:latest",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["ephemeralContainers"].([]interface{})
+				assert.True(t, ok, "expected unstructured ephemeral containers")
+				assert.Len(t, containers, 1)
+
+				container, ok := containers[0].(map[string]interface{})
+				assert.True(t, ok, "expected unstructured ephemeral container map")
+
+				assert.NotEqual(t, "debug-shell", container["name"])
+				assert.NotEqual(t, "busybox:latest", container["image"])
+				assert.Contains(t, container["name"], "ctr-")
+				assert.Contains(t, container["image"], "img-")
 			},
 		},
 	}
 
-	m := NewMapping()
-	anonymizeContainerList(obj, "containers", m)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapping := NewMapping()
+			resource := workloadinterface.NewWorkloadObj(test.object)
 
-	containers, ok := obj["containers"].([]corev1.Container)
-	assert.True(t, ok, "after fix, containers must be []corev1.Container")
-	assert.Len(t, containers, 2)
-	assert.NotEqual(t, "my-secret-app", containers[0].Name)
-	assert.NotEqual(t, "private.registry.io/app:v1", containers[0].Image)
-	assert.NotEqual(t, "sidecar", containers[1].Name)
-	assert.NotEqual(t, "private.registry.io/sidecar:v1", containers[1].Image)
-	assert.Contains(t, containers[0].Name, "ctr-")
-	assert.Contains(t, containers[0].Image, "img-")
-}
+			anonymizeContainerMetadata(resource, mapping)
 
-func TestAnonymizeContainerMetadata_AnonymizesContainerNamesAndImages(t *testing.T) {
-	resource := workloadinterface.NewWorkloadObj(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Pod",
-		"metadata": map[string]interface{}{
-			"name":      "my-pod",
-			"namespace": "default",
-		},
-		"spec": map[string]interface{}{
-			"containers": []interface{}{
-				map[string]interface{}{
-					"name":  "secret-container",
-					"image": "private.io/app:v1",
-				},
-			},
-		},
-	})
+			spec, ok := resource.GetObject()["spec"].(map[string]interface{})
+			assert.True(t, ok, "expected spec to be a map[string]interface{}")
 
-	m := NewMapping()
-	anonymizeContainerMetadata(resource, m)
-
-	obj := resource.GetObject()
-	spec := obj["spec"].(map[string]interface{})
-	containers, ok := spec["containers"].([]corev1.Container)
-	assert.True(t, ok)
-	assert.Len(t, containers, 1)
-	assert.NotEqual(t, "secret-container", containers[0].Name)
-	assert.NotEqual(t, "private.io/app:v1", containers[0].Image)
-	assert.Contains(t, containers[0].Name, "ctr-")
-	assert.Contains(t, containers[0].Image, "img-")
+			test.validate(t, spec)
+		})
+	}
 }
 
 func TestAnonymizeContainerList_MissingKey(t *testing.T) {
 	obj := map[string]interface{}{}
-	m := NewMapping()
-	anonymizeContainerList(obj, "containers", m)
+	mapping := NewMapping()
+
+	assert.NotPanics(t, func() {
+		anonymizeContainerList(obj, "containers", mapping)
+	})
 }
 
 func TestAnonymizeContainerList_NilValue(t *testing.T) {
-	obj := map[string]interface{}{"containers": nil}
-	m := NewMapping()
-	anonymizeContainerList(obj, "containers", m)
+	obj := map[string]interface{}{
+		"containers": nil,
+	}
+	mapping := NewMapping()
+
+	assert.NotPanics(t, func() {
+		anonymizeContainerList(obj, "containers", mapping)
+	})
 }
 
-func TestAnonymizeEphemeralContainerList_AnonymizesNamesAndImages(t *testing.T) {
-	// Simulate runtime shape: []interface{} with map[string]interface{} items
+func TestAnonymizeContainerList_InvalidType(t *testing.T) {
 	obj := map[string]interface{}{
-		"ephemeralContainers": []interface{}{
-			map[string]interface{}{
-				"name":  "debug-container",
-				"image": "private.registry.io/debug:v1",
-			},
-		},
+		"containers": "invalid",
 	}
+	mapping := NewMapping()
 
-	m := NewMapping()
-	anonymizeEphemeralContainerList(obj, "ephemeralContainers", m)
-
-	containers, ok := obj["ephemeralContainers"].([]corev1.EphemeralContainer)
-	assert.True(t, ok, "after fix, ephemeral containers must be []corev1.EphemeralContainer")
-	assert.Len(t, containers, 1)
-	assert.NotEqual(t, "debug-container", containers[0].Name)
-	assert.NotEqual(t, "private.registry.io/debug:v1", containers[0].Image)
-	assert.Contains(t, containers[0].Name, "ctr-")
-	assert.Contains(t, containers[0].Image, "img-")
+	assert.NotPanics(t, func() {
+		anonymizeContainerList(obj, "containers", mapping)
+	})
 }


### PR DESCRIPTION
Part of #1200

### Problem

Kubernetes object handling can surface container metadata in different representations depending on the object source:

typed Go objects (`[]corev1.Container, []corev1.EphemeralContainer`)
unstructured objects (`[]interface{} / map[string]interface{}`)

Both are valid shapes, and limiting anonymization to a single representation can leave container metadata unanonymized in certain paths. A dual handling approach ensures robust coverage without affecting the current scan flow.

### Changes introduced in this PR

* Added support for anonymizing container metadata from both typed and unstructured object representations
* Extended container metadata anonymization to:
 containers
 initContainers
 ephemeralContainers
 Refactored container field anonymization to reuse shared logic for name and image handling
### Added unit test coverage for:
- typed containers
- unstructured containers
- typed ephemeral containers
- unstructured ephemeral containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable anonymization of container names and images across both typed and unstructured container definitions, with improved performance and fallback handling for unexpected types.
  * Better coverage of container metadata across various workload structures.

* **Tests**
  * Consolidated into a table-driven test suite covering standard and ephemeral containers in multiple data shapes; added edge-case checks to ensure no panics on invalid types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2155)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->