### PR TITLE
test(cmd): cover initLogger name precedence

### DIFF
--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -18,12 +18,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var isTerminal = isatty.IsTerminal
+
 func initLogger() {
 	if rootInfo.LoggerName == "" {
 		if l := os.Getenv("KS_LOGGER_NAME"); l != "" {
 			rootInfo.LoggerName = l
 		} else {
-			if isatty.IsTerminal(os.Stdout.Fd()) {
+			if isTerminal(os.Stdout.Fd()) {
 				rootInfo.LoggerName = iconlogger.LoggerName
 			} else {
 				rootInfo.LoggerName = zaplogger.LoggerName

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/go-logger/helpers"
-
+	"github.com/kubescape/go-logger/iconlogger"
 	"github.com/kubescape/go-logger/zaplogger"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/spf13/cobra"
@@ -99,6 +99,42 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		initLoggerLevel(versionCmd)
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
+	})
+}
+
+func TestInitLoggerNameFallback(t *testing.T) {
+	t.Run("terminal uses iconlogger", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		prevIsTerminal := isTerminal
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+			isTerminal = prevIsTerminal
+		})
+
+		rootInfo.LoggerName = ""
+		t.Setenv("KS_LOGGER_NAME", "")
+		isTerminal = func(uintptr) bool { return true }
+
+		initLogger()
+
+		assert.Equal(t, iconlogger.LoggerName, rootInfo.LoggerName)
+	})
+
+	t.Run("non-terminal uses zaplogger", func(t *testing.T) {
+		prevLoggerName := rootInfo.LoggerName
+		prevIsTerminal := isTerminal
+		t.Cleanup(func() {
+			rootInfo.LoggerName = prevLoggerName
+			isTerminal = prevIsTerminal
+		})
+
+		rootInfo.LoggerName = ""
+		t.Setenv("KS_LOGGER_NAME", "")
+		isTerminal = func(uintptr) bool { return false }
+
+		initLogger()
+
+		assert.Equal(t, zaplogger.LoggerName, rootInfo.LoggerName)
 	})
 }
 


### PR DESCRIPTION
## Summary\n- Add unit tests for initLogger name precedence (env, explicit, fallback)\n- Covers iconlogger/zaplogger selection and KS_LOGGER_NAME\n\n## Testing\n- go test ./cmd\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying logger name fallback behavior when the configured logger name is empty, ensuring correct selection for terminal vs non-terminal environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->