### PR TITLE
fix: populate generationTime in JSON report and invocations in SARIF

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/presenter/models"
@@ -183,6 +184,11 @@ func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 }
 
 func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
+	startedAt := opaSessionObj.Report.ReportGenerationTime
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+
 	report, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return err
@@ -224,6 +230,14 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 			}
 		}
 	}
+
+	finishedAt := time.Now().UTC()
+	executionSuccessful := true
+	run.Invocations = append(run.Invocations, &sarif.Invocation{
+		StartTimeUTC:        &startedAt,
+		EndTimeUTC:          &finishedAt,
+		ExecutionSuccessful: &executionSuccessful,
+	})
 
 	report.AddRun(run)
 

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -2,8 +2,10 @@ package printer
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -264,4 +266,94 @@ func TestPrintConfigurationScan_MissingControl(t *testing.T) {
 		err := sp.printConfigurationScan(context.Background(), session)
 		assert.NoError(t, err)
 	})
+}
+
+// TestPrintConfigurationScan_PopulatesInvocations is the regression test for
+// the SARIF half of kubescape/kubescape#2325: runs[].invocations was absent
+// from every SARIF report, so GitHub code-scanning ingestion collapsed every
+// upload to "scanned just now" and there was no startTimeUtc/endTimeUtc.
+func TestPrintConfigurationScan_PopulatesInvocations(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{},
+		},
+	}
+
+	tmp, err := os.CreateTemp("", "sarif-invocations-*.sarif")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+
+	before := time.Now().UTC()
+	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
+	after := time.Now().UTC()
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 1)
+
+	invocations := report.Runs[0].Invocations
+	require.Len(t, invocations, 1, "exactly one invocation must be recorded per run")
+
+	inv := invocations[0]
+	require.NotNil(t, inv.StartTimeUTC, "startTimeUtc must be populated")
+	require.NotNil(t, inv.EndTimeUTC, "endTimeUtc must be populated")
+	require.NotNil(t, inv.ExecutionSuccessful)
+	assert.True(t, *inv.ExecutionSuccessful)
+
+	// endTime is set just before the SARIF file is written, so it must fall
+	// inside the [before, after] window observed by this test.
+	assert.False(t, inv.EndTimeUTC.Before(before), "endTimeUtc precedes the test's before-marker")
+	assert.False(t, inv.EndTimeUTC.After(after), "endTimeUtc is after the test's after-marker")
+	assert.False(t, inv.EndTimeUTC.Before(*inv.StartTimeUTC), "endTimeUtc must be >= startTimeUtc")
+}
+
+// TestPrintConfigurationScan_InvocationStartTimeUsesReportGenerationTime
+// verifies the start-time fallback chain: when ReportGenerationTime is already
+// set (e.g. by FinalizeResults running earlier on the same session), the SARIF
+// invocation uses it as startTimeUtc instead of "now". This keeps the JSON and
+// SARIF outputs reporting the same scan start for the same scan.
+func TestPrintConfigurationScan_InvocationStartTimeUsesReportGenerationTime(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	preset := time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC)
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{},
+		},
+		ReportGenerationTime: preset,
+	}
+
+	tmp, err := os.CreateTemp("", "sarif-start-*.sarif")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+
+	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 1)
+	require.Len(t, report.Runs[0].Invocations, 1)
+
+	inv := report.Runs[0].Invocations[0]
+	require.NotNil(t, inv.StartTimeUTC)
+	assert.True(t, inv.StartTimeUTC.Equal(preset),
+		"startTimeUtc must reuse ReportGenerationTime, got %s want %s", inv.StartTimeUTC, preset)
 }

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,6 +1,8 @@
 package printer
 
 import (
+	"time"
+
 	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/match"
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -195,6 +197,9 @@ func extractResourceLabels(allResources map[string]workloadinterface.IMetadata, 
 
 // FinalizeResults finalize the results objects by copying data from map to lists
 func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureReport {
+	if data.Report.ReportGenerationTime.IsZero() {
+		data.Report.ReportGenerationTime = time.Now().UTC()
+	}
 	report := reporthandlingv2.PostureReport{
 		SummaryDetails:       data.Report.SummaryDetails,
 		Metadata:             *data.Metadata,

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/match"
@@ -927,4 +928,42 @@ func TestConvertToPostureReport_NilCoverageNotAttached(t *testing.T) {
 	)
 	require.NotNil(t, result)
 	assert.Nil(t, result.ScanCoverage)
+}
+
+// TestFinalizeResults_SetsGenerationTimeWhenZero is the regression test for
+// kubescape/kubescape#2325: JSON reports were emitting
+// "generationTime":"0001-01-01T00:00:00Z" because nothing on the scan path
+// ever assigned ReportGenerationTime. FinalizeResults is the single funnel
+// for both file output and SaaS submission, so the fix lives there.
+func TestFinalizeResults_SetsGenerationTimeWhenZero(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	require.True(t, session.Report.ReportGenerationTime.IsZero(),
+		"precondition: mock starts with the zero-value time that #2325 reported")
+
+	before := time.Now().UTC()
+	report := FinalizeResults(session)
+	after := time.Now().UTC()
+
+	require.NotNil(t, report)
+	assert.False(t, report.ReportGenerationTime.IsZero(),
+		"FinalizeResults must populate ReportGenerationTime")
+	assert.False(t, session.Report.ReportGenerationTime.IsZero(),
+		"FinalizeResults must also write back to the session so downstream consumers see it")
+	assert.Equal(t, session.Report.ReportGenerationTime, report.ReportGenerationTime)
+	assert.WithinDuration(t, before, report.ReportGenerationTime, after.Sub(before)+time.Second)
+}
+
+// TestFinalizeResults_PreservesExistingGenerationTime ensures we don't clobber
+// a timestamp that the caller has already set (e.g. when callers eventually
+// thread a real scan-start time through Scan(...)).
+func TestFinalizeResults_PreservesExistingGenerationTime(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	preset := time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC)
+	session.Report.ReportGenerationTime = preset
+
+	report := FinalizeResults(session)
+
+	require.NotNil(t, report)
+	assert.Equal(t, preset, report.ReportGenerationTime)
+	assert.Equal(t, preset, session.Report.ReportGenerationTime)
 }


### PR DESCRIPTION
## Overview

Every JSON report emitted by `kubescape scan --format json` had `"generationTime":"0001-01-01T00:00:00Z"` — Go's `time.Time{}` zero value, serialised through `(time.Time).MarshalJSON`. The field is part of the public report schema but was never assigned anywhere on the scan path. The matching SARIF problem was the opposite shape: `runs[].invocations` was absent entirely, so `startTimeUtc` / `endTimeUtc` were missing.

**Current behavior**
- JSON: `"generationTime":"0001-01-01T00:00:00Z"` on every report
- SARIF: `runs[0].invocations` is `null`

**New behavior**
- JSON: `"generationTime"` is the real RFC3339 UTC timestamp from scan finalisation
- SARIF: `runs[0].invocations[0]` carries `startTimeUtc`, `endTimeUtc`, and `executionSuccessful: true`

This unblocks `kubescape diff` (can now tell base vs head from filename-agnostic timestamps), historical dashboards (no more "every scan plotted at year 0001"), audit/SOC2 evidence packets (timestamp no longer looks tampered), and GitHub code-scanning ingestion (SARIF without `invocations` collapsed every upload to "scanned just now").

## Additional Information

**Where the fix lives**

- `core/pkg/resultshandling/printer/v2/utils.go` — `FinalizeResults` sets `data.Report.ReportGenerationTime = time.Now().UTC()` when it's the zero value, and writes back to the session so downstream consumers (SaaS uploader, `diff` tool) see the same value. `FinalizeResults` is the single funnel for both file output and SaaS submission, so one assignment fixes every code path.
- `core/pkg/resultshandling/printer/v2/sarifprinter.go` — `printConfigurationScan` captures `startedAt` at entry (preferring `opaSessionObj.Report.ReportGenerationTime` if already set, else `time.Now().UTC()`) and `finishedAt` just before `report.PrettyWrite`. Both are attached to `run.Invocations` along with `ExecutionSuccessful: true`. Falling back to `ReportGenerationTime` keeps JSON and SARIF outputs reporting the same scan start.

**Why not thread a real scan-start time through `Scan(...)`?** That's the cleanest fix but requires touching every entry point. The current change is the minimal, surgical fix — and since `FinalizeResults` runs early in serialisation, the timestamp is captured close enough to scan completion to be meaningful for every consumer named in the issue.

## How to Test

Using the issue's exact reproducer:

```bash
cat > /tmp/p.yaml <<'EOF'
apiVersion: v1
kind: Pod
metadata: {name: t}
spec:
  containers: [{name: c, image: nginx, securityContext: {privileged: true}}]
EOF

kubescape scan /tmp/p.yaml --format json  --output /tmp/report >/dev/null 2>&1
jq -r '.generationTime' /tmp/report.json
# Expect: a recent RFC3339 UTC timestamp, NOT 0001-01-01T00:00:00Z

kubescape scan /tmp/p.yaml --format sarif --output /tmp/report >/dev/null 2>&1
jq '.runs[0].invocations' /tmp/report.sarif
# Expect: a one-element array with startTimeUtc, endTimeUtc, executionSuccessful
```

Unit tests:

```bash
go test ./core/pkg/resultshandling/printer/v2/ -run "FinalizeResults|PrintConfigurationScan_Populates|PrintConfigurationScan_InvocationStartTime" -v
```

Four new regression tests cover the fix:

| Test                                                              | What it pins down                                                         |
| ----------------------------------------------------------------- | ------------------------------------------------------------------------- |
| `TestFinalizeResults_SetsGenerationTimeWhenZero`                  | Zero-value `ReportGenerationTime` is replaced with `time.Now().UTC()` and written back to the session |
| `TestFinalizeResults_PreservesExistingGenerationTime`             | A preset timestamp is **not** clobbered (forward-compatible with a future real scan-start thread)     |
| `TestPrintConfigurationScan_PopulatesInvocations`                 | SARIF output now has exactly one `invocation` with both UTC times, end ≥ start, `executionSuccessful: true` |
| `TestPrintConfigurationScan_InvocationStartTimeUsesReportGenerationTime` | SARIF `startTimeUtc` reuses `ReportGenerationTime` so JSON and SARIF agree on the same scan start |


## Related issues/PRs

- Resolved #2325

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* SARIF reports now capture invocation timing details, including start and end timestamps for better audit trails
* Report generation time is automatically tracked and set when not provided

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->