### PR TITLE
fix: add error log when ProcessRulesListener fails in scan.go

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -205,7 +205,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
 	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint)
 	if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
-		// TODO - do something
+		logger.L().Ctx(ctxOpa).Error("failed to process rules", helpers.Error(err))
 		return resultsHandling, fmt.Errorf("%w", err)
 	}
 


### PR DESCRIPTION
Closes #2207

## Summary

In `core/core/scan.go`, when `ProcessRulesListener()` returns an error, there was a developer TODO comment with no actual log message:

```go
// Before
if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
    // TODO - do something
    return resultsHandling, fmt.Errorf("%w", err)
}
```

This meant users and operators had zero visibility into what failed during the OPA rules processing phase.

## Fix

Added a structured error log before returning:

```go
// After
if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
    logger.L().Ctx(ctxOpa).Error("failed to process rules", helpers.Error(err))
    return resultsHandling, fmt.Errorf("%w", err)
}
```

## Changes

- Replaced `// TODO - do something` with a structured error log
- No logic changes — purely improves observability on failure
- Follows the structured logging pattern used throughout the codebase

## Related

Follows the same logging pattern as PR #2130 (merged).

## Checklist

- [x] No logic changes introduced
- [x] Follows existing structured logging conventions
- [x] No new dependencies added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for OPA rule processing failures to provide better visibility into system operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->