### PR TITLE
Add BoolPtrFlag unit tests

### DIFF
--- a/core/cautils/boolptrflag_test.go
+++ b/core/cautils/boolptrflag_test.go
@@ -47,4 +47,6 @@ func TestBoolPtrFlag_Set(t *testing.T) {
 
 	assert.NoError(t, flag.Set("unknown"))
 	assert.False(t, flag.GetBool())
+	assert.NotNil(t, flag.Get())
+	assert.Equal(t, "false", flag.String())
 }

--- a/core/cautils/boolptrflag_test.go
+++ b/core/cautils/boolptrflag_test.go
@@ -1,0 +1,50 @@
+package cautils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolPtrFlag_Defaults(t *testing.T) {
+	flag := NewBoolPtr(nil)
+
+	assert.Equal(t, "bool", flag.Type())
+	assert.Equal(t, "", flag.String())
+	assert.Nil(t, flag.Get())
+	assert.False(t, flag.GetBool())
+}
+
+func TestBoolPtrFlag_NewValue(t *testing.T) {
+	value := true
+	flag := NewBoolPtr(&value)
+
+	assert.Equal(t, "true", flag.String())
+	assert.NotNil(t, flag.Get())
+	assert.True(t, flag.GetBool())
+}
+
+func TestBoolPtrFlag_SetBool(t *testing.T) {
+	flag := NewBoolPtr(nil)
+
+	flag.SetBool(true)
+	assert.Equal(t, "true", flag.String())
+	assert.True(t, flag.GetBool())
+
+	flag.SetBool(false)
+	assert.Equal(t, "false", flag.String())
+	assert.False(t, flag.GetBool())
+}
+
+func TestBoolPtrFlag_Set(t *testing.T) {
+	flag := NewBoolPtr(nil)
+
+	assert.NoError(t, flag.Set("true"))
+	assert.True(t, flag.GetBool())
+
+	assert.NoError(t, flag.Set("false"))
+	assert.False(t, flag.GetBool())
+
+	assert.NoError(t, flag.Set("unknown"))
+	assert.False(t, flag.GetBool())
+}


### PR DESCRIPTION
Add BoolPtrFlag unit tests

- Cover default/nil pointer behavior
- Verify `SetBool` updates value and string output
- Validate `Set` handles true/false and ignores unknown input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for BoolPtrFlag to verify behavior when constructed with nil or non-nil pointers, correct default values, updates via boolean setters, and parsing of string inputs ("true", "false", and unrecognized values) to ensure the flag state and string representation are consistent across scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2183)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->