### PR TITLE
fix: validate --format flag value in patch command before running

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -41,6 +41,22 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
+			}
+			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format != "" {
+				supported := []string{"pretty-printer", "json", "sarif"}
+				valid := false
+				for _, s := range supported {
+					if scanInfo.Format == s {
+						valid = true
+						break
+					}
+				}
+				if !valid {
+					return fmt.Errorf("invalid format %q, supported formats: pretty-printer, json, sarif", scanInfo.Format)
+				}
+			}
 			if err := shared.ValidateImageScanInfo(&scanInfo); err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 			initLogger()
 			initLoggerLevel(cmd)
 			initEnvironment()
-			initCacheDir()
+			initCacheDir(cmd)
 		},
 	}
 

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -58,16 +58,28 @@ func initLoggerLevel(cmd *cobra.Command) {
 	}
 }
 
-func initCacheDir() {
-	if rootInfo.CacheDir != getter.DefaultLocalStore {
-		getter.DefaultLocalStore = rootInfo.CacheDir
-	} else if cacheDir := os.Getenv("KS_CACHE_DIR"); cacheDir != "" {
-		getter.DefaultLocalStore = cacheDir
-	} else {
-		return // using default cache dir location
+func initCacheDir(cmd *cobra.Command) {
+	cacheDirExplicit := false
+	if cmd != nil {
+		// Persistent flags are parsed on the root while traversing to the subcommand.
+		// cmd.Flag("cache-dir") on a child can be a merged copy that never gets Changed=true;
+		// the root flag holds the authoritative parse state (see cobra Traverse + ParseFlags).
+		r := cmd.Root()
+		if f := r.Flag("cache-dir"); f != nil {
+			cacheDirExplicit = f.Changed
+		} else if f := cmd.Flag("cache-dir"); f != nil {
+			cacheDirExplicit = f.Changed
+		}
 	}
-
-	logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+	if !cacheDirExplicit {
+		if cacheDir := os.Getenv("KS_CACHE_DIR"); cacheDir != "" {
+			getter.DefaultLocalStore = cacheDir
+			logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+		}
+	} else {
+		getter.DefaultLocalStore = rootInfo.CacheDir
+		logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
+	}
 }
 func initEnvironment() {
 	if rootInfo.DiscoveryServerURL == "" {

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/kubescape/go-logger/helpers"
+
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/go-logger/zaplogger"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -97,5 +99,122 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		initLoggerLevel(versionCmd)
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+}
+
+// testCmdWithCacheDirFlag mirrors root: cache-dir on PersistentFlags, bound to rootInfo.CacheDir.
+func testCmdWithCacheDirFlag(t *testing.T) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "kubescape-test"}
+	c.PersistentFlags().StringVar(&rootInfo.CacheDir, "cache-dir", getter.DefaultLocalStore, "cache dir")
+	return c
+}
+
+func TestInitCacheDir_KSCacheDirPrecedence(t *testing.T) {
+	t.Run("KS_CACHE_DIR applies when --cache-dir flag not set", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, "/tmp/ks-env-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir wins over KS_CACHE_DIR even when value equals default", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		defaultVal := getter.DefaultLocalStore
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		// Pass the default value explicitly — this is the core bug case
+		assert.NoError(t, cmd.ParseFlags([]string{"--cache-dir", defaultVal}))
+
+		initCacheDir(cmd)
+
+		// env var must NOT win; flag value (== default) must be used
+		assert.Equal(t, defaultVal, getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir with non-default value wins over KS_CACHE_DIR", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{"--cache-dir", "/tmp/explicit-cache"}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, "/tmp/explicit-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("nil cmd falls back to KS_CACHE_DIR", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+
+		initCacheDir(nil)
+
+		assert.Equal(t, "/tmp/ks-env-cache", getter.DefaultLocalStore)
+	})
+
+	t.Run("no flag no env — default store unchanged", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		cmd := testCmdWithCacheDirFlag(t)
+		assert.NoError(t, cmd.ParseFlags([]string{}))
+
+		initCacheDir(cmd)
+
+		assert.Equal(t, prevStore, getter.DefaultLocalStore)
+	})
+
+	t.Run("explicit --cache-dir on root wins for subcommand path", func(t *testing.T) {
+		prevStore := getter.DefaultLocalStore
+		prevCacheDir := rootInfo.CacheDir
+		t.Cleanup(func() {
+			getter.DefaultLocalStore = prevStore
+			rootInfo.CacheDir = prevCacheDir
+		})
+
+		defaultVal := getter.DefaultLocalStore
+		t.Setenv("KS_CACHE_DIR", "/tmp/ks-env-cache")
+
+		rootCmd := &cobra.Command{Use: "kubescape"}
+		rootCmd.PersistentFlags().StringVar(&rootInfo.CacheDir, "cache-dir", getter.DefaultLocalStore, "cache dir")
+		scanCmd := &cobra.Command{Use: "scan"}
+		rootCmd.AddCommand(scanCmd)
+		assert.NoError(t, rootCmd.ParseFlags([]string{"--cache-dir", defaultVal}))
+
+		initCacheDir(scanCmd)
+
+		assert.Equal(t, defaultVal, getter.DefaultLocalStore)
 	})
 }

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -436,19 +436,16 @@ func GetConfigMapNamespace() string {
 }
 
 func updateCredentials(configObj *ConfigObj, accountID, accessKey string) {
+	// Explicit flags take precedence over env vars; env vars are only applied as fallback.
 	if accessKey != "" {
 		configObj.AccessKey = accessKey
-	}
-
-	if envAccessKey := os.Getenv(accessKeyEnvVar); envAccessKey != "" {
+	} else if envAccessKey := os.Getenv(accessKeyEnvVar); envAccessKey != "" {
 		configObj.AccessKey = envAccessKey
 	}
 
 	if accountID != "" {
 		configObj.AccountID = accountID
-	}
-
-	if envAccountID := os.Getenv(accountIdEnvVar); envAccountID != "" {
+	} else if envAccountID := os.Getenv(accountIdEnvVar); envAccountID != "" {
 		configObj.AccountID = envAccountID
 	}
 }

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -384,3 +384,35 @@ func TestUpdateEmptyFields(t *testing.T) {
 		checkIsUpdateCorrectly(t, beforeChangesOutCO.ClusterName, tests[i].outCo.ClusterName)
 	}
 }
+
+func TestUpdateCredentials_FlagTakesPrecedenceOverEnv(t *testing.T) {
+	// Regression test: explicit flag values must not be overwritten by env vars.
+	t.Setenv(accountIdEnvVar, "env-account-id")
+	t.Setenv(accessKeyEnvVar, "env-access-key")
+
+	configObj := &ConfigObj{}
+	updateCredentials(configObj, "flag-account-id", "flag-access-key")
+
+	if configObj.AccountID != "flag-account-id" {
+		t.Errorf("expected AccountID=flag-account-id, got %s", configObj.AccountID)
+	}
+	if configObj.AccessKey != "flag-access-key" {
+		t.Errorf("expected AccessKey=flag-access-key, got %s", configObj.AccessKey)
+	}
+}
+
+func TestUpdateCredentials_EnvAppliedWhenNoFlag(t *testing.T) {
+	// Env vars should apply as fallback when no flag value is provided.
+	t.Setenv(accountIdEnvVar, "env-account-id")
+	t.Setenv(accessKeyEnvVar, "env-access-key")
+
+	configObj := &ConfigObj{}
+	updateCredentials(configObj, "", "")
+
+	if configObj.AccountID != "env-account-id" {
+		t.Errorf("expected AccountID=env-account-id, got %s", configObj.AccountID)
+	}
+	if configObj.AccessKey != "env-access-key" {
+		t.Errorf("expected AccessKey=env-access-key, got %s", configObj.AccessKey)
+	}
+}


### PR DESCRIPTION
## Overview
`kubescape patch --format <invalid>` silently ran the full scan and patch
operation without validating the format value, wasting time and resources.
`kubescape scan image` correctly rejects invalid formats immediately — patch
was missing the same guard.

Before:
kubescape patch --format invalidfmt --image nginx:latest
# Runs full scan + patch silently with invalid format 

After:
kubescape patch --format invalidfmt --image nginx:latest
# Error: invalid format "invalidfmt", supported formats: pretty-printer, json, sarif 

## How to Test
kubescape patch --format invalidfmt --image nginx:latest
# Expected: Error: invalid format "invalidfmt", supported formats: pretty-printer, json, sarif

kubescape patch --format "" --image nginx:latest
# Expected: Error: format cannot be empty, supported formats: pretty-printer, json, sarif

kubescape patch --format json --image nginx:latest
# Expected: proceeds normally

## Related issues/PRs
* Resolves #2166

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Credential configuration now correctly prioritizes explicit settings over environment variables
  * Cache directory configuration now properly respects command-line flags over environment variables

* **Improvements**
  * Added validation for output format flag to reject invalid values and provide clear error messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2169)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->