### PR TITLE
test: add v1 printer coverage

### DIFF
--- a/core/pkg/resultshandling/printer/v1/printer_extra_test.go
+++ b/core/pkg/resultshandling/printer/v1/printer_extra_test.go
@@ -1,0 +1,127 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonPrinterSetWriter(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		wantSuffix string
+	}{
+		{
+			name:       "adds json extension",
+			outputFile: filepath.Join(t.TempDir(), "scan-result"),
+			wantSuffix: "scan-result.json",
+		},
+		{
+			name:       "keeps json extension",
+			outputFile: filepath.Join(t.TempDir(), "scan-result.json"),
+			wantSuffix: "scan-result.json",
+		},
+		{
+			name:       "blank output uses default report name",
+			outputFile: filepath.Join(t.TempDir(), "   "),
+			wantSuffix: "   .json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewJsonPrinter()
+			p.SetWriter(context.Background(), tt.outputFile)
+			defer p.writer.Close()
+
+			assert.True(t, strings.HasSuffix(p.writer.Name(), tt.wantSuffix), p.writer.Name())
+		})
+	}
+}
+
+func TestJsonPrinterSetWriterUsesStdoutForEmptyOutput(t *testing.T) {
+	p := NewJsonPrinter()
+
+	p.SetWriter(context.Background(), "")
+
+	assert.Equal(t, os.Stdout.Name(), p.writer.Name())
+}
+
+func TestPrometheusPrinterPrintDetails(t *testing.T) {
+	tests := []struct {
+		name        string
+		resources   []string
+		wantLines   []string
+		notWantLine string
+	}{
+		{
+			name:      "prints namespaced resource count",
+			resources: []string{"deploy-1", "deploy-1", "pod-1"},
+			wantLines: []string{
+				`kubescape_object_failed_count{framework="fw",control="ctrl",namespace="default",name="api",groupVersionKind="apps/v1/Deployment"} 2`,
+				`kubescape_object_failed_count{framework="fw",control="ctrl",namespace="default",name="worker",groupVersionKind="v1/Pod"} 1`,
+			},
+		},
+		{
+			name:        "omits namespace label for cluster scoped resource",
+			resources:   []string{"node-1"},
+			wantLines:   []string{`kubescape_object_failed_count{framework="fw",control="ctrl",name="node-a",groupVersionKind="v1/Node"} 1`},
+			notWantLine: `namespace=`,
+		},
+		{
+			name:      "empty resource list prints nothing",
+			resources: []string{},
+		},
+	}
+
+	allResources := map[string]workloadinterface.IMetadata{
+		"deploy-1": workload("apps/v1", "Deployment", "default", "api"),
+		"pod-1":    workload("v1", "Pod", "default", "worker"),
+		"node-1":   workload("v1", "Node", "", "node-a"),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputFile := filepath.Join(t.TempDir(), "prometheus.out")
+			writer, err := os.Create(outputFile)
+			require.NoError(t, err)
+
+			p := NewPrometheusPrinter(false)
+			p.writer = writer
+			p.printDetails(allResources, tt.resources, "fw", "ctrl", "failed")
+			require.NoError(t, writer.Close())
+
+			got, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+			for _, want := range tt.wantLines {
+				assert.Contains(t, string(got), want)
+			}
+			if tt.notWantLine != "" {
+				assert.NotContains(t, string(got), tt.notWantLine)
+			}
+		})
+	}
+}
+
+func TestNewPrometheusPrinterStoresVerboseMode(t *testing.T) {
+	assert.False(t, NewPrometheusPrinter(false).verboseMode)
+	assert.True(t, NewPrometheusPrinter(true).verboseMode)
+}
+
+func workload(apiVersion, kind, namespace, name string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"namespace": namespace,
+			"name":      name,
+		},
+	})
+}


### PR DESCRIPTION
## Summary
- Add focused unit tests for v1 JSON and Prometheus printers
- Cover JSON writer output path handling, stdout fallback, Prometheus resource aggregation, and verbose mode initialization
- Keep the change limited to tests only

## Why
The v1 printer package contains output formatting logic that had limited direct unit coverage. The added tests make file writer behavior and Prometheus metric output easier to verify during future changes.

## Testing
- go test ./core/pkg/resultshandling/printer/v1

## Notes
No production code was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for JSON printer output handling, verifying extension behavior and defaulting to standard output when no path is provided.
  * Added Prometheus metrics tests to confirm emitted lines include correct labels and handle namespaced vs cluster-scoped resources.
  * Expanded coverage to validate verbose-mode configuration in printer implementations and included helpers to construct test workloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->