### PR TITLE
fix: normalize mixed-case YAML/JSON manifest extension detection

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -380,11 +380,11 @@ func convertYamlToJson(i interface{}) interface{} {
 }
 
 func IsYaml(filePath string) bool {
-	return slices.Contains(YAML_PREFIX, strings.ReplaceAll(filepath.Ext(filePath), ".", ""))
+	return slices.Contains(YAML_PREFIX, strings.ToLower(strings.TrimPrefix(filepath.Ext(filePath), ".")))
 }
 
 func IsJson(filePath string) bool {
-	return slices.Contains(JSON_PREFIX, strings.ReplaceAll(filepath.Ext(filePath), ".", ""))
+	return slices.Contains(JSON_PREFIX, strings.ToLower(strings.TrimPrefix(filepath.Ext(filePath), ".")))
 }
 
 func glob(root, pattern string, onlyDirectories bool) ([]string, error) {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -45,6 +45,23 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 	}
 }
 
+func TestLoadResourcesFromFiles_SupportsMixedCaseExtensions(t *testing.T) {
+	o, _ := os.Getwd()
+	testDir := filepath.Join(o, "testdata", "mixed_extensions")
+	workloads := LoadResourcesFromFiles(context.Background(), testDir, "")
+	assert.Equal(t, 2, len(workloads))
+
+	expectedFiles := []string{
+		filepath.Join(testDir, "pod.yaml"),
+		filepath.Join(testDir, "service.YAML"),
+	}
+
+	for _, ef := range expectedFiles {
+		_, ok := workloads[ef]
+		assert.True(t, ok, "Expected workload for file %s", ef)
+	}
+}
+
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	sourceToWorkloads, sourceToChartName, err := LoadResourcesFromHelmCharts(context.Background(), helmChartPath(), HelmValueOptions{})
 	assert.NoError(t, err)
@@ -146,7 +163,19 @@ func TestIsYaml(t *testing.T) {
 			want: true,
 		},
 		{
+			path: "temp.YAML",
+			want: true,
+		},
+		{
 			path: "temp.yml",
+			want: true,
+		},
+		{
+			path: "temp.Yml",
+			want: true,
+		},
+		{
+			path: "temp.Yaml",
 			want: true,
 		},
 		{
@@ -154,7 +183,15 @@ func TestIsYaml(t *testing.T) {
 			want: false,
 		},
 		{
+			path: "temp.Json",
+			want: false,
+		},
+		{
 			path: "random.txt",
+			want: false,
+		},
+		{
+			path: "no-ext",
 			want: false,
 		},
 	}
@@ -184,7 +221,23 @@ func TestIsJson(t *testing.T) {
 			want: true,
 		},
 		{
+			path: "temp.JSON",
+			want: true,
+		},
+		{
+			path: "temp.Json",
+			want: true,
+		},
+		{
+			path: "temp.Yaml",
+			want: false,
+		},
+		{
 			path: "random.txt",
+			want: false,
+		},
+		{
+			path: "no-ext",
 			want: false,
 		},
 	}
@@ -207,11 +260,31 @@ func TestGetFileFormat(t *testing.T) {
 			want: YAML_FILE_FORMAT,
 		},
 		{
+			path: "temp.YAML",
+			want: YAML_FILE_FORMAT,
+		},
+		{
 			path: "temp.yml",
 			want: YAML_FILE_FORMAT,
 		},
 		{
+			path: "temp.Yml",
+			want: YAML_FILE_FORMAT,
+		},
+		{
+			path: "temp.Yaml",
+			want: YAML_FILE_FORMAT,
+		},
+		{
 			path: "temp.json",
+			want: JSON_FILE_FORMAT,
+		},
+		{
+			path: "temp.JSON",
+			want: JSON_FILE_FORMAT,
+		},
+		{
+			path: "temp.Json",
 			want: JSON_FILE_FORMAT,
 		},
 		{

--- a/core/cautils/testdata/mixed_extensions/pod.yaml
+++ b/core/cautils/testdata/mixed_extensions/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-yaml
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2

--- a/core/cautils/testdata/mixed_extensions/service.YAML
+++ b/core/cautils/testdata/mixed_extensions/service.YAML
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service-upper-yaml
+spec:
+  ports:
+  - port: 80
+    targetPort: 80


### PR DESCRIPTION
### Problem Summary
Kubescape currently fails to detect and scan valid Kubernetes manifests when they use uppercase or mixed-case extensions (e.g. `.YAML`, `.JSON`, `.Yml`). These files are silently bypassed during directory scans.

### Root Cause
The `IsYaml()` and `IsJson()` file format detection utilities relied on a strictly case-sensitive exact match (`slices.Contains()`) without normalizing the incoming file extension.

### Scope of Fix
This fix updates `core/cautils/fileutils.go` by wrapping the extension extraction in `strings.ToLower(strings.TrimPrefix(...))`. This applies case-insensitive normalization strictly during format validation.

### Verification Steps
1. Executed unit tests (`go test ./core/cautils/...`) asserting all supported extensions.
2. Evaluated table-driven test cases enforcing correctness for `.yaml`, `.YAML`, `.Yaml`, `.json`, `.JSON`, and `.Json`.
3. Added and verified an integration-style directory scan test leveraging mixed-case mocks (`testdata/mixed_extensions/`).

### Before/After Behavior Summary

| Scenario         | Before Fix | After Fix |
| ---------------- | ---------- | --------- |
| `.yaml` manifest | Detected   | Detected  |
| `.YAML` manifest | Ignored    | Detected  |
| `.Yaml` manifest | Ignored    | Detected  |
| `.json` manifest | Detected   | Detected  |
| `.JSON` manifest | Ignored    | Detected  |
| `.Json` manifest | Ignored    | Detected  |

### Regression Safety Confirmation
This fix is fully additive and explicitly backward-compatible. It preserves existing exact behavior for lowercase extensions while safely allowing mixed-case resources to load. Scan semantics, traversal patterns, and lifecycle logic are entirely unaffected.

Closes #2292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File extension detection is now case-insensitive, so resources with mixed-case extensions (e.g., .YAML, .Yaml, .JSON, .Json) are recognized correctly.

* **Tests**
  * Added tests and test data to verify mixed-case extension handling and resource loading for both YAML and JSON formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->