### PR TITLE
test(cmd): cover KS_LOGGER_NAME env

### DIFF
--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -18,12 +18,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var isTerminal = isatty.IsTerminal
+
 func initLogger() {
 	if rootInfo.LoggerName == "" {
 		if l := os.Getenv("KS_LOGGER_NAME"); l != "" {
 			rootInfo.LoggerName = l
 		} else {
-			if isatty.IsTerminal(os.Stdout.Fd()) {
+			if isTerminal(os.Stdout.Fd()) {
 				rootInfo.LoggerName = iconlogger.LoggerName
 			} else {
 				rootInfo.LoggerName = zaplogger.LoggerName

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/go-logger/helpers"
-
+	"github.com/kubescape/go-logger/iconlogger"
 	"github.com/kubescape/go-logger/zaplogger"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/spf13/cobra"
@@ -100,6 +100,23 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
 	})
+}
+
+func TestInitLogger_KSLoggerNameEnv(t *testing.T) {
+	prevLoggerName := rootInfo.LoggerName
+	prevIsTerminal := isTerminal
+	t.Cleanup(func() {
+		rootInfo.LoggerName = prevLoggerName
+		isTerminal = prevIsTerminal
+	})
+
+	rootInfo.LoggerName = ""
+	t.Setenv("KS_LOGGER_NAME", iconlogger.LoggerName)
+	isTerminal = func(uintptr) bool { return false }
+
+	initLogger()
+
+	assert.Equal(t, iconlogger.LoggerName, rootInfo.LoggerName)
 }
 
 // testCmdWithCacheDirFlag mirrors root: cache-dir on PersistentFlags, bound to rootInfo.CacheDir.


### PR DESCRIPTION
## Summary\n- add unit test for KS_LOGGER_NAME precedence in initLogger\n\n## Testing\n- go test ./cmd\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for logger initialization with environment variable configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->