### PR TITLE
test: add metrics and ksinit coverage

### DIFF
--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func resetMetricsForTest(t *testing.T) {
@@ -27,6 +30,18 @@ func resetMetricsForTest(t *testing.T) {
 	})
 }
 
+func setMeterProviderForTest(t *testing.T, provider *sdkmetric.MeterProvider) {
+	t.Helper()
+
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		otel.SetMeterProvider(previousProvider)
+	})
+}
+
 func TestInit(t *testing.T) {
 	resetMetricsForTest(t)
 
@@ -38,6 +53,51 @@ func TestInit(t *testing.T) {
 	assert.NotPanics(t, func() { Init() })
 	require.NotNil(t, kubernetesResourcesCount)
 	require.NotNil(t, workerNodesCount)
+}
+
+func TestInitRegistersCountersAndUpdatesValues(t *testing.T) {
+	resetMetricsForTest(t)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	setMeterProviderForTest(t, provider)
+
+	Init()
+	UpdateKubernetesResourcesCount(context.Background(), 3)
+	UpdateKubernetesResourcesCount(context.Background(), 4)
+	UpdateWorkerNodesCount(context.Background(), 2)
+
+	got := collectMetricSums(t, reader)
+
+	assert.Equal(t, int64(7), got["kubescape_kubernetes_resources_count"])
+	assert.Equal(t, int64(2), got["kubescape_worker_nodes_count"])
+}
+
+func TestInitOnlyRegistersOnce(t *testing.T) {
+	resetMetricsForTest(t)
+	firstReader := sdkmetric.NewManualReader()
+	firstProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(firstReader))
+	setMeterProviderForTest(t, firstProvider)
+
+	Init()
+
+	secondReader := sdkmetric.NewManualReader()
+	secondProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(secondReader))
+	setMeterProviderForTest(t, secondProvider)
+
+	Init()
+	UpdateWorkerNodesCount(context.Background(), 5)
+
+	assert.Equal(t, int64(5), collectMetricSums(t, firstReader)["kubescape_worker_nodes_count"])
+	assert.Empty(t, collectMetricSums(t, secondReader))
+}
+
+func TestUpdateBeforeInitDoesNotPanic(t *testing.T) {
+	resetMetricsForTest(t)
+
+	assert.NotPanics(t, func() {
+		UpdateKubernetesResourcesCount(context.Background(), 1)
+		UpdateWorkerNodesCount(context.Background(), 1)
+	})
 }
 
 func TestUpdateKubernetesResourcesCount_NilCounter(t *testing.T) {
@@ -76,4 +136,23 @@ func TestUpdateWorkerNodesCount_AfterInit(t *testing.T) {
 	assert.NotPanics(t, func() {
 		UpdateWorkerNodesCount(context.Background(), 4)
 	})
+}
+
+func collectMetricSums(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	got := map[string]int64{}
+	for _, scopeMetric := range rm.ScopeMetrics {
+		for _, metric := range scopeMetric.Metrics {
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok || len(sum.DataPoints) == 0 {
+				continue
+			}
+			got[metric.Name] = sum.DataPoints[0].Value
+		}
+	}
+	return got
 }

--- a/pkg/ksinit/ksinit_test.go
+++ b/pkg/ksinit/ksinit_test.go
@@ -1,0 +1,56 @@
+package ksinit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKsObjectConnectionReturnsKubeconfigErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupEnv      func(t *testing.T)
+		wantErrSubstr string
+	}{
+		{
+			name: "explicit kubeconfig path does not exist",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing-config"))
+			},
+			wantErrSubstr: "no such file or directory",
+		},
+		{
+			name: "home kubeconfig path does not exist and in cluster config is unavailable",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("KUBECONFIG", "")
+				t.Setenv("HOME", t.TempDir())
+				t.Setenv("KUBERNETES_SERVICE_HOST", "")
+				t.Setenv("KUBERNETES_SERVICE_PORT", "")
+			},
+			wantErrSubstr: "KUBERNETES_SERVICE_HOST",
+		},
+		{
+			name: "invalid explicit kubeconfig content",
+			setupEnv: func(t *testing.T) {
+				configPath := filepath.Join(t.TempDir(), "config")
+				require.NoError(t, os.WriteFile(configPath, []byte("bad: ["), 0600))
+				t.Setenv("KUBECONFIG", configPath)
+			},
+			wantErrSubstr: "error loading config file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupEnv(t)
+
+			got, err := CreateKsObjectConnection("default", time.Second)
+
+			require.Nil(t, got)
+			require.ErrorContains(t, err, tt.wantErrSubstr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add focused unit tests for metrics initialization and KS object connection setup
- Cover OpenTelemetry counter registration, metric updates, init-once behavior, pre-init update safety, and kubeconfig error paths
- Keep the change limited to tests only

## Why
These packages contain startup and instrumentation logic that should remain predictable. The added tests verify deterministic behavior without requiring a live Kubernetes cluster.

## Testing
- go test ./core/metrics
- go test ./pkg/ksinit

## Notes
No production code was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added OpenTelemetry-backed unit tests verifying metrics counters register, accumulate across updates, remain idempotent when reinitialized, and that updates before initialization do not panic.
  * Added table-driven unit tests covering kubeconfig error scenarios (missing file, missing in-cluster variables, and invalid kubeconfig content) and asserting appropriate error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->