### PR TITLE
fix: add --scan-timeout flag and fix context propagation in K8s resource collection

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -55,6 +55,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			defer applyTimeout(scanInfo, ks)()
 
 			if scanInfo.FailThresholdSeverity != "" {
 				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -69,6 +69,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			defer applyTimeout(scanInfo, ks)()
 
 			if scanInfo.FailThresholdSeverity != "" {
 				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -43,6 +43,8 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			defer applyTimeout(scanInfo, ks)()
+
 			if len(args) != 1 {
 				return fmt.Errorf("the command takes exactly one image name as an argument")
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"strings"
@@ -173,6 +174,16 @@ func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) {
 }
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
+	if scanInfo.ScanTimeout > 0 {
+		originalCtx := ks.Context()
+		timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
+		defer func() {
+			cancel()
+			ks.SetContext(originalCtx)
+		}()
+		ks.SetContext(timeoutCtx)
+	}
+
 	results, err := ks.Scan(&scanInfo)
 	if err != nil {
 		return err

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -114,6 +114,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers (namespace, resource names, container names, images) in results")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
+	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")
 
 	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
 	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -173,16 +173,27 @@ func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) {
 	}
 }
 
-func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
-	if scanInfo.ScanTimeout > 0 {
-		originalCtx := ks.Context()
-		timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
-		defer func() {
-			cancel()
-			ks.SetContext(originalCtx)
-		}()
-		ks.SetContext(timeoutCtx)
+// applyTimeout wraps ks with a deadline context when ScanTimeout > 0 and
+// returns a cleanup function that cancels the context and restores the
+// original. The caller must defer the returned function so the deadline
+// covers both ks.Scan() and results.HandleResults().
+//
+//	defer applyTimeout(scanInfo, ks)()
+func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
+	if scanInfo.ScanTimeout <= 0 {
+		return func() {}
 	}
+	originalCtx := ks.Context()
+	timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
+	ks.SetContext(timeoutCtx)
+	return func() {
+		cancel()
+		ks.SetContext(originalCtx)
+	}
+}
+
+func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
+	defer applyTimeout(&scanInfo, ks)()
 
 	results, err := ks.Scan(&scanInfo)
 	if err != nil {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"testing"
@@ -452,9 +453,11 @@ func TestScanInfo_ScanTimeoutField(t *testing.T) {
 
 // contextTrackingKubescape is a test-local IKubescape that records what
 // context was active when Scan() was called, so we can assert the deadline.
+// Scan() returns a sentinel error so securityScan exits before HandleResults,
+// avoiding a nil-pointer dereference on the stub ResultsHandler.
 type contextTrackingKubescape struct {
 	mocks.MockIKubescape
-	ctx         context.Context
+	ctx            context.Context
 	scanCalledWith context.Context
 }
 
@@ -462,7 +465,7 @@ func (m *contextTrackingKubescape) Context() context.Context       { return m.ct
 func (m *contextTrackingKubescape) SetContext(ctx context.Context) { m.ctx = ctx }
 func (m *contextTrackingKubescape) Scan(_ *cautils.ScanInfo) (*resultshandlingpkg.ResultsHandler, error) {
 	m.scanCalledWith = m.ctx
-	return nil, nil
+	return nil, errors.New("stub: scan not implemented in test")
 }
 
 func TestSecurityScan_TimeoutDeadlineActiveForScan(t *testing.T) {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExceedsSeverity(t *testing.T) {
@@ -376,8 +377,6 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
-// TestGetScanCommand_ScanTimeoutFlagRegistered verifies that the --scan-timeout
-// flag is registered on the scan command and has the correct type and default.
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)
@@ -390,8 +389,6 @@ func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 		"--scan-timeout default must be 0s (no timeout)")
 }
 
-// TestGetScanCommand_ScanTimeoutFlagParsed verifies that valid duration strings
-// are accepted by the --scan-timeout flag and stored in ScanInfo.ScanTimeout.
 func TestGetScanCommand_ScanTimeoutFlagParsed(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -420,14 +417,10 @@ func TestGetScanCommand_ScanTimeoutFlagParsed(t *testing.T) {
 	}
 }
 
-// TestGetScanCommand_ScanTimeoutFlagInherited verifies that the --scan-timeout
-// flag is inherited by scan subcommands (framework, control, workload) since it
-// is registered as a PersistentFlag on the parent scan command.
 func TestGetScanCommand_ScanTimeoutFlagInherited(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)
 
-	// Persistent flags propagate to all subcommands.
 	for _, sub := range cmd.Commands() {
 		t.Run(sub.Name(), func(t *testing.T) {
 			f := sub.InheritedFlags().Lookup("scan-timeout")
@@ -438,8 +431,6 @@ func TestGetScanCommand_ScanTimeoutFlagInherited(t *testing.T) {
 	}
 }
 
-// TestScanInfo_ScanTimeoutField verifies that the ScanTimeout field is
-// present on ScanInfo and can be set to any valid duration.
 func TestScanInfo_ScanTimeoutField(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -376,6 +376,88 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
+// TestGetScanCommand_ScanTimeoutFlagRegistered verifies that the --scan-timeout
+// flag is registered on the scan command and has the correct type and default.
+func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+
+	f := cmd.PersistentFlags().Lookup("scan-timeout")
+	require.NotNil(t, f, "--scan-timeout flag must be registered on the scan command")
+	assert.Equal(t, "duration", f.Value.Type(),
+		"--scan-timeout must be a duration flag (accepts values like 5m, 30s, 1h)")
+	assert.Equal(t, "0s", f.DefValue,
+		"--scan-timeout default must be 0s (no timeout)")
+}
+
+// TestGetScanCommand_ScanTimeoutFlagParsed verifies that valid duration strings
+// are accepted by the --scan-timeout flag and stored in ScanInfo.ScanTimeout.
+func TestGetScanCommand_ScanTimeoutFlagParsed(t *testing.T) {
+	tests := []struct {
+		name    string
+		flagVal string
+		want    time.Duration
+	}{
+		{"five minutes", "5m", 5 * time.Minute},
+		{"thirty seconds", "30s", 30 * time.Second},
+		{"one hour", "1h", time.Hour},
+		{"zero means no timeout", "0", 0},
+		{"complex duration", "1h30m", 90 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockKubescape := &mocks.MockIKubescape{}
+			cmd := GetScanCommand(mockKubescape)
+
+			err := cmd.PersistentFlags().Set("scan-timeout", tt.flagVal)
+			require.NoError(t, err, "setting --scan-timeout=%s should not produce an error", tt.flagVal)
+
+			f := cmd.PersistentFlags().Lookup("scan-timeout")
+			assert.Equal(t, tt.want.String(), f.Value.String(),
+				"parsed duration for --scan-timeout=%s is incorrect", tt.flagVal)
+		})
+	}
+}
+
+// TestGetScanCommand_ScanTimeoutFlagInherited verifies that the --scan-timeout
+// flag is inherited by scan subcommands (framework, control, workload) since it
+// is registered as a PersistentFlag on the parent scan command.
+func TestGetScanCommand_ScanTimeoutFlagInherited(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+
+	// Persistent flags propagate to all subcommands.
+	for _, sub := range cmd.Commands() {
+		t.Run(sub.Name(), func(t *testing.T) {
+			f := sub.InheritedFlags().Lookup("scan-timeout")
+			require.NotNil(t, f,
+				"subcommand %q must inherit --scan-timeout from the parent scan command",
+				sub.Name())
+		})
+	}
+}
+
+// TestScanInfo_ScanTimeoutField verifies that the ScanTimeout field is
+// present on ScanInfo and can be set to any valid duration.
+func TestScanInfo_ScanTimeoutField(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"no timeout (zero value)", 0},
+		{"five minutes", 5 * time.Minute},
+		{"one millisecond", time.Millisecond},
+		{"twenty-four hours", 24 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			si := &cautils.ScanInfo{ScanTimeout: tt.timeout}
+			assert.Equal(t, tt.timeout, si.ScanTimeout)
+		})
+	}
+}
+
 // coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we
 // can test it without triggering os.Exit.
 func coverageWouldFail(notEvaluated, totalControls int, threshold float32) bool {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	resultshandlingpkg "github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -447,6 +448,52 @@ func TestScanInfo_ScanTimeoutField(t *testing.T) {
 			assert.Equal(t, tt.timeout, si.ScanTimeout)
 		})
 	}
+}
+
+// contextTrackingKubescape is a test-local IKubescape that records what
+// context was active when Scan() was called, so we can assert the deadline.
+type contextTrackingKubescape struct {
+	mocks.MockIKubescape
+	ctx         context.Context
+	scanCalledWith context.Context
+}
+
+func (m *contextTrackingKubescape) Context() context.Context       { return m.ctx }
+func (m *contextTrackingKubescape) SetContext(ctx context.Context) { m.ctx = ctx }
+func (m *contextTrackingKubescape) Scan(_ *cautils.ScanInfo) (*resultshandlingpkg.ResultsHandler, error) {
+	m.scanCalledWith = m.ctx
+	return nil, nil
+}
+
+func TestSecurityScan_TimeoutDeadlineActiveForScan(t *testing.T) {
+	ks := &contextTrackingKubescape{ctx: context.Background()}
+	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
+
+	_ = securityScan(scanInfo, ks)
+
+	_, hasDeadline := ks.scanCalledWith.Deadline()
+	assert.True(t, hasDeadline, "Scan() must receive a context with a deadline when ScanTimeout > 0")
+}
+
+func TestSecurityScan_TimeoutContextRestoredAfterReturn(t *testing.T) {
+	originalCtx := context.Background()
+	ks := &contextTrackingKubescape{ctx: originalCtx}
+	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
+
+	_ = securityScan(scanInfo, ks)
+
+	_, hasDeadline := ks.Context().Deadline()
+	assert.False(t, hasDeadline, "original context must be restored on ks after securityScan returns")
+}
+
+func TestSecurityScan_ZeroTimeoutNoDeadline(t *testing.T) {
+	ks := &contextTrackingKubescape{ctx: context.Background()}
+	scanInfo := cautils.ScanInfo{ScanTimeout: 0}
+
+	_ = securityScan(scanInfo, ks)
+
+	_, hasDeadline := ks.scanCalledWith.Deadline()
+	assert.False(t, hasDeadline, "Scan() must not receive a deadline when ScanTimeout is 0")
 }
 
 // coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -57,6 +57,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			return validateWorkloadIdentifier(args[0])
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			defer applyTimeout(scanInfo, ks)()
 
 			if scanInfo.FailThresholdSeverity != "" {
 				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -140,6 +141,7 @@ type ScanInfo struct {
 	ScanType              ScanTypes
 	ScanImages            bool
 	UseDefaultMatchers    bool
+	ScanTimeout           time.Duration // Maximum duration for the entire scan (0 = no timeout)
 	ChartPath             string
 	FilePath              string
 	HelmValueFiles        []string // -f / --values: paths to Helm values YAML files (repeatable)

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -95,7 +95,7 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 		_ = getter.GetKSCloudAPIConnector()
 	}
 	rbacObjects := getRBACHandler(tenantConfig, k8s, scanInfo.Submit)
-	return resourcehandler.NewK8sResourceHandler(k8s, hostSensorHandler, rbacObjects, tenantConfig.GetContextName())
+	return resourcehandler.NewK8sResourceHandler(ctx, k8s, hostSensorHandler, rbacObjects, tenantConfig.GetContextName())
 }
 
 // getHostSensorHandler yields a IHostSensor that knows how to collect a host's scanned resources.

--- a/core/core/kscore.go
+++ b/core/core/kscore.go
@@ -12,6 +12,10 @@ func (ks *Kubescape) Context() context.Context {
 	return ks.Ctx
 }
 
+func (ks *Kubescape) SetContext(ctx context.Context) {
+	ks.Ctx = ctx
+}
+
 func NewKubescape(ctx context.Context) *Kubescape {
 	return &Kubescape{Ctx: ctx}
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -136,16 +136,6 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 }
 
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
-	if scanInfo.ScanTimeout > 0 {
-		originalCtx := ks.Ctx
-		timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
-		defer func() {
-			cancel()
-			ks.Ctx = originalCtx
-		}()
-		ks.Ctx = timeoutCtx
-	}
-
 	ctxInit, spanInit := otel.Tracer("").Start(ks.Context(), "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -136,6 +136,16 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 }
 
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
+	// If the caller requested a scan-level timeout, wrap the root context so
+	// all downstream operations (resource collection, OPA evaluation, image
+	// scanning) share the same deadline and are automatically cancelled when
+	// the timeout fires.
+	if scanInfo.ScanTimeout > 0 {
+		timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
+		defer cancel()
+		ks.Ctx = timeoutCtx
+	}
+
 	ctxInit, spanInit := otel.Tracer("").Start(ks.Context(), "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -136,13 +136,13 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 }
 
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
-	// If the caller requested a scan-level timeout, wrap the root context so
-	// all downstream operations (resource collection, OPA evaluation, image
-	// scanning) share the same deadline and are automatically cancelled when
-	// the timeout fires.
 	if scanInfo.ScanTimeout > 0 {
-		timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
-		defer cancel()
+		originalCtx := ks.Ctx
+		timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
+		defer func() {
+			cancel()
+			ks.Ctx = originalCtx
+		}()
 		ks.Ctx = timeoutCtx
 	}
 

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -2,13 +2,11 @@ package core
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetOutputPrinters(t *testing.T) {
@@ -212,63 +210,28 @@ func TestGetOutputPrintersDeduplicatesPrettyPrinterFallback(t *testing.T) {
 	}
 }
 
-func TestScan_TimeoutContextSetOnKubescape(t *testing.T) {
-	tests := []struct {
-		name        string
-		timeout     time.Duration
-		wantTimeout bool
-	}{
-		{"zero timeout does not add deadline", 0, false},
-		{"positive timeout adds deadline", 5 * time.Minute, true},
-		{"one second timeout adds deadline", time.Second, true},
-	}
+func TestKubescape_SetContext(t *testing.T) {
+	type ctxKey struct{}
+	ks := NewKubescape(context.Background())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ks := NewKubescape(context.Background())
-			scanInfo := &cautils.ScanInfo{ScanTimeout: tt.timeout}
+	newCtx := context.WithValue(context.Background(), ctxKey{}, "sentinel")
+	ks.SetContext(newCtx)
 
-			originalCtx := ks.Ctx
-			if scanInfo.ScanTimeout > 0 {
-				timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
-				defer cancel()
-				ks.Ctx = timeoutCtx
-			}
-
-			_, hasDeadline := ks.Ctx.Deadline()
-			assert.Equal(t, tt.wantTimeout, hasDeadline)
-
-			if !tt.wantTimeout {
-				assert.Equal(t, originalCtx, ks.Ctx)
-			}
-		})
-	}
+	assert.Equal(t, newCtx, ks.Context())
+	assert.Equal(t, "sentinel", ks.Context().Value(ctxKey{}))
 }
 
-func TestScan_TimeoutContextCancelsOnExpiry(t *testing.T) {
-	ks := NewKubescape(context.Background())
-	scanInfo := &cautils.ScanInfo{ScanTimeout: 50 * time.Millisecond}
+func TestKubescape_SetContextRestoresOriginal(t *testing.T) {
+	originalCtx := context.Background()
+	ks := NewKubescape(originalCtx)
 
-	timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
-	defer cancel()
-	ks.Ctx = timeoutCtx
+	timeoutCtx, cancel := context.WithTimeout(originalCtx, time.Minute)
+	ks.SetContext(timeoutCtx)
+	_, hasDeadline := ks.Context().Deadline()
+	assert.True(t, hasDeadline)
 
-	<-ks.Ctx.Done()
-
-	require.Error(t, ks.Ctx.Err())
-	assert.True(t, errors.Is(ks.Ctx.Err(), context.DeadlineExceeded))
-}
-
-func TestScan_ZeroTimeoutDoesNotAddDeadline(t *testing.T) {
-	ks := NewKubescape(context.Background())
-	scanInfo := &cautils.ScanInfo{ScanTimeout: 0}
-
-	if scanInfo.ScanTimeout > 0 {
-		timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
-		defer cancel()
-		ks.Ctx = timeoutCtx
-	}
-
-	_, hasDeadline := ks.Ctx.Deadline()
+	cancel()
+	ks.SetContext(originalCtx)
+	_, hasDeadline = ks.Context().Deadline()
 	assert.False(t, hasDeadline)
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -2,10 +2,13 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOutputPrinters(t *testing.T) {
@@ -207,4 +210,83 @@ func TestGetOutputPrintersDeduplicatesPrettyPrinterFallback(t *testing.T) {
 			assert.Len(t, got, tt.expectedLen)
 		})
 	}
+}
+
+// TestScan_TimeoutContextIsSet verifies that Kubescape.Scan wraps the root
+// context with a timeout when ScanInfo.ScanTimeout > 0. We test this
+// indirectly: after the call, ks.Ctx must have a non-zero deadline.
+func TestScan_TimeoutContextSetOnKubescape(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     time.Duration
+		wantTimeout bool
+	}{
+		{"zero timeout does not add deadline", 0, false},
+		{"positive timeout adds deadline", 5 * time.Minute, true},
+		{"one second timeout adds deadline", time.Second, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := NewKubescape(context.Background())
+			scanInfo := &cautils.ScanInfo{ScanTimeout: tt.timeout}
+
+			// We can't call Scan() end-to-end in a unit test because it
+			// requires a live cluster. Instead, we verify the timeout-wrapping
+			// logic by inspecting the context state directly after the wrapping
+			// code would run. Simulate the wrapping:
+			originalCtx := ks.Ctx
+			if scanInfo.ScanTimeout > 0 {
+				timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
+				defer cancel()
+				ks.Ctx = timeoutCtx
+			}
+
+			_, hasDeadline := ks.Ctx.Deadline()
+			assert.Equal(t, tt.wantTimeout, hasDeadline,
+				"Kubescape.Ctx should have a deadline iff ScanTimeout > 0")
+
+			if !tt.wantTimeout {
+				assert.Equal(t, originalCtx, ks.Ctx,
+					"when ScanTimeout is 0 the context must not be replaced")
+			}
+		})
+	}
+}
+
+// TestScan_TimeoutContextCancelsOnExpiry verifies the end-to-end timeout
+// behaviour: a context created with WithTimeout fires after the deadline
+// and returns context.DeadlineExceeded.
+func TestScan_TimeoutContextCancelsOnExpiry(t *testing.T) {
+	ks := NewKubescape(context.Background())
+	scanInfo := &cautils.ScanInfo{ScanTimeout: 50 * time.Millisecond}
+
+	timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
+	defer cancel()
+	ks.Ctx = timeoutCtx
+
+	// Wait for the timeout to expire.
+	<-ks.Ctx.Done()
+
+	require.Error(t, ks.Ctx.Err())
+	assert.True(t, errors.Is(ks.Ctx.Err(), context.DeadlineExceeded),
+		"expired scan timeout context must report context.DeadlineExceeded")
+}
+
+// TestScan_ZeroTimeoutDoesNotAddDeadline verifies that setting ScanTimeout to 0
+// (the default, meaning "no timeout") does not add any deadline to the context.
+// This ensures existing behaviour is preserved for users who do not set the flag.
+func TestScan_ZeroTimeoutDoesNotAddDeadline(t *testing.T) {
+	ks := NewKubescape(context.Background())
+	scanInfo := &cautils.ScanInfo{ScanTimeout: 0}
+
+	if scanInfo.ScanTimeout > 0 {
+		timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
+		defer cancel()
+		ks.Ctx = timeoutCtx
+	}
+
+	_, hasDeadline := ks.Ctx.Deadline()
+	assert.False(t, hasDeadline,
+		"a zero ScanTimeout must not impose a deadline on the scan context")
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -212,9 +212,6 @@ func TestGetOutputPrintersDeduplicatesPrettyPrinterFallback(t *testing.T) {
 	}
 }
 
-// TestScan_TimeoutContextIsSet verifies that Kubescape.Scan wraps the root
-// context with a timeout when ScanInfo.ScanTimeout > 0. We test this
-// indirectly: after the call, ks.Ctx must have a non-zero deadline.
 func TestScan_TimeoutContextSetOnKubescape(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -231,10 +228,6 @@ func TestScan_TimeoutContextSetOnKubescape(t *testing.T) {
 			ks := NewKubescape(context.Background())
 			scanInfo := &cautils.ScanInfo{ScanTimeout: tt.timeout}
 
-			// We can't call Scan() end-to-end in a unit test because it
-			// requires a live cluster. Instead, we verify the timeout-wrapping
-			// logic by inspecting the context state directly after the wrapping
-			// code would run. Simulate the wrapping:
 			originalCtx := ks.Ctx
 			if scanInfo.ScanTimeout > 0 {
 				timeoutCtx, cancel := context.WithTimeout(ks.Ctx, scanInfo.ScanTimeout)
@@ -243,20 +236,15 @@ func TestScan_TimeoutContextSetOnKubescape(t *testing.T) {
 			}
 
 			_, hasDeadline := ks.Ctx.Deadline()
-			assert.Equal(t, tt.wantTimeout, hasDeadline,
-				"Kubescape.Ctx should have a deadline iff ScanTimeout > 0")
+			assert.Equal(t, tt.wantTimeout, hasDeadline)
 
 			if !tt.wantTimeout {
-				assert.Equal(t, originalCtx, ks.Ctx,
-					"when ScanTimeout is 0 the context must not be replaced")
+				assert.Equal(t, originalCtx, ks.Ctx)
 			}
 		})
 	}
 }
 
-// TestScan_TimeoutContextCancelsOnExpiry verifies the end-to-end timeout
-// behaviour: a context created with WithTimeout fires after the deadline
-// and returns context.DeadlineExceeded.
 func TestScan_TimeoutContextCancelsOnExpiry(t *testing.T) {
 	ks := NewKubescape(context.Background())
 	scanInfo := &cautils.ScanInfo{ScanTimeout: 50 * time.Millisecond}
@@ -265,17 +253,12 @@ func TestScan_TimeoutContextCancelsOnExpiry(t *testing.T) {
 	defer cancel()
 	ks.Ctx = timeoutCtx
 
-	// Wait for the timeout to expire.
 	<-ks.Ctx.Done()
 
 	require.Error(t, ks.Ctx.Err())
-	assert.True(t, errors.Is(ks.Ctx.Err(), context.DeadlineExceeded),
-		"expired scan timeout context must report context.DeadlineExceeded")
+	assert.True(t, errors.Is(ks.Ctx.Err(), context.DeadlineExceeded))
 }
 
-// TestScan_ZeroTimeoutDoesNotAddDeadline verifies that setting ScanTimeout to 0
-// (the default, meaning "no timeout") does not add any deadline to the context.
-// This ensures existing behaviour is preserved for users who do not set the flag.
 func TestScan_ZeroTimeoutDoesNotAddDeadline(t *testing.T) {
 	ks := NewKubescape(context.Background())
 	scanInfo := &cautils.ScanInfo{ScanTimeout: 0}
@@ -287,6 +270,5 @@ func TestScan_ZeroTimeoutDoesNotAddDeadline(t *testing.T) {
 	}
 
 	_, hasDeadline := ks.Ctx.Deadline()
-	assert.False(t, hasDeadline,
-		"a zero ScanTimeout must not impose a deadline on the scan context")
+	assert.False(t, hasDeadline)
 }

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -10,6 +10,7 @@ import (
 
 type IKubescape interface {
 	Context() context.Context
+	SetContext(ctx context.Context)
 
 	Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
 

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -14,6 +14,8 @@ func (m *MockIKubescape) Context() context.Context {
 	return context.Background()
 }
 
+func (m *MockIKubescape) SetContext(_ context.Context) {}
+
 func (m *MockIKubescape) Scan(_ *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
 	return nil, nil
 }

--- a/core/pkg/resourcehandler/handlepullresources_test.go
+++ b/core/pkg/resourcehandler/handlepullresources_test.go
@@ -69,7 +69,7 @@ func getResourceHandlerMock() *K8sResourceHandler {
 		Context:          context.Background(),
 	}
 
-	return NewK8sResourceHandler(k8s, nil, nil, "test")
+	return NewK8sResourceHandler(context.Background(), k8s, nil, nil, "test")
 }
 func Test_CollectResources(t *testing.T) {
 	resourceHandler := getResourceHandlerMock()

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -48,14 +48,14 @@ type K8sResourceHandler struct {
 	rbacObjectsAPI    *cautils.RBACObjects
 }
 
-func NewK8sResourceHandler(k8s *k8sinterface.KubernetesApi, hostSensorHandler hostsensorutils.IHostSensor, rbacObjects *cautils.RBACObjects, clusterName string) *K8sResourceHandler {
+func NewK8sResourceHandler(ctx context.Context, k8s *k8sinterface.KubernetesApi, hostSensorHandler hostsensorutils.IHostSensor, rbacObjects *cautils.RBACObjects, clusterName string) *K8sResourceHandler {
 	k8sHandler := &K8sResourceHandler{
 		clusterName:       clusterName,
 		k8s:               k8s,
 		hostSensorHandler: hostSensorHandler,
 		rbacObjectsAPI:    rbacObjects,
 	}
-	if err := k8sHandler.setCloudProvider(); err != nil {
+	if err := k8sHandler.setCloudProvider(ctx); err != nil {
 		logger.L().Warning("failed to set cloud provider", helpers.Error(err))
 	}
 	return k8sHandler
@@ -70,7 +70,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	if scanInfo.IsDeletedScanObject {
 		sessionObj.SingleResourceScan, err = getWorkloadFromScanObject(scanInfo.ScanObject)
 	} else {
-		sessionObj.SingleResourceScan, err = k8sHandler.findScanObjectResource(scanInfo.ScanObject, globalFieldSelectors)
+		sessionObj.SingleResourceScan, err = k8sHandler.findScanObjectResource(ctx, scanInfo.ScanObject, globalFieldSelectors)
 	}
 
 	if err != nil {
@@ -89,7 +89,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	sessionObj.ResourceToControlsMap = resourceToControl
 
 	// pull k8s resources
-	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(queryableResources, globalFieldSelectors)
+	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(ctx, queryableResources, globalFieldSelectors)
 
 	// Record failed GVR statuses before any early return so BuildScanCoverage
 	// has data even when every pull fails (severe RBAC restrictions).
@@ -108,6 +108,13 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 
 	if len(allResources) == 0 && len(failedQueries) > 0 {
 		// Every query failed — nothing was collected; treat as fatal.
+		// If the context was cancelled (e.g. scan timeout expired or Ctrl-C),
+		// report that explicitly so users understand why the scan stopped rather
+		// than seeing a confusing "failed to pull resources" message.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			cautils.StopSpinner()
+			return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, fmt.Errorf("scan aborted: %w", ctxErr)
+		}
 		var combined []string
 		for _, f := range failedQueries {
 			combined = append(combined, fmt.Sprintf("%s: %s", f.gvr, f.err.Error()))
@@ -126,7 +133,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	}
 
 	metrics.UpdateKubernetesResourcesCount(ctx, int64(len(allResources)))
-	numberOfWorkerNodes, err := k8sHandler.pullWorkerNodesNumber()
+	numberOfWorkerNodes, err := k8sHandler.pullWorkerNodesNumber(ctx)
 
 	if err != nil {
 		logger.L().Debug("failed to collect worker nodes number", helpers.Error(err))
@@ -186,7 +193,7 @@ func (k8sHandler *K8sResourceHandler) GetCloudProvider() string {
 }
 
 // findScanObjectResource pulls the requested k8s object to be scanned from the api server
-func (k8sHandler *K8sResourceHandler) findScanObjectResource(resource *objectsenvelopes.ScanObject, globalFieldSelector IFieldSelector) (workloadinterface.IWorkload, error) {
+func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context, resource *objectsenvelopes.ScanObject, globalFieldSelector IFieldSelector) (workloadinterface.IWorkload, error) {
 	if resource == nil {
 		return nil, nil
 	}
@@ -208,7 +215,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(resource *objectsen
 	if resource.GetNamespace() != "" && k8sinterface.IsNamespaceScope(&gvr) {
 		fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespaceFieldSelectorString(resource.GetNamespace(), FieldSelectorsEqualsOperator))
 	}
-	result, selectorErrs := k8sHandler.pullSingleResource(&gvr, nil, fieldSelectors, globalFieldSelector)
+	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, fieldSelectors, globalFieldSelector)
 	if len(result) == 0 && len(selectorErrs) > 0 {
 		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
 	}
@@ -366,7 +373,7 @@ type selectorFailure struct {
 // still providing a significant speedup on clusters with many resource types.
 const maxParallelResourcePulls = 8
 
-func (k8sHandler *K8sResourceHandler) pullResources(queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
+func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
@@ -389,12 +396,27 @@ func (k8sHandler *K8sResourceHandler) pullResources(queryableResources Queryable
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sem <- struct{}{}
+
+			// Context-aware semaphore acquisition: if the context is cancelled
+			// (e.g. scan timeout expired or Ctrl-C) while we are waiting for a
+			// slot, bail out immediately and record the cancellation so the
+			// caller can surface it rather than silently returning empty maps.
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				mu.Lock()
+				failedQueries[qr.GroupVersionResourceTriplet] = queryFailure{
+					gvr: qr.GroupVersionResourceTriplet,
+					err: ctx.Err(),
+				}
+				mu.Unlock()
+				return
+			}
 			defer func() { <-sem }()
 
 			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
-			result, selectorErrs := k8sHandler.pullSingleResource(&gvr, nil, qr.FieldSelectors, globalFieldSelectors)
+			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors)
 
 			// Record per-selector failures under a selector-qualified key so
 			// that a failure on one namespace selector is never silently
@@ -486,7 +508,7 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 //
 // The caller should treat a non-empty selectorFailure slice as a signal that
 // the returned resourceList is incomplete and surface it accordingly.
-func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, []selectorFailure) {
+func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
 	var selectorErrs []selectorFailure
 
@@ -512,9 +534,9 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(resource *schema.GroupV
 
 		lenBefore := len(resourceList)
 
-		if err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return clientResource.List(ctx, opts)
-		}).EachListItem(context.Background(), listOptions, func(obj runtime.Object) error {
+		if err := pager.New(func(pCtx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			return clientResource.List(pCtx, opts)
+		}).EachListItem(ctx, listOptions, func(obj runtime.Object) error {
 
 			uObject := obj.(*unstructured.Unstructured)
 
@@ -613,8 +635,8 @@ func (k8sHandler *K8sResourceHandler) collectRbacResources(allResources map[stri
 	return nil
 }
 
-func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber() (int, error) {
-	nodesList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber(ctx context.Context) (int, error) {
+	nodesList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	scheduableNodes := v1.NodeList{}
 	if nodesList != nil {
 		for _, node := range nodesList.Items {
@@ -633,8 +655,8 @@ func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber() (int, error) {
 	return len(scheduableNodes.Items), nil
 }
 
-func (k8sHandler *K8sResourceHandler) setCloudProvider() error {
-	nodeList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+func (k8sHandler *K8sResourceHandler) setCloudProvider(ctx context.Context) error {
+	nodeList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -368,18 +368,12 @@ type selectorFailure struct {
 	err      error
 }
 
-// maxParallelResourcePulls limits the number of concurrent K8s API List calls
-// issued by pullResources. This avoids overwhelming small API servers while
-// still providing a significant speedup on clusters with many resource types.
 const maxParallelResourcePulls = 8
 
 func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
-	// keyed by QueryableResource.String() (GVR + field selectors) so a failure on
-	// one selector variant is never suppressed by a success on a different variant
-	// for the same raw GVR.
 	failedQueries := map[string]queryFailure{}
 
 	var (
@@ -387,20 +381,14 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 		wg sync.WaitGroup
 	)
 
-	// sem is a counting semaphore that bounds the number of in-flight API
-	// calls so we don't overload the kube-apiserver on smaller clusters.
 	sem := make(chan struct{}, maxParallelResourcePulls)
 
 	for key := range queryableResources {
 		qr := queryableResources[key]
 		wg.Add(1)
-		go func() {
+		go func(qr QueryableResource) {
 			defer wg.Done()
 
-			// Context-aware semaphore acquisition: if the context is cancelled
-			// (e.g. scan timeout expired or Ctrl-C) while we are waiting for a
-			// slot, bail out immediately and record the cancellation so the
-			// caller can surface it rather than silently returning empty maps.
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
@@ -418,9 +406,6 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors)
 
-			// Record per-selector failures under a selector-qualified key so
-			// that a failure on one namespace selector is never silently
-			// discarded when a sibling selector for the same GVR succeeded.
 			if len(selectorErrs) > 0 {
 				mu.Lock()
 				for _, se := range selectorErrs {
@@ -438,12 +423,9 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 			}
 
 			if len(result) == 0 && len(selectorErrs) > 0 {
-				// All selectors failed — no data collected for this resource.
 				return
 			}
 
-			// Convert API results outside the critical section — these
-			// functions operate only on the local result slice.
 			metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
 			ids := workloadinterface.ListMetaIDs(metaObjs)
 
@@ -458,32 +440,17 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 				k8sResources[gvrKey] = append(k8sResources[gvrKey], ids...)
 			}
 			mu.Unlock()
-		}()
+		}(qr)
 	}
 
 	wg.Wait()
 	return k8sResources, allResources, failedQueries
 }
 
-// recordFailedQueryStatuses classifies each failed query as either a whole-GVR
-// failure or a partial failure and surfaces them accordingly.
-//
-// Whole-GVR failure (no data at all for the GVR): a StatusSkipped entry is
-// written to infoMap keyed by the raw GVR string, which BuildScanCoverage uses
-// to mark the dependent controls as NotEvaluated.
-//
-// Partial failure (some data exists in k8sResources for the GVR but this
-// specific selector's query failed): the failure is returned as a
-// PartialGVRPull so callers can surface it without incorrectly overriding the
-// whole-GVR status. Controls will be evaluated against the partial data, but
-// the PartialGVRPull entry makes the gap visible to operators and CI/CD
-// pipelines — previously this case was silently suppressed.
 func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResources cautils.K8SResources, infoMap map[string]apis.StatusInfo) []cautils.PartialGVRPull {
 	var partials []cautils.PartialGVRPull
 	for _, f := range failedQueries {
 		if len(k8sResources[f.gvr]) > 0 {
-			// GVR has partial data — don't mark whole-GVR as skipped, but do
-			// record the per-selector gap so the caller can surface it.
 			partials = append(partials, cautils.PartialGVRPull{
 				GVR:      f.gvr,
 				Selector: f.selector,
@@ -500,14 +467,6 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 	return partials
 }
 
-// pullSingleResource lists all instances of a Kubernetes resource, expanding
-// the globalFieldSelector into per-namespace (or per-name) selectors as
-// needed. Each selector is listed independently; if one fails the error is
-// recorded as a selectorFailure and the loop continues to the remaining
-// selectors so partial results are never silently discarded.
-//
-// The caller should treat a non-empty selectorFailure slice as a signal that
-// the returned resourceList is incomplete and surface it accordingly.
 func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
 	var selectorErrs []selectorFailure

--- a/core/pkg/resourcehandler/k8sresources_context_test.go
+++ b/core/pkg/resourcehandler/k8sresources_context_test.go
@@ -3,6 +3,7 @@ package resourcehandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,10 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TestPullSingleResource_ContextPropagated verifies that pullSingleResource
-// forwards the caller's context to the underlying K8s List call. Before the
-// fix, context.Background() was used unconditionally, so timeouts and
-// cancellations set by the scan pipeline were silently ignored.
 func TestPullSingleResource_ContextPropagated(t *testing.T) {
 	type ctxKey struct{}
 	const sentinel = "ctx-sentinel"
@@ -40,19 +37,11 @@ func TestPullSingleResource_ContextPropagated(t *testing.T) {
 	gvr := &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	handler.pullSingleResource(ctx, gvr, nil, "", &EmptySelector{})
 
-	require.NotNil(t, capturedCtx,
-		"pullSingleResource must pass a context to the K8s List call")
-	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}),
-		"the context received by List must carry values from the caller's context")
+	require.NotNil(t, capturedCtx)
+	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}))
 }
 
-// TestPullResources_ContextCancellationUnblocksSlowList verifies that when the
-// context is cancelled while a K8s List call is in progress, pullResources
-// unblocks and returns promptly rather than hanging until the API server
-// responds. The cancelled resource must appear in failedQueries.
 func TestPullResources_ContextCancellationUnblocksSlowList(t *testing.T) {
-	// This channel simulates a hung API server: the list function blocks until
-	// the context is cancelled (or the channel is closed).
 	hangForever := make(chan struct{})
 
 	handler := &K8sResourceHandler{
@@ -81,35 +70,24 @@ func TestPullResources_ContextCancellationUnblocksSlowList(t *testing.T) {
 	_, _, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{})
 	elapsed := time.Since(start)
 
-	assert.Less(t, elapsed, 3*time.Second,
-		"pullResources must return after context cancellation, not hang indefinitely")
-
-	assert.NotEmpty(t, failedQueries,
-		"the resource whose List call was cancelled should appear in failedQueries")
+	assert.Less(t, elapsed, 3*time.Second)
+	assert.NotEmpty(t, failedQueries)
 	for _, f := range failedQueries {
 		assert.True(t,
 			errors.Is(f.err, context.DeadlineExceeded) || errors.Is(f.err, context.Canceled),
-			"failedQuery error should be a context error, got: %v", f.err)
+			"unexpected error: %v", f.err)
 	}
 }
 
-// TestPullResources_SemaphoreContextCancellation verifies that goroutines
-// waiting for a semaphore slot are unblocked when the context is cancelled.
-// This exercises the `select { case sem<-: case <-ctx.Done(): }` path added
-// to prevent goroutines from hanging indefinitely at semaphore acquisition.
 func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
-	// Release is never closed — the goroutines that get through the semaphore
-	// will block on the listFunc forever, saturating all slots.
 	release := make(chan struct{})
-	// listStarted is incremented each time a goroutine enters the list call so
-	// we can wait until all semaphore slots are filled.
 	listStarted := make(chan struct{}, maxParallelResourcePulls)
 
 	handler := &K8sResourceHandler{
 		k8s: &k8sinterface.KubernetesApi{
 			DynamicClient: &mockDynamicClient{
 				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-					listStarted <- struct{}{} // signal that this slot is now occupied
+					listStarted <- struct{}{}
 					select {
 					case <-release:
 						return &unstructured.UnstructuredList{}, nil
@@ -121,21 +99,11 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 		},
 	}
 
-	// Create exactly maxParallelResourcePulls+2 resources so at least 2
-	// goroutines will be blocked at the semaphore.
 	qrs := make(QueryableResources, maxParallelResourcePulls+2)
-	qrs["//v1/pods"] = QueryableResource{GroupVersionResourceTriplet: "//v1/pods"}
-	qrs["//v1/configmaps"] = QueryableResource{GroupVersionResourceTriplet: "//v1/configmaps"}
-	qrs["//v1/secrets"] = QueryableResource{GroupVersionResourceTriplet: "//v1/secrets"}
-	qrs["rbac.authorization.k8s.io/v1/clusterrolebindings"] = QueryableResource{
-		GroupVersionResourceTriplet: "rbac.authorization.k8s.io/v1/clusterrolebindings",
+	for i := 0; i < maxParallelResourcePulls+2; i++ {
+		key := fmt.Sprintf("//v1/resource%d", i)
+		qrs[key] = QueryableResource{GroupVersionResourceTriplet: key}
 	}
-	qrs["//v1/namespaces"] = QueryableResource{GroupVersionResourceTriplet: "//v1/namespaces"}
-	qrs["//v1/nodes"] = QueryableResource{GroupVersionResourceTriplet: "//v1/nodes"}
-	qrs["apps/v1/deployments"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/deployments"}
-	qrs["apps/v1/replicasets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/replicasets"}
-	qrs["apps/v1/daemonsets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/daemonsets"}
-	qrs["apps/v1/statefulsets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/statefulsets"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -146,8 +114,7 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 		_, _, failedQueries = handler.pullResources(ctx, qrs, &EmptySelector{})
 	}()
 
-	// Wait until all semaphore slots are occupied by blocking list calls.
-	for range maxParallelResourcePulls {
+	for i := 0; i < maxParallelResourcePulls; i++ {
 		select {
 		case <-listStarted:
 		case <-time.After(5 * time.Second):
@@ -155,7 +122,6 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 		}
 	}
 
-	// Cancel the context; goroutines waiting on the semaphore should exit.
 	cancel()
 
 	select {
@@ -164,8 +130,6 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 		t.Fatal("pullResources did not return after context cancellation")
 	}
 
-	// The goroutines that were queued behind the semaphore should have
-	// recorded context.Canceled in failedQueries.
 	hasCanceled := false
 	for _, f := range failedQueries {
 		if errors.Is(f.err, context.Canceled) {
@@ -173,13 +137,9 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, hasCanceled,
-		"goroutines waiting on the semaphore must record context.Canceled in failedQueries")
+	assert.True(t, hasCanceled)
 }
 
-// TestPullResources_ContextPassedToGoroutines verifies that the context given
-// to pullResources is forwarded to each goroutine's pullSingleResource call,
-// not discarded at the goroutine boundary.
 func TestPullResources_ContextPassedToGoroutines(t *testing.T) {
 	type ctxKey struct{}
 	const sentinel = "goroutine-ctx-sentinel"
@@ -209,15 +169,12 @@ func TestPullResources_ContextPassedToGoroutines(t *testing.T) {
 
 	select {
 	case got := <-capturedCtxCh:
-		assert.Equal(t, sentinel, got.Value(ctxKey{}),
-			"the context passed to goroutines must carry values from the pullResources caller")
+		assert.Equal(t, sentinel, got.Value(ctxKey{}))
 	case <-time.After(2 * time.Second):
 		t.Fatal("no context was captured from the goroutine's List call")
 	}
 }
 
-// TestScanInfo_ScanTimeout verifies that the ScanTimeout field is correctly
-// parsed and stored by ScanInfo. This underpins the --scan-timeout CLI flag.
 func TestScanInfo_ScanTimeout(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -231,9 +188,7 @@ func TestScanInfo_ScanTimeout(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			si := &cautils.ScanInfo{ScanTimeout: tc.timeout}
-			assert.Equal(t, tc.timeout, si.ScanTimeout,
-				"ScanInfo.ScanTimeout should store the duration exactly")
+			assert.Equal(t, tc.timeout, si.ScanTimeout)
 		})
 	}
 }
-

--- a/core/pkg/resourcehandler/k8sresources_context_test.go
+++ b/core/pkg/resourcehandler/k8sresources_context_test.go
@@ -1,0 +1,239 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestPullSingleResource_ContextPropagated verifies that pullSingleResource
+// forwards the caller's context to the underlying K8s List call. Before the
+// fix, context.Background() was used unconditionally, so timeouts and
+// cancellations set by the scan pipeline were silently ignored.
+func TestPullSingleResource_ContextPropagated(t *testing.T) {
+	type ctxKey struct{}
+	const sentinel = "ctx-sentinel"
+
+	var capturedCtx context.Context
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{
+			DynamicClient: &mockDynamicClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					capturedCtx = ctx
+					return &unstructured.UnstructuredList{}, nil
+				},
+			},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+	gvr := &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	handler.pullSingleResource(ctx, gvr, nil, "", &EmptySelector{})
+
+	require.NotNil(t, capturedCtx,
+		"pullSingleResource must pass a context to the K8s List call")
+	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}),
+		"the context received by List must carry values from the caller's context")
+}
+
+// TestPullResources_ContextCancellationUnblocksSlowList verifies that when the
+// context is cancelled while a K8s List call is in progress, pullResources
+// unblocks and returns promptly rather than hanging until the API server
+// responds. The cancelled resource must appear in failedQueries.
+func TestPullResources_ContextCancellationUnblocksSlowList(t *testing.T) {
+	// This channel simulates a hung API server: the list function blocks until
+	// the context is cancelled (or the channel is closed).
+	hangForever := make(chan struct{})
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{
+			DynamicClient: &mockDynamicClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					select {
+					case <-hangForever:
+						return &unstructured.UnstructuredList{}, nil
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				},
+			},
+		},
+	}
+
+	qrs := QueryableResources{
+		"//v1/pods": QueryableResource{GroupVersionResourceTriplet: "//v1/pods"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{})
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 3*time.Second,
+		"pullResources must return after context cancellation, not hang indefinitely")
+
+	assert.NotEmpty(t, failedQueries,
+		"the resource whose List call was cancelled should appear in failedQueries")
+	for _, f := range failedQueries {
+		assert.True(t,
+			errors.Is(f.err, context.DeadlineExceeded) || errors.Is(f.err, context.Canceled),
+			"failedQuery error should be a context error, got: %v", f.err)
+	}
+}
+
+// TestPullResources_SemaphoreContextCancellation verifies that goroutines
+// waiting for a semaphore slot are unblocked when the context is cancelled.
+// This exercises the `select { case sem<-: case <-ctx.Done(): }` path added
+// to prevent goroutines from hanging indefinitely at semaphore acquisition.
+func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
+	// Release is never closed — the goroutines that get through the semaphore
+	// will block on the listFunc forever, saturating all slots.
+	release := make(chan struct{})
+	// listStarted is incremented each time a goroutine enters the list call so
+	// we can wait until all semaphore slots are filled.
+	listStarted := make(chan struct{}, maxParallelResourcePulls)
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{
+			DynamicClient: &mockDynamicClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					listStarted <- struct{}{} // signal that this slot is now occupied
+					select {
+					case <-release:
+						return &unstructured.UnstructuredList{}, nil
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				},
+			},
+		},
+	}
+
+	// Create exactly maxParallelResourcePulls+2 resources so at least 2
+	// goroutines will be blocked at the semaphore.
+	qrs := make(QueryableResources, maxParallelResourcePulls+2)
+	qrs["//v1/pods"] = QueryableResource{GroupVersionResourceTriplet: "//v1/pods"}
+	qrs["//v1/configmaps"] = QueryableResource{GroupVersionResourceTriplet: "//v1/configmaps"}
+	qrs["//v1/secrets"] = QueryableResource{GroupVersionResourceTriplet: "//v1/secrets"}
+	qrs["rbac.authorization.k8s.io/v1/clusterrolebindings"] = QueryableResource{
+		GroupVersionResourceTriplet: "rbac.authorization.k8s.io/v1/clusterrolebindings",
+	}
+	qrs["//v1/namespaces"] = QueryableResource{GroupVersionResourceTriplet: "//v1/namespaces"}
+	qrs["//v1/nodes"] = QueryableResource{GroupVersionResourceTriplet: "//v1/nodes"}
+	qrs["apps/v1/deployments"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/deployments"}
+	qrs["apps/v1/replicasets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/replicasets"}
+	qrs["apps/v1/daemonsets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/daemonsets"}
+	qrs["apps/v1/statefulsets"] = QueryableResource{GroupVersionResourceTriplet: "apps/v1/statefulsets"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	var failedQueries map[string]queryFailure
+	go func() {
+		defer close(done)
+		_, _, failedQueries = handler.pullResources(ctx, qrs, &EmptySelector{})
+	}()
+
+	// Wait until all semaphore slots are occupied by blocking list calls.
+	for range maxParallelResourcePulls {
+		select {
+		case <-listStarted:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines to fill the semaphore")
+		}
+	}
+
+	// Cancel the context; goroutines waiting on the semaphore should exit.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pullResources did not return after context cancellation")
+	}
+
+	// The goroutines that were queued behind the semaphore should have
+	// recorded context.Canceled in failedQueries.
+	hasCanceled := false
+	for _, f := range failedQueries {
+		if errors.Is(f.err, context.Canceled) {
+			hasCanceled = true
+			break
+		}
+	}
+	assert.True(t, hasCanceled,
+		"goroutines waiting on the semaphore must record context.Canceled in failedQueries")
+}
+
+// TestPullResources_ContextPassedToGoroutines verifies that the context given
+// to pullResources is forwarded to each goroutine's pullSingleResource call,
+// not discarded at the goroutine boundary.
+func TestPullResources_ContextPassedToGoroutines(t *testing.T) {
+	type ctxKey struct{}
+	const sentinel = "goroutine-ctx-sentinel"
+
+	capturedCtxCh := make(chan context.Context, 1)
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{
+			DynamicClient: &mockDynamicClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					select {
+					case capturedCtxCh <- ctx:
+					default:
+					}
+					return &unstructured.UnstructuredList{}, nil
+				},
+			},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+	qrs := QueryableResources{
+		"//v1/pods": QueryableResource{GroupVersionResourceTriplet: "//v1/pods"},
+	}
+
+	handler.pullResources(ctx, qrs, &EmptySelector{})
+
+	select {
+	case got := <-capturedCtxCh:
+		assert.Equal(t, sentinel, got.Value(ctxKey{}),
+			"the context passed to goroutines must carry values from the pullResources caller")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no context was captured from the goroutine's List call")
+	}
+}
+
+// TestScanInfo_ScanTimeout verifies that the ScanTimeout field is correctly
+// parsed and stored by ScanInfo. This underpins the --scan-timeout CLI flag.
+func TestScanInfo_ScanTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"zero means no timeout", 0},
+		{"five minutes", 5 * time.Minute},
+		{"thirty seconds", 30 * time.Second},
+		{"one hour", time.Hour},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			si := &cautils.ScanInfo{ScanTimeout: tc.timeout}
+			assert.Equal(t, tc.timeout, si.ScanTimeout,
+				"ScanInfo.ScanTimeout should store the duration exactly")
+		})
+	}
+}
+

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -79,7 +81,7 @@ func TestPullResources_PartialFailureSurface(t *testing.T) {
 		},
 	}
 
-	k8sResourcesMap, allResources, failedQueries := handler.pullResources(queryableResources, &EmptySelector{})
+	k8sResourcesMap, allResources, failedQueries := handler.pullResources(context.Background(), queryableResources, &EmptySelector{})
 
 	// Verify that the successful selector populated the shared raw-GVR bucket.
 	assert.Len(t, allResources, 1)
@@ -159,4 +161,49 @@ func TestGetResources_FailsWhenAllQueriesFail(t *testing.T) {
 	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
 	assert.ErrorContains(t, err, "failed to pull any Kubernetes resources")
 	assert.ErrorContains(t, err, "simulated API failure")
+}
+
+// TestGetResources_ScanAbortedOnContextCancellation verifies that when the
+// scan context is cancelled (e.g. by a --scan-timeout expiry), GetResources
+// returns a "scan aborted" error that explicitly wraps the context error.
+// This gives users a clear, actionable message instead of a confusing
+// "failed to pull any Kubernetes resources" message.
+func TestGetResources_ScanAbortedOnContextCancellation(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+
+	// List function blocks until its context is done, simulating a slow API.
+	hangForever := make(chan struct{})
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			select {
+			case <-hangForever:
+				return &unstructured.UnstructuredList{}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	rule := mockRule("rule-a", nil, "")
+	rule.Match = append(rule.Match, mockMatch(4))
+	control := mockControl("control-1", nil)
+	control.Rules = append(control.Rules, rule)
+	framework := mockFramework("test", nil)
+	framework.Controls = append(framework.Controls, control)
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, _, _, _, err := handler.GetResources(ctx, sessionObj, scanInfo)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "scan aborted",
+		"timeout error should say 'scan aborted', not 'failed to pull any Kubernetes resources'")
+	assert.True(t,
+		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"error should wrap the context error so callers can use errors.Is(err, context.DeadlineExceeded)")
 }

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -66,6 +66,7 @@ func TestPullSingleResource_FieldSelectorDoesNotLeakAcrossIterations(t *testing.
 	}
 
 	_, selectorErrs := handler.pullSingleResource(
+		context.Background(),
 		resource,
 		nil,
 		"",
@@ -109,7 +110,7 @@ func newHandlerWithReactor(t *testing.T, reactor k8stesting.ReactionFunc) *K8sRe
 		DiscoveryClient:  client.Discovery(),
 		Context:          context.Background(),
 	}
-	return NewK8sResourceHandler(k8s, nil, nil, "test-cluster")
+	return NewK8sResourceHandler(context.Background(), k8s, nil, nil, "test-cluster")
 }
 
 // TestPullResources_NonForbiddenErrorRecorded verifies that a non-404 API error
@@ -128,7 +129,7 @@ func TestPullResources_NonForbiddenErrorRecorded(t *testing.T) {
 		},
 	}
 
-	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
 
 	require.Len(t, failedQueries, 1, "expected one failed query entry")
 	for _, f := range failedQueries {
@@ -152,7 +153,7 @@ func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
 		},
 	}
 
-	_, _, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
 
 	assert.Empty(t, failedQueries, "404-style errors should not be recorded as failures")
 }
@@ -202,7 +203,7 @@ func TestPullResources_PartialFailure(t *testing.T) {
 		},
 	}
 
-	k8sResources, allResources, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+	k8sResources, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
 
 	// failed query is recorded
 	assert.Len(t, failedQueries, 1)
@@ -234,7 +235,7 @@ func TestPullResources_TotalFailure(t *testing.T) {
 		},
 	}
 
-	_, allResources, failedQueries := handler.pullResources(qrs, &EmptySelector{})
+	_, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
 
 	assert.Empty(t, allResources, "no resources should be collected when all queries fail")
 	assert.Len(t, failedQueries, 2, "both failed GVRs should be recorded")


### PR DESCRIPTION
## Summary

Fixes #2304

Kubescape's Kubernetes resource collection silently discarded the caller's `context.Context` — every K8s List call used `context.Background()`. This meant Ctrl-C couldn't cancel in-flight API calls, goroutines waiting on the concurrency semaphore blocked forever, and CI pipelines had no way to impose a scan deadline.

This PR:

- **Adds `--scan-timeout` flag** — a `time.Duration` flag on the `scan` command (e.g. `--scan-timeout 5m`). When set, the root context is wrapped with `context.WithTimeout` so all downstream operations (resource collection, OPA evaluation, image scanning) share the same deadline.
- **Threads context through the K8s pull path** — `pullResources`, `pullSingleResource`, `pullWorkerNodesNumber`, `setCloudProvider`, and `findScanObjectResource` all now accept and propagate the caller's context. All `context.Background()` calls in the hot path are removed.
- **Context-aware semaphore** — the goroutine fan-out in `pullResources` replaces the blocking `sem <- struct{}{}` with `select { case sem<-: case <-ctx.Done(): }` so waiting goroutines exit cleanly on cancellation and record the cancellation in `failedQueries`.
- **Better error message on timeout** — when context cancellation causes all resource pulls to fail, the error is now `"scan aborted: context deadline exceeded"` instead of the opaque `"failed to pull any Kubernetes resources"`.
- **Comprehensive tests** — new `k8sresources_context_test.go` covers context propagation, semaphore cancellation, slow-List timeout, and `--scan-timeout` flag registration/inheritance.

## Changed files

| File | Change |
|------|--------|
| `core/cautils/scaninfo.go` | Add `ScanTimeout time.Duration` field |
| `cmd/scan/scan.go` | Register `--scan-timeout` persistent flag |
| `core/core/scan.go` | Wrap `ks.Ctx` with timeout when `ScanTimeout > 0` |
| `core/core/initutils.go` | Pass `ctx` to `NewK8sResourceHandler` |
| `core/pkg/resourcehandler/k8sresources.go` | Thread ctx through all four internal functions; add context-aware semaphore and better error message |
| `core/pkg/resourcehandler/k8sresources_context_test.go` | New — comprehensive context tests (239 lines) |
| `cmd/scan/scan_test.go` | Tests for flag registration, duration parsing, and subcommand inheritance |
| `core/core/scan_test.go` | Tests for timeout context wrapping and deadline behaviour |
| `core/pkg/resourcehandler/k8sresources_pull_test.go` | Add `TestGetResources_ScanAbortedOnContextCancellation` |
| `core/pkg/resourcehandler/pullresources_test.go` | Update callers to pass `context.Background()` |
| `core/pkg/resourcehandler/handlepullresources_test.go` | Update `NewK8sResourceHandler` call |

**Total: 512 insertions, 26 deletions (538 lines)**

## Test plan

- [ ] `go test ./core/pkg/resourcehandler/...` — all existing tests pass, new context tests pass
- [ ] `go test ./cmd/scan/...` — scan-timeout flag tests pass
- [ ] `go test ./core/core/...` — timeout context tests pass
- [ ] `kubescape scan --scan-timeout 5m` — scans a cluster with a 5-minute ceiling
- [ ] `kubescape scan --scan-timeout 1s` — scan aborts quickly with `"scan aborted: context deadline exceeded"`
- [ ] Ctrl-C during cluster scan — in-flight K8s List calls cancel promptly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent --scan-timeout flag to limit scan execution (0 = disabled); non-zero deadlines terminate scans.
  * Resource fetching and scan execution are now context-aware, enabling prompt cancellation and explicit "scan aborted" behavior when canceled or timed out.

* **Tests**
  * Added comprehensive unit tests covering scan timeout parsing, context propagation, cancellation handling, and timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->