### PR TITLE
fix: resolve TOCTOU race in TimedCache.invalidateTask()

### DIFF
--- a/core/pkg/policyhandler/cache.go
+++ b/core/pkg/policyhandler/cache.go
@@ -20,6 +20,17 @@ type TimedCache[T any] struct {
 	stopChan   chan struct{}
 	stopWg     sync.WaitGroup
 	stopped    uint32
+	// invalidateHook, if non-nil, is called inside invalidateTask after the expiry
+	// check succeeds and before invalidateLocked. In the fixed implementation this
+	// call occurs while the write lock is held, so a concurrent Set blocks until
+	// after invalidation. Tests set this field to observe that property; it is
+	// always nil outside of tests.
+	invalidateHook func()
+	// afterInvalidateHook, if non-nil, is called inside invalidateTask immediately
+	// after invalidateLocked returns, still while the write lock is held. Tests use
+	// this to know when the full invalidation cycle is complete. Always nil outside
+	// of tests.
+	afterInvalidateHook func()
 }
 
 func NewTimedCache[T any](ttl time.Duration) *TimedCache[T] {
@@ -79,7 +90,13 @@ func (c *TimedCache[T]) invalidateTask() {
 		case <-ticker.C:
 			c.mutex.Lock()
 			if time.Now().After(c.expiration) {
+				if c.invalidateHook != nil {
+					c.invalidateHook()
+				}
 				c.invalidateLocked()
+				if c.afterInvalidateHook != nil {
+					c.afterInvalidateHook()
+				}
 			}
 			c.mutex.Unlock()
 		case <-c.stopChan:

--- a/core/pkg/policyhandler/cache.go
+++ b/core/pkg/policyhandler/cache.go
@@ -78,11 +78,10 @@ func (c *TimedCache[T]) invalidateTask() {
 		select {
 		case <-ticker.C:
 			c.mutex.Lock()
-			expired := time.Now().After(c.expiration)
-			c.mutex.Unlock()
-			if expired {
-				c.invalidateExternal()
+			if time.Now().After(c.expiration) {
+				c.invalidateLocked()
 			}
+			c.mutex.Unlock()
 		case <-c.stopChan:
 			return
 		}

--- a/core/pkg/policyhandler/cache_bug_test.go
+++ b/core/pkg/policyhandler/cache_bug_test.go
@@ -254,45 +254,102 @@ func TestTimedCacheMultipleInvalidatesDontBreakTTL(t *testing.T) {
 	t.Error("TTL expiration did not fire after multiple Invalidate() calls")
 }
 
-func TestTimedCacheFreshSetNotClearedByExpiredTick(t *testing.T) {
-	cache := NewTimedCache[string](10 * time.Millisecond)
-	defer cache.Stop()
-
-	cache.Set("original")
-
-	time.Sleep(25 * time.Millisecond)
-
-	cache.Set("fresh")
-
-	val, ok := cache.Get()
-	if !ok || val != "fresh" {
-		t.Errorf("Expected 'fresh' after Set(), got val=%q ok=%v", val, ok)
-	}
-
-	time.Sleep(5 * time.Millisecond)
-
-	val, ok = cache.Get()
-	if !ok || val != "fresh" {
-		t.Errorf("Expected 'fresh' to persist within TTL, got val=%q ok=%v", val, ok)
-	}
-}
-
-func TestTimedCacheSetSurvivesBackgroundInvalidation(t *testing.T) {
+// TestTimedCacheTOCTOURace is a deterministic regression test for the TOCTOU bug
+// that existed in invalidateTask before the fix.
+//
+// Old buggy flow inside invalidateTask:
+//
+//	lock → check expiry (true) → unlock
+//	                              ← Set("fresh") runs here (lock is free)
+//	invalidateExternal() → clears "fresh"  ← BUG
+//
+// Fixed flow: the write lock is held across the check AND invalidateLocked(), so
+// any concurrent Set() blocks until after invalidation and the fresh value is safe.
+//
+// Synchronization strategy:
+//   - invalidateHook fires before invalidateLocked (inside the write lock in fixed code,
+//     outside it in the old buggy code). It signals a goroutine to call Set("fresh")
+//     and waits, ensuring Set runs in the TOCTOU window if the lock is free.
+//   - afterInvalidateHook fires after invalidateLocked (inside the write lock in fixed
+//     code, after invalidateExternal() in old code). It signals that the full invalidation
+//     cycle is complete, giving the test a reliable point to assert from.
+//
+// On old buggy code: Set("fresh") succeeds inside the gap, hook returns, then
+// invalidateExternal clears "fresh". afterInvalidateHook fires after the clear.
+// Test asserts after both signals → Get() returns false → FAIL (correctly).
+//
+// On fixed code: Set("fresh") blocks on the held write lock. Hook times out, then
+// invalidateLocked runs (clearing the old expiration). afterInvalidateHook fires.
+// Lock is released. Set("fresh") then runs. Test asserts after both signals →
+// Get() returns "fresh" → PASS.
+func TestTimedCacheTOCTOURace(t *testing.T) {
 	const ttl = 20 * time.Millisecond
+
+	var armed atomic.Bool
+	var afterArmed atomic.Bool
+	hookReached := make(chan struct{})
+	setDone := make(chan struct{})
+	afterInvalidateDone := make(chan struct{})
+
 	cache := NewTimedCache[string](ttl)
 	defer cache.Stop()
 
-	time.Sleep(3 * ttl)
-
-	i := 0
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		cache.Set("v")
-		val, ok := cache.Get()
-		if !ok || val != "v" {
-			t.Fatalf("iteration %d: Get() returned ok=%v val=%q after Set() within TTL", i, ok, val)
+	cache.invalidateHook = func() {
+		if !armed.CompareAndSwap(true, false) {
+			return
 		}
-		time.Sleep(ttl / 2)
-		i++
+		afterArmed.Store(true)
+		close(hookReached)
+		select {
+		case <-setDone:
+			// old buggy path: Set("fresh") completed inside the lock-release gap;
+			// invalidation will run next and clear it
+		case <-time.After(50 * time.Millisecond):
+			// fixed path: Set("fresh") is blocked on the write lock held here;
+			// it runs only after invalidateLocked and the lock are released
+		}
+	}
+
+	cache.afterInvalidateHook = func() {
+		if !afterArmed.CompareAndSwap(true, false) {
+			return
+		}
+		close(afterInvalidateDone)
+	}
+
+	cache.Set("seed")
+	time.Sleep(2 * ttl) // let "seed" expire and early ticks fire with hooks unarmed
+	armed.Store(true)   // arm for the next qualifying tick
+
+	go func() {
+		select {
+		case <-hookReached:
+		case <-time.After(200 * time.Millisecond):
+			t.Error("invalidateHook never reached the invalidation point")
+			return
+		}
+		cache.Set("fresh")
+		close(setDone)
+	}()
+
+	// Wait for the full invalidation cycle to complete before asserting.
+	select {
+	case <-afterInvalidateDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("afterInvalidateHook never fired; invalidation did not complete")
+	}
+
+	// In fixed code, Set("fresh") may still be running (it was blocked on the lock
+	// during the hook; the lock is released after afterInvalidateHook fires). Wait
+	// for it to finish before reading the cache.
+	select {
+	case <-setDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Set(\"fresh\") goroutine did not complete")
+	}
+
+	val, ok := cache.Get()
+	if !ok || val != "fresh" {
+		t.Errorf("TOCTOU bug: 'fresh' was cleared by the expired-tick invalidation; got val=%q ok=%v", val, ok)
 	}
 }

--- a/core/pkg/policyhandler/cache_bug_test.go
+++ b/core/pkg/policyhandler/cache_bug_test.go
@@ -277,20 +277,21 @@ func TestTimedCacheFreshSetNotClearedByExpiredTick(t *testing.T) {
 }
 
 func TestTimedCacheSetSurvivesBackgroundInvalidation(t *testing.T) {
-	const iterations = 500
+	const ttl = 20 * time.Millisecond
+	cache := NewTimedCache[string](ttl)
+	defer cache.Stop()
 
-	for i := 0; i < iterations; i++ {
-		cache := NewTimedCache[string](1 * time.Millisecond)
+	time.Sleep(3 * ttl)
 
-		time.Sleep(3 * time.Millisecond)
-
+	i := 0
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
 		cache.Set("v")
 		val, ok := cache.Get()
 		if !ok || val != "v" {
-			cache.Stop()
 			t.Fatalf("iteration %d: Get() returned ok=%v val=%q after Set() within TTL", i, ok, val)
 		}
-
-		cache.Stop()
+		time.Sleep(ttl / 2)
+		i++
 	}
 }

--- a/core/pkg/policyhandler/cache_bug_test.go
+++ b/core/pkg/policyhandler/cache_bug_test.go
@@ -253,3 +253,44 @@ func TestTimedCacheMultipleInvalidatesDontBreakTTL(t *testing.T) {
 
 	t.Error("TTL expiration did not fire after multiple Invalidate() calls")
 }
+
+func TestTimedCacheFreshSetNotClearedByExpiredTick(t *testing.T) {
+	cache := NewTimedCache[string](10 * time.Millisecond)
+
+	cache.Set("original")
+
+	time.Sleep(25 * time.Millisecond)
+
+	cache.Set("fresh")
+
+	val, ok := cache.Get()
+	if !ok || val != "fresh" {
+		t.Errorf("Expected 'fresh' after Set(), got val=%q ok=%v", val, ok)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	val, ok = cache.Get()
+	if !ok || val != "fresh" {
+		t.Errorf("Expected 'fresh' to persist within TTL, got val=%q ok=%v", val, ok)
+	}
+}
+
+func TestTimedCacheSetSurvivesBackgroundInvalidation(t *testing.T) {
+	const iterations = 500
+
+	for i := 0; i < iterations; i++ {
+		cache := NewTimedCache[string](1 * time.Millisecond)
+
+		time.Sleep(3 * time.Millisecond)
+
+		cache.Set("v")
+		val, ok := cache.Get()
+		if !ok || val != "v" {
+			cache.Stop()
+			t.Fatalf("iteration %d: Get() returned ok=%v val=%q after Set() within TTL", i, ok, val)
+		}
+
+		cache.Stop()
+	}
+}

--- a/core/pkg/policyhandler/cache_bug_test.go
+++ b/core/pkg/policyhandler/cache_bug_test.go
@@ -256,6 +256,7 @@ func TestTimedCacheMultipleInvalidatesDontBreakTTL(t *testing.T) {
 
 func TestTimedCacheFreshSetNotClearedByExpiredTick(t *testing.T) {
 	cache := NewTimedCache[string](10 * time.Millisecond)
+	defer cache.Stop()
 
 	cache.Set("original")
 

--- a/core/pkg/policyhandler/cache_bug_test.go
+++ b/core/pkg/policyhandler/cache_bug_test.go
@@ -288,6 +288,7 @@ func TestTimedCacheTOCTOURace(t *testing.T) {
 	var armed atomic.Bool
 	var afterArmed atomic.Bool
 	hookReached := make(chan struct{})
+	setAttempted := make(chan struct{})
 	setDone := make(chan struct{})
 	afterInvalidateDone := make(chan struct{})
 
@@ -300,14 +301,7 @@ func TestTimedCacheTOCTOURace(t *testing.T) {
 		}
 		afterArmed.Store(true)
 		close(hookReached)
-		select {
-		case <-setDone:
-			// old buggy path: Set("fresh") completed inside the lock-release gap;
-			// invalidation will run next and clear it
-		case <-time.After(50 * time.Millisecond):
-			// fixed path: Set("fresh") is blocked on the write lock held here;
-			// it runs only after invalidateLocked and the lock are released
-		}
+		<-setAttempted
 	}
 
 	cache.afterInvalidateHook = func() {
@@ -318,38 +312,35 @@ func TestTimedCacheTOCTOURace(t *testing.T) {
 	}
 
 	cache.Set("seed")
-	time.Sleep(2 * ttl) // let "seed" expire and early ticks fire with hooks unarmed
-	armed.Store(true)   // arm for the next qualifying tick
+	time.Sleep(2 * ttl)
+	armed.Store(true)
 
 	go func() {
 		select {
 		case <-hookReached:
+			close(setAttempted)
+			cache.Set("fresh")
+			close(setDone)
 		case <-time.After(200 * time.Millisecond):
-			t.Error("invalidateHook never reached the invalidation point")
-			return
+			close(setAttempted)
+			close(setDone)
 		}
-		cache.Set("fresh")
-		close(setDone)
 	}()
 
-	// Wait for the full invalidation cycle to complete before asserting.
 	select {
 	case <-afterInvalidateDone:
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("afterInvalidateHook never fired; invalidation did not complete")
+		t.Fatal("afterInvalidateHook never fired")
 	}
 
-	// In fixed code, Set("fresh") may still be running (it was blocked on the lock
-	// during the hook; the lock is released after afterInvalidateHook fires). Wait
-	// for it to finish before reading the cache.
 	select {
 	case <-setDone:
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Set(\"fresh\") goroutine did not complete")
+		t.Fatal("Set(fresh) goroutine did not complete")
 	}
 
 	val, ok := cache.Get()
 	if !ok || val != "fresh" {
-		t.Errorf("TOCTOU bug: 'fresh' was cleared by the expired-tick invalidation; got val=%q ok=%v", val, ok)
+		t.Errorf("TOCTOU: fresh value was cleared by stale invalidation; got val=%q ok=%v", val, ok)
 	}
 }


### PR DESCRIPTION

### Overview

`invalidateTask()` was releasing the mutex after reading the expiration time, then re-acquiring it inside `invalidateExternal()`. This created a race window where a concurrent `Set()` could store a fresh value with a new expiration, only to have the background goroutine clear it moments later.

**The fix:** hold the lock across both the check and the `invalidateLocked()` call so the two operations are atomic.

---

### How to Test

```bash
go test -v -race -count=10 -run "TestTimedCache" ./core/pkg/policyhandler/
```

All 15 tests should pass with zero race reports.

---

### Related Issues / PRs

- Resolves #2294

---

### Checklist

- [x] Code follows the project's style guidelines
- [x] Hard-to-understand areas are commented
- [x] Self-review completed
- [x] Thorough tests added for core feature changes
- [x] New and existing unit tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a timing-related expiration race so concurrently written values are preserved and not cleared by background expiration.

* **Tests**
  * Added a deterministic timing-focused regression test that reproduces and prevents the TOCTOU expiration/invalidation race during concurrent updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->