### PR TITLE
fix(anonymizer): extend --hide coverage for container config references

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -1,6 +1,8 @@
 package anonymizer
 
 import (
+	"strings"
+
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -150,7 +152,8 @@ func anonymizeTypedEnv(envVars []corev1.EnvVar, mapping *Mapping) {
 	for i := range envVars {
 		envVar := &envVars[i]
 
-		if envVar.Value != "" {
+		if envVar.Value != "" &&
+			(isSensitiveEnvName(envVar.Name) || isSensitiveEnvValue(envVar.Value)) {
 			envVar.Value = mapping.GetOrCreate("env", envVar.Value)
 		}
 
@@ -188,7 +191,11 @@ func anonymizeUnstructuredEnv(container map[string]interface{}, mapping *Mapping
 			continue
 		}
 
-		if value, ok := envVar["value"].(string); ok && value != "" {
+		name, _ := envVar["name"].(string)
+
+		if value, ok := envVar["value"].(string); ok &&
+			value != "" &&
+			(isSensitiveEnvName(name) || isSensitiveEnvValue(value)) {
 			envVar["value"] = mapping.GetOrCreate("env", value)
 		}
 
@@ -263,6 +270,59 @@ func anonymizeUnstructuredReference(
 
 	ref["name"] = mapping.GetOrCreate("ref", name)
 }
+
+func isSensitiveEnvValue(value string) bool {
+	value = strings.ToLower(value)
+
+	sensitivePatterns := []string{
+		"://", // postgres:// redis:// mongodb:// etc
+		"password=",
+		"pwd=",
+		"user id=",
+		"userid=",
+		"dsn=",
+		"sslmode=",
+	}
+
+	for _, pattern := range sensitivePatterns {
+		if strings.Contains(value, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isSensitiveEnvName(name string) bool {
+	name = strings.ToLower(name)
+
+	sensitivePatterns := []string{
+		"password",
+		"passwd",
+		"pwd",
+		"secret",
+		"token",
+		"api_key",
+		"access_key",
+		"credential",
+		"database_url",
+		"db_url",
+		"redis_url",
+		"mongo_uri",
+		"mongodb_uri",
+		"dsn",
+		"connection_string",
+	}
+
+	for _, pattern := range sensitivePatterns {
+		if strings.Contains(name, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func anonymizeImagePullSecrets(
 	obj map[string]interface{},
 	mapping *Mapping,

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -1,9 +1,8 @@
 package anonymizer
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *Mapping) {
@@ -20,12 +19,20 @@ func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *M
 	resource.SetObject(obj)
 }
 
+// anonymizePodSpecs recursively traverses workload objects looking for pod-spec
+// shaped sections where container-related metadata may exist.
+//
+// Kubernetes resources may reach this layer as either typed objects converted
+// into generic maps or as fully unstructured manifests depending on the scan source,
+// so traversal stays representation-agnostic and delegates shape-specific handling
+// to dedicated helpers.
 func anonymizePodSpecs(node interface{}, mapping *Mapping) {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		anonymizeContainerList(v, "containers", mapping)
 		anonymizeContainerList(v, "initContainers", mapping)
 		anonymizeEphemeralContainerList(v, "ephemeralContainers", mapping)
+		anonymizeImagePullSecrets(v, mapping)
 
 		for _, child := range v {
 			anonymizePodSpecs(child, mapping)
@@ -38,6 +45,8 @@ func anonymizePodSpecs(node interface{}, mapping *Mapping) {
 	}
 }
 
+// anonymizeContainerFields handles unstructured container objects represented
+// as map[string]interface{}.
 func anonymizeContainerFields(container map[string]interface{}, mapping *Mapping) {
 	if name, ok := container["name"].(string); ok && name != "" {
 		container["name"] = mapping.GetOrCreate("ctr", name)
@@ -46,6 +55,9 @@ func anonymizeContainerFields(container map[string]interface{}, mapping *Mapping
 	if image, ok := container["image"].(string); ok && image != "" {
 		container["image"] = mapping.GetOrCreate("img", image)
 	}
+
+	anonymizeUnstructuredEnv(container, mapping)
+	anonymizeUnstructuredEnvFrom(container, mapping)
 }
 
 func anonymizeContainerList(
@@ -67,6 +79,9 @@ func anonymizeContainerList(
 			if containers[i].Image != "" {
 				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
 			}
+
+			anonymizeTypedEnv(containers[i].Env, mapping)
+			anonymizeTypedEnvFrom(containers[i].EnvFrom, mapping)
 		}
 
 		obj[key] = containers
@@ -106,6 +121,9 @@ func anonymizeEphemeralContainerList(
 			if containers[i].Image != "" {
 				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
 			}
+
+			anonymizeTypedEnv(containers[i].Env, mapping)
+			anonymizeTypedEnvFrom(containers[i].EnvFrom, mapping)
 		}
 
 		obj[key] = containers
@@ -123,5 +141,165 @@ func anonymizeEphemeralContainerList(
 		}
 
 		obj[key] = containers
+	}
+}
+
+// anonymizeTypedEnv anonymizes literal env values and resource references
+// inside typed EnvVar definitions.
+func anonymizeTypedEnv(envVars []corev1.EnvVar, mapping *Mapping) {
+	for i := range envVars {
+		envVar := &envVars[i]
+
+		if envVar.Value != "" {
+			envVar.Value = mapping.GetOrCreate("env", envVar.Value)
+		}
+
+		if envVar.ValueFrom == nil {
+			continue
+		}
+
+		if secretRef := envVar.ValueFrom.SecretKeyRef; secretRef != nil &&
+			secretRef.Name != "" {
+			secretRef.Name = mapping.GetOrCreate("ref", secretRef.Name)
+		}
+
+		if configMapRef := envVar.ValueFrom.ConfigMapKeyRef; configMapRef != nil &&
+			configMapRef.Name != "" {
+			configMapRef.Name = mapping.GetOrCreate("ref", configMapRef.Name)
+		}
+	}
+}
+
+// anonymizeUnstructuredEnv handles env entries in generic manifest maps.
+func anonymizeUnstructuredEnv(container map[string]interface{}, mapping *Mapping) {
+	rawEnv, exists := container["env"]
+	if !exists || rawEnv == nil {
+		return
+	}
+
+	envVars, ok := rawEnv.([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, item := range envVars {
+		envVar, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if value, ok := envVar["value"].(string); ok && value != "" {
+			envVar["value"] = mapping.GetOrCreate("env", value)
+		}
+
+		rawValueFrom, exists := envVar["valueFrom"]
+		if !exists || rawValueFrom == nil {
+			continue
+		}
+
+		valueFrom, ok := rawValueFrom.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		anonymizeUnstructuredReference(valueFrom, "secretKeyRef", mapping)
+		anonymizeUnstructuredReference(valueFrom, "configMapKeyRef", mapping)
+	}
+}
+
+// anonymizeTypedEnvFrom anonymizes typed envFrom resource references.
+func anonymizeTypedEnvFrom(envFrom []corev1.EnvFromSource, mapping *Mapping) {
+	for i := range envFrom {
+		source := &envFrom[i]
+
+		if source.SecretRef != nil && source.SecretRef.Name != "" {
+			source.SecretRef.Name = mapping.GetOrCreate(
+				"ref",
+				source.SecretRef.Name,
+			)
+		}
+
+		if source.ConfigMapRef != nil && source.ConfigMapRef.Name != "" {
+			source.ConfigMapRef.Name = mapping.GetOrCreate(
+				"ref",
+				source.ConfigMapRef.Name,
+			)
+		}
+	}
+}
+
+// anonymizeUnstructuredEnvFrom handles envFrom entries in generic manifest maps.
+func anonymizeUnstructuredEnvFrom(container map[string]interface{}, mapping *Mapping) {
+	rawEnvFrom, ok := container["envFrom"].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, item := range rawEnvFrom {
+		envFrom, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		anonymizeUnstructuredReference(envFrom, "secretRef", mapping)
+		anonymizeUnstructuredReference(envFrom, "configMapRef", mapping)
+	}
+}
+
+func anonymizeUnstructuredReference(
+	obj map[string]interface{},
+	key string,
+	mapping *Mapping,
+) {
+	ref, ok := obj[key].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	name, ok := ref["name"].(string)
+	if !ok || name == "" {
+		return
+	}
+
+	ref["name"] = mapping.GetOrCreate("ref", name)
+}
+func anonymizeImagePullSecrets(
+	obj map[string]interface{},
+	mapping *Mapping,
+) {
+	rawRefs, ok := obj["imagePullSecrets"]
+	if !ok || rawRefs == nil {
+		return
+	}
+
+	// Typed Kubernetes objects (manifest decoding path)
+	if refs, ok := rawRefs.([]corev1.LocalObjectReference); ok {
+		for i := range refs {
+			if refs[i].Name != "" {
+				refs[i].Name = mapping.GetOrCreate("ref", refs[i].Name)
+			}
+		}
+
+		obj["imagePullSecrets"] = refs
+		return
+	}
+
+	// Unstructured objects (runtime / normalized object path)
+	if refs, ok := rawRefs.([]interface{}); ok {
+		for _, item := range refs {
+			ref, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			name, ok := ref["name"].(string)
+			if !ok || name == "" {
+				continue
+			}
+
+			ref["name"] = mapping.GetOrCreate("ref", name)
+		}
+
+		obj["imagePullSecrets"] = refs
 	}
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -28,8 +28,12 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			},
 			validate: func(t *testing.T, spec map[string]interface{}) {
 				containers, ok := spec["containers"].([]corev1.Container)
-				assert.True(t, ok, "expected typed containers")
-				assert.Len(t, containers, 1)
+				if !assert.True(t, ok, "expected typed containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
 				assert.NotEqual(t, "payment-api", containers[0].Name)
 				assert.NotEqual(t, "nginx:latest", containers[0].Image)
@@ -51,11 +55,17 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			},
 			validate: func(t *testing.T, spec map[string]interface{}) {
 				containers, ok := spec["containers"].([]interface{})
-				assert.True(t, ok, "expected unstructured containers")
-				assert.Len(t, containers, 1)
+				if !assert.True(t, ok, "expected unstructured containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
 				container, ok := containers[0].(map[string]interface{})
-				assert.True(t, ok, "expected unstructured container map")
+				if !assert.True(t, ok, "expected unstructured container map") {
+					return
+				}
 
 				assert.NotEqual(t, "payment-api", container["name"])
 				assert.NotEqual(t, "nginx:latest", container["image"])
@@ -77,8 +87,12 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			},
 			validate: func(t *testing.T, spec map[string]interface{}) {
 				containers, ok := spec["initContainers"].([]corev1.Container)
-				assert.True(t, ok, "expected typed init containers")
-				assert.Len(t, containers, 1)
+				if !assert.True(t, ok, "expected typed init containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
 				assert.NotEqual(t, "init-db", containers[0].Name)
 				assert.NotEqual(t, "postgres:latest", containers[0].Image)
@@ -102,8 +116,12 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			},
 			validate: func(t *testing.T, spec map[string]interface{}) {
 				containers, ok := spec["ephemeralContainers"].([]corev1.EphemeralContainer)
-				assert.True(t, ok, "expected typed ephemeral containers")
-				assert.Len(t, containers, 1)
+				if !assert.True(t, ok, "expected typed ephemeral containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
 				assert.NotEqual(t, "debug-shell", containers[0].Name)
 				assert.NotEqual(t, "busybox:latest", containers[0].Image)
@@ -125,11 +143,17 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			},
 			validate: func(t *testing.T, spec map[string]interface{}) {
 				containers, ok := spec["ephemeralContainers"].([]interface{})
-				assert.True(t, ok, "expected unstructured ephemeral containers")
-				assert.Len(t, containers, 1)
+				if !assert.True(t, ok, "expected unstructured ephemeral containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
 				container, ok := containers[0].(map[string]interface{})
-				assert.True(t, ok, "expected unstructured ephemeral container map")
+				if !assert.True(t, ok, "expected unstructured ephemeral container map") {
+					return
+				}
 
 				assert.NotEqual(t, "debug-shell", container["name"])
 				assert.NotEqual(t, "busybox:latest", container["image"])
@@ -137,8 +161,408 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 				assert.Contains(t, container["image"], "img-")
 			},
 		},
-	}
+		{
+			name: "typed container env references should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []corev1.Container{
+						{
+							Name:  "payment-api",
+							Image: "nginx:latest",
+							Env: []corev1.EnvVar{
+								{
+									Name: "SECRET_TOKEN",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "payment-secret",
+											},
+										},
+									},
+								},
+								{
+									Name: "CONFIG_PATH",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "payment-config",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]corev1.Container)
+				if !assert.True(t, ok, "expected typed containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
 
+				assert.NotEqual(t, "payment-secret", containers[0].Env[0].ValueFrom.SecretKeyRef.Name)
+				assert.NotEqual(t, "payment-config", containers[0].Env[1].ValueFrom.ConfigMapKeyRef.Name)
+
+				assert.Contains(t, containers[0].Env[0].ValueFrom.SecretKeyRef.Name, "ref-")
+				assert.Contains(t, containers[0].Env[1].ValueFrom.ConfigMapKeyRef.Name, "ref-")
+			},
+		},
+		{
+			name: "unstructured container env references should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "payment-api",
+							"image": "nginx:latest",
+							"env": []interface{}{
+								map[string]interface{}{
+									"name": "SECRET_TOKEN",
+									"valueFrom": map[string]interface{}{
+										"secretKeyRef": map[string]interface{}{
+											"name": "payment-secret",
+										},
+									},
+								},
+								map[string]interface{}{
+									"name": "CONFIG_PATH",
+									"valueFrom": map[string]interface{}{
+										"configMapKeyRef": map[string]interface{}{
+											"name": "payment-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]interface{})
+				if !assert.True(t, ok, "expected unstructured containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+
+				container, ok := containers[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected unstructured container map") {
+					return
+				}
+
+				env, ok := container["env"].([]interface{})
+				if !assert.True(t, ok, "expected env slice") {
+					return
+				}
+				if !assert.Len(t, env, 2) {
+					return
+				}
+
+				secretEnv, ok := env[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected secret env map") {
+					return
+				}
+
+				configEnv, ok := env[1].(map[string]interface{})
+				if !assert.True(t, ok, "expected config env map") {
+					return
+				}
+
+				secretValueFrom, ok := secretEnv["valueFrom"].(map[string]interface{})
+				if !assert.True(t, ok, "expected secret valueFrom map") {
+					return
+				}
+
+				configValueFrom, ok := configEnv["valueFrom"].(map[string]interface{})
+				if !assert.True(t, ok, "expected config valueFrom map") {
+					return
+				}
+
+				secretRef, ok := secretValueFrom["secretKeyRef"].(map[string]interface{})
+				if !assert.True(t, ok, "expected secretKeyRef map") {
+					return
+				}
+
+				configRef, ok := configValueFrom["configMapKeyRef"].(map[string]interface{})
+				if !assert.True(t, ok, "expected configMapKeyRef map") {
+					return
+				}
+
+				assert.NotEqual(t, "payment-secret", secretRef["name"])
+				assert.NotEqual(t, "payment-config", configRef["name"])
+				assert.Contains(t, secretRef["name"], "ref-")
+				assert.Contains(t, configRef["name"], "ref-")
+			},
+		},
+		{
+			name: "typed container envFrom references should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []corev1.Container{
+						{
+							Name: "payment-api",
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									SecretRef: &corev1.SecretEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "payment-secret",
+										},
+									},
+								},
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "payment-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]corev1.Container)
+				if !assert.True(t, ok, "expected typed containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+
+				assert.NotEqual(t, "payment-secret", containers[0].EnvFrom[0].SecretRef.Name)
+				assert.NotEqual(t, "payment-config", containers[0].EnvFrom[1].ConfigMapRef.Name)
+				assert.Contains(t, containers[0].EnvFrom[0].SecretRef.Name, "ref-")
+				assert.Contains(t, containers[0].EnvFrom[1].ConfigMapRef.Name, "ref-")
+			},
+		},
+		{
+			name: "unstructured container envFrom references should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "payment-api",
+							"envFrom": []interface{}{
+								map[string]interface{}{
+									"secretRef": map[string]interface{}{
+										"name": "payment-secret",
+									},
+								},
+								map[string]interface{}{
+									"configMapRef": map[string]interface{}{
+										"name": "payment-config",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]interface{})
+				if !assert.True(t, ok, "expected unstructured containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+
+				container, ok := containers[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected unstructured container map") {
+					return
+				}
+
+				envFrom, ok := container["envFrom"].([]interface{})
+				if !assert.True(t, ok, "expected envFrom slice") {
+					return
+				}
+				if !assert.Len(t, envFrom, 2) {
+					return
+				}
+
+				secretEnvFrom, ok := envFrom[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected secret envFrom map") {
+					return
+				}
+
+				configEnvFrom, ok := envFrom[1].(map[string]interface{})
+				if !assert.True(t, ok, "expected config envFrom map") {
+					return
+				}
+
+				secretRef, ok := secretEnvFrom["secretRef"].(map[string]interface{})
+				if !assert.True(t, ok, "expected secretRef map") {
+					return
+				}
+
+				configRef, ok := configEnvFrom["configMapRef"].(map[string]interface{})
+				if !assert.True(t, ok, "expected configMapRef map") {
+					return
+				}
+
+				assert.NotEqual(t, "payment-secret", secretRef["name"])
+				assert.NotEqual(t, "payment-config", configRef["name"])
+				assert.Contains(t, secretRef["name"], "ref-")
+				assert.Contains(t, configRef["name"], "ref-")
+			},
+		},
+		{
+			name: "typed container literal env values should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []corev1.Container{
+						{
+							Name: "payment-api",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DATABASE_URL",
+									Value: "postgres://user:pass@db.internal/prod",
+								},
+								{
+									Name:  "CONNECTION_STRING",
+									Value: "Server=db;User=admin;Password=secret;",
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]corev1.Container)
+				if !assert.True(t, ok, "expected typed containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+
+				assert.NotEqual(t, "postgres://user:pass@db.internal/prod", containers[0].Env[0].Value)
+				assert.NotEqual(t, "Server=db;User=admin;Password=secret;", containers[0].Env[1].Value)
+				assert.Contains(t, containers[0].Env[0].Value, "env-")
+				assert.Contains(t, containers[0].Env[1].Value, "env-")
+			},
+		},
+		{
+			name: "unstructured container literal env values should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "payment-api",
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "DATABASE_URL",
+									"value": "postgres://user:pass@db.internal/prod",
+								},
+								map[string]interface{}{
+									"name":  "REDIS_URL",
+									"value": "redis://:secret@redis.internal:6379",
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				containers, ok := spec["containers"].([]interface{})
+				if !assert.True(t, ok, "expected unstructured containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+
+				container, ok := containers[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected unstructured container map") {
+					return
+				}
+
+				env, ok := container["env"].([]interface{})
+				if !assert.True(t, ok, "expected env slice") {
+					return
+				}
+				if !assert.Len(t, env, 2) {
+					return
+				}
+
+				firstEnv, ok := env[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected first env map") {
+					return
+				}
+
+				secondEnv, ok := env[1].(map[string]interface{})
+				if !assert.True(t, ok, "expected second env map") {
+					return
+				}
+
+				assert.NotEqual(t, "postgres://user:pass@db.internal/prod", firstEnv["value"])
+				assert.NotEqual(t, "redis://:secret@redis.internal:6379", secondEnv["value"])
+				assert.Contains(t, firstEnv["value"], "env-")
+				assert.Contains(t, secondEnv["value"], "env-")
+			},
+		},
+		{
+			name: "typed image pull secrets should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"imagePullSecrets": []corev1.LocalObjectReference{
+						{
+							Name: "corp-registry-creds",
+						},
+					},
+				},
+			},
+
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				refs, ok := spec["imagePullSecrets"].([]corev1.LocalObjectReference)
+				if !assert.True(t, ok, "expected typed image pull secrets") {
+					return
+				}
+				if !assert.Len(t, refs, 1) {
+					return
+				}
+
+				assert.NotEqual(t, "corp-registry-creds", refs[0].Name)
+				assert.Contains(t, refs[0].Name, "ref-")
+			},
+		},
+
+		{
+			name: "unstructured image pull secrets should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"imagePullSecrets": []interface{}{
+						map[string]interface{}{
+							"name": "corp-registry-creds",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				refs, ok := spec["imagePullSecrets"].([]interface{})
+				if !assert.True(t, ok, "expected unstructured image pull secrets") {
+					return
+				}
+				if !assert.Len(t, refs, 1) {
+					return
+				}
+
+				ref, ok := refs[0].(map[string]interface{})
+				if !assert.True(t, ok, "expected image pull secret map") {
+					return
+				}
+
+				assert.NotEqual(t, "corp-registry-creds", ref["name"])
+				assert.Contains(t, ref["name"], "ref-")
+			},
+		},
+	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mapping := NewMapping()
@@ -152,6 +576,12 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 			test.validate(t, spec)
 		})
 	}
+}
+
+func TestAnonymizeContainerMetadata_NilResource(t *testing.T) {
+	assert.NotPanics(t, func() {
+		anonymizeContainerMetadata(nil, NewMapping())
+	})
 }
 
 func TestAnonymizeContainerList_MissingKey(t *testing.T) {

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -422,11 +422,23 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "DATABASE_URL",
-									Value: "postgres://user:pass@db.internal/prod",
+									Value: "postgres://example-user@example-host.internal/prod",
 								},
 								{
 									Name:  "CONNECTION_STRING",
-									Value: "Server=db;User=admin;Password=secret;",
+									Value: "Server=db;User=demo;Password=masked;",
+								},
+								{
+									Name:  "CONFIG",
+									Value: "redis://:secret@redis.internal:6379",
+								},
+								{
+									Name:  "LOG_LEVEL",
+									Value: "info",
+								},
+								{
+									Name:  "PORT",
+									Value: "8080",
 								},
 							},
 						},
@@ -442,10 +454,16 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 					return
 				}
 
-				assert.NotEqual(t, "postgres://user:pass@db.internal/prod", containers[0].Env[0].Value)
-				assert.NotEqual(t, "Server=db;User=admin;Password=secret;", containers[0].Env[1].Value)
+				assert.NotEqual(t, "postgres://example-user@example-host.internal/prod", containers[0].Env[0].Value)
+				assert.NotEqual(t, "Server=db;User=demo;Password=masked;", containers[0].Env[1].Value)
+				assert.NotEqual(t, "redis://:secret@redis.internal:6379", containers[0].Env[2].Value)
+
 				assert.Contains(t, containers[0].Env[0].Value, "env-")
 				assert.Contains(t, containers[0].Env[1].Value, "env-")
+				assert.Contains(t, containers[0].Env[2].Value, "env-")
+
+				assert.Equal(t, "info", containers[0].Env[3].Value)
+				assert.Equal(t, "8080", containers[0].Env[4].Value)
 			},
 		},
 		{
@@ -458,11 +476,23 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 							"env": []interface{}{
 								map[string]interface{}{
 									"name":  "DATABASE_URL",
-									"value": "postgres://user:pass@db.internal/prod",
+									"value": "postgres://example-user@example-host.internal/prod",
 								},
 								map[string]interface{}{
 									"name":  "REDIS_URL",
 									"value": "redis://:secret@redis.internal:6379",
+								},
+								map[string]interface{}{
+									"name":  "CONFIG",
+									"value": "mongodb://example-user@example-host.internal:27017/prod",
+								},
+								map[string]interface{}{
+									"name":  "FEATURE_FLAG",
+									"value": "true",
+								},
+								map[string]interface{}{
+									"name":  "PORT",
+									"value": "8080",
 								},
 							},
 						},
@@ -487,7 +517,7 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 				if !assert.True(t, ok, "expected env slice") {
 					return
 				}
-				if !assert.Len(t, env, 2) {
+				if !assert.Len(t, env, 5) {
 					return
 				}
 
@@ -501,12 +531,34 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 					return
 				}
 
-				assert.NotEqual(t, "postgres://user:pass@db.internal/prod", firstEnv["value"])
+				thirdEnv, ok := env[2].(map[string]interface{})
+				if !assert.True(t, ok, "expected third env map") {
+					return
+				}
+
+				fourthEnv, ok := env[3].(map[string]interface{})
+				if !assert.True(t, ok, "expected fourth env map") {
+					return
+				}
+
+				fifthEnv, ok := env[4].(map[string]interface{})
+				if !assert.True(t, ok, "expected fifth env map") {
+					return
+				}
+
+				assert.NotEqual(t, "postgres://example-user@example-host.internal/prod", firstEnv["value"])
 				assert.NotEqual(t, "redis://:secret@redis.internal:6379", secondEnv["value"])
+				assert.NotEqual(t, "mongodb://example-user@example-host.internal:27017/prod", thirdEnv["value"])
+
 				assert.Contains(t, firstEnv["value"], "env-")
 				assert.Contains(t, secondEnv["value"], "env-")
+				assert.Contains(t, thirdEnv["value"], "env-")
+
+				assert.Equal(t, "true", fourthEnv["value"])
+				assert.Equal(t, "8080", fifthEnv["value"])
 			},
 		},
+
 		{
 			name: "typed image pull secrets should be anonymized",
 			object: map[string]interface{}{


### PR DESCRIPTION
Part of: #1200

Extend `--hide` anonymization coverage for additional container-related sensitive metadata that can leak infrastructure or credential information.

This PR adds anonymization for:

### Container config references

* `spec.containers[].env[].valueFrom.secretKeyRef.name`
* `spec.containers[].env[].valueFrom.configMapKeyRef.name`
* `spec.containers[].envFrom[].secretRef.name`
* `spec.containers[].envFrom[].configMapRef.name`

### Registry identity

* `spec.imagePullSecrets[].name`

### Sensitive literal environment values
- `spec.containers[].env[].value` when the environment variable is identified as sensitive by name (e.g. password/token/connection identifiers) or by sensitive value patterns (e.g. URI/DSN/connection-string style values).

The implementation supports both typed Kubernetes objects and unstructured object shapes, consistent with the existing container metadata anonymization approach.

## Validation
- Extended the existing table driven container anonymizer tests to cover:
  - typed and unstructured resource reference anonymization
  - sensitive literal env value anonymization
  - regression coverage proving non-sensitive env literals remain unchanged

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container anonymization to cover environment variable values and secret/configmap references, and to anonymize image pull secret names.
  * Support for both structured (typed) and unstructured container metadata formats.

* **Tests**
  * Added and strengthened tests covering new anonymization cases and nil-resource handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->