### PR TITLE
refactor: replace unstructured Warning(err.Error()) with structured helpers.Error(err) across codebase

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -165,7 +165,7 @@ func (lc *LocalConfig) UpdateCachedConfig() error {
 
 func (lc *LocalConfig) DeleteCachedConfig(ctx context.Context) error {
 	if err := DeleteConfigFile(); err != nil {
-		logger.L().Ctx(ctx).Warning(err.Error())
+		logger.L().Ctx(ctx).Warning("failed to delete cached config", helpers.Error(err))
 	}
 	return nil
 }
@@ -247,7 +247,7 @@ func (c *ClusterConfig) UpdateCachedConfig() error {
 
 func (c *ClusterConfig) DeleteCachedConfig(ctx context.Context) error {
 	if err := DeleteConfigFile(); err != nil {
-		logger.L().Ctx(ctx).Warning(err.Error())
+		logger.L().Ctx(ctx).Warning("failed to delete cached config", helpers.Error(err))
 	}
 	return nil
 }

--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/pkg/fixhandler"
 )
@@ -72,7 +73,7 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 
 	if len(errors) > 0 {
 		for _, err := range errors {
-			logger.L().Ctx(ks.Context()).Warning(err.Error())
+			logger.L().Ctx(ks.Context()).Warning("failed to fix resource", helpers.Error(err))
 		}
 		return fmt.Errorf("failed to fix some resources, check the logs for more details")
 	}


### PR DESCRIPTION
Closes #2205

## Summary

Multiple files across the codebase were using `err.Error()` as a 
plain string in warning log calls, which is inconsistent with the 
structured logging pattern used throughout the project.

## Changes

### `core/cautils/customerloader.go`
- `LocalConfig.DeleteCachedConfig` (line 168)
- `ClusterConfig.DeleteCachedConfig` (line 250)

```go
// Before
logger.L().Ctx(ctx).Warning(err.Error())

// After
logger.L().Ctx(ctx).Warning("failed to delete cached config", helpers.Error(err))
```

### `core/core/fix.go`
- `Fix()` function (line 75)

```go
// Before
logger.L().Ctx(ks.Context()).Warning(err.Error())

// After
logger.L().Ctx(ks.Context()).Warning("failed to fix resource", helpers.Error(err))
```

## Benefits

- Consistent structured logging across the codebase
- Log aggregators can query the `error` field directly
- No logic changes — purely a logging consistency fix

## Related

Follows the same pattern as PR #2130 (merged).

## Checklist

- [x] No logic changes introduced
- [x] Follows existing structured logging conventions
- [x] No new dependencies added
- [x] 3 occurrences fixed across 2 files