### PR TITLE
Nil guard for kubernetes client initialisation

### DIFF
--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -28,6 +28,9 @@ type OperatorAdapter struct {
 }
 
 func getOperatorPod(k8sClient *k8sinterface.KubernetesApi, ns string) (*v1.Pod, error) {
+	if k8sClient == nil || k8sClient.KubernetesClient == nil {
+		return nil, errors.New("kubernetes client is not initialised")
+	}
 	listOptions := metav1.ListOptions{
 		LabelSelector: "app=operator",
 	}
@@ -44,6 +47,9 @@ func getOperatorPod(k8sClient *k8sinterface.KubernetesApi, ns string) (*v1.Pod, 
 
 func NewOperatorAdapter(scanInfo cautils.OperatorScanInfo, ns string) (*OperatorAdapter, error) {
 	k8sClient := getKubernetesApi()
+	if k8sClient == nil || k8sClient.KubernetesClient == nil {
+		return nil, errors.New("could not connect to cluster: set --kubeconfig, $KUBECONFIG, or $KUBERNETES_MASTER")
+	}
 	pod, err := getOperatorPod(k8sClient, ns)
 	if err != nil {
 		return nil, err

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -81,3 +81,11 @@ func Test_getOperatorPod(t *testing.T) {
 		})
 	}
 }
+
+func Test_getOperatorPod_nilClient(t *testing.T) {
+	_, err := getOperatorPod(nil, kubescapeNamespace)
+	assert.EqualError(t, err, "kubernetes client is not initialised")
+
+	_, err = getOperatorPod(&k8sinterface.KubernetesApi{}, kubescapeNamespace)
+	assert.EqualError(t, err, "kubernetes client is not initialised")
+}


### PR DESCRIPTION
## Overview

`kubescape operator scan configurations` and `kubescape operator scan vulnerabilities` previously panicked with a nil-pointer dereference and dumped a full Go runtime stack trace when run without a working kube client (no kubeconfig, kubeconfig pointing at an unreachable cluster, etc.). `getKubernetesApi()` returns `nil` when `k8sinterface.IsConnectedToCluster()` is false, and `NewOperatorAdapter` used the returned client without checking, so the first call into `k8sClient.KubernetesClient.CoreV1()...` crashed the process.

With this change, the operator subcommand now exits cleanly with a user-facing fatal error, matching the behavior of `kubescape scan` in the same scenario:

```
[fatal] could not connect to cluster: set --kubeconfig, $KUBECONFIG, or $KUBERNETES_MASTER
```

Two guards are added in `core/core/clusterconnector.go`:
- `NewOperatorAdapter` checks the result of `getKubernetesApi()` and returns a clear error instead of dereferencing nil.
- `getOperatorPod` has a defensive nil-check, so any other caller path can't reintroduce the same panic.

## How to Test

Simulate a machine with no working kube client and run either operator scan subcommand:

```
$ unset KUBECONFIG
$ mv ~/.kube/config ~/.kube/config.bak    # or just run on a host with no kubeconfig

$ kubescape operator scan configurations
{"level":"fatal", ... ,"msg":"could not connect to cluster: set --kubeconfig, $KUBECONFIG, or $KUBERNETES_MASTER"}
$ echo $?
1

$ kubescape operator scan vulnerabilities
{"level":"fatal", ... ,"msg":"could not connect to cluster: set --kubeconfig, $KUBECONFIG, or $KUBERNETES_MASTER"}
```

Before this change, both commands printed `panic: runtime error: invalid memory address or nil pointer dereference` followed by a goroutine stack trace.

Unit test coverage:

```
go test ./core/core/ -run Test_getOperatorPod -v
```

A new `Test_getOperatorPod_nilClient` covers both a `nil` client and a zero-value `KubernetesApi` (no inner `KubernetesClient`).

## Related issues/PRs:

* Resolved #2265

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when cluster connection configuration is missing or incomplete, helping users identify configuration issues more easily.

* **Tests**
  * Added test validation for cluster connection error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->