### PR TITLE
perf: parallelize K8s resource collection in pullResources

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -336,6 +337,11 @@ type queryFailure struct {
 	err error
 }
 
+// maxParallelResourcePulls limits the number of concurrent K8s API List calls
+// issued by pullResources. This avoids overwhelming small API servers while
+// still providing a significant speedup on clusters with many resource types.
+const maxParallelResourcePulls = 8
+
 func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
@@ -344,34 +350,60 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 	// one selector variant is never suppressed by a success on a different variant
 	// for the same raw GVR.
 	failedQueries := map[string]queryFailure{}
-	for i := range queryableResources {
-		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(queryableResources[i].GroupVersionResourceTriplet)
-		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
-		result, err := k8sHandler.pullSingleResource(&gvr, nil, queryableResources[i].FieldSelectors, globalFieldSelectors)
-		if err != nil {
-			if !strings.Contains(err.Error(), "the server could not find the requested resource") {
-				qr := queryableResources[i]
-				failedQueries[qr.String()] = queryFailure{
-					gvr: queryableResources[i].GroupVersionResourceTriplet,
-					err: err,
-				}
-			}
-			continue
-		}
-		// store result as []map[string]interface{}
-		metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
-		for i := range metaObjs {
-			allResources[metaObjs[i].GetID()] = metaObjs[i]
-		}
 
-		key := queryableResources[i].GroupVersionResourceTriplet
-		if _, ok := k8sResources[key]; !ok {
-			k8sResources[key] = workloadinterface.ListMetaIDs(metaObjs)
-		} else {
-			k8sResources[key] = append(k8sResources[key], workloadinterface.ListMetaIDs(metaObjs)...)
-		}
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+
+	// sem is a counting semaphore that bounds the number of in-flight API
+	// calls so we don't overload the kube-apiserver on smaller clusters.
+	sem := make(chan struct{}, maxParallelResourcePulls)
+
+	for key := range queryableResources {
+		qr := queryableResources[key]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
+			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
+			result, err := k8sHandler.pullSingleResource(&gvr, nil, qr.FieldSelectors, globalFieldSelectors)
+
+			if err != nil {
+				if !strings.Contains(err.Error(), "the server could not find the requested resource") {
+					mu.Lock()
+					failedQueries[qr.String()] = queryFailure{
+						gvr: qr.GroupVersionResourceTriplet,
+						err: err,
+					}
+					mu.Unlock()
+				}
+				return
+			}
+
+			// Convert API results outside the critical section — these
+			// functions operate only on the local result slice.
+			metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
+			ids := workloadinterface.ListMetaIDs(metaObjs)
+
+			mu.Lock()
+			for j := range metaObjs {
+				allResources[metaObjs[j].GetID()] = metaObjs[j]
+			}
+			gvrKey := qr.GroupVersionResourceTriplet
+			if _, ok := k8sResources[gvrKey]; !ok {
+				k8sResources[gvrKey] = ids
+			} else {
+				k8sResources[gvrKey] = append(k8sResources[gvrKey], ids...)
+			}
+			mu.Unlock()
+		}()
 	}
 
+	wg.Wait()
 	return k8sResources, allResources, failedQueries
 }
 


### PR DESCRIPTION
## What

Parallelizes GVR queries in `K8sResourceHandler.pullResources` using bounded goroutines, reducing scan time on clusters with many resource types.

## Why

Currently, `pullResources` queries each GroupVersionResource (GVR) sequentially. On clusters with many CRDs or when scanning against multiple frameworks, this becomes a significant bottleneck — each API List call blocks the next. Since each GVR targets a different API endpoint, these calls are naturally independent and safe to parallelize.

## How

- Each `QueryableResource` is fetched in its own goroutine.
- A **buffered channel** acts as a counting semaphore (`maxParallelResourcePulls = 8`) to bound the number of in-flight API calls and avoid overwhelming smaller API servers.
- A `sync.Mutex` protects the shared result maps (`k8sResources`, `allResources`, `failedQueries`) during the merge phase.
- The mutex is acquired **only after** `pullSingleResource` returns, so the I/O-bound API calls run fully in parallel — the critical section is just the map writes.

### Design decisions

| Decision | Rationale |
|---|---|
| **Concurrency limit of 8** | Balances throughput vs. API server load. Comparable to `kubectl` defaults (10). Safe for small clusters; fast for large ones. |
| **stdlib only** | Uses `sync.WaitGroup` + `sync.Mutex` + channel semaphore. Zero new dependencies. |
| **Behavioral parity** | Produces identical results. Map iteration order was already non-deterministic, so parallelism introduces no new non-determinism. |
| **Mutex after I/O** | The lock protects only the fast map-write path, not the slow API call. This minimizes contention. |

## Testing

- `go build ./...` ✅
- `go test -race -count=1 ./core/pkg/resourcehandler/...` ✅ (race detector clean)
- `go test -count=1 ./...` ✅ (full suite, all packages pass)
- `golangci-lint run --timeout 10m` ✅ (zero new issues in changed file)

## Notes for Reviewers

- The `pullSingleResource` method is stateless and uses only thread-safe K8s dynamic client operations, making it safe for concurrent invocation.
- The concurrency limit constant (`maxParallelResourcePulls`) can be made configurable via environment variable or ScanInfo flag in a follow-up if desired.
- This change does NOT address the `context.Background()` usage inside `pullSingleResource` — that is tracked separately as a context propagation improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Kubernetes resource fetching is now concurrent with controlled parallelism for faster pulls and reduced resource exhaustion.

* **Bug Fixes**
  * Improved handling of missing-resource errors to reduce noise and more granular recording of failed queries for clearer diagnostics.

* **Stability**
  * Safer concurrency coordination to improve overall reliability during resource retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2187)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->