### PR TITLE
test(imagescan): validate default DB config

### DIFF
--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -1,6 +1,7 @@
 package imagescan
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -247,6 +248,49 @@ func TestNewDefaultDBConfig(t *testing.T) {
 				assert.NotEmpty(t, installCfg.DBRootDir)
 				assert.True(t, strings.HasSuffix(installCfg.DBRootDir, defaultDBDirName))
 			}
+		})
+	}
+}
+
+func TestValidateDBLoad(t *testing.T) {
+	tests := []struct {
+		name    string
+		loadErr error
+		status  *vulnerability.ProviderStatus
+		wantErr string
+	}{
+		{
+			name:    "load error is wrapped",
+			loadErr: errors.New("boom"),
+			wantErr: "failed to load vulnerability db: boom",
+		},
+		{
+			name:    "nil status is rejected",
+			wantErr: "unable to determine the status of the vulnerability db",
+		},
+		{
+			name: "status error is wrapped",
+			status: &vulnerability.ProviderStatus{
+				Error: errors.New("status failure"),
+			},
+			wantErr: "db could not be loaded: status failure",
+		},
+		{
+			name:   "valid status passes",
+			status: &vulnerability.ProviderStatus{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDBLoad(tt.loadErr, tt.status)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -1,6 +1,7 @@
 package imagescan
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/anchore/grype/grype/vulnerability"
@@ -189,4 +190,63 @@ func TestNewScanServiceWithMatchersIntegration(t *testing.T) {
 	require.NoError(t, err)
 	defer svcWithoutDefault.Close()
 	assert.False(t, svcWithoutDefault.useDefaultMatchers)
+}
+
+func TestNewDefaultDBConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		grypeURL    string
+		wantURL     string
+		wantErr     bool
+		wantUpdate  bool
+		checkDBRoot bool
+	}{
+		{
+			name:        "Default URL when empty",
+			grypeURL:    "",
+			wantURL:     defaultGrypeListingURL,
+			wantErr:     false,
+			wantUpdate:  true,
+			checkDBRoot: true,
+		},
+		{
+			name:        "Custom HTTPS URL",
+			grypeURL:    "https://example.com/grype/db/listing.json",
+			wantURL:     "https://example.com/grype/db/listing.json",
+			wantErr:     false,
+			wantUpdate:  true,
+			checkDBRoot: true,
+		},
+		{
+			name:       "Invalid scheme",
+			grypeURL:   "ftp://example.com/db/listing.json",
+			wantErr:    true,
+			wantUpdate: false,
+		},
+		{
+			name:       "Invalid URL",
+			grypeURL:   "https://",
+			wantErr:    true,
+			wantUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			distCfg, installCfg, shouldUpdate, err := NewDefaultDBConfig(tt.grypeURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantUpdate, shouldUpdate)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantUpdate, shouldUpdate)
+			assert.Equal(t, tt.wantURL, distCfg.LatestURL)
+			if tt.checkDBRoot {
+				assert.NotEmpty(t, installCfg.DBRootDir)
+				assert.True(t, strings.HasSuffix(installCfg.DBRootDir, defaultDBDirName))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary\n- add unit coverage for default DB config URL validation and update behavior\n- verify default DB root dir suffix for valid inputs\n\n## Testing\n- go test ./pkg/imagescan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for configuration initialization covering defaults, custom URL handling, and invalid inputs.
  * Added validations for database load/status handling: rejects missing status, verifies error wrapping for load/status failures, and accepts valid status without error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2198)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->