### PR TITLE
test(imagescan): cover default matcher config

### DIFF
--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
@@ -225,40 +224,6 @@ func TestNewDefaultDBConfig(t *testing.T) {
 			name:     "unsupported URL scheme is rejected",
 			grypeURL: "ftp://example.com/custom-db/listing.json",
 			wantErr:  "invalid scheme: ftp",
-		name        string
-		grypeURL    string
-		wantURL     string
-		wantErr     bool
-		wantUpdate  bool
-		checkDBRoot bool
-	}{
-		{
-			name:        "Default URL when empty",
-			grypeURL:    "",
-			wantURL:     defaultGrypeListingURL,
-			wantErr:     false,
-			wantUpdate:  true,
-			checkDBRoot: true,
-		},
-		{
-			name:        "Custom HTTPS URL",
-			grypeURL:    "https://example.com/grype/db/listing.json",
-			wantURL:     "https://example.com/grype/db/listing.json",
-			wantErr:     false,
-			wantUpdate:  true,
-			checkDBRoot: true,
-		},
-		{
-			name:       "Invalid scheme",
-			grypeURL:   "ftp://example.com/db/listing.json",
-			wantErr:    true,
-			wantUpdate: false,
-		},
-		{
-			name:       "Invalid URL",
-			grypeURL:   "https://",
-			wantErr:    true,
-			wantUpdate: false,
 		},
 	}
 
@@ -268,9 +233,6 @@ func TestNewDefaultDBConfig(t *testing.T) {
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.EqualError(t, err, tt.wantErr)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Equal(t, tt.wantUpdate, shouldUpdate)
 				return
 			}
 
@@ -278,12 +240,20 @@ func TestNewDefaultDBConfig(t *testing.T) {
 			assert.Equal(t, tt.wantURL, distCfg.LatestURL)
 			assert.Equal(t, tt.wantDir, installCfg.DBRootDir)
 			assert.Equal(t, tt.wantUpdate, shouldUpdate)
-			assert.Equal(t, tt.wantUpdate, shouldUpdate)
-			assert.Equal(t, tt.wantURL, distCfg.LatestURL)
-			if tt.checkDBRoot {
-				assert.NotEmpty(t, installCfg.DBRootDir)
-				assert.True(t, strings.HasSuffix(installCfg.DBRootDir, defaultDBDirName))
-			}
 		})
 	}
+}
+
+func TestDefaultMatcherConfig(t *testing.T) {
+	cfg := defaultMatcherConfig()
+	assert.Equal(t, "https://search.maven.org/solrsearch/select", cfg.Java.ExternalSearchConfig.MavenBaseURL)
+	assert.False(t, cfg.Java.UseCPEs)
+	assert.False(t, cfg.Ruby.UseCPEs)
+	assert.False(t, cfg.Python.UseCPEs)
+	assert.False(t, cfg.Dotnet.UseCPEs)
+	assert.False(t, cfg.Javascript.UseCPEs)
+	assert.False(t, cfg.Golang.UseCPEs)
+	assert.True(t, cfg.Golang.AlwaysUseCPEForStdlib)
+	assert.False(t, cfg.Golang.AllowMainModulePseudoVersionComparison)
+	assert.True(t, cfg.Stock.UseCPEs)
 }


### PR DESCRIPTION
## Summary\n- fix the NewDefaultDBConfig test table structure\n- add coverage for defaultMatcherConfig behavior\n\n## Testing\n- go test ./pkg/imagescan\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation tests for database and matcher configuration defaults with improved assertion coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->