### PR TITLE
test(opaprocessor): cover manual review summary

### DIFF
--- a/core/pkg/opaprocessor/utils_test.go
+++ b/core/pkg/opaprocessor/utils_test.go
@@ -3,12 +3,15 @@ package opaprocessor
 import (
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	v2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertFrameworksToPolicies(t *testing.T) {
@@ -41,4 +44,52 @@ func TestInitializeSummaryDetails(t *testing.T) {
 	ConvertFrameworksToSummaryDetails(&summaryDetails, frameworks, policies)
 	assert.Equal(t, 2, len(summaryDetails.Frameworks))
 	// assert.Equal(t, 3, len(summaryDetails.Controls))
+}
+
+func TestInitializeSummaryDetails_ManualReviewControl(t *testing.T) {
+	framework := reporthandling.Framework{
+		PortalBase: armotypes.PortalBase{Name: "test-framework"},
+		Controls: []reporthandling.Control{
+			{
+				PortalBase:  armotypes.PortalBase{Name: "manual review control"},
+				ControlID:   "C-0001",
+				Description: "requires human review",
+				Remediation: "inspect manually",
+				BaseScore:   3.5,
+			},
+			{
+				PortalBase:  armotypes.PortalBase{Name: "not selected"},
+				ControlID:   "C-0002",
+				Description: "should be skipped because it is not in policies",
+			},
+		},
+	}
+	framework.Controls[0].Attributes = map[string]interface{}{
+		reporthandling.ActionRequiredAttribute: string(apis.SubStatusManualReview),
+	}
+
+	policies := cautils.NewPolicies()
+	policies.Frameworks = []string{framework.Name}
+	policies.Controls = map[string]reporthandling.Control{
+		"C-0001": framework.Controls[0],
+	}
+
+	summaryDetails := reportsummary.SummaryDetails{}
+	ConvertFrameworksToSummaryDetails(&summaryDetails, []reporthandling.Framework{framework}, policies)
+
+	require.Len(t, summaryDetails.Frameworks, 1)
+	require.Contains(t, summaryDetails.Controls, "C-0001")
+	assert.NotContains(t, summaryDetails.Controls, "C-0002")
+
+	ctrl := summaryDetails.Controls["C-0001"]
+	assert.Equal(t, apis.StatusSkipped, ctrl.Status)
+	assert.Equal(t, apis.StatusSkipped, ctrl.StatusInfo.InnerStatus)
+	assert.Equal(t, apis.SubStatusManualReview, ctrl.StatusInfo.SubStatus)
+	assert.Equal(t, string(apis.SubStatusManualReviewInfo), ctrl.StatusInfo.InnerInfo)
+	assert.Equal(t, float32(3.5), ctrl.ScoreFactor)
+	assert.Equal(t, "requires human review", ctrl.Description)
+	assert.Equal(t, "inspect manually", ctrl.Remediation)
+	assert.NotNil(t, summaryDetails.Frameworks[0].Controls)
+	assert.Contains(t, summaryDetails.Frameworks[0].Controls, "C-0001")
+	assert.NotContains(t, summaryDetails.Frameworks[0].Controls, "C-0002")
 }


### PR DESCRIPTION
## What this PR does
Adds unit tests for ConvertFrameworksToSummaryDetails in core/pkg/opaprocessor/utils_test.go.

## Why
The summary initialization logic contains a manual-review branch that sets skipped status and substatus metadata for controls with the actionRequired attribute, but that behavior did not have direct unit coverage. This PR adds focused tests for that path and for skipping controls that are not selected in policies.

## Test cases added
- initializes a manual-review control with skipped status and manual review substatus
- preserves score, description, and remediation when building the summary control
- excludes controls that are not present in the selected policies map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for manual review control handling in policy processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->