### PR TITLE
test(httphandler): add unit tests for RecoverFunc panic handler

### DIFF
--- a/httphandler/listener/helpers_test.go
+++ b/httphandler/listener/helpers_test.go
@@ -1,0 +1,53 @@
+package listener
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecoverFunc_NoPanic(t *testing.T) {
+	// When no panic occurs, RecoverFunc should be a no-op.
+	recorder := httptest.NewRecorder()
+	func() {
+		defer RecoverFunc(recorder)
+		// no panic here
+	}()
+
+	// Response should not have been written to
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Empty(t, recorder.Body.String())
+}
+
+func TestRecoverFunc_WithStringPanic(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	func() {
+		defer RecoverFunc(recorder)
+		panic("something went wrong")
+	}()
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotEmpty(t, recorder.Body.String())
+}
+
+func TestRecoverFunc_WithErrorPanic(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	func() {
+		defer RecoverFunc(recorder)
+		panic(assert.AnError)
+	}()
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+func TestRecoverFunc_WithIntPanic(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	func() {
+		defer RecoverFunc(recorder)
+		panic(42)
+	}()
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}


### PR DESCRIPTION
## What this PR does:

The `httphandler/listener/helpers.go` file contains `RecoverFunc`, a deferred panic recovery handler used across the HTTP handler layer. It had no test coverage. This PR adds tests that verify:

- When no panic occurs, the response writer is left untouched (status 200, empty body).
- When a string panic occurs, the handler returns HTTP 500 and writes the error to the response body.
- When an error type panic occurs, the handler returns HTTP 500.
- When an integer panic occurs (testing non-string, non-error types), the handler returns HTTP 500.
- These tests guard against regressions in the recovery path that protects the HTTP server from crashing on unexpected panics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests verifying that unexpected system errors are properly handled with appropriate error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->