### PR TITLE
fix: replace read-all with explicit permissions in a-pr-scanner workflow

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -1,5 +1,10 @@
 name: a-pr-scanner
-permissions: read-all
+permissions:
+  contents: read
+  checks: read
+  actions: read
+  packages: read
+  pull-requests: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Overview

The `a-pr-scanner.yaml` workflow had `permissions: read-all` which expands to include `code-quality` and `vulnerability-alerts` scopes. GitHub blocks these two scopes for workflows triggered by fork PRs, causing every contributor using a fork to see this error:

```
The workflow is requesting 'code-quality: read, vulnerability-alerts: read', but is only allowed 'code-quality: none, vulnerability-alerts: none'.
```

Replaced `read-all` with an explicit list of only the permissions the workflow actually needs. This removes the two restricted scopes while keeping everything required for build, lint, and test steps.

## How to Test

Open a PR from a fork against kubescape:master and verify `00-pr-scanner` passes without the permission error.

## Related issues/PRs

* Resolved #2167

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration with enhanced access control settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2168)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->