### PR TITLE
Add image command RunE tests

### DIFF
--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/spf13/cobra"
@@ -32,4 +33,38 @@ func TestGetImageCmd(t *testing.T) {
 
 	err = cmd.RunE(&cobra.Command{}, []string{})
 	assert.Equal(t, expectedErrorMessage, err.Error())
+}
+
+func TestGetImageCmd_RunE_InvalidSeverity(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{FailThresholdSeverity: "unknown"}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+
+	err := cmd.RunE(cmd, []string{"nginx"})
+	assert.Equal(t, shared.ErrUnknownSeverity, err)
+}
+
+func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parent := &cobra.Command{}
+	parent.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "", "")
+	parent.AddCommand(cmd)
+	assert.NoError(t, parent.PersistentFlags().Set("format", ""))
+
+	err := cmd.RunE(cmd, []string{"nginx"})
+	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, sarif", err.Error())
+}
+
+func TestGetImageCmd_RunE_Success(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+
+	err := cmd.RunE(cmd, []string{"nginx"})
+	assert.NoError(t, err)
 }

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -18,6 +18,9 @@ func TestGetImageCmd(t *testing.T) {
 	}
 
 	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"`)
+	parentCmd.AddCommand(cmd)
 
 	// Verify the command name and short description
 	assert.Equal(t, "image <image>:<tag> [flags]", cmd.Use)
@@ -33,6 +36,13 @@ func TestGetImageCmd(t *testing.T) {
 
 	err = cmd.RunE(&cobra.Command{}, []string{})
 	assert.Equal(t, expectedErrorMessage, err.Error())
+
+	formatFlag := cmd.InheritedFlags().Lookup("format")
+	assert.NotNil(t, formatFlag)
+	assert.False(t, formatFlag.Changed)
+
+	err = cmd.RunE(cmd, []string{"nginx"})
+	assert.NoError(t, err)
 }
 
 func TestGetImageCmd_RunE_InvalidSeverity(t *testing.T) {

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -74,6 +74,9 @@ func TestGetImageCmd_RunE_Success(t *testing.T) {
 	scanInfo := cautils.ScanInfo{}
 
 	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"`)
+	parentCmd.AddCommand(cmd)
 
 	err := cmd.RunE(cmd, []string{"nginx"})
 	assert.NoError(t, err)


### PR DESCRIPTION
Add image command RunE unit tests

- Cover invalid severity handling in `getImageCmd` RunE
- Verify empty `--format` flag errors as expected
- Add a success-path RunE test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the image scanning command:
    * verifies error on invalid severity threshold
    * verifies specific error when output format is empty (includes supported formats)
    * verifies successful execution with a valid image
    * validates the persistent output-format flag is correctly honored

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->