### PR TITLE
fix(fixhandler): reconcile unfixed controls against planned YAML edits

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -477,11 +477,24 @@ func plannedPathsFromExpressions(exprs map[string]armotypes.FixPath) []string {
 	return out
 }
 
+// normalizeFailedPath strips an "=<expected>" suffix that some FailedPath
+// values carry to encode the value the check expected (e.g.
+// "spec.…runAsNonRoot=true"). The reconciliation pass compares pure YAML
+// paths, so the suffix must not participate in the segment-boundary check.
+func normalizeFailedPath(p string) string {
+	if i := strings.IndexByte(p, '='); i >= 0 {
+		return p[:i]
+	}
+	return p
+}
+
 // yamlPathCovers reports whether setting `planned` necessarily satisfies a
 // check that observed `failed`. Coverage holds when planned == failed, or
 // planned is an ancestor of failed on YAML-segment boundaries — segments are
 // separated by '.' or '['. String prefix alone is not enough: "spec.host" must
-// not be treated as covering "spec.hostNetwork".
+// not be treated as covering "spec.hostNetwork". Callers must pass a
+// normalized `failed` (see normalizeFailedPath) since FailedPath values may
+// carry "=<expected>" suffixes.
 func yamlPathCovers(planned, failed string) bool {
 	if planned == "" || failed == "" {
 		return false
@@ -496,25 +509,49 @@ func yamlPathCovers(planned, failed string) bool {
 	return next == '.' || next == '['
 }
 
-// controlIsCoveredByPlannedPaths reports whether every failed path on the
-// control's failed rules is covered by at least one planned path. Controls
-// with no FailedPath data (e.g. rules that only carry ReviewPath/DeletePath)
-// are NOT promoted — without a concrete failed location we can't prove
-// coverage, and silently promoting would re-introduce the bug in reverse.
+// actionableLocation returns the YAML location a path entry describes,
+// regardless of which remediation field it was stored in. PosturePaths
+// entries carry exactly one of FailedPath / DeletePath / ReviewPath / FixPath
+// in practice (see appendPaths in opa-utils), so taking the first non-empty
+// one yields the location the check was actually pointing at.
+func actionableLocation(p armotypes.PosturePaths) string {
+	if p.FailedPath != "" {
+		return normalizeFailedPath(p.FailedPath)
+	}
+	if p.DeletePath != "" {
+		return normalizeFailedPath(p.DeletePath)
+	}
+	if p.ReviewPath != "" {
+		return normalizeFailedPath(p.ReviewPath)
+	}
+	if p.FixPath.Path != "" {
+		return p.FixPath.Path
+	}
+	return ""
+}
+
+// controlIsCoveredByPlannedPaths reports whether every actionable path entry
+// on the control's failed rules is covered by some planned FixPath. Every
+// entry counts — FailedPath, DeletePath, and ReviewPath alike — so a control
+// that requires (for example) deleting `spec.hostNetwork` cannot be promoted
+// just because an unrelated FailedPath happens to overlap with a planned
+// edit. A control whose rules carry no actionable locations at all is not
+// promoted either (nothing concrete to match against).
 func controlIsCoveredByPlannedPaths(ac *resourcesresults.ResourceAssociatedControl, plannedPaths []string) bool {
-	sawFailedPath := false
+	sawActionablePath := false
 	for _, rule := range ac.ResourceAssociatedRules {
 		if !rule.GetStatus(nil).IsFailed() {
 			continue
 		}
 		for _, p := range rule.Paths {
-			if p.FailedPath == "" {
+			loc := actionableLocation(p)
+			if loc == "" {
 				continue
 			}
-			sawFailedPath = true
+			sawActionablePath = true
 			covered := false
 			for _, planned := range plannedPaths {
-				if yamlPathCovers(planned, p.FailedPath) {
+				if yamlPathCovers(planned, loc) {
 					covered = true
 					break
 				}
@@ -524,7 +561,7 @@ func controlIsCoveredByPlannedPaths(ac *resourcesresults.ResourceAssociatedContr
 			}
 		}
 	}
-	return sawFailedPath
+	return sawActionablePath
 }
 
 // addYamlExpressionsFromResourceAssociatedControl appends one yaml expression

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -195,6 +195,15 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 			DocumentIndex:   documentIndex,
 		}
 
+		// Tentative unfixed entries for this resource. We collect them locally
+		// so a post-loop reconciliation pass can promote controls whose failed
+		// paths are covered by another control's planned YamlExpressions.
+		type pendingUnfixed struct {
+			entry UnfixedControl
+			ac    *resourcesresults.ResourceAssociatedControl
+		}
+		var tentativeUnfixed []pendingUnfixed
+
 		for i := range result.AssociatedControls {
 			ac := &result.AssociatedControls[i]
 			if !ac.GetStatus(nil).IsFailed() {
@@ -220,14 +229,31 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 			if added > 0 {
 				reason = "partial: " + reason
 			}
-			h.unfixedControls = append(h.unfixedControls, UnfixedControl{
-				ControlID:    ac.GetID(),
-				ControlName:  ac.GetName(),
-				ResourceName: resourceObj.GetName(),
-				ResourceKind: resourceObj.GetKind(),
-				FilePath:     absolutePath,
-				Reason:       reason,
+			tentativeUnfixed = append(tentativeUnfixed, pendingUnfixed{
+				entry: UnfixedControl{
+					ControlID:    ac.GetID(),
+					ControlName:  ac.GetName(),
+					ResourceName: resourceObj.GetName(),
+					ResourceKind: resourceObj.GetKind(),
+					FilePath:     absolutePath,
+					Reason:       reason,
+				},
+				ac: ac,
 			})
+		}
+
+		// Reconcile tentative-unfixed entries against the final set of planned
+		// YamlExpressions for this resource: a control's failed paths may be
+		// covered by another control's FixPath (e.g. C-0016's
+		// "privileged = false" also remediates C-0057). Promote those to
+		// fixed instead of misleading the user with "no auto-fix available".
+		plannedPaths := plannedPathsFromExpressions(rfi.YamlExpressions)
+		for _, pu := range tentativeUnfixed {
+			if len(plannedPaths) > 0 && controlIsCoveredByPlannedPaths(pu.ac, plannedPaths) {
+				h.fixedControlsCount++
+				continue
+			}
+			h.unfixedControls = append(h.unfixedControls, pu.entry)
 		}
 
 		if len(rfi.YamlExpressions) > 0 {
@@ -429,6 +455,76 @@ func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) ma
 	}
 
 	return fileYamlExpressions
+}
+
+// plannedPathsFromExpressions returns the distinct, non-empty FixPath.Path
+// values from a YamlExpressions map. Used by the unfixed-control reconciliation
+// pass to test whether a control's failed paths are covered by some planned
+// edit.
+func plannedPathsFromExpressions(exprs map[string]armotypes.FixPath) []string {
+	if len(exprs) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(exprs))
+	out := make([]string, 0, len(exprs))
+	for _, fp := range exprs {
+		if fp.Path == "" || seen[fp.Path] {
+			continue
+		}
+		seen[fp.Path] = true
+		out = append(out, fp.Path)
+	}
+	return out
+}
+
+// yamlPathCovers reports whether setting `planned` necessarily satisfies a
+// check that observed `failed`. Coverage holds when planned == failed, or
+// planned is an ancestor of failed on YAML-segment boundaries — segments are
+// separated by '.' or '['. String prefix alone is not enough: "spec.host" must
+// not be treated as covering "spec.hostNetwork".
+func yamlPathCovers(planned, failed string) bool {
+	if planned == "" || failed == "" {
+		return false
+	}
+	if planned == failed {
+		return true
+	}
+	if !strings.HasPrefix(failed, planned) {
+		return false
+	}
+	next := failed[len(planned)]
+	return next == '.' || next == '['
+}
+
+// controlIsCoveredByPlannedPaths reports whether every failed path on the
+// control's failed rules is covered by at least one planned path. Controls
+// with no FailedPath data (e.g. rules that only carry ReviewPath/DeletePath)
+// are NOT promoted — without a concrete failed location we can't prove
+// coverage, and silently promoting would re-introduce the bug in reverse.
+func controlIsCoveredByPlannedPaths(ac *resourcesresults.ResourceAssociatedControl, plannedPaths []string) bool {
+	sawFailedPath := false
+	for _, rule := range ac.ResourceAssociatedRules {
+		if !rule.GetStatus(nil).IsFailed() {
+			continue
+		}
+		for _, p := range rule.Paths {
+			if p.FailedPath == "" {
+				continue
+			}
+			sawFailedPath = true
+			covered := false
+			for _, planned := range plannedPaths {
+				if yamlPathCovers(planned, p.FailedPath) {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				return false
+			}
+		}
+	}
+	return sawFailedPath
 }
 
 // addYamlExpressionsFromResourceAssociatedControl appends one yaml expression

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -517,13 +517,13 @@ func TestUnfixedControls_ReturnsCopy(t *testing.T) {
 		"caller mutation must not leak into internal state")
 }
 
-// --- cross-control reconciliation (issue-5) ------------------------------
+// --- cross-control reconciliation (#2279) --------------------------------
 
 func TestYamlPathCovers(t *testing.T) {
 	cases := []struct {
-		name           string
+		name            string
 		planned, failed string
-		want           bool
+		want            bool
 	}{
 		{"exact match", "spec.containers[0].securityContext.privileged", "spec.containers[0].securityContext.privileged", true},
 		{"planned is parent (.)", "spec.containers[0].securityContext", "spec.containers[0].securityContext.privileged", true},

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -821,6 +821,191 @@ func TestPrepareResourcesToFix_PartialPromotedWhenRemainderCovered(t *testing.T)
 	assert.Empty(t, h.UnfixedControls())
 }
 
+// --- blocker regressions -------------------------------------------------
+
+// Some FailedPath values in the wild carry an "=<expected>" suffix
+// (e.g. "spec.…runAsNonRoot=true", as in resourcetable_test.go). Coverage
+// must compare against the normalized path; otherwise a planned edit on the
+// same field is silently rejected because the next char after the planned
+// prefix is '=' rather than '.'/'['.
+func TestPrepareResourcesToFix_FailedPathWithEqualsSuffix(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-FIX", "owns runAsNonRoot fix",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.runAsNonRoot", "true"),
+				),
+				failedControl("C-OBS", "fails on same field with =<value> suffix",
+					failedRuleNoFixAtPath("spec.template.spec.containers[0].securityContext.runAsNonRoot=true"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 2, h.FixedControlsCount(), "normalized FailedPath must match planned FixPath even with =<value> suffix")
+	assert.Empty(t, h.UnfixedControls())
+}
+
+func TestNormalizeFailedPath(t *testing.T) {
+	cases := map[string]string{
+		"spec.a.b":                           "spec.a.b",
+		"spec.a.b=true":                      "spec.a.b",
+		"spec.a[0].b=null":                   "spec.a[0].b",
+		"":                                   "",
+		"=onlyValue":                         "",
+		"spec.containers[0].image=nginx:1.0": "spec.containers[0].image",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, normalizeFailedPath(in), in)
+	}
+}
+
+// A control whose rule emits an outstanding DeletePath that another planned
+// edit does NOT touch must remain unfixed — covering only an unrelated
+// FailedPath in the same rule must not be enough to promote.
+func TestPrepareResourcesToFix_OutstandingDeletePathBlocksPromotion(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	// C-MIXED has two path entries: a FailedPath that another control will
+	// cover, and a DeletePath at a completely different location that nothing
+	// covers. The control must NOT be promoted.
+	mixed := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-MIXED",
+		Name:      "mixed-with-delete",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "rule-mixed",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{FailedPath: "spec.template.spec.containers[0].image"},
+					{DeletePath: "spec.template.spec.hostNetwork"},
+				},
+			},
+		},
+	}
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				mixed,
+				failedControl("C-IMG", "owns image fix",
+					failedRuleWithFix("spec.template.spec.containers[0].image", "nginx:1.25"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount(), "only C-IMG; C-MIXED has an unsatisfied DeletePath")
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-MIXED", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// Same shape with ReviewPath: an outstanding ReviewPath at a location no
+// planned edit touches must keep the control unfixed.
+func TestPrepareResourcesToFix_OutstandingReviewPathBlocksPromotion(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	mixed := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-MIXED",
+		Name:      "mixed-with-review",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "rule-mixed",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{FailedPath: "spec.template.spec.containers[0].image"},
+					{ReviewPath: "spec.template.spec.serviceAccountName"},
+				},
+			},
+		},
+	}
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				mixed,
+				failedControl("C-IMG", "owns image fix",
+					failedRuleWithFix("spec.template.spec.containers[0].image", "nginx:1.25"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount())
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-MIXED", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// The headline reproducer's exact path shape: C-0057 has TWO path entries
+// for the SAME YAML location — one carrying FailedPath, the other carrying
+// DeletePath. C-0016's planned FixPath covers that location, so BOTH entries
+// are covered and C-0057 must be promoted. (This is the canonical regolibrary
+// shape and the original bug.)
+func TestPrepareResourcesToFix_DeletePathAtSameLocationStillPromoted(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	c0057 := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-0057",
+		Name:      "Privileged container",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "rule-privilege-escalation",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{FailedPath: "spec.template.spec.containers[0].securityContext.privileged"},
+					{DeletePath: "spec.template.spec.containers[0].securityContext.privileged"},
+				},
+			},
+		},
+	}
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				c0057,
+				failedControl("C-0016", "Allow privilege escalation",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.privileged", "false"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 2, h.FixedControlsCount(), "both C-0016 and C-0057 promoted (delete & failed at same location both covered)")
+	assert.Empty(t, h.UnfixedControls())
+}
+
 func TestNewFixHandler_AcceptsValidReport(t *testing.T) {
 	dir := t.TempDir()
 	report := reporthandlingv2.PostureReport{

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -42,6 +42,16 @@ func failedRuleNoFix() resourcesresults.ResourceAssociatedRule {
 	}
 }
 
+func failedRuleNoFixAtPath(failedPath string) resourcesresults.ResourceAssociatedRule {
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-no-fix-" + failedPath,
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{FailedPath: failedPath},
+		},
+	}
+}
+
 func failedControl(id, name string, rules ...resourcesresults.ResourceAssociatedRule) resourcesresults.ResourceAssociatedControl {
 	return resourcesresults.ResourceAssociatedControl{
 		ControlID:               id,
@@ -505,6 +515,310 @@ func TestUnfixedControls_ReturnsCopy(t *testing.T) {
 	got[0].ControlName = "mutated"
 	assert.Equal(t, "orig", h.unfixedControls[0].ControlName,
 		"caller mutation must not leak into internal state")
+}
+
+// --- cross-control reconciliation (issue-5) ------------------------------
+
+func TestYamlPathCovers(t *testing.T) {
+	cases := []struct {
+		name           string
+		planned, failed string
+		want           bool
+	}{
+		{"exact match", "spec.containers[0].securityContext.privileged", "spec.containers[0].securityContext.privileged", true},
+		{"planned is parent (.)", "spec.containers[0].securityContext", "spec.containers[0].securityContext.privileged", true},
+		{"planned is parent ([)", "spec.containers", "spec.containers[0].securityContext", true},
+		{"failed is parent of planned — NOT covered", "spec.containers[0].securityContext.privileged", "spec.containers[0].securityContext", false},
+		{"sibling with shared prefix — NOT covered", "spec.host", "spec.hostNetwork", false},
+		{"unrelated path", "metadata.labels.app", "spec.hostNetwork", false},
+		{"empty planned", "", "spec.hostNetwork", false},
+		{"empty failed", "spec.hostNetwork", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, yamlPathCovers(tc.planned, tc.failed))
+		})
+	}
+}
+
+func TestPlannedPathsFromExpressions_DedupesAndSkipsEmpty(t *testing.T) {
+	exprs := map[string]armotypes.FixPath{
+		"e1": {Path: "spec.a", Value: "1"},
+		"e2": {Path: "spec.b", Value: "2"},
+		"e3": {Path: "spec.a", Value: "1"}, // duplicate path under different expression key
+		"e4": {Path: "", Value: ""},        // empty — must be skipped
+	}
+	got := plannedPathsFromExpressions(exprs)
+	assert.ElementsMatch(t, []string{"spec.a", "spec.b"}, got)
+}
+
+func TestPlannedPathsFromExpressions_EmptyInput(t *testing.T) {
+	assert.Nil(t, plannedPathsFromExpressions(nil))
+	assert.Nil(t, plannedPathsFromExpressions(map[string]armotypes.FixPath{}))
+}
+
+// The headline bug: C-0016 owns a FixPath for `…privileged = false`. C-0057
+// (Privileged container) has a FailedPath on the same field but no FixPath of
+// its own. After reconciliation, C-0057 must be counted as fixed, not listed
+// under "no auto-fix available for this control".
+func TestPrepareResourcesToFix_PromotesCrossControlCoveredControl(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				// C-0016: owns the FixPath that toggles privileged=false.
+				failedControl("C-0016", "Allow privilege escalation",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.privileged", "false"),
+				),
+				// C-0057: fails on the same field but exposes no FixPath. Must
+				// be promoted to fixed because the planned edit covers it.
+				failedControl("C-0057", "Privileged container",
+					failedRuleNoFixAtPath("spec.template.spec.containers[0].securityContext.privileged"),
+				),
+				// C-0041: genuinely unfixed — failedPath not touched by any planned edit.
+				failedControl("C-0041", "HostNetwork access",
+					failedRuleNoFixAtPath("spec.template.spec.hostNetwork"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 2, h.FixedControlsCount(), "C-0016 fully fixed + C-0057 promoted by reconciliation")
+	if assert.Len(t, h.UnfixedControls(), 1, "only C-0041 must remain unfixed") {
+		assert.Equal(t, "C-0041", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// Parent-path coverage: planned edit sets `securityContext = {...}`, failed
+// path is `securityContext.privileged`. The parent overwrites the child, so
+// the control must be promoted.
+func TestPrepareResourcesToFix_ParentPathCoversChildFailedPath(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-PARENT", "owns parent fix",
+					failedRuleWithFix("spec.containers[0].securityContext", "{}"),
+				),
+				failedControl("C-CHILD", "fails on child",
+					failedRuleNoFixAtPath("spec.containers[0].securityContext.privileged"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 2, h.FixedControlsCount())
+	assert.Empty(t, h.UnfixedControls())
+}
+
+// Reverse direction: planned edit is on the CHILD, failed path is on the
+// PARENT. We don't know what other parent fields the check observed, so the
+// control must remain unfixed (no false promotion).
+func TestPrepareResourcesToFix_ChildPlannedDoesNotCoverParentFailed(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-CHILD", "owns child fix",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+				),
+				failedControl("C-PARENT", "fails on parent",
+					failedRuleNoFixAtPath("spec.containers[0].securityContext"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount(), "only C-CHILD; C-PARENT must NOT be promoted")
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-PARENT", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// Lookalike-prefix safety: planned `spec.host` must not cover failed
+// `spec.hostNetwork`. The promotion check is on YAML segments, not raw string
+// prefix.
+func TestPrepareResourcesToFix_LookalikePrefixDoesNotPromote(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-A", "owns spec.host fix",
+					failedRuleWithFix("spec.host", "something"),
+				),
+				failedControl("C-0041", "HostNetwork access",
+					failedRuleNoFixAtPath("spec.hostNetwork"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount(), "only C-A; C-0041 must remain unfixed")
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-0041", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// A control whose rules have NO FailedPath data at all (only DeletePath or
+// ReviewPath, or nothing) must not be silently promoted just because some
+// planned edits exist — without a concrete failed location we can't prove
+// coverage.
+func TestPrepareResourcesToFix_NoFailedPathDoesNotPromote(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	noPathRule := resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-only-delete",
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{DeletePath: "spec.something"},
+		},
+	}
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-OTHER", "owns a fix",
+					failedRuleWithFix("spec.unrelated", "x"),
+				),
+				failedControl("C-NOFAIL", "no failed paths", noPathRule),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount())
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-NOFAIL", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+// Multi-resource: planned paths on resource A must not promote unfixed
+// controls on resource B.
+func TestPrepareResourcesToFix_PromotionIsScopedPerResource(t *testing.T) {
+	dir := t.TempDir()
+	mA := writeManifest(t, dir, "a.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	mB := writeManifest(t, dir, "b.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	relA, _ := filepath.Rel(dir, mA)
+	relB, _ := filepath.Rel(dir, mB)
+	resA := buildResource(t, dir, relA, "Deployment", "demo-a", 0)
+	resB := buildResource(t, dir, relB, "Deployment", "demo-b", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  resA.GetID(),
+			RawResource: resA,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0016", "Allow privilege escalation",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.privileged", "false"),
+				),
+			},
+		},
+		{
+			ResourceID:  resB.GetID(),
+			RawResource: resB,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				// Same failedPath, different resource — must NOT be promoted
+				// by resource A's planned edit.
+				failedControl("C-0057", "Privileged container",
+					failedRuleNoFixAtPath("spec.template.spec.containers[0].securityContext.privileged"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount(), "only C-0016 on resource A")
+	if assert.Len(t, h.UnfixedControls(), 1) {
+		assert.Equal(t, "C-0057", h.UnfixedControls()[0].ControlID)
+		assert.Equal(t, "demo-b", h.UnfixedControls()[0].ResourceName)
+	}
+}
+
+// A partial control whose remaining (skipped) paths are covered by another
+// control's planned edits should be promoted to fixed by the reconciliation
+// pass.
+func TestPrepareResourcesToFix_PartialPromotedWhenRemainderCovered(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	// C-MIXED has one concrete fix (privileged) and one rule with only a
+	// FailedPath (hostNetwork). C-NET separately owns the FixPath for
+	// hostNetwork. Together they cover all of C-MIXED's failed paths.
+	mixed := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-MIXED",
+		Name:      "mixed",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "fix-priv",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{
+						FailedPath: "spec.template.spec.containers[0].securityContext.privileged",
+						FixPath:    armotypes.FixPath{Path: "spec.template.spec.containers[0].securityContext.privileged", Value: "false"},
+					},
+				},
+			},
+			failedRuleNoFixAtPath("spec.template.spec.hostNetwork"),
+		},
+	}
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				mixed,
+				failedControl("C-NET", "owns hostNetwork fix",
+					failedRuleWithFix("spec.template.spec.hostNetwork", "false"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 2, h.FixedControlsCount(), "C-NET fully fixed + C-MIXED promoted (all failed paths covered)")
+	assert.Empty(t, h.UnfixedControls())
 }
 
 func TestNewFixHandler_AcceptsValidReport(t *testing.T) {


### PR DESCRIPTION
## Overview

`kubescape fix` previously reported `"no auto-fix available for this control"` for controls that were, in the same run, being remediated by another control's planned YAML edit. The dry-run output was internally contradictory: a change like

```
spec.template.spec.containers[0].securityContext.privileged = false
```

would appear under the planned-changes list, and on the very next line C-0057 *"Privileged container"* would be listed as needing manual remediation. In CI gates that fail on a non-empty unfixed list, this turned successful auto-fixes into false-positive failures.

The cause was in `core/pkg/fixhandler/fixhandler.go`: the per-control loop decided fixed-vs-unfixed strictly from `ResourceAssociatedControl.ResourceAssociatedRules[*].Paths[*].FixPath`, i.e. from that control's own FixPaths only. If C-0016 owned a FixPath that toggled `privileged = false`, C-0057 — whose failed path was the same field but which carried no FixPath of its own — was still recorded as unfixed.

This change adds a post-loop reconciliation pass inside `PrepareResourcesToFix`. After the per-control loop has produced the final set of `rfi.YamlExpressions` for a resource, each tentative-unfixed control is checked: if every one of its `FailedPath`s is covered by some planned FixPath path (equal-or-ancestor on YAML segment boundaries), the control is promoted from unfixed to fixed.

Three helpers were added:
- `plannedPathsFromExpressions` — distinct non-empty paths from `rfi.YamlExpressions`.
- `yamlPathCovers` — segment-aware coverage. `spec.host` does **not** cover `spec.hostNetwork`; segments are split on `.` or `[`.
- `controlIsCoveredByPlannedPaths` — promotes only when the control has at least one `FailedPath` and every such path is covered. Controls with no FailedPath data (e.g. only `DeletePath`/`ReviewPath`) are not silently promoted.

The reconciliation pass is scoped per-resource: planned edits on resource A cannot promote unfixed controls on resource B. The `rfi.YamlExpressions` map — i.e. the bytes that `ApplyChanges` will actually write — is unchanged. Only the bookkeeping (`fixedControlsCount`, `unfixedControls`) is affected.

## How to Test

Reproduce the original bug with a deployment that mixes covered and genuinely-unfixed failures:

```
cat > /tmp/bad.yaml << 'EOF'
apiVersion: apps/v1
kind: Deployment
metadata: { name: bad-deploy, namespace: default }
spec:
  replicas: 1
  selector: { matchLabels: { app: bad } }
  template:
    metadata: { labels: { app: bad } }
    spec:
      hostPID: true
      hostNetwork: true
      containers:
      - name: c
        image: nginx:latest
        securityContext:
          privileged: true
          runAsUser: 0
          allowPrivilegeEscalation: true
        ports: [{ containerPort: 80 }]
EOF

kubescape scan /tmp/bad.yaml --format json --output /tmp/r.json
kubescape fix /tmp/r.json --dry-run
```

Before this change:

```
Would auto-fix 3 of 16 flagged control instances. The following require manual remediation:
  - C-0057 Privileged container … — no auto-fix available for this control
  - C-0038 Host PID/IPC privileges … — no auto-fix available for this control
  - C-0041 HostNetwork access … — no auto-fix available for this control
  ...
```

After this change:

```
Would auto-fix 4 of 16 flagged control instances. The following require manual remediation:
  - C-0038 Host PID/IPC privileges … — no auto-fix available for this control
  - C-0041 HostNetwork access … — no auto-fix available for this control
  ...
```

C-0057 is correctly absent from the manual-remediation list and counted in the auto-fixed total. C-0038 and C-0041 remain unfixed because their failed paths (`spec.template.spec.hostPID`, `spec.template.spec.hostNetwork`) are not touched by any planned edit — which is the correct behavior.

End-to-end verification with apply:

```
kubescape fix /tmp/r.json --no-confirm
kubescape scan /tmp/bad.yaml --format json --output /tmp/r2.json
# C-0057 now passes; C-0038/C-0041 still fail (expected)
```

Unit test coverage (`core/pkg/fixhandler/unfixed_test.go`):

```
go test ./core/pkg/fixhandler/ -v
```

New tests:
- `TestYamlPathCovers` — 8 sub-cases covering exact match, parent-via-`.`, parent-via-`[`, reverse direction rejected, lookalike-prefix rejected, unrelated paths, empty inputs.
- `TestPlannedPathsFromExpressions_DedupesAndSkipsEmpty`, `_EmptyInput`.
- `TestPrepareResourcesToFix_PromotesCrossControlCoveredControl` — the headline regression: C-0016 covers C-0057.
- `TestPrepareResourcesToFix_ParentPathCoversChildFailedPath` — parent-overwrite case.
- `TestPrepareResourcesToFix_ChildPlannedDoesNotCoverParentFailed` — child planned must not promote parent-failed (no false promotion).
- `TestPrepareResourcesToFix_LookalikePrefixDoesNotPromote` — `spec.host` does not promote `spec.hostNetwork`.
- `TestPrepareResourcesToFix_NoFailedPathDoesNotPromote` — controls without FailedPath data are not silently promoted.
- `TestPrepareResourcesToFix_PromotionIsScopedPerResource` — planned edits on one resource cannot promote unfixed controls on another.
- `TestPrepareResourcesToFix_PartialPromotedWhenRemainderCovered` — partial controls whose remaining skipped paths are covered elsewhere are also promoted.

Full repo test suite passes with no regressions:

```
go test ./...
```

## Related issues/PRs:

* Resolved #2279 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-fix reconciliation: tentative unfixed controls are now promoted when planned edits fully cover their failed YAML paths (respecting YAML-segment boundaries), including normalization of failed-paths with =<value> suffixes; promotion is blocked by outstanding delete/review locations and scoped per resource.

* **Tests**
  * Added extensive regression tests and a new test helper covering cross-control promotion, path-coverage rules, planned-path deduplication, scope isolation, and partial-control reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->