### PR TITLE
fix(opaprocessor): sanitize namespace split parsing

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -368,17 +368,20 @@ func (h *FixHandler) ApplyChanges(ctx context.Context, resourcesToFix []Resource
 }
 
 func (h *FixHandler) getFilePathAndIndex(filePathWithIndex string) (filePath string, documentIndex int, err error) {
-	splittedPath := strings.Split(filePathWithIndex, ":")
-	if len(splittedPath) <= 1 {
+	lastColon := strings.LastIndex(filePathWithIndex, ":")
+	if lastColon == -1 {
 		return "", 0, fmt.Errorf("expected to find ':' in file path")
 	}
 
-	filePath = splittedPath[0]
-	if documentIndex, err := strconv.Atoi(splittedPath[1]); err != nil {
+	filePath = filePathWithIndex[:lastColon]
+	indexStr := filePathWithIndex[lastColon+1:]
+
+	documentIndex, err = strconv.Atoi(indexStr)
+	if err != nil {
 		return "", 0, err
-	} else {
-		return filePath, documentIndex, nil
 	}
+
+	return filePath, documentIndex, nil
 }
 
 func ApplyFixToContent(ctx context.Context, yamlAsString, yamlExpression string) (fixedString string, err error) {

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -14,6 +14,7 @@ import (
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/op/go-logging.v1"
 )
 
@@ -651,6 +652,65 @@ func TestGetLocalPath(t *testing.T) {
 			if got := getLocalPath(tt.args.report); got != tt.want {
 				t.Errorf("getLocalPath() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestGetFilePathAndIndex(t *testing.T) {
+	h := &FixHandler{}
+
+	tests := []struct {
+		name          string
+		input         string
+		expectedPath  string
+		expectedIndex int
+		expectErr     bool
+	}{
+		{
+			name:          "windows absolute path",
+			input:         "C:\\Users\\admin\\deploy.yaml:2",
+			expectedPath:  "C:\\Users\\admin\\deploy.yaml",
+			expectedIndex: 2,
+			expectErr:     false,
+		},
+		{
+			name:          "unix path containing colon",
+			input:         "dir:with:colon/deploy.yaml:3",
+			expectedPath:  "dir:with:colon/deploy.yaml",
+			expectedIndex: 3,
+			expectErr:     false,
+		},
+		{
+			name:          "standard unix path",
+			input:         "/tmp/deploy.yaml:1",
+			expectedPath:  "/tmp/deploy.yaml",
+			expectedIndex: 1,
+			expectErr:     false,
+		},
+		{
+			name:      "missing separator",
+			input:     "deploy.yaml",
+			expectErr: true,
+		},
+		{
+			name:      "invalid document index",
+			input:     "deploy.yaml:not-a-number",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, index, err := h.getFilePathAndIndex(tt.input)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPath, path)
+			require.Equal(t, tt.expectedIndex, index)
 		})
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -500,10 +500,17 @@ func (opap *OPAProcessor) skipNamespace(ns string) bool {
 }
 
 func split(namespaces string) []string {
-	if namespaces == "" {
-		return nil
+	parts := strings.Split(namespaces, ",")
+	result := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
 	}
-	return strings.Split(namespaces, ",")
+
+	return result
 }
 
 func (opap *OPAProcessor) getCompiledRule(ctx context.Context, ruleName, ruleData string, printEnabled bool) (*ast.Compiler, error) {

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -561,3 +561,42 @@ func TestSkipNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "removes empty entries",
+			input:    "default,,kube-system,",
+			expected: []string{"default", "kube-system"},
+		},
+		{
+			name:     "only commas",
+			input:    ",,",
+			expected: []string{},
+		},
+		{
+			name:     "trims whitespace",
+			input:    " default , kube-system ",
+			expected: []string{"default", "kube-system"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := split(tt.input)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("split(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview
Sanitize namespace parsing by trimming whitespace and filtering empty entries from the split helper.

This prevents malformed namespace inputs such as:

* trailing commas
* consecutive commas
* whitespace-padded values

from producing empty namespace entries during processing.

## Changes

* trim namespace values using `strings.TrimSpace`
* skip empty namespace entries
* add unit tests covering:

  * empty entries
  * whitespace handling
  * trailing commas
  * empty input

## Testing

```bash id="rjlwm6"
go test ./core/pkg/opaprocessor/...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace selector parsing: splits on commas, trims whitespace, removes empty segments, and returns an empty list when no valid namespaces.
  * Fixed file-path+index parsing to correctly handle paths containing colons and to validate numeric indices.

* **Tests**
  * Added unit tests for namespace parsing (commas, whitespace, empty cases).
  * Added tests for path+index parsing covering Windows/Unix paths and malformed inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->