### PR TITLE
fix: restore kubescape_resource_* metrics in prometheus output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -55,7 +55,7 @@ func (pp *PrometheusPrinter) generatePrometheusFormat(
 
 	m := &Metrics{}
 	m.setComplianceScores(summaryDetails)
-	// m.setResourcesCounters(resources, results)
+	m.setResourcesCounters(resources, results)
 
 	return m
 }

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,4 +96,53 @@ func TestScore(t *testing.T) {
 			assert.Equal(t, tt.want, string(got))
 		})
 	}
+}
+
+func TestResourceMetricsEmitted(t *testing.T) {
+	// Regression test for https://github.com/kubescape/kubescape/issues/2236
+	// Fails on master (setResourcesCounters commented out), passes with patch.
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "nginx",
+			"namespace": "default",
+		},
+	}
+	wl := workloadinterface.NewWorkloadObj(obj)
+	resourceID := wl.GetID()
+
+	failedRule := resourcesresults.ResourceAssociatedRule{}
+	failedRule.SetStatus(apis.StatusFailed, nil)
+
+	skippedRule := resourcesresults.ResourceAssociatedRule{}
+	skippedRule.SetStatus(apis.StatusSkipped, nil)
+
+	failedCtrl1 := resourcesresults.ResourceAssociatedControl{}
+	failedCtrl1.ResourceAssociatedRules = []resourcesresults.ResourceAssociatedRule{failedRule}
+
+	failedCtrl2 := resourcesresults.ResourceAssociatedControl{}
+	failedCtrl2.ResourceAssociatedRules = []resourcesresults.ResourceAssociatedRule{failedRule}
+
+	skippedCtrl := resourcesresults.ResourceAssociatedControl{}
+	skippedCtrl.ResourceAssociatedRules = []resourcesresults.ResourceAssociatedRule{skippedRule}
+
+	result := resourcesresults.Result{}
+	result.ResourceID = resourceID
+	result.AssociatedControls = []resourcesresults.ResourceAssociatedControl{
+		failedCtrl1, failedCtrl2, skippedCtrl,
+	}
+
+	pp := NewPrometheusPrinter(false)
+	metrics := pp.generatePrometheusFormat(
+		map[string]workloadinterface.IMetadata{resourceID: wl},
+		map[string]resourcesresults.Result{resourceID: result},
+		&reportsummary.SummaryDetails{},
+	)
+	output := metrics.String()
+
+	assert.Contains(t, output, "kubescape_resource_count_controls_failed",
+		"missing kubescape_resource_count_controls_failed — setResourcesCounters may be commented out")
+	assert.Contains(t, output, "kubescape_resource_count_controls_skipped",
+		"missing kubescape_resource_count_controls_skipped — setResourcesCounters may be commented out")
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
 type metricsName string
@@ -253,11 +255,11 @@ type mFrameworkComplianceScore struct {
 }
 
 type mResources struct {
-	name       string
-	namespace  string
-	apiVersion string
-	kind       string
-	// controlsCountPassed   int // unused
+	name                 string
+	namespace            string
+	apiVersion           string
+	kind                 string
+	controlsCountPassed  int
 	controlsCountFailed  int
 	controlsCountSkipped int
 }
@@ -318,7 +320,6 @@ func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetai
 	}
 }
 
-/* unused for now
 // return -> (passed, skipped, failed)
 func resourceControlStatusCounters(result *resourcesresults.Result) (int, int, int) {
 	failed := 0
@@ -363,4 +364,3 @@ func (m *Metrics) setResourcesCounters(
 	}
 
 }
-*/


### PR DESCRIPTION
## Overview

`kubescape scan --format prometheus` was silently dropping all `kubescape_resource_*` metrics. Per-resource control failure and skip counts were never emitted regardless of what was scanned.

Root cause: in commit `ec4a098b` (Mar 15 2023, "replace error by warning"), `setResourcesCounters` was accidentally wrapped in a `/* unused for now */` block comment and its call site was commented out — in a commit unrelated to prometheus. The function, struct, and helper `resourceControlStatusCounters` were all fully intact.

After this fix, metrics like:
```
kubescape_resource_count_controls_failed{apiVersion="apps/v1",kind="Deployment",...} 3
kubescape_resource_count_controls_skipped{apiVersion="apps/v1",kind="Deployment",...} 1
```
are correctly emitted for each scanned resource.

## How to Test

```bash
kubescape scan /tmp/deploy.yaml --format prometheus --output /tmp/metrics.txt
grep "kubescape_resource" /tmp/metrics.txt
# Should now show per-resource metrics instead of empty output
```

## Related issues/PRs

* Resolved #2236

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus output now includes per-resource control status counters (passed/failed/skipped), restoring resource-level metrics so monitoring shows complete visibility for each resource.
* **Tests**
  * Added a regression test ensuring per-resource control counters are emitted in Prometheus output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->