### PR TITLE
clarification for score threshold scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,11 @@ kubescape scan --exclude-namespaces kube-system,kube-public
 # Use alternative kubeconfig
 kubescape scan --kubeconfig /path/to/kubeconfig
 
-# Set compliance threshold (exit code 1 if below threshold)
-kubescape scan --compliance-threshold 80
+# Set compliance threshold (exit code 1 if below threshold).
+# Score thresholds apply to the framework/control subcommands and to
+# --view resource|control.
+kubescape scan framework nsa --compliance-threshold 80
+kubescape scan --view resource --compliance-threshold 80
 
 # Set severity threshold
 kubescape scan --severity-threshold high

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -89,8 +89,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. e.g: --exclude-namespaces ns-a,ns-b. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")
 
-	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
-	scanCmd.PersistentFlags().Float32VarP(&scanInfo.ComplianceThreshold, "compliance-threshold", "", 0, "Compliance threshold is the percent below which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1. Applies to 'scan framework', 'scan control', and '--view resource|control'")
+	scanCmd.PersistentFlags().Float32VarP(&scanInfo.ComplianceThreshold, "compliance-threshold", "", 0, "Compliance threshold is the percent below which the command fails and returns exit code 1. Applies to 'scan framework', 'scan control', and '--view resource|control'")
 	scanCmd.PersistentFlags().Float32Var(&scanInfo.FailCoverageThreshold, "fail-coverage-below", 0, "Minimum percentage of controls that must be evaluated (0 to disable). If coverage drops below this threshold the command returns exit code 1")
 
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -38,7 +38,7 @@ kubescape scan [target] [flags]
 |------|-------------|---------|
 | `--account <id>` | Kubescape SaaS account ID | from cache |
 | `--access-key <key>` | Kubescape SaaS access key | from cache |
-| `--compliance-threshold <float>` | Fail if compliance score is below threshold | `0` |
+| `--compliance-threshold <float>` | Fail if compliance score is below threshold. Applies to `scan framework`, `scan control`, and `--view resource\|control` — see [score thresholds](#score-thresholds). | `0` |
 | `--controls-config <path>` | Path to controls configuration file | - |
 | `-e, --exclude-namespaces <ns>` | Namespaces to exclude (comma-separated) | - |
 | `--exceptions <path>` | Path to exceptions file | - |
@@ -78,12 +78,28 @@ kubescape scan https://github.com/org/repo
 # Output to JSON file
 kubescape scan --format json --output results.json
 
-# Set compliance threshold (exit 1 if below)
-kubescape scan --compliance-threshold 80
+# Set compliance threshold (exit 1 if below). Combine with a framework,
+# control, or --view resource|control (see "Score thresholds" below).
+kubescape scan framework nsa --compliance-threshold 80
+kubescape scan --view resource --compliance-threshold 80
 
 # Exclude namespaces
 kubescape scan --exclude-namespaces kube-system,kube-public
 ```
+
+### Score thresholds
+
+`--compliance-threshold` (compliance score) and the deprecated
+`--fail-threshold` (risk score) apply to the following invocations:
+
+- `kubescape scan framework <name> ...`
+- `kubescape scan control <id> ...`
+- `kubescape scan --view resource ...` or `--view control ...`
+
+The default `kubescape scan [path]` uses `--view security`, which does
+not evaluate against a score threshold. To gate a pipeline on the
+compliance or risk score, use one of the forms above.
+`--severity-threshold` and `--fail-coverage-below` apply in every view.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -252,14 +252,23 @@ kubescape operator scan vulnerabilities
 
 We offer two important metrics to assess compliance:
 
-- Control Compliance Score: This score measures the compliance of individual controls within a framework. It is calculated by evaluating the ratio of resources that passed to the total number of resources evaluated against that control.
+- Control Compliance Score: This score measures the compliance of individual controls within a framework. It is calculated by evaluating the ratio of resources that passed to the total number of resources evaluated against that control. To check against a threshold, use the resource or control view:
     ```bash
-    kubescape scan --compliance-threshold <SCORE_VALUE[float32]>
+    kubescape scan --view resource  --compliance-threshold <SCORE_VALUE[float32]>
+    kubescape scan --view control   --compliance-threshold <SCORE_VALUE[float32]>
+    kubescape scan control <CONTROL_ID> --compliance-threshold <SCORE_VALUE[float32]>
     ```
 - Framework Compliance Score: This score provides an overall assessment of your cluster's compliance with a specific framework. It is calculated by averaging the Control Compliance Scores of all controls within the framework.
     ```bash
     kubescape scan framework <FRAMEWORK_NAME> --compliance-threshold <SCORE_VALUE[float32]>
     ```
+
+`--compliance-threshold` (compliance score) and the deprecated
+`--fail-threshold` (risk score) apply to the framework/control
+subcommands and to `--view resource|control`. The default
+`kubescape scan <path>` (security view) does not evaluate against
+these score thresholds, so use one of the forms above when you want
+the exit code to reflect the score.
 
 ### Output Formats
 


### PR DESCRIPTION
## Overview

`--compliance-threshold` and the deprecated `--fail-threshold` are only enforced by `kubescape scan framework`, `kubescape scan control`, and `kubescape scan --view resource|control`. The default `kubescape scan <path>` uses `--view security` and does not evaluate against a score threshold, so the exit code is always `0` regardless of the compliance/risk score.

Updates in this repo:

- `cmd/scan/scan.go` — flag help text for `--compliance-threshold` and `--fail-threshold` now states which invocations enforce the threshold.
- `README.md` — the "Scan Options" example replaces the bare `kubescape scan --compliance-threshold 80` with the enforcing forms (`scan framework nsa ...` and `scan --view resource ...`).
- `docs/cli-reference.md` — flag table entry annotated and a new "Score thresholds" subsection added under `kubescape scan`, listing the enforcing invocations and noting that `--severity-threshold` / `--fail-coverage-below` apply in every view.
- `docs/getting-started.md` — Compliance Score section updated to use the enforcing invocations and to call out that the default security view doesn't evaluate against a score threshold.

A companion PR against [kubescape/kubescape.io](https://github.com/kubescape/kubescape.io) adds the same "Score-based thresholds" section to `docs/docs/scanning.md` so the public docs site matches.
will raise that PR once this lands.

## How to Test

A single privileged Deployment scores well below 99, so the reproducer from the issue is a clean way to verify the documented scope. Build, then run:

```
$ cat > /tmp/priv.yaml <<'EOF'
apiVersion: apps/v1
kind: Deployment
metadata: {name: priv, namespace: default}
spec:
  replicas: 1
  selector: {matchLabels: {app: x}}
  template:
    metadata: {labels: {app: x}}
    spec:
      containers:
      - name: c
        image: nginx:latest
        securityContext: {privileged: true}
EOF

$ go build -o /tmp/kubescape .

# Default security view — documented as NOT evaluating the threshold:
$ /tmp/kubescape scan --compliance-threshold 99 /tmp/priv.yaml; echo $?
0

# Enforcing forms — all four documented invocations exit 1 with a fatal log:
$ /tmp/kubescape scan framework nsa --compliance-threshold 99 /tmp/priv.yaml; echo $?
{"level":"fatal","msg":"scan compliance-score is below permitted threshold","compliance-score":"60.00","compliance-threshold":"99.00"}
1

$ /tmp/kubescape scan control C-0057 --compliance-threshold 99 /tmp/priv.yaml; echo $?
1

$ /tmp/kubescape scan --view resource --compliance-threshold 99 /tmp/priv.yaml; echo $?
1

$ /tmp/kubescape scan --view control --compliance-threshold 99 /tmp/priv.yaml; echo $?
1

# Deprecated --fail-threshold has the same scope (separate metric — risk score):
$ /tmp/kubescape scan --fail-threshold 0 /tmp/priv.yaml; echo $?
0
$ /tmp/kubescape scan framework nsa --fail-threshold 0 /tmp/priv.yaml; echo $?
1

# --severity-threshold applies in every view, as documented:
$ /tmp/kubescape scan --severity-threshold low /tmp/priv.yaml; echo $?
1
```

Also render `docs/cli-reference.md` and `docs/getting-started.md` and confirm the new "Score thresholds" subsection / Compliance Score callout read correctly.


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. *(docs-only change; no behavior change)*
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated threshold flag documentation with clearer scope definitions and practical command examples.
  * Expanded CLI reference with detailed usage examples for framework, control, and resource views.
  * Enhanced guidance on compliance score calculation and threshold behavior across scan modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->