### PR TITLE
feat(exceptions): prefer cloud exceptions over CRD

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter_dedup_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_dedup_test.go
@@ -8,13 +8,16 @@ import (
 )
 
 func TestDeduplicateExceptions(t *testing.T) {
-	buildPolicy := func(name, controlID, namespace, kind, workloadName string) armotypes.PostureExceptionPolicy {
+	buildPolicy := func(name, controlID, namespace, kind, apiGroup, workloadName string) armotypes.PostureExceptionPolicy {
 		attrs := map[string]string{}
 		if namespace != "" {
 			attrs[identifiers.AttributeNamespace] = namespace
 		}
 		if kind != "" {
 			attrs[identifiers.AttributeKind] = kind
+		}
+		if apiGroup != "" {
+			attrs[identifiers.AttributeApiGroup] = apiGroup
 		}
 		if workloadName != "" {
 			attrs[identifiers.AttributeName] = workloadName
@@ -44,30 +47,40 @@ func TestDeduplicateExceptions(t *testing.T) {
 		{
 			name: "cloud wins for same control and workload",
 			cloud: []armotypes.PostureExceptionPolicy{
-				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "apps", "api"),
 			},
 			crd: []armotypes.PostureExceptionPolicy{
-				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "api"),
+				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "apps", "api"),
 			},
 			wantNames: []string{"cloud-1"},
 		},
 		{
 			name: "different controls are merged",
 			cloud: []armotypes.PostureExceptionPolicy{
-				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "apps", "api"),
 			},
 			crd: []armotypes.PostureExceptionPolicy{
-				buildPolicy("crd-1", "C-0002", "team-a", "Deployment", "api"),
+				buildPolicy("crd-1", "C-0002", "team-a", "Deployment", "apps", "api"),
 			},
 			wantNames: []string{"cloud-1", "crd-1"},
 		},
 		{
 			name: "same control different workload is merged",
 			cloud: []armotypes.PostureExceptionPolicy{
-				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "apps", "api"),
 			},
 			crd: []armotypes.PostureExceptionPolicy{
-				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "worker"),
+				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "apps", "worker"),
+			},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name: "same control same workload but different api groups are merged",
+			cloud: []armotypes.PostureExceptionPolicy{
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "apps", "api"),
+			},
+			crd: []armotypes.PostureExceptionPolicy{
+				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "batch", "api"),
 			},
 			wantNames: []string{"cloud-1", "crd-1"},
 		},
@@ -75,14 +88,14 @@ func TestDeduplicateExceptions(t *testing.T) {
 			name:  "no cloud exceptions keeps all CRD",
 			cloud: nil,
 			crd: []armotypes.PostureExceptionPolicy{
-				buildPolicy("crd-1", "C-0003", "team-b", "StatefulSet", "db"),
+				buildPolicy("crd-1", "C-0003", "team-b", "StatefulSet", "apps", "db"),
 			},
 			wantNames: []string{"crd-1"},
 		},
 		{
 			name: "no CRD exceptions keeps all cloud",
 			cloud: []armotypes.PostureExceptionPolicy{
-				buildPolicy("cloud-1", "C-0004", "team-b", "DaemonSet", "agent"),
+				buildPolicy("cloud-1", "C-0004", "team-b", "DaemonSet", "apps", "agent"),
 			},
 			crd:       nil,
 			wantNames: []string{"cloud-1"},

--- a/core/cautils/getter/crdexceptionsgetter_dedup_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_dedup_test.go
@@ -1,0 +1,109 @@
+package getter
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+)
+
+func TestDeduplicateExceptions(t *testing.T) {
+	buildPolicy := func(name, controlID, namespace, kind, workloadName string) armotypes.PostureExceptionPolicy {
+		attrs := map[string]string{}
+		if namespace != "" {
+			attrs[identifiers.AttributeNamespace] = namespace
+		}
+		if kind != "" {
+			attrs[identifiers.AttributeKind] = kind
+		}
+		if workloadName != "" {
+			attrs[identifiers.AttributeName] = workloadName
+		}
+		return armotypes.PostureExceptionPolicy{
+			Name: name,
+			PosturePolicies: []armotypes.PosturePolicy{
+				{ControlID: controlID},
+			},
+			Resources: []identifiers.PortalDesignator{
+				{
+					DesignatorType: identifiers.DesignatorAttributes,
+					Attributes:     attrs,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		cloud     []armotypes.PostureExceptionPolicy
+		crd       []armotypes.PostureExceptionPolicy
+		wantNames []string
+	}{
+		{
+			name: "cloud wins for same control and workload",
+			cloud: []armotypes.PostureExceptionPolicy{
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+			},
+			crd: []armotypes.PostureExceptionPolicy{
+				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "api"),
+			},
+			wantNames: []string{"cloud-1"},
+		},
+		{
+			name: "different controls are merged",
+			cloud: []armotypes.PostureExceptionPolicy{
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+			},
+			crd: []armotypes.PostureExceptionPolicy{
+				buildPolicy("crd-1", "C-0002", "team-a", "Deployment", "api"),
+			},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name: "same control different workload is merged",
+			cloud: []armotypes.PostureExceptionPolicy{
+				buildPolicy("cloud-1", "C-0001", "team-a", "Deployment", "api"),
+			},
+			crd: []armotypes.PostureExceptionPolicy{
+				buildPolicy("crd-1", "C-0001", "team-a", "Deployment", "worker"),
+			},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name:  "no cloud exceptions keeps all CRD",
+			cloud: nil,
+			crd: []armotypes.PostureExceptionPolicy{
+				buildPolicy("crd-1", "C-0003", "team-b", "StatefulSet", "db"),
+			},
+			wantNames: []string{"crd-1"},
+		},
+		{
+			name: "no CRD exceptions keeps all cloud",
+			cloud: []armotypes.PostureExceptionPolicy{
+				buildPolicy("cloud-1", "C-0004", "team-b", "DaemonSet", "agent"),
+			},
+			crd:       nil,
+			wantNames: []string{"cloud-1"},
+		},
+		{
+			name:      "empty both",
+			cloud:     nil,
+			crd:       nil,
+			wantNames: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deduplicateExceptions(tc.cloud, tc.crd)
+			if len(got) != len(tc.wantNames) {
+				t.Fatalf("expected %d exceptions, got %d", len(tc.wantNames), len(got))
+			}
+			for i, wantName := range tc.wantNames {
+				if got[i].Name != wantName {
+					t.Fatalf("expected exception %d to be %q, got %q", i, wantName, got[i].Name)
+				}
+			}
+		})
+	}
+}

--- a/core/cautils/getter/crdexceptionsgetter_dedup_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_dedup_test.go
@@ -20,7 +20,9 @@ func TestDeduplicateExceptions(t *testing.T) {
 			attrs[identifiers.AttributeName] = workloadName
 		}
 		return armotypes.PostureExceptionPolicy{
-			Name: name,
+			PortalBase: armotypes.PortalBase{
+				Name: name,
+			},
 			PosturePolicies: []armotypes.PosturePolicy{
 				{ControlID: controlID},
 			},


### PR DESCRIPTION
- Enforces cloud over CRD precedence when exceptions overlap on controlID and workload identity.
- Merges non-overlapping CRD exceptions to support GitOps users migrating from cloud-managed exceptions.
- Aligns with https://github.com/kubescape/kubevuln/blob/main/docs/security-exception-design.md and kubescape/kubescape#1982.

**Testing**
- [ ] go build ./...
- [ ] go vet ./...
- [ ] go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud-sourced exceptions now take precedence; overlapping CRD resources are removed while CRD-only entries are preserved.
  * Primary source is queried first and its errors are surfaced immediately; calling on no getter returns empty.
  * Individual invalid CRD entries are skipped instead of failing retrieval; improved fallback when cluster client or CRD listing is unavailable.
  * Final results preserve cloud-derived policies first, then uncovered CRD remainder.

* **Tests**
  * Added unit tests covering deduplication, merging, ordering, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->