### PR TITLE
vap: resolve CEL control IDs for policy bindings

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -28,8 +28,10 @@ var vapHelperCmdExamples = fmt.Sprintf(`
 
   # Install Kubescape CEL admission policy library
   %[1]s vap deploy-library | kubectl apply -f -
-  # Create a policy binding
-  %[1]s vap create-policy-binding --name my-policy-binding --policy c-0016 --namespace=my-namespace | kubectl apply -f -
+  # Create a policy binding by Kubescape control ID
+  %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --namespace=my-namespace | kubectl apply -f -
+  # Create a policy binding by ValidatingAdmissionPolicy name
+  %[1]s vap create-policy-binding --name my-policy-binding --policy kubescape-c-0016-allow-privilege-escalation --namespace=my-namespace | kubectl apply -f -
 `, cautils.ExecName())
 
 func GetVapHelperCmd() *cobra.Command {
@@ -73,6 +75,7 @@ func getDeployLibraryCmd() *cobra.Command {
 func getCreatePolicyBindingCmd() *cobra.Command {
 	var policyBindingName string
 	var policyName string
+	var controlID string
 	var namespaceArr []string
 	var labelArr []string
 	var action string
@@ -88,8 +91,12 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 			if err := isValidK8sObjectName(policyBindingName); err != nil {
 				return fmt.Errorf("invalid policy binding name %s: %w", policyBindingName, err)
 			}
-			if err := isValidK8sObjectName(policyName); err != nil {
-				return fmt.Errorf("invalid policy name %s: %w", policyName, err)
+			resolvedPolicyName, err := resolvePolicyName(policyName, controlID)
+			if err != nil {
+				return err
+			}
+			if err := isValidK8sObjectName(resolvedPolicyName); err != nil {
+				return fmt.Errorf("invalid policy name %s: %w", resolvedPolicyName, err)
 			}
 			for _, namespace := range namespaceArr {
 				if err := isValidNamespace(namespace); err != nil {
@@ -117,7 +124,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				}
 			}
 
-			content, err := createPolicyBinding(policyBindingName, policyName, action, parameterReference, namespaceArr, labelArr)
+			content, err := createPolicyBinding(policyBindingName, resolvedPolicyName, action, parameterReference, namespaceArr, labelArr)
 			if err != nil {
 				return err
 			}
@@ -127,8 +134,8 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	// Must specify the name of the policy binding
 	createPolicyBindingCmd.Flags().StringVarP(&policyBindingName, "name", "n", "", "Name of the policy binding")
 	createPolicyBindingCmd.MarkFlagRequired("name")
-	createPolicyBindingCmd.Flags().StringVarP(&policyName, "policy", "p", "", "Name of the policy to bind the resources to")
-	createPolicyBindingCmd.MarkFlagRequired("policy")
+	createPolicyBindingCmd.Flags().StringVarP(&policyName, "policy", "p", "", "Name of the ValidatingAdmissionPolicy to bind resources to")
+	createPolicyBindingCmd.Flags().StringVarP(&controlID, "control", "c", "", "Kubescape control ID to bind resources to")
 	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector")
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringVarP(&action, "action", "a", "Deny", "Action to take when policy fails")
@@ -136,6 +143,67 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
 	return createPolicyBindingCmd
+}
+
+var celAdmissionPolicyByControlID = map[string]string{
+	"C-0001": "kubescape-c-0001-deny-forbidden-container-registries",
+	"C-0004": "kubescape-c-0004-deny-resources-with-memory-limit-or-request-not-set",
+	"C-0009": "kubescape-c-0009-deny-resources-with-memory-or-cpu-limit-not-set",
+	"C-0012": "kubescape-c-0012-deny-resources-with-sensitive-information-in-environment-variables",
+	"C-0013": "kubescape-c-0013-deny-resources-with-capability-to-run-as-root",
+	"C-0016": "kubescape-c-0016-allow-privilege-escalation",
+	"C-0017": "kubescape-c-0017-deny-resources-with-mutable-container-filesystem",
+	"C-0018": "kubescape-c-0018-deny-resources-without-configured-readiness-probes",
+	"C-0020": "kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials",
+	"C-0026": "kubescape-c-0026-deny-cronjobs",
+	"C-0034": "kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled",
+	"C-0038": "kubescape-c-0038-deny-resources-with-host-ipc-or-pid-privileges",
+	"C-0041": "kubescape-c-0041-deny-resources-with-host-network-access",
+	"C-0042": "kubescape-c-0042-deny-resources-with-ssh-server-running",
+	"C-0044": "kubescape-c-0044-deny-resources-with-host-port",
+	"C-0045": "kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false",
+	"C-0046": "kubescape-c-0046-deny-resources-with-insecure-capabilities",
+	"C-0048": "kubescape-c-0048-deny-workloads-with-hostpath-mounts",
+	"C-0050": "kubescape-c-0050-deny-resources-with-cpu-limit-or-request-not-set",
+	"C-0055": "kubescape-c-0055-linux-hardening",
+	"C-0056": "kubescape-c-0056-deny-resources-without-configured-liveliness-probes",
+	"C-0057": "kubescape-c-0057-privileged-container-denied",
+	"C-0061": "kubescape-c-0061-deny-workloads-in-default-namespace",
+	"C-0062": "kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint",
+	"C-0073": "kubescape-c-0073-deny-naked-pods",
+	"C-0074": "kubescape-c-0074-resources-mounting-docker-socket-denied",
+	"C-0075": "kubescape-c-0075-deny-resources-with-image-pull-policy-not-set-to-always-for-latest-tag",
+	"C-0076": "kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set",
+	"C-0077": "kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set",
+	"C-0078": "kubescape-c-0078-only-allow-images-from-allowed-registry",
+	"C-0198": "kubescape-c-0198-deny-root-containers",
+	"C-0210": "kubescape-c-0210-deny-seccomp-profile-unconfined",
+	"C-0268": "kubescape-c-0268-deny-resources-with-cpu-request-not-set",
+	"C-0269": "kubescape-c-0269-deny-resources-with-memory-request-not-set",
+	"C-0270": "kubescape-c-0270-deny-resources-with-cpu-limit-not-set",
+	"C-0271": "kubescape-c-0271-deny-resources-with-memory-limit-not-set",
+	"C-0280": "kubescape-c-0280-deny-access-to-csr-approval-subresource",
+}
+
+func resolvePolicyName(policyName, controlID string) (string, error) {
+	policyName = strings.TrimSpace(policyName)
+	controlID = strings.ToUpper(strings.TrimSpace(controlID))
+
+	if policyName == "" && controlID == "" {
+		return "", fmt.Errorf("either --policy or --control must be specified")
+	}
+	if policyName != "" && controlID != "" {
+		return "", fmt.Errorf("only one of --policy or --control can be specified")
+	}
+	if policyName != "" {
+		return policyName, nil
+	}
+
+	resolved, ok := celAdmissionPolicyByControlID[controlID]
+	if !ok {
+		return "", fmt.Errorf("unsupported control ID %s", controlID)
+	}
+	return resolved, nil
 }
 
 // Implementation of the VAP helper commands

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -387,6 +387,44 @@ func TestCreatePolicyBindingCmdValidation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("valid control ID resolves policy name", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0016"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("lowercase control ID resolves policy name", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "c-0016"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("unsupported control ID", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-9999"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported control ID")
+	})
+
+	t.Run("policy and control are mutually exclusive", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "kubescape-c-0016-allow-privilege-escalation", "--control", "C-0016"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only one of --policy or --control")
+	})
+
+	t.Run("policy or control is required", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "either --policy or --control")
+	})
+
 	t.Run("invalid binding name", func(t *testing.T) {
 		cmd := getCreatePolicyBindingCmd()
 		cmd.SetArgs([]string{"--name", "INVALID-name", "--policy", "c-0016"})
@@ -468,6 +506,10 @@ func TestGetCreatePolicyBindingCmd(t *testing.T) {
 	require.NotNil(t, policyFlag)
 	assert.Equal(t, "p", policyFlag.Shorthand)
 
+	controlFlag := cmd.Flags().Lookup("control")
+	require.NotNil(t, controlFlag)
+	assert.Equal(t, "c", controlFlag.Shorthand)
+
 	namespaceFlag := cmd.Flags().Lookup("namespace")
 	require.NotNil(t, namespaceFlag)
 
@@ -481,6 +523,60 @@ func TestGetCreatePolicyBindingCmd(t *testing.T) {
 	paramRefFlag := cmd.Flags().Lookup("parameter-reference")
 	require.NotNil(t, paramRefFlag)
 	assert.Equal(t, "r", paramRefFlag.Shorthand)
+}
+
+func TestResolvePolicyName(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyName string
+		controlID  string
+		want       string
+		wantErr    string
+	}{
+		{
+			name:       "policy name is returned as-is",
+			policyName: "kubescape-c-0016-allow-privilege-escalation",
+			want:       "kubescape-c-0016-allow-privilege-escalation",
+		},
+		{
+			name:      "control ID resolves to library policy",
+			controlID: "C-0016",
+			want:      "kubescape-c-0016-allow-privilege-escalation",
+		},
+		{
+			name:      "lowercase control ID resolves",
+			controlID: "c-0016",
+			want:      "kubescape-c-0016-allow-privilege-escalation",
+		},
+		{
+			name:    "neither policy nor control",
+			wantErr: "either --policy or --control",
+		},
+		{
+			name:       "both policy and control",
+			policyName: "kubescape-c-0016-allow-privilege-escalation",
+			controlID:  "C-0016",
+			wantErr:    "only one of --policy or --control",
+		},
+		{
+			name:      "unsupported control",
+			controlID: "C-9999",
+			wantErr:   "unsupported control ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolvePolicyName(tt.policyName, tt.controlID)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestGetVapHelperCmd(t *testing.T) {
@@ -554,10 +650,11 @@ func TestCreatePolicyBindingCmdRequiredFlags(t *testing.T) {
 
 	policyFlag := cmd.Flags().Lookup("policy")
 	require.NotNil(t, policyFlag)
-	annotations = policyFlag.Annotations
-	require.NotNil(t, annotations)
-	_, isRequired = annotations[cobra.BashCompOneRequiredFlag]
-	assert.True(t, isRequired, "policy flag should be marked as required")
+	assert.Nil(t, policyFlag.Annotations[cobra.BashCompOneRequiredFlag])
+
+	controlFlag := cmd.Flags().Lookup("control")
+	require.NotNil(t, controlFlag)
+	assert.Nil(t, controlFlag.Annotations[cobra.BashCompOneRequiredFlag])
 }
 
 func TestDeployLibraryCmdTimeoutFlag(t *testing.T) {


### PR DESCRIPTION
### Summary

This PR fixes the `vap create-policy-binding` workflow so users do not accidentally create bindings to policy names that are not installed by `cel-admission-library`.

Today the command example uses `--policy c-0016`, which generates `spec.policyName: c-0016`. The installed policy is named `kubescape-c-0016-allow-privilege-escalation`, so the generated binding does not target the library policy.

### Fixes #2234  

### Changes

- Update the `vap create-policy-binding` example to use the full VAP policy name.
- Add a `--control` flag that accepts Kubescape control IDs such as `C-0016`.
- Resolve supported control IDs to CEL admission library policy names.
- Reject unknown control IDs with a clear error.
- Add unit tests for full policy names, lowercase control IDs, uppercase control IDs, and unknown IDs.
- Keep `--policy` as the exact policy name path for advanced users.

### Testing

```bash
go test ./cmd/vap
```

Manual smoke test:

```bash
kubescape vap create-policy-binding --name c0016-binding --control C-0016 --namespace policy-example
```

Expected output:

```yaml
spec:
  policyName: kubescape-c-0016-allow-privilege-escalation
```

### Why this is safe

The existing `--policy` behavior remains available for users who pass full `ValidatingAdmissionPolicy` names. The new `--control` path removes ambiguity and gives users a Kubescape-native way to bind a control by ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validating Admission Policy binding command now accepts `--control` flag to specify policies by Kubescape control ID (e.g., `C-0016`)
  * `--policy` and `--control` flags are mutually exclusive; at least one is required
  * Enhanced policy name validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->