### PR TITLE
fix(printer): default pdf/html output to file instead of stdout

### DIFF
--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -47,6 +47,39 @@ func GetWriter(ctx context.Context, outputFile string) *os.File {
 
 }
 
+// GetWriterNoStdoutFallback opens outputFile for writing for formats whose
+// output (binary, markup) would corrupt a TTY if dumped to stdout. On any
+// failure to open the requested file it falls back to a uniquely-named file
+// under os.TempDir() using tempPattern (e.g. "kubescape-report-*.pdf"). Only
+// if even that fails does it return os.DevNull — it never returns os.Stdout.
+func GetWriterNoStdoutFallback(ctx context.Context, outputFile, tempPattern string) *os.File {
+	if outputFile != "" {
+		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err == nil {
+			if f, err := os.Create(outputFile); err == nil {
+				return f
+			} else {
+				logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to open file for writing, reason: %s", err.Error()))
+			}
+		} else {
+			logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to create directory, reason: %s", err.Error()))
+		}
+	}
+	if tmp, err := os.CreateTemp("", tempPattern); err == nil {
+		logger.L().Ctx(ctx).Warning("could not write to requested output path; falling back to temp file",
+			helpers.String("filename", tmp.Name()))
+		return tmp
+	} else {
+		logger.L().Ctx(ctx).Error(fmt.Sprintf("failed to create temp output file, reason: %s", err.Error()))
+	}
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		// os.DevNull should always be openable; if not, fall back to a closed
+		// file rather than stdout so the TTY stays clean.
+		return os.NewFile(0, os.DevNull)
+	}
+	return devNull
+}
+
 func LogOutputFile(fileName string) {
 	if fileName != os.Stdout.Name() && fileName != os.Stderr.Name() && fileName != os.DevNull {
 		logger.L().Success("Scan results saved", helpers.String("filename", fileName))

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -3,6 +3,8 @@ package printer
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,4 +15,49 @@ func TestGetWriter_EmptyFileName(t *testing.T) {
 	outputFile := ""
 	file := GetWriter(ctx, outputFile)
 	assert.Equal(t, os.Stdout, file)
+}
+
+// Regression: GetWriterNoStdoutFallback must never hand back os.Stdout, even
+// when the requested path is unwritable — the whole point is to protect TTYs
+// from binary/markup formats.
+func TestGetWriterNoStdoutFallback_UnwritableTargetFallsBackToTemp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics required for this test")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file-mode permissions; cannot exercise the failure path")
+	}
+	ctx := context.Background()
+
+	// Create a 0555 directory we cannot write into, then ask to create a file
+	// inside it. This is the same shape as matthyx's reproducer (read-only cwd).
+	roDir := filepath.Join(t.TempDir(), "ro")
+	assert.NoError(t, os.Mkdir(roDir, 0o555))
+	target := filepath.Join(roDir, "report.pdf")
+
+	f := GetWriterNoStdoutFallback(ctx, target, "kubescape-report-*.pdf")
+	if f != nil {
+		t.Cleanup(func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		})
+	}
+	assert.NotNil(t, f)
+	assert.NotEqual(t, os.Stdout.Name(), f.Name(),
+		"must not fall back to stdout for binary/markup formats")
+	assert.NotEqual(t, target, f.Name(),
+		"target was unwritable; expected a fallback path")
+}
+
+func TestGetWriterNoStdoutFallback_EmptyFileNameStillAvoidsStdout(t *testing.T) {
+	ctx := context.Background()
+	f := GetWriterNoStdoutFallback(ctx, "", "kubescape-report-*.pdf")
+	if f != nil {
+		t.Cleanup(func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		})
+	}
+	assert.NotNil(t, f)
+	assert.NotEqual(t, os.Stdout.Name(), f.Name())
 }

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -42,13 +42,13 @@ func NewHtmlPrinter() *HtmlPrinter {
 }
 
 func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = htmlOutputFile
-		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != htmlOutputExt {
-			outputFile = outputFile + htmlOutputExt
-		}
+	if strings.TrimSpace(outputFile) == "" {
+		// Raw HTML markup must never fall back to stdout on a TTY.
+		outputFile = htmlOutputFile + htmlOutputExt
+		logger.L().Info("no --output specified for html format; writing to default file",
+			helpers.String("filename", outputFile))
+	} else if filepath.Ext(strings.TrimSpace(outputFile)) != htmlOutputExt {
+		outputFile = outputFile + htmlOutputExt
 	}
 	hp.writer = printer.GetWriter(ctx, outputFile)
 }

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -42,12 +42,13 @@ func NewHtmlPrinter() *HtmlPrinter {
 }
 
 func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
-	if strings.TrimSpace(outputFile) == "" {
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile == "" {
 		// Raw HTML markup must never fall back to stdout on a TTY.
 		outputFile = htmlOutputFile + htmlOutputExt
 		logger.L().Info("no --output specified for html format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(strings.TrimSpace(outputFile)) != htmlOutputExt {
+	} else if filepath.Ext(outputFile) != htmlOutputExt {
 		outputFile = outputFile + htmlOutputExt
 	}
 	hp.writer = printer.GetWriter(ctx, outputFile)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -51,7 +51,9 @@ func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
 	} else if filepath.Ext(outputFile) != htmlOutputExt {
 		outputFile = outputFile + htmlOutputExt
 	}
-	hp.writer = printer.GetWriter(ctx, outputFile)
+	// HTML must never fall back to stdout on file-create errors either
+	// (e.g. read-only cwd) — use the no-stdout-fallback helper.
+	hp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+htmlOutputExt)
 }
 
 func (hp *HtmlPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -42,6 +42,11 @@ func TestSetWriter_Html(t *testing.T) {
 			outputFile: "   ",
 			expected:   "report.html",
 		},
+		{
+			name:       "Surrounding whitespace is trimmed",
+			outputFile: "  myfile  ",
+			expected:   "myfile.html",
+		},
 	}
 
 	hp := NewHtmlPrinter()

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -1,0 +1,64 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHtmlPrinter(t *testing.T) {
+	hp := NewHtmlPrinter()
+	assert.NotNil(t, hp)
+	assert.Empty(t, hp)
+}
+
+func TestSetWriter_Html(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		expected   string
+	}{
+		{
+			name:       "Output file name doesn't contain any extension",
+			outputFile: "customFilename",
+			expected:   "customFilename.html",
+		},
+		{
+			name:       "Output file name already contains .html",
+			outputFile: "customFilename.html",
+			expected:   "customFilename.html",
+		},
+		{
+			// Regression for issue-6: empty --output must NOT fall through to
+			// stdout — default to ./report.html instead.
+			name:       "Output file name is empty defaults to report.html",
+			outputFile: "",
+			expected:   "report.html",
+		},
+		{
+			name:       "Whitespace-only output file is treated as empty",
+			outputFile: "   ",
+			expected:   "report.html",
+		},
+	}
+
+	hp := NewHtmlPrinter()
+	ctx := context.Background()
+
+	tmp := t.TempDir()
+	origWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hp.SetWriter(ctx, tt.outputFile)
+			assert.Equal(t, tt.expected, hp.writer.Name())
+			assert.NotEqual(t, "/dev/stdout", hp.writer.Name(),
+				"HTML printer must never write to stdout")
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -35,13 +35,14 @@ func NewPdfPrinter() *PdfPrinter {
 }
 
 func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
-	if strings.TrimSpace(outputFile) == "" {
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile == "" {
 		// Binary PDF must never fall back to stdout: it corrupts TTYs and
 		// is rarely what the user intended. Default to ./report.pdf.
 		outputFile = pdfOutputFile + pdfOutputExt
 		logger.L().Info("no --output specified for pdf format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(strings.TrimSpace(outputFile)) != pdfOutputExt {
+	} else if filepath.Ext(outputFile) != pdfOutputExt {
 		outputFile = outputFile + pdfOutputExt
 	}
 	pp.writer = printer.GetWriter(ctx, outputFile)

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -35,15 +35,14 @@ func NewPdfPrinter() *PdfPrinter {
 }
 
 func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
-	if outputFile != "" {
-		// Ensure to have an available output file, otherwise create it.
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = pdfOutputFile
-		}
-		// Ensure to have the right file extension.
-		if filepath.Ext(strings.TrimSpace(outputFile)) != pdfOutputExt {
-			outputFile = outputFile + pdfOutputExt
-		}
+	if strings.TrimSpace(outputFile) == "" {
+		// Binary PDF must never fall back to stdout: it corrupts TTYs and
+		// is rarely what the user intended. Default to ./report.pdf.
+		outputFile = pdfOutputFile + pdfOutputExt
+		logger.L().Info("no --output specified for pdf format; writing to default file",
+			helpers.String("filename", outputFile))
+	} else if filepath.Ext(strings.TrimSpace(outputFile)) != pdfOutputExt {
+		outputFile = outputFile + pdfOutputExt
 	}
 	pp.writer = printer.GetWriter(ctx, outputFile)
 }

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -45,7 +45,10 @@ func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
 	} else if filepath.Ext(outputFile) != pdfOutputExt {
 		outputFile = outputFile + pdfOutputExt
 	}
-	pp.writer = printer.GetWriter(ctx, outputFile)
+	// PDF must never fall back to stdout on file-create errors either
+	// (e.g. read-only cwd) — use the no-stdout-fallback helper, which
+	// falls back to a temp file rather than corrupting the TTY.
+	pp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+pdfOutputExt)
 }
 
 func (pp *PdfPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -113,6 +113,13 @@ func TestSetWriter_Pdf(t *testing.T) {
 			outputFile: "   ",
 			expected:   "report.pdf",
 		},
+		{
+			// Surrounding whitespace must be trimmed before extension handling,
+			// otherwise we'd produce filenames like "  myfile  .pdf".
+			name:       "Surrounding whitespace is trimmed",
+			outputFile: "  myfile  ",
+			expected:   "myfile.pdf",
+		},
 	}
 
 	pp := NewPdfPrinter()

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -102,20 +102,36 @@ func TestSetWriter_Pdf(t *testing.T) {
 			expected:   "customFilename.pdf",
 		},
 		{
-			name:       "Output file name is empty",
+			// Regression for issue-6: empty --output must NOT fall through to
+			// stdout for binary formats — default to ./report.pdf instead.
+			name:       "Output file name is empty defaults to report.pdf",
 			outputFile: "",
-			expected:   "/dev/stdout",
+			expected:   "report.pdf",
+		},
+		{
+			name:       "Whitespace-only output file is treated as empty",
+			outputFile: "   ",
+			expected:   "report.pdf",
 		},
 	}
 
 	pp := NewPdfPrinter()
 	ctx := context.Background()
 
+	// Run from a temp cwd so the default-named file lands somewhere disposable.
+	tmp := t.TempDir()
+	origWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			pp.SetWriter(ctx, tt.outputFile)
 			assert.Equal(t, tt.expected, pp.writer.Name())
+			assert.NotEqual(t, "/dev/stdout", pp.writer.Name(),
+				"PDF printer must never write to stdout")
 		})
 	}
 }


### PR DESCRIPTION
## Overview

Fixes the bug reported where `kubescape scan --format pdf` (and `--format html`) without `--output` dumps the entire binary PDF (~130 KB starting with `%PDF-1.4`) or raw HTML markup directly to **stdout**, corrupting interactive terminals and producing output that no consumer actually wants on a TTY.

**Current behavior:** With no `--output` flag, both the PDF and HTML printers fall through to `printer.GetWriter(ctx, "")`, which returns `os.Stdout`. The full binary PDF or unrendered HTML is written to the terminal, exit code is `0`, and the user gets no warning that this was almost certainly not what they intended. The same fallback is fine for `json`/`sarif`/`junit`/`prometheus` (those are pipeable) — but it is wrong for binary and markup formats.

**Future behavior:** When `--output` is empty or whitespace-only, the PDF printer writes to `./report.pdf` and the HTML printer writes to `./report.html`, both in the current working directory. The chosen filename is announced via the existing `logger.L().Info` path so users aren't surprised. Existing behavior with `--output <file>` (including extension auto-completion when the user passes a bare name) is unchanged. Text formats remain pipeable and are not touched.

## Additional Information

Root cause locations are in `core/pkg/resultshandling/printer/v2/pdf.go` and `core/pkg/resultshandling/printer/v2/htmlprinter.go`. Both `SetWriter` methods had the same structural bug:

- **empty `outputFile` fell through to stdout:** the extension-fixing logic was wrapped in `if outputFile != ""`, then `printer.GetWriter(ctx, outputFile)` was called unconditionally. With an empty string, `GetWriter` returns `os.Stdout` (`printresults.go:46`). Fix: when `outputFile` is empty/whitespace, substitute `report.pdf` / `report.html` before calling `GetWriter`, and log the filename.
- **dead unreachable branch:** an inner `if strings.TrimSpace(outputFile) == ""` block sat inside the outer `if outputFile != ""` guard — unreachable. Removed.

The related `GetWriter` permission-error → stdout fallback (`printresults.go:37,42`) is a separate concern and is intentionally left untouched here; it warrants its own ticket because it also hides errors for text formats.

A bonus is the whitespace-only guard (`strings.TrimSpace`): previously `--output "   "` would have been treated as a real filename request and either failed obscurely or created a file with a whitespace name. It now consistently routes to the default.

## How to Test

1. Build: `go build -o /tmp/kubescape ./`
2. Reproduce against an insecure manifest (same fixture used in the issue write-up):
   ```sh
   cat > /tmp/pod.yaml <<'EOF'
   apiVersion: v1
   kind: Pod
   metadata: { name: bad-pod }
   spec:
     containers:
     - name: c
       image: nginx
       securityContext: { privileged: true }
   EOF
   ```
3. Verify the PDF path no longer writes to stdout and creates the default file:
   ```sh
   cd /tmp && rm -f report.pdf
   /tmp/kubescape scan /tmp/pod.yaml --format pdf > /tmp/out.bin
   wc -c < /tmp/out.bin          # must be 0
   file /tmp/report.pdf          # PDF document, version 1.4, 1 page(s)
   ```
4. Verify the HTML path:
   ```sh
   cd /tmp && rm -f report.html
   /tmp/kubescape scan /tmp/pod.yaml --format html > /tmp/out.html
   wc -c < /tmp/out.html         # must be 0
   head -1 /tmp/report.html      # <!DOCTYPE html>
   ```
5. Verify explicit `--output` paths still behave as before:
   ```sh
   /tmp/kubescape scan /tmp/pod.yaml --format pdf  --output /tmp/mine.pdf
   /tmp/kubescape scan /tmp/pod.yaml --format pdf  --output /tmp/mine        # adds .pdf
   /tmp/kubescape scan /tmp/pod.yaml --format html --output /tmp/mine.html
   file /tmp/mine.pdf && head -1 /tmp/mine.html
   ```
6. Run the unit + regression tests:
   ```sh
   go test ./core/pkg/resultshandling/printer/v2/...
   ```
   This now includes:
   - `TestSetWriter_Pdf` — updated. Previously asserted the buggy `/dev/stdout` behavior for empty input; flipped to assert `report.pdf`, added a whitespace-only case, and added an explicit `NotEqual("/dev/stdout")` guard. Hermeticized via `t.TempDir()` + `os.Chdir`.
   - `TestSetWriter_Html` — new (`htmlprinter_test.go` didn't exist before). Mirrors the PDF matrix: extension auto-completion, already-correct extension, empty input, whitespace-only input, and the `NotEqual("/dev/stdout")` guard.

## Examples

**Before the fix:**
```sh
$ kubescape scan pod.yaml --format pdf
%PDF-1.4
%����
3 0 obj
<</Filter/FlateDecode/Length 1234>>stream
<binary garbage continues for ~130 KB, corrupting the terminal>
...
$ echo $?
0
```
- 130 KB of binary on stdout, no warning, exit 0
- HTML behaves the same way (`<!DOCTYPE html>...` and the rest of the markup on stdout)
- Piping to a file works but is undiscoverable; piping to a browser does not

**After the fix:**
```sh
$ kubescape scan pod.yaml --format pdf
... scan progress on stderr ...
[info] no --output specified for pdf format; writing to default file. filename: report.pdf
[success] Scan results saved. filename: report.pdf

$ file report.pdf
report.pdf: PDF document, version 1.4, 1 page(s)
```
- Stdout is empty
- Default `report.pdf` / `report.html` lands in the current directory
- The existing `LogOutputFile` success line still fires, so existing CI parsers that watch for it keep working

## Related
fixes #2153 
## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report output filenames are normalized: surrounding whitespace is trimmed, missing `.html`/`.pdf` extensions are added, and empty/whitespace-only outputs default to `report.html` or `report.pdf`.
  * Report writers no longer fall back to stdout on file-create/write failures for non-text formats, avoiding accidental terminal output.

* **Tests**
  * Added tests covering filename normalization, defaulting behavior, and non-stdout writer fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2192)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->