### PR TITLE
fix: explicit --cache-dir flag now correctly wins over KS_CACHE_DIR env var

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 			initLogger()
 			initLoggerLevel(cmd)
 			initEnvironment()
-			initCacheDir()
+			initCacheDir(cmd)
 		},
 	}
 

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -58,16 +58,28 @@ func initLoggerLevel(cmd *cobra.Command) {
 	}
 }
 
-func initCacheDir() {
-	if rootInfo.CacheDir != getter.DefaultLocalStore {
-		getter.DefaultLocalStore = rootInfo.CacheDir
-	} else if cacheDir := os.Getenv("KS_CACHE_DIR"); cacheDir != "" {
-		getter.DefaultLocalStore = cacheDir
-	} else {
-		return // using default cache dir location
+func initCacheDir(cmd *cobra.Command) {
+	cacheDirExplicit := false
+	if cmd != nil {
+		// Persistent flags are parsed on the root while traversing to the subcommand.
+		// cmd.Flag("cache-dir") on a child can be a merged copy that never gets Changed=true;
+		// the root flag holds the authoritative parse state (see cobra Traverse + ParseFlags).
+		r := cmd.Root()
+		if f := r.Flag("cache-dir"); f != nil {
+			cacheDirExplicit = f.Changed
+		} else if f := cmd.Flag("cache-dir"); f != nil {
+			cacheDirExplicit = f.Changed
+		}
 	}
-
-	logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+	if !cacheDirExplicit {
+		if cacheDir := os.Getenv("KS_CACHE_DIR"); cacheDir != "" {
+			getter.DefaultLocalStore = cacheDir
+			logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+		}
+	} else {
+		getter.DefaultLocalStore = rootInfo.CacheDir
+		logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+	}
 }
 func initEnvironment() {
 	if rootInfo.DiscoveryServerURL == "" {

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/kubescape/go-logger/helpers"
+
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/go-logger/zaplogger"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -97,5 +99,122 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		initLoggerLevel(versionCmd)
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+}
+
+// testCmdWithCacheDirFlag mirrors root: cache-dir on PersistentFlags, bound to rootInfo.CacheDir.
+func testCmdWithCacheDirFlag(t *testing.T) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "kubescape-test"}
+	c.PersistentFlags().StringVar(&rootInfo.CacheDir, "cache-dir", getter.DefaultLocalStore, "cache dir")
+	return c
+}
+
+func TestInitCacheDir_KSCacheDirPrecedence(t *testing.T) {
+	t.Run("KS_CACHE_DIR applies when --cache-dir flag not set", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, "/tmp/ks-env-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir wins over KS_CACHE_DIR even when value equals default", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		defaultVal := getter.DefaultLocalStore
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		// Pass the default value explicitly — this is the core bug case
+		assert.NoError(t, cmd.ParseFlags([]string{"--cache-dir", defaultVal}))
+
+		initCacheDir(cmd)
+
+		// env var must NOT win; flag value (== default) must be used
+		assert.Equal(t, defaultVal, getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir with non-default value wins over KS_CACHE_DIR", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"--cache-dir", "/tmp/explicit-cache"}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, "/tmp/explicit-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("nil cmd falls back to KS_CACHE_DIR", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+
+		initCacheDir(nil)
+
+		assert.Equal(t, "/tmp/ks-env-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("no flag no env — default store unchanged", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, prevStore, getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir on root wins for subcommand path", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		defaultVal := getter.DefaultLocalStore
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+
+		rootCmd := &cobra.Command{Use: "kubescape"}
+		rootCmd.PersistentFlags().StringVar(&rootInfo.CacheDir, "cache-dir", getter.DefaultLocalStore, "cache dir")
+		scanCmd := &cobra.Command{Use: "scan"}
+		rootCmd.AddCommand(scanCmd)
+		assert.NoError(t, rootCmd.ParseFlags([]string{"--cache-dir", defaultVal}))
+
+		initCacheDir(scanCmd)
+
+		assert.Equal(t, defaultVal, getter.DefaultLocalStore)
 	})
 }


### PR DESCRIPTION
## Problem

`initCacheDir()` used value-equality to decide if `--cache-dir` was explicitly set:

if rootInfo.CacheDir != getter.DefaultLocalStore {

If a user passed `--cache-dir ~/.kubescape` with a value equal to the default,
the condition evaluated to false and `KS_CACHE_DIR` silently overrode the flag —
even though the user explicitly passed it.

## Fix

Accept `cmd *cobra.Command` and check `f.Changed` on the root flag instead,
mirroring the pattern used in `initLoggerLevel()` (#2123).

Precedence is now always: **explicit flag > KS_CACHE_DIR > compiled default**

## Changes
- `cmd/rootutils.go`: `initCacheDir()` → `initCacheDir(cmd *cobra.Command)`
- `cmd/root.go`: updated call site to pass `cmd`
- `cmd/rootutils_test.go`: 6 new subtests covering all cases

## Tests
All 6 subtests pass including the core bug case (flag value == default):

--- PASS: TestInitCacheDir_KSCacheDirPrecedence (6/6)
ok  github.com/kubescape/kubescape/v3/cmd  0.279s

Fixes #2151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache directory handling to properly prioritize explicit `--cache-dir` arguments over environment variables.

* **Tests**
  * Added comprehensive test coverage for cache directory configuration precedence rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->