### PR TITLE
Preserve existing file permissions during fix rewrites

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -511,8 +511,12 @@ func GetFileString(filepath string) (string, error) {
 }
 
 func writeFixesToFile(filepath, content string) error {
-	err := os.WriteFile(filepath, []byte(content), 0644) //nolint:gosec
+	info, err := os.Stat(filepath)
+	if err != nil {
+		return fmt.Errorf("error getting file permissions: %w", err)
+	}
 
+	err = os.WriteFile(filepath, []byte(content), info.Mode()) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("error writing fixes to file: %w", err)
 	}

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- helpers --------------------------------------------------------------
@@ -203,7 +205,7 @@ func TestPrepareResourcesToFix_ClassifiesFixedAndUnfixed(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				// fixable
@@ -281,7 +283,7 @@ func TestPrepareResourcesToFix_SkipUserValuesReason(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0076", "Label usage",
@@ -306,7 +308,7 @@ func TestPrepareResourcesToFix_MissingFile(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0057", "Privileged",
@@ -332,7 +334,7 @@ func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0057", "Privileged",
@@ -493,6 +495,34 @@ func TestApplyChanges_OnlyCountsSuccessfulWrites(t *testing.T) {
 	count, errs := h.ApplyChanges(context.Background(), []ResourceFixInfo{rfi})
 	assert.Equal(t, 0, count, "write failed → file must not be counted as updated")
 	assert.NotEmpty(t, errs)
+}
+
+func TestWriteFixesToFile_PreservesFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on windows")
+	}
+
+	dir := t.TempDir()
+
+	manifest := writeManifest(t, dir, "deploy.yaml",
+		"apiVersion: v1\nkind: Pod\n")
+
+	originalMode := os.FileMode(0600)
+
+	if err := os.Chmod(manifest, originalMode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	err := writeFixesToFile(manifest,
+		"apiVersion: v1\nkind: Pod\nmetadata:\n  name: updated\n",
+	)
+
+	require.NoError(t, err)
+
+	info, err := os.Stat(manifest)
+	require.NoError(t, err)
+
+	assert.Equal(t, originalMode, info.Mode().Perm())
 }
 
 func TestUnfixedControls_ReturnsCopy(t *testing.T) {


### PR DESCRIPTION
## Overview

Preserve existing file permissions when `kubescape fix` rewrites manifest files.

`writeFixesToFile` previously rewrote files using a fixed `0644` mode:

```go
os.WriteFile(filepath, []byte(content), 0644)
```

This discarded the original file permissions on every rewrite.

As a result:

* executable bits could be lost
* stricter permissions (for example `0600`) could be weakened
* existing operator-defined file modes were not preserved

## Fix

Read the existing file mode via `os.Stat()` and reuse it during the rewrite operation.

## How to Test

Run:

```bash
go test ./core/pkg/fixhandler/...
```

Added regression coverage validating that rewritten files preserve their original permissions on Unix-like systems.

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the fix handler would reset file permissions to default values when writing updates. Files now properly retain their original permission mode after fixes are applied.

* **Tests**
  * Added a new test suite to verify that file permission modes are correctly preserved when applying fixes, ensuring consistent behavior across different platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->