### PR TITLE
fix(httphandler): add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -102,7 +102,7 @@ func SetupHTTPListener(ctx context.Context) error {
 	// Block until a termination signal or a listener error.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-
+	defer signal.Stop(sigCh)
 	select {
 	case sig := <-sigCh:
 		logger.L().Info("received shutdown signal, draining in-flight requests",

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -1,10 +1,15 @@
 package listener
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -27,16 +32,22 @@ const (
 	// healtcheck paths
 	livePath  = "/livez"
 	readyPath = "/readyz"
+
+	// shutdownGracePeriod is the maximum time to wait for in-flight
+	// requests to complete before forcing the server to stop.
+	shutdownGracePeriod = 30 * time.Second
 )
 
-// SetupHTTPListener set up listening http servers
-func SetupHTTPListener() error {
+// SetupHTTPListener sets up the HTTP server and blocks until the server
+// is shut down. On SIGTERM or SIGINT the server drains in-flight requests
+// for up to shutdownGracePeriod before returning.
+func SetupHTTPListener(ctx context.Context) error {
 	keyPair, err := loadTLSKey(getCertFile(), getKeyFile())
 	if err != nil {
 		return err
 	}
 	server := &http.Server{
-		Addr: fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
+		Addr: fmt.Sprintf(":%s", getPort()),
 	}
 	if keyPair != nil {
 		server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*keyPair}}
@@ -72,10 +83,50 @@ func SetupHTTPListener() error {
 
 	servePprof()
 
-	if keyPair != nil {
-		return server.ListenAndServeTLS("", "")
+	// Start the server in a goroutine so we can listen for shutdown signals.
+	errCh := make(chan error, 1)
+	go func() {
+		var listenErr error
+		if keyPair != nil {
+			listenErr = server.ListenAndServeTLS("", "")
+		} else {
+			listenErr = server.ListenAndServe()
+		}
+		// ErrServerClosed is returned by Shutdown — not an error.
+		if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
+			errCh <- listenErr
+		}
+		close(errCh)
+	}()
+
+	// Block until a termination signal or a listener error.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case sig := <-sigCh:
+		logger.L().Info("received shutdown signal, draining in-flight requests",
+			helpers.String("signal", sig.String()))
+	case err := <-errCh:
+		// Listener failed to start (e.g. port conflict).
+		return err
+	case <-ctx.Done():
+		logger.L().Info("context cancelled, shutting down server")
 	}
-	return server.ListenAndServe()
+
+	// Graceful shutdown: give in-flight requests time to complete.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGracePeriod)
+	defer cancel()
+
+	logger.L().Info("shutting down HTTP server",
+		helpers.String("gracePeriod", shutdownGracePeriod.String()))
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("server shutdown error: %w", err)
+	}
+
+	logger.L().Info("HTTP server stopped gracefully")
+	return nil
 }
 
 func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
@@ -88,7 +139,7 @@ func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
 
 	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load key pair: %v", err)
+		return nil, fmt.Errorf("failed to load key pair: %w", err)
 	}
 	return &pair, nil
 }

--- a/httphandler/main.go
+++ b/httphandler/main.go
@@ -75,7 +75,9 @@ func main() {
 	initializeStorage(clusterName, cfg)
 	// traces will be created by otelmux.Middleware in SetupHTTPListener()
 
-	logger.L().Ctx(ctx).Fatal(listener.SetupHTTPListener().Error())
+	if err := listener.SetupHTTPListener(ctx); err != nil {
+		logger.L().Ctx(ctx).Fatal(err.Error())
+	}
 }
 
 func initializeStorage(clusterName string, cfg config.Config) {


### PR DESCRIPTION
Fixes #2220

## What

Adds graceful shutdown to the httphandler (in-cluster operator binary) so that SIGTERM/SIGINT from Kubernetes triggers a clean drain of in-flight requests instead of an abrupt process kill.

## Why

The httphandler had **no graceful shutdown**:

1. `ListenAndServe()` blocked forever with no signal handling
2. The only exit path was `logger.Fatal()` → `os.Exit(1)`, which **skips all defers** — including `defer logger.ShutdownOtel(ctx)` (main.go:66), so OTEL traces were never flushed
3. On SIGTERM (Kubernetes pod termination), in-flight HTTP requests were dropped mid-flight — active scans and storage writes were aborted

This is critical for the in-cluster operator mode where Kubernetes regularly sends SIGTERM during rolling updates, scale-downs, and node drains.

## How

| File | Change |
|---|---|
| `listener/setup.go` | Accept `context.Context`; listen for SIGTERM/SIGINT via `signal.Notify`; run `ListenAndServe` in a goroutine; on signal, call `server.Shutdown()` with a 30s grace period; use `%w` for error wrapping |
| `main.go` | Pass `ctx` to `SetupHTTPListener(ctx)`; call `Fatal` only on startup errors; normal shutdown returns cleanly so defers execute |

### Shutdown flow

```
SIGTERM received
  → log "received shutdown signal, draining in-flight requests"
  → server.Shutdown(ctx) with 30s grace period
    → net/http stops accepting new connections
    → waits for in-flight requests to complete (up to 30s)
  → log "HTTP server stopped gracefully"
  → main() returns normally
  → defer logger.ShutdownOtel(ctx) executes ← previously unreachable
  → process exits with code 0
```

## Testing

- `go build ./...` ✅
- `go test -race -count=1 ./...` ✅ (all packages pass, race detector clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now reports and surfaces server start errors (e.g., port conflicts) instead of silently failing.
  * Improved TLS error reporting for clearer diagnostics.
  * Server performs graceful shutdown on termination signals with a configurable grace period.
  * Successful graceful shutdowns are now logged for monitoring and observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->