### PR TITLE
docs: add Gitlab CI/CD Integartion Guide with gitlab-ci.yml example

### DIFF
--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -1,0 +1,101 @@
+# Integrating with GitLab CI/CD
+
+Use GitLab CI to scan your Kubernetes manifests for misconfigurations with Kubescape. Scan results are published as part of your GitLab CI/CD pipeline.
+
+## Prerequisites
+
+- GitLab account with a repository
+- GitLab Runner configured (Docker executor recommended)
+- Network access to GitHub.com from the runner
+  
+## Basic Example
+
+1. Create a .gitlab-ci.yml file in the root of your repository.
+2. Add the following configuration:
+
+```yaml
+stages:
+  - scan
+
+scan_with_kubescape:
+  stage: scan
+  image: alpine:latest
+  script:
+    - apk add curl gcompat
+    - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+    - export PATH=$PATH:$HOME/.kubescape/bin
+    - kubescape scan . --format junit --output results.xml --exclude-namespaces kube-system,kube-public
+  artifacts:
+    reports:
+      junit: results.xml
+    paths:
+      - results.xml
+    expire_in: 30 days
+  only:
+    - merge_requests
+    - main
+```
+3. Push the .gitlab-ci.yml file to your repository.
+4. Create a merge request or push to the main branch.
+5. Check the pipeline status in your GitLab project.
+   
+Using a Security Gate
+To enforce a security gate, add the --compliance-threshold option
+```yaml
+stages:
+  - scan
+
+scan_with_kubescape:
+  stage: scan
+  image: alpine:latest
+  script:
+    - apk add curl gcompat
+    - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+    - export PATH=$PATH:$HOME/.kubescape/bin
+    - kubescape scan . --format junit --output results.xml --compliance-threshold 80 --exclude-namespaces kube-system,kube-public
+  artifacts:
+    reports:
+      junit: results.xml
+    paths:
+      - results.xml
+    expire_in: 30 days
+  only:
+    - merge_requests
+    - main
+```
+The pipeline will fail if fewer than 80% of controls pass.
+
+Scan a Specific Framework
+
+To scan against a specific compliance framework:
+```yaml
+stages:
+  - scan
+
+scan_nsa_framework:
+  stage: scan
+  image: alpine:latest
+  script:
+    - apk add curl gcompat
+    - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+    - export PATH=$PATH:$HOME/.kubescape/bin
+    - kubescape scan framework nsa . --format junit --output results.xml
+  artifacts:
+    reports:
+      junit: results.xml
+```
+Supported frameworks: nsa, mitre, cis-v1.23-t1.0.1. Run kubescape list frameworks for the full list.
+
+Troubleshooting
+
+kubescape: command not found
+This occurs when the install script runs in one shell step and kubescape is invoked in another. The solution is to export the PATH in the same script step:
+script:
+  - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+  - export PATH=$PATH:$HOME/.kubescape/bin
+  - kubescape scan . --format junit --output results.xml
+    
+Further Reading
+- Kubescape CLI Reference
+- GitLab CI/CD Documentation
+- Kubescape Getting Started Guide

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -21,7 +21,7 @@ scan_with_kubescape:
   stage: scan
   image: alpine:latest
   script:
-    - apk add curl gcompat
+    - apk add --no-cache bash curl gcompat
     - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
     - export PATH=$PATH:$HOME/.kubescape/bin
     - kubescape scan . --format junit --output results.xml --exclude-namespaces kube-system,kube-public
@@ -49,10 +49,10 @@ scan_with_kubescape:
   stage: scan
   image: alpine:latest
   script:
-    - apk add curl gcompat
+    - apk add --no-cache bash curl gcompat
     - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
     - export PATH=$PATH:$HOME/.kubescape/bin
-    - kubescape scan . --format junit --output results.xml --compliance-threshold 80 --exclude-namespaces kube-system,kube-public
+    - kubescape scan framework nsa . --format junit --output results.xml --compliance-threshold 80
   artifacts:
     reports:
       junit: results.xml
@@ -76,7 +76,7 @@ scan_nsa_framework:
   stage: scan
   image: alpine:latest
   script:
-    - apk add curl gcompat
+    - apk add --no-cache bash curl gcompat
     - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
     - export PATH=$PATH:$HOME/.kubescape/bin
     - kubescape scan framework nsa . --format junit --output results.xml


### PR DESCRIPTION
## What this PR does
Adds comprehensive GitLab CI/CD integration documentation for Kubescape.

## Content included
- Basic .gitlab-ci.yml example with proper PATH export
- Security gate / compliance threshold example
- Framework-specific scan examples
- Troubleshooting section for common issues
- Prerequisites and further reading

## Structure
Following the same approach as the Jenkins integration docs (PR #2278)
to ensure consistency across CI/CD platform documentation.

All code blocks verified, URLs checked (raw.githubusercontent.com), and examples tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for running Kubescape scans in GitLab CI/CD: setup prerequisites (runners, network), a CI configuration example that installs Kubescape and produces JUnit results as pipeline artifacts, namespace exclusion examples, restricting jobs to merge requests/main, enforcing compliance/security gates via a threshold, scanning specific frameworks with a supported-frameworks list, troubleshooting (PATH issues), and links to further CLI and GitLab docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->