### PR TITLE
Fix/validate scan format flag

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -63,9 +63,11 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
-				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+				normalized, err := shared.ValidateScanFormat(scanInfo.Format)
+				if err != nil {
 					return err
 				}
+				scanInfo.Format = normalized
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -62,8 +62,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 					return err
 				}
 			}
-			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
+				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+					return err
+				}
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -76,8 +76,10 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 					return err
 				}
 			}
-			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
+				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+					return err
+				}
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -77,9 +77,11 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
-				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+				normalized, err := shared.ValidateScanFormat(scanInfo.Format)
+				if err != nil {
 					return err
 				}
+				scanInfo.Format = normalized
 			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -49,8 +49,10 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				return fmt.Errorf("the command takes exactly one image name as an argument")
 			}
 
-			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
+				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+					return err
+				}
 			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -50,9 +50,11 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			}
 
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
-				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+				normalized, err := shared.ValidateScanFormat(scanInfo.Format)
+				if err != nil {
 					return err
 				}
+				scanInfo.Format = normalized
 			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -66,7 +66,7 @@ func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", ""))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, sarif", err.Error())
+	assert.Equal(t, "invalid format. Supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif", err.Error())
 }
 
 func TestGetImageCmd_RunE_Success(t *testing.T) {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -53,9 +53,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				}
 			}
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed {
-				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+				normalized, err := shared.ValidateScanFormat(scanInfo.Format)
+				if err != nil {
 					return err
 				}
+				scanInfo.Format = normalized
 			}
 			requestedView := scanInfo.View
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -52,8 +52,10 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
-			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed {
+				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+					return err
+				}
 			}
 			requestedView := scanInfo.View
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -65,9 +65,11 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
-				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+				normalized, err := shared.ValidateScanFormat(scanInfo.Format)
+				if err != nil {
 					return err
 				}
+				scanInfo.Format = normalized
 			}
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -64,8 +64,10 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 					return err
 				}
 			}
-			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed {
+				if err := shared.ValidateScanFormat(scanInfo.Format); err != nil {
+					return err
+				}
 			}
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -7,8 +7,33 @@ import (
 
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 )
+
+// supportedScanFormats lists all valid output formats for scan commands.
+var supportedScanFormats = []string{
+	printer.PrettyFormat,
+	printer.JsonFormat,
+	printer.JunitResultFormat,
+	printer.PrometheusFormat,
+	printer.PdfFormat,
+	printer.HtmlFormat,
+	printer.SARIFFormat,
+}
+
+// ErrInvalidScanFormat is returned when the format flag is set to an unsupported value.
+var ErrInvalidScanFormat = fmt.Errorf("invalid format. Supported formats: %s", strings.Join(supportedScanFormats, ", "))
+
+// ValidateScanFormat returns an error if the given format string is not a supported scan output format.
+func ValidateScanFormat(format string) error {
+	for _, f := range supportedScanFormats {
+		if strings.EqualFold(format, f) {
+			return nil
+		}
+	}
+	return ErrInvalidScanFormat
+}
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))
 

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -26,13 +26,14 @@ var supportedScanFormats = []string{
 var ErrInvalidScanFormat = fmt.Errorf("invalid format. Supported formats: %s", strings.Join(supportedScanFormats, ", "))
 
 // ValidateScanFormat returns an error if the given format string is not a supported scan output format.
-func ValidateScanFormat(format string) error {
+// It also normalizes the format to lowercase so downstream printers receive a consistent value.
+func ValidateScanFormat(format string) (string, error) {
 	for _, f := range supportedScanFormats {
 		if strings.EqualFold(format, f) {
-			return nil
+			return f, nil
 		}
 	}
-	return ErrInvalidScanFormat
+	return "", ErrInvalidScanFormat
 }
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -120,7 +120,7 @@ func TestValidateScanFormat(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Description, func(t *testing.T) {
-			got := ValidateScanFormat(testCase.Input)
+			_, got := ValidateScanFormat(testCase.Input)
 			if got != testCase.Want {
 				t.Errorf("got: %v, want: %v", got, testCase.Want)
 			}

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -98,6 +98,36 @@ func TestTerminateOnExceedingSeverity(t *testing.T) {
 	}
 }
 
+func TestValidateScanFormat(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Input       string
+		Want        error
+	}{
+		{"pretty-printer should be valid", "pretty-printer", nil},
+		{"json should be valid", "json", nil},
+		{"junit should be valid", "junit", nil},
+		{"prometheus should be valid", "prometheus", nil},
+		{"pdf should be valid", "pdf", nil},
+		{"html should be valid", "html", nil},
+		{"sarif should be valid", "sarif", nil},
+		{"JSON uppercase should be valid", "JSON", nil},
+		{"empty string should be invalid", "", ErrInvalidScanFormat},
+		{"xml should be invalid", "xml", ErrInvalidScanFormat},
+		{"csv should be invalid", "csv", ErrInvalidScanFormat},
+		{"bogus should be invalid", "bogus", ErrInvalidScanFormat},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			got := ValidateScanFormat(testCase.Input)
+			if got != testCase.Want {
+				t.Errorf("got: %v, want: %v", got, testCase.Want)
+			}
+		})
+	}
+}
+
 func TestValidateSeverity(t *testing.T) {
 	testCases := []struct {
 		Description string


### PR DESCRIPTION
## Overview
Previously, passing an unsupported format like `--format xml` to any scan command would emit a warning and silently fall back to `pretty-printer`, running the full scan anyway. Users had no idea their `--format` flag was being ignored.

This PR adds early validation so an invalid format fails immediately with a clear error before any scan work begins — consistent with how other flags like `--severity-threshold` are already validated.

**Before:**
```
{"level":"warn","msg":"Invalid format \"xml\", default format \"pretty-printer\" is applied"}
{"level":"info","msg":"Initialized scanner"}
... (full scan runs and completes)
```

**After:**
```
Error: invalid format. Supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif
```

## How to Test
```bash
# These should all fail immediately with an error, no scan starts
./kubescape scan --format xml
./kubescape scan framework nsa --format xml
./kubescape scan control C-0057 --format xml
./kubescape scan workload deploy/nginx --format xml
./kubescape scan image nginx --format xml

# These should still work normally
./kubescape scan --format json
./kubescape scan --format pretty-printer
```

## Related issues/PRs
* Resolved #2320

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `--format` flag validation across all scan commands to consistently validate against the complete set of supported formats and provide informative error messages that list available format options when invalid formats are specified.

* **Tests**
  * Added comprehensive test coverage for format validation logic to ensure proper error handling for both supported and unsupported format inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->