### PR TITLE
fix: propagate context through cosign OPA built-in functions

### DIFF
--- a/core/pkg/opaprocessor/cosign_has_signature.go
+++ b/core/pkg/opaprocessor/cosign_has_signature.go
@@ -7,12 +7,12 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 )
 
-func has_signature(img string) bool {
+func has_signature(ctx context.Context, img string) bool {
 	ref, err := name.ParseReference(img)
 	if err != nil {
 		return false
 	}
-	sins, err := cosign.FetchSignaturesForReference(context.Background(), ref)
+	sins, err := cosign.FetchSignaturesForReference(ctx, ref)
 
 	if err != nil {
 		return false

--- a/core/pkg/opaprocessor/cosign_has_signature_test.go
+++ b/core/pkg/opaprocessor/cosign_has_signature_test.go
@@ -1,6 +1,7 @@
 package opaprocessor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func Test_has_signature(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, has_signature(tt.img), tt.name)
+			assert.Equal(t, tt.want, has_signature(context.Background(), tt.img), tt.name)
 		})
 	}
 }

--- a/core/pkg/opaprocessor/cosign_verify.go
+++ b/core/pkg/opaprocessor/cosign_verify.go
@@ -43,7 +43,7 @@ type VerifyCommand struct {
 }
 
 // Exec runs the verification command
-func verify(img string, key string) (bool, error) {
+func verify(ctx context.Context, img string, key string) (bool, error) {
 
 	co := &cosign.CheckOpts{}
 	var ociremoteOpts []ociremote.Option
@@ -67,12 +67,12 @@ func verify(img string, key string) (bool, error) {
 		return false, fmt.Errorf("resolving attachment type %s for image %s: %w", attachment, img, err)
 	}
 
-	co.RekorPubKeys, err = cosign.GetRekorPubs(context.Background())
+	co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
 	if err != nil {
 		return false, fmt.Errorf("getting Rekor public keys: %w", err)
 	}
 
-	_, _, err = cosign.VerifyImageSignatures(context.Background(), ref, co)
+	_, _, err = cosign.VerifyImageSignatures(ctx, ref, co)
 	if err != nil {
 		return false, fmt.Errorf("verifying signature: %w", err)
 	}

--- a/core/pkg/opaprocessor/cosign_verify_test.go
+++ b/core/pkg/opaprocessor/cosign_verify_test.go
@@ -1,6 +1,7 @@
 package opaprocessor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -48,7 +49,7 @@ func Test_verify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := verify(tt.args.img, tt.args.key)
+			got, err := verify(context.Background(), tt.args.img, tt.args.key)
 			if !tt.wantErr(t, err, fmt.Sprintf("verify(%v, %v)", tt.args.img, tt.args.key)) {
 				return
 			}

--- a/core/pkg/opaprocessor/utils.go
+++ b/core/pkg/opaprocessor/utils.go
@@ -78,7 +78,7 @@ var cosignVerifySignatureDefinition = func(bctx rego.BuiltinContext, a, b *ast.T
 	}
 	// Replace double backslashes with single backslashes
 	bbStr := strings.ReplaceAll(string(bStr), "\\n", "\n")
-	result, err := verify(string(aStr), bbStr)
+	result, err := verify(bctx.Context, string(aStr), bbStr)
 	if err != nil {
 		// Do not change this log from debug level. We might find a lot of images without signature
 		logger.L().Debug("failed to verify signature", helpers.String("image", string(aStr)), helpers.String("key", string(bStr)), helpers.Error(err))
@@ -96,7 +96,7 @@ var cosignHasSignatureDefinition = func(bctx rego.BuiltinContext, a *ast.Term) (
 	if err != nil {
 		return nil, fmt.Errorf("invalid parameter type: %v", err)
 	}
-	return ast.BooleanTerm(has_signature(string(aStr))), nil
+	return ast.BooleanTerm(has_signature(bctx.Context, string(aStr))), nil
 }
 
 var imageNameNormalizeDeclaration = &rego.Function{


### PR DESCRIPTION
Fixes #2190

## What

Threads `context.Context` through the Cosign OPA built-in functions (`cosign.has_signature`, `cosign.verify`), replacing 3 instances of `context.Background()`.

## Why

The OPA evaluation engine provides a `rego.BuiltinContext` to every built-in function, which carries the scan's context (cancellation, timeouts, OTEL traces). Both Cosign built-ins were discarding this context by using `context.Background()`, which means:

1. **Scan cancellation** (Ctrl+C, HTTP timeout) does not propagate to Cosign registry/Rekor network calls
2. **OTEL trace spans** are orphaned — distributed tracing shows gaps at the Cosign boundary
3. **Scan-level timeouts** cannot be enforced on Cosign operations, which can hang on unresponsive registries

## How

| File | Change |
|---|---|
| `cosign_has_signature.go` | Add `ctx context.Context` parameter, replace `context.Background()` |
| `cosign_verify.go` | Add `ctx context.Context` parameter, replace 2× `context.Background()` |
| `utils.go` | Pass `bctx.Context` at both OPA built-in call sites |
| `cosign_has_signature_test.go` | Pass `context.Background()` in tests |
| `cosign_verify_test.go` | Pass `context.Background()` in tests |

## Testing

- `go build ./...` ✅
- `go test -race -count=1 ./core/pkg/opaprocessor/...` ✅ (race detector clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal context handling for signature verification and detection operations to improve lifecycle management across downstream systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->