### PR TITLE
fix(imagescan): repair interleaved type definitions in test file

### DIFF
--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 type thresholdStubVulnerabilityProvider struct {
-type stubVulnerabilityProvider struct {
 	metadataByID map[string]*vulnerability.Metadata
 	errByID      map[string]error
 }
@@ -30,6 +29,42 @@ func (s thresholdStubVulnerabilityProvider) FindVulnerabilities(...vulnerability
 }
 
 func (s thresholdStubVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference) (*vulnerability.Metadata, error) {
+	if err, ok := s.errByID[ref.ID]; ok {
+		return nil, err
+	}
+
+	if metadata, ok := s.metadataByID[ref.ID]; ok {
+		return metadata, nil
+	}
+
+	return nil, errors.New("metadata not found")
+}
+
+func (s thresholdStubVulnerabilityProvider) Close() error {
+	return nil
+}
+
+func makeThresholdTestMatch(id string) match.Match {
+	return match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{
+				ID:        id,
+				Namespace: "nvd",
+			},
+		},
+		Package: grypepkg.Package{
+			ID:      grypepkg.ID("pkg-" + id),
+			Name:    "pkg-" + id,
+			Version: "1.0.0",
+		},
+	}
+}
+
+type stubVulnerabilityProvider struct {
+	metadataByID map[string]*vulnerability.Metadata
+	errByID      map[string]error
+}
+
 func (s stubVulnerabilityProvider) PackageSearchNames(grypepkg.Package) []string {
 	return nil
 }
@@ -50,11 +85,6 @@ func (s stubVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Refer
 	return nil, errors.New("metadata not found")
 }
 
-func (s thresholdStubVulnerabilityProvider) Close() error {
-	return nil
-}
-
-func makeThresholdTestMatch(id string) match.Match {
 func (s stubVulnerabilityProvider) Close() error {
 	return nil
 }


### PR DESCRIPTION
## Summary

- PRs #2210 and #2211 each added a stub vulnerability provider type and a test helper to `pkg/imagescan/imagescan_test.go`, but their declarations landed interleaved, leaving the file syntactically broken (`go vet` reports *expected '}', found 'type'* at line 19).
- Untangle the two sets: `thresholdStubVulnerabilityProvider` (with its methods and `makeThresholdTestMatch`) is now defined contiguously before `stubVulnerabilityProvider` (with its methods and `makeTestMatch`).
- No logic changes — only structural repair.

## Test plan

- [ ] `go vet ./pkg/imagescan/...` passes with no issues
- [ ] `go build ./pkg/imagescan/...` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure organization for vulnerability provider tests by refactoring test scaffolding for better clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->