### PR TITLE
fix: honor namespace argument in list_vulnerability_manifests MCP tool

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -256,10 +256,12 @@ func (ksServer *KubescapeMcpserver) ReadConfigurationResource(ctx context.Contex
 func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	switch name {
 	case "list_vulnerability_manifests":
-		//namespace, ok := arguments["namespace"]
-		//if !ok {
-		//	namespace = ""
-		//}
+		namespace := metav1.NamespaceAll
+		if ns, ok := arguments["namespace"]; ok {
+			if nsStr, ok := ns.(string); ok && nsStr != "" {
+				namespace = nsStr
+			}
+		}
 		level, ok := arguments["level"]
 		if !ok {
 			level = "both"
@@ -281,9 +283,9 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		var manifests *v1beta1.VulnerabilityManifestList
 		var err error
 		if labelSelector == "" {
-			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+			manifests, err = ksServer.ksClient.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{})
 		} else {
-			manifests, err = ksServer.ksClient.VulnerabilityManifests(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			manifests, err = ksServer.ksClient.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: labelSelector,
 			})
 		}


### PR DESCRIPTION
## Overview
The `list_vulnerability_manifests` MCP tool accepted a `namespace` parameter in its tool definition but the implementation had the namespace filtering logic commented out. As a result, the tool always called `VulnerabilityManifests(metav1.NamespaceAll)` regardless of what namespace the user passed, silently ignoring the argument.

This fix removes the commented-out block and replaces it with working namespace logic — consistent with how `list_vulnerabilities_in_manifest` handles its namespace argument. When a namespace is provided it filters to that namespace; when omitted it defaults to all namespaces.

## How to Test
```bash
go build ./cmd/mcpserver/...
go vet ./cmd/mcpserver/...
go test ./cmd/mcpserver/... -v
```

## Related issues/PRs
Closes #2174

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional namespace filtering when listing vulnerability manifests. Users can now specify a target namespace to narrow query results, with the system defaulting to all namespaces when no namespace is specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->