### PR TITLE
anonymizer: hide git repository context metadata

### DIFF
--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
 // anonymizeSession rewrites sensitive resource identifiers and metadata while
@@ -114,7 +115,14 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 	}
 	session.ResourceAttackTracks = newResourceAttackTracks
 
+	if session.Metadata != nil {
+		anonymizeRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, mapping)
+	}
+
 	if session.Report != nil {
+
+		anonymizeRepoContextMetadata(session.Report.Metadata.ContextMetadata.RepoContextMetadata, mapping)
+
 		for controlID, control := range session.Report.SummaryDetails.Controls {
 			remappedResourceIDs := control.ResourceIDs
 
@@ -341,4 +349,34 @@ func anonymizeLastCommit(commit *reporthandling.LastCommit, mapping *Mapping) {
 	if commit.Message != "" {
 		commit.Message = mapping.GetOrCreate("git", commit.Message)
 	}
+}
+
+// anonymizeRepoContextMetadata anonymizes repository identity metadata while
+// preserving operational fields required by downstream consumers.
+func anonymizeRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, mapping *Mapping) {
+	if repo == nil {
+		return
+	}
+
+	if repo.Repo != "" {
+		repo.Repo = mapping.GetOrCreate("git", repo.Repo)
+	}
+
+	if repo.Owner != "" {
+		repo.Owner = mapping.GetOrCreate("git", repo.Owner)
+	}
+
+	if repo.Branch != "" {
+		repo.Branch = mapping.GetOrCreate("git", repo.Branch)
+	}
+
+	if repo.DefaultBranch != "" {
+		repo.DefaultBranch = mapping.GetOrCreate("git", repo.DefaultBranch)
+	}
+
+	if repo.RemoteURL != "" {
+		repo.RemoteURL = mapping.GetOrCreate("git", repo.RemoteURL)
+	}
+
+	anonymizeLastCommit(&repo.LastCommit, mapping)
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -559,3 +559,101 @@ func TestAnonymizeSession_Annotations(t *testing.T) {
 		})
 	}
 }
+
+func TestAnonymizeSession_RepoContextMetadata(t *testing.T) {
+	repoContext := &reporthandlingv2.RepoContextMetadata{
+		Provider:      "github",
+		Repo:          "kubescape",
+		Owner:         "jijo-OO7",
+		Branch:        "feature/private-work",
+		DefaultBranch: "main",
+		RemoteURL:     "https://github.com/jijo-OO7/kubescape",
+		LocalRootPath: "/home/devjijo/work/kubescape",
+		LastCommit: reporthandling.LastCommit{
+			Hash:           "abcdef123456",
+			CommitterName:  "Platform Engineer",
+			CommitterEmail: "platform.engineer@example.com",
+			Message:        "internal security fixes",
+		},
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+					Provider:      repoContext.Provider,
+					Repo:          repoContext.Repo,
+					Owner:         repoContext.Owner,
+					Branch:        repoContext.Branch,
+					DefaultBranch: repoContext.DefaultBranch,
+					RemoteURL:     repoContext.RemoteURL,
+					LocalRootPath: repoContext.LocalRootPath,
+					LastCommit:    repoContext.LastCommit,
+				},
+			},
+		},
+
+		Report: &reporthandlingv2.PostureReport{
+			Metadata: reporthandlingv2.Metadata{
+				ContextMetadata: reporthandlingv2.ContextMetadata{
+					RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+						Provider:      repoContext.Provider,
+						Repo:          repoContext.Repo,
+						Owner:         repoContext.Owner,
+						Branch:        repoContext.Branch,
+						DefaultBranch: repoContext.DefaultBranch,
+						RemoteURL:     repoContext.RemoteURL,
+						LocalRootPath: repoContext.LocalRootPath,
+						LastCommit:    repoContext.LastCommit,
+					},
+				},
+			},
+		},
+	}
+
+	mapping := NewMapping()
+	anonymizeSession(session, mapping)
+
+	for _, repo := range []*reporthandlingv2.RepoContextMetadata{
+		session.Metadata.ContextMetadata.RepoContextMetadata,
+		session.Report.Metadata.ContextMetadata.RepoContextMetadata,
+	} {
+		assert.NotNil(t, repo)
+
+		if repo == nil {
+			return
+		}
+
+		assert.Equal(t, "github", repo.Provider)
+
+		assert.NotEqual(t, "kubescape", repo.Repo)
+		assert.NotEqual(t, "jijo-OO7", repo.Owner)
+		assert.NotEqual(t, "feature/private-work", repo.Branch)
+		assert.NotEqual(t, "main", repo.DefaultBranch)
+		assert.NotEqual(t, "https://github.com/jijo-OO7/kubescape", repo.RemoteURL)
+
+		assert.Equal(t, "/home/devjijo/work/kubescape", repo.LocalRootPath)
+
+		assert.Contains(t, repo.Repo, "git-")
+		assert.Contains(t, repo.Owner, "git-")
+		assert.Contains(t, repo.Branch, "git-")
+		assert.Contains(t, repo.DefaultBranch, "git-")
+		assert.Contains(t, repo.RemoteURL, "git-")
+
+		assert.NotEqual(t, "abcdef123456", repo.LastCommit.Hash)
+		assert.NotEqual(t, "Platform Engineer", repo.LastCommit.CommitterName)
+		assert.NotEqual(t, "platform.engineer@example.com", repo.LastCommit.CommitterEmail)
+		assert.NotEqual(t, "internal security fixes", repo.LastCommit.Message)
+
+		assert.Contains(t, repo.LastCommit.Hash, "git-")
+		assert.Contains(t, repo.LastCommit.CommitterName, "git-")
+		assert.Contains(t, repo.LastCommit.CommitterEmail, "git-")
+		assert.Contains(t, repo.LastCommit.Message, "git-")
+	}
+}


### PR DESCRIPTION
Part of : #1200 
## Overview

This PR extends `--hide` anonymization coverage to sensitive git repository context metadata included in scan output.

### Changes

* anonymize `metadata.targetMetadata.gitRepoContextMetadata` fields:

  * repo
  * owner
  * branch
  * default branch
  * remote URL
  * last commit metadata (hash / committer details / message)

* preserve operational metadata required by downstream consumers (for example `localRootPath`)
* preserve non-sensitive provider metadata (`github`, `gitlab`, etc.)
* add unit test coverage for repo context anonymization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anonymization capability for repository context metadata, including repository name, owner, branch, default branch, remote URL, local root path, and commit details.

* **Tests**
  * Added comprehensive test coverage to validate repository context metadata anonymization across different metadata structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->