### PR TITLE
test: cover requiresResourceMatch designator constraints

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -633,6 +633,98 @@ func TestApplyExceptionsToManualControls(t *testing.T) {
 	})
 }
 
+func TestRequiresResourceMatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		designator identifiers.PortalDesignator
+		want       bool
+	}{
+		{
+			name:       "empty designator does not require a resource match",
+			designator: identifiers.PortalDesignator{},
+			want:       false,
+		},
+		{
+			name: "cluster-only attributes do not require a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeCluster: "prod-cluster"},
+			},
+			want: false,
+		},
+		{
+			name: "wlid requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorWlid,
+				WLID:           "wlid://cluster-prod/namespace-default/deployment-nginx",
+			},
+			want: true,
+		},
+		{
+			name: "wild wlid requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorWildWlid,
+				WildWLID:       "wlid://cluster-prod/*/deployment-*",
+			},
+			want: true,
+		},
+		{
+			name: "namespace attribute requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeNamespace: "kube-system"},
+			},
+			want: true,
+		},
+		{
+			name: "name attribute requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeName: "nginx"},
+			},
+			want: true,
+		},
+		{
+			name: "kind attribute requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeKind: "Deployment"},
+			},
+			want: true,
+		},
+		{
+			name: "path attribute requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributePath: "/spec/template"},
+			},
+			want: true,
+		},
+		{
+			name: "resourceID attribute requires a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeResourceID: "resource-123"},
+			},
+			want: true,
+		},
+		{
+			name: "labels require a resource match",
+			designator: identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{"app": "nginx"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requiresResourceMatch(tt.designator))
+		})
+	}
+}
+
 // mockCounters implements reportsummary.ICounters for testing
 type mockCounters struct {
 	failed, skipped, passed, excluded int


### PR DESCRIPTION
## Summary
- add unit tests for requiresResourceMatch across WLID, wild WLID, and attribute/label constraints
- verify cluster-only designators do not require a resource match

## Testing
- go test ./core/pkg/opaprocessor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests to validate internal resource matching logic with multiple test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->