### PR TITLE
fix: anonymize sensitive env var values and annotations with --hide flag

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -7,6 +7,70 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// sensitiveEnvKeyPatterns lists substrings that indicate a sensitive env var value.
+var sensitiveEnvKeyPatterns = []string{
+	"password", "passwd", "secret", "token", "key", "credential",
+	"auth", "cert", "private", "api_key", "apikey", "access_key",
+	"url", "uri", "dsn", "connection", "database", "mongo", "redis",
+	"jdbc", "conn",
+}
+
+func isSensitiveEnvKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range sensitiveEnvKeyPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// anonymizeEnvVars redacts values of environment variables whose key matches
+// a sensitive pattern (password, token, secret, key, credential, etc.).
+func anonymizeEnvVars(container map[string]interface{}, mapping *Mapping) {
+	rawEnv, ok := container["env"]
+	if !ok || rawEnv == nil {
+		return
+	}
+	envList, ok := rawEnv.([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range envList {
+		envVar, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, ok := envVar["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		if isSensitiveEnvKey(name) {
+			if val, ok := envVar["value"].(string); ok && val != "" {
+				envVar["value"] = mapping.GetOrCreate("env", val)
+			}
+		}
+	}
+	container["env"] = envList
+}
+
+// anonymizeAnnotations redacts all annotation values on a resource.
+func anonymizeAnnotations(resource workloadinterface.IMetadata, mapping *Mapping) {
+	bw, ok := resource.(workloadinterface.IWorkload)
+	if !ok {
+		return
+	}
+	annotations := bw.GetAnnotations()
+	if len(annotations) == 0 {
+		return
+	}
+	for key, val := range annotations {
+		if val != "" {
+			bw.SetAnnotation(key, mapping.GetOrCreate("ann", val))
+		}
+	}
+}
+
 func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *Mapping) {
 	if resource == nil {
 		return
@@ -18,6 +82,7 @@ func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *M
 	}
 
 	anonymizePodSpecs(obj, mapping)
+	anonymizeAnnotations(resource, mapping)
 	resource.SetObject(obj)
 }
 

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -54,19 +54,29 @@ func anonymizeEnvVars(container map[string]interface{}, mapping *Mapping) {
 	container["env"] = envList
 }
 
-// anonymizeAnnotations redacts all annotation values on a resource.
+// anonymizeAnnotations redacts all annotation values on a resource,
+// including both top-level metadata.annotations and pod-template
+// spec.template.metadata.annotations for controller workloads such as
+// Deployments, StatefulSets, DaemonSets, and CronJobs.
 func anonymizeAnnotations(resource workloadinterface.IMetadata, mapping *Mapping) {
 	bw, ok := resource.(workloadinterface.IWorkload)
 	if !ok {
 		return
 	}
-	annotations := bw.GetAnnotations()
-	if len(annotations) == 0 {
-		return
-	}
-	for key, val := range annotations {
+
+	// Top-level metadata.annotations
+	for key, val := range bw.GetAnnotations() {
 		if val != "" {
 			bw.SetAnnotation(key, mapping.GetOrCreate("ann", val))
+		}
+	}
+
+	// Pod-template spec.template.metadata.annotations (Deployments, StatefulSets, etc.)
+	if w, ok := resource.(*workloadinterface.Workload); ok {
+		for key, val := range w.GetPodAnnotations() {
+			if val != "" {
+				w.SetPodAnnotation(key, mapping.GetOrCreate("ann", val))
+			}
 		}
 	}
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -793,3 +793,44 @@ func TestAnonymizeEphemeralContainerList_TypedEnvRedacted(t *testing.T) {
 	assert.NotEqual(t, "tok-secret", result[0].Env[0].Value, "sensitive env value must be anonymized")
 	assert.Equal(t, "8080", result[0].Env[1].Value, "non-sensitive env value must be preserved")
 }
+
+func TestAnonymizeAnnotations_DeploymentPodTemplateAnnotations(t *testing.T) {
+	deployment := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "payment-service",
+			"namespace": "production",
+			"annotations": map[string]interface{}{
+				"top-level-key": "top-level-secret-value",
+			},
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"vault.hashicorp.com/agent-inject-secret": "secret/prod/db",
+						"iam.amazonaws.com/role":                  "arn:aws:iam::123:role/svc",
+					},
+				},
+			},
+		},
+	}
+
+	resource := workloadinterface.NewWorkloadObj(deployment)
+	mapping := NewMapping()
+
+	anonymizeContainerMetadata(resource, mapping)
+
+	// Top-level annotations must be anonymized
+	topAnnotations := resource.GetAnnotations()
+	assert.NotEqual(t, "top-level-secret-value", topAnnotations["top-level-key"], "top-level annotation value must be anonymized")
+
+	// Pod-template annotations must also be anonymized
+	podAnnotations := resource.GetPodAnnotations()
+	assert.NotEqual(t, "secret/prod/db", podAnnotations["vault.hashicorp.com/agent-inject-secret"], "pod-template annotation value must be anonymized")
+	assert.NotEqual(t, "arn:aws:iam::123:role/svc", podAnnotations["iam.amazonaws.com/role"], "pod-template annotation value must be anonymized")
+
+	assert.Contains(t, podAnnotations["vault.hashicorp.com/agent-inject-secret"], "ann-", "anonymized value must use ann- prefix")
+	assert.Contains(t, podAnnotations["iam.amazonaws.com/role"], "ann-", "anonymized value must use ann- prefix")
+}

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -666,3 +666,130 @@ func TestAnonymizeContainerList_InvalidType(t *testing.T) {
 		anonymizeContainerList(obj, "containers", mapping)
 	})
 }
+
+func TestIsSensitiveEnvKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"password key", "DB_PASSWORD", true},
+		{"secret key", "MY_SECRET", true},
+		{"token key", "API_TOKEN", true},
+		{"access key", "ACCESS_KEY", true},
+		{"credential key", "CREDENTIAL_VALUE", true},
+		{"auth key", "AUTH_HEADER", true},
+		{"cert key", "TLS_CERT", true},
+		{"non sensitive app name", "APP_NAME", false},
+		{"non sensitive port", "PORT", false},
+		{"non sensitive env", "NODE_ENV", false},
+		{"case insensitive", "db_password", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSensitiveEnvKey(tt.key))
+		})
+	}
+}
+
+func TestAnonymizeEnvVars_SensitiveValuesRedacted(t *testing.T) {
+	mapping := NewMapping()
+	container := map[string]interface{}{
+		"name": "app",
+		"env": []interface{}{
+			map[string]interface{}{"name": "DB_PASSWORD", "value": "supersecret"},
+			map[string]interface{}{"name": "API_TOKEN", "value": "tok-abc123"},
+			map[string]interface{}{"name": "APP_NAME", "value": "myapp"},
+		},
+	}
+
+	anonymizeEnvVars(container, mapping)
+
+	envs := container["env"].([]interface{})
+	for _, item := range envs {
+		env := item.(map[string]interface{})
+		name := env["name"].(string)
+		val, _ := env["value"].(string)
+		switch name {
+		case "DB_PASSWORD":
+			assert.NotEqual(t, "supersecret", val, "password must be anonymized")
+			assert.NotEmpty(t, val)
+		case "API_TOKEN":
+			assert.NotEqual(t, "tok-abc123", val, "token must be anonymized")
+			assert.NotEmpty(t, val)
+		case "APP_NAME":
+			assert.Equal(t, "myapp", val, "non-sensitive value must be preserved")
+		}
+	}
+}
+
+func TestAnonymizeEnvVars_NilEnv(t *testing.T) {
+	mapping := NewMapping()
+	container := map[string]interface{}{"name": "app", "env": nil}
+	// must not panic
+	anonymizeEnvVars(container, mapping)
+}
+
+func TestAnonymizeEnvVars_NoEnvKey(t *testing.T) {
+	mapping := NewMapping()
+	container := map[string]interface{}{"name": "app"}
+	// must not panic
+	anonymizeEnvVars(container, mapping)
+}
+
+func TestAnonymizeEnvVars_SameValueSameMappedToken(t *testing.T) {
+	mapping := NewMapping()
+	container := map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{"name": "DB_PASSWORD", "value": "same-secret"},
+			map[string]interface{}{"name": "API_TOKEN", "value": "same-secret"},
+		},
+	}
+	anonymizeEnvVars(container, mapping)
+	envs := container["env"].([]interface{})
+	val1 := envs[0].(map[string]interface{})["value"].(string)
+	val2 := envs[1].(map[string]interface{})["value"].(string)
+	assert.Equal(t, val1, val2, "same input value must produce same anonymized token")
+}
+
+func TestAnonymizeContainerList_TypedContainerEnvRedacted(t *testing.T) {
+	mapping := NewMapping()
+	obj := map[string]interface{}{}
+	containers := []corev1.Container{
+		{
+			Name:  "app",
+			Image: "nginx:latest",
+			Env: []corev1.EnvVar{
+				{Name: "DB_PASSWORD", Value: "supersecret"},
+				{Name: "APP_NAME", Value: "myapp"},
+			},
+		},
+	}
+	obj["containers"] = containers
+	anonymizeContainerList(obj, "containers", mapping)
+	result := obj["containers"].([]corev1.Container)
+	assert.NotEqual(t, "supersecret", result[0].Env[0].Value, "sensitive env value must be anonymized")
+	assert.Equal(t, "myapp", result[0].Env[1].Value, "non-sensitive env value must be preserved")
+}
+
+func TestAnonymizeEphemeralContainerList_TypedEnvRedacted(t *testing.T) {
+	mapping := NewMapping()
+	obj := map[string]interface{}{}
+	containers := []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "busybox",
+				Env: []corev1.EnvVar{
+					{Name: "API_TOKEN", Value: "tok-secret"},
+					{Name: "PORT", Value: "8080"},
+				},
+			},
+		},
+	}
+	obj["ephemeralContainers"] = containers
+	anonymizeEphemeralContainerList(obj, "ephemeralContainers", mapping)
+	result := obj["ephemeralContainers"].([]corev1.EphemeralContainer)
+	assert.NotEqual(t, "tok-secret", result[0].Env[0].Value, "sensitive env value must be anonymized")
+	assert.Equal(t, "8080", result[0].Env[1].Value, "non-sensitive env value must be preserved")
+}


### PR DESCRIPTION
## Overview

`kubescape scan --hide` anonymizes container names, images, pod names,
namespaces, and label values — but never touched container environment
variable values or resource annotations. Both can contain highly sensitive
data that appears in plain text in the scan output even with `--hide` set.

## Root Cause

`anonymizeContainerFields()` only handled two fields:

```go
// Before — env and annotations never touched
func anonymizeContainerFields(container map[string]interface{}, mapping *Mapping) {
    container["name"] = mapping.GetOrCreate("ctr", name)
    container["image"] = mapping.GetOrCreate("img", image)
    // ← env values never touched
    // ← annotations never touched
}
```

## Fix

Added two new functions following the existing `mapping.GetOrCreate()` pattern:

**`anonymizeEnvVars()`** — redacts values of env vars whose key matches a
sensitive pattern (`password`, `token`, `secret`, `key`, `credential`,
`auth`, `cert`, `api_key`, etc.). Non-sensitive env vars like `APP_NAME`
or `PORT` are preserved unchanged.

**`anonymizeAnnotations()`** — redacts all annotation values via
`SetAnnotation()`, consistent with how names and namespaces are handled.

Both are wired into the existing call chain:
- `anonymizeEnvVars()` called from `anonymizeContainerFields()`
- `anonymizeAnnotations()` called from `anonymizeContainerMetadata()`

## Example

```bash
# Before: sensitive values in plain text
grep "supersecret" out.json   # found

# After: anonymized
grep "supersecret" out.json   # not found — replaced with deterministic token
```

## Changes

- `core/pkg/anonymizer/container.go` — added `anonymizeEnvVars()`,
  `anonymizeAnnotations()`, `isSensitiveEnvKey()`, wired both into
  existing call chain
- `core/pkg/anonymizer/container_test.go` — added 5 new tests:
  `TestIsSensitiveEnvKey`, `TestAnonymizeEnvVars_SensitiveValuesRedacted`,
  `TestAnonymizeEnvVars_NilEnv`, `TestAnonymizeEnvVars_NoEnvKey`,
  `TestAnonymizeEnvVars_SameValueSameMappedToken`

## Tests

```
ok  github.com/kubescape/kubescape/v3/core/pkg/anonymizer
--- PASS: TestAnonymizeContainerMetadata (all subtests)
--- PASS: TestIsSensitiveEnvKey (11 subtests)
--- PASS: TestAnonymizeEnvVars_SensitiveValuesRedacted
--- PASS: TestAnonymizeEnvVars_NilEnv
--- PASS: TestAnonymizeEnvVars_NoEnvKey
--- PASS: TestAnonymizeEnvVars_SameValueSameMappedToken
```

## Related Issues
Fixes #2272

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variable values with names matching common sensitive-key patterns are now redacted (case-insensitive) and consistently mapped so the same secret yields the same token.
  * Annotations on containers and ephemeral containers (including pod-template annotations) are now anonymized, expanding metadata redaction.

* **Tests**
  * Added tests covering sensitive-key detection, env var redaction (including nil/missing cases), determinism of mapping, and typed container/ephemeral container anonymization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->