### PR TITLE
test(cautils): add unit tests for datastructures helpers

### DIFF
--- a/core/cautils/datastructures_test.go
+++ b/core/cautils/datastructures_test.go
@@ -1,0 +1,145 @@
+package cautils
+
+import (
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateClusterSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    K8SResources
+		expected int
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: 0,
+		},
+		{
+			name:     "empty map",
+			input:    K8SResources{},
+			expected: 0,
+		},
+		{
+			name: "single group with resources",
+			input: K8SResources{
+				"apps/v1/deployments": {"id1", "id2", "id3"},
+			},
+			expected: 3,
+		},
+		{
+			name: "multiple groups",
+			input: K8SResources{
+				"apps/v1/deployments": {"id1", "id2"},
+				"v1/pods":            {"id3", "id4", "id5"},
+				"v1/services":        {"id6"},
+			},
+			expected: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, estimateClusterSize(tt.input))
+		})
+	}
+}
+
+func TestNewOPASessionObjMock(t *testing.T) {
+	obj := NewOPASessionObjMock()
+
+	require.NotNil(t, obj)
+	assert.NotNil(t, obj.AllResources)
+	assert.NotNil(t, obj.ResourcesResult)
+	assert.NotNil(t, obj.ResourcesPrioritized)
+	assert.NotNil(t, obj.Report)
+	assert.NotNil(t, obj.Metadata)
+	assert.Nil(t, obj.Policies)
+	assert.Nil(t, obj.K8SResources)
+}
+
+func TestSetNumberOfWorkerNodes(t *testing.T) {
+	t.Run("initializes ClusterContextMetadata when nil", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.Metadata.ContextMetadata.ClusterContextMetadata = nil
+
+		obj.SetNumberOfWorkerNodes(5)
+
+		require.NotNil(t, obj.Metadata.ContextMetadata.ClusterContextMetadata)
+		assert.Equal(t, 5, obj.Metadata.ContextMetadata.ClusterContextMetadata.NumberOfWorkerNodes)
+	})
+
+	t.Run("updates existing ClusterContextMetadata", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{
+			NumberOfWorkerNodes: 3,
+		}
+
+		obj.SetNumberOfWorkerNodes(10)
+		assert.Equal(t, 10, obj.Metadata.ContextMetadata.ClusterContextMetadata.NumberOfWorkerNodes)
+	})
+}
+
+func TestSetMapNamespaceToNumberOfResources(t *testing.T) {
+	t.Run("initializes maps when nil", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.Metadata.ContextMetadata.ClusterContextMetadata = nil
+
+		nsMap := map[string]int{"default": 10, "kube-system": 20}
+		obj.SetMapNamespaceToNumberOfResources(nsMap)
+
+		require.NotNil(t, obj.Metadata.ContextMetadata.ClusterContextMetadata)
+		assert.Equal(t, nsMap, obj.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
+	})
+
+	t.Run("replaces existing map", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{
+			MapNamespaceToNumberOfResources: map[string]int{"old": 1},
+		}
+
+		newMap := map[string]int{"new": 42}
+		obj.SetMapNamespaceToNumberOfResources(newMap)
+		assert.Equal(t, newMap, obj.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
+	})
+}
+
+func TestSetTopWorkloads(t *testing.T) {
+	t.Run("empty prioritized resources", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.SetTopWorkloads()
+
+		assert.Empty(t, obj.TopWorkloadsByScore)
+	})
+
+	t.Run("fewer resources than TopWorkloadsNumber", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.ResourcesPrioritized = map[string]prioritization.PrioritizedResource{
+			"res1": {ResourceID: "res1", Score: 80},
+		}
+		obj.ResourceSource = map[string]reporthandling.Source{}
+
+		obj.SetTopWorkloads()
+
+		assert.Len(t, obj.TopWorkloadsByScore, 1)
+	})
+
+	t.Run("nil report gets initialized", func(t *testing.T) {
+		obj := NewOPASessionObjMock()
+		obj.Report = nil
+		obj.ResourcesPrioritized = map[string]prioritization.PrioritizedResource{
+			"res1": {ResourceID: "res1", Score: 50},
+		}
+		obj.ResourceSource = map[string]reporthandling.Source{}
+
+		obj.SetTopWorkloads()
+
+		require.NotNil(t, obj.Report)
+	})
+}


### PR DESCRIPTION
## What this PR does:

The `core/cautils/datastructures.go` file contains several helper functions and methods on `OPASessionObj` that had no test coverage. This PR adds tests for:

- `estimateClusterSize`: verifies correct counting with nil, empty, single-group, and multi-group `K8SResources` maps.
- `NewOPASessionObjMock`: confirms that all internal maps are initialized (not nil) and that Policies and K8SResources are intentionally nil in the mock.
- `SetNumberOfWorkerNodes`: tests both the case where `ClusterContextMetadata` is nil (should initialize it) and the case where it already exists (should update in place).
- `SetMapNamespaceToNumberOfResources`: tests nil initialization and replacement of existing namespace maps.
- `SetTopWorkloads`: tests empty prioritized resources, fewer resources than the top-N limit, and nil report initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for core data-structure utilities with comprehensive test cases for initialization, configuration, and edge-case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->