### PR TITLE
fix(resourcehandler): don't silently drop partial GVR collection failures

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -62,6 +62,7 @@ type OPASessionObj struct {
 	InfoMap               map[string]apis.StatusInfo         // Map errors of resources to StatusInfo
 	ResourceToControlsMap map[string][]string                // map[<apigroup/apiversion/resource>] = [<control_IDs>]
 	ScanCoverage          ScanCoverage                       // runtime coverage gaps (failed GVR pulls + not-evaluated controls)
+	PartialGVRFailures    []PartialGVRPull                   // per-selector LIST failures for GVRs that were partially collected
 	SessionID             string                             // SessionID
 	Policies              []reporthandling.Framework         // list of frameworks to scan
 	Exceptions            []armotypes.PostureExceptionPolicy // list of exceptions to apply on scan results

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -13,12 +13,27 @@ import (
 type ScanCoverage struct {
 	FailedGVRPulls       []FailedGVRPull       `json:"failedGVRPulls,omitempty"`
 	NotEvaluatedControls []NotEvaluatedControl `json:"notEvaluatedControls,omitempty"`
+	// PartialGVRPulls records per-selector LIST failures for GVRs that had at
+	// least one successful query. Controls are still evaluated against the
+	// partial data, but this field surfaces the gap so operators and CI/CD
+	// pipelines can detect incomplete scans without a false-green result.
+	PartialGVRPulls []PartialGVRPull `json:"partialGVRPulls,omitempty"`
 }
 
 // FailedGVRPull records a single GVR whose resources could not be collected.
 type FailedGVRPull struct {
 	GVR   string `json:"gvr"`
 	Error string `json:"error"`
+}
+
+// PartialGVRPull records a LIST failure scoped to a specific field selector
+// (e.g. a namespace or name selector) for a GVR that was otherwise partially
+// collected. Unlike FailedGVRPull, other queries for the same GVR succeeded,
+// so controls are evaluated against an incomplete resource set.
+type PartialGVRPull struct {
+	GVR      string `json:"gvr"`
+	Selector string `json:"selector"`
+	Error    string `json:"error"`
 }
 
 // NotEvaluatedControl records a control that was skipped because every GVR it
@@ -28,8 +43,8 @@ type NotEvaluatedControl struct {
 	MissingGVRs []string `json:"missingGVRs"`
 }
 
-// BuildScanCoverage derives a ScanCoverage from the InfoMap and
-// ResourceToControlsMap on the session object.
+// BuildScanCoverage derives a ScanCoverage from the InfoMap,
+// ResourceToControlsMap, and any partial GVR pull failures on the session.
 //
 // A control is considered NotEvaluated when every GVR listed in
 // ResourceToControlsMap for that control appears in InfoMap as a pull failure.
@@ -39,8 +54,13 @@ type NotEvaluatedControl struct {
 // string) AND resource-level OPA evaluation skips (keyed by resource ID). To
 // avoid surfacing per-resource eval skips as GVR pull failures, only InfoMap
 // entries whose key is also a key in ResourceToControlsMap are considered.
-func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string) ScanCoverage {
-	coverage := ScanCoverage{}
+//
+// partialPulls carries per-selector LIST failures for GVRs that were partially
+// collected; they are included as-is in ScanCoverage.PartialGVRPulls.
+func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, partialPulls []PartialGVRPull) ScanCoverage {
+	coverage := ScanCoverage{
+		PartialGVRPulls: partialPulls,
+	}
 
 	if len(infoMap) == 0 || len(resourceToControlsMap) == 0 {
 		return coverage

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildScanCoverage_EmptyInfoMap(t *testing.T) {
-	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}})
+	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -17,7 +17,7 @@ func TestBuildScanCoverage_NoFailedGVRs(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusPassed},
 	}
-	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}})
+	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -32,7 +32,7 @@ func TestBuildScanCoverage_FailedGVRPopulated(t *testing.T) {
 	resourceToControlsMap := map[string][]string{
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, "networking.k8s.io/v1/networkpolicies", coverage.FailedGVRPulls[0].GVR)
 	assert.Equal(t, "RBAC denied", coverage.FailedGVRPulls[0].Error)
@@ -44,7 +44,7 @@ func TestBuildScanCoverage_NoResourceMap(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusSkipped},
 	}
-	coverage := BuildScanCoverage(infoMap, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 }
 
@@ -57,7 +57,7 @@ func TestBuildScanCoverage_AllGVRsFailedControlNotEvaluated(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies":          {"C-0001", "C-0002"},
 		"rbac.authorization.k8s.io/v1/clusterroles":     {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 2)
 
@@ -84,7 +84,7 @@ func TestBuildScanCoverage_IgnoresResourceLevelEvalSkips(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 
 	// Only the GVR-keyed entry should be in FailedGVRPulls
 	assert.Len(t, coverage.FailedGVRPulls, 1)
@@ -108,9 +108,9 @@ func TestBuildScanCoverage_DeterministicOrder(t *testing.T) {
 		"m/v1/mthings": {"C-0002"},
 	}
 
-	first := BuildScanCoverage(infoMap, resourceToControlsMap)
+	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 	for i := 0; i < 10; i++ {
-		next := BuildScanCoverage(infoMap, resourceToControlsMap)
+		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 		assert.Equal(t, first, next)
 	}
 
@@ -133,8 +133,26 @@ func TestBuildScanCoverage_PartialGVRFailureControlStillEvaluated(t *testing.T) 
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 1)
+	assert.Empty(t, coverage.NotEvaluatedControls)
+}
+
+func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
+	// Partial failures (GVR has some data, specific selector failed) must flow
+	// into ScanCoverage.PartialGVRPulls so consumers can detect incomplete scans
+	// without marking controls as NotEvaluated (the GVR still has partial data).
+	partials := []PartialGVRPull{
+		{GVR: "/v1/pods", Selector: "metadata.namespace==prod", Error: "RBAC denied for prod"},
+		{GVR: "core/v1/secrets", Selector: "metadata.name==prod-secret", Error: "forbidden"},
+	}
+	coverage := BuildScanCoverage(nil, nil, partials)
+
+	assert.Len(t, coverage.PartialGVRPulls, 2)
+	assert.Equal(t, "/v1/pods", coverage.PartialGVRPulls[0].GVR)
+	assert.Equal(t, "metadata.namespace==prod", coverage.PartialGVRPulls[0].Selector)
+	assert.Contains(t, coverage.PartialGVRPulls[0].Error, "RBAC denied")
+	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -35,7 +35,7 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	opaSessionObj.AllResources = allResources
 	opaSessionObj.ExternalResources = externalResources
 	opaSessionObj.ExcludedRules = excludedRulesMap
-	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap)
+	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opaSessionObj.PartialGVRFailures)
 
 	if getErr != nil {
 		return getErr

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -93,7 +93,18 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 
 	// Record failed GVR statuses before any early return so BuildScanCoverage
 	// has data even when every pull fails (severe RBAC restrictions).
-	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, sessionObj.InfoMap)
+	// Partial failures (some selectors succeeded for the GVR) are returned
+	// separately so they can be surfaced without overriding the whole-GVR status.
+	partialFailures := recordFailedQueryStatuses(failedQueries, k8sResourcesMap, sessionObj.InfoMap)
+	if len(partialFailures) > 0 {
+		sessionObj.PartialGVRFailures = partialFailures
+		for _, p := range partialFailures {
+			logger.L().Ctx(ctx).Warning("partial resource collection: some resources may be missing from scan results",
+				helpers.String("gvr", p.GVR),
+				helpers.String("selector", p.Selector),
+				helpers.String("error", p.Error))
+		}
+	}
 
 	if len(allResources) == 0 && len(failedQueries) > 0 {
 		// Every query failed — nothing was collected; treat as fatal.
@@ -197,9 +208,15 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(resource *objectsen
 	if resource.GetNamespace() != "" && k8sinterface.IsNamespaceScope(&gvr) {
 		fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespaceFieldSelectorString(resource.GetNamespace(), FieldSelectorsEqualsOperator))
 	}
-	result, err := k8sHandler.pullSingleResource(&gvr, nil, fieldSelectors, globalFieldSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), err)
+	result, selectorErrs := k8sHandler.pullSingleResource(&gvr, nil, fieldSelectors, globalFieldSelector)
+	if len(result) == 0 && len(selectorErrs) > 0 {
+		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
+	}
+	for _, se := range selectorErrs {
+		logger.L().Warning("partial collection during single resource scan",
+			helpers.String("resource", getReadableID(resource)),
+			helpers.String("selector", se.selector),
+			helpers.Error(se.err))
 	}
 
 	if len(result) == 0 {
@@ -333,8 +350,15 @@ func setMapNamespaceToNumOfResources(ctx context.Context, allResources map[strin
 
 // queryFailure records a failed pull at query granularity (GVR + field selectors).
 type queryFailure struct {
-	gvr string
-	err error
+	gvr      string
+	selector string // the field selector that failed; empty for whole-GVR failures
+	err      error
+}
+
+// selectorFailure records a single per-field-selector LIST error inside pullSingleResource.
+type selectorFailure struct {
+	selector string
+	err      error
 }
 
 // maxParallelResourcePulls limits the number of concurrent K8s API List calls
@@ -370,17 +394,29 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 
 			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
-			result, err := k8sHandler.pullSingleResource(&gvr, nil, qr.FieldSelectors, globalFieldSelectors)
+			result, selectorErrs := k8sHandler.pullSingleResource(&gvr, nil, qr.FieldSelectors, globalFieldSelectors)
 
-			if err != nil {
-				if !strings.Contains(err.Error(), "the server could not find the requested resource") {
-					mu.Lock()
-					failedQueries[qr.String()] = queryFailure{
-						gvr: qr.GroupVersionResourceTriplet,
-						err: err,
+			// Record per-selector failures under a selector-qualified key so
+			// that a failure on one namespace selector is never silently
+			// discarded when a sibling selector for the same GVR succeeded.
+			if len(selectorErrs) > 0 {
+				mu.Lock()
+				for _, se := range selectorErrs {
+					if strings.Contains(se.err.Error(), "the server could not find the requested resource") {
+						continue
 					}
-					mu.Unlock()
+					qualifiedKey := qr.GroupVersionResourceTriplet + "/" + se.selector
+					failedQueries[qualifiedKey] = queryFailure{
+						gvr:      qr.GroupVersionResourceTriplet,
+						selector: se.selector,
+						err:      se.err,
+					}
 				}
+				mu.Unlock()
+			}
+
+			if len(result) == 0 && len(selectorErrs) > 0 {
+				// All selectors failed — no data collected for this resource.
 				return
 			}
 
@@ -407,18 +443,30 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 	return k8sResources, allResources, failedQueries
 }
 
-// recordFailedQueryStatuses writes a StatusSkipped entry to infoMap for each
-// failed GVR that has no successfully collected resources in k8sResources.
-// InfoMap and ResourceToControlsMap are both keyed by raw GVR, not by query
-// string, so we can only mark controls as skipped when the whole resource type
-// is absent. If any selector-specific query succeeded and populated
-// k8sResources[gvr], the control already has data to evaluate; marking it
-// skipped via a sibling-query failure would be incorrect. A follow-up should
-// introduce query-granular control mapping so partial-collection failures can
-// be surfaced with the right scope.
-func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResources cautils.K8SResources, infoMap map[string]apis.StatusInfo) {
+// recordFailedQueryStatuses classifies each failed query as either a whole-GVR
+// failure or a partial failure and surfaces them accordingly.
+//
+// Whole-GVR failure (no data at all for the GVR): a StatusSkipped entry is
+// written to infoMap keyed by the raw GVR string, which BuildScanCoverage uses
+// to mark the dependent controls as NotEvaluated.
+//
+// Partial failure (some data exists in k8sResources for the GVR but this
+// specific selector's query failed): the failure is returned as a
+// PartialGVRPull so callers can surface it without incorrectly overriding the
+// whole-GVR status. Controls will be evaluated against the partial data, but
+// the PartialGVRPull entry makes the gap visible to operators and CI/CD
+// pipelines — previously this case was silently suppressed.
+func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResources cautils.K8SResources, infoMap map[string]apis.StatusInfo) []cautils.PartialGVRPull {
+	var partials []cautils.PartialGVRPull
 	for _, f := range failedQueries {
 		if len(k8sResources[f.gvr]) > 0 {
+			// GVR has partial data — don't mark whole-GVR as skipped, but do
+			// record the per-selector gap so the caller can surface it.
+			partials = append(partials, cautils.PartialGVRPull{
+				GVR:      f.gvr,
+				Selector: f.selector,
+				Error:    f.err.Error(),
+			})
 			continue
 		}
 		infoMap[f.gvr] = apis.StatusInfo{
@@ -427,31 +475,37 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 			SubStatus:   apis.SubStatusNotEvaluated,
 		}
 	}
+	return partials
 }
 
-func (k8sHandler *K8sResourceHandler) pullSingleResource(
-	resource *schema.GroupVersionResource,
-	labels map[string]string,
-	fields string,
-	fieldSelector IFieldSelector,
-) ([]unstructured.Unstructured, error) {
-
+// pullSingleResource lists all instances of a Kubernetes resource, expanding
+// the globalFieldSelector into per-namespace (or per-name) selectors as
+// needed. Each selector is listed independently; if one fails the error is
+// recorded as a selectorFailure and the loop continues to the remaining
+// selectors so partial results are never silently discarded.
+//
+// The caller should treat a non-empty selectorFailure slice as a signal that
+// the returned resourceList is incomplete and surface it accordingly.
+func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
+	var selectorErrs []selectorFailure
 
 	fieldSelectors := fieldSelector.GetNamespacesSelectors(resource)
 
 	for i := range fieldSelectors {
 		listOptions := metav1.ListOptions{}
 
+		if len(labels) > 0 {
+			set := k8slabels.Set(labels)
+			listOptions.LabelSelector = set.AsSelector().String()
+		}
+
 		if fieldSelectors[i] != "" {
 			listOptions.FieldSelector = combineFieldSelectors(fieldSelectors[i], fields)
 		} else if fields != "" {
 			listOptions.FieldSelector = fields
-		}
-
-		if len(labels) > 0 {
-			set := k8slabels.Set(labels)
-			listOptions.LabelSelector = set.AsSelector().String()
+		} else {
+			listOptions.FieldSelector = ""
 		}
 
 		clientResource := k8sHandler.k8s.DynamicClient.Resource(*resource)
@@ -481,14 +535,15 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(
 			return nil
 
 		}); err != nil {
-
-			return nil, fmt.Errorf(
-				"failed to get resource: %v, labelSelector: %v, fieldSelector: %v, reason: %w",
-				resource,
-				listOptions.LabelSelector,
-				listOptions.FieldSelector,
-				err,
-			)
+			selectorErrs = append(selectorErrs, selectorFailure{
+				selector: listOptions.FieldSelector,
+				err:      fmt.Errorf("failed to get resource: %v, labelSelector: %v, fieldSelector: %v, reason: %w", resource, listOptions.LabelSelector, listOptions.FieldSelector, err),
+			})
+			logger.L().Warning("failed to list resource for selector",
+				helpers.String("resource", resource.String()),
+				helpers.String("fieldSelector", listOptions.FieldSelector),
+				helpers.Error(err))
+			continue
 		}
 
 		logger.L().Debug(
@@ -500,7 +555,7 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(
 		)
 	}
 
-	return resourceList, nil
+	return resourceList, selectorErrs
 }
 func ConvertMapListToMeta(resourceMap []map[string]interface{}) []workloadinterface.IMetadata {
 	var workloads []workloadinterface.IMetadata

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,14 +65,14 @@ func TestPullSingleResource_FieldSelectorDoesNotLeakAcrossIterations(t *testing.
 		},
 	}
 
-	_, err := handler.pullSingleResource(
+	_, selectorErrs := handler.pullSingleResource(
 		resource,
 		nil,
 		"",
 		fieldSelector,
 	)
 
-	require.NoError(t, err)
+	require.Empty(t, selectorErrs)
 
 	require.Len(t, capturedSelectors, 2)
 
@@ -254,31 +255,114 @@ func TestRecordFailedQueryStatuses_WrittenWhenGVRTotallyAbsent(t *testing.T) {
 		failedGVR: {gvr: failedGVR, err: fmt.Errorf("forbidden")},
 	}
 
-	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
+	partials := recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
 
 	info, ok := infoMap[failedGVR]
 	require.True(t, ok, "InfoMap should have an entry for the failed GVR")
 	assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
 	assert.Contains(t, info.InnerInfo, "forbidden")
+	assert.Empty(t, partials, "whole-GVR failure should not produce a PartialGVRPull")
 }
 
-// TestRecordFailedQueryStatuses_NotWrittenWhenGVRHasData verifies that when a
-// GVR failed for one field-selector query but another query for the same GVR
-// succeeded and populated k8sResources, the helper does NOT write to infoMap —
-// preventing controls from being incorrectly marked skipped when they do have
-// data. Drives the real production helper.
-func TestRecordFailedQueryStatuses_NotWrittenWhenGVRHasData(t *testing.T) {
+// TestRecordFailedQueryStatuses_PartialFailureSurfaced verifies the fix for the
+// silent false-negative bug: when a GVR failed for one field-selector query but
+// another selector for the same GVR succeeded, the failure must NOT be silently
+// suppressed. Instead it must be returned as a PartialGVRPull so the operator
+// and CI/CD pipelines can detect the incomplete scan.
+//
+// Prior to the fix, the presence of data in k8sResources[gvr] caused the
+// failure to be discarded entirely, leaving controls to evaluate (and silently
+// pass) against a truncated resource set.
+func TestRecordFailedQueryStatuses_PartialFailureSurfaced(t *testing.T) {
 	gvr := "/v1/pods"
+	selector := "metadata.namespace==prod"
 	infoMap := map[string]apis.StatusInfo{}
 
 	k8sResourcesMap := cautils.K8SResources{
-		gvr: []string{"default/pod-abc"},
+		gvr: []string{"default/pod-abc"}, // data from the successful selector
 	}
 	failedQueries := map[string]queryFailure{
-		gvr + "/metadata.namespace=prod": {gvr: gvr, err: fmt.Errorf("forbidden for prod")},
+		gvr + "/" + selector: {gvr: gvr, selector: selector, err: fmt.Errorf("forbidden for prod namespace")},
 	}
 
-	recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
+	partials := recordFailedQueryStatuses(failedQueries, k8sResourcesMap, infoMap)
 
-	assert.Empty(t, infoMap, "InfoMap should NOT be written when k8sResources already has data for the GVR")
+	// InfoMap must NOT be written — the whole GVR is not absent, so marking
+	// it as skipped would incorrectly suppress control evaluation.
+	assert.Empty(t, infoMap, "InfoMap must not be written for a partial GVR failure")
+
+	// The failure must be surfaced as a PartialGVRPull — not silently dropped.
+	require.Len(t, partials, 1, "partial failure must be returned, not suppressed")
+	assert.Equal(t, gvr, partials[0].GVR)
+	assert.Equal(t, selector, partials[0].Selector)
+	assert.Contains(t, partials[0].Error, "forbidden for prod namespace")
+}
+
+// TestRecordFailedQueryStatuses_PartialFailureSessionField verifies that when
+// two field-selector queries target the same GVR and one succeeds while the
+// other fails, GetResources stores the failure in sessionObj.PartialGVRFailures
+// rather than suppressing it silently.
+//
+// This is the end-to-end regression test for the silent false-negative bug:
+// prior to the fix, the presence of data from the first selector caused the
+// second selector's failure to be silently discarded, leaving the caller with
+// no indication that the resource set is incomplete.
+func TestRecordFailedQueryStatuses_PartialFailureSessionField(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+
+	fakeSecret := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata":   map[string]interface{}{"name": "secret1", "namespace": "default"},
+		},
+	}
+	secretList := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{"apiVersion": "v1", "kind": "SecretList"},
+		Items:  []unstructured.Unstructured{*fakeSecret},
+	}
+
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			// First secret selector succeeds; second fails to simulate a
+			// per-resource RBAC restriction on a different secret.
+			if opts.FieldSelector == "metadata.name=secret1" {
+				return secretList, nil
+			}
+			if opts.FieldSelector == "metadata.name=secret2,metadata.namespace=default" {
+				return nil, fmt.Errorf("RBAC denied for secret2")
+			}
+			// Any other query (e.g. Namespace list) returns empty — not an error.
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}, nil
+		},
+	}
+
+	// mockMatch(4) produces two field-selectors for the Secret GVR:
+	//   1. metadata.name=secret1  → succeeds
+	//   2. metadata.name=secret2,metadata.namespace=default → fails
+	rule := mockRule("rule-a", nil, "")
+	rule.Match = append(rule.Match, mockMatch(6), mockMatch(4))
+	control := mockControl("control-1", nil)
+	control.Rules = append(control.Rules, rule)
+	framework := mockFramework("test", nil)
+	framework.Controls = append(framework.Controls, control)
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	// The GVR has data (from selector 1), so InfoMap must NOT have a whole-GVR
+	// skip entry — that would incorrectly mark the control as NotEvaluated.
+	_, inInfoMap := sessionObj.InfoMap["core/v1/secrets"]
+	assert.False(t, inInfoMap, "a partially-collected GVR must not appear as a whole-GVR skip in InfoMap")
+
+	// The per-selector failure must surface in PartialGVRFailures so the caller
+	// can warn the operator — this is the fix for the silent false-negative.
+	require.NotEmpty(t, sessionObj.PartialGVRFailures,
+		"the failed selector must be recorded in PartialGVRFailures, not silently dropped")
+	assert.Contains(t, sessionObj.PartialGVRFailures[0].Error, "RBAC denied for secret2")
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -331,9 +331,10 @@ func isPrintSeparatorType(scanType cautils.ScanTypes) bool {
 }
 
 // printScanCoverage prints a "Scan Coverage" warning block when GVR pull
-// failures caused controls to be skipped. Nothing is printed on a clean scan.
+// failures caused controls to be skipped or partial data was collected.
+// Nothing is printed on a clean scan.
 func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
-	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 {
+	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 {
 		return
 	}
 
@@ -353,6 +354,14 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 		for _, c := range coverage.NotEvaluatedControls {
 			fmt.Fprintf(pp.writer, "  • %s (missing: %s)\n", c.ControlID, strings.Join(c.MissingGVRs, ", "))
 		}
+	}
+
+	if len(coverage.PartialGVRPulls) > 0 {
+		fmt.Fprintf(pp.writer, "\nThe following resource types were only partially collected (some namespace/name selectors failed):\n")
+		for _, p := range coverage.PartialGVRPulls {
+			fmt.Fprintf(pp.writer, "  • %s (selector: %q): %s\n", p.GVR, p.Selector, p.Error)
+		}
+		fmt.Fprintf(pp.writer, "\nControls depending on these resource types were evaluated against incomplete data.\n")
 	}
 
 	fmt.Fprintf(pp.writer, "\nTo fix this, ensure the scanning identity has list/get permissions on the missing resource types.\n")

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -1,9 +1,13 @@
 package printer
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsPrintSeparatorType(t *testing.T) {
@@ -52,4 +56,73 @@ func TestIsPrintSeparatorType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestPrettyPrinterFile creates a PrettyPrinter backed by a temp file and
+// returns the printer and a teardown function that reads and removes the file.
+func newTestPrettyPrinterFile(t *testing.T) (*PrettyPrinter, func() string) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "pp-test-*.txt")
+	require.NoError(t, err)
+	pp := &PrettyPrinter{writer: f}
+	return pp, func() string {
+		f.Close()
+		data, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+		return string(data)
+	}
+}
+
+// TestPrintScanCoverage_PartialOnlyRendered verifies that a ScanCoverage with
+// only PartialGVRPulls (no whole-GVR failures) is still rendered. Prior to the
+// fix, the early-return guard checked only FailedGVRPulls and
+// NotEvaluatedControls, so a partial-only scan produced no CLI output at all.
+func TestPrintScanCoverage_PartialOnlyRendered(t *testing.T) {
+	pp, read := newTestPrettyPrinterFile(t)
+
+	coverage := cautils.ScanCoverage{
+		PartialGVRPulls: []cautils.PartialGVRPull{
+			{GVR: "/v1/pods", Selector: "metadata.namespace=prod", Error: "forbidden for prod"},
+		},
+	}
+	pp.printScanCoverage(coverage)
+
+	out := read()
+	assert.Contains(t, out, "Scan Coverage Warning", "header must appear for partial-only coverage")
+	assert.Contains(t, out, "/v1/pods", "GVR must appear in output")
+	assert.Contains(t, out, "metadata.namespace=prod", "selector must appear in output")
+	assert.Contains(t, out, "incomplete data", "incomplete-data notice must appear")
+}
+
+// TestPrintScanCoverage_CleanScanNoOutput verifies no output is produced when
+// the coverage struct is completely empty.
+func TestPrintScanCoverage_CleanScanNoOutput(t *testing.T) {
+	pp, read := newTestPrettyPrinterFile(t)
+	pp.printScanCoverage(cautils.ScanCoverage{})
+	assert.Empty(t, read())
+}
+
+// TestPrintScanCoverage_AllSectionsRendered verifies that when all three
+// coverage fields are populated, all three sections appear in the output.
+func TestPrintScanCoverage_AllSectionsRendered(t *testing.T) {
+	pp, read := newTestPrettyPrinterFile(t)
+
+	coverage := cautils.ScanCoverage{
+		FailedGVRPulls: []cautils.FailedGVRPull{
+			{GVR: "rbac.authorization.k8s.io/v1/clusterroles", Error: "forbidden"},
+		},
+		NotEvaluatedControls: []cautils.NotEvaluatedControl{
+			{ControlID: "C-0001", MissingGVRs: []string{"rbac.authorization.k8s.io/v1/clusterroles"}},
+		},
+		PartialGVRPulls: []cautils.PartialGVRPull{
+			{GVR: "/v1/pods", Selector: "metadata.namespace=prod", Error: "forbidden for prod"},
+		},
+	}
+	pp.printScanCoverage(coverage)
+
+	out := read()
+	assert.True(t, strings.Count(out, "Scan Coverage Warning") == 1, "exactly one header")
+	assert.Contains(t, out, "clusterroles")
+	assert.Contains(t, out, "C-0001")
+	assert.Contains(t, out, "/v1/pods")
 }

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -131,7 +131,7 @@ func ConvertToPostureReportWithSeverityLabelsAndCoverage(report *reporthandlingv
 
 	// only attach coverage when there is something to show
 	var scanCoverage *cautils.ScanCoverage
-	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0) {
+	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0) {
 		scanCoverage = coverage
 	}
 

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -9,9 +9,16 @@ import (
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func minimalPostureReport() *reporthandlingv2.PostureReport {
+	return &reporthandlingv2.PostureReport{}
+}
 
 func TestExtractCVEs(t *testing.T) {
 	tests := []struct {
@@ -882,4 +889,42 @@ func TestExtractResourceLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConvertToPostureReport_PartialOnlyCoverageAttached verifies that a
+// ScanCoverage containing only PartialGVRPulls (no whole-GVR failures, no
+// NotEvaluatedControls) is still attached to the serialized report. Prior to
+// the fix, the guard only checked FailedGVRPulls and NotEvaluatedControls, so
+// a partial-only scan would produce a JSON/API response with no scanCoverage
+// field at all — hiding the incomplete-data condition from consumers.
+func TestConvertToPostureReport_PartialOnlyCoverageAttached(t *testing.T) {
+	coverage := &cautils.ScanCoverage{
+		PartialGVRPulls: []cautils.PartialGVRPull{
+			{GVR: "/v1/pods", Selector: "metadata.namespace=prod", Error: "forbidden for prod"},
+		},
+	}
+
+	result := ConvertToPostureReportWithSeverityLabelsAndCoverage(nil, nil, nil, coverage)
+	require.Nil(t, result, "nil report should return nil")
+
+	// Use a minimal non-nil report so we can inspect the ScanCoverage field.
+	result = ConvertToPostureReportWithSeverityLabelsAndCoverage(
+		minimalPostureReport(),
+		nil, nil, coverage,
+	)
+	require.NotNil(t, result)
+	require.NotNil(t, result.ScanCoverage, "ScanCoverage must be attached when PartialGVRPulls is non-empty")
+	assert.Len(t, result.ScanCoverage.PartialGVRPulls, 1)
+	assert.Equal(t, "/v1/pods", result.ScanCoverage.PartialGVRPulls[0].GVR)
+}
+
+// TestConvertToPostureReport_NilCoverageNotAttached verifies that a nil
+// coverage pointer (clean scan) produces a nil ScanCoverage in the output.
+func TestConvertToPostureReport_NilCoverageNotAttached(t *testing.T) {
+	result := ConvertToPostureReportWithSeverityLabelsAndCoverage(
+		minimalPostureReport(),
+		nil, nil, nil,
+	)
+	require.NotNil(t, result)
+	assert.Nil(t, result.ScanCoverage)
 }


### PR DESCRIPTION
## Overview

So there's this bug where kubescape silently throws away certain resource collection failures. Here's what happens: when a rule has multiple field selectors for the same GVR (like metadata.name=kube-apiserver and metadata.name=etcd), and one selector succeeds while the other fails due to something like an RBAC denial, the failure just gets dropped. No warning, no error, nothing. The scan finishes looking totally clean.

  The root cause is in recordFailedQueryStatuses. It checks if k8sResources[gvr] already has data from a successful query, and if it does, it skips recording the failure entirely. So controls end up evaluating against an incomplete resource set and can report PASSED when they genuinely shouldn't.

  There was also a second issue inside pullSingleResource. It loops over namespace selectors and on the first failure it just returns immediately with return nil, err. So if ns1 succeeds and ns2 fails, the ns1 results get thrown out too. That's just wasted work and wrong behavior.

  What I fixed: pullSingleResource now returns []selectorFailure instead of a single error so partial results aren't lost anymore. recordFailedQueryStatuses returns the partial failures as []PartialGVRPull instead of suppressing them. These get stored on sessionObj.PartialGVRFailures and flow into ScanCoverage.PartialGVRPulls.   A warning log also gets emitted now whenever partial collection happens so at least it's visible.
  
 ### Relates to #2010

The coverage work in #2010 surfaces GVR failures correctly when a whole GVR fails to collect. But there was a case it couldn't catch , when one field-selector query for a GVR succeeded and another failed, the failure got silently dropped before it could even reach the coverage report. This PR fixes that upstream gap so partial failures actually get tracked and show up in ScanCoverage.PartialGVRPulls.  
  
## How to Test

  Run the core unit test that directly covers the fix:
`
  go test ./core/pkg/resourcehandler/ -run TestRecordFailedQueryStatuses_PartialFailureSurfaced
 `
 This checks that when one selector succeeds and another fails for the same GVR, the failure comes back as a PartialGVRPull instead of disappearing.

  For the end to end version that goes through GetResources:                                                                                                         
  `
go test ./core/pkg/resourcehandler/ -run TestRecordFailedQueryStatuses_PartialFailureSessionField
  `
  This verifies sessionObj.PartialGVRFailures actually gets populated when a sibling selector fails.
  
  Full suite to check nothing broke:
`
  go test ./core/cautils/ ./core/pkg/resourcehandler/
`

## Checklist 

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks and reports partial resource-collection failures at selector granularity and surfaces them in scan coverage and reports with a warning listing affected resource types, selectors, and errors.
* **Bug Fixes**
  * Preserves successfully collected partial data instead of treating selector failures as whole-resource skips.
* **Tests**
  * Added/updated tests to validate partial-failure propagation, rendering, and deterministic coverage output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2170)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->