### PR TITLE
test(cautils): expand normalize image name tests

### DIFF
--- a/core/cautils/normalize_image_name_test.go
+++ b/core/cautils/normalize_image_name_test.go
@@ -9,20 +9,45 @@ import (
 func Test_normalize_name(t *testing.T) {
 
 	tests := []struct {
-		name string
-		img  string
-		want string
+		name    string
+		img     string
+		want    string
+		wantErr bool
 	}{
 		{
-			name: "Normalize image name",
-			img:  "nginx",
-			want: "docker.io/library/nginx",
+			name:    "Normalize simple image name",
+			img:     "nginx",
+			want:    "docker.io/library/nginx",
+			wantErr: false,
+		},
+		{
+			name:    "Normalize image with tag",
+			img:     "nginx:latest",
+			want:    "docker.io/library/nginx:latest",
+			wantErr: false,
+		},
+		{
+			name:    "Normalize image with custom registry",
+			img:     "quay.io/coreos/etcd:v3.5",
+			want:    "quay.io/coreos/etcd:v3.5",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid image name",
+			img:     "https://docker.io/library/nginx",
+			want:    "",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			name, _ := NormalizeImageName(tt.img)
-			assert.Equal(t, tt.want, name, tt.name)
+			name, err := NormalizeImageName(tt.img)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, name, tt.name)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Adding more test cases to NormalizeImageName including tags, custom registries, and invalid names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for image name normalization, including error scenarios and multiple input cases such as simple names, tagged names, custom registries, and invalid formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->