### PR TITLE
fix(cache): canonicalise framework/control cache filenames

### DIFF
--- a/core/cautils/getter/getpoliciesutils.go
+++ b/core/cautils/getter/getpoliciesutils.go
@@ -22,6 +22,9 @@ func PolicyCacheFilename(identifier string) (string, error) {
 	if norm == "" {
 		return "", fmt.Errorf("policy identifier is empty")
 	}
+	if norm == "." || norm == ".." || strings.ContainsAny(norm, `/\`) {
+		return "", fmt.Errorf("policy identifier contains path separators")
+	}
 	return norm + ".json", nil
 }
 

--- a/core/cautils/getter/getpoliciesutils.go
+++ b/core/cautils/getter/getpoliciesutils.go
@@ -16,6 +16,24 @@ func GetDefaultPath(name string) string {
 	return filepath.Join(DefaultLocalStore, name)
 }
 
+// PolicyCacheFilename returns the canonical cache filename for a framework or control identifier.
+func PolicyCacheFilename(identifier string) (string, error) {
+	norm := strings.ToLower(strings.TrimSpace(identifier))
+	if norm == "" {
+		return "", fmt.Errorf("policy identifier is empty")
+	}
+	return norm + ".json", nil
+}
+
+// PolicyCachePath returns the canonical cache file path under the local kubescape store for a framework or control identifier.
+func PolicyCachePath(identifier string) (string, error) {
+	name, err := PolicyCacheFilename(identifier)
+	if err != nil {
+		return "", err
+	}
+	return GetDefaultPath(name), nil
+}
+
 // SaveInFile serializes any object as a JSON file.
 func SaveInFile(object interface{}, targetFile string) error {
 	encodedData, err := json.MarshalIndent(object, "", "  ")

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -50,6 +50,18 @@ func TestPolicyCacheFilename(t *testing.T) {
 		require.Equal(t, "mitre.json", got)
 	})
 
+	t.Run("should lowercase a mixed-case control ID to a single filename", func(t *testing.T) {
+		upper, err := PolicyCacheFilename("C-0001")
+		require.NoError(t, err)
+		require.Equal(t, "c-0001.json", upper)
+
+		lower, err := PolicyCacheFilename("c-0001")
+		require.NoError(t, err)
+		require.Equal(t, "c-0001.json", lower)
+
+		require.Equal(t, upper, lower)
+	})
+
 	t.Run("should error on an empty identifier", func(t *testing.T) {
 		got, err := PolicyCacheFilename("")
 		require.Error(t, err)
@@ -113,6 +125,17 @@ func TestPolicyCachePath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "mitre.json", filepath.Base(pth))
 		require.Equal(t, ".kubescape", filepath.Base(filepath.Dir(pth)))
+	})
+
+	t.Run("should map mixed-case and lowercase control IDs to the same path", func(t *testing.T) {
+		upper, err := PolicyCachePath("C-0001")
+		require.NoError(t, err)
+		require.Equal(t, "c-0001.json", filepath.Base(upper))
+
+		lower, err := PolicyCachePath("c-0001")
+		require.NoError(t, err)
+
+		require.Equal(t, upper, lower)
 	})
 
 	t.Run("should error on an empty identifier", func(t *testing.T) {

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -23,6 +23,87 @@ func TestGetDefaultPath(t *testing.T) {
 	require.Equal(t, ".kubescape", filepath.Base(filepath.Dir(pth)))
 }
 
+func TestPolicyCacheFilename(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should lowercase an uppercase identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename("NSA")
+		require.NoError(t, err)
+		require.Equal(t, "nsa.json", got)
+	})
+
+	t.Run("should leave an already-lowercase identifier unchanged", func(t *testing.T) {
+		got, err := PolicyCacheFilename("nsa")
+		require.NoError(t, err)
+		require.Equal(t, "nsa.json", got)
+	})
+
+	t.Run("should trim whitespace and lowercase a mixed-case identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename("  Nsa  ")
+		require.NoError(t, err)
+		require.Equal(t, "nsa.json", got)
+	})
+
+	t.Run("should lowercase MITRE to mitre.json", func(t *testing.T) {
+		got, err := PolicyCacheFilename("MITRE")
+		require.NoError(t, err)
+		require.Equal(t, "mitre.json", got)
+	})
+
+	t.Run("should error on an empty identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename("")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("should error on a whitespace-only identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename("   ")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+}
+
+func TestPolicyCachePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return canonical path for an uppercase identifier", func(t *testing.T) {
+		pth, err := PolicyCachePath("NSA")
+		require.NoError(t, err)
+		require.Equal(t, "nsa.json", filepath.Base(pth))
+		require.Equal(t, ".kubescape", filepath.Base(filepath.Dir(pth)))
+	})
+
+	t.Run("should map mixed-case and lowercase identifiers to the same path", func(t *testing.T) {
+		upper, err := PolicyCachePath("NSA")
+		require.NoError(t, err)
+		lower, err := PolicyCachePath("nsa")
+		require.NoError(t, err)
+		spaced, err := PolicyCachePath("  Nsa  ")
+		require.NoError(t, err)
+		require.Equal(t, upper, lower)
+		require.Equal(t, upper, spaced)
+	})
+
+	t.Run("should lowercase MITRE to mitre.json under the local store", func(t *testing.T) {
+		pth, err := PolicyCachePath("MITRE")
+		require.NoError(t, err)
+		require.Equal(t, "mitre.json", filepath.Base(pth))
+		require.Equal(t, ".kubescape", filepath.Base(filepath.Dir(pth)))
+	})
+
+	t.Run("should error on an empty identifier", func(t *testing.T) {
+		pth, err := PolicyCachePath("")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+
+	t.Run("should error on a whitespace-only identifier", func(t *testing.T) {
+		pth, err := PolicyCachePath("   ")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+}
+
 func TestSaveInFile(t *testing.T) {
 	t.Parallel()
 

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -61,6 +61,30 @@ func TestPolicyCacheFilename(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, got)
 	})
+
+	t.Run("should error on a dot identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename(".")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("should error on a double-dot identifier", func(t *testing.T) {
+		got, err := PolicyCacheFilename("..")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("should error on an identifier containing a forward slash", func(t *testing.T) {
+		got, err := PolicyCacheFilename("../etc/passwd")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("should error on an identifier containing a backslash", func(t *testing.T) {
+		got, err := PolicyCacheFilename(`nsa\evil`)
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func TestPolicyCachePath(t *testing.T) {
@@ -99,6 +123,30 @@ func TestPolicyCachePath(t *testing.T) {
 
 	t.Run("should error on a whitespace-only identifier", func(t *testing.T) {
 		pth, err := PolicyCachePath("   ")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+
+	t.Run("should error on a dot identifier", func(t *testing.T) {
+		pth, err := PolicyCachePath(".")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+
+	t.Run("should error on a double-dot identifier", func(t *testing.T) {
+		pth, err := PolicyCachePath("..")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+
+	t.Run("should error on an identifier containing a forward slash", func(t *testing.T) {
+		pth, err := PolicyCachePath("../etc/passwd")
+		require.Error(t, err)
+		require.Empty(t, pth)
+	})
+
+	t.Run("should error on an identifier containing a backslash", func(t *testing.T) {
+		pth, err := PolicyCachePath(`nsa\evil`)
 		require.Error(t, err)
 		require.Empty(t, pth)
 	})

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -219,7 +219,12 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 func (scanInfo *ScanInfo) setUseFrom() {
 	if scanInfo.UseDefault {
 		for _, policy := range scanInfo.PolicyIdentifier {
-			scanInfo.UseFrom = append(scanInfo.UseFrom, getter.GetDefaultPath(policy.Identifier+".json"))
+			path, err := getter.PolicyCachePath(policy.Identifier)
+			if err != nil {
+				logger.L().Warning("skipping default cache lookup for policy", helpers.String("identifier", policy.Identifier), helpers.Error(err))
+				continue
+			}
+			scanInfo.UseFrom = append(scanInfo.UseFrom, path)
 		}
 	}
 }

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -178,7 +178,12 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 			return err
 		}
 		for _, fw := range frameworks {
-			downloadTo := filepath.Join(downloadInfo.Path, (strings.ToLower(fw.Name) + ".json"))
+			filename, err := getter.PolicyCacheFilename(fw.Name)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("skipping framework with empty name", helpers.Error(err))
+				continue
+			}
+			downloadTo := filepath.Join(downloadInfo.Path, filename)
 			err = getter.SaveInFile(fw, downloadTo)
 			if err != nil {
 				return err
@@ -188,7 +193,11 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 		// return fmt.Errorf("missing framework name")
 	} else {
 		if downloadInfo.FileName == "" {
-			downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Identifier)
+			filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)
+			if err != nil {
+				return err
+			}
+			downloadInfo.FileName = filename
 		}
 		framework, err := g.GetFramework(downloadInfo.Identifier)
 		if err != nil {

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -227,7 +227,11 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) err
 		return fmt.Errorf("missing control ID")
 	}
 	if downloadInfo.FileName == "" {
-		downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Identifier)
+		filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)
+		if err != nil {
+			return err
+		}
+		downloadInfo.FileName = filename
 	}
 	controls, err := g.GetControl(downloadInfo.Identifier)
 	if err != nil {

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -158,9 +158,13 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedFramework != nil {
 				frameworks = append(frameworks, *receivedFramework)
-				cache := getter.GetDefaultPath(rule.Identifier + ".json")
 				if _, ok := policyHandler.getters.PolicyGetter.(*getter.LoadPolicy); ok {
 					continue // skip caching for local files
+				}
+				cache, err := getter.PolicyCachePath(rule.Identifier)
+				if err != nil {
+					logger.L().Ctx(ctx).Warning("skipping framework cache write", helpers.String("identifier", rule.Identifier), helpers.Error(err))
+					continue
 				}
 				if err := getter.SaveInFile(receivedFramework, cache); err != nil {
 					logger.L().Ctx(ctx).Warning("failed to cache framework", helpers.String("file", cache), helpers.Error(err))
@@ -180,7 +184,11 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			if receivedControl != nil {
 				f.Controls = append(f.Controls, *receivedControl)
 
-				cache := getter.GetDefaultPath(policy.Identifier + ".json")
+				cache, err := getter.PolicyCachePath(policy.Identifier)
+				if err != nil {
+					logger.L().Ctx(ctx).Warning("skipping control cache write", helpers.String("identifier", policy.Identifier), helpers.Error(err))
+					continue
+				}
 				if err := getter.SaveInFile(receivedControl, cache); err != nil {
 					logger.L().Ctx(ctx).Warning("failed to cache control", helpers.String("file", cache), helpers.Error(err))
 				}


### PR DESCRIPTION
## Overview

Framework and control cache filenames under `~/.kubescape/` were being constructed ad-hoc in five different code paths, with inconsistent case handling. The result on case-sensitive filesystems (Linux) was that the same framework could end up on disk under two filenames that differ only in case - e.g. both `NSA.json` and `nsa.json` - leading to duplicate cache entries, wasted disk, and a stale-read window where the write path and read path looked at different copies.

**Current behavior**

- `kubescape download framework NSA` writes `~/.kubescape/NSA.json` (preserves caller case).
- `kubescape download framework` (all) writes `~/.kubescape/nsa.json` (lowercased).
- The scan-time cache write at `handlepullpolicies.go:161` preserves caller case too, so `scan framework NSA` and `scan framework nsa` produce two separate cache files.
- The read path `setUseFrom` in `scaninfo.go:222` looks up the cache using the caller's case, so it may read a stale copy that a different command never refreshed.
- An empty framework name (`fw.Name == ""`) flows through `strings.ToLower("")` and silently writes a literal `.json` file (upstream of the empty-`.json` cache-poisoning symptom in the related issue).
- The same un-normalised pattern exists one branch below for the controls cache (`handlepullpolicies.go:183`), so `C-0001` and `c-0001` would also map to two files.

**Future behavior**

- Every framework and control cache filename is routed through a single helper (`getter.PolicyCachePath` / `PolicyCacheFilename`) that trims whitespace, lowercases the identifier, and rejects empty input.
- `download framework NSA`, `download framework nsa`, `download framework` (all), `scan framework NSA`, and `scan framework nsa` all read and write the same `~/.kubescape/nsa.json`.
- The control cache write uses the same helper, so `C-0001` and `c-0001` map to a single `c-0001.json`.
- An empty identifier returns an error from the helper; the affected scan logs a warning and continues instead of writing a stray `.json` file.

## Additional Information

The fix touches five call sites but introduces only two new helpers in `core/cautils/getter/getpoliciesutils.go`:

| Helper | Returns |
| --- | --- |
| `PolicyCacheFilename(identifier string) (string, error)` | canonical basename, e.g. `nsa.json` |
| `PolicyCachePath(identifier string) (string, error)` | full path under `$HOME/.kubescape`, e.g. `/home/<user>/.kubescape/nsa.json` |

Call sites routed through the helpers:

| File | Branch |
| --- | --- |
| `core/core/download.go` | `downloadFramework`, both branches (all-frameworks loop and named-framework branch) |
| `core/pkg/policyhandler/handlepullpolicies.go:161` | framework cache write during scans |
| `core/pkg/policyhandler/handlepullpolicies.go:183` | control cache write during scans (additional fix, same bug class) |
| `core/cautils/scaninfo.go:222` | `setUseFrom` — the read path |

The `setUseFrom` read-path change is critical: without it, writers would only produce `nsa.json` while readers kept looking for `NSA.json`, and the fix would self-defeat. `core/core/initutils.go:getDefaultFrameworksPaths` already iterates `getter.NativeFrameworks` which is hardcoded lowercase, so it was left untouched.

No existing public APIs were renamed or removed; the helpers are additive.

## How to Test

Unit tests:

```bash
go test ./core/cautils/getter/...
go test ./core/cautils/... ./core/core/... ./core/pkg/policyhandler/...
go build ./...
```

Fixes: #2312 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consistent policy cache handling: identifiers are normalized (trimmed, lowercased, basename), mapped to a .json basename, and invalid names (empty, ".", "..", or containing path separators) are rejected.
  * Cache file names and paths resolved uniformly across download and scan flows.
  * On cache-path resolution failure, operations log a warning and skip writing the cache without interrupting the process.

* **Tests**
  * Added tests validating normalization, alias mapping, canonical path resolution, and error behavior for invalid identifier inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->