### PR TITLE
Avoid nil source dereference in report marshal logging

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -159,12 +159,16 @@ func (report *ReportEventReceiver) setResults(reportObj *reporthandlingv2.Postur
 		if results, ok := prioritizedResources[resourceID]; ok {
 			v.PrioritizedResource = &results
 		}
+		sourcePath := ""
+		if source := resource.GetSource(); source != nil {
+			sourcePath = source.RelativePath
+		}
 
 		r, err := json.Marshal(v)
 		if err != nil {
 			logger.L().Error("failed to marshal resource to JSON - skipping",
 				helpers.Error(err),
-				helpers.String("file", resource.GetSource().RelativePath),
+				helpers.String("file", sourcePath),
 			)
 			continue
 		}
@@ -206,11 +210,15 @@ func (report *ReportEventReceiver) setResources(reportObj *reporthandlingv2.Post
 		if r, ok := resourcesSource[resourceID]; ok {
 			resource.SetSource(&r)
 		}
+		sourcePath := ""
+		if source := resource.GetSource(); source != nil {
+			sourcePath = source.RelativePath
+		}
 		r, err := json.Marshal(resource)
 		if err != nil {
 			logger.L().Error("failed to marshal resource to JSON - skipping",
 				helpers.Error(err),
-				helpers.String("file", resource.GetSource().RelativePath),
+				helpers.String("file", sourcePath),
 			)
 			continue
 		}


### PR DESCRIPTION
## Overview

Avoid a potential nil dereference while handling resource marshal failures in `reporteventreceiver`.

Both `setResults` and `setResources` logged the failing resource path using:

```go id="v9m2qx"
resource.GetSource().RelativePath
```

However, `SetSource()` is only applied conditionally when an entry exists in `resourcesSource`.

If a marshal failure occurred for a resource without an attached source, the error-handling path itself could panic while attempting to log the missing source path.

## Fix

Safely extract the source path only when `resource.GetSource()` is non-nil before emitting the log message.

This preserves the existing logging behavior while avoiding secondary panics during marshal error handling.

## How to Test

Run:

```bash id="x6q1vn"
go test ./core/pkg/resultshandling/reporter/v2/...
```

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging reliability in report generation to handle edge cases gracefully and prevent potential failures during resource processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->