### PR TITLE
fix(printer): bucket failed controls by their own category, not a hardcoded ID allowlist

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/category_bucketing_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/category_bucketing_test.go
@@ -1,0 +1,178 @@
+package configurationprinter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+// failedCtrl is a tiny helper that returns a ControlSummary that the rendering
+// code will treat as a failing control belonging to the given category /
+// sub-category.
+func failedCtrl(id, name, catID, catName, subCatID, subCatName string) reportsummary.ControlSummary {
+	cat := &reporthandling.Category{ID: catID, Name: catName}
+	if subCatID != "" {
+		cat.SubCategory = &reporthandling.SubCategory{ID: subCatID, Name: subCatName}
+	}
+	return reportsummary.ControlSummary{
+		ControlID: id,
+		Name:      name,
+		Status:    apis.StatusFailed,
+		StatusCounters: reportsummary.StatusCounters{
+			FailedResources: 1,
+		},
+		Category: cat,
+	}
+}
+
+func TestBucketControlsByCategory_UsesControlOwnCategory(t *testing.T) {
+	// Two controls whose IDs are NOT in any legacy hardcoded allowlist; the
+	// previous implementation dropped both. They carry valid category metadata
+	// so the new bucketing function must surface them.
+	c270 := failedCtrl("C-0270", "Ensure CPU limits are set", "Cat-5", "Workload", "Cat-7", "Resource management")
+	c260 := failedCtrl("C-0260", "Missing network policy", "Cat-4", "Network", "", "")
+	sd := reportsummary.SummaryDetails{
+		Controls: map[string]reportsummary.ControlSummary{
+			"C-0270": c270,
+			"C-0260": c260,
+		},
+	}
+
+	got := bucketControlsByCategory(sd.ListControls())
+
+	if _, ok := got["Cat-7"]; !ok {
+		t.Errorf("expected sub-category Cat-7 (resource management) to be bucketed, got keys: %v", keys(got))
+	}
+	if _, ok := got["Cat-4"]; !ok {
+		t.Errorf("expected top-level Cat-4 (network) to be bucketed, got keys: %v", keys(got))
+	}
+	if got["Cat-7"].CategoryName != "Resource management" {
+		t.Errorf("expected sub-category name to be used, got %q", got["Cat-7"].CategoryName)
+	}
+}
+
+func TestBucketControlsByCategory_NilCategorySkipped(t *testing.T) {
+	sd := reportsummary.SummaryDetails{
+		Controls: map[string]reportsummary.ControlSummary{
+			"C-1": {ControlID: "C-1", Status: apis.StatusFailed},
+		},
+	}
+	got := bucketControlsByCategory(sd.ListControls())
+	if len(got) != 0 {
+		t.Errorf("expected nil-category controls to be skipped, got %v", got)
+	}
+}
+
+func TestCategoryRenderOrder_PreservesPreferredAndAppendsExtras(t *testing.T) {
+	categories := map[string]CategoryControls{
+		"Cat-1":   {},
+		"Cat-99":  {},
+		"Cat-2":   {},
+		"Cat-3":   {},
+		"Cat-XYZ": {},
+	}
+	got := categoryRenderOrder([]string{"Cat-1", "Cat-2", "Cat-3"}, categories)
+	want := []string{"Cat-1", "Cat-2", "Cat-3", "Cat-99", "Cat-XYZ"}
+	if !equalStrings(got, want) {
+		t.Errorf("expected order %v, got %v", want, got)
+	}
+}
+
+func TestCategoryRenderOrder_SkipsMissingPreferred(t *testing.T) {
+	categories := map[string]CategoryControls{
+		"Cat-2": {},
+		"Cat-7": {},
+	}
+	got := categoryRenderOrder([]string{"Cat-1", "Cat-2", "Cat-3"}, categories)
+	want := []string{"Cat-2", "Cat-7"}
+	if !equalStrings(got, want) {
+		t.Errorf("expected order %v, got %v", want, got)
+	}
+}
+
+// End-to-end-ish: render the repo printer against a SummaryDetails that
+// reproduces the bug scenario (C-0270 in resource-management, an upstream
+// addition past the August-2023 allowlist) and assert the rendered output
+// includes the control. Before the fix this fails because the control is
+// silently dropped at the rendering layer.
+func TestRepoPrinter_RendersControlsBeyondLegacyAllowlist(t *testing.T) {
+	ctrls := map[string]reportsummary.ControlSummary{
+		"C-0270": failedCtrl("C-0270", "Ensure CPU limits are set", "Cat-5", "Workload", "Cat-7", "Resource management"),
+		"C-0260": failedCtrl("C-0260", "Missing network policy", "Cat-4", "Network", "", ""),
+		"C-0013": failedCtrl("C-0013", "Non-root containers", "Cat-5", "Workload", "", ""),
+	}
+	sd := &reportsummary.SummaryDetails{Controls: ctrls}
+
+	var buf bytes.Buffer
+	NewRepoPrinter([]string{"/tmp/chart-test"}).PrintCategoriesTables(&buf, sd, nil)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Ensure CPU limits are set", // C-0270, was previously dropped
+		"Missing network policy",    // C-0260
+		"Non-root containers",       // C-0013, was already in the legacy allowlist
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected rendered output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestWorkloadPrinter_RendersControlsBeyondLegacyAllowlist(t *testing.T) {
+	ctrls := map[string]reportsummary.ControlSummary{
+		"C-0270": failedCtrl("C-0270", "Ensure CPU limits are set", "Cat-5", "Workload", "Cat-7", "Resource management"),
+		"C-0271": failedCtrl("C-0271", "Ensure memory limits are set", "Cat-5", "Workload", "Cat-7", "Resource management"),
+	}
+	sd := &reportsummary.SummaryDetails{Controls: ctrls}
+
+	var buf bytes.Buffer
+	NewWorkloadPrinter().PrintCategoriesTables(&buf, sd, nil)
+	out := buf.String()
+
+	for _, want := range []string{"Ensure CPU limits are set", "Ensure memory limits are set"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected rendered output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestClusterPrinter_RendersControlsInUnknownCategory(t *testing.T) {
+	// A control sitting in a brand-new category that isn't part of any
+	// preferred-order list. It must still surface in the output.
+	ctrls := map[string]reportsummary.ControlSummary{
+		"C-9999": failedCtrl("C-9999", "Brand new control", "Cat-NEW", "New category", "", ""),
+	}
+	sd := &reportsummary.SummaryDetails{Controls: ctrls}
+
+	var buf bytes.Buffer
+	NewClusterPrinter().PrintCategoriesTables(&buf, sd, nil)
+	out := buf.String()
+
+	if !strings.Contains(out, "Brand new control") {
+		t.Errorf("expected unknown-category control to be rendered, got:\n%s", out)
+	}
+}
+
+func keys(m map[string]CategoryControls) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/clusterscan.go
@@ -24,15 +24,17 @@ func (cp *ClusterPrinter) PrintSummaryTable(_ io.Writer, _ *reportsummary.Summar
 
 func (cp *ClusterPrinter) PrintCategoriesTables(writer io.Writer, summaryDetails *reportsummary.SummaryDetails, _ [][]string) {
 
-	categoriesToCategoryControls := mapCategoryToSummary(summaryDetails.ListControls(), mapClusterControlsToCategories)
+	categoriesToCategoryControls := bucketControlsByCategory(summaryDetails.ListControls())
 
-	for _, id := range clusterCategoriesDisplayOrder {
-		categoryControl, ok := categoriesToCategoryControls[id]
+	for _, id := range categoryRenderOrder(clusterCategoriesDisplayOrder, categoriesToCategoryControls) {
+		categoryControl := categoriesToCategoryControls[id]
+
+		categoryType, ok := mapCategoryToType[id]
 		if !ok {
-			continue
+			categoryType = TypeCounting
 		}
 
-		cp.renderSingleCategoryTable(categoryControl.CategoryName, mapCategoryToType[id], writer, categoryControl.controlSummaries, utils.MapInfoToPrintInfoFromIface(categoryControl.controlSummaries))
+		cp.renderSingleCategoryTable(categoryControl.CategoryName, categoryType, writer, categoryControl.controlSummaries, utils.MapInfoToPrintInfoFromIface(categoryControl.controlSummaries))
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/datastructures.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/datastructures.go
@@ -17,7 +17,10 @@ const (
 	TypeCounting CategoryType = "COUNTING"
 	TypeStatus   CategoryType = "STATUS"
 
-	// Categories to show are hardcoded by ID, so their names are not important. We also want full control over the categories and their order, so a new release of the security checks will not affect the output
+	// The lists below pin the preferred *render order* for well-known
+	// categories. Any category present in the report but absent here is still
+	// rendered (appended after the known ones, alphabetically) so controls
+	// added to the rego library are never silently dropped from the table.
 
 	// cluster scan categories
 	controlPlaneCategoryID  = "Cat-1"
@@ -66,83 +69,3 @@ var mapCategoryToType = map[string]CategoryType{
 	workloadsCategoryID:     TypeCounting,
 }
 
-var mapClusterControlsToCategories = map[string]string{
-	"C-0066": controlPlaneCategoryID,
-	"C-0088": controlPlaneCategoryID,
-	"C-0067": controlPlaneCategoryID,
-	"C-0005": controlPlaneCategoryID,
-	"C-0262": controlPlaneCategoryID,
-
-	"C-0015": accessControlCategoryID,
-	"C-0002": accessControlCategoryID,
-	"C-0007": accessControlCategoryID,
-	"C-0063": accessControlCategoryID,
-	"C-0036": accessControlCategoryID,
-	"C-0039": accessControlCategoryID,
-	"C-0035": accessControlCategoryID,
-	"C-0188": accessControlCategoryID,
-	"C-0187": accessControlCategoryID,
-
-	"C-0012": secretsCategoryID,
-
-	"C-0260": networkCategoryID,
-	"C-0256": networkCategoryID,
-
-	"C-0038": workloadsCategoryID,
-	"C-0041": workloadsCategoryID,
-	"C-0048": workloadsCategoryID,
-	"C-0057": workloadsCategoryID,
-	"C-0013": workloadsCategoryID,
-}
-
-var mapWorkloadControlsToCategories = map[string]string{
-	"C-0078": supplyChainCategoryID,
-	"C-0236": supplyChainCategoryID,
-	"C-0237": supplyChainCategoryID,
-
-	"C-0004": resourceManagementCategoryID,
-	"C-0050": resourceManagementCategoryID,
-
-	"C-0045": storageCategoryID,
-	"C-0048": storageCategoryID,
-	"C-0257": storageCategoryID,
-
-	"C-0207": secretsCategoryID,
-	"C-0034": secretsCategoryID,
-	"C-0012": secretsCategoryID,
-
-	"C-0041": networkCategoryID,
-	"C-0260": networkCategoryID,
-	"C-0044": networkCategoryID,
-
-	"C-0038": nodeEscapeCategoryID,
-	"C-0046": nodeEscapeCategoryID,
-	"C-0013": nodeEscapeCategoryID,
-	"C-0016": nodeEscapeCategoryID,
-	"C-0017": nodeEscapeCategoryID,
-	"C-0055": nodeEscapeCategoryID,
-	"C-0057": nodeEscapeCategoryID,
-}
-
-var mapRepoControlsToCategories = map[string]string{
-	"C-0015": accessControlCategoryID,
-	"C-0002": accessControlCategoryID,
-	"C-0007": accessControlCategoryID,
-	"C-0063": accessControlCategoryID,
-	"C-0036": accessControlCategoryID,
-	"C-0039": accessControlCategoryID,
-	"C-0035": accessControlCategoryID,
-	"C-0188": accessControlCategoryID,
-	"C-0187": accessControlCategoryID,
-
-	"C-0012": secretsCategoryID,
-
-	"C-0260": networkCategoryID,
-	"C-0256": networkCategoryID,
-
-	"C-0038": workloadsCategoryID,
-	"C-0041": workloadsCategoryID,
-	"C-0048": workloadsCategoryID,
-	"C-0057": workloadsCategoryID,
-	"C-0013": workloadsCategoryID,
-}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/reposcan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/reposcan.go
@@ -30,20 +30,24 @@ func (rp *RepoPrinter) PrintSummaryTable(_ io.Writer, _ *reportsummary.SummaryDe
 
 func (rp *RepoPrinter) PrintCategoriesTables(writer io.Writer, summaryDetails *reportsummary.SummaryDetails, _ [][]string) {
 
-	categoriesToCategoryControls := mapCategoryToSummary(summaryDetails.ListControls(), mapRepoControlsToCategories)
+	categoriesToCategoryControls := bucketControlsByCategory(summaryDetails.ListControls())
 
 	tableRendered := false
-	for _, id := range repoCategoriesDisplayOrder {
-		categoryControl, ok := categoriesToCategoryControls[id]
-		if !ok {
-			continue
-		}
+	for _, id := range categoryRenderOrder(repoCategoriesDisplayOrder, categoriesToCategoryControls) {
+		categoryControl := categoriesToCategoryControls[id]
 
 		if categoryControl.Status != apis.StatusFailed {
 			continue
 		}
 
-		tableRendered = tableRendered || rp.renderSingleCategoryTable(categoryControl.CategoryName, mapCategoryToType[id], writer, categoryControl.controlSummaries, utils.MapInfoToPrintInfoFromIface(categoryControl.controlSummaries))
+		categoryType, ok := mapCategoryToType[id]
+		if !ok {
+			categoryType = TypeCounting
+		}
+
+		if rp.renderSingleCategoryTable(categoryControl.CategoryName, categoryType, writer, categoryControl.controlSummaries, utils.MapInfoToPrintInfoFromIface(categoryControl.controlSummaries)) {
+			tableRendered = true
+		}
 	}
 
 	if !tableRendered {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/utils.go
@@ -12,6 +12,56 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
+// bucketControlsByCategory groups every control by the category it carries in
+// its own metadata (sub-category preferred when present). Unlike the previous
+// hardcoded-ID approach this never silently drops controls added to the rego
+// library after the printer was last updated.
+func bucketControlsByCategory(controlSummaries []reportsummary.IControlSummary) map[string]CategoryControls {
+	mapCategoriesToCtrlSummary := map[string][]reportsummary.IControlSummary{}
+	mapCategoryIDToName := make(map[string]string)
+
+	for i := range controlSummaries {
+		cat := controlSummaries[i].GetCategory()
+		if cat == nil {
+			continue
+		}
+		catID, catName := cat.ID, cat.Name
+		if cat.SubCategory != nil && cat.SubCategory.ID != "" {
+			catID, catName = cat.SubCategory.ID, cat.SubCategory.Name
+		}
+		if _, ok := mapCategoriesToCtrlSummary[catID]; !ok {
+			mapCategoryIDToName[catID] = catName
+			mapCategoriesToCtrlSummary[catID] = []reportsummary.IControlSummary{}
+		}
+		mapCategoriesToCtrlSummary[catID] = append(mapCategoriesToCtrlSummary[catID], controlSummaries[i])
+	}
+
+	return buildCategoryToControlsMap(mapCategoriesToCtrlSummary, mapCategoryIDToName)
+}
+
+// categoryRenderOrder returns preferredOrder entries that are present in
+// categoriesToControls (in that order), then any other category IDs found in
+// categoriesToControls appended alphabetically. This guarantees no bucket is
+// silently skipped while preserving the curated ordering for known categories.
+func categoryRenderOrder(preferredOrder []string, categoriesToControls map[string]CategoryControls) []string {
+	out := make([]string, 0, len(categoriesToControls))
+	seen := make(map[string]bool, len(preferredOrder))
+	for _, id := range preferredOrder {
+		if _, ok := categoriesToControls[id]; ok {
+			out = append(out, id)
+			seen[id] = true
+		}
+	}
+	extras := make([]string, 0)
+	for id := range categoriesToControls {
+		if !seen[id] {
+			extras = append(extras, id)
+		}
+	}
+	sort.Strings(extras)
+	return append(out, extras...)
+}
+
 // returns map of category ID to category controls (name and controls)
 // controls will be on the map only if the are in the mapClusterControlsToCategories map
 func mapCategoryToSummary(controlSummaries []reportsummary.IControlSummary, mapDisplayCtrlIDToCategory map[string]string) map[string]CategoryControls {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/workloadscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/workloadscan.go
@@ -23,13 +23,10 @@ func (wp *WorkloadPrinter) PrintSummaryTable(_ io.Writer, _ *reportsummary.Summa
 
 func (wp *WorkloadPrinter) PrintCategoriesTables(writer io.Writer, summaryDetails *reportsummary.SummaryDetails, _ [][]string) {
 
-	categoriesToCategoryControls := mapCategoryToSummary(summaryDetails.ListControls(), mapWorkloadControlsToCategories)
+	categoriesToCategoryControls := bucketControlsByCategory(summaryDetails.ListControls())
 
-	for _, id := range workloadCategoriesDisplayOrder {
-		categoryControl, ok := categoriesToCategoryControls[id]
-		if !ok {
-			continue
-		}
+	for _, id := range categoryRenderOrder(workloadCategoriesDisplayOrder, categoriesToCategoryControls) {
+		categoryControl := categoriesToCategoryControls[id]
 
 		wp.renderSingleCategoryTable(categoryControl.CategoryName, writer, categoryControl.controlSummaries, utils.MapInfoToPrintInfoFromIface(categoryControl.controlSummaries))
 	}


### PR DESCRIPTION
## Overview

`kubescape scan <path>`  the documented entry-point command silently dropped ~85% of failed controls from its "Security posture overview" table. For the issue's reproducer (a privileged Deployment with no resource limits), the JSON report listed 14 failed controls but the table showed only 2 (`C-0013`, `C-0057`). High-severity findings like `C-0270`/`C-0271` (CPU/memory limits), `C-0260` (missing network policy), and `C-0055` (Linux hardening) never made it to the user. Same hole reproduced in `scan workload` and cluster scans, which share the same printer pipeline.

Root cause: `configurationprinter/datastructures.go` held three hardcoded ID-to-category allowlists (`mapRepoControlsToCategories`, `mapClusterControlsToCategories`, `mapWorkloadControlsToCategories`), last touched on 2023-08-03 in commit `5379b9b0`. `utils.go:mapCategoryToSummary` dropped any control whose ID wasn't in the relevant allowlist. The file's own comment framed this as a feature — "Categories to show are hardcoded by ID … so a new release of the security checks will not affect the output" — but the realized behavior was that users never saw newly-introduced findings.

### The fix

- New `bucketControlsByCategory` helper in `utils.go` groups each control by the category it carries in its own `Category`/`SubCategory` metadata. Nothing is ever silently dropped at this layer.
- New `categoryRenderOrder` helper produces the render order: preferred (known) categories first in their curated order, then any other categories with content appended alphabetically. Adding a control under a brand-new category in the rego library now surfaces automatically, no kubescape code change required.
- `reposcan.go`, `clusterscan.go`, `workloadscan.go` switched to the new helpers; unknown categories default to `TypeCounting`.
- Deleted the three obsolete hardcoded `map*ControlsToCategories` maps from `datastructures.go` and updated the misleading comment.
- Fixed a latent short-circuit in `reposcan.go` where `tableRendered = tableRendered || rp.renderSingleCategoryTable(...)` skipped subsequent renders once any returned `true`. The old allowlist only ever populated one category in practice, so this never manifested; the fix above exposed it.

### Files changed

```
core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/
  utils.go                       (+ bucketControlsByCategory, + categoryRenderOrder)
  reposcan.go                    (use new helpers, fix short-circuit)
  clusterscan.go                 (use new helpers)
  workloadscan.go                (use new helpers)
  datastructures.go              (- 3 hardcoded maps, - misleading comment)
  category_bucketing_test.go     (NEW — tests for the fix)
```

## How to Test

Reproducer from the issue:

```bash
mkdir -p /tmp/chart-test/templates
cat > /tmp/chart-test/templates/deploy.yaml <<'EOF'
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-app
spec:
  replicas: 1
  selector: {matchLabels: {app: x}}
  template:
    metadata: {labels: {app: x}}
    spec:
      containers:
      - name: c
        image: nginx:latest
        securityContext: {privileged: true}
EOF
```

**Before** — table shows 2 controls:

```
Workload
╭──────────────────────┬───────────┬──────────────────────────────────────────────────╮
│ Control name         │ Resources │ View details                                     │
├──────────────────────┼───────────┼──────────────────────────────────────────────────┤
│ Non-root containers  │     2     │ $ kubescape scan control C-0013 /tmp/chart-test/ │
│ Privileged container │     2     │ $ kubescape scan control C-0057 /tmp/chart-test/ │
╰──────────────────────┴───────────┴──────────────────────────────────────────────────╯
```

**After** — table shows all 14, bucketed across `Workload`, `Network`, `Resource management`, `Node escape`:

```
Workload:           C-0018 C-0056 C-0061 C-0076 C-0077
Network:            C-0030 C-0260
Resource management: C-0270 C-0271
Node escape:        C-0013 C-0016 C-0017 C-0055 C-0057
```

Programmatic equivalence check — the rendered table and the JSON report now agree exactly:

```bash
kubescape scan /tmp/chart-test/ 2>/dev/null \
  | grep -oE 'C-[0-9]+' | sort -u > /tmp/table-ids.txt

kubescape scan --format json -o /tmp/def.json /tmp/chart-test/ 2>/dev/null >/dev/null
jq -r '.summaryDetails.controls | to_entries[]
       | select((.value.ResourceCounters.failedResources // 0) > 0)
       | .value.controlID' /tmp/def.json | sort -u > /tmp/json-ids.txt

diff /tmp/table-ids.txt /tmp/json-ids.txt    # (empty)
wc -l /tmp/table-ids.txt /tmp/json-ids.txt   # 14 / 14
```

### Unit test coverage

```bash
go test ./core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/... -v
```

New tests in `category_bucketing_test.go`:

- `TestBucketControlsByCategory_UsesControlOwnCategory` — controls outside the legacy allowlist (`C-0270`, `C-0260`) are bucketed by their own category/sub-category metadata.
- `TestBucketControlsByCategory_NilCategorySkipped` — controls with no category metadata are gracefully skipped.
- `TestCategoryRenderOrder_PreservesPreferredAndAppendsExtras` — preferred (known) categories render first in curated order; unknown categories appear at the end, alphabetically.
- `TestCategoryRenderOrder_SkipsMissingPreferred` — preferred IDs not present in the bucket map are skipped without panicking.
- `TestRepoPrinter_RendersControlsBeyondLegacyAllowlist` — full repo-printer render against three failed controls across three categories. Asserts `C-0270` (previously dropped), `C-0260` (previously dropped), and `C-0013` (was in legacy allowlist) all appear. Would fail against both the allowlist-drop and short-circuit regressions.
- `TestWorkloadPrinter_RendersControlsBeyondLegacyAllowlist` — same shape for the workload printer using `C-0270` and `C-0271`.
- `TestClusterPrinter_RendersControlsInUnknownCategory` — synthetic `Cat-NEW` category proves any newly-introduced rego category surfaces automatically.

All 64 existing + new tests in the `configurationprinter` package pass; wider `core/pkg/resultshandling/...` suite passes unchanged.

## Related issues/PRs

* Resolves #2303 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dynamic category rendering that includes new/unknown categories instead of dropping them from results.
  * Improved category organization that maintains preferred ordering while accommodating newly discovered categories.

* **Tests**
  * Added comprehensive test coverage for category bucketing and render-order logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->