### PR TITLE
fix(resourcehandler): dedupe cluster-scoped LISTs under --include-namespaces

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -69,9 +69,18 @@ func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
 	fieldSelectors := []string{}
 	for _, n := range strings.Split(is.namespace, FieldSelectorsSeparator) {
-		if n != "" {
-			fieldSelectors = append(fieldSelectors, getNamespacesSelector(resource.Resource, n, FieldSelectorsEqualsOperator))
+		if n == "" {
+			continue
 		}
+		sel := getNamespacesSelector(resource.Resource, n, FieldSelectorsEqualsOperator)
+		if sel == "" {
+			// Cluster-scoped target: per-namespace filtering is meaningless, so a
+			// single unfiltered query suffices. Returning one entry per namespace
+			// would cause pullSingleResource to LIST the full cluster-scoped
+			// collection N times and append duplicates to k8sResources[gvr].
+			return []string{""}
+		}
+		fieldSelectors = append(fieldSelectors, sel)
 	}
 	return fieldSelectors
 }

--- a/core/pkg/resourcehandler/fieldselector_test.go
+++ b/core/pkg/resourcehandler/fieldselector_test.go
@@ -55,4 +55,15 @@ func TestIncludeNamespacesSelectors(t *testing.T) {
 
 	manyNs := NewIncludeSelector("a,b,c,d,e")
 	assert.Equal(t, []string{""}, manyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "clusterroles"}))
+
+	// empty namespace string: no valid namespace to include, so result is empty
+	emptyNs := NewIncludeSelector("")
+	assert.Empty(t, emptyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"}))
+
+	// malformed input with empty segments: empty segments are skipped
+	malformed := NewIncludeSelector("ns1,,ns3")
+	malformedSelectors := malformed.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"})
+	assert.Equal(t, 2, len(malformedSelectors))
+	assert.Equal(t, "metadata.namespace==ns1", malformedSelectors[0])
+	assert.Equal(t, "metadata.namespace==ns3", malformedSelectors[1])
 }

--- a/core/pkg/resourcehandler/fieldselector_test.go
+++ b/core/pkg/resourcehandler/fieldselector_test.go
@@ -45,4 +45,14 @@ func TestIncludeNamespacesSelectors(t *testing.T) {
 	assert.Equal(t, 2, len(selectors2))
 	assert.Equal(t, "metadata.name==default", selectors2[0])
 	assert.Equal(t, "metadata.name==ingress", selectors2[1])
+
+	// Cluster-scoped resources must collapse to a single unfiltered query
+	// regardless of how many namespaces were included; otherwise
+	// pullSingleResource would LIST the collection once per namespace and
+	// duplicate every cluster-scoped object N times in k8sResources[gvr].
+	clusterScopedSelectors := is.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "nodes"})
+	assert.Equal(t, []string{""}, clusterScopedSelectors)
+
+	manyNs := NewIncludeSelector("a,b,c,d,e")
+	assert.Equal(t, []string{""}, manyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "clusterroles"}))
 }


### PR DESCRIPTION
## Overview
So I found a bug where if you run kubescape with --include-namespaces ns1,ns2,ns3, cluster-scoped resources like ClusterRoles, ClusterRoleBindings, Nodes, etc. were getting listed multiple times. Like, once for each namespace you passed in.

The reason this happens is that IncludeSelector.GetNamespacesSelectors was returning one entry per namespace no matter what. For namespace-scoped stuff like pods, that makes sense. But for cluster-scoped resources, the namespace doesn't mean anything, so each entry just collapsed to an empty string "". And then pullSingleResource would loop over those empty strings and do a full LIST call each time, appending all the objects every single time.
  
So if you passed 3 namespaces, every ClusterRole shows up 3 times in the scan results. The OPA evaluator then sees duplicates and counts the same failing resource multiple times, which messes up your compliance score completely and you'd never know.

The fix is pretty small . I just made it so when the selector comes back empty (which means it's a cluster-scoped resource), we return [""] right away instead of looping and adding duplicates. One LIST, one result, no more bloat.

## How to Test
`
go test ./core/pkg/resourcehandler/...
`

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected namespace filtering to skip empty namespace segments and to treat cluster-scoped resources as unfiltered (collapse namespace selectors).

* **Tests**
  * Expanded test coverage to verify behavior for cluster-scoped resources, empty include strings, and malformed include input with empty segments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2160)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->