### PR TITLE
test(metrics): add unit tests for Init and Update functions

### DIFF
--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -2,22 +2,46 @@ package metrics
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func resetMetricsForTest(t *testing.T) {
+	t.Helper()
+
+	savedInitOnce := initOnce
+	savedKubernetesResourcesCount := kubernetesResourcesCount
+	savedWorkerNodesCount := workerNodesCount
+
+	initOnce = sync.Once{}
+	kubernetesResourcesCount = nil
+	workerNodesCount = nil
+
+	t.Cleanup(func() {
+		initOnce = savedInitOnce
+		kubernetesResourcesCount = savedKubernetesResourcesCount
+		workerNodesCount = savedWorkerNodesCount
+	})
+}
+
 func TestInit(t *testing.T) {
+	resetMetricsForTest(t)
+
 	// Init should be safe to call multiple times thanks to sync.Once.
 	assert.NotPanics(t, func() { Init() })
+	require.NotNil(t, kubernetesResourcesCount)
+	require.NotNil(t, workerNodesCount)
+
 	assert.NotPanics(t, func() { Init() })
+	require.NotNil(t, kubernetesResourcesCount)
+	require.NotNil(t, workerNodesCount)
 }
 
 func TestUpdateKubernetesResourcesCount_NilCounter(t *testing.T) {
-	// Before Init(), the counter is nil. Update should not panic.
-	saved := kubernetesResourcesCount
-	kubernetesResourcesCount = nil
-	defer func() { kubernetesResourcesCount = saved }()
+	resetMetricsForTest(t)
 
 	assert.NotPanics(t, func() {
 		UpdateKubernetesResourcesCount(context.Background(), 5)
@@ -25,10 +49,7 @@ func TestUpdateKubernetesResourcesCount_NilCounter(t *testing.T) {
 }
 
 func TestUpdateWorkerNodesCount_NilCounter(t *testing.T) {
-	// Before Init(), the counter is nil. Update should not panic.
-	saved := workerNodesCount
-	workerNodesCount = nil
-	defer func() { workerNodesCount = saved }()
+	resetMetricsForTest(t)
 
 	assert.NotPanics(t, func() {
 		UpdateWorkerNodesCount(context.Background(), 3)
@@ -36,16 +57,22 @@ func TestUpdateWorkerNodesCount_NilCounter(t *testing.T) {
 }
 
 func TestUpdateKubernetesResourcesCount_AfterInit(t *testing.T) {
+	resetMetricsForTest(t)
+
 	Init()
-	// After Init(), the counter is set. Update should not panic.
+	require.NotNil(t, kubernetesResourcesCount)
+
 	assert.NotPanics(t, func() {
 		UpdateKubernetesResourcesCount(context.Background(), 10)
 	})
 }
 
 func TestUpdateWorkerNodesCount_AfterInit(t *testing.T) {
+	resetMetricsForTest(t)
+
 	Init()
-	// After Init(), the counter is set. Update should not panic.
+	require.NotNil(t, workerNodesCount)
+
 	assert.NotPanics(t, func() {
 		UpdateWorkerNodesCount(context.Background(), 4)
 	})

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	// Init should be safe to call multiple times thanks to sync.Once.
+	assert.NotPanics(t, func() { Init() })
+	assert.NotPanics(t, func() { Init() })
+}
+
+func TestUpdateKubernetesResourcesCount_NilCounter(t *testing.T) {
+	// Before Init(), the counter is nil. Update should not panic.
+	saved := kubernetesResourcesCount
+	kubernetesResourcesCount = nil
+	defer func() { kubernetesResourcesCount = saved }()
+
+	assert.NotPanics(t, func() {
+		UpdateKubernetesResourcesCount(context.Background(), 5)
+	})
+}
+
+func TestUpdateWorkerNodesCount_NilCounter(t *testing.T) {
+	// Before Init(), the counter is nil. Update should not panic.
+	saved := workerNodesCount
+	workerNodesCount = nil
+	defer func() { workerNodesCount = saved }()
+
+	assert.NotPanics(t, func() {
+		UpdateWorkerNodesCount(context.Background(), 3)
+	})
+}
+
+func TestUpdateKubernetesResourcesCount_AfterInit(t *testing.T) {
+	Init()
+	// After Init(), the counter is set. Update should not panic.
+	assert.NotPanics(t, func() {
+		UpdateKubernetesResourcesCount(context.Background(), 10)
+	})
+}
+
+func TestUpdateWorkerNodesCount_AfterInit(t *testing.T) {
+	Init()
+	// After Init(), the counter is set. Update should not panic.
+	assert.NotPanics(t, func() {
+		UpdateWorkerNodesCount(context.Background(), 4)
+	})
+}


### PR DESCRIPTION
## What this PR does: 
The `core/metrics/metrics.go` file had zero test coverage. This PR adds unit tests that verify:

- `Init()` is safe to call multiple times thanks to `sync.Once` and does not panic on repeated invocations.
- `UpdateKubernetesResourcesCount()` does not panic when the counter is nil (before `Init()` is called).
- `UpdateWorkerNodesCount()` does not panic when the counter is nil.
- Both update functions work correctly after `Init()` has been called.

These tests ensure the nil-guard pattern used throughout the metrics package is working as intended and will catch regressions if someone accidentally removes those guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to improve metrics reliability: verify initialization can be invoked repeatedly without errors and that metrics update operations behave safely both before and after initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->