### PR TITLE
fix: nil pointer panic in SARIF, HTML, and JUnit printers when control is missing from summary details

### DIFF
--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -161,6 +161,9 @@ func buildResourceControlResultTable(resourceControls []resourcesresults.Resourc
 	for _, resourceControl := range resourceControls {
 		if resourceControl.GetStatus(nil).IsFailed() {
 			control := summaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, resourceControl.GetID())
+			if control == nil {
+				continue
+			}
 			ctlResult := buildResourceControlResult(resourceControl, control)
 
 			ctlResults = append(ctlResults, ctlResult)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,4 +72,20 @@ func TestSetWriter_Html(t *testing.T) {
 				"HTML printer must never write to stdout")
 		})
 	}
+}
+
+func TestBuildResourceControlResultTable_MissingControl(t *testing.T) {
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-MISSING",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+
+	summaryDetails := &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{},
+	}
+
+	assert.NotPanics(t, func() {
+		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails)
+		assert.Empty(t, results)
+	})
 }

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -227,7 +227,7 @@ func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControls
 
 	for _, cID := range sortedIDs {
 		testCase := JUnitTestCase{}
-		control := results.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, cID)
+		control := controls.GetControl(reportsummary.EControlCriteriaID, cID)
 		if control == nil {
 			continue
 		}

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -228,7 +228,9 @@ func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControls
 	for _, cID := range sortedIDs {
 		testCase := JUnitTestCase{}
 		control := results.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, cID)
-
+		if control == nil {
+			continue
+		}
 		testCase.Name = control.GetName()
 		testCase.Classname = classname
 

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -651,3 +651,25 @@ func TestAggregateSuiteCounts(t *testing.T) {
 		})
 	}
 }
+
+func TestTestCases_MissingControl(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{},
+		},
+	}
+
+	externalControls := reportsummary.ControlSummaries{
+		"C-MISSING": {
+			ControlID:  "C-MISSING",
+			Name:       "missing",
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		cases := testsCases(session, &externalControls, "TestSuite")
+		assert.Empty(t, cases)
+	})
+}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -664,12 +664,15 @@ func TestTestCases_MissingControl(t *testing.T) {
 		"C-MISSING": {
 			ControlID:  "C-MISSING",
 			Name:       "missing",
-			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed},
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusPassed},
 		},
 	}
 
 	assert.NotPanics(t, func() {
 		cases := testsCases(session, &externalControls, "TestSuite")
-		assert.Empty(t, cases)
+		if assert.Len(t, cases, 1) {
+			assert.Equal(t, "missing", cases[0].Name)
+			assert.Nil(t, cases[0].Failure)
+		}
 	})
 }

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -212,6 +212,10 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 
 				if ac.GetStatus(nil).IsFailed() {
 					ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
+					if ctl == nil {
+						logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
+						continue
+					}
 					location := sp.resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
 					sp.addRule(run, ctl)
 					r := sp.addResult(run, ctl, filepath, location)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -237,6 +237,7 @@ func TestPrintConfigurationScan_MissingControl(t *testing.T) {
 		ResourceID:         resourceID,
 		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
 	}
+	require.True(t, result.GetStatus(nil).IsFailed())
 
 	session := cautils.NewOPASessionObjMock()
 	session.ResourcesResult[resourceID] = result
@@ -251,7 +252,10 @@ func TestPrintConfigurationScan_MissingControl(t *testing.T) {
 
 	tmp, err := os.CreateTemp("", "sarif-missing-*.sarif")
 	require.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
 
 	sp := NewSARIFPrinter()
 	sp.writer = tmp

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -1,11 +1,20 @@
 package printer
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_scoreToSeverityLevel(t *testing.T) {
@@ -215,4 +224,40 @@ func TestAddFix_AddsNewFixToResult(t *testing.T) {
 	})
 
 	assert.Equal(t, expectedFix, result.Fixes[0])
+}
+
+func TestPrintConfigurationScan_MissingControl(t *testing.T) {
+	resourceID := "apps/v1/Deployment/default/my-deployment"
+
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-MISSING",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+	result := resourcesresults.Result{
+		ResourceID:         resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.ResourcesResult[resourceID] = result
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {RelativePath: "deploy.yaml"},
+	}
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{},
+		},
+	}
+
+	tmp, err := os.CreateTemp("", "sarif-missing-*.sarif")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+
+	assert.NotPanics(t, func() {
+		err := sp.printConfigurationScan(context.Background(), session)
+		assert.NoError(t, err)
+	})
 }

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -458,6 +458,9 @@ func getControlsSummaryMapFromScannedControlMap(ctx context.Context, scannedCont
 }
 
 func parseControlSeverity(controlSummary reportsummary.IControlSummary) v1beta1.ControlSeverity {
+	if controlSummary == nil {
+		return v1beta1.ControlSeverity{}
+	}
 	scoreFactor := controlSummary.GetScoreFactor()
 	severity := apis.ControlSeverityToString(scoreFactor)
 

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -94,6 +94,30 @@ func Test_getControlsMapFromResult(t *testing.T) {
 	}
 }
 
+func TestParseControlSeverity_Nil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		result := parseControlSeverity(nil)
+		assert.Equal(t, v1beta1.ControlSeverity{}, result)
+	})
+}
+
+func TestGetControlsMapFromResult_MissingControl(t *testing.T) {
+	scanResult := resourcesresults.Result{
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-MISSING",
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		actual := getControlsMapFromResult(context.Background(), &scanResult, reportsummary.ControlSummaries{})
+		assert.Contains(t, actual, "C-MISSING")
+		assert.Equal(t, v1beta1.ControlSeverity{}, actual["C-MISSING"].Severity)
+	})
+}
+
 type FakeMetadata struct {
 	workloadinterface.IMetadata
 


### PR DESCRIPTION
## Overview
Currently, when kubescape runs a scan and generates output in SARIF, HTML, or JUnit format, it can crash with a nil pointer panic if a control ID found in the scan results is not present in the summary details map. The same crash happens in operator mode when the API server storage layer tries to read the severity of a control that has no corresponding summary entry.

The root cause is that `ControlSummaries.GetControl()` in opa-utils explicitly returns nil when the requested ID is not in the map, and four call sites were using that return value without checking for nil first.

This PR adds a nil guard at each of those four call sites. The SARIF, HTML, and JUnit printers now skip the entry and continue processing the rest of the report. The operator storage layer returns a zero-value severity instead of panicking. A debug log is added in the SARIF printer so the skip is visible during troubleshooting.

After this change kubescape completes the scan and writes the output file normally, even when a control summary entry is missing.


## Additional Information

The four affected locations are:

- `core/pkg/resultshandling/printer/v2/sarifprinter.go` line 214
- `core/pkg/resultshandling/printer/v2/htmlprinter.go` line 163
- `core/pkg/resultshandling/printer/v2/junit.go` line 230
- `httphandler/storage/apiserver.go` line 461

In operator mode the impact is worse than a one-off crash. The `watchForScan` goroutine has no panic recovery, so a single nil hit kills it permanently and the operator stops processing all future scan requests for the lifetime of the pod without any visible error.




## How to Test
Run the new tests that directly target the nil guard added in this PR:
```
go test -v -run "TestPrintConfigurationScan_MissingControl|TestBuildResourceControlResultTable_MissingControl|TestTestCases_MissingControl" \
  ./core/pkg/resultshandling/printer/v2/
```
```
cd httphandler
go test -v -run "TestParseControlSeverity_Nil|TestGetControlsMapFromResult_MissingControl" \
  ./storage/...
```
Run the full printer and storage test suites to confirm no regressions:

`go test ./core/pkg/resultshandling/printer/v2/...`

```
cd httphandler
go test ./storage/...
```
<!--
## Examples/Screenshots

> Here you add related screenshots 
-->


## Related issues/PRs:

Resolves #2314



## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive checks to report exporters and API parsing so missing control definitions are skipped and no longer cause crashes or invalid output.

* **Tests**
  * Added tests covering missing-control scenarios to verify exporters and parsing helpers handle absent controls gracefully across HTML, JUnit, SARIF, and API flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->