### PR TITLE
anonymize resource source metadata in hidden output

### DIFF
--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -1,6 +1,8 @@
 package anonymizer
 
 import (
+	"strings"
+
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -28,6 +30,11 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 		if namespace := resource.GetNamespace(); namespace != "" {
 			resource.SetNamespace(mapping.GetOrCreate("ns", namespace))
 		}
+
+		// sourcePath leaks manifest filenames/line references in hidden output
+		// (for example test-anonymize.yaml:1), so anonymize it alongside other
+		// resource-local metadata.
+		anonymizeResourceObjectSourcePath(resource, mapping)
 
 		// Annotations may contain infrastructure identifiers, secret paths, or
 		// other sensitive metadata at both top-level and nested workload templates.
@@ -87,6 +94,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 	newResourceSource := make(map[string]reporthandling.Source, len(session.ResourceSource))
 	for oldID, source := range session.ResourceSource {
 		newID := resolveMappedID(mapping, idMapping, oldID, "ref")
+		anonymizeResourceSource(&source, mapping)
 		newResourceSource[newID] = source
 	}
 	session.ResourceSource = newResourceSource
@@ -175,6 +183,50 @@ func anonymizeResourceAnnotations(resource workloadinterface.IMetadata, mapping 
 	resource.SetObject(obj)
 }
 
+// anonymizeResourceObjectSourcePath anonymizes object.sourcePath while
+// preserving line number context (e.g. src-xxxx:12).
+func anonymizeResourceObjectSourcePath(resource workloadinterface.IMetadata, mapping *Mapping) {
+	if resource == nil {
+		return
+	}
+
+	obj := resource.GetObject()
+	if obj == nil {
+		return
+	}
+
+	rawSourcePath, ok := obj["sourcePath"]
+	if !ok {
+		return
+	}
+
+	sourcePath, ok := rawSourcePath.(string)
+	if !ok || sourcePath == "" {
+		return
+	}
+
+	obj["sourcePath"] = anonymizeSourcePath(sourcePath, mapping)
+	resource.SetObject(obj)
+}
+
+// anonymizeSourcePath preserves trailing line numbers while anonymizing the
+// underlying file path.
+func anonymizeSourcePath(sourcePath string, mapping *Mapping) string {
+	lastColon := strings.LastIndex(sourcePath, ":")
+	if lastColon == -1 {
+		return mapping.GetOrCreate("src", sourcePath)
+	}
+
+	pathPart := sourcePath[:lastColon]
+	linePart := sourcePath[lastColon:]
+
+	if pathPart == "" {
+		return mapping.GetOrCreate("src", sourcePath)
+	}
+
+	return mapping.GetOrCreate("src", pathPart) + linePart
+}
+
 // anonymizeAnnotationNodes recursively traverses unstructured resource objects
 // to locate metadata blocks regardless of workload nesting depth.
 func anonymizeAnnotationNodes(node interface{}, mapping *Mapping) {
@@ -223,5 +275,70 @@ func anonymizeAnnotationMap(obj map[string]interface{}, mapping *Mapping) {
 		}
 
 		annotations[key] = mapping.GetOrCreate("ann", str)
+	}
+}
+
+// anonymizeResourceSource anonymizes source metadata that may expose local
+// filesystem structure, repository layout, Helm/Kustomize metadata, or git
+// commit identity in hidden scan output.
+func anonymizeResourceSource(source *reporthandling.Source, mapping *Mapping) {
+	if source == nil {
+		return
+	}
+
+	if source.Path != "" {
+		source.Path = mapping.GetOrCreate("src", source.Path)
+	}
+
+	if source.RelativePath != "" {
+		source.RelativePath = mapping.GetOrCreate("src", source.RelativePath)
+	}
+
+	if source.HelmPath != "" {
+		source.HelmPath = mapping.GetOrCreate("src", source.HelmPath)
+	}
+
+	if source.HelmChartName != "" {
+		source.HelmChartName = mapping.GetOrCreate("src", source.HelmChartName)
+	}
+
+	if source.HelmTemplateFile != "" {
+		source.HelmTemplateFile = mapping.GetOrCreate("src", source.HelmTemplateFile)
+	}
+
+	if source.KustomizeDirectoryName != "" {
+		source.KustomizeDirectoryName = mapping.GetOrCreate("src", source.KustomizeDirectoryName)
+	}
+
+	for i := range source.HelmValuesPaths {
+		if source.HelmValuesPaths[i] != "" {
+			source.HelmValuesPaths[i] = mapping.GetOrCreate("src", source.HelmValuesPaths[i])
+		}
+	}
+
+	anonymizeLastCommit(&source.LastCommit, mapping)
+}
+
+// anonymizeLastCommit anonymizes commit metadata that may reveal repository
+// identity or contributor information while preserving non-sensitive timestamps.
+func anonymizeLastCommit(commit *reporthandling.LastCommit, mapping *Mapping) {
+	if commit == nil {
+		return
+	}
+
+	if commit.Hash != "" {
+		commit.Hash = mapping.GetOrCreate("git", commit.Hash)
+	}
+
+	if commit.CommitterName != "" {
+		commit.CommitterName = mapping.GetOrCreate("git", commit.CommitterName)
+	}
+
+	if commit.CommitterEmail != "" {
+		commit.CommitterEmail = mapping.GetOrCreate("git", commit.CommitterEmail)
+	}
+
+	if commit.Message != "" {
+		commit.Message = mapping.GetOrCreate("git", commit.Message)
 	}
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -151,7 +151,27 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 			},
 		},
 		ResourceSource: map[string]reporthandling.Source{
-			oldID: {},
+			oldID: {
+				Path:             "/home/devjijo/work/acme-platform/manifests/payments/api-deployment.yaml",
+				RelativePath:     "clusters/production/payments/api/deployment.yaml",
+				HelmPath:         "charts/platform-security",
+				FileType:         "Helm Chart",
+				HelmChartName:    "payments-service",
+				HelmTemplateFile: "templates/api-deployment.yaml",
+				HelmValuesPaths: []string{
+					"database.connection.url",
+					"redis.auth.password",
+					"serviceAccount.name",
+				},
+				HelmTemplateLine:       87,
+				KustomizeDirectoryName: "production-overlays",
+				LastCommit: reporthandling.LastCommit{
+					Hash:           "9f8c7a6b5d4e3f21",
+					CommitterName:  "Platform Engineer",
+					CommitterEmail: "platform.engineer@example.com",
+					Message:        "update deployment configuration",
+				},
+			},
 		},
 		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
 			oldID: {ResourceID: oldID},
@@ -197,8 +217,89 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 		result.AssociatedControls[0].ResourceAssociatedRules[0].RelatedResourcesIDs[0],
 	)
 
-	_, ok = session.ResourceSource[newID]
+	source, ok := session.ResourceSource[newID]
 	assert.True(t, ok)
+
+	assert.NotEqual(
+		t,
+		"/home/devjijo/work/acme-platform/manifests/payments/api-deployment.yaml",
+		source.Path,
+	)
+
+	assert.NotEqual(
+		t,
+		"clusters/production/payments/api/deployment.yaml",
+		source.RelativePath,
+	)
+
+	assert.NotEqual(
+		t,
+		"charts/platform-security",
+		source.HelmPath,
+	)
+
+	assert.NotEqual(
+		t,
+		"payments-service",
+		source.HelmChartName,
+	)
+
+	assert.NotEqual(
+		t,
+		"templates/api-deployment.yaml",
+		source.HelmTemplateFile,
+	)
+
+	assert.NotEqual(
+		t,
+		"production-overlays",
+		source.KustomizeDirectoryName,
+	)
+
+	assert.NotEqual(
+		t,
+		"database.connection.url",
+		source.HelmValuesPaths[0],
+	)
+
+	assert.NotEqual(
+		t,
+		"redis.auth.password",
+		source.HelmValuesPaths[1],
+	)
+
+	assert.NotEqual(
+		t,
+		"serviceAccount.name",
+		source.HelmValuesPaths[2],
+	)
+
+	assert.NotEqual(
+		t,
+		"9f8c7a6b5d4e3f21",
+		source.LastCommit.Hash,
+	)
+
+	assert.NotEqual(
+		t,
+		"Platform Engineer",
+		source.LastCommit.CommitterName,
+	)
+
+	assert.NotEqual(
+		t,
+		"platform.engineer@example.com",
+		source.LastCommit.CommitterEmail,
+	)
+
+	assert.NotEqual(
+		t,
+		"update deployment configuration",
+		source.LastCommit.Message,
+	)
+
+	assert.Equal(t, "Helm Chart", source.FileType)
+	assert.Equal(t, 87, source.HelmTemplateLine)
 
 	prioritized, ok := session.ResourcesPrioritized[newID]
 	assert.True(t, ok)


### PR DESCRIPTION
Part of: #1200

Extend ``--hide`` anonymization coverage for resource source metadata that can expose local filesystem, repository, or contributor information in hidden scan output.

This PR adds anonymization for:
-  Resource source metadata
-  Git commit metadata within resource source
- Resource object source references
 object.sourcePath (while preserving line number context)

NOTE : :
Non-sensitive metadata such as file type, template line numbers, and commit date are preserved.
