### PR TITLE
fix(cautils): make SetTopWorkloads idempotent

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -150,7 +150,7 @@ func (sessionObj *OPASessionObj) SetTopWorkloads() {
 	}
 
 	sessionObj.TopWorkloadsByScore = topWorkloads
-}	
+}
 
 func (sessionObj *OPASessionObj) SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources map[string]int) {
 	if sessionObj.Metadata.ContextMetadata.ClusterContextMetadata == nil {

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -132,20 +132,25 @@ func (sessionObj *OPASessionObj) SetTopWorkloads() {
 	}
 
 	// set top workloads according to number of top workloads
+	topWorkloads := make([]reporthandling.IResource, 0, TopWorkloadsNumber)
 	for i := 0; i < TopWorkloadsNumber; i++ {
 		if i >= len(topWorkloadsSorted) {
 			break
 		}
+
 		source := sessionObj.ResourceSource[topWorkloadsSorted[i].ResourceID]
+
 		wlObj := &reporthandling.Resource{
 			IMetadata: sessionObj.AllResources[topWorkloadsSorted[i].ResourceID],
 			Source:    &source,
 		}
 
-		sessionObj.TopWorkloadsByScore = append(sessionObj.TopWorkloadsByScore, wlObj)
+		topWorkloads = append(topWorkloads, wlObj)
 		count++
 	}
-}
+
+	sessionObj.TopWorkloadsByScore = topWorkloads
+}	
 
 func (sessionObj *OPASessionObj) SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources map[string]int) {
 	if sessionObj.Metadata.ContextMetadata.ClusterContextMetadata == nil {

--- a/core/cautils/datastructures_test.go
+++ b/core/cautils/datastructures_test.go
@@ -37,8 +37,8 @@ func TestEstimateClusterSize(t *testing.T) {
 			name: "multiple groups",
 			input: K8SResources{
 				"apps/v1/deployments": {"id1", "id2"},
-				"v1/pods":            {"id3", "id4", "id5"},
-				"v1/services":        {"id6"},
+				"v1/pods":             {"id3", "id4", "id5"},
+				"v1/services":         {"id6"},
 			},
 			expected: 6,
 		},
@@ -142,4 +142,23 @@ func TestSetTopWorkloads(t *testing.T) {
 
 		require.NotNil(t, obj.Report)
 	})
+}
+
+func TestSetTopWorkloads_Idempotent(t *testing.T) {
+	obj := NewOPASessionObjMock()
+
+	obj.ResourcesPrioritized = map[string]prioritization.PrioritizedResource{
+		"res1": {ResourceID: "res1", Score: 100},
+		"res2": {ResourceID: "res2", Score: 90},
+	}
+
+	obj.ResourceSource = map[string]reporthandling.Source{}
+
+	obj.SetTopWorkloads()
+
+	firstLen := len(obj.TopWorkloadsByScore)
+
+	obj.SetTopWorkloads()
+
+	assert.Len(t, obj.TopWorkloadsByScore, firstLen)
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -43,12 +43,12 @@ type OPAProcessor struct {
 	regoDependenciesData *resources.RegoDependenciesData
 	*cautils.OPASessionObj
 	exceptionEventRecorder record.EventRecorder
-	opaRegisterOnce   sync.Once
-	excludeNamespaces []string
-	includeNamespaces []string
-	printEnabled      bool
-	compiledModules   map[string]*ast.Compiler
-	compiledMu        sync.RWMutex
+	opaRegisterOnce        sync.Once
+	excludeNamespaces      []string
+	includeNamespaces      []string
+	printEnabled           bool
+	compiledModules        map[string]*ast.Compiler
+	compiledMu             sync.RWMutex
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -58,14 +58,14 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 	}
 
 	return &OPAProcessor{
-		OPASessionObj:        sessionObj,
-		regoDependenciesData: regoDependenciesData,
-		clusterName:          clusterName,
+		OPASessionObj:          sessionObj,
+		regoDependenciesData:   regoDependenciesData,
+		clusterName:            clusterName,
 		exceptionEventRecorder: exceptionEventRecorder,
-		excludeNamespaces:    split(excludeNamespaces),
-		includeNamespaces:    split(includeNamespaces),
-		printEnabled:         enableRegoPrint,
-		compiledModules:      make(map[string]*ast.Compiler),
+		excludeNamespaces:      split(excludeNamespaces),
+		includeNamespaces:      split(includeNamespaces),
+		printEnabled:           enableRegoPrint,
+		compiledModules:        make(map[string]*ast.Compiler),
 	}
 }
 
@@ -468,11 +468,16 @@ func (opap *OPAProcessor) enumerateData(ctx context.Context, rule *reporthandlin
 //
 // If some extra fixedControlInputs are provided, they are merged into the "posture" control inputs.
 func (opap *OPAProcessor) makeRegoDeps(configInputs []reporthandling.ControlConfigInputs, fixedControlInputs map[string][]string) resources.RegoDependenciesData {
-	postureControlInputs := opap.regoDependenciesData.GetFilteredPostureControlConfigInputs(configInputs) // get store
+	postureControlInputs := opap.regoDependenciesData.GetFilteredPostureControlConfigInputs(configInputs)
 
-	// merge configurable control input and fixed control input
+	clonedPostureInputs := make(map[string][]string, len(postureControlInputs)+len(fixedControlInputs))
+
+	for k, v := range postureControlInputs {
+		clonedPostureInputs[k] = slices.Clone(v)
+	}
+
 	for k, v := range fixedControlInputs {
-		postureControlInputs[k] = v
+		clonedPostureInputs[k] = slices.Clone(v)
 	}
 
 	dataControlInputs := map[string]string{
@@ -481,7 +486,7 @@ func (opap *OPAProcessor) makeRegoDeps(configInputs []reporthandling.ControlConf
 
 	return resources.RegoDependenciesData{
 		DataControlInputs:    dataControlInputs,
-		PostureControlInputs: postureControlInputs,
+		PostureControlInputs: clonedPostureInputs,
 	}
 }
 

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
@@ -599,4 +600,31 @@ func TestSplit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMakeRegoDeps_InputIsolation(t *testing.T) {
+	regoDeps := resources.NewRegoDependenciesDataMock()
+
+	regoDeps.PostureControlInputs = map[string][]string{
+		"severity": {"high"},
+	}
+
+	opap := &OPAProcessor{
+		OPASessionObj: &cautils.OPASessionObj{
+			Report: &reporthandlingv2.PostureReport{
+				ClusterCloudProvider: "aws",
+			},
+		},
+		regoDependenciesData: regoDeps,
+	}
+
+	deps := opap.makeRegoDeps(nil, map[string][]string{
+		"runtime": {"enabled"},
+	})
+
+	deps.PostureControlInputs["runtime"][0] = "disabled"
+
+	_, runtimeExists := opap.regoDependenciesData.PostureControlInputs["runtime"]
+
+	assert.False(t, runtimeExists)
 }


### PR DESCRIPTION
## Fix duplicate accumulation in `SetTopWorkloads()`

`SetTopWorkloads()` now builds workload results in local state before assigning them, preventing duplicate entries across repeated calls.

### Changes

* avoid appending to retained session state
* assign finalized workload results once
* add idempotency regression test coverage

### Testing

```bash
go test ./core/cautils -run TestSetTopWorkloads -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended mutation of control input data to improve stability.

* **Refactor**
  * Optimized internal data allocation to reduce unnecessary mutations and improve reliability.

* **Tests**
  * Added tests verifying idempotent behavior and input isolation to catch regressions early.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->