### PR TITLE
fix: route PrometheusPrinter.Score() output to pp.writer instead of stdout

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -43,7 +43,7 @@ func (pp *PrometheusPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(pp.writer, "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
 }
 
 func (pp *PrometheusPrinter) generatePrometheusFormat(

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -74,20 +74,17 @@ func TestScore(t *testing.T) {
 		},
 	}
 
-	promPrinter := NewPrometheusPrinter(false)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Redirect stdout to a buffer
-			rescueStdout := os.Stdout
+			// Score() must write to pp.writer, not stdout
 			r, w, _ := os.Pipe()
-			os.Stdout = w
+			promPrinter := NewPrometheusPrinter(false)
+			promPrinter.writer = w
 
 			promPrinter.Score(tt.score)
 
 			w.Close()
 			got, _ := io.ReadAll(r)
-			os.Stdout = rescueStdout
 			assert.Equal(t, tt.want, string(got))
 		})
 	}


### PR DESCRIPTION
## Overview

`PrometheusPrinter.Score()` used `fmt.Printf` which writes to stdout
unconditionally. When the user passes `--output metrics.txt`, all other
metrics are correctly written to the file via `pp.writer` in `ActionPrint()`,
but `kubescape_score` went to stdout instead — the metric was silently
missing from the output file.

## Before

```bash
kubescape scan /tmp/deploy.yaml --format prometheus --output /tmp/metrics.txt

# kubescape_score printed to terminal (stdout) — missing from file
grep kubescape_score /tmp/metrics.txt   # returns empty
```

## After

```bash
kubescape scan /tmp/deploy.yaml --format prometheus --output /tmp/metrics.txt

# kubescape_score correctly written to /tmp/metrics.txt
grep kubescape_score /tmp/metrics.txt   # returns the metric line
```

## Root Cause

```go
// Before: always writes to stdout, ignores --output
fmt.Printf("\n# Overall compliance-score...\nkubescape_score %d\n", ...)

// After: respects pp.writer set by SetWriter() / --output
fmt.Fprintf(pp.writer, "\n# Overall compliance-score...\nkubescape_score %d\n", ...)
```

Compare with `JsonPrinter.Score()` which correctly uses `fmt.Fprintf(os.Stderr)`
to keep its human-readable summary out of the structured output.

## Changes

- `core/pkg/resultshandling/printer/v2/prometheus.go`: replace `fmt.Printf`
  with `fmt.Fprintf(pp.writer, ...)` in `Score()`
- `core/pkg/resultshandling/printer/v2/prometheus_test.go`: update test to
  assert output goes to `pp.writer` instead of capturing stdout

## Tests

```
--- PASS: TestScore/Score_less_than_0
--- PASS: TestScore/Score_greater_than_100
--- PASS: TestScore/Score_50
--- PASS: TestScore/Zero_Score
--- PASS: TestScore/Perfect_Score
ok github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2
```

## Related Issues
Closes #2176

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Prometheus metrics output handling to ensure consistent routing through the configured output channel rather than defaulting to standard output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2178)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->