### PR TITLE
test(anonymizer): reorganize and expand unit coverage

### DIFF
--- a/core/pkg/anonymizer/anonymizer_test.go
+++ b/core/pkg/anonymizer/anonymizer_test.go
@@ -3,297 +3,31 @@ package anonymizer
 import (
 	"testing"
 
-	"github.com/armosec/armoapi-go/armotypes"
-	"github.com/kubescape/k8s-interface/workloadinterface"
-	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
-	"github.com/kubescape/opa-utils/reporthandling"
-	"github.com/kubescape/opa-utils/reporthandling/apis"
-	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
-	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
-	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
-	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
-	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
-	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 )
 
-// ── Mapping ───────────────────────────────────────────────────────────────────
-
-func TestMapping_GetOrCreate_SameInputReturnsSameOutput(t *testing.T) {
-	m := NewMapping()
-	first := m.GetOrCreate("res", "my-pod")
-	second := m.GetOrCreate("res", "my-pod")
-	assert.Equal(t, first, second)
-}
-
-func TestMapping_GetOrCreate_DifferentInputsReturnDifferentOutputs(t *testing.T) {
-	m := NewMapping()
-	a := m.GetOrCreate("res", "pod-a")
-	b := m.GetOrCreate("res", "pod-b")
-	assert.NotEqual(t, a, b)
-}
-
-func TestMapping_GetOrCreate_PrefixIsolation(t *testing.T) {
-	m := NewMapping()
-	resVal := m.GetOrCreate("res", "myname")
-	nsVal := m.GetOrCreate("ns", "myname")
-	assert.NotEqual(t, resVal, nsVal)
-	assert.Contains(t, resVal, "res-")
-	assert.Contains(t, nsVal, "ns-")
-}
-
-// ── resolveMappedID ───────────────────────────────────────────────────────────
-
-func TestResolveMappedID_KnownID(t *testing.T) {
-	m := NewMapping()
-	idMapping := map[string]string{"old-id": "new-id"}
-	result := resolveMappedID(m, idMapping, "old-id", "ref")
-	assert.Equal(t, "new-id", result)
-}
-
-func TestResolveMappedID_UnknownIDFallsBackToMapping(t *testing.T) {
-	m := NewMapping()
-	idMapping := map[string]string{}
-	result := resolveMappedID(m, idMapping, "unknown-id", "ref")
-	assert.NotEqual(t, "unknown-id", result)
-	assert.Contains(t, result, "ref-")
-}
-
-// ── Apply ─────────────────────────────────────────────────────────────────────
-
-func TestApply_NilHandler(t *testing.T) {
-	assert.NoError(t, Apply(nil))
-}
-
-func TestApply_NilScanData(t *testing.T) {
-	rh := &resultshandling.ResultsHandler{}
-	assert.NoError(t, Apply(rh))
-}
-
-// ── anonymizeSession ──────────────────────────────────────────────────────────
-
-func TestAnonymizeSession_NilSession(t *testing.T) {
-	m := NewMapping()
-	anonymizeSession(nil, m)
-}
-
-func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
-	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Pod",
-		"metadata": map[string]interface{}{
-			"name":      "my-secret-pod",
-			"namespace": "my-secret-ns",
+func TestApply(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler *resultshandling.ResultsHandler
+	}{
+		{
+			name:    "nil handler should return without error",
+			handler: nil,
 		},
-	})
-
-	oldID := pod.GetID()
-	session := &cautils.OPASessionObj{
-		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
-		ResourcesResult:      make(map[string]resourcesresults.Result),
-		ResourceSource:       make(map[string]reporthandling.Source),
-		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
-	}
-
-	m := NewMapping()
-	anonymizeSession(session, m)
-
-	for _, r := range session.AllResources {
-		assert.NotEqual(t, "my-secret-pod", r.GetName())
-		assert.NotEqual(t, "my-secret-ns", r.GetNamespace())
-	}
-}
-
-// TestAnonymizeSession_IDConsistencyAcrossMaps seeds the same oldID into every
-// remapped collection and asserts they all resolve to the same anonymized ID
-// after anonymizeSession runs — covering all 6 paths the maintainer requested.
-func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
-	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Pod",
-		"metadata": map[string]interface{}{
-			"name":      "my-pod",
-			"namespace": "default",
-		},
-	})
-
-	oldID := pod.GetID()
-
-	// seed ResourceIDs in a ControlSummary
-	resourceIDs := helpersv1.AllLists{}
-	resourceIDs.Append(apis.StatusFailed, oldID)
-
-	session := &cautils.OPASessionObj{
-		// path 1: AllResources
-		AllResources: map[string]workloadinterface.IMetadata{oldID: pod},
-
-		// path 2: ResourcesResult — with nested Paths and RelatedResourcesIDs
-		ResourcesResult: map[string]resourcesresults.Result{
-			oldID: {
-				ResourceID: oldID,
-				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
-					{
-						ControlID: "C-0001",
-						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-							{
-								Name: "rule-1",
-								// path 4: Paths[*].ResourceID
-								Paths: []armotypes.PosturePaths{
-									{ResourceID: oldID},
-								},
-								// path 5: RelatedResourcesIDs
-								RelatedResourcesIDs: []string{oldID},
-							},
-						},
-					},
-				},
-			},
-		},
-
-		// path 3: ResourceSource
-		ResourceSource: map[string]reporthandling.Source{
-			oldID: {},
-		},
-
-		// path 3: ResourcesPrioritized
-		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
-			oldID: {ResourceID: oldID},
-		},
-
-		// path 3: ResourceAttackTracks
-		ResourceAttackTracks: map[string]v1alpha1.IAttackTrack{
-			oldID: &v1alpha1.AttackTrack{},
-		},
-
-		// path 6: Report.SummaryDetails.Controls[*].ResourceIDs
-		Report: &reporthandlingv2.PostureReport{
-			SummaryDetails: reportsummary.SummaryDetails{
-				Controls: reportsummary.ControlSummaries{
-					"C-0001": reportsummary.ControlSummary{
-						ResourceIDs: resourceIDs,
-					},
-				},
-			},
+		{
+			name:    "nil scan data should return without error",
+			handler: &resultshandling.ResultsHandler{},
 		},
 	}
 
-	m := NewMapping()
-	anonymizeSession(session, m)
-
-	// get the new ID from AllResources
-	var newID string
-	for id := range session.AllResources {
-		newID = id
-	}
-	assert.NotEmpty(t, newID)
-	assert.NotEqual(t, oldID, newID, "ID must be anonymized")
-
-	// path 2: ResourcesResult key
-	_, inResult := session.ResourcesResult[newID]
-	assert.True(t, inResult, "ResourcesResult must use remapped ID as key")
-
-	// path 2: ResourcesResult.ResourceID field
-	result := session.ResourcesResult[newID]
-	assert.Equal(t, newID, result.ResourceID, "Result.ResourceID must be remapped")
-
-	// path 4: Paths[*].ResourceID
-	pathResourceID := result.AssociatedControls[0].ResourceAssociatedRules[0].Paths[0].ResourceID
-	assert.Equal(t, newID, pathResourceID, "Paths[*].ResourceID must be remapped")
-
-	// path 5: RelatedResourcesIDs
-	relatedID := result.AssociatedControls[0].ResourceAssociatedRules[0].RelatedResourcesIDs[0]
-	assert.Equal(t, newID, relatedID, "RelatedResourcesIDs must be remapped")
-
-	// path 3: ResourceSource key
-	_, inSource := session.ResourceSource[newID]
-	assert.True(t, inSource, "ResourceSource must use remapped ID as key")
-
-	// path 3: ResourcesPrioritized key + field
-	prioritized, inPrioritized := session.ResourcesPrioritized[newID]
-	assert.True(t, inPrioritized, "ResourcesPrioritized must use remapped ID as key")
-	assert.Equal(t, newID, prioritized.ResourceID, "PrioritizedResource.ResourceID must be remapped")
-
-	// path 6: Report.SummaryDetails.Controls ResourceIDs
-	control := session.Report.SummaryDetails.Controls["C-0001"]
-	allIDs := control.ResourceIDs.All()
-	_, found := allIDs[newID]
-	assert.True(t, found, "Report.SummaryDetails.Controls ResourceIDs must use remapped ID")
-
-	// path 3: ResourceAttackTracks key
-	_, inAttackTracks := session.ResourceAttackTracks[newID]
-	assert.True(t, inAttackTracks, "ResourceAttackTracks must use remapped ID as key")
-}
-
-func TestAnonymizeSession_LabelsToCopyAreAnonymized(t *testing.T) {
-	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Pod",
-		"metadata": map[string]interface{}{
-			"name":      "my-pod",
-			"namespace": "default",
-			"labels": map[string]interface{}{
-				"team": "payments",
-				"env":  "production",
-			},
-		},
-	})
-
-	oldID := pod.GetID()
-	session := &cautils.OPASessionObj{
-		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
-		ResourcesResult:      make(map[string]resourcesresults.Result),
-		ResourceSource:       make(map[string]reporthandling.Source),
-		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
-		LabelsToCopy:         []string{"team", "env"},
-	}
-
-	m := NewMapping()
-	anonymizeSession(session, m)
-
-	for _, r := range session.AllResources {
-		wl, ok := r.(workloadinterface.IWorkload)
-		assert.True(t, ok)
-		labels := wl.GetLabels()
-		assert.NotEqual(t, "payments", labels["team"], "label value team must be anonymized")
-		assert.NotEqual(t, "production", labels["env"], "label value env must be anonymized")
-		assert.NotEmpty(t, labels["team"], "label key must still exist")
-		assert.NotEmpty(t, labels["env"], "label key must still exist")
-	}
-}
-
-func TestAnonymizeSession_EmptyLabelsToCopy_LabelsUnchanged(t *testing.T) {
-	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Pod",
-		"metadata": map[string]interface{}{
-			"name":      "my-pod",
-			"namespace": "default",
-			"labels": map[string]interface{}{
-				"team": "payments",
-			},
-		},
-	})
-
-	oldID := pod.GetID()
-	session := &cautils.OPASessionObj{
-		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
-		ResourcesResult:      make(map[string]resourcesresults.Result),
-		ResourceSource:       make(map[string]reporthandling.Source),
-		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
-		LabelsToCopy:         []string{},
-	}
-
-	m := NewMapping()
-	anonymizeSession(session, m)
-
-	for _, r := range session.AllResources {
-		wl, ok := r.(workloadinterface.IWorkload)
-		assert.True(t, ok)
-		labels := wl.GetLabels()
-		assert.Equal(t, "payments", labels["team"], "label must be unchanged when LabelsToCopy is empty")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				err := Apply(test.handler)
+				assert.NoError(t, err)
+			})
+		})
 	}
 }

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -1,0 +1,83 @@
+package anonymizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapping_GetOrCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixA  string
+		valueA   string
+		prefixB  string
+		valueB   string
+		validate func(t *testing.T, first, second string)
+	}{
+		{
+			name:    "same input should return same output",
+			prefixA: "res",
+			valueA:  "my-pod",
+			prefixB: "res",
+			valueB:  "my-pod",
+			validate: func(t *testing.T, first, second string) {
+				assert.Equal(t, first, second)
+			},
+		},
+		{
+			name:    "different inputs should return different outputs",
+			prefixA: "res",
+			valueA:  "pod-a",
+			prefixB: "res",
+			valueB:  "pod-b",
+			validate: func(t *testing.T, first, second string) {
+				assert.NotEqual(t, first, second)
+			},
+		},
+		{
+			name:    "different prefixes should isolate mappings",
+			prefixA: "res",
+			valueA:  "same-value",
+			prefixB: "ns",
+			valueB:  "same-value",
+			validate: func(t *testing.T, first, second string) {
+				assert.NotEqual(t, first, second)
+			},
+		},
+		{
+			name:    "empty value should still produce deterministic mapping",
+			prefixA: "res",
+			valueA:  "",
+			prefixB: "res",
+			valueB:  "",
+			validate: func(t *testing.T, first, second string) {
+				assert.Equal(t, first, second)
+				assert.Contains(t, first, "res-")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapping := NewMapping()
+
+			first := mapping.GetOrCreate(test.prefixA, test.valueA)
+			second := mapping.GetOrCreate(test.prefixB, test.valueB)
+
+			test.validate(t, first, second)
+		})
+	}
+}
+
+func TestMapping_GetOrCreate_PrefixIsolationAcrossMultiplePrefixes(t *testing.T) {
+	mapping := NewMapping()
+
+	resource := mapping.GetOrCreate("res", "same-value")
+	namespace := mapping.GetOrCreate("ns", "same-value")
+	label := mapping.GetOrCreate("lbl", "same-value")
+
+	assert.NotEqual(t, resource, namespace)
+	assert.NotEqual(t, resource, label)
+	assert.NotEqual(t, namespace, label)
+}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -1,0 +1,302 @@
+package anonymizer
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
+	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+type metadataOnly struct{}
+
+func (m *metadataOnly) SetNamespace(string)                {}
+func (m *metadataOnly) SetName(string)                     {}
+func (m *metadataOnly) SetKind(string)                     {}
+func (m *metadataOnly) SetWorkload(map[string]interface{}) {}
+func (m *metadataOnly) SetObject(map[string]interface{})   {}
+func (m *metadataOnly) SetApiVersion(string)               {}
+
+func (m *metadataOnly) GetNamespace() string                { return "" }
+func (m *metadataOnly) GetName() string                     { return "" }
+func (m *metadataOnly) GetKind() string                     { return "" }
+func (m *metadataOnly) GetApiVersion() string               { return "" }
+func (m *metadataOnly) GetWorkload() map[string]interface{} { return nil }
+func (m *metadataOnly) GetObject() map[string]interface{}   { return nil }
+func (m *metadataOnly) GetID() string                       { return "metadata-only" }
+
+func (m *metadataOnly) GetObjectType() workloadinterface.ObjectType {
+	return workloadinterface.ObjectType("metadataOnly")
+}
+
+func TestResolveMappedID(t *testing.T) {
+	tests := []struct {
+		name      string
+		idMapping map[string]string
+		original  string
+		validate  func(t *testing.T, result string)
+	}{
+		{
+			name:      "known id should return mapped value",
+			idMapping: map[string]string{"old-id": "new-id"},
+			original:  "old-id",
+			validate: func(t *testing.T, result string) {
+				assert.Equal(t, "new-id", result)
+			},
+		},
+		{
+			name:      "unknown id should fall back to generated mapping",
+			idMapping: map[string]string{},
+			original:  "unknown-id",
+			validate: func(t *testing.T, result string) {
+				assert.NotEqual(t, "unknown-id", result)
+				assert.Contains(t, result, "ref-")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapping := NewMapping()
+			result := resolveMappedID(mapping, test.idMapping, test.original, "ref")
+			test.validate(t, result)
+		})
+	}
+}
+
+func TestAnonymizeSession_NilSession(t *testing.T) {
+	mapping := NewMapping()
+
+	assert.NotPanics(t, func() {
+		anonymizeSession(nil, mapping)
+	})
+}
+
+func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "my-secret-pod",
+			"namespace": "my-secret-ns",
+		},
+	})
+
+	oldID := pod.GetID()
+
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+	}
+
+	mapping := NewMapping()
+	anonymizeSession(session, mapping)
+
+	for _, resource := range session.AllResources {
+		assert.NotEqual(t, "my-secret-pod", resource.GetName())
+		assert.NotEqual(t, "my-secret-ns", resource.GetNamespace())
+		assert.Contains(t, resource.GetName(), "res-")
+		assert.Contains(t, resource.GetNamespace(), "ns-")
+	}
+}
+
+func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "my-pod",
+			"namespace": "default",
+		},
+	})
+
+	oldID := pod.GetID()
+
+	resourceIDs := helpersv1.AllLists{}
+	resourceIDs.Append(apis.StatusFailed, oldID)
+
+	session := &cautils.OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			oldID: pod,
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			oldID: {
+				ResourceID: oldID,
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: "C-0001",
+						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+							{
+								Name: "rule-1",
+								Paths: []armotypes.PosturePaths{
+									{ResourceID: oldID},
+								},
+								RelatedResourcesIDs: []string{oldID},
+							},
+						},
+					},
+				},
+			},
+		},
+		ResourceSource: map[string]reporthandling.Source{
+			oldID: {},
+		},
+		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
+			oldID: {ResourceID: oldID},
+		},
+		ResourceAttackTracks: map[string]v1alpha1.IAttackTrack{
+			oldID: &v1alpha1.AttackTrack{},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{
+					"C-0001": {
+						ResourceIDs: resourceIDs,
+					},
+				},
+			},
+		},
+	}
+
+	mapping := NewMapping()
+	anonymizeSession(session, mapping)
+
+	var newID string
+	for id := range session.AllResources {
+		newID = id
+	}
+
+	assert.NotEmpty(t, newID)
+	assert.NotEqual(t, oldID, newID)
+
+	result, ok := session.ResourcesResult[newID]
+	assert.True(t, ok)
+	assert.Equal(t, newID, result.ResourceID)
+
+	assert.Equal(
+		t,
+		newID,
+		result.AssociatedControls[0].ResourceAssociatedRules[0].Paths[0].ResourceID,
+	)
+
+	assert.Equal(
+		t,
+		newID,
+		result.AssociatedControls[0].ResourceAssociatedRules[0].RelatedResourcesIDs[0],
+	)
+
+	_, ok = session.ResourceSource[newID]
+	assert.True(t, ok)
+
+	prioritized, ok := session.ResourcesPrioritized[newID]
+	assert.True(t, ok)
+	assert.Equal(t, newID, prioritized.ResourceID)
+
+	control := session.Report.SummaryDetails.Controls["C-0001"]
+	_, found := control.ResourceIDs.All()[newID]
+	assert.True(t, found)
+
+	_, ok = session.ResourceAttackTracks[newID]
+	assert.True(t, ok)
+}
+
+func TestAnonymizeSession_LabelHandling(t *testing.T) {
+	tests := []struct {
+		name         string
+		labelsToCopy []string
+		validate     func(t *testing.T, labels map[string]string)
+	}{
+		{
+			name:         "selected labels should be anonymized",
+			labelsToCopy: []string{"team", "env"},
+			validate: func(t *testing.T, labels map[string]string) {
+				assert.NotEqual(t, "payments", labels["team"])
+				assert.NotEqual(t, "production", labels["env"])
+				assert.Contains(t, labels["team"], "lbl-")
+				assert.Contains(t, labels["env"], "lbl-")
+			},
+		},
+		{
+			name:         "empty labelsToCopy should preserve labels",
+			labelsToCopy: []string{},
+			validate: func(t *testing.T, labels map[string]string) {
+				assert.Equal(t, "payments", labels["team"])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "my-pod",
+					"namespace": "default",
+					"labels": map[string]interface{}{
+						"team": "payments",
+						"env":  "production",
+					},
+				},
+			})
+
+			oldID := pod.GetID()
+
+			session := &cautils.OPASessionObj{
+				AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
+				ResourcesResult:      make(map[string]resourcesresults.Result),
+				ResourceSource:       make(map[string]reporthandling.Source),
+				ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+				ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+				LabelsToCopy:         test.labelsToCopy,
+			}
+
+			mapping := NewMapping()
+			anonymizeSession(session, mapping)
+
+			for _, resource := range session.AllResources {
+				workload, ok := resource.(workloadinterface.IWorkload)
+				assert.True(t, ok)
+				test.validate(t, workload.GetLabels())
+			}
+		})
+	}
+}
+
+func TestAnonymizeResourceLabels_Guards(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource workloadinterface.IMetadata
+	}{
+		{
+			name:     "non workload resource should be ignored",
+			resource: &metadataOnly{},
+		},
+		{
+			name:     "workload without labels should be ignored",
+			resource: workloadinterface.NewWorkloadMock(nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapping := NewMapping()
+
+			assert.NotPanics(t, func() {
+				anonymizeResourceLabels(test.resource, []string{"team"}, mapping)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/kubescape/kubescape/issues/1200
## Summary

Reorganizes anonymizer unit tests for better consistency and maintainability.

## Changes
- moved mapping-related tests into `mapping_test.go`
- moved session-related tests into `session_test.go`
- reduced `anonymizer_test.go` to focus only on `Apply()` behavior
- aligned test structure and naming across the anonymizer package

## Notes
This is a test-only cleanup PR with no production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for anonymizer module functionality
  * Introduced new test suites for mapping logic including determinism verification, value differentiation, and prefix isolation scenarios
  * Added comprehensive anonymization tests validating ID consistency across maps, workload replacement, label handling configurations, and edge case protection
  * Refactored test structure using table-driven subtests for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2202)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->