### PR TITLE
fix(opaprocessor): isolate rego dependency control inputs

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -43,12 +43,12 @@ type OPAProcessor struct {
 	regoDependenciesData *resources.RegoDependenciesData
 	*cautils.OPASessionObj
 	exceptionEventRecorder record.EventRecorder
-	opaRegisterOnce   sync.Once
-	excludeNamespaces []string
-	includeNamespaces []string
-	printEnabled      bool
-	compiledModules   map[string]*ast.Compiler
-	compiledMu        sync.RWMutex
+	opaRegisterOnce        sync.Once
+	excludeNamespaces      []string
+	includeNamespaces      []string
+	printEnabled           bool
+	compiledModules        map[string]*ast.Compiler
+	compiledMu             sync.RWMutex
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -58,14 +58,14 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 	}
 
 	return &OPAProcessor{
-		OPASessionObj:        sessionObj,
-		regoDependenciesData: regoDependenciesData,
-		clusterName:          clusterName,
+		OPASessionObj:          sessionObj,
+		regoDependenciesData:   regoDependenciesData,
+		clusterName:            clusterName,
 		exceptionEventRecorder: exceptionEventRecorder,
-		excludeNamespaces:    split(excludeNamespaces),
-		includeNamespaces:    split(includeNamespaces),
-		printEnabled:         enableRegoPrint,
-		compiledModules:      make(map[string]*ast.Compiler),
+		excludeNamespaces:      split(excludeNamespaces),
+		includeNamespaces:      split(includeNamespaces),
+		printEnabled:           enableRegoPrint,
+		compiledModules:        make(map[string]*ast.Compiler),
 	}
 }
 
@@ -468,11 +468,16 @@ func (opap *OPAProcessor) enumerateData(ctx context.Context, rule *reporthandlin
 //
 // If some extra fixedControlInputs are provided, they are merged into the "posture" control inputs.
 func (opap *OPAProcessor) makeRegoDeps(configInputs []reporthandling.ControlConfigInputs, fixedControlInputs map[string][]string) resources.RegoDependenciesData {
-	postureControlInputs := opap.regoDependenciesData.GetFilteredPostureControlConfigInputs(configInputs) // get store
+	postureControlInputs := opap.regoDependenciesData.GetFilteredPostureControlConfigInputs(configInputs)
 
-	// merge configurable control input and fixed control input
+	clonedPostureInputs := make(map[string][]string, len(postureControlInputs)+len(fixedControlInputs))
+
+	for k, v := range postureControlInputs {
+		clonedPostureInputs[k] = slices.Clone(v)
+	}
+
 	for k, v := range fixedControlInputs {
-		postureControlInputs[k] = v
+		clonedPostureInputs[k] = slices.Clone(v)
 	}
 
 	dataControlInputs := map[string]string{
@@ -481,7 +486,7 @@ func (opap *OPAProcessor) makeRegoDeps(configInputs []reporthandling.ControlConf
 
 	return resources.RegoDependenciesData{
 		DataControlInputs:    dataControlInputs,
-		PostureControlInputs: postureControlInputs,
+		PostureControlInputs: clonedPostureInputs,
 	}
 }
 

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
@@ -599,4 +600,31 @@ func TestSplit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMakeRegoDeps_InputIsolation(t *testing.T) {
+	regoDeps := resources.NewRegoDependenciesDataMock()
+
+	regoDeps.PostureControlInputs = map[string][]string{
+		"severity": {"high"},
+	}
+
+	opap := &OPAProcessor{
+		OPASessionObj: &cautils.OPASessionObj{
+			Report: &reporthandlingv2.PostureReport{
+				ClusterCloudProvider: "aws",
+			},
+		},
+		regoDependenciesData: regoDeps,
+	}
+
+	deps := opap.makeRegoDeps(nil, map[string][]string{
+		"runtime": {"enabled"},
+	})
+
+	deps.PostureControlInputs["runtime"][0] = "disabled"
+
+	_, runtimeExists := opap.regoDependenciesData.PostureControlInputs["runtime"]
+
+	assert.False(t, runtimeExists)
 }


### PR DESCRIPTION
## Overview

Fix shared ownership in `makeRegoDeps()` by cloning posture control input maps and slices before merging fixed inputs.

Previously, returned dependency inputs reused shared underlying data, allowing mutations to leak into processor state across evaluations.

## Changes

* clone `PostureControlInputs`
* clone nested `[]string` values with `slices.Clone`
* merge fixed inputs into the cloned structure
* add `TestMakeRegoDeps_InputIsolation` regression coverage

## Testing

```bash
go test ./core/pkg/opaprocessor -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input isolation in OPA processor to prevent unintended data mutation when processing posture control configurations.

* **Tests**
  * Added test coverage for input isolation in Rego dependency processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->