### PR TITLE
test(cautils): add unit tests for operator scan info validation

### DIFF
--- a/core/cautils/operatorscaninfo_test.go
+++ b/core/cautils/operatorscaninfo_test.go
@@ -1,0 +1,123 @@
+package cautils
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigScanInfo_ValidatePayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      ConfigScanInfo
+		expectErr bool
+	}{
+		{
+			name:      "no namespaces set",
+			info:      ConfigScanInfo{},
+			expectErr: false,
+		},
+		{
+			name: "only included namespaces",
+			info: ConfigScanInfo{
+				IncludedNamespaces: []string{"ns-a"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "only excluded namespaces",
+			info: ConfigScanInfo{
+				ExcludedNamespaces: []string{"ns-b"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "both included and excluded namespaces",
+			info: ConfigScanInfo{
+				IncludedNamespaces: []string{"ns-a"},
+				ExcludedNamespaces: []string{"ns-b"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.info.ValidatePayload(&apis.Commands{})
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfigScanInfo_GetRequestPayload(t *testing.T) {
+	t.Run("default frameworks when none specified", func(t *testing.T) {
+		info := &ConfigScanInfo{}
+		payload := info.GetRequestPayload()
+
+		require.NotNil(t, payload)
+		require.Len(t, payload.Commands, 1)
+		assert.Equal(t, apis.TypeRunKubescape, payload.Commands[0].CommandName)
+		// When no frameworks are set, "all" should be the default
+		assert.Contains(t, info.Frameworks, "all")
+	})
+
+	t.Run("uses provided frameworks", func(t *testing.T) {
+		info := &ConfigScanInfo{
+			Frameworks: []string{"nsa", "mitre"},
+		}
+		payload := info.GetRequestPayload()
+
+		require.NotNil(t, payload)
+		require.Len(t, payload.Commands, 1)
+		assert.Equal(t, []string{"nsa", "mitre"}, info.Frameworks)
+	})
+
+	t.Run("includes excluded namespaces in payload", func(t *testing.T) {
+		info := &ConfigScanInfo{
+			ExcludedNamespaces: []string{"kube-system"},
+		}
+		payload := info.GetRequestPayload()
+
+		require.NotNil(t, payload)
+		require.Len(t, payload.Commands, 1)
+	})
+}
+
+func TestVulnerabilitiesScanInfo_ValidatePayload(t *testing.T) {
+	info := &VulnerabilitiesScanInfo{}
+	err := info.ValidatePayload(&apis.Commands{})
+	assert.NoError(t, err, "ValidatePayload should always return nil")
+}
+
+func TestVulnerabilitiesScanInfo_GetRequestPayload(t *testing.T) {
+	t.Run("no namespaces produces single wildcard command", func(t *testing.T) {
+		info := &VulnerabilitiesScanInfo{
+			ClusterName: "test-cluster",
+		}
+		payload := info.GetRequestPayload()
+
+		require.NotNil(t, payload)
+		require.Len(t, payload.Commands, 1)
+		assert.Equal(t, apis.TypeScanImages, payload.Commands[0].CommandName)
+	})
+
+	t.Run("multiple namespaces produce one command per namespace", func(t *testing.T) {
+		info := &VulnerabilitiesScanInfo{
+			ClusterName:       "test-cluster",
+			IncludeNamespaces: []string{"ns-a", "ns-b", "ns-c"},
+		}
+		payload := info.GetRequestPayload()
+
+		require.NotNil(t, payload)
+		require.Len(t, payload.Commands, 3)
+		for _, cmd := range payload.Commands {
+			assert.Equal(t, apis.TypeScanImages, cmd.CommandName)
+		}
+	})
+}

--- a/core/cautils/operatorscaninfo_test.go
+++ b/core/cautils/operatorscaninfo_test.go
@@ -4,9 +4,24 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/apis"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func requireConfigScanRequest(t *testing.T, payload *apis.Commands) utilsmetav1.PostScanRequest {
+	t.Helper()
+
+	require.NotNil(t, payload)
+	require.Len(t, payload.Commands, 1)
+	assert.Equal(t, apis.TypeRunKubescape, payload.Commands[0].CommandName)
+	require.Contains(t, payload.Commands[0].Args, KubescapeScanV1)
+
+	request, ok := payload.Commands[0].Args[KubescapeScanV1].(utilsmetav1.PostScanRequest)
+	require.True(t, ok)
+	return request
+}
 
 func TestConfigScanInfo_ValidatePayload(t *testing.T) {
 	tests := []struct {
@@ -59,12 +74,14 @@ func TestConfigScanInfo_GetRequestPayload(t *testing.T) {
 	t.Run("default frameworks when none specified", func(t *testing.T) {
 		info := &ConfigScanInfo{}
 		payload := info.GetRequestPayload()
+		request := requireConfigScanRequest(t, payload)
 
-		require.NotNil(t, payload)
-		require.Len(t, payload.Commands, 1)
-		assert.Equal(t, apis.TypeRunKubescape, payload.Commands[0].CommandName)
-		// When no frameworks are set, "all" should be the default
-		assert.Contains(t, info.Frameworks, "all")
+		assert.Equal(t, apisv1.KindFramework, request.TargetType)
+		assert.Equal(t, []string{"all"}, request.TargetNames)
+		assert.Empty(t, request.IncludeNamespaces)
+		assert.Empty(t, request.ExcludedNamespaces)
+		require.NotNil(t, request.HostScanner)
+		assert.False(t, *request.HostScanner)
 	})
 
 	t.Run("uses provided frameworks", func(t *testing.T) {
@@ -72,20 +89,39 @@ func TestConfigScanInfo_GetRequestPayload(t *testing.T) {
 			Frameworks: []string{"nsa", "mitre"},
 		}
 		payload := info.GetRequestPayload()
+		request := requireConfigScanRequest(t, payload)
 
-		require.NotNil(t, payload)
-		require.Len(t, payload.Commands, 1)
-		assert.Equal(t, []string{"nsa", "mitre"}, info.Frameworks)
+		assert.Equal(t, apisv1.KindFramework, request.TargetType)
+		assert.Equal(t, []string{"nsa", "mitre"}, request.TargetNames)
 	})
 
 	t.Run("includes excluded namespaces in payload", func(t *testing.T) {
 		info := &ConfigScanInfo{
 			ExcludedNamespaces: []string{"kube-system"},
+			Frameworks:         []string{"nsa"},
 		}
 		payload := info.GetRequestPayload()
+		request := requireConfigScanRequest(t, payload)
 
-		require.NotNil(t, payload)
-		require.Len(t, payload.Commands, 1)
+		assert.Equal(t, []string{"kube-system"}, request.ExcludedNamespaces)
+		assert.Empty(t, request.IncludeNamespaces)
+		assert.Equal(t, []string{"nsa"}, request.TargetNames)
+	})
+
+	t.Run("includes included namespaces in payload", func(t *testing.T) {
+		info := &ConfigScanInfo{
+			IncludedNamespaces: []string{"prod"},
+			Frameworks:         []string{"mitre"},
+			HostScanner:        true,
+		}
+		payload := info.GetRequestPayload()
+		request := requireConfigScanRequest(t, payload)
+
+		assert.Equal(t, []string{"prod"}, request.IncludeNamespaces)
+		assert.Empty(t, request.ExcludedNamespaces)
+		assert.Equal(t, []string{"mitre"}, request.TargetNames)
+		require.NotNil(t, request.HostScanner)
+		assert.True(t, *request.HostScanner)
 	})
 }
 
@@ -105,6 +141,7 @@ func TestVulnerabilitiesScanInfo_GetRequestPayload(t *testing.T) {
 		require.NotNil(t, payload)
 		require.Len(t, payload.Commands, 1)
 		assert.Equal(t, apis.TypeScanImages, payload.Commands[0].CommandName)
+		assert.Equal(t, "wlid://cluster-test-cluster/namespace-", payload.Commands[0].WildWlid)
 	})
 
 	t.Run("multiple namespaces produce one command per namespace", func(t *testing.T) {
@@ -116,8 +153,14 @@ func TestVulnerabilitiesScanInfo_GetRequestPayload(t *testing.T) {
 
 		require.NotNil(t, payload)
 		require.Len(t, payload.Commands, 3)
-		for _, cmd := range payload.Commands {
+		expectedWildWlids := []string{
+			"wlid://cluster-test-cluster/namespace-ns-a",
+			"wlid://cluster-test-cluster/namespace-ns-b",
+			"wlid://cluster-test-cluster/namespace-ns-c",
+		}
+		for i, cmd := range payload.Commands {
 			assert.Equal(t, apis.TypeScanImages, cmd.CommandName)
+			assert.Equal(t, expectedWildWlids[i], cmd.WildWlid)
 		}
 	})
 }


### PR DESCRIPTION
## What this PR does:

The `core/cautils/operatorscaninfo.go` file had no dedicated test coverage. This PR adds comprehensive tests for the operator scan info types:

- `ConfigScanInfo.ValidatePayload`: tests that passing both --include-namespaces and --exclude-namespaces together correctly returns an error, while passing either one alone or neither is accepted.
- `ConfigScanInfo.GetRequestPayload`: verifies that when no frameworks are specified, the default "all" framework is used, and that explicitly provided frameworks are preserved.
- `VulnerabilitiesScanInfo.ValidatePayload`: confirms the always-nil return behavior.
- `VulnerabilitiesScanInfo.GetRequestPayload`: verifies that no namespaces produces a single wildcard scan command, while multiple namespaces produce one command per namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for operator scan behavior: validation of namespace include/exclude rules, defaults for selected frameworks and host-scanner flag, and payload generation for configuration and vulnerability scans. Covers scenarios producing a single wildcard image-scan command versus per-namespace commands to strengthen scanning reliability and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->