### PR TITLE
Emit SecurityException events for posture exception matches

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -258,7 +258,11 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 	case "list_vulnerability_manifests":
 		namespace := metav1.NamespaceAll
 		if ns, ok := arguments["namespace"]; ok {
-			if nsStr, ok := ns.(string); ok && nsStr != "" {
+			nsStr, ok := ns.(string)
+			if !ok {
+				return nil, fmt.Errorf("namespace must be a string")
+			}
+			if nsStr != "" {
 				namespace = nsStr
 			}
 		}

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -239,6 +239,7 @@ func TestIsFileAndIsDir(t *testing.T) {
 	assert.True(t, isFile(tempFile))
 	assert.False(t, isDir(tempFile))
 
-	assert.False(t, isFile("non-existent-path"))
-	assert.False(t, isDir("non-existent-path"))
+	missingPath := filepath.Join(tempDir, "missing-path")
+	assert.False(t, isFile(missingPath))
+	assert.False(t, isDir(missingPath))
 }

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -101,7 +101,10 @@ func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind stri
 	reason, _, _ := unstructured.NestedString(obj.Object, "spec", "reason")
 	expiresAt, _, _ := unstructured.NestedString(obj.Object, "spec", "expiresAt")
 	postureItems, _, _ := unstructured.NestedSlice(obj.Object, "spec", "posture")
-	resources, _ := buildResourceDesignators(obj, kind)
+	resources, err := buildResourceDesignators(obj, kind)
+	if err != nil {
+		return nil, err
+	}
 
 	policies := make([]armotypes.PostureExceptionPolicy, 0, len(postureItems))
 	for _, raw := range postureItems {
@@ -142,6 +145,10 @@ func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]ma
 	namespace := obj.GetNamespace()
 	if kind == "SecurityException" && namespace != "" {
 		designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
+	}
+
+	if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "match", "objectSelector"); found {
+		return nil, fmt.Errorf("spec.match.objectSelector is not supported")
 	}
 
 	resources, _, _ := unstructured.NestedSlice(obj.Object, "spec", "match", "resources")

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +150,11 @@ func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]ma
 	}
 
 	if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "match", "objectSelector"); found {
+		logger.L().Warning("SecurityException CRD uses unsupported spec.match.objectSelector; skipping",
+			helpers.String("name", obj.GetName()),
+			helpers.String("namespace", namespace),
+			helpers.String("kind", kind),
+		)
 		return nil, fmt.Errorf("spec.match.objectSelector is not supported")
 	}
 

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -1,0 +1,239 @@
+package getter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	securityExceptionGroup   = "kubescape.io"
+	securityExceptionVersion = "v1"
+)
+
+var (
+	securityExceptionGVR = schema.GroupVersionResource{
+		Group:    securityExceptionGroup,
+		Version:  securityExceptionVersion,
+		Resource: "securityexceptions",
+	}
+	clusterSecurityExceptionGVR = schema.GroupVersionResource{
+		Group:    securityExceptionGroup,
+		Version:  securityExceptionVersion,
+		Resource: "clustersecurityexceptions",
+	}
+)
+
+var _ IExceptionsGetter = &CRDExceptionsGetter{}
+
+// CRDExceptionsGetter retrieves posture exceptions from SecurityException CRDs in-cluster.
+type CRDExceptionsGetter struct {
+	client dynamic.Interface
+}
+
+func NewCRDExceptionsGetter() *CRDExceptionsGetter {
+	if !k8sinterface.IsConnectedToCluster() {
+		return &CRDExceptionsGetter{}
+	}
+	config := k8sinterface.GetK8sConfig()
+	if config == nil {
+		return &CRDExceptionsGetter{}
+	}
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return &CRDExceptionsGetter{}
+	}
+	return &CRDExceptionsGetter{client: client}
+}
+
+func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExceptionPolicy, error) {
+	if g == nil || g.client == nil {
+		return []armotypes.PostureExceptionPolicy{}, nil
+	}
+
+	var out []armotypes.PostureExceptionPolicy
+
+	seList, err := g.client.Resource(securityExceptionGVR).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range seList.Items {
+		policies, convErr := convertCRDObjectToPosturePolicies(&seList.Items[i], "SecurityException")
+		if convErr != nil {
+			continue
+		}
+		out = append(out, policies...)
+	}
+
+	cseList, err := g.client.Resource(clusterSecurityExceptionGVR).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range cseList.Items {
+		policies, convErr := convertCRDObjectToPosturePolicies(&cseList.Items[i], "ClusterSecurityException")
+		if convErr != nil {
+			continue
+		}
+		out = append(out, policies...)
+	}
+
+	return out, nil
+}
+
+func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind string) ([]armotypes.PostureExceptionPolicy, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("nil object")
+	}
+	name := obj.GetName()
+	if name == "" {
+		return nil, fmt.Errorf("missing name")
+	}
+
+	reason, _, _ := unstructured.NestedString(obj.Object, "spec", "reason")
+	expiresAt, _, _ := unstructured.NestedString(obj.Object, "spec", "expiresAt")
+	postureItems, _, _ := unstructured.NestedSlice(obj.Object, "spec", "posture")
+	resources, _ := buildResourceDesignators(obj, kind)
+
+	policies := make([]armotypes.PostureExceptionPolicy, 0, len(postureItems))
+	for _, raw := range postureItems {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		controlID, _ := item["controlID"].(string)
+		if controlID == "" {
+			continue
+		}
+		action, _ := item["action"].(string)
+		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, "", action, expiresAt, reason, resources)
+		if err != nil {
+			continue
+		}
+		attrs := securityexception.CRDReferenceAttributes(securityexception.CRDReference{
+			Kind:      kind,
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+			UID:       string(obj.GetUID()),
+		})
+		if policy.Attributes == nil {
+			policy.Attributes = map[string]interface{}{}
+		}
+		for k, v := range attrs {
+			policy.Attributes[k] = v
+		}
+		policies = append(policies, policy)
+	}
+
+	return policies, nil
+}
+
+func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]map[string]string, error) {
+	designators := make([]map[string]string, 0, 2)
+
+	namespace := obj.GetNamespace()
+	if kind == "SecurityException" && namespace != "" {
+		designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
+	}
+
+	resources, _, _ := unstructured.NestedSlice(obj.Object, "spec", "match", "resources")
+	for _, raw := range resources {
+		resource, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		attrs := map[string]string{}
+		if namespace != "" {
+			attrs[identifiers.AttributeNamespace] = namespace
+		}
+		if kindVal, ok := resource["kind"].(string); ok && kindVal != "" {
+			attrs[identifiers.AttributeKind] = kindVal
+		}
+		if nameVal, ok := resource["name"].(string); ok && nameVal != "" {
+			attrs[identifiers.AttributeName] = nameVal
+		}
+		if apiGroup, ok := resource["apiGroup"].(string); ok && apiGroup != "" {
+			attrs[identifiers.AttributeApiGroup] = apiGroup
+		}
+		if len(attrs) > 0 {
+			designators = append(designators, attrs)
+		}
+	}
+
+	// Ensure the exception has at least one scope designator, otherwise exception processor ignores it.
+	if len(designators) == 0 {
+		designators = append(designators, map[string]string{identifiers.AttributeKind: "*"})
+	}
+
+	return designators, nil
+}
+
+func convertSecurityExceptionToPosturePolicy(
+	name string,
+	controlID string,
+	frameworkName string,
+	action string,
+	expiresAt string,
+	reason string,
+	resources []map[string]string,
+) (armotypes.PostureExceptionPolicy, error) {
+	var actions []armotypes.PostureExceptionPolicyActions
+	switch action {
+	case "ignore":
+		actions = []armotypes.PostureExceptionPolicyActions{armotypes.Disable}
+	case "alert_only", "":
+		actions = []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly}
+	default:
+		return armotypes.PostureExceptionPolicy{}, fmt.Errorf("unknown action %q: must be ignore or alert_only", action)
+	}
+
+	var expirationDate *time.Time
+	if expiresAt != "" {
+		t, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil {
+			return armotypes.PostureExceptionPolicy{}, fmt.Errorf("invalid expiresAt %q: %w", expiresAt, err)
+		}
+		expirationDate = &t
+	}
+
+	var designators []identifiers.PortalDesignator
+	for _, res := range resources {
+		if len(res) == 0 {
+			continue
+		}
+		designators = append(designators, identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
+			Attributes:     res,
+		})
+	}
+
+	var reasonPtr *string
+	if reason != "" {
+		reasonPtr = &reason
+	}
+
+	policy := armotypes.PostureExceptionPolicy{
+		PolicyType: string(armotypes.PostureExceptionPolicyType),
+		Actions:    actions,
+		Resources:  designators,
+		PosturePolicies: []armotypes.PosturePolicy{
+			{
+				ControlID:     controlID,
+				FrameworkName: frameworkName,
+			},
+		},
+		ExpirationDate: expirationDate,
+		Reason:         reasonPtr,
+	}
+	policy.Name = fmt.Sprintf("%s/%s", name, controlID)
+
+	return policy, nil
+}

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -92,3 +92,25 @@ func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 	require.Len(t, policies, 1)
 	assert.Equal(t, "*", policies[0].Resources[0].Attributes[identifiers.AttributeKind])
 }
+
+func TestConvertCRDObjectToPosturePolicies_ObjectSelectorIsRejected(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "SecurityException"})
+	obj.SetName("se-selector")
+	obj.SetNamespace("team-a")
+	obj.Object["spec"] = map[string]interface{}{
+		"match": map[string]interface{}{
+			"objectSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": "nginx"},
+			},
+		},
+		"posture": []interface{}{
+			map[string]interface{}{"controlID": "C-0100", "action": "ignore"},
+		},
+	}
+
+	policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec.match.objectSelector is not supported")
+	assert.Nil(t, policies)
+}

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -1,0 +1,94 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewSimpleDynamicClient(scheme,
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       "SecurityException",
+				"metadata": map[string]interface{}{
+					"name":      "se-a",
+					"namespace": "team-a",
+					"uid":       "uid-se-a",
+				},
+				"spec": map[string]interface{}{
+					"reason": "maintenance",
+					"posture": []interface{}{
+						map[string]interface{}{"controlID": "C-0001", "action": "ignore"},
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       "ClusterSecurityException",
+				"metadata": map[string]interface{}{
+					"name": "cse-a",
+					"uid":  "uid-cse-a",
+				},
+				"spec": map[string]interface{}{
+					"posture": []interface{}{
+						map[string]interface{}{"controlID": "C-0002", "action": "alert_only"},
+					},
+				},
+			},
+		},
+	)
+
+	getter := &CRDExceptionsGetter{client: client}
+	exceptions, err := getter.GetExceptions("cluster-a")
+	require.NoError(t, err)
+	require.Len(t, exceptions, 2)
+
+	assert.Equal(t, string(armotypes.PostureExceptionPolicyType), exceptions[0].PolicyType)
+	assert.Equal(t, "C-0001", exceptions[0].PosturePolicies[0].ControlID)
+	assert.True(t, exceptions[0].IsDisable())
+	assert.Equal(t, "team-a", exceptions[0].Resources[0].Attributes[identifiers.AttributeNamespace])
+	assert.Equal(t, "SecurityException", exceptions[0].Attributes["securityExceptionKind"])
+	assert.Equal(t, "se-a", exceptions[0].Attributes["securityExceptionName"])
+	assert.Equal(t, "team-a", exceptions[0].Attributes["securityExceptionNamespace"])
+
+	assert.Equal(t, "C-0002", exceptions[1].PosturePolicies[0].ControlID)
+	assert.True(t, exceptions[1].IsAlertOnly())
+	assert.Equal(t, "ClusterSecurityException", exceptions[1].Attributes["securityExceptionKind"])
+	assert.Equal(t, "cse-a", exceptions[1].Attributes["securityExceptionName"])
+}
+
+func TestCRDExceptionsGetter_NilClient(t *testing.T) {
+	getter := &CRDExceptionsGetter{}
+	exceptions, err := getter.GetExceptions("cluster-a")
+	require.NoError(t, err)
+	assert.Empty(t, exceptions)
+}
+
+func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "ClusterSecurityException"})
+	obj.SetName("cse-empty")
+	obj.SetUID("uid-cse")
+	obj.Object["spec"] = map[string]interface{}{
+		"posture": []interface{}{
+			map[string]interface{}{"controlID": "C-0099"},
+		},
+	}
+
+	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException")
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "*", policies[0].Resources[0].Attributes[identifiers.AttributeKind])
+}

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -1,0 +1,45 @@
+package getter
+
+import "github.com/armosec/armoapi-go/armotypes"
+
+var _ IExceptionsGetter = &MergedExceptionsGetter{}
+
+// MergedExceptionsGetter combines exceptions from a primary source and a secondary source.
+// Primary source failures are returned as errors; secondary source failures are ignored.
+type MergedExceptionsGetter struct {
+	primary   IExceptionsGetter
+	secondary IExceptionsGetter
+}
+
+func NewMergedExceptionsGetter(primary, secondary IExceptionsGetter) *MergedExceptionsGetter {
+	return &MergedExceptionsGetter{primary: primary, secondary: secondary}
+}
+
+func (g *MergedExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	if g == nil || g.primary == nil {
+		return []armotypes.PostureExceptionPolicy{}, nil
+	}
+
+	exceptions, err := g.primary.GetExceptions(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if g.secondary == nil {
+		return exceptions, nil
+	}
+
+	crdExceptions, err := g.secondary.GetExceptions(clusterName)
+	if err != nil {
+		return exceptions, nil
+	}
+
+	if len(crdExceptions) == 0 {
+		return exceptions, nil
+	}
+
+	merged := make([]armotypes.PostureExceptionPolicy, 0, len(exceptions)+len(crdExceptions))
+	merged = append(merged, exceptions...)
+	merged = append(merged, crdExceptions...)
+	return merged, nil
+}

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -1,0 +1,81 @@
+package getter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type exceptionsGetterStub struct {
+	exceptions []armotypes.PostureExceptionPolicy
+	err        error
+}
+
+func (s *exceptionsGetterStub) GetExceptions(_ string) ([]armotypes.PostureExceptionPolicy, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.exceptions, nil
+}
+
+func TestMergedExceptionsGetter(t *testing.T) {
+	tests := []struct {
+		name    string
+		getter  *MergedExceptionsGetter
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "nil getter returns empty",
+			getter:  nil,
+			wantLen: 0,
+		},
+		{
+			name: "primary only",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+				nil,
+			),
+			wantLen: 1,
+		},
+		{
+			name: "merge both",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
+			),
+			wantLen: 2,
+		},
+		{
+			name: "secondary error ignored",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+				&exceptionsGetterStub{err: fmt.Errorf("secondary failed")},
+			),
+			wantLen: 1,
+		},
+		{
+			name: "primary error returned",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{err: fmt.Errorf("primary failed")},
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
+			),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.getter.GetExceptions("cluster-a")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, out, tc.wantLen)
+		})
+	}
+}

--- a/core/core/exceptionevents.go
+++ b/core/core/exceptionevents.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func newSecurityExceptionEventRecorder() record.EventRecorder {
+	if !k8sinterface.IsConnectedToCluster() {
+		return nil
+	}
+
+	k8s := getKubernetesApi()
+	if k8s == nil || k8s.KubernetesClient == nil {
+		return nil
+	}
+
+	return newSecurityExceptionEventRecorderWithClient(k8s.KubernetesClient)
+}
+
+func newSecurityExceptionEventRecorderWithClient(k8sClient kubernetes.Interface) record.EventRecorder {
+	if k8sClient == nil {
+		return nil
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
+	return broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kubescape"})
+}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -29,13 +29,17 @@ func getKubernetesApi() *k8sinterface.KubernetesApi {
 }
 
 func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IExceptionsGetter {
+	var primary getter.IExceptionsGetter
+
 	if useExceptions != "" {
 		// load exceptions from file
-		return getter.NewLoadPolicy([]string{useExceptions})
+		primary = getter.NewLoadPolicy([]string{useExceptions})
+		return primary
 	}
 	if accountID != "" {
 		// download exceptions from Kubescape Cloud backend
-		return getter.GetKSCloudAPIConnector()
+		primary = getter.GetKSCloudAPIConnector()
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
 	}
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
@@ -43,9 +47,11 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	}
 	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading attack tracks from cache", helpers.Error(err))
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
+		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
 	}
-	return downloadReleasedPolicy
+	primary = downloadReleasedPolicy
+	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
 
 }
 

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -86,7 +86,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 				accountID:              "",
 				downloadReleasedPolicy: nil,
 			},
-			want: "*getter.DownloadReleasedPolicy",
+			want: "*getter.MergedExceptionsGetter",
 		},
 		{
 			name: "Test GetExceptionsGetter empty useExceptions",
@@ -96,7 +96,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 				accountID:              "",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
 			},
-			want: "*getter.DownloadReleasedPolicy",
+			want: "*getter.MergedExceptionsGetter",
 		},
 		{
 			name: "Test GetExceptionsGetter with useExceptions and empty accountID",
@@ -126,7 +126,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 				accountID:              "123456789012",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
 			},
-			want: "*v1.KSCloudAPI",
+			want: "*getter.MergedExceptionsGetter",
 		},
 	}
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -203,7 +203,8 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	defer spanOpa.End()
 
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
-	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint)
+	var exceptionRecorder = newSecurityExceptionEventRecorder()
+	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, exceptionRecorder)
 	if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
 		logger.L().Ctx(ctxOpa).Error("failed to process rules", helpers.Error(err))
 		return resultsHandling, fmt.Errorf("%w", err)

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -15,7 +15,6 @@ import (
 func resetMetricsForTest(t *testing.T) {
 	t.Helper()
 
-	savedInitOnce := initOnce
 	savedKubernetesResourcesCount := kubernetesResourcesCount
 	savedWorkerNodesCount := workerNodesCount
 
@@ -24,7 +23,7 @@ func resetMetricsForTest(t *testing.T) {
 	workerNodesCount = nil
 
 	t.Cleanup(func() {
-		initOnce = savedInitOnce
+		initOnce = sync.Once{}
 		kubernetesResourcesCount = savedKubernetesResourcesCount
 		workerNodesCount = savedWorkerNodesCount
 	})

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -744,9 +744,20 @@ func GetFileString(filepath string) (string, error) {
 }
 
 func writeFixesToFile(filepath, content string) error {
-	err := os.WriteFile(filepath, []byte(content), 0644) //nolint:gosec // Writes back to user's own manifest files; 0644 preserves expected permissions.
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(filepath); err == nil {
+		perm = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("error reading file permissions: %w", err)
+	}
 
+	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // Writes back to user's own manifest files; preserve existing permissions.
 	if err != nil {
+		return fmt.Errorf("error writing fixes to file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(content); err != nil {
 		return fmt.Errorf("error writing fixes to file: %w", err)
 	}
 

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -751,7 +751,7 @@ func writeFixesToFile(filepath, content string) error {
 		return fmt.Errorf("error reading file permissions: %w", err)
 	}
 
-	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // Writes back to user's own manifest files; preserve existing permissions.
+	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return fmt.Errorf("error writing fixes to file: %w", err)
 	}

--- a/core/pkg/opaprocessor/exceptionevents.go
+++ b/core/pkg/opaprocessor/exceptionevents.go
@@ -1,0 +1,60 @@
+package opaprocessor
+
+import (
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (opap *OPAProcessor) emitExceptionMatchEvents(resource workloadinterface.IMetadata, result resourcesresults.Result) {
+	if opap.exceptionEventRecorder == nil || resource == nil {
+		return
+	}
+
+	resourceKind := resource.GetKind()
+	resourceName := resource.GetName()
+	if resourceKind == "" || resourceName == "" {
+		return
+	}
+
+	namespace := resource.GetNamespace()
+	if namespace == "" {
+		namespace = "cluster-scope"
+	}
+
+	emitted := map[string]struct{}{}
+	resourceID := resource.GetID()
+
+	for _, control := range result.AssociatedControls {
+		if control.ControlID == "" {
+			continue
+		}
+		for _, rule := range control.ResourceAssociatedRules {
+			for _, exception := range rule.Exception {
+				ref, ok := securityexception.CRDReferenceFromPolicy(exception)
+				if !ok {
+					continue
+				}
+				key := fmt.Sprintf("%s/%s/%s/%s/%s", ref.Kind, ref.Namespace, ref.Name, control.ControlID, resourceID)
+				if _, exists := emitted[key]; exists {
+					continue
+				}
+				emitted[key] = struct{}{}
+				obj := securityexception.UnstructuredForCRD(ref)
+				opap.exceptionEventRecorder.Eventf(
+					obj,
+					corev1.EventTypeNormal,
+					"ExceptionMatched",
+					"Matched control %s on %s/%s in namespace %s",
+					control.ControlID,
+					resourceKind,
+					resourceName,
+					namespace,
+				)
+			}
+		}
+	}
+}

--- a/core/pkg/opaprocessor/exceptionevents_test.go
+++ b/core/pkg/opaprocessor/exceptionevents_test.go
@@ -1,0 +1,87 @@
+package opaprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestEmitExceptionMatchEvents(t *testing.T) {
+	resourceJSON := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx-frontend","namespace":"production"}}`)
+	resource, err := workloadinterface.NewWorkload(resourceJSON)
+	if err != nil {
+		t.Fatalf("failed to create workload: %v", err)
+	}
+
+	crdException := armotypes.PostureExceptionPolicy{
+		PortalBase: armotypes.PortalBase{
+			Attributes: securityexception.CRDReferenceAttributes(securityexception.CRDReference{
+				Kind:      "SecurityException",
+				Name:      "nginx-exceptions",
+				Namespace: "production",
+			}),
+		},
+	}
+
+	tests := []struct {
+		name            string
+		exceptions      []armotypes.PostureExceptionPolicy
+		expectEvent     bool
+		expectedMessage string
+	}{
+		{
+			name:        "event emitted on match",
+			exceptions:  []armotypes.PostureExceptionPolicy{crdException},
+			expectEvent: true,
+			expectedMessage: "Matched control C-0034 on Deployment/nginx-frontend in namespace production",
+		},
+		{
+			name:        "no event on non-crd exception",
+			exceptions:  []armotypes.PostureExceptionPolicy{{}},
+			expectEvent: false,
+		},
+		{
+			name:        "no event on no match",
+			exceptions:  nil,
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(1)
+			opap := &OPAProcessor{exceptionEventRecorder: recorder}
+
+			result := resourcesresults.Result{
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: "C-0034",
+						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+							{Exception: tt.exceptions},
+						},
+					},
+				},
+			}
+
+			opap.emitExceptionMatchEvents(resource, result)
+
+			select {
+			case got := <-recorder.Events:
+				if !tt.expectEvent {
+					t.Fatalf("unexpected event: %s", got)
+				}
+				assert.Equal(t, "Normal ExceptionMatched "+tt.expectedMessage, got)
+			case <-time.After(100 * time.Millisecond):
+				if tt.expectEvent {
+					t.Fatalf("expected an event but none was recorded")
+				}
+			}
+		})
+	}
+}

--- a/core/pkg/opaprocessor/exceptionevents_test.go
+++ b/core/pkg/opaprocessor/exceptionevents_test.go
@@ -36,9 +36,9 @@ func TestEmitExceptionMatchEvents(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name:        "event emitted on match",
-			exceptions:  []armotypes.PostureExceptionPolicy{crdException},
-			expectEvent: true,
+			name:            "event emitted on match",
+			exceptions:      []armotypes.PostureExceptionPolicy{crdException},
+			expectEvent:     true,
 			expectedMessage: "Matched control C-0034 on Deployment/nginx-frontend in namespace production",
 		},
 		{

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	opaprint "github.com/open-policy-agent/opa/v1/topdown/print"
 	"go.opentelemetry.io/otel"
+	"k8s.io/client-go/tools/record"
 )
 
 const ScoreConfigPath = "/resources/config"
@@ -41,6 +42,7 @@ type OPAProcessor struct {
 	clusterName          string
 	regoDependenciesData *resources.RegoDependenciesData
 	*cautils.OPASessionObj
+	exceptionEventRecorder record.EventRecorder
 	opaRegisterOnce   sync.Once
 	excludeNamespaces []string
 	includeNamespaces []string
@@ -49,7 +51,7 @@ type OPAProcessor struct {
 	compiledMu        sync.RWMutex
 }
 
-func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool) *OPAProcessor {
+func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
 	if regoDependenciesData != nil && sessionObj != nil {
 		regoDependenciesData.PostureControlInputs = sessionObj.RegoInputData.PostureControlInputs
 		regoDependenciesData.DataControlInputs = sessionObj.RegoInputData.DataControlInputs
@@ -59,6 +61,7 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		OPASessionObj:        sessionObj,
 		regoDependenciesData: regoDependenciesData,
 		clusterName:          clusterName,
+		exceptionEventRecorder: exceptionEventRecorder,
 		excludeNamespaces:    split(excludeNamespaces),
 		includeNamespaces:    split(includeNamespaces),
 		printEnabled:         enableRegoPrint,

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -201,7 +201,7 @@ func TestProcessResourcesResult(t *testing.T) {
 	opaSessionObj.K8SResources = k8sResources
 	opaSessionObj.AllResources[deployment.GetID()] = deployment
 
-	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false)
+	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
 	opap.AllPolicies = policies
 	opap.Process(context.Background(), policies, nil)
 

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -61,6 +61,7 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 				opap.AllPolicies.Controls, // update status depending on action required
 				resourcesresults.WithExceptionsProcessor(processor),
 			)
+			opap.emitExceptionMatchEvents(resource, t)
 		}
 
 		// summarize the resources

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -50,8 +51,9 @@ func GetWriter(ctx context.Context, outputFile string) *os.File {
 // GetWriterNoStdoutFallback opens outputFile for writing for formats whose
 // output (binary, markup) would corrupt a TTY if dumped to stdout. On any
 // failure to open the requested file it falls back to a uniquely-named file
-// under os.TempDir() using tempPattern (e.g. "kubescape-report-*.pdf"). Only
-// if even that fails does it return os.DevNull — it never returns os.Stdout.
+// under os.TempDir() using tempPattern (e.g. "kubescape-report-*.pdf"). If
+// that fails it tries os.DevNull, then a pipe-based sink as a last resort.
+// It never returns os.Stdout.
 func GetWriterNoStdoutFallback(ctx context.Context, outputFile, tempPattern string) *os.File {
 	if outputFile != "" {
 		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err == nil {
@@ -73,9 +75,23 @@ func GetWriterNoStdoutFallback(ctx context.Context, outputFile, tempPattern stri
 	}
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err != nil {
-		// os.DevNull should always be openable; if not, fall back to a closed
-		// file rather than stdout so the TTY stays clean.
-		return os.NewFile(0, os.DevNull)
+		// os.DevNull should always be openable; if not, fall back to a temp file
+		// so we still return a writable, closable handle.
+		if tmp, tmpErr := os.CreateTemp(".", tempPattern); tmpErr == nil {
+			logger.L().Ctx(ctx).Warning("failed to open os.DevNull; falling back to temp file",
+				helpers.String("filename", tmp.Name()))
+			return tmp
+		}
+		r, w, pipeErr := os.Pipe()
+		if pipeErr == nil {
+			go func() {
+				_, _ = io.Copy(io.Discard, r)
+				_ = r.Close()
+			}()
+			return w
+		}
+		// Final fallback: return a non-nil file handle even if it is not writable.
+		return os.NewFile(^uintptr(0), os.DevNull)
 	}
 	return devNull
 }

--- a/core/pkg/resultshandling/printer/v1/printer_extra_test.go
+++ b/core/pkg/resultshandling/printer/v1/printer_extra_test.go
@@ -106,6 +106,9 @@ func TestPrometheusPrinterPrintDetails(t *testing.T) {
 			if tt.notWantLine != "" {
 				assert.NotContains(t, string(got), tt.notWantLine)
 			}
+			if len(tt.resources) == 0 {
+				assert.Empty(t, strings.TrimSpace(string(got)))
+			}
 		})
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -11,7 +11,6 @@ import (
 func TestNewHtmlPrinter(t *testing.T) {
 	hp := NewHtmlPrinter()
 	assert.NotNil(t, hp)
-	assert.Empty(t, hp)
 }
 
 func TestSetWriter_Html(t *testing.T) {
@@ -49,7 +48,6 @@ func TestSetWriter_Html(t *testing.T) {
 		},
 	}
 
-	hp := NewHtmlPrinter()
 	ctx := context.Background()
 
 	tmp := t.TempDir()
@@ -60,7 +58,11 @@ func TestSetWriter_Html(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			hp := NewHtmlPrinter()
 			hp.SetWriter(ctx, tt.outputFile)
+			t.Cleanup(func() {
+				_ = hp.writer.Close()
+			})
 			assert.Equal(t, tt.expected, hp.writer.Name())
 			assert.NotEqual(t, "/dev/stdout", hp.writer.Name(),
 				"HTML printer must never write to stdout")

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -11,6 +11,7 @@ import (
 func TestNewHtmlPrinter(t *testing.T) {
 	hp := NewHtmlPrinter()
 	assert.NotNil(t, hp)
+	assert.Nil(t, hp.writer)
 }
 
 func TestSetWriter_Html(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPrometheusPrinter(t *testing.T) {
@@ -77,14 +78,17 @@ func TestScore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Score() must write to pp.writer, not stdout
-			r, w, _ := os.Pipe()
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
 			promPrinter := NewPrometheusPrinter(false)
 			promPrinter.writer = w
 
 			promPrinter.Score(tt.score)
 
-			w.Close()
-			got, _ := io.ReadAll(r)
+			require.NoError(t, w.Close())
+			got, err := io.ReadAll(r)
+			require.NoError(t, err)
+			require.NoError(t, r.Close())
 			assert.Equal(t, tt.want, string(got))
 		})
 	}

--- a/core/pkg/securityexception/exception_events.go
+++ b/core/pkg/securityexception/exception_events.go
@@ -1,0 +1,88 @@
+package securityexception
+
+import (
+	"github.com/armosec/armoapi-go/armotypes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	securityExceptionAPIVersion = "kubescape.io/v1"
+	crdKindAttribute            = "securityExceptionKind"
+	crdNameAttribute            = "securityExceptionName"
+	crdNamespaceAttribute       = "securityExceptionNamespace"
+	crdUIDAttribute             = "securityExceptionUID"
+)
+
+// CRDReference identifies the SecurityException or ClusterSecurityException that produced a policy.
+type CRDReference struct {
+	Kind      string
+	Name      string
+	Namespace string
+	UID       string
+}
+
+// CRDReferenceAttributes builds attribute entries that mark a policy as CRD-backed.
+func CRDReferenceAttributes(ref CRDReference) map[string]interface{} {
+	attrs := map[string]interface{}{
+		crdKindAttribute: ref.Kind,
+		crdNameAttribute: ref.Name,
+	}
+	if ref.Namespace != "" {
+		attrs[crdNamespaceAttribute] = ref.Namespace
+	}
+	if ref.UID != "" {
+		attrs[crdUIDAttribute] = ref.UID
+	}
+	return attrs
+}
+
+// CRDReferenceFromPolicy extracts the CRD reference from a PostureExceptionPolicy.
+func CRDReferenceFromPolicy(policy armotypes.PostureExceptionPolicy) (CRDReference, bool) {
+	if policy.Attributes == nil {
+		return CRDReference{}, false
+	}
+	kind, ok := getStringAttribute(policy.Attributes, crdKindAttribute)
+	if !ok {
+		return CRDReference{}, false
+	}
+	name, ok := getStringAttribute(policy.Attributes, crdNameAttribute)
+	if !ok {
+		return CRDReference{}, false
+	}
+	namespace, _ := getStringAttribute(policy.Attributes, crdNamespaceAttribute)
+	uid, _ := getStringAttribute(policy.Attributes, crdUIDAttribute)
+	return CRDReference{
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		UID:       uid,
+	}, true
+}
+
+// UnstructuredForCRD builds an unstructured object to use as an Event reference.
+func UnstructuredForCRD(ref CRDReference) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(securityExceptionAPIVersion)
+	obj.SetKind(ref.Kind)
+	obj.SetName(ref.Name)
+	if ref.Namespace != "" {
+		obj.SetNamespace(ref.Namespace)
+	}
+	if ref.UID != "" {
+		obj.SetUID(types.UID(ref.UID))
+	}
+	return obj
+}
+
+func getStringAttribute(attrs map[string]interface{}, key string) (string, bool) {
+	raw, ok := attrs[key]
+	if !ok {
+		return "", false
+	}
+	val, ok := raw.(string)
+	if !ok || val == "" {
+		return "", false
+	}
+	return val, true
+}

--- a/examples/helm_chart/templates/clusterrole.yaml
+++ b/examples/helm_chart/templates/clusterrole.yaml
@@ -8,4 +8,7 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "list", "describe"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/anchore/grype/grype/vulnerability"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/match"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/anchore/grype/grype/vulnerability"
-	grypepkg "github.com/anchore/grype/grype/pkg"
-	"github.com/anchore/grype/grype/match"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary
- Emit Kubernetes Events when posture exceptions from SecurityException or ClusterSecurityException match a scanned resource
- Add CRD reference helpers and wire event emission into OPA result processing
- Add events create and patch permissions to the example Helm chart ClusterRole

## Testing
- not run (suggest: go test ./core/pkg/opaprocessor -run TestEmitExceptionMatchEvents)

Refs: #1982, 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security exceptions now emit Kubernetes "ExceptionMatched" events with CRD-reference support and deduplication for clearer audit trails.

* **Bug Fixes**
  * Preserve existing file permissions when writing fixes.
  * More robust stdout fallback when generating printer output (additional temp/pipe fallbacks).

* **Chores**
  * Helm RBAC updated to allow creating/patching Kubernetes events.
  * Minor CLI parsing robustness and various test improvements (including event emission tests).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->