### PR TITLE
test(listener): cover env config helpers

### DIFF
--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -1,0 +1,42 @@
+package listener
+
+import "testing"
+
+func TestGetPort(t *testing.T) {
+	t.Run("returns env var when set", func(t *testing.T) {
+		t.Setenv("KS_PORT", "9090")
+		if got := getPort(); got != "9090" {
+			t.Fatalf("getPort() = %q, want %q", got, "9090")
+		}
+	})
+
+	t.Run("returns default when unset", func(t *testing.T) {
+		t.Setenv("KS_PORT", "")
+		if got := getPort(); got != "8080" {
+			t.Fatalf("getPort() = %q, want %q", got, "8080")
+		}
+	})
+}
+
+func TestGetOffline(t *testing.T) {
+	t.Run("returns true only for literal true", func(t *testing.T) {
+		t.Setenv("KS_OFFLINE", "true")
+		if !getOffline() {
+			t.Fatal("getOffline() = false, want true")
+		}
+	})
+
+	t.Run("returns false when unset", func(t *testing.T) {
+		t.Setenv("KS_OFFLINE", "")
+		if getOffline() {
+			t.Fatal("getOffline() = true, want false")
+		}
+	})
+
+	t.Run("returns false for other values", func(t *testing.T) {
+		t.Setenv("KS_OFFLINE", "TRUE")
+		if getOffline() {
+			t.Fatal("getOffline() = true, want false")
+		}
+	})
+}


### PR DESCRIPTION
## What this PR does
Adds unit tests for getPort and getOffline in httphandler/listener/setup_test.go.

## Why
These helpers control HTTP listener behavior through environment variables, but they did not have direct unit coverage for the env override and default paths. This PR adds focused tests around that behavior.

## Test cases added
- getPort returns the configured KS_PORT value
- getPort falls back to the default port when KS_PORT is unset
- getOffline returns true only for the literal true value
- getOffline returns false when KS_OFFLINE is unset or any other value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for port configuration via environment variables, verifying fallback behavior when configuration is unset.
  * Added test coverage for offline mode detection, ensuring proper handling of environment variable values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->