### PR TITLE
fix: add bounds check before accessing container index in addContainerNameToAssistedRemediation

### DIFF
--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -105,6 +105,9 @@ func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata,
 			index, _ := strconv.Atoi(match[1])
 			wl := workloadinterface.NewWorkloadObj(resource.GetObject())
 			containers, _ := wl.GetContainers()
+			if index >= len(containers) {
+				continue
+			}
 			containerName := containers[index].Name
 			(*paths)[i] = (*paths)[i] + " (" + containerName + ")"
 		}

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
+var specContainerRegex = regexp.MustCompile(`spec\.containers\[(\d+)]`)
+
 const (
 	resourceColumnSeverity = iota
 	resourceColumnName     = iota
@@ -99,10 +101,12 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 
 func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata, paths *[]string) {
 	for i := range *paths {
-		re := regexp.MustCompile(`spec\.containers\[(\d+)]`)
-		match := re.FindStringSubmatch((*paths)[i])
+		match := specContainerRegex.FindStringSubmatch((*paths)[i])
 		if len(match) == 2 {
-			index, _ := strconv.Atoi(match[1])
+			index, err := strconv.Atoi(match[1])
+			if err != nil {
+				continue
+			}
 			wl := workloadinterface.NewWorkloadObj(resource.GetObject())
 			containers, _ := wl.GetContainers()
 			if index >= len(containers) {

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -528,3 +528,97 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 		})
 	}
 }
+
+func TestAddContainerNameToAssistedRemediation_OutOfBounds(t *testing.T) {
+	tests := []struct {
+		name          string
+		resource      workloadinterface.IMetadata
+		paths         []string
+		expectedPaths []string
+	}{
+		{
+			name: "valid container index appends name",
+			resource: workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:latest",
+						},
+					},
+				},
+			}),
+			paths:         []string{"spec.containers[0].securityContext.runAsNonRoot"},
+			expectedPaths: []string{"spec.containers[0].securityContext.runAsNonRoot (nginx)"},
+		},
+		{
+			name: "out of bounds container index is skipped",
+			resource: workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:latest",
+						},
+					},
+				},
+			}),
+			paths:         []string{"spec.containers[5].securityContext.readOnlyRootFilesystem"},
+			expectedPaths: []string{"spec.containers[5].securityContext.readOnlyRootFilesystem"},
+		},
+		{
+			name: "mixed valid and out of bounds indices",
+			resource: workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:latest",
+						},
+						map[string]interface{}{
+							"name":  "sidecar",
+							"image": "sidecar:latest",
+						},
+					},
+				},
+			}),
+			paths: []string{
+				"spec.containers[0].securityContext.runAsNonRoot",
+				"spec.containers[10].securityContext.readOnlyRootFilesystem",
+				"spec.containers[1].securityContext.allowPrivilegeEscalation",
+			},
+			expectedPaths: []string{
+				"spec.containers[0].securityContext.runAsNonRoot (nginx)",
+				"spec.containers[10].securityContext.readOnlyRootFilesystem",
+				"spec.containers[1].securityContext.allowPrivilegeEscalation (sidecar)",
+			},
+		},
+		{
+			name: "path without container index is unchanged",
+			resource: workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:latest",
+						},
+					},
+				},
+			}),
+			paths:         []string{"metadata.labels.app"},
+			expectedPaths: []string{"metadata.labels.app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := tt.paths
+			addContainerNameToAssistedRemediation(tt.resource, &paths)
+			assert.Equal(t, tt.expectedPaths, paths)
+		})
+	}
+}


### PR DESCRIPTION
## Overview
Added a bounds check in `addContainerNameToAssistedRemediation` to prevent a panic when the assisted remediation path references a container index that exceeds the actual number of containers in the workload. Previously, accessing `containers[index]` without checking bounds would cause a runtime panic with `index out of range` error.

## Additional Information
The fix checks `if index >= len(containers)` before accessing `containers[index].Name`. If the index is out of bounds, the loop continues to the next path instead of panicking.

## How to Test
1. Create a Kubernetes YAML file with a deployment that has 2 containers
2. Run a kubescape scan that triggers a control producing an assisted remediation path containing `spec.containers[N]` where N is greater than or equal to the actual container count
3. Verify the scan completes without panic and returns results

## Related issues/PRs
* Resolved #2269

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a potential crash when processing container remediation paths by validating and bounds-checking container references; invalid or out-of-range references are now safely skipped.

* **Tests**
  * Added a unit test covering valid, out-of-range, mixed, and non-container path cases to ensure correct behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->