### PR TITLE
Add threshold bounds unit tests

### DIFF
--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -120,6 +120,32 @@ func Test_validateCoverageThreshold(t *testing.T) {
 	}
 }
 
+func Test_validateThresholdsOnly_ComplianceAndFail(t *testing.T) {
+	testCases := []struct {
+		Description string
+		ScanInfo    *cautils.ScanInfo
+		Want        error
+	}{
+		{"Compliance threshold above 100 is out of range", &cautils.ScanInfo{ComplianceThreshold: 101}, ErrBadThreshold},
+		{"Compliance threshold below 0 is out of range", &cautils.ScanInfo{ComplianceThreshold: -1}, ErrBadThreshold},
+		{"Compliance threshold at 0 is valid", &cautils.ScanInfo{ComplianceThreshold: 0}, nil},
+		{"Compliance threshold at 100 is valid", &cautils.ScanInfo{ComplianceThreshold: 100}, nil},
+		{"Fail threshold above 100 is out of range", &cautils.ScanInfo{FailThreshold: 101}, ErrBadThreshold},
+		{"Fail threshold below 0 is out of range", &cautils.ScanInfo{FailThreshold: -1}, ErrBadThreshold},
+		{"Fail threshold at 0 is valid", &cautils.ScanInfo{FailThreshold: 0}, nil},
+		{"Fail threshold at 100 is valid", &cautils.ScanInfo{FailThreshold: 100}, nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got := validateThresholdsOnly(tc.ScanInfo)
+			if got != tc.Want {
+				t.Errorf("got: %v, want: %v", got, tc.Want)
+			}
+		})
+	}
+}
+
 func Test_validateWorkloadIdentifier(t *testing.T) {
 	testCases := []struct {
 		Description string


### PR DESCRIPTION
Add threshold bounds unit tests

- Add coverage for compliance and fail threshold bounds in validateThresholdsOnly
- Verify out-of-range values error and boundary values pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for threshold validation boundary conditions to ensure accurate error handling and reporting for invalid ranges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->