### PR TITLE
test(cmd): cover KS_LOGGER_NAME env

### DIFF
--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -218,3 +218,62 @@ func TestInitCacheDir_KSCacheDirPrecedence(t *testing.T) {
 		assert.Equal(t, defaultVal, getter.DefaultLocalStore)
 	})
 }
+
+func TestInitLogger_KSLoggerNameEnv(t *testing.T) {
+	t.Run("env sets logger name when empty", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		rootInfo.LoggerName = ""
+		t.Setenv("KS_LOGGER_NAME", "custom-logger")
+
+		initLogger()
+
+		assert.Equal(t, "custom-logger", rootInfo.LoggerName)
+	})
+
+	t.Run("existing logger name wins over env", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		rootInfo.LoggerName = zaplogger.LoggerName
+		t.Setenv("KS_LOGGER_NAME", "custom-logger")
+
+		initLogger()
+
+		assert.Equal(t, zaplogger.LoggerName, rootInfo.LoggerName)
+	})
+
+	t.Run("existing logger name stays when env empty", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		rootInfo.LoggerName = zaplogger.LoggerName
+		t.Setenv("KS_LOGGER_NAME", "")
+
+		initLogger()
+
+		assert.Equal(t, zaplogger.LoggerName, rootInfo.LoggerName)
+	})
+
+	t.Run("env applies after logger name cleared", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+		})
+
+		rootInfo.LoggerName = zaplogger.LoggerName
+		t.Setenv("KS_LOGGER_NAME", "custom-logger")
+		rootInfo.LoggerName = ""
+
+		initLogger()
+
+		assert.Equal(t, "custom-logger", rootInfo.LoggerName)
+	})
+}


### PR DESCRIPTION
## Summary\n- add tests for KS_LOGGER_NAME behavior in initLogger\n\n## Testing\n- go test ./cmd\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for logger initialization with environment variable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->