### PR TITLE
feat(getter): resolve namespaceSelector for cluster exceptions

### DIFF
--- a/core/cautils/datastructures_test.go
+++ b/core/cautils/datastructures_test.go
@@ -37,8 +37,8 @@ func TestEstimateClusterSize(t *testing.T) {
 			name: "multiple groups",
 			input: K8SResources{
 				"apps/v1/deployments": {"id1", "id2"},
-				"v1/pods":            {"id3", "id4", "id5"},
-				"v1/services":        {"id6"},
+				"v1/pods":             {"id3", "id4", "id5"},
+				"v1/services":         {"id6"},
 			},
 			expected: 6,
 		},

--- a/core/cautils/fileformat_test.go
+++ b/core/cautils/fileformat_test.go
@@ -63,9 +63,9 @@ func TestMergeMaps(t *testing.T) {
 
 func TestSplitYAMLDocuments(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		wantLen  int
+		name    string
+		input   string
+		wantLen int
 	}{
 		{
 			name:    "single document no separator",

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -3,6 +3,7 @@ package getter
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -11,10 +12,14 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -39,22 +44,26 @@ var _ IExceptionsGetter = &CRDExceptionsGetter{}
 
 // CRDExceptionsGetter retrieves posture exceptions from SecurityException CRDs in-cluster.
 type CRDExceptionsGetter struct {
-	client dynamic.Interface
+	client    dynamic.Interface
+	k8sClient client.Client
 }
 
-func NewCRDExceptionsGetter() *CRDExceptionsGetter {
+// NewCRDExceptionsGetter creates a CRD-backed exceptions getter with an injected Kubernetes client.
+func NewCRDExceptionsGetter(k8sClient client.Client) *CRDExceptionsGetter {
+	getter := &CRDExceptionsGetter{k8sClient: k8sClient}
 	if !k8sinterface.IsConnectedToCluster() {
-		return &CRDExceptionsGetter{}
+		return getter
 	}
 	config := k8sinterface.GetK8sConfig()
 	if config == nil {
-		return &CRDExceptionsGetter{}
+		return getter
 	}
 	client, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return &CRDExceptionsGetter{}
+		return getter
 	}
-	return &CRDExceptionsGetter{client: client}
+	getter.client = client
+	return getter
 }
 
 func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExceptionPolicy, error) {
@@ -69,7 +78,7 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 		return nil, err
 	}
 	for i := range seList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(&seList.Items[i], "SecurityException")
+		policies, convErr := convertCRDObjectToPosturePolicies(&seList.Items[i], "SecurityException", g.k8sClient)
 		if convErr != nil {
 			continue
 		}
@@ -81,7 +90,7 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 		return nil, err
 	}
 	for i := range cseList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(&cseList.Items[i], "ClusterSecurityException")
+		policies, convErr := convertCRDObjectToPosturePolicies(&cseList.Items[i], "ClusterSecurityException", g.k8sClient)
 		if convErr != nil {
 			continue
 		}
@@ -91,7 +100,11 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 	return out, nil
 }
 
-func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind string) ([]armotypes.PostureExceptionPolicy, error) {
+func convertCRDObjectToPosturePolicies(
+	obj *unstructured.Unstructured,
+	kind string,
+	k8sClient client.Client,
+) ([]armotypes.PostureExceptionPolicy, error) {
 	if obj == nil {
 		return nil, fmt.Errorf("nil object")
 	}
@@ -100,25 +113,46 @@ func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind stri
 		return nil, fmt.Errorf("missing name")
 	}
 
-	reason, _, _ := unstructured.NestedString(obj.Object, "spec", "reason")
-	expiresAt, _, _ := unstructured.NestedString(obj.Object, "spec", "expiresAt")
-	postureItems, _, _ := unstructured.NestedSlice(obj.Object, "spec", "posture")
-	resources, err := buildResourceDesignators(obj, kind)
+	reason, reasonFound, err := unstructured.NestedString(obj.Object, "spec", "reason")
+	if err != nil {
+		return nil, fmt.Errorf("read reason: %w", err)
+	}
+	if !reasonFound {
+		reason = ""
+	}
+	expiresAt, expiresAtFound, err := unstructured.NestedString(obj.Object, "spec", "expiresAt")
+	if err != nil {
+		return nil, fmt.Errorf("read expiresAt: %w", err)
+	}
+	if !expiresAtFound {
+		expiresAt = ""
+	}
+	postureItems, postureFound, err := unstructured.NestedSlice(obj.Object, "spec", "posture")
+	if err != nil {
+		return nil, fmt.Errorf("read posture: %w", err)
+	}
+	if !postureFound {
+		postureItems = nil
+	}
+	resources, err := buildResourceDesignators(obj, kind, k8sClient)
 	if err != nil {
 		return nil, err
 	}
 
 	policies := make([]armotypes.PostureExceptionPolicy, 0, len(postureItems))
 	for _, raw := range postureItems {
-		item, ok := raw.(map[string]interface{})
+		item, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
-		controlID, _ := item["controlID"].(string)
-		if controlID == "" {
+		controlID, ok := item["controlID"].(string)
+		if !ok || controlID == "" {
 			continue
 		}
-		action, _ := item["action"].(string)
+		action, ok := item["action"].(string)
+		if !ok {
+			action = ""
+		}
 		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, "", action, expiresAt, reason, resources)
 		if err != nil {
 			continue
@@ -130,7 +164,7 @@ func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind stri
 			UID:       string(obj.GetUID()),
 		})
 		if policy.Attributes == nil {
-			policy.Attributes = map[string]interface{}{}
+			policy.Attributes = map[string]any{}
 		}
 		for k, v := range attrs {
 			policy.Attributes[k] = v
@@ -141,7 +175,11 @@ func convertCRDObjectToPosturePolicies(obj *unstructured.Unstructured, kind stri
 	return policies, nil
 }
 
-func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]map[string]string, error) {
+func buildResourceDesignators(
+	obj *unstructured.Unstructured,
+	kind string,
+	k8sClient client.Client,
+) ([]map[string]string, error) {
 	designators := make([]map[string]string, 0, 2)
 
 	namespace := obj.GetNamespace()
@@ -149,7 +187,11 @@ func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]ma
 		designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
 	}
 
-	if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "match", "objectSelector"); found {
+	_, objectSelectorFound, err := unstructured.NestedFieldNoCopy(obj.Object, "spec", "match", "objectSelector")
+	if err != nil {
+		return nil, fmt.Errorf("read objectSelector: %w", err)
+	}
+	if objectSelectorFound {
 		logger.L().Warning("SecurityException CRD uses unsupported spec.match.objectSelector; skipping",
 			helpers.String("name", obj.GetName()),
 			helpers.String("namespace", namespace),
@@ -158,9 +200,44 @@ func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]ma
 		return nil, fmt.Errorf("spec.match.objectSelector is not supported")
 	}
 
-	resources, _, _ := unstructured.NestedSlice(obj.Object, "spec", "match", "resources")
+	namespaceSelectorFound := false
+	var namespaceNames []string
+	if kind == "ClusterSecurityException" {
+		selectorRaw, found, err := unstructured.NestedFieldCopy(obj.Object, "spec", "match", "namespaceSelector")
+		if err != nil {
+			return nil, fmt.Errorf("read namespaceSelector: %w", err)
+		}
+		if found {
+			namespaceSelectorFound = true
+			if k8sClient == nil {
+				return nil, fmt.Errorf("namespaceSelector requires a kubernetes client")
+			}
+			selectorMap, ok := selectorRaw.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("namespaceSelector has unexpected type")
+			}
+			labelSelector := metav1.LabelSelector{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(selectorMap, &labelSelector); err != nil {
+				return nil, fmt.Errorf("decode namespaceSelector: %w", err)
+			}
+			names, err := resolveNamespaceSelector(labelSelector, k8sClient)
+			if err != nil {
+				return nil, err
+			}
+			namespaceNames = names
+		}
+	}
+
+	resources, resourcesFound, err := unstructured.NestedSlice(obj.Object, "spec", "match", "resources")
+	if err != nil {
+		return nil, fmt.Errorf("read resources: %w", err)
+	}
+	if !resourcesFound {
+		resources = nil
+	}
+	resourceDesignators := make([]map[string]string, 0, len(resources))
 	for _, raw := range resources {
-		resource, ok := raw.(map[string]interface{})
+		resource, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -178,16 +255,64 @@ func buildResourceDesignators(obj *unstructured.Unstructured, kind string) ([]ma
 			attrs[identifiers.AttributeApiGroup] = apiGroup
 		}
 		if len(attrs) > 0 {
-			designators = append(designators, attrs)
+			resourceDesignators = append(resourceDesignators, attrs)
 		}
 	}
 
+	if namespaceSelectorFound {
+		if len(namespaceNames) > 0 && len(resourceDesignators) > 0 {
+			for _, ns := range namespaceNames {
+				for _, res := range resourceDesignators {
+					combined := map[string]string{identifiers.AttributeNamespace: ns}
+					for k, v := range res {
+						combined[k] = v
+					}
+					designators = append(designators, combined)
+				}
+			}
+		} else if len(namespaceNames) > 0 {
+			for _, ns := range namespaceNames {
+				designators = append(designators, map[string]string{identifiers.AttributeNamespace: ns})
+			}
+		}
+	} else if len(resourceDesignators) > 0 {
+		designators = append(designators, resourceDesignators...)
+	}
+
 	// Ensure the exception has at least one scope designator, otherwise exception processor ignores it.
-	if len(designators) == 0 {
+	if len(designators) == 0 && !namespaceSelectorFound {
 		designators = append(designators, map[string]string{identifiers.AttributeKind: "*"})
 	}
 
 	return designators, nil
+}
+
+// resolveNamespaceSelector returns namespace names matching a label selector.
+func resolveNamespaceSelector(selector metav1.LabelSelector, k8sClient client.Client) ([]string, error) {
+	if k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client is nil")
+	}
+	parsedSelector := labels.Everything()
+	if len(selector.MatchLabels) != 0 || len(selector.MatchExpressions) != 0 {
+		selectorStr := metav1.FormatLabelSelector(&selector)
+		var err error
+		parsedSelector, err = labels.Parse(selectorStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse namespaceSelector: %w", err)
+		}
+	}
+
+	var namespaces corev1.NamespaceList
+	if err := k8sClient.List(context.Background(), &namespaces, client.MatchingLabelsSelector{Selector: parsedSelector}); err != nil {
+		return nil, fmt.Errorf("list namespaces: %w", err)
+	}
+
+	names := make([]string, 0, len(namespaces.Items))
+	for i := range namespaces.Items {
+		names = append(names, namespaces.Items[i].Name)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func convertSecurityExceptionToPosturePolicy(

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -7,43 +7,46 @@ import (
 	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	client := fake.NewSimpleDynamicClient(scheme,
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "kubescape.io/v1",
 				"kind":       "SecurityException",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "se-a",
 					"namespace": "team-a",
 					"uid":       "uid-se-a",
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"reason": "maintenance",
-					"posture": []interface{}{
-						map[string]interface{}{"controlID": "C-0001", "action": "ignore"},
+					"posture": []any{
+						map[string]any{"controlID": "C-0001", "action": "ignore"},
 					},
 				},
 			},
 		},
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "kubescape.io/v1",
 				"kind":       "ClusterSecurityException",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name": "cse-a",
 					"uid":  "uid-cse-a",
 				},
-				"spec": map[string]interface{}{
-					"posture": []interface{}{
-						map[string]interface{}{"controlID": "C-0002", "action": "alert_only"},
+				"spec": map[string]any{
+					"posture": []any{
+						map[string]any{"controlID": "C-0002", "action": "alert_only"},
 					},
 				},
 			},
@@ -76,18 +79,62 @@ func TestCRDExceptionsGetter_NilClient(t *testing.T) {
 	assert.Empty(t, exceptions)
 }
 
+func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging", Labels: map[string]string{"env": "staging"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod", Labels: map[string]string{"env": "prod"}}},
+	).Build()
+
+	listKinds := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds,
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       "ClusterSecurityException",
+				"metadata": map[string]any{
+					"name": "cse-staging",
+					"uid":  "uid-cse-staging",
+				},
+				"spec": map[string]any{
+					"match": map[string]any{
+						"namespaceSelector": map[string]any{
+							"matchLabels": map[string]any{"env": "staging"},
+						},
+					},
+					"posture": []any{
+						map[string]any{"controlID": "C-0003", "action": "alert_only"},
+					},
+				},
+			},
+		},
+	)
+
+	getter := &CRDExceptionsGetter{client: dynamicClient, k8sClient: k8sClient}
+	exceptions, err := getter.GetExceptions("cluster-a")
+	require.NoError(t, err)
+	require.Len(t, exceptions, 1)
+	require.Len(t, exceptions[0].Resources, 1)
+	assert.Equal(t, "staging", exceptions[0].Resources[0].Attributes[identifiers.AttributeNamespace])
+	assert.Equal(t, "ClusterSecurityException", exceptions[0].Attributes["securityExceptionKind"])
+}
+
 func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "ClusterSecurityException"})
 	obj.SetName("cse-empty")
 	obj.SetUID("uid-cse")
-	obj.Object["spec"] = map[string]interface{}{
-		"posture": []interface{}{
-			map[string]interface{}{"controlID": "C-0099"},
+	obj.Object["spec"] = map[string]any{
+		"posture": []any{
+			map[string]any{"controlID": "C-0099"},
 		},
 	}
 
-	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException")
+	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException", nil)
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	assert.Equal(t, "*", policies[0].Resources[0].Attributes[identifiers.AttributeKind])
@@ -98,19 +145,168 @@ func TestConvertCRDObjectToPosturePolicies_ObjectSelectorIsRejected(t *testing.T
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "SecurityException"})
 	obj.SetName("se-selector")
 	obj.SetNamespace("team-a")
-	obj.Object["spec"] = map[string]interface{}{
-		"match": map[string]interface{}{
-			"objectSelector": map[string]interface{}{
-				"matchLabels": map[string]interface{}{"app": "nginx"},
+	obj.Object["spec"] = map[string]any{
+		"match": map[string]any{
+			"objectSelector": map[string]any{
+				"matchLabels": map[string]any{"app": "nginx"},
 			},
 		},
-		"posture": []interface{}{
-			map[string]interface{}{"controlID": "C-0100", "action": "ignore"},
+		"posture": []any{
+			map[string]any{"controlID": "C-0100", "action": "ignore"},
 		},
 	}
 
-	policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException")
+	policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "spec.match.objectSelector is not supported")
 	assert.Nil(t, policies)
+}
+
+func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging", Labels: map[string]string{"env": "staging"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging-2", Labels: map[string]string{"env": "staging"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod", Labels: map[string]string{"env": "prod"}}},
+	).Build()
+
+	tests := []struct {
+		name      string
+		kind      string
+		namespace string
+		selector  map[string]any
+		resources []map[string]any
+		want      []map[string]string
+	}{
+		{
+			name: "namespaceSelector matches one namespace",
+			kind: "ClusterSecurityException",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "prod"},
+			},
+			want: []map[string]string{{identifiers.AttributeNamespace: "prod"}},
+		},
+		{
+			name: "namespaceSelector matches multiple namespaces",
+			kind: "ClusterSecurityException",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "staging"},
+			},
+			want: []map[string]string{
+				{identifiers.AttributeNamespace: "staging"},
+				{identifiers.AttributeNamespace: "staging-2"},
+			},
+		},
+		{
+			name: "namespaceSelector with resources combines scope",
+			kind: "ClusterSecurityException",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "staging"},
+			},
+			resources: []map[string]any{
+				{
+					"kind":     "Deployment",
+					"name":     "frontend",
+					"apiGroup": "apps",
+				},
+			},
+			want: []map[string]string{
+				{
+					identifiers.AttributeNamespace: "staging",
+					identifiers.AttributeKind:      "Deployment",
+					identifiers.AttributeName:      "frontend",
+					identifiers.AttributeApiGroup:  "apps",
+				},
+				{
+					identifiers.AttributeNamespace: "staging-2",
+					identifiers.AttributeKind:      "Deployment",
+					identifiers.AttributeName:      "frontend",
+					identifiers.AttributeApiGroup:  "apps",
+				},
+			},
+		},
+		{
+			name: "namespaceSelector matches no namespaces",
+			kind: "ClusterSecurityException",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "dev"},
+			},
+			want: []map[string]string{},
+		},
+		{
+			name: "namespaceSelector matches no namespaces with resources",
+			kind: "ClusterSecurityException",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "dev"},
+			},
+			resources: []map[string]any{
+				{
+					"kind":     "Deployment",
+					"name":     "frontend",
+					"apiGroup": "apps",
+				},
+			},
+			want: []map[string]string{},
+		},
+		{
+			name:     "empty namespaceSelector matches all namespaces",
+			kind:     "ClusterSecurityException",
+			selector: map[string]any{},
+			want: []map[string]string{
+				{identifiers.AttributeNamespace: "prod"},
+				{identifiers.AttributeNamespace: "staging"},
+				{identifiers.AttributeNamespace: "staging-2"},
+			},
+		},
+		{
+			name: "nil namespaceSelector skips resolution",
+			kind: "ClusterSecurityException",
+			want: []map[string]string{{identifiers.AttributeKind: "*"}},
+		},
+		{
+			name:      "namespaceSelector on namespaced SecurityException is ignored",
+			kind:      "SecurityException",
+			namespace: "team-a",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"env": "staging"},
+			},
+			want: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match := map[string]any{}
+			if tc.selector != nil {
+				match["namespaceSelector"] = tc.selector
+			}
+			if len(tc.resources) > 0 {
+				resources := make([]any, 0, len(tc.resources))
+				for _, res := range tc.resources {
+					resources = append(resources, res)
+				}
+				match["resources"] = resources
+			}
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       tc.kind,
+				"metadata": map[string]any{
+					"name":      "exception-a",
+					"namespace": tc.namespace,
+				},
+				"spec": map[string]any{
+					"match": match,
+					"posture": []any{
+						map[string]any{"controlID": "C-0001", "action": "alert_only"},
+					},
+				},
+			}}
+
+			got, err := buildResourceDesignators(obj, tc.kind, k8sClient)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
 }

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -18,6 +18,9 @@ import (
 	reporterv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2"
 	"github.com/kubescape/rbac-utils/rbacscanner"
 	"go.opentelemetry.io/otel"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // getKubernetesApi
@@ -26,6 +29,27 @@ func getKubernetesApi() *k8sinterface.KubernetesApi {
 		return nil
 	}
 	return k8sinterface.NewKubernetesApi()
+}
+
+func getExceptionsK8sClient(ctx context.Context) client.Client {
+	if !k8sinterface.IsConnectedToCluster() {
+		return nil
+	}
+	config := k8sinterface.GetK8sConfig()
+	if config == nil {
+		return nil
+	}
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		logger.L().Ctx(ctx).Warning("failed to add corev1 scheme", helpers.Error(err))
+		return nil
+	}
+	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("failed to create controller-runtime client", helpers.Error(err))
+		return nil
+	}
+	return k8sClient
 }
 
 func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IExceptionsGetter {
@@ -39,7 +63,8 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	if accountID != "" {
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIConnector()
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
+		k8sClient := getExceptionsK8sClient(ctx)
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
@@ -48,10 +73,12 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading attack tracks from cache", helpers.Error(err))
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
+		k8sClient := getExceptionsK8sClient(ctx)
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
 	primary = downloadReleasedPolicy
-	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter())
+	k8sClient := getExceptionsK8sClient(ctx)
+	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 
 }
 

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -616,9 +616,9 @@ func TestJunitMultiFrameworkSharedControl(t *testing.T) {
 // testsSuites. This unit test pins the loop itself.
 func TestAggregateSuiteCounts(t *testing.T) {
 	cases := []struct {
-		name                                 string
-		in                                   []JUnitTestSuite
-		wantTests, wantFailures, wantErrors  int
+		name                                string
+		in                                  []JUnitTestSuite
+		wantTests, wantFailures, wantErrors int
 	}{
 		{
 			name: "empty slice yields zeros",

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/datastructures.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/datastructures.go
@@ -68,4 +68,3 @@ var mapCategoryToType = map[string]CategoryType{
 	networkCategoryID:       TypeCounting,
 	workloadsCategoryID:     TypeCounting,
 }
-

--- a/go.mod
+++ b/go.mod
@@ -257,6 +257,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/f-amaral/go-async v0.3.0 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -656,6 +656,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/f-amaral/go-async v0.3.0 h1:h4kLsX7aKfdWaHvV0lf+/EE3OIeCzyeDYJDb/vDZUyg=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -240,6 +240,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/f-amaral/go-async v0.3.0 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -656,6 +656,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/f-amaral/go-async v0.3.0 h1:h4kLsX7aKfdWaHvV0lf+/EE3OIeCzyeDYJDb/vDZUyg=

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -39,7 +39,7 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 		assert.False(t, scanInfo.ScanAll) // Don't scan all when specific frameworks are set
 		assert.False(t, scanInfo.HostSensorEnabled.GetBool())
 		assert.Equal(t, getter.DefaultLocalStore, scanInfo.UseArtifactsFrom)
-		
+
 		// Verify specific frameworks are set
 		assert.Len(t, scanInfo.PolicyIdentifier, 3)
 		assert.Equal(t, "nsa", scanInfo.PolicyIdentifier[0].Identifier)

--- a/httphandler/handlerequests/v1/requestshandler_test.go
+++ b/httphandler/handlerequests/v1/requestshandler_test.go
@@ -96,7 +96,7 @@ func TestResultsDeleteAll(t *testing.T) {
 
 	h.Results(w, rq)
 	rs := w.Result()
-	
+
 	if rs.StatusCode != http.StatusOK {
 		t.Errorf("Expected StatusOK (200), got %v", rs.StatusCode)
 	}
@@ -107,7 +107,7 @@ func TestResultsDeleteAll(t *testing.T) {
 
 	h.Results(w, rq)
 	rs = w.Result()
-	
+
 	if rs.StatusCode != http.StatusBadRequest {
 		t.Errorf("Expected StatusBadRequest (400) for missing ScanID, got %v", rs.StatusCode)
 	}

--- a/httphandler/handlerequests/v1/results_handler_test.go
+++ b/httphandler/handlerequests/v1/results_handler_test.go
@@ -205,9 +205,9 @@ func TestResults_GetEmptyID_OfflineFallback_TableDriven(t *testing.T) {
 
 	type tc struct {
 		name       string
-		seedLatest bool                         // call setBusy/setNotBusy so latestID == validUUID
-		writeFile  bool                         // create the result file on disk
-		query      string                       // query string appended to /results
+		seedLatest bool   // call setBusy/setNotBusy so latestID == validUUID
+		writeFile  bool   // create the result file on disk
+		query      string // query string appended to /results
 		wantStatus int
 		wantType   utilsapisv1.ScanResponseType // zero value means "don't assert type"
 		wantKept   bool                         // must the file still exist after the call?


### PR DESCRIPTION
## Summary

Resolves `spec.match.namespaceSelector` on `ClusterSecurityException` objects at CRD fetch time so Kubescape stores concrete namespace-scoped `PortalDesignator` entries before posture exception matching runs. This satisfies the design doc requirement: "namespaceSelector is resolved to a namespace list, then individual PortalDesignator entries are created per namespace." Fetch-time resolution keeps the exception processor working with the same resource designator shape it already understands.

References kubescape/kubescape#1982.
Design doc: https://github.com/kubescape/kubevuln/blob/main/docs/security-exception-design.md

## Changes

- Injects a controller-runtime `client.Client` into `CRDExceptionsGetter`.
- Resolves ClusterSecurityException namespace selectors against live Namespace objects.
- Merges resolved namespaces with explicit resource matchers.
- Leaves namespaced SecurityException namespace selectors ignored because namespaced exceptions are scoped to their own namespace.
- Covers one, many, none, empty, nil, and namespaced selector cases with fake controller-runtime clients.

## Testing

- [x] `go test ./core/cautils/getter ./core/core`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
