### PR TITLE
fix(patch): use canonical image reference for buildkit export name

### DIFF
--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anchore/grype/grype/presenter/models"
 	copaGrype "github.com/anubhav06/copa-grype/grype"
 	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
 	"github.com/docker/buildx/build"
 	"github.com/docker/cli/cli/config"
 	"github.com/kubescape/go-logger"
@@ -94,7 +95,10 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 
 	// ===================== Patch the image using copacetic =====================
 	logger.L().Start("Patching image...")
-	patchedImageName := fmt.Sprintf("%s:%s", patchInfo.ImageName, patchInfo.PatchedImageTag)
+	patchedImageName, err := buildPatchedImageName(patchInfo.Image, patchInfo.PatchedImageTag)
+	if err != nil {
+		return false, err
+	}
 
 	sout, serr := os.Stdout, os.Stderr
 	if logger.L().GetLevel() != "debug" {
@@ -135,6 +139,19 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	resultsHandler.ImageScanData = []cautils.ImageScanData{*scanResultsPatched}
 
 	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), scanResultsPatched.Matches), resultsHandler.HandleResults(ks.Context(), scanInfo)
+}
+
+// buildPatchedImageName returns the canonical "<name>:<tag>" used as the buildkit
+// export name for the patched image. Using the canonical reference (e.g.
+// docker.io/library/nginx) ensures containerd registers the patched image under
+// the prefix docker's resolver and grype's docker-provider expect; without it,
+// the patched image is unresolvable locally — see kubescape/kubescape#2189.
+func buildPatchedImageName(image, patchedTag string) (string, error) {
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image reference %q: %w", image, err)
+	}
+	return fmt.Sprintf("%s:%s", ref.Name(), patchedTag), nil
 }
 
 func disableCopaLogger() {

--- a/core/core/patch_test.go
+++ b/core/core/patch_test.go
@@ -8,6 +8,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestBuildPatchedImageName guards the fix for kubescape/kubescape#2189: the
+// patched image must be exported under its canonical reference so containerd
+// registers it under docker.io/library/... and docker/grype can resolve it
+// locally.
+func TestBuildPatchedImageName(t *testing.T) {
+	tests := []struct {
+		name       string
+		image      string
+		patchedTag string
+		expected   string
+		wantErr    bool
+	}{
+		{
+			name:       "official docker hub image expands to docker.io/library",
+			image:      "nginx:1.23",
+			patchedTag: "1.23-patched",
+			expected:   "docker.io/library/nginx:1.23-patched",
+		},
+		{
+			name:       "fully qualified official image",
+			image:      "docker.io/library/nginx:1.23",
+			patchedTag: "1.23-patched",
+			expected:   "docker.io/library/nginx:1.23-patched",
+		},
+		{
+			name:       "docker hub user image",
+			image:      "myuser/myapp:v1",
+			patchedTag: "v1-patched",
+			expected:   "docker.io/myuser/myapp:v1-patched",
+		},
+		{
+			name:       "private registry image preserves host",
+			image:      "quay.io/foo/bar:1.0",
+			patchedTag: "1.0-patched",
+			expected:   "quay.io/foo/bar:1.0-patched",
+		},
+		{
+			name:    "invalid reference returns error",
+			image:   "Invalid Image!!",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildPatchedImageName(tt.image, tt.patchedTag)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestGetOSType(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Overview

After `kubescape patch -i nginx:1.23`, the patched image is created but is not resolvable locally , `docker inspect nginx:1.23-patched` and `grype nginx:1.23-patched` both fail, and kubescape's own post-patch re-scan errors out with `MANIFEST_UNKNOWN`. The image only becomes resolvable after a manual `ctr ... images tag` to add the `docker.io/library/` prefix.

Root cause: `cmd/patch/patch.go:152-160` strips `docker.io/library/` from the image name for official Docker Hub images and stores just `nginx` in `PatchInfo.ImageName`. That bare string then becomes the buildkit export `name` attr in `core/core/patch.go:97`, so containerd writes the patched image under the bare reference `nginx:1.23-patched` — without the `docker.io/library/` prefix that docker's resolver and grype's docker-provider need for local resolution.

**Fix:** build the buildkit export name from the canonical reference (`reference.ParseNormalizedNamed(patchInfo.Image).Name()`) instead of the stripped `PatchInfo.ImageName`. The patched image is then registered as `docker.io/library/nginx:1.23-patched`, which both short (`nginx:1.23-patched`) and fully-qualified lookups resolve.

## Additional Information

The stripping in `cmd/patch/patch.go` is used to derive the report filename and other display-side fields and is fine for that purpose, the fix is scoped to the one place where that stripped name was wrongly reused as the buildkit export identifier.

Changes:
- `core/core/patch.go` - import `github.com/distribution/reference`; replace `fmt.Sprintf("%s:%s", patchInfo.ImageName, patchInfo.PatchedImageTag)` with a call to a new helper `buildPatchedImageName(patchInfo.Image, patchInfo.PatchedImageTag)` that uses `reference.ParseNormalizedNamed(...).Name()` to produce the canonical reference.
- `core/core/patch_test.go` - added `TestBuildPatchedImageName` covering official Docker Hub images, already-qualified refs, user repos, private registries, and an invalid-ref error case.

## How to Test

Prereqs: Docker with the containerd snapshotter enabled (this is the configuration where the bug surfaces — see issue #2189), and a host-reachable `buildkitd`.

```bash
docker pull nginx:1.23

# Before the fix: docker inspect fails after patch.
# After the fix: docker inspect succeeds and the post-patch re-scan completes.
kubescape patch -i nginx:1.23

docker inspect nginx:1.23-patched | head -5
# Expect: "RepoTags": ["docker.io/library/nginx:1.23-patched"]

docker inspect docker.io/library/nginx:1.23-patched | head -5
# Expect: same image resolves under the canonical name too

kubescape scan image nginx:1.23-patched
# Expect: scan succeeds, prints the patched vuln report (curl/libc/nginx fixes applied)
```

Unit tests:

```bash
go test ./core/core/ -run TestBuildPatchedImageName -v
go test ./core/... ./cmd/...
```

Verified locally:

| Case | Expected | Result |
|---|---|---|
| `buildPatchedImageName("nginx:1.23", "1.23-patched")` | `docker.io/library/nginx:1.23-patched` | ✅ |
| `buildPatchedImageName("docker.io/library/nginx:1.23", "1.23-patched")` | `docker.io/library/nginx:1.23-patched` | ✅ |
| `buildPatchedImageName("myuser/myapp:v1", "v1-patched")` | `docker.io/myuser/myapp:v1-patched` | ✅ |
| `buildPatchedImageName("quay.io/foo/bar:1.0", "1.0-patched")` | `quay.io/foo/bar:1.0-patched` | ✅ |
| Invalid reference | Returns error | ✅ |
| Existing `core/core` and `cmd/patch` tests | Pass | ✅ |
| `go build ./...` | Clean | ✅ |

## Related issues/PRs

* Resolves #2189

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved patched image name computation to properly normalize Docker image references across different formats (official Docker Hub images, fully-qualified references, and custom registries).
* Enhanced error handling for invalid image references during the patching process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2203)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->