### PR TITLE
test: add unit tests for SetCachedConfig and DeleteCachedConfig in cachedconfig.go

### DIFF
--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 // redirectHome redirects HOME to a temp dir for the duration of the test.
@@ -107,6 +107,7 @@ func TestDeleteCachedConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	output := buf.String()
+	// DeleteCachedConfig only clears Account and AccessKey; URL fields are intentionally not asserted
 	assert.NotContains(t, output, "to-delete-account")
 	assert.NotContains(t, output, "to-delete-key")
 }

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -21,6 +21,10 @@ func redirectStore(t *testing.T) {
 
 func TestSetCachedConfig_AllFields(t *testing.T) {
 	redirectStore(t)
+	t.Setenv("KS_ACCOUNT_ID", "")
+	t.Setenv("KS_ACCESS_KEY", "")
+	t.Setenv("KS_CLOUD_API_URL", "")
+	t.Setenv("KS_CLOUD_REPORT_URL", "")
 
 	ks := &Kubescape{}
 	setConfig := &metav1.SetConfig{
@@ -47,6 +51,10 @@ func TestSetCachedConfig_AllFields(t *testing.T) {
 
 func TestSetCachedConfig_EmptyFields(t *testing.T) {
 	redirectStore(t)
+	t.Setenv("KS_ACCOUNT_ID", "")
+	t.Setenv("KS_ACCESS_KEY", "")
+	t.Setenv("KS_CLOUD_API_URL", "")
+	t.Setenv("KS_CLOUD_REPORT_URL", "")
 
 	ks := &Kubescape{}
 
@@ -59,7 +67,7 @@ func TestSetCachedConfig_EmptyFields(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// Step 2: apply empty fields — should NOT overwrite existing values
+	// Step 2: apply empty fields - should NOT overwrite existing values
 	err = ks.SetCachedConfig(&metav1.SetConfig{
 		Account:        "",
 		AccessKey:      "",
@@ -82,6 +90,10 @@ func TestSetCachedConfig_EmptyFields(t *testing.T) {
 
 func TestDeleteCachedConfig(t *testing.T) {
 	redirectStore(t)
+	t.Setenv("KS_ACCOUNT_ID", "")
+	t.Setenv("KS_ACCESS_KEY", "")
+	t.Setenv("KS_CLOUD_API_URL", "")
+	t.Setenv("KS_CLOUD_REPORT_URL", "")
 
 	ks := &Kubescape{}
 

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -2,28 +2,25 @@ package core
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/stretchr/testify/assert"
 )
 
-// redirectHome redirects HOME to a temp dir for the duration of the test.
-// This prevents SetCachedConfig / DeleteCachedConfig from touching the
-// real ~/.kubescape on the developer's or CI machine.
-func redirectHome(t *testing.T) {
+func redirectStore(t *testing.T) {
 	t.Helper()
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
+	prevStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = tmpDir
 	t.Cleanup(func() {
-		os.Setenv("HOME", origHome)
+		getter.DefaultLocalStore = prevStore
 	})
 }
 
 func TestSetCachedConfig_AllFields(t *testing.T) {
-	redirectHome(t)
+	redirectStore(t)
 
 	ks := &Kubescape{}
 	setConfig := &metav1.SetConfig{
@@ -49,7 +46,7 @@ func TestSetCachedConfig_AllFields(t *testing.T) {
 }
 
 func TestSetCachedConfig_EmptyFields(t *testing.T) {
-	redirectHome(t)
+	redirectStore(t)
 
 	ks := &Kubescape{}
 
@@ -84,7 +81,7 @@ func TestSetCachedConfig_EmptyFields(t *testing.T) {
 }
 
 func TestDeleteCachedConfig(t *testing.T) {
-	redirectHome(t)
+	redirectStore(t)
 
 	ks := &Kubescape{}
 

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+)
+
+func TestSetCachedConfig_AllFields(t *testing.T) {
+	ks := &Kubescape{}
+	setConfig := &metav1.SetConfig{
+		Account:        "test-account",
+		AccessKey:      "test-access-key",
+		CloudAPIURL:    "https://api.test.com",
+		CloudReportURL: "https://report.test.com",
+	}
+	err := ks.SetCachedConfig(setConfig)
+	assert.NoError(t, err)
+}
+
+func TestSetCachedConfig_EmptyFields(t *testing.T) {
+	ks := &Kubescape{}
+	setConfig := &metav1.SetConfig{
+		Account:        "",
+		AccessKey:      "",
+		CloudAPIURL:    "",
+		CloudReportURL: "",
+	}
+	err := ks.SetCachedConfig(setConfig)
+	assert.NoError(t, err)
+}
+
+func TestDeleteCachedConfig(t *testing.T) {
+	ks := &Kubescape{}
+	deleteConfig := &metav1.DeleteConfig{}
+	err := ks.DeleteCachedConfig(deleteConfig)
+	assert.NoError(t, err)
+}

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -1,13 +1,30 @@
 package core
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 )
 
+// redirectHome redirects HOME to a temp dir for the duration of the test.
+// This prevents SetCachedConfig / DeleteCachedConfig from touching the
+// real ~/.kubescape on the developer's or CI machine.
+func redirectHome(t *testing.T) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+	})
+}
+
 func TestSetCachedConfig_AllFields(t *testing.T) {
+	redirectHome(t)
+
 	ks := &Kubescape{}
 	setConfig := &metav1.SetConfig{
 		Account:        "test-account",
@@ -15,25 +32,81 @@ func TestSetCachedConfig_AllFields(t *testing.T) {
 		CloudAPIURL:    "https://api.test.com",
 		CloudReportURL: "https://report.test.com",
 	}
+
 	err := ks.SetCachedConfig(setConfig)
 	assert.NoError(t, err)
+
+	// Read back and assert all fields were persisted
+	var buf bytes.Buffer
+	err = ks.ViewCachedConfig(&metav1.ViewConfig{Writer: &buf})
+	assert.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "test-account")
+	assert.Contains(t, output, "test-access-key")
+	assert.Contains(t, output, "https://api.test.com")
+	assert.Contains(t, output, "https://report.test.com")
 }
 
 func TestSetCachedConfig_EmptyFields(t *testing.T) {
+	redirectHome(t)
+
 	ks := &Kubescape{}
-	setConfig := &metav1.SetConfig{
+
+	// Step 1: seed with real values first
+	err := ks.SetCachedConfig(&metav1.SetConfig{
+		Account:        "seed-account",
+		AccessKey:      "seed-key",
+		CloudAPIURL:    "https://seed-api",
+		CloudReportURL: "https://seed-report",
+	})
+	assert.NoError(t, err)
+
+	// Step 2: apply empty fields — should NOT overwrite existing values
+	err = ks.SetCachedConfig(&metav1.SetConfig{
 		Account:        "",
 		AccessKey:      "",
 		CloudAPIURL:    "",
 		CloudReportURL: "",
-	}
-	err := ks.SetCachedConfig(setConfig)
+	})
 	assert.NoError(t, err)
+
+	// Step 3: verify original seeded values are still intact
+	var buf bytes.Buffer
+	err = ks.ViewCachedConfig(&metav1.ViewConfig{Writer: &buf})
+	assert.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "seed-account")
+	assert.Contains(t, output, "seed-key")
+	assert.Contains(t, output, "https://seed-api")
+	assert.Contains(t, output, "https://seed-report")
 }
 
 func TestDeleteCachedConfig(t *testing.T) {
+	redirectHome(t)
+
 	ks := &Kubescape{}
-	deleteConfig := &metav1.DeleteConfig{}
-	err := ks.DeleteCachedConfig(deleteConfig)
+
+	// Step 1: seed a config so there is something to delete
+	err := ks.SetCachedConfig(&metav1.SetConfig{
+		Account:        "to-delete-account",
+		AccessKey:      "to-delete-key",
+		CloudAPIURL:    "https://delete-api",
+		CloudReportURL: "https://delete-report",
+	})
 	assert.NoError(t, err)
+
+	// Step 2: delete the cached config
+	err = ks.DeleteCachedConfig(&metav1.DeleteConfig{})
+	assert.NoError(t, err)
+
+	// Step 3: verify the seeded values are no longer present
+	var buf bytes.Buffer
+	err = ks.ViewCachedConfig(&metav1.ViewConfig{Writer: &buf})
+	assert.NoError(t, err)
+
+	output := buf.String()
+	assert.NotContains(t, output, "to-delete-account")
+	assert.NotContains(t, output, "to-delete-key")
 }


### PR DESCRIPTION
Closes #2216

## Summary

`core/core/cachedconfig.go` had no unit test coverage. This PR adds a new `cachedconfig_test.go` file with 3 unit tests covering the core cached configuration functions.

## Tests Added

### `TestSetCachedConfig_AllFields`
Tests `SetCachedConfig()` with all fields populated — Account, AccessKey, CloudAPIURL, CloudReportURL.

### `TestSetCachedConfig_EmptyFields`
Tests `SetCachedConfig()` with all empty fields — verifies empty values don't override existing config.

### `TestDeleteCachedConfig`
Tests `DeleteCachedConfig()` runs without error.

## Test Results

--- PASS: TestSetCachedConfig_AllFields (0.00s)
--- PASS: TestSetCachedConfig_EmptyFields (0.00s)
--- PASS: TestDeleteCachedConfig (0.00s)
PASS

## Checklist

- [x] All tests pass locally
- [x] No logic changes — tests only
- [x] Follows existing test conventions in `core/core/`
- [x] No new dependencies added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for cached configuration management covering set, view, and delete flows.
  * Verifies supplied account/access credentials and API/report endpoints are persisted when provided.
  * Confirms existing values remain unchanged when empty fields are supplied.
  * Confirms deletion removes stored credentials (account/access keys); endpoint behavior is not asserted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->