### PR TITLE
fix: guard IsConnectedToCluster() with mutex to resolve KSConfig race condition 

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/kubescape/go-logger"
@@ -98,6 +99,10 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 	return resourcehandler.NewK8sResourceHandler(k8s, hostSensorHandler, rbacObjects, tenantConfig.GetContextName())
 }
 
+// ksConfigMu guards the call to k8sinterface.IsConnectedToCluster,
+// which accesses package-level globals without internal synchronization.
+var ksConfigMu sync.Mutex
+
 // getHostSensorHandler yields a IHostSensor that knows how to collect a host's scanned resources.
 //
 // A noop sensor is returned whenever host scanning is disabled or an error prevented the scanner to properly deploy.
@@ -106,7 +111,11 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 	hostSensorVal := scanInfo.HostSensorEnabled.Get()
 
 	switch {
-	case !k8sinterface.IsConnectedToCluster() || k8s == nil: // TODO(fred): fix race condition on global KSConfig there
+	case func() bool {
+		ksConfigMu.Lock()
+		defer ksConfigMu.Unlock()
+		return !k8sinterface.IsConnectedToCluster()
+	}() || k8s == nil:
 		return hostsensorutils.NewHostSensorHandlerMock()
 
 	case hostSensorVal != nil && *hostSensorVal:

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -23,7 +23,7 @@ import (
 
 // getKubernetesApi
 func getKubernetesApi() *k8sinterface.KubernetesApi {
-	if !k8sinterface.IsConnectedToCluster() {
+	if !isConnectedToCluster() {
 		return nil
 	}
 	return k8sinterface.NewKubernetesApi()
@@ -99,9 +99,16 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 	return resourcehandler.NewK8sResourceHandler(k8s, hostSensorHandler, rbacObjects, tenantConfig.GetContextName())
 }
 
-// ksConfigMu guards the call to k8sinterface.IsConnectedToCluster,
+// ksConfigMu guards all calls to k8sinterface.IsConnectedToCluster,
 // which accesses package-level globals without internal synchronization.
 var ksConfigMu sync.Mutex
+
+// isConnectedToCluster is a thread-safe wrapper around k8sinterface.IsConnectedToCluster.
+func isConnectedToCluster() bool {
+	ksConfigMu.Lock()
+	defer ksConfigMu.Unlock()
+	return k8sinterface.IsConnectedToCluster()
+}
 
 // getHostSensorHandler yields a IHostSensor that knows how to collect a host's scanned resources.
 //
@@ -111,11 +118,7 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 	hostSensorVal := scanInfo.HostSensorEnabled.Get()
 
 	switch {
-	case func() bool {
-		ksConfigMu.Lock()
-		defer ksConfigMu.Unlock()
-		return !k8sinterface.IsConnectedToCluster()
-	}() || k8s == nil:
+	case !isConnectedToCluster() || k8s == nil:
 		return hostsensorutils.NewHostSensorHandlerMock()
 
 	case hostSensorVal != nil && *hostSensorVal:


### PR DESCRIPTION
Closes #2194 

## Overview
`k8sinterface.IsConnectedToCluster()` reads and writes package-level globals
(`KBSConfig`, `connectedToCluster`) without any synchronization. In concurrent
scan scenarios, multiple goroutines calling `getHostSensorHandler()` simultaneously
can cause a data race on these globals, leading to non-deterministic behavior.

This PR introduces a `sync.Mutex` (`ksConfigMu`) in `initutils.go` to guard
the call to `IsConnectedToCluster()`, ensuring only one goroutine accesses
it at a time. This resolves the TODO left by @fredbi.

## Additional Information
The race originates in the upstream `k8s-interface` package (k8sconfig.go)
which does not internally synchronize its globals. The fix is applied at
the call site in `getHostSensorHandler()` as a safe, minimal change.

Closes #2194

## How to Test
go test -race ./core/core/...

Expected output:
ok  github.com/kubescape/kubescape/v3/core/core  19.144s  (no race detected)

## Examples/Screenshots
Verified with Go race detector:
ok  github.com/kubescape/kubescape/v3/core/core  19.144s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serialized Kubernetes connectivity checks to prevent race conditions and improve stability during concurrent operations.
  * Ensured host-sensor enablement reliably respects cluster connectivity, reducing flakiness when toggling sensor state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->