### PR TITLE
fix: add # HELP and # TYPE headers to kubescape_score metric

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -43,7 +43,9 @@ func (pp *PrometheusPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(pp.writer, "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(pp.writer, "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n")
+	fmt.Fprintf(pp.writer, "# TYPE kubescape_score gauge\n")
+	fmt.Fprintf(pp.writer, "kubescape_score %d\n", cautils.Float32ToInt(score))
 }
 
 func (pp *PrometheusPrinter) generatePrometheusFormat(

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -50,27 +50,27 @@ func TestScore(t *testing.T) {
 		{
 			name:  "Score less than 0",
 			score: -20.0,
-			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 0\n",
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 0\n",
 		},
 		{
 			name:  "Score greater than 100",
 			score: 120.0,
-			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 100\n",
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 100\n",
 		},
 		{
 			name:  "Score 50",
 			score: 50.0,
-			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 50\n",
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 50\n",
 		},
 		{
 			name:  "Zero Score",
 			score: 0.0,
-			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 0\n",
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 0\n",
 		},
 		{
 			name:  "Perfect Score",
 			score: 100,
-			want:  "\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score 100\n",
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 100\n",
 		},
 	}
 


### PR DESCRIPTION
## Overview

`kubescape scan --format prometheus` emitted the `kubescape_score` metric 
with no `# HELP` or `# TYPE` metadata lines, violating the Prometheus 
exposition format spec. The plain comment `# Overall compliance-score...` 
is not a valid Prometheus HELP line and causes `promtool check metrics` 
to reject it.

All other metrics were fixed in #2196 but `kubescape_score` is written 
directly inside `Score()` outside of `Metrics.String()` and was missed.

Before:
```
# Overall compliance-score (100- Excellent, 0- All failed)
kubescape_score 85
```

After:
```
# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)
# TYPE kubescape_score gauge
kubescape_score 85
```

## How to Test

```bash
kubescape scan /tmp/deploy.yaml --format prometheus --output /tmp/metrics.txt
promtool check metrics < /tmp/metrics.txt
# kubescape_score line should now pass validation
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

## Related issues/PRs

* Resolved #2237
* Related #2196
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus score metrics output format updated: metric metadata headers (HELP and TYPE) are now emitted, and the score is written as a proper gauge metric value. Tests updated to match the new serialized format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->