### PR TITLE
Feat/vap enforcement reconcile

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -11,6 +11,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
@@ -70,7 +71,9 @@ type OPASessionObj struct {
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
 	TriggeredByCLI        bool
-	LabelsToCopy          []string // Labels to copy from workloads to scan reports
+	LabelsToCopy          []string                   // Labels to copy from workloads to scan reports
+	VAPPolicies           []unstructured.Unstructured // ValidatingAdmissionPolicy resources collected from the cluster
+	VAPBindings           []unstructured.Unstructured // ValidatingAdmissionPolicyBinding resources collected from the cluster
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo) *OPASessionObj {

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -11,12 +11,12 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // K8SResources map[<api group>/<api version>/<resource>][]<resourceID>
@@ -71,7 +71,7 @@ type OPASessionObj struct {
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
 	TriggeredByCLI        bool
-	LabelsToCopy          []string                   // Labels to copy from workloads to scan reports
+	LabelsToCopy          []string                    // Labels to copy from workloads to scan reports
 	VAPPolicies           []unstructured.Unstructured // ValidatingAdmissionPolicy resources collected from the cluster
 	VAPBindings           []unstructured.Unstructured // ValidatingAdmissionPolicyBinding resources collected from the cluster
 }

--- a/core/pkg/resourcehandler/handlepullresources_test.go
+++ b/core/pkg/resourcehandler/handlepullresources_test.go
@@ -11,7 +11,9 @@ import (
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	reportv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -56,6 +58,22 @@ func Test_getCloudMetadata(t *testing.T) {
 	}
 }
 
+// vapTestScheme returns a runtime.Scheme with VAP and VAPBinding list types
+// registered so the fake dynamic client doesn't panic when vapreconcile.Collect
+// lists them during cluster scans.
+func vapTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingAdmissionPolicyList"},
+		&unstructured.UnstructuredList{},
+	)
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingAdmissionPolicyBindingList"},
+		&unstructured.UnstructuredList{},
+	)
+	return s
+}
+
 // https://github.com/kubescape/kubescape/pull/1004
 // Cluster named .*eks.* config without a cloudconfig panics whereas we just want to scan a file
 func getResourceHandlerMock() *K8sResourceHandler {
@@ -64,7 +82,7 @@ func getResourceHandlerMock() *K8sResourceHandler {
 
 	k8s := &k8sinterface.KubernetesApi{
 		KubernetesClient: client,
-		DynamicClient:    fake.NewSimpleDynamicClient(runtime.NewScheme()),
+		DynamicClient:    fake.NewSimpleDynamicClient(vapTestScheme()),
 		DiscoveryClient:  fakeDiscovery,
 		Context:          context.Background(),
 	}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/metrics"
 	"github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils"
+	"github.com/kubescape/kubescape/v3/core/pkg/vapreconcile"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	v1 "k8s.io/api/core/v1"
@@ -175,6 +176,16 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 		if err != nil {
 			cautils.SetInfoMapForResources(err.Error(), cloudResources, sessionObj.InfoMap)
 			logger.L().Debug("failed to collect cloud data", helpers.Error(err))
+		}
+	}
+
+	if scanInfo.GetScanningContext() == cautils.ContextCluster {
+		policies, bindings, err := vapreconcile.Collect(ctx, k8sHandler.k8s)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("failed to collect VAP resources", helpers.Error(err))
+		} else {
+			sessionObj.VAPPolicies = policies
+			sessionObj.VAPBindings = bindings
 		}
 	}
 

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -12,6 +12,7 @@ import (
 	printerv1 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v1"
 	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter"
+	"github.com/kubescape/kubescape/v3/core/pkg/vapreconcile"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
@@ -76,6 +77,11 @@ func (rh *ResultsHandler) GetResults() *reporthandlingv2.PostureReport {
 
 // HandleResults handles all necessary actions for the scan results
 func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.ScanInfo) error {
+	if len(rh.ScanData.VAPPolicies) > 0 {
+		index := vapreconcile.BuildIndex(rh.ScanData.VAPPolicies, rh.ScanData.VAPBindings)
+		vapreconcile.EnrichSummary(rh.ScanData.Report.SummaryDetails.Controls, index)
+	}
+
 	// Display scan results in the UI first to give immediate value.
 
 	rh.UiPrinter.ActionPrint(ctx, rh.ScanData, rh.ImageScanData)

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -63,6 +63,8 @@ func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*repo
 		}
 	}
 
+	seenActions := make(map[string]map[string]struct{})
+
 	for i := range bindings {
 		vapb := &bindings[i]
 		spec, ok := vapb.Object["spec"].(map[string]interface{})
@@ -75,18 +77,24 @@ func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*repo
 			continue
 		}
 
-		var actions []string
+		status, ok := index[controlID]
+		if !ok {
+			continue
+		}
+		status.Bound = true
+
+		if seenActions[controlID] == nil {
+			seenActions[controlID] = make(map[string]struct{})
+		}
 		if actionsRaw, ok := spec["validationActions"].([]interface{}); ok {
 			for _, a := range actionsRaw {
 				if s, ok := a.(string); ok {
-					actions = append(actions, s)
+					if _, dup := seenActions[controlID][s]; !dup {
+						seenActions[controlID][s] = struct{}{}
+						status.Actions = append(status.Actions, s)
+					}
 				}
 			}
-		}
-
-		if status, ok := index[controlID]; ok {
-			status.Bound = true
-			status.Actions = actions
 		}
 	}
 

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -1,0 +1,105 @@
+package vapreconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	vapGVR = schema.GroupVersionResource{
+		Group:    "admissionregistration.k8s.io",
+		Version:  "v1",
+		Resource: "validatingadmissionpolicies",
+	}
+	vapbGVR = schema.GroupVersionResource{
+		Group:    "admissionregistration.k8s.io",
+		Version:  "v1",
+		Resource: "validatingadmissionpolicybindings",
+	}
+)
+
+// Collect lists ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+// resources from the live cluster. Both resource types are cluster-scoped so no
+// namespace selector is needed.
+func Collect(ctx context.Context, k8s *k8sinterface.KubernetesApi) ([]unstructured.Unstructured, []unstructured.Unstructured, error) {
+	vapList, err := k8s.DynamicClient.Resource(vapGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list ValidatingAdmissionPolicies: %w", err)
+	}
+
+	vapbList, err := k8s.DynamicClient.Resource(vapbGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list ValidatingAdmissionPolicyBindings: %w", err)
+	}
+
+	return vapList.Items, vapbList.Items, nil
+}
+
+// BuildIndex builds a map of controlId -> VAPEnforcementStatus by reading the
+// controlId label that cel-admission-library stamps on every VAP, then joining
+// bindings back via spec.policyName to determine the enforcement mode.
+func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*reportsummary.VAPEnforcementStatus {
+	// map policyName -> controlId so we can join bindings
+	policyNameToControlID := make(map[string]string, len(policies))
+	index := make(map[string]*reportsummary.VAPEnforcementStatus, len(policies))
+
+	for i := range policies {
+		vap := &policies[i]
+		labels := vap.GetLabels()
+		controlID, ok := labels["controlId"]
+		if !ok || controlID == "" {
+			continue
+		}
+		policyNameToControlID[vap.GetName()] = controlID
+		index[controlID] = &reportsummary.VAPEnforcementStatus{
+			PolicyName: vap.GetName(),
+			Bound:      false,
+		}
+	}
+
+	for i := range bindings {
+		vapb := &bindings[i]
+		spec, ok := vapb.Object["spec"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		policyName, _ := spec["policyName"].(string)
+		controlID, ok := policyNameToControlID[policyName]
+		if !ok {
+			continue
+		}
+
+		var actions []string
+		if actionsRaw, ok := spec["validationActions"].([]interface{}); ok {
+			for _, a := range actionsRaw {
+				if s, ok := a.(string); ok {
+					actions = append(actions, s)
+				}
+			}
+		}
+
+		if status, ok := index[controlID]; ok {
+			status.Bound = true
+			status.Actions = actions
+		}
+	}
+
+	return index
+}
+
+// EnrichSummary attaches VAPEnforcementStatus to each ControlSummary whose
+// controlId appears in the index.
+func EnrichSummary(controls reportsummary.ControlSummaries, index map[string]*reportsummary.VAPEnforcementStatus) {
+	for controlID, status := range index {
+		if cs, ok := controls[controlID]; ok {
+			cs.VAPEnforcement = status
+			controls[controlID] = cs
+		}
+	}
+}

--- a/core/pkg/vapreconcile/reconcile_test.go
+++ b/core/pkg/vapreconcile/reconcile_test.go
@@ -127,6 +127,22 @@ func TestBuildIndex_MultipleControls(t *testing.T) {
 	assert.False(t, index["C-0038"].Bound)
 }
 
+func TestBuildIndex_SameControlMultipleBindings(t *testing.T) {
+	// two bindings pointing at the same policy — actions should be merged, not overwritten
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0041-binding-deny", "kubescape-c-0041-deny-host-network", []string{"Deny"}),
+		makeVAPB("c0041-binding-audit", "kubescape-c-0041-deny-host-network", []string{"Audit"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.True(t, index["C-0041"].Bound)
+	assert.ElementsMatch(t, []string{"Deny", "Audit"}, index["C-0041"].Actions)
+}
+
 func TestEnrichSummary_AttachesStatus(t *testing.T) {
 	controls := reportsummary.ControlSummaries{
 		"C-0041": reportsummary.ControlSummary{ControlID: "C-0041"},

--- a/core/pkg/vapreconcile/reconcile_test.go
+++ b/core/pkg/vapreconcile/reconcile_test.go
@@ -1,0 +1,161 @@
+package vapreconcile
+
+import (
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeVAP(name, controlID string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetName(name)
+	if controlID != "" {
+		u.SetLabels(map[string]string{"controlId": controlID})
+	}
+	return u
+}
+
+func makeVAPB(name, policyName string, actions []string) unstructured.Unstructured {
+	u := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"policyName":        policyName,
+				"validationActions": toInterfaceSlice(actions),
+			},
+		},
+	}
+	u.SetName(name)
+	return u
+}
+
+func toInterfaceSlice(ss []string) []interface{} {
+	out := make([]interface{}, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+func TestBuildIndex_BoundDeny(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0041-binding", "kubescape-c-0041-deny-host-network", []string{"Deny"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.Contains(t, index, "C-0041")
+	assert.Equal(t, "kubescape-c-0041-deny-host-network", index["C-0041"].PolicyName)
+	assert.True(t, index["C-0041"].Bound)
+	assert.Equal(t, []string{"Deny"}, index["C-0041"].Actions)
+}
+
+func TestBuildIndex_BoundWarn(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0016-privilege-escalation", "C-0016"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0016-binding", "kubescape-c-0016-privilege-escalation", []string{"Warn"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.True(t, index["C-0016"].Bound)
+	assert.Equal(t, []string{"Warn"}, index["C-0016"].Actions)
+}
+
+func TestBuildIndex_VAPWithNoBinding(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0038-host-ipc", "C-0038"),
+	}
+
+	index := BuildIndex(policies, nil)
+
+	assert.Contains(t, index, "C-0038")
+	assert.False(t, index["C-0038"].Bound)
+	assert.Nil(t, index["C-0038"].Actions)
+}
+
+func TestBuildIndex_VAPWithNoControlIDLabel(t *testing.T) {
+	// VAPs without controlId label (e.g. runtime policies) should be ignored
+	policies := []unstructured.Unstructured{
+		makeVAP("cluster-policy-deny-exec", ""),
+	}
+
+	index := BuildIndex(policies, nil)
+
+	assert.Empty(t, index)
+}
+
+func TestBuildIndex_BindingForUnknownPolicy(t *testing.T) {
+	// binding points to a policy not in our VAP list — should not panic or error
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("unknown-binding", "some-other-policy", []string{"Deny"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.False(t, index["C-0041"].Bound)
+}
+
+func TestBuildIndex_MultipleControls(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+		makeVAP("kubescape-c-0016-privilege-escalation", "C-0016"),
+		makeVAP("kubescape-c-0038-host-ipc", "C-0038"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0041-binding", "kubescape-c-0041-deny-host-network", []string{"Warn"}),
+		makeVAPB("c0016-binding", "kubescape-c-0016-privilege-escalation", []string{"Deny"}),
+		// C-0038 has no binding
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.Len(t, index, 3)
+	assert.True(t, index["C-0041"].Bound)
+	assert.Equal(t, []string{"Warn"}, index["C-0041"].Actions)
+	assert.True(t, index["C-0016"].Bound)
+	assert.Equal(t, []string{"Deny"}, index["C-0016"].Actions)
+	assert.False(t, index["C-0038"].Bound)
+}
+
+func TestEnrichSummary_AttachesStatus(t *testing.T) {
+	controls := reportsummary.ControlSummaries{
+		"C-0041": reportsummary.ControlSummary{ControlID: "C-0041"},
+		"C-0016": reportsummary.ControlSummary{ControlID: "C-0016"},
+	}
+	index := map[string]*reportsummary.VAPEnforcementStatus{
+		"C-0041": {PolicyName: "kubescape-c-0041", Bound: true, Actions: []string{"Warn"}},
+	}
+
+	EnrichSummary(controls, index)
+
+	assert.NotNil(t, controls["C-0041"].VAPEnforcement)
+	assert.Equal(t, "kubescape-c-0041", controls["C-0041"].VAPEnforcement.PolicyName)
+	assert.True(t, controls["C-0041"].VAPEnforcement.Bound)
+	// C-0016 has no VAP — field should remain nil
+	assert.Nil(t, controls["C-0016"].VAPEnforcement)
+}
+
+func TestEnrichSummary_NoMatchingControl(t *testing.T) {
+	// index has a controlId that isn't in the scan results — should not panic
+	controls := reportsummary.ControlSummaries{
+		"C-0041": reportsummary.ControlSummary{ControlID: "C-0041"},
+	}
+	index := map[string]*reportsummary.VAPEnforcementStatus{
+		"C-9999": {PolicyName: "some-policy", Bound: true, Actions: []string{"Deny"}},
+	}
+
+	assert.NotPanics(t, func() {
+		EnrichSummary(controls, index)
+	})
+	assert.Nil(t, controls["C-0041"].VAPEnforcement)
+}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.295
+	github.com/kubescape/opa-utils v0.0.298
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1192,8 +1192,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.295 h1:S1YEICEVX2hgVFgdTciROYxRkHF5p3PRcWJTW4bKiuQ=
-github.com/kubescape/opa-utils v0.0.295/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.298 h1:SVoUhvUluHpXW+r8V1o4hbRZFPfLNpkRvGunNp2LK1g=
+github.com/kubescape/opa-utils v0.0.298/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.295
+	github.com/kubescape/opa-utils v0.0.298
 	github.com/kubescape/storage v0.0.258
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1198,8 +1198,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.295 h1:S1YEICEVX2hgVFgdTciROYxRkHF5p3PRcWJTW4bKiuQ=
-github.com/kubescape/opa-utils v0.0.295/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.298 h1:SVoUhvUluHpXW+r8V1o4hbRZFPfLNpkRvGunNp2LK1g=
+github.com/kubescape/opa-utils v0.0.298/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview

  This is the second part of the work for kubescape/kubescape#2299, and it depends on kubescape/opa-utils#172 which added the VAPEnforcementStatus type to ControlSummary.

  the problem I found while going through the codebase: kubescape has a `vap deploy-library` command to deploy the cel-admission-library VAPs to a cluster, and `vap create-policy-binding` to create bindings. but once those are deployed, `kubescape scan` has no idea they exist. it just shows pass/fail with zero info about whether a control is being enforced scan output had no mention of the VAP or binding even when a Deny-mode binding was active for that exact control.
  
  every VAP that cel-admission-library ships has a `controlId` label on it (like `metadata.labels.controlId: "C-0041"`). that's the same ID kubescape uses for controls in scan results. nothing in the scan pipeline was reading it. this PR fixes that. 
  
  ### what this PR does:
  
  - adds a new `vapreconcile` package with three functions: `Collect` fetches ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding resources from the live cluster, `BuildIndex` joins them by policyName and reads the controlId label to build a controlId → enforcement map, and `EnrichSummary` attaches the result to each matching ControlSummary
   
  - hooks collection into `GetResources` in k8sresources.go, gated on cluster scan context so file and repo scans are unaffected
   
  - bumps opa-utils to v0.0.298 to pick up the VAPEnforcementStatus field
  
  - enriches results in HandleResults before printing so the field shows up in JSON output automatically
   
I tested this on a kind cluster with the full cel-admission-library deployed and two bindings (one Warn, one Deny). the JSON output correctly shows enforcement status per control , bound with actions for controls that have a binding, bound: false for controls with a VAP but no binding, and the field is completely absent for controls that have no VAP in cel-admission-library at all.

  Closes #2299

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collect and analyze Kubernetes ValidatingAdmissionPolicy resources and bindings during cluster scans.
  * Scan results now include ValidatingAdmissionPolicy enforcement details for applicable controls (binding status, policy name, validation actions); collection failures are logged as warnings.

* **Tests**
  * Added comprehensive unit tests and test helpers for ValidatingAdmissionPolicy collection, indexing, and summary enrichment.

* **Chores**
  * Bumped a dependency version used by the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->