### PR TITLE
test: expand workload scan unit tests

### DIFF
--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 func TestSetWorkloadScanInfo(t *testing.T) {
-	test := []struct {
+	tests := []struct {
 		Description string
 		kind        string
 		name        string
+		namespace   string
+		filePath    string
 		want        *cautils.ScanInfo
 	}{
 		{
@@ -33,7 +35,8 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 						Kind:       v1.KindFramework,
 					},
 				},
-				ScanType: cautils.ScanTypeWorkload,
+				ScanType:   cautils.ScanTypeWorkload,
+				ScanImages: true,
 				ScanObject: &objectsenvelopes.ScanObject{
 					Kind: "Deployment",
 					Metadata: objectsenvelopes.ScanObjectMetadata{
@@ -42,17 +45,56 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			Description: "Set workload scan info with namespace and file path",
+			kind:        "Pod",
+			name:        "api",
+			namespace:   "default",
+			filePath:    "manifests/pod.yaml",
+			want: &cautils.ScanInfo{
+				PolicyIdentifier: []cautils.PolicyIdentifier{
+					{
+						Identifier: "workloadscan",
+						Kind:       v1.KindFramework,
+					},
+					{
+						Identifier: "allcontrols",
+						Kind:       v1.KindFramework,
+					},
+				},
+				ScanType:   cautils.ScanTypeWorkload,
+				ScanImages: true,
+				ScanObject: &objectsenvelopes.ScanObject{
+					Kind: "Pod",
+					Metadata: objectsenvelopes.ScanObjectMetadata{
+						Name:      "api",
+						Namespace: "default",
+					},
+				},
+				InputPatterns: []string{"manifests/pod.yaml"},
+			},
+		},
 	}
 
-	for _, tc := range test {
+	for _, tc := range tests {
 		t.Run(
 			tc.Description,
 			func(t *testing.T) {
-				scanInfo := &cautils.ScanInfo{}
+				prevNamespace := namespace
+				t.Cleanup(func() {
+					namespace = prevNamespace
+				})
+				namespace = tc.namespace
+
+				scanInfo := &cautils.ScanInfo{FilePath: tc.filePath}
 				setWorkloadScanInfo(scanInfo, tc.kind, tc.name)
 
 				if scanInfo.ScanType != tc.want.ScanType {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanType, tc.want.ScanType)
+				}
+
+				if scanInfo.ScanImages != tc.want.ScanImages {
+					t.Errorf("got: %v, want: %v", scanInfo.ScanImages, tc.want.ScanImages)
 				}
 
 				if scanInfo.ScanObject.Kind != tc.want.ScanObject.Kind {
@@ -61,6 +103,16 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 
 				if scanInfo.ScanObject.Metadata.Name != tc.want.ScanObject.Metadata.Name {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanObject.Metadata.Name, tc.want.ScanObject.Metadata.Name)
+				}
+
+				if scanInfo.ScanObject.Metadata.Namespace != tc.want.ScanObject.Metadata.Namespace {
+					t.Errorf("got: %v, want: %v", scanInfo.ScanObject.Metadata.Namespace, tc.want.ScanObject.Metadata.Namespace)
+				}
+
+				if tc.filePath == "" {
+					assert.Len(t, scanInfo.InputPatterns, 0)
+				} else {
+					assert.Equal(t, tc.want.InputPatterns, scanInfo.InputPatterns)
 				}
 
 				if len(scanInfo.PolicyIdentifier) != len(tc.want.PolicyIdentifier) {
@@ -85,12 +137,11 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 func TestGetWorkloadCmd_ChartPathAndFilePathEmpty(t *testing.T) {
 	// Create a mock Kubescape interface
 	mockKubescape := &mocks.MockIKubescape{}
-	scanInfo := cautils.ScanInfo{
-		ChartPath: "temp",
-		FilePath:  "",
-	}
+	scanInfo := cautils.ScanInfo{}
 
 	cmd := getWorkloadCmd(mockKubescape, &scanInfo)
+	scanInfo.ChartPath = "temp"
+	scanInfo.FilePath = ""
 
 	// Verify the command name and short description
 	assert.Equal(t, "workload <kind>/<name> [`<glob pattern>`/`-`] [flags]", cmd.Use)
@@ -102,20 +153,38 @@ func TestGetWorkloadCmd_ChartPathAndFilePathEmpty(t *testing.T) {
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = cmd.Args(&cobra.Command{}, []string{"nginx"})
-	expectedErrorMessage = "invalid workload identifier"
+	expectedErrorMessage = "usage: --chart-path <chart path> --file-path <file path>"
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
 
-func Test_parseWorkloadIdentifierString_Empty(t *testing.T) {
-	t.Run("empty identifier", func(t *testing.T) {
-		_, _, err := parseWorkloadIdentifierString("")
-		assert.Error(t, err)
-	})
+func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty identifier",
+			input: "",
+		},
+		{
+			name:  "too many segments",
+			input: "default/Deployment/nginx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseWorkloadIdentifierString(tt.input)
+			assert.Error(t, err)
+		})
+	}
 }
 
-func Test_parseWorkloadIdentifierString_NoError(t *testing.T) {
+func Test_parseWorkloadIdentifierString_Valid(t *testing.T) {
 	t.Run("valid identifier", func(t *testing.T) {
-		_, _, err := parseWorkloadIdentifierString("default/Deployment")
+		kind, name, err := parseWorkloadIdentifierString("default/Deployment")
 		assert.NoError(t, err)
+		assert.Equal(t, "default", kind)
+		assert.Equal(t, "Deployment", name)
 	})
 }


### PR DESCRIPTION
This pull request enhances the test coverage and robustness of the workload scanning functionality by expanding test cases, improving assertions, and clarifying error messages. The changes focus on making the tests more comprehensive and maintainable, especially around namespace, file path handling, and workload identifier parsing.

**Test enhancements and coverage:**

* Expanded the `TestSetWorkloadScanInfo` test cases to include scenarios with namespace and file path, and added assertions for `ScanImages`, `Namespace`, and `InputPatterns` fields. [[1]](diffhunk://#diff-8c6c225b43581478881b5a9409df8feb5398d207cac87b3929978a341bfdc225L15-R20) [[2]](diffhunk://#diff-8c6c225b43581478881b5a9409df8feb5398d207cac87b3929978a341bfdc225R39) [[3]](diffhunk://#diff-8c6c225b43581478881b5a9409df8feb5398d207cac87b3929978a341bfdc225R48-R99) [[4]](diffhunk://#diff-8c6c225b43581478881b5a9409df8feb5398d207cac87b3929978a341bfdc225R108-R117)
* Updated the test loop variable from `test` to `tests` for clarity and consistency.
* Improved test cleanup by resetting the `namespace` global variable after each test case.

**Error handling and messaging:**

* Updated error messages in `TestGetWorkloadCmd_ChartPathAndFilePathEmpty` to provide clearer usage instructions when required arguments are missing.
* Refactored workload identifier parsing tests to cover both invalid (empty or too many segments) and valid cases, improving test organization and coverage.

**Test refactoring and maintenance:**

* Refactored test setup in `TestGetWorkloadCmd_ChartPathAndFilePathEmpty` to initialize `ChartPath` and `FilePath` after command creation, simplifying test logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened workload scan tests to validate namespace handling and conditional inclusion of file path input.
  * Added scenarios ensuring scan input patterns appear only when a file path is provided.
  * Consolidated workload identifier parsing checks into explicit valid and invalid case coverage.
  * Updated expected error behavior for workload command usage reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2177)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->