### PR TITLE
test: cover patch default tags

### DIFF
--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -67,3 +67,28 @@ func Test_validateImagePatchInfo_Image(t *testing.T) {
 	err := validateImagePatchInfo(patchInfo)
 	assert.Nil(t, err)
 }
+
+func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {
+	patchInfo := &metav1.PatchInfo{
+		Image: "nginx",
+	}
+
+	err := validateImagePatchInfo(patchInfo)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "docker.io/library/nginx:latest", patchInfo.Image)
+	assert.Equal(t, "latest", patchInfo.ImageTag)
+	assert.Equal(t, "latest-patched", patchInfo.PatchedImageTag)
+	assert.Equal(t, "nginx", patchInfo.ImageName)
+}
+
+func Test_validateImagePatchInfo_DigestOnlyReturnsError(t *testing.T) {
+	patchInfo := &metav1.PatchInfo{
+		Image: "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	err := validateImagePatchInfo(patchInfo)
+
+	assert.Error(t, err)
+	assert.Equal(t, "unexpected error while parsing image tag", err.Error())
+}


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage for the `validateImagePatchInfo` function in `patch_test.go`. The new tests verify defaulting behavior and error handling for specific image input scenarios.

**Testing improvements:**

* Added `Test_validateImagePatchInfo_DefaultsTagAndPatchedTag` to ensure that when only an image name is provided, default values for tag, patched tag, and image name are correctly set (`patch_test.go`).
* Added `Test_validateImagePatchInfo_DigestOnlyReturnsError` to verify that providing an image with only a digest (no tag) results in an appropriate error (`patch_test.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for image patch validation to ensure correct defaulting behavior when processing image names and proper error handling for digest-only image references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->