### PR TITLE
test(cautils): add unit tests for YAML separator, mergeMaps, and splitYAMLDocuments

### DIFF
--- a/core/cautils/fileformat_test.go
+++ b/core/cautils/fileformat_test.go
@@ -1,0 +1,103 @@
+package cautils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsYAMLDocumentSeparator(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"standard separator", "---", true},
+		{"separator with trailing spaces", "---   ", true},
+		{"separator with comment", "--- # start", true},
+		{"separator with tab", "---\t", true},
+		{"separator with CR", "---\r", true},
+		{"not a separator - content after", "---foo", false},
+		{"not a separator - plain text", "hello", false},
+		{"not a separator - dashes in text", "-- not enough", false},
+		{"empty line", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isYAMLDocumentSeparator([]byte(tt.line)))
+		})
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	t.Run("override wins on conflict", func(t *testing.T) {
+		base := map[string]interface{}{"a": 1, "b": 2}
+		over := map[string]interface{}{"b": 99}
+		got := mergeMaps(base, over)
+		assert.Equal(t, 1, got["a"])
+		assert.Equal(t, 99, got["b"])
+	})
+
+	t.Run("deep merge nested maps", func(t *testing.T) {
+		base := map[string]interface{}{
+			"top": map[string]interface{}{"x": 1, "y": 2},
+		}
+		over := map[string]interface{}{
+			"top": map[string]interface{}{"y": 42, "z": 3},
+		}
+		got := mergeMaps(base, over)
+		nested := got["top"].(map[string]interface{})
+		assert.Equal(t, 1, nested["x"])
+		assert.Equal(t, 42, nested["y"])
+		assert.Equal(t, 3, nested["z"])
+	})
+
+	t.Run("does not mutate base", func(t *testing.T) {
+		base := map[string]interface{}{"k": "original"}
+		over := map[string]interface{}{"k": "changed"}
+		mergeMaps(base, over)
+		assert.Equal(t, "original", base["k"])
+	})
+}
+
+func TestSplitYAMLDocuments(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+	}{
+		{
+			name:    "single document no separator",
+			input:   "apiVersion: v1\nkind: Pod",
+			wantLen: 1,
+		},
+		{
+			name:    "two documents",
+			input:   "apiVersion: v1\nkind: Pod\n---\napiVersion: v1\nkind: Service",
+			wantLen: 2,
+		},
+		{
+			name:    "leading separator is ignored",
+			input:   "---\napiVersion: v1\nkind: Pod",
+			wantLen: 1,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantLen: 0,
+		},
+		{
+			name:    "only separators",
+			input:   "---\n---\n---",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs := splitYAMLDocuments([]byte(tt.input))
+			assert.Len(t, docs, tt.wantLen)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add table-driven unit tests for previously untested pure utility functions in `core/cautils/fileutils.go`.

## Tests Added

### isYAMLDocumentSeparator (9 sub-tests)
- Standard `---` separator
- Trailing spaces, tabs, carriage return
- Separator with comment (`--- # start`)
- Rejects content after dashes (`---foo`), plain text, insufficient dashes, empty lines

### mergeMaps (3 sub-tests)
- Override wins on key conflict
- Deep merge of nested maps preserves non-conflicting keys
- Base map is not mutated

### splitYAMLDocuments (5 sub-tests)
- Single document without separator
- Two documents split correctly
- Leading separator is ignored (no empty first doc)
- Empty input returns zero documents
- Only separators returns zero documents

## Test Results

All **17 test cases pass** with `go test -v`.

Signed-off-by: Anvay <anvaykharb007@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests to verify YAML document processing, including separator recognition, multi-document splitting, and nested map merging with conflict resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->