### PR TITLE
refactor: replace fmt.Sprintf with structured helpers.Error in getHostSensorHandler

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/google/uuid"
@@ -113,8 +112,7 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 	case hostSensorVal != nil && *hostSensorVal:
 		hostSensorHandler, err := hostsensorutils.NewHostSensorHandler(k8s, scanInfo.HostSensorYamlPath)
 		if err != nil {
-			logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to create host scanner: %s", err.Error()))
-
+			logger.L().Ctx(ctx).Warning("failed to create host scanner", helpers.Error(err))
 			return hostsensorutils.NewHostSensorHandlerMock()
 		}
 


### PR DESCRIPTION

## Summary

In `core/core/initutils.go`, the `getHostSensorHandler()` function 
was logging a warning using `fmt.Sprintf` with `err.Error()` as a 
plain string:

```go
// Before
logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to create host scanner: %s", err.Error()))
```

This has been replaced with the structured logging pattern used 
throughout the rest of the codebase:

```go
// After
logger.L().Ctx(ctx).Warning("failed to create host scanner", helpers.Error(err))
```

## Changes

- Removed `fmt.Sprintf` wrapper around the warning message
- Replaced `err.Error()` plain string with structured `helpers.Error(err)` field
- No logic changes — purely a logging consistency fix

## Related

Follows the same pattern as PR #2130 (merged).

## Checklist

- [x] No logic changes introduced
- [x] Follows existing structured logging conventions
- [x] No new dependencies added