### PR TITLE
anonymizer: hide service account names in pod specs

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -35,6 +35,7 @@ func anonymizePodSpecs(node interface{}, mapping *Mapping) {
 		anonymizeContainerList(v, "initContainers", mapping)
 		anonymizeEphemeralContainerList(v, "ephemeralContainers", mapping)
 		anonymizeImagePullSecrets(v, mapping)
+		anonymizeServiceAccountName(v, mapping)
 
 		for _, child := range v {
 			anonymizePodSpecs(child, mapping)
@@ -361,5 +362,29 @@ func anonymizeImagePullSecrets(
 		}
 
 		obj["imagePullSecrets"] = refs
+	}
+}
+
+// anonymizeServiceAccountName anonymizes pod-level service account references
+// across both typed and unstructured workload representations.
+func anonymizeServiceAccountName(
+	obj map[string]interface{},
+	mapping *Mapping,
+) {
+	for _, key := range []string{
+		"serviceAccountName",
+		"serviceAccount",
+	} {
+		rawName, ok := obj[key]
+		if !ok || rawName == nil {
+			continue
+		}
+
+		name, ok := rawName.(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		obj[key] = mapping.GetOrCreate("sa", name)
 	}
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -586,6 +586,103 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 		},
 
 		{
+			name: "typed service account name should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"serviceAccountName": "payments-runtime",
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				serviceAccountName, ok := spec["serviceAccountName"].(string)
+				if !assert.True(t, ok, "expected serviceAccountName string") {
+					return
+				}
+
+				assert.NotEqual(t, "payments-runtime", serviceAccountName)
+				assert.Contains(t, serviceAccountName, "sa-")
+			},
+		},
+		{
+			name: "deprecated service account should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"serviceAccount": "payments-runtime",
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				serviceAccount, ok := spec["serviceAccount"].(string)
+				if !assert.True(t, ok, "expected serviceAccount string") {
+					return
+				}
+
+				assert.NotEqual(t, "payments-runtime", serviceAccount)
+				assert.Contains(t, serviceAccount, "sa-")
+			},
+		},
+		{
+			name: "nested template deprecated service account should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"serviceAccount": "analytics-runtime",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				template, ok := spec["template"].(map[string]interface{})
+				if !assert.True(t, ok, "expected template map") {
+					return
+				}
+
+				templateSpec, ok := template["spec"].(map[string]interface{})
+				if !assert.True(t, ok, "expected template spec map") {
+					return
+				}
+
+				serviceAccount, ok := templateSpec["serviceAccount"].(string)
+				if !assert.True(t, ok, "expected serviceAccount string") {
+					return
+				}
+
+				assert.NotEqual(t, "analytics-runtime", serviceAccount)
+				assert.Contains(t, serviceAccount, "sa-")
+			},
+		},
+		{
+			name: "nested template service account name should be anonymized",
+			object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"serviceAccountName": "analytics-runtime",
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]interface{}) {
+				template, ok := spec["template"].(map[string]interface{})
+				if !assert.True(t, ok, "expected template map") {
+					return
+				}
+
+				templateSpec, ok := template["spec"].(map[string]interface{})
+				if !assert.True(t, ok, "expected template spec map") {
+					return
+				}
+
+				serviceAccountName, ok := templateSpec["serviceAccountName"].(string)
+				if !assert.True(t, ok, "expected serviceAccountName string") {
+					return
+				}
+
+				assert.NotEqual(t, "analytics-runtime", serviceAccountName)
+				assert.Contains(t, serviceAccountName, "sa-")
+			},
+		},
+
+		{
 			name: "unstructured image pull secrets should be anonymized",
 			object: map[string]interface{}{
 				"spec": map[string]interface{}{


### PR DESCRIPTION
Part of: #1200

## Overview

This PR extends `--hide` anonymization coverage to Kubernetes `serviceAccountName` fields exposed in scan output.

### Changes

* anonymize `serviceAccountName` values across pod-spec based resources
* support both direct pod specs and nested pod templates
* support structured and unstructured workload representations
* preserve workload structure while anonymizing sensitive identifiers
* add unit test coverage for service account anonymization
* validate behavior with end-to-end hidden scan output

## Additional Information

Service account names may expose internal workload identity, privilege boundaries, cloud IAM integrations, or platform naming conventions in generated reports.

This change ensures hidden output consistently anonymizes those values across workload types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service account names in pod specs (including deprecated and nested fields) are now consistently anonymized.
* **Tests**
  * Added tests covering deprecated, nested, and variant service account fields to validate anonymization and output format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->