### PR TITLE
test: expand scan validators coverage

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -132,7 +132,7 @@ func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
 	severity := scanInfo.FailThresholdSeverity
 
 	if scanInfo.Submit && scanInfo.OmitRawResources {
-		return fmt.Errorf("you can use `omit-raw-resources` or `submit`, but not both")
+		return ErrOmitRawResourcesOrSubmit
 	}
 
 	if err := shared.ValidateSeverity(severity); severity != "" && err != nil {

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -29,6 +29,11 @@ func Test_validateControlScanInfo(t *testing.T) {
 			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
 			shared.ErrUnknownSeverity,
 		},
+		{
+			"Submit with omit-raw-resources should be invalid",
+			&cautils.ScanInfo{Submit: true, OmitRawResources: true},
+			ErrOmitRawResourcesOrSubmit,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -49,6 +54,8 @@ func Test_validateControlScanInfo(t *testing.T) {
 
 // Test_validateFrameworkScanInfo tests how scan info is validated for the `scan framework` command
 func Test_validateFrameworkScanInfo(t *testing.T) {
+	const validAccountID = "22019933-feac-4012-a8eb-e81461ba6655"
+
 	testCases := []struct {
 		Description string
 		ScanInfo    *cautils.ScanInfo
@@ -56,27 +63,57 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 	}{
 		{
 			"Empty severity should be valid for scan info",
-			&cautils.ScanInfo{FailThresholdSeverity: ""},
+			&cautils.ScanInfo{FailThresholdSeverity: "", AccountID: validAccountID},
 			nil,
 		},
 		{
 			"High severity should be valid for scan info",
-			&cautils.ScanInfo{FailThresholdSeverity: "High"},
+			&cautils.ScanInfo{FailThresholdSeverity: "High", AccountID: validAccountID},
 			nil,
 		},
 		{
 			"Unknown severity should be invalid for scan info",
-			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
+			&cautils.ScanInfo{FailThresholdSeverity: "Unknown", AccountID: validAccountID},
 			shared.ErrUnknownSeverity,
 		},
 		{
 			"Security view should be invalid for scan info",
-			&cautils.ScanInfo{View: string(cautils.SecurityViewType)},
+			&cautils.ScanInfo{View: string(cautils.SecurityViewType), AccountID: validAccountID},
 			nil,
 		},
 		{
 			"Empty view should be valid for scan info",
-			&cautils.ScanInfo{},
+			&cautils.ScanInfo{AccountID: validAccountID},
+			nil,
+		},
+		{
+			"Submit with keep-local should be invalid",
+			&cautils.ScanInfo{Submit: true, Local: true, AccountID: validAccountID},
+			ErrKeepLocalOrSubmit,
+		},
+		{
+			"Submit with omit-raw-resources should be invalid",
+			&cautils.ScanInfo{Submit: true, OmitRawResources: true, AccountID: validAccountID},
+			ErrOmitRawResourcesOrSubmit,
+		},
+		{
+			"Fail threshold above 100 should be invalid",
+			&cautils.ScanInfo{FailThreshold: 101, AccountID: validAccountID},
+			ErrBadThreshold,
+		},
+		{
+			"Compliance threshold below 0 should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: -1, AccountID: validAccountID},
+			ErrBadThreshold,
+		},
+		{
+			"Coverage threshold above 100 should be invalid",
+			&cautils.ScanInfo{FailCoverageThreshold: 150, AccountID: validAccountID},
+			ErrBadThreshold,
+		},
+		{
+			"Invalid account ID should be rejected",
+			&cautils.ScanInfo{AccountID: "not-a-uuid"},
 			nil,
 		},
 	}
@@ -89,6 +126,13 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 
 				got := validateFrameworkScanInfo(tc.ScanInfo)
 
+				if tc.Description == "Invalid account ID should be rejected" {
+					if got == nil {
+						t.Errorf("got: %v, want: error", got)
+					}
+					return
+				}
+
 				if got != want {
 					t.Errorf("got: %v, want: %v", got, want)
 				}
@@ -96,6 +140,23 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 		)
 	}
 }
+
+	func Test_validateFrameworkScanInfo_SecurityViewMutatesToResourceView(t *testing.T) {
+		const validAccountID = "22019933-feac-4012-a8eb-e81461ba6655"
+
+		scanInfo := &cautils.ScanInfo{
+			View:      string(cautils.SecurityViewType),
+			AccountID: validAccountID,
+		}
+
+		err := validateFrameworkScanInfo(scanInfo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scanInfo.View != string(cautils.ResourceViewType) {
+			t.Fatalf("got view: %v, want: %v", scanInfo.View, string(cautils.ResourceViewType))
+		}
+	}
 
 func Test_validateCoverageThreshold(t *testing.T) {
 	testCases := []struct {

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -141,22 +141,22 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 	}
 }
 
-	func Test_validateFrameworkScanInfo_SecurityViewMutatesToResourceView(t *testing.T) {
-		const validAccountID = "22019933-feac-4012-a8eb-e81461ba6655"
+func Test_validateFrameworkScanInfo_SecurityViewMutatesToResourceView(t *testing.T) {
+	const validAccountID = "22019933-feac-4012-a8eb-e81461ba6655"
 
-		scanInfo := &cautils.ScanInfo{
-			View:      string(cautils.SecurityViewType),
-			AccountID: validAccountID,
-		}
-
-		err := validateFrameworkScanInfo(scanInfo)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if scanInfo.View != string(cautils.ResourceViewType) {
-			t.Fatalf("got view: %v, want: %v", scanInfo.View, string(cautils.ResourceViewType))
-		}
+	scanInfo := &cautils.ScanInfo{
+		View:      string(cautils.SecurityViewType),
+		AccountID: validAccountID,
 	}
+
+	err := validateFrameworkScanInfo(scanInfo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scanInfo.View != string(cautils.ResourceViewType) {
+		t.Fatalf("got view: %v, want: %v", scanInfo.View, string(cautils.ResourceViewType))
+	}
+}
 
 func Test_validateCoverageThreshold(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
This pull request expands and improves the validation tests for scan information in the `cmd/scan/validators_test.go` file. It adds new test cases to cover more edge conditions, ensures that invalid combinations of flags are properly tested, and verifies that certain input values result in expected validation errors. Additionally, it introduces a targeted test to confirm that the `SecurityView` is mutated to `ResourceView` during validation.

**Enhancements to scan info validation tests:**

* Added test cases to ensure invalid flag combinations, such as using both `Submit` and `OmitRawResources` or `Submit` and `keep-local`, are correctly rejected (`Test_validateControlScanInfo`, `Test_validateFrameworkScanInfo`). [[1]](diffhunk://#diff-d1d463499ccb658e39c004889384266f007183e05adaa0d3531b5e3cb3290971R32-R36) [[2]](diffhunk://#diff-d1d463499ccb658e39c004889384266f007183e05adaa0d3531b5e3cb3290971R57-R116)
* Introduced validation for threshold values, including tests for fail, compliance, and coverage thresholds being outside the accepted range (above 100 or below 0).
* Added a test to check that an invalid (non-UUID) `AccountID` is rejected by the validator. [[1]](diffhunk://#diff-d1d463499ccb658e39c004889384266f007183e05adaa0d3531b5e3cb3290971R57-R116) [[2]](diffhunk://#diff-d1d463499ccb658e39c004889384266f007183e05adaa0d3531b5e3cb3290971R129-R135)

**Behavioral validation:**

* Implemented a specific test (`Test_validateFrameworkScanInfo_SecurityViewMutatesToResourceView`) to verify that when `SecurityView` is provided, it is automatically converted to `ResourceView` as part of the validation process.

**Test consistency improvements:**

* Updated existing test cases to consistently include a valid `AccountID` where required, ensuring that tests are not inadvertently failing due to missing required fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validator tests with broader coverage of submission/omit-resource combos, account ID validation, threshold boundary checks, and verification that validation converts Security view to Resource view.
* **Bug Fixes**
  * Validation now rejects submitting while omitting raw resources and returns a specific, clearer error for that case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->