### PR TITLE
Add HTTP server timeouts and header limits

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -284,6 +284,12 @@ Configure the HTTP handler using environment variables:
 | `KS_LOGGER_NAME` | Logger name | `kubescape` |
 | `KS_LOGGER_LEVEL` | Log level | `info`, `debug`, `warning`, `error` |
 | `KS_DOWNLOAD_ARTIFACTS` | Download artifacts on each scan | `true`, `false` |
+| `KS_HTTP_READ_HEADER_TIMEOUT` | Time to read request headers | `10s` |
+| `KS_HTTP_READ_TIMEOUT` | Time to read full request (including body) | `30s` |
+| `KS_HTTP_WRITE_TIMEOUT` | Time to write the response | `15m` |
+| `KS_HTTP_IDLE_TIMEOUT` | Keep-alive idle timeout | `2m` |
+| `KS_HTTP_MAX_HEADER_BYTES` | Maximum request header size in bytes | `1048576` |
+| `KS_PPROF_PORT` | pprof listener port (debug only) | `6060` |
 
 ---
 
@@ -316,6 +322,10 @@ export KS_LOGGER_LEVEL=debug
 ### Performance Profiling
 
 The HTTP handler exposes pprof endpoints for performance analysis:
+
+```bash
+export KS_PPROF_PORT=6060
+```
 
 ```bash
 # Heap profile

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -4,7 +4,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -14,6 +17,17 @@ import (
 	"github.com/kubescape/kubescape/v3/httphandler/docs"
 	handlerequestsv1 "github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+)
+
+// HTTP listener constants
+const (
+	defaultPort      = "8080"
+	envPort          = "KS_PORT"
+	envCertFile      = "KS_CERT_FILE"
+	envKeyFile       = "KS_KEY_FILE"
+	envOffline       = "KS_OFFLINE"
+	defaultPprofPort = "6060"
+	envPprofPort     = "KS_PPROF_PORT"
 )
 
 const (
@@ -29,6 +43,22 @@ const (
 	readyPath = "/readyz"
 )
 
+const (
+	envReadHeaderTimeout = "KS_HTTP_READ_HEADER_TIMEOUT"
+	envReadTimeout       = "KS_HTTP_READ_TIMEOUT"
+	envWriteTimeout      = "KS_HTTP_WRITE_TIMEOUT"
+	envIdleTimeout       = "KS_HTTP_IDLE_TIMEOUT"
+	envMaxHeaderBytes    = "KS_HTTP_MAX_HEADER_BYTES"
+)
+
+const (
+	defaultReadHeaderTimeout = 10 * time.Second
+	defaultReadTimeout       = 30 * time.Second
+	defaultWriteTimeout      = 15 * time.Minute
+	defaultIdleTimeout       = 2 * time.Minute
+	defaultMaxHeaderBytes    = http.DefaultMaxHeaderBytes
+)
+
 // SetupHTTPListener set up listening http servers
 func SetupHTTPListener() error {
 	keyPair, err := loadTLSKey(getCertFile(), getKeyFile())
@@ -36,7 +66,12 @@ func SetupHTTPListener() error {
 		return err
 	}
 	server := &http.Server{
-		Addr: fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
+		Addr:              fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
+		ReadHeaderTimeout: getDurationFromEnv(envReadHeaderTimeout, defaultReadHeaderTimeout),
+		ReadTimeout:       getDurationFromEnv(envReadTimeout, defaultReadTimeout),
+		WriteTimeout:      getDurationFromEnv(envWriteTimeout, defaultWriteTimeout),
+		IdleTimeout:       getDurationFromEnv(envIdleTimeout, defaultIdleTimeout),
+		MaxHeaderBytes:    getMaxHeaderBytes(),
 	}
 	if keyPair != nil {
 		server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*keyPair}}
@@ -82,42 +117,110 @@ func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
 	switch {
 	case certFile == "" && keyFile == "":
 		return nil, nil
-	case certFile == "" || keyFile == "":
-		return nil, fmt.Errorf("both KS_CERT_FILE and KS_KEY_FILE must be set to enable TLS (got certFile=%q, keyFile=%q)", certFile, keyFile)
+	case certFile != "" && keyFile != "":
+		keyPair, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load key pair: %v", err)
+		}
+		return &keyPair, nil
+	default:
+		return nil, fmt.Errorf("both %s and %s must be set to enable TLS (got certFile=%q, keyFile=%q)", envCertFile, envKeyFile, certFile, keyFile)
 	}
-
-	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load key pair: %v", err)
-	}
-	return &pair, nil
-}
-
-func getOffline() bool {
-	return os.Getenv("KS_OFFLINE") == "true"
 }
 
 func getPort() string {
-	if p := os.Getenv("KS_PORT"); p != "" {
+	if p := os.Getenv(envPort); p != "" {
 		return p
 	}
-	return "8080"
+	return defaultPort
 }
 
 func getCertFile() string {
-	return os.Getenv("KS_CERT_FILE")
+	return os.Getenv(envCertFile)
 }
 
 func getKeyFile() string {
-	return os.Getenv("KS_KEY_FILE")
+	return os.Getenv(envKeyFile)
+}
+
+func getOffline() bool {
+	return os.Getenv(envOffline) == "true"
+}
+
+func getPprofPort() string {
+	if p := os.Getenv(envPprofPort); p != "" {
+		return p
+	}
+	return defaultPprofPort
 }
 
 func servePprof() {
+	if logger.L().GetLevel() != helpers.DebugLevel.String() {
+		return
+	}
+
+	pprofPort := getPprofPort()
+	pprofMux := http.NewServeMux()
+	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
+	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	pprofServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", pprofPort),
+		Handler:           pprofMux,
+		ReadHeaderTimeout: getDurationFromEnv(envReadHeaderTimeout, defaultReadHeaderTimeout),
+		ReadTimeout:       getDurationFromEnv(envReadTimeout, defaultReadTimeout),
+		WriteTimeout:      getDurationFromEnv(envWriteTimeout, defaultWriteTimeout),
+		IdleTimeout:       getDurationFromEnv(envIdleTimeout, defaultIdleTimeout),
+		MaxHeaderBytes:    getMaxHeaderBytes(),
+	}
+
 	go func() {
-		// start pprof server -> https://pkg.go.dev/net/http/pprof
-		if logger.L().GetLevel() == helpers.DebugLevel.String() {
-			logger.L().Info("starting pprof server", helpers.String("port", "6060"))
-			logger.L().Error(http.ListenAndServe(":6060", nil).Error())
+		logger.L().Info("starting pprof server", helpers.String("port", pprofPort))
+		if err := pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.L().Error("failed to serve pprof", helpers.Error(err))
 		}
 	}()
+}
+
+func getDurationFromEnv(envVar string, defaultValue time.Duration) time.Duration {
+	if value := os.Getenv(envVar); value != "" {
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			logger.L().Warning("invalid duration for env var, using default",
+				helpers.String("env", envVar),
+				helpers.String("value", value),
+				helpers.Error(err),
+				helpers.String("default", defaultValue.String()))
+			return defaultValue
+		}
+		if parsed <= 0 {
+			logger.L().Warning("non-positive duration for env var, using default",
+				helpers.String("env", envVar),
+				helpers.String("value", value),
+				helpers.String("default", defaultValue.String()))
+			return defaultValue
+		}
+		return parsed
+	}
+
+	return defaultValue
+}
+
+func getMaxHeaderBytes() int {
+	if value := os.Getenv(envMaxHeaderBytes); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed <= 0 {
+			logger.L().Warning("invalid max header bytes value, using default",
+				helpers.String("env", envMaxHeaderBytes),
+				helpers.String("value", value),
+				helpers.Int("default", defaultMaxHeaderBytes))
+			return defaultMaxHeaderBytes
+		}
+		return parsed
+	}
+
+	return defaultMaxHeaderBytes
 }

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -113,3 +113,52 @@ func TestGetOffline(t *testing.T) {
 		}
 	})
 }
+
+func TestGetDurationFromEnv(t *testing.T) {
+	t.Run("returns default when unset", func(t *testing.T) {
+		t.Setenv(envReadTimeout, "")
+		assert.Equal(t, defaultReadTimeout, getDurationFromEnv(envReadTimeout, defaultReadTimeout))
+	})
+
+	t.Run("returns parsed duration when valid", func(t *testing.T) {
+		t.Setenv(envReadTimeout, "45s")
+		assert.Equal(t, 45*time.Second, getDurationFromEnv(envReadTimeout, defaultReadTimeout))
+	})
+
+	t.Run("returns default on invalid duration", func(t *testing.T) {
+		t.Setenv(envReadTimeout, "not-a-duration")
+		assert.Equal(t, defaultReadTimeout, getDurationFromEnv(envReadTimeout, defaultReadTimeout))
+	})
+
+	t.Run("returns default on negative duration", func(t *testing.T) {
+		t.Setenv(envReadTimeout, "-5s")
+		assert.Equal(t, defaultReadTimeout, getDurationFromEnv(envReadTimeout, defaultReadTimeout))
+	})
+
+	t.Run("returns default on zero duration", func(t *testing.T) {
+		t.Setenv(envReadTimeout, "0s")
+		assert.Equal(t, defaultReadTimeout, getDurationFromEnv(envReadTimeout, defaultReadTimeout))
+	})
+}
+
+func TestGetMaxHeaderBytes(t *testing.T) {
+	t.Run("returns default when unset", func(t *testing.T) {
+		t.Setenv(envMaxHeaderBytes, "")
+		assert.Equal(t, defaultMaxHeaderBytes, getMaxHeaderBytes())
+	})
+
+	t.Run("returns parsed integer when valid", func(t *testing.T) {
+		t.Setenv(envMaxHeaderBytes, "2048")
+		assert.Equal(t, 2048, getMaxHeaderBytes())
+	})
+
+	t.Run("returns default on invalid integer", func(t *testing.T) {
+		t.Setenv(envMaxHeaderBytes, "not-a-number")
+		assert.Equal(t, defaultMaxHeaderBytes, getMaxHeaderBytes())
+	})
+
+	t.Run("returns default on non-positive integer", func(t *testing.T) {
+		t.Setenv(envMaxHeaderBytes, "0")
+		assert.Equal(t, defaultMaxHeaderBytes, getMaxHeaderBytes())
+	})
+}


### PR DESCRIPTION
Add default HTTP server timeouts and max header size with env overrides.
Apply the same limits to the debug pprof listener.
Document the new timeout environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five environment variables to configure HTTP server timeouts and maximum header size; the profiling endpoint now runs on a configurable port and respects these settings.

* **Bug Fixes**
  * Namespace include/exclude parsing trims surrounding whitespace to prevent empty or incorrect entries.

* **Documentation**
  * Updated HTTP handler docs to document the new env options and added a Go upgrade/audit snapshot guide.

* **Tests**
  * Added unit tests covering env-driven timeout and header-size parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->