### PR TITLE
test(imagescan): cover severity filtering

### DIFF
--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -186,7 +186,7 @@ func getIgnoredMatches(vulnerabilityExceptions []string, vp vulnerability.Provid
 
 // Filter the remaining matches based on severity exceptions.
 func filterMatchesBasedOnSeverity(severityExceptions []string, remainingMatches match.Matches, vp vulnerability.Provider) match.Matches {
-	if severityExceptions == nil {
+	if len(severityExceptions) == 0 {
 		return remainingMatches
 	}
 

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
-	"testing"
 
 	"github.com/anchore/grype/grype/match"
 	grypepkg "github.com/anchore/grype/grype/pkg"

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -7,10 +7,67 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stubVulnerabilityProvider struct {
+	metadataByID map[string]*vulnerability.Metadata
+	errByID      map[string]error
+}
+
+func (s stubVulnerabilityProvider) PackageSearchNames(grypepkg.Package) []string {
+	return nil
+}
+
+func (s stubVulnerabilityProvider) FindVulnerabilities(...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+
+func (s stubVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference) (*vulnerability.Metadata, error) {
+	if err, ok := s.errByID[ref.ID]; ok {
+		return nil, err
+	}
+
+	if metadata, ok := s.metadataByID[ref.ID]; ok {
+		return metadata, nil
+	}
+
+	return nil, errors.New("metadata not found")
+}
+
+func (s stubVulnerabilityProvider) Close() error {
+	return nil
+}
+
+func makeTestMatch(id string) match.Match {
+	return match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{
+				ID:        id,
+				Namespace: "nvd",
+			},
+		},
+		Package: grypepkg.Package{
+			ID:      grypepkg.ID("pkg-" + id),
+			Name:    "pkg-" + id,
+			Version: "1.0.0",
+		},
+	}
+}
+
+func matchIDs(matches match.Matches) []string {
+	ids := make([]string, 0, matches.Count())
+	for m := range matches.Enumerate() {
+		ids = append(ids, m.Vulnerability.ID)
+	}
+	return ids
+}
 
 func TestParseSeverity(t *testing.T) {
 	tests := []struct {
@@ -353,4 +410,41 @@ func TestNewDefaultDBConfig_SanitizationHarden(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilterMatchesBasedOnSeverity(t *testing.T) {
+	provider := stubVulnerabilityProvider{
+		metadataByID: map[string]*vulnerability.Metadata{
+			"CVE-high": {
+				Severity: "high",
+			},
+			"CVE-medium": {
+				Severity: "medium",
+			},
+		},
+		errByID: map[string]error{
+			"CVE-error": errors.New("lookup failed"),
+		},
+	}
+
+	remainingMatches := match.NewMatches(
+		makeTestMatch("CVE-high"),
+		makeTestMatch("CVE-medium"),
+		makeTestMatch("CVE-error"),
+	)
+
+	t.Run("nil severity exceptions keep all matches", func(t *testing.T) {
+		filtered := filterMatchesBasedOnSeverity(nil, remainingMatches, provider)
+		assert.ElementsMatch(t, []string{"CVE-high", "CVE-medium", "CVE-error"}, matchIDs(filtered))
+	})
+
+	t.Run("empty severity exceptions keep all matches", func(t *testing.T) {
+		filtered := filterMatchesBasedOnSeverity([]string{}, remainingMatches, provider)
+		assert.ElementsMatch(t, []string{"CVE-high", "CVE-medium", "CVE-error"}, matchIDs(filtered))
+	})
+
+	t.Run("excluded severities are removed and metadata errors are skipped", func(t *testing.T) {
+		filtered := filterMatchesBasedOnSeverity([]string{"HIGH"}, remainingMatches, provider)
+		assert.ElementsMatch(t, []string{"CVE-medium"}, matchIDs(filtered))
+	})
 }


### PR DESCRIPTION
## What this PR does
Adds unit tests for filterMatchesBasedOnSeverity in pkg/imagescan/imagescan_test.go.

## Why
The severity filtering helper is responsible for removing matches based on vulnerability metadata and for handling metadata lookup failures safely, but it did not have direct unit coverage. This adds focused tests around those branches.

## Test cases added
- returns all matches unchanged when no severity exceptions are provided
- removes matches whose metadata severity is listed in the exclusions
- skips matches when vulnerability metadata lookup fails

Signed-off-by: Anvay <anvaykharb007@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treat empty severity-exception lists the same as no filter, avoiding unnecessary lookups and preserving matches when no severities are excluded.

* **Tests**
  * Added test helpers and a stub vulnerability provider to exercise severity-filtering scenarios.
  * Added a unit test validating severity-based filtering: preserves matches when no filter is given, excludes disallowed severities, and skips matches when metadata lookup fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->