### PR TITLE
Fix master node taint classification

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -293,8 +293,7 @@ func (h *FixHandler) PrintUnfixedControls(phase Phase) {
 
 	deduped := dedupUnfixedControls(h.unfixedControls)
 	var sb strings.Builder
-	totalFailed := h.fixedControlsCount + len(h.unfixedControls)
-
+	totalFailed := h.fixedControlsCount + len(deduped)
 	verb := "Would auto-fix"
 	if phase == PhaseApplied {
 		verb = "Auto-fixed"

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -203,7 +203,7 @@ func TestPrepareResourcesToFix_ClassifiesFixedAndUnfixed(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				// fixable
@@ -281,7 +281,7 @@ func TestPrepareResourcesToFix_SkipUserValuesReason(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0076", "Label usage",
@@ -306,7 +306,7 @@ func TestPrepareResourcesToFix_MissingFile(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0057", "Privileged",
@@ -332,7 +332,7 @@ func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
 
 	results := []resourcesresults.Result{
 		{
-			ResourceID: res.GetID(),
+			ResourceID:  res.GetID(),
 			RawResource: res,
 			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
 				failedControl("C-0057", "Privileged",

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -351,7 +351,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		if err != nil {
 			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
 				qr := queryableResources[i]
-			failedQueries[qr.String()] = queryFailure{
+				failedQueries[qr.String()] = queryFailure{
 					gvr: queryableResources[i].GroupVersionResourceTriplet,
 					err: err,
 				}
@@ -526,16 +526,15 @@ func (k8sHandler *K8sResourceHandler) setCloudProvider() error {
 // NoSchedule taint with empty value is usually applied to controlplane
 func isMasterNodeTaints(taints []v1.Taint) bool {
 	for _, taint := range taints {
-		if taint.Effect == v1.TaintEffectNoSchedule {
-			// NoSchedule taint with empty value is usually applied to controlplane
-			if taint.Value == "" {
-				return true
-			}
-
-			if taint.Key == "node-role.kubernetes.io/control-plane" && taint.Value == "true" {
-				return true
-			}
+		if taint.Effect != v1.TaintEffectNoSchedule {
+			continue
+		}
+		switch taint.Key {
+		case "node-role.kubernetes.io/master",
+			"node-role.kubernetes.io/control-plane":
+			return true
 		}
 	}
+
 	return false
 }

--- a/core/pkg/resourcehandler/k8sresources_test.go
+++ b/core/pkg/resourcehandler/k8sresources_test.go
@@ -534,7 +534,7 @@ func TestIsMasterNodeTaints(t *testing.T) {
 `
 	var taintNode v1.Node
 	_ = json.Unmarshal([]byte(taintNodeJson), &taintNode)
-	assert.True(t, isMasterNodeTaints(taintNode.Spec.Taints))
+	assert.False(t, isMasterNodeTaints(taintNode.Spec.Taints))
 
 	taintNodeJson1 :=
 		`

--- a/core/pkg/resourcehandler/k8sresources_test.go
+++ b/core/pkg/resourcehandler/k8sresources_test.go
@@ -629,3 +629,50 @@ func TestCloudResourceRequired(t *testing.T) {
 	assert.True(t, cloudResourceRequired(cloudResources, ClusterDescribe))
 	assert.False(t, cloudResourceRequired(cloudResources, "ListRolePolicies"))
 }
+
+func Test_isMasterNodeTaints(t *testing.T) {
+	tests := []struct {
+		name   string
+		taints []v1.Taint
+		want   bool
+	}{
+		{
+			name: "control plane taint",
+			taints: []v1.Taint{
+				{
+					Key:    "node-role.kubernetes.io/control-plane",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "cordoned worker node taint",
+			taints: []v1.Taint{
+				{
+					Key:    "node.kubernetes.io/unschedulable",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "custom empty-value taint",
+			taints: []v1.Taint{
+				{
+					Key:    "dedicated-gpu",
+					Value:  "",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isMasterNodeTaints(tt.taints))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Fix false-positive master/control-plane node classification in `isMasterNodeTaints` (`core/pkg/resourcehandler/k8sresources.go`).

Previously, the implementation treated any `NoSchedule` taint with an empty value as a master node taint:

```go
if taint.Value == "" {
	return true
}
```

This incorrectly classified legitimate worker-node taints as control-plane taints.

For example, cordoned worker nodes commonly receive:

```yaml
key: node.kubernetes.io/unschedulable
effect: NoSchedule
value: ""
```

Under the previous behavior, these worker nodes were incorrectly excluded from worker-node accounting because they were treated as master nodes.

This change removes the empty-value heuristic and instead explicitly matches standard Kubernetes control-plane taint keys:

* `node-role.kubernetes.io/master`
* `node-role.kubernetes.io/control-plane`

As a result:

* cordoned worker nodes are no longer misclassified
* custom empty-value taints are no longer treated as master taints
* worker-node accounting is more accurate during maintenance/autoscaling scenarios

Also adds regression coverage for:

* standard control-plane taints
* cordoned worker-node taints
* custom empty-value taints

## How to Test

Run the targeted resourcehandler tests:

```bash
go test -count=1 ./core/pkg/resourcehandler -run Test_isMasterNodeTaints -v
```

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have added regression test coverage for the fix
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated master/control-plane node identification logic for NoSchedule taint handling.

* **Bug Fixes**
  * Fixed failed control instances count calculation to use deduplicated values in summary output.

* **Tests**
  * Added comprehensive test coverage for node taint identification.
  * Updated existing node taint behavior tests.

* **Style**
  * Formatting adjustments in test files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2158)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->