### PR TITLE
test: add request and resource handler coverage

### DIFF
--- a/core/pkg/resourcehandler/handlerpullresources_extra_test.go
+++ b/core/pkg/resourcehandler/handlerpullresources_extra_test.go
@@ -1,0 +1,112 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	reportv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type collectResourcesMock struct {
+	k8sResources      cautils.K8SResources
+	allResources      map[string]workloadinterface.IMetadata
+	externalResources cautils.ExternalResources
+	excludedRules     map[string]bool
+	err               error
+	cloudProvider     string
+	apiServerInfo     *version.Info
+}
+
+func (m collectResourcesMock) GetResources(context.Context, *cautils.OPASessionObj, *cautils.ScanInfo) (cautils.K8SResources, map[string]workloadinterface.IMetadata, cautils.ExternalResources, map[string]bool, error) {
+	return m.k8sResources, m.allResources, m.externalResources, m.excludedRules, m.err
+}
+
+func (m collectResourcesMock) GetClusterAPIServerInfo(context.Context) *version.Info {
+	return m.apiServerInfo
+}
+
+func (m collectResourcesMock) GetCloudProvider() string {
+	return m.cloudProvider
+}
+
+func TestCollectResources(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    collectResourcesMock
+		wantErr    string
+		assertions func(t *testing.T, session *cautils.OPASessionObj)
+	}{
+		{
+			name: "assigns returned resource maps",
+			handler: collectResourcesMock{
+				k8sResources:  cautils.K8SResources{"apps/v1/deployments": []string{"resource-1"}},
+				allResources:  map[string]workloadinterface.IMetadata{"resource-1": nil},
+				excludedRules: map[string]bool{"rule-1": true},
+				apiServerInfo: &version.Info{GitVersion: "v1.30.0"},
+			},
+			assertions: func(t *testing.T, session *cautils.OPASessionObj) {
+				assert.Equal(t, []string{"resource-1"}, session.K8SResources["apps/v1/deployments"])
+				assert.Contains(t, session.AllResources, "resource-1")
+				assert.True(t, session.ExcludedRules["rule-1"])
+				assert.Equal(t, "v1.30.0", session.Report.ClusterAPIServerInfo.GitVersion)
+			},
+		},
+		{
+			name: "returns get resources error after assigning maps",
+			handler: collectResourcesMock{
+				k8sResources: cautils.K8SResources{"v1/pods": []string{"pod-1"}},
+				allResources: map[string]workloadinterface.IMetadata{"pod-1": nil},
+				err:          errors.New("pull failed"),
+			},
+			wantErr: "pull failed",
+			assertions: func(t *testing.T, session *cautils.OPASessionObj) {
+				assert.Equal(t, []string{"pod-1"}, session.K8SResources["v1/pods"])
+				assert.Contains(t, session.AllResources, "pod-1")
+			},
+		},
+		{
+			name: "returns no resources error for empty results",
+			handler: collectResourcesMock{
+				k8sResources: cautils.K8SResources{},
+				allResources: map[string]workloadinterface.IMetadata{},
+			},
+			wantErr: "no resources found to scan",
+		},
+		{
+			name: "ignores unknown cloud provider",
+			handler: collectResourcesMock{
+				k8sResources:  cautils.K8SResources{"v1/configmaps": []string{"cm-1"}},
+				allResources:  map[string]workloadinterface.IMetadata{"cm-1": nil},
+				cloudProvider: "unknown",
+			},
+			assertions: func(t *testing.T, session *cautils.OPASessionObj) {
+				assert.Empty(t, session.Report.ClusterCloudProvider)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &cautils.OPASessionObj{
+				Metadata: &reportv2.Metadata{},
+				Report:   &reportv2.PostureReport{},
+			}
+
+			err := CollectResources(context.Background(), tt.handler, session, &cautils.ScanInfo{})
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.assertions != nil {
+				tt.assertions(t, session)
+			}
+		})
+	}
+}

--- a/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
@@ -1,0 +1,64 @@
+package v1
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvHelpers(t *testing.T) {
+	t.Run("envToString returns default when unset", func(t *testing.T) {
+		t.Setenv("KS_TEST_STRING", "")
+		require.NoError(t, os.Unsetenv("KS_TEST_STRING"))
+
+		assert.Equal(t, "fallback", envToString("KS_TEST_STRING", "fallback"))
+	})
+
+	t.Run("envToString returns configured value", func(t *testing.T) {
+		t.Setenv("KS_TEST_STRING", "configured")
+
+		assert.Equal(t, "configured", envToString("KS_TEST_STRING", "fallback"))
+	})
+
+	t.Run("envToBool returns default when unset", func(t *testing.T) {
+		t.Setenv("KS_TEST_BOOL", "")
+		require.NoError(t, os.Unsetenv("KS_TEST_BOOL"))
+
+		assert.True(t, envToBool("KS_TEST_BOOL", true))
+	})
+
+	t.Run("envToBool parses configured value", func(t *testing.T) {
+		t.Setenv("KS_TEST_BOOL", "true")
+
+		assert.True(t, envToBool("KS_TEST_BOOL", false))
+	})
+}
+
+func TestResponseToBytes(t *testing.T) {
+	got := responseToBytes(&utilsmetav1.Response{
+		Type:     "done",
+		Response: "ok",
+	})
+
+	assert.JSONEq(t, `{"id":"","type":"done","response":"ok"}`, string(got))
+}
+
+func TestWriteScanErrorToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldFailedOutputDir := FailedOutputDir
+	FailedOutputDir = tmpDir
+	defer func() { FailedOutputDir = oldFailedOutputDir }()
+
+	err := writeScanErrorToFile(errors.New("scan failed"), "scan-id")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to scan. reason: 'scan failed'")
+	got, readErr := os.ReadFile(filepath.Join(tmpDir, "scan-id"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "scan failed", string(got))
+}


### PR DESCRIPTION
## Summary
- Add focused unit tests for HTTP request utility helpers and resource collection handling
- Cover environment helper defaults, response serialization, scan error file writing, resource map assignment, and empty resource errors
- Keep the change limited to tests only

## Why
These packages contain request handling and resource collection logic that benefits from direct unit coverage. The added tests verify deterministic behavior without requiring a live Kubernetes cluster.

## Testing
- cd httphandler && go test ./handlerequests/v1
- go test ./core/pkg/resourcehandler

## Notes
No production code was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for resource collection behavior: session population, error propagation, handling of empty results, API server version capture, and ignoring unknown cloud provider values.
  * Added tests for request utilities: environment-variable parsing, response JSON serialization shape, and writing scan error output to file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->