### PR TITLE
test(cautils): add TestIsFileAndIsDir unit test

### DIFF
--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -212,5 +212,19 @@ func TestGetFileFormat(t *testing.T) {
 			assert.Equal(t, tt.want, getFileFormat(tt.path))
 		})
 	}
+}
 
+func TestIsFileAndIsDir(t *testing.T) {
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "test_file.txt")
+	_ = os.WriteFile(tempFile, []byte("test"), 0644)
+
+	assert.True(t, isDir(tempDir))
+	assert.False(t, isFile(tempDir))
+
+	assert.True(t, isFile(tempFile))
+	assert.False(t, isDir(tempFile))
+
+	assert.False(t, isFile("non-existent-path"))
+	assert.False(t, isDir("non-existent-path"))
 }

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func onlineBoutiquePath() string {
@@ -217,7 +218,8 @@ func TestGetFileFormat(t *testing.T) {
 func TestIsFileAndIsDir(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "test_file.txt")
-	_ = os.WriteFile(tempFile, []byte("test"), 0644)
+	err := os.WriteFile(tempFile, []byte("test"), 0644)
+	require.NoError(t, err)
 
 	assert.True(t, isDir(tempDir))
 	assert.False(t, isFile(tempDir))


### PR DESCRIPTION
Adding unit test coverage for isFile and isDir helper functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test that validates file vs. directory detection, covering temporary files, temporary directories, and non-existent paths to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->