### PR TITLE
fix: validate threshold ranges in scan image and patch commands

### DIFF
--- a/cmd/shared/image_scan.go
+++ b/cmd/shared/image_scan.go
@@ -14,5 +14,8 @@ func ValidateImageScanInfo(scanInfo *cautils.ScanInfo) error {
 	if err := ValidateSeverity(severity); severity != "" && err != nil {
 		return err
 	}
+	if err := ValidateThresholds(scanInfo); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/shared/image_scan_test.go
+++ b/cmd/shared/image_scan_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"math"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -43,6 +44,51 @@ func TestValidateImageScanInfo(t *testing.T) {
 			"Unknown severity is invalid",
 			&cautils.ScanInfo{FailThresholdSeverity: "unknown"},
 			ErrUnknownSeverity,
+		},
+		{
+			"Fail threshold above 100 should be invalid",
+			&cautils.ScanInfo{FailThreshold: 101},
+			ErrBadThreshold,
+		},
+		{
+			"Fail threshold below 0 should be invalid",
+			&cautils.ScanInfo{FailThreshold: -1},
+			ErrBadThreshold,
+		},
+		{
+			"Compliance threshold above 100 should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: 101},
+			ErrBadThreshold,
+		},
+		{
+			"Compliance threshold below 0 should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: -1},
+			ErrBadThreshold,
+		},
+		{
+			"Coverage threshold above 100 should be invalid",
+			&cautils.ScanInfo{FailCoverageThreshold: 150},
+			ErrBadThreshold,
+		},
+		{
+			"Valid thresholds should be accepted",
+			&cautils.ScanInfo{FailThreshold: 80, ComplianceThreshold: 70},
+			nil,
+		},
+		{
+			"NaN fail threshold should be invalid",
+			&cautils.ScanInfo{FailThreshold: float32(math.NaN())},
+			ErrBadThreshold,
+		},
+		{
+			"NaN compliance threshold should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: float32(math.NaN())},
+			ErrBadThreshold,
+		},
+		{
+			"NaN fail coverage threshold should be invalid",
+			&cautils.ScanInfo{FailCoverageThreshold: float32(math.NaN())},
+			ErrBadThreshold,
 		},
 	}
 

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/kubescape/go-logger/helpers"
@@ -10,6 +11,25 @@ import (
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))
+
+// ErrBadThreshold is returned when a numeric threshold is outside the valid range [0, 100].
+var ErrBadThreshold = fmt.Errorf("bad argument: out of range threshold")
+
+// ValidateThresholds validates that FailThreshold, ComplianceThreshold and
+// FailCoverageThreshold are all within [0, 100]. This mirrors the check in
+// validateFrameworkScanInfo and validateControlScanInfo.
+func ValidateThresholds(scanInfo *cautils.ScanInfo) error {
+	if math.IsNaN(float64(scanInfo.FailThreshold)) || 100 < scanInfo.FailThreshold || 0 > scanInfo.FailThreshold {
+		return ErrBadThreshold
+	}
+	if math.IsNaN(float64(scanInfo.ComplianceThreshold)) || 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
+		return ErrBadThreshold
+	}
+	if math.IsNaN(float64(scanInfo.FailCoverageThreshold)) || 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
+		return ErrBadThreshold
+	}
+	return nil
+}
 
 // ValidateSeverity returns an error if a given severity is not known, nil otherwise
 func ValidateSeverity(severity string) error {


### PR DESCRIPTION
## Overview

`ValidateImageScanInfo()` validated severity but never checked numeric
threshold ranges. Passing `--fail-threshold 150` or `--compliance-threshold -1`
to `kubescape scan image` or `kubescape patch` was silently accepted and
only failed at runtime — unlike `scan framework` and `scan control` which
correctly reject out-of-range values with `ErrBadThreshold` before the scan starts.

## Before

```bash
kubescape scan framework nsa --fail-threshold 150
# Error: bad argument: out of range threshold 

kubescape scan image nginx:latest --fail-threshold 150
# No error — scan runs then fails at runtime 

kubescape patch --image nginx:latest --fail-threshold 150
# No error — patch runs then fails at runtime 
```

## After

```bash
kubescape scan image nginx:latest --fail-threshold 150
# Error: bad argument: out of range threshold 

kubescape patch --image nginx:latest --fail-threshold 150
# Error: bad argument: out of range threshold 
```

## Root Cause

```go
// Before — threshold range never checked
func ValidateImageScanInfo(scanInfo *cautils.ScanInfo) error {
    if err := ValidateSeverity(severity); severity != "" && err != nil {
        return err
    }
    return nil  // ← ValidateThresholds never called
}
```

## Fix

Added `ValidateThresholds()` to `cmd/shared/scan.go` — a shared,
exported version of the existing `validateThresholdsOnly()` in
`cmd/scan/framework.go`. Called it from `ValidateImageScanInfo()`.
Both `scan image` and `patch` call `ValidateImageScanInfo()` so
both are fixed in one change.

## Changes

- `cmd/shared/scan.go` — added `ErrBadThreshold` and `ValidateThresholds()`
- `cmd/shared/image_scan.go` — call `ValidateThresholds()` in `ValidateImageScanInfo()`
- `cmd/shared/image_scan_test.go` — added 6 new threshold test cases

## Tests

```
--- PASS: TestValidateImageScanInfo (12/12 subtests)
ok  github.com/kubescape/kubescape/v3/cmd/shared
ok  github.com/kubescape/kubescape/v3/cmd/scan
```

## Related Issues
Fixes #2271

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image scan validation to correctly validate all threshold values, ensuring each threshold is numeric and within the inclusive 0–100 range to prevent invalid configurations.

* **Tests**
  * Added comprehensive test coverage for threshold validation, including out-of-range and NaN cases, plus confirmations that valid thresholds are accepted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->