### PR TITLE
Fix inverted keepResults cleanup logic

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -127,7 +127,7 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		// wait for scan to complete
 		response = <-scanRequestParams.resp
 
-		if scanRequestParams.scanQueryParams.KeepResults {
+		if !scanRequestParams.scanQueryParams.KeepResults {
 			// delete results after returning
 			logger.L().Debug("deleting results", helpers.String("ID", scanID))
 			removeResultsFile(scanID)


### PR DESCRIPTION
## Overview

Fix inverted `keepResults` cleanup logic in the synchronous scan HTTP handler (`httphandler/handlerequests/v1/requestshandler.go`).

Previously, the synchronous scan flow deleted scan results when `keepResults=true`:

```go
if scanRequestParams.scanQueryParams.KeepResults {
	// delete results after returning
	removeResultsFile(scanID)
}
```

This behavior contradicted both:

* the meaning of the `keepResults` flag
* the cleanup logic already implemented in the adjacent `Results()` handler

As a result:

* scans explicitly requesting result persistence could immediately lose their generated artifacts
* follow-up `/results` API calls could fail because the file had already been deleted
* scans using the default cleanup behavior could unintentionally retain results on disk

This change fixes the condition by inverting the cleanup check so results are only removed when `keepResults=false`.

The updated behavior now correctly aligns with the API semantics and the existing cleanup behavior used elsewhere in the same handler package.

## How to Test

Run a synchronous scan with:

```bash
keepResults=true
```

and verify the generated results remain available for retrieval.

Run a synchronous scan with:

```bash
keepResults=false
```

and verify temporary results are cleaned up after the response completes.

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Scan endpoint's result handling behavior. Results are now properly deleted when result retention is disabled, ensuring accurate cleanup of scan data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2173)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->