### PR TITLE
fix(opaprocessor): preserve cluster-scoped paths across namespace iterations

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -260,6 +260,9 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 				}
 				id := failedResource.GetID()
 				failedIDs[id] = struct{}{}
+				if _, exists := resources[id]; exists {
+					continue
+				}
 				resources[id] = &resourcesresults.ResourceAssociatedRule{
 					Name:                  rule.Name,
 					ControlConfigurations: ruleRegoDependenciesData.PostureControlInputs,

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -1,0 +1,112 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProcessRule_ClusterScopedPathsAcrossNamespaces guards against a
+// regression where the per-namespace pre-seed inside processRule
+// unconditionally overwrites the result entry of a cluster-scoped resource,
+// silently dropping Paths and Status accumulated by earlier namespace
+// iterations.
+//
+// Setup: large-cluster mode (each namespace becomes its own bucket in
+// resourcesPerNS) with one cluster-scoped ClusterRole and one Pod in each
+// of two namespaces. The Rego fails the ClusterRole and emits a failedPath
+// that contains the namespace of the Pod present in the iteration's input,
+// so iteration over ns-a and ns-b produces two distinct paths. Both must
+// survive in the final result.
+func TestProcessRule_ClusterScopedPathsAcrossNamespaces(t *testing.T) {
+	origLarge := largeClusterSize
+	largeClusterSize = 1
+	t.Cleanup(func() { largeClusterSize = origLarge })
+
+	clusterRole := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]interface{}{"name": "wide-open"},
+	})
+	podA := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "pa", "namespace": "ns-a"},
+	})
+	podB := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "pb", "namespace": "ns-b"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"rbac.authorization.k8s.io/v1/clusterroles": {clusterRole.GetID()},
+		"/v1/pods": {podA.GetID(), podB.GetID()},
+	}
+	sess.AllResources[clusterRole.GetID()] = clusterRole
+	sess.AllResources[podA.GetID()] = podA
+	sess.AllResources[podB.GetID()] = podB
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+
+	rule := &reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+
+deny[msga] {
+    cr := input[_]
+    cr.kind == "ClusterRole"
+    pod := input[_]
+    pod.kind == "Pod"
+    failPath := [sprintf("metadata.annotations.bound-by-%s", [pod.metadata.namespace])]
+    msga := {
+        "alertMessage": "wide-open binds pod",
+        "packagename":  "armo_builtins",
+        "alertScore":   5,
+        "fixPaths":     [],
+        "failedPaths":  failPath,
+        "alertObject":  {"k8sApiObjects": [cr]},
+    }
+}
+`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{
+				APIGroups:   []string{"rbac.authorization.k8s.io"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"ClusterRole"},
+			},
+			{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"Pod"},
+			},
+		},
+	}
+	rule.Name = "cluster-role-path-accumulation"
+
+	got, err := opap.processRule(context.Background(), rule, nil)
+	assert.NoError(t, err)
+
+	crResult, ok := got[clusterRole.GetID()]
+	assert.True(t, ok, "ClusterRole must appear in results")
+	if !ok {
+		return
+	}
+
+	failed := map[string]bool{}
+	for _, p := range crResult.Paths {
+		if p.FailedPath != "" {
+			failed[p.FailedPath] = true
+		}
+	}
+	assert.True(t, failed["metadata.annotations.bound-by-ns-a"],
+		"ns-a path missing — pre-seed overwrite regressed; got paths=%v", crResult.Paths)
+	assert.True(t, failed["metadata.annotations.bound-by-ns-b"],
+		"ns-b path missing — pre-seed overwrite regressed; got paths=%v", crResult.Paths)
+}


### PR DESCRIPTION
## Overview

 So basically processRule runs once per namespace in large-cluster mode. Cluster scoped stuff like ClusterRoles gets
  fed into every namespace iteration, which means the same resource can fail more than once.

  The bug was in this pre-seed block. Every time a resource showed up as failed, the code did resources[id] =
  &ResourceAssociatedRule{...} without checking if there was already an entry. So if ns-a already filled in the Status
  and Paths for a ClusterRole, ns-b would just wipe all of that and start fresh. Only the last namespace's paths
  survived.

  The pass-marking loop right below it already had a guard for this exact thing (it checks if existing status is Failed
  or Skipped before touching). The pre-seed just didn't.

  My fix is one line really. Before assigning, check if resources[id] already exists, and if it does, skip. That's it.
  The merge loop further down already knows how to reuse an existing entry and append new paths, so once the pre-seed
  stops clobbering, everything else just works.

  I also added a regression test. It forces large cluster mode, sets up a ClusterRole plus two pods in two different
  namespaces, and uses a tiny Rego rule that builds the failed path from the pod's namespace. So each iteration produces
   a different path. Test asserts both paths show up. Without the fix it only sees one, with the fix it sees both.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate overwrites when pre-populating failed-resource entries during processing, ensuring accumulated results for cluster-scoped resources are preserved.

* **Tests**
  * Added a regression test to verify cluster-scoped resources retain accumulated paths/statuses across multiple namespaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->