### PR TITLE
fix(vap): require params for configurable controls

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -95,6 +95,10 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			normalizedControlID := strings.ToUpper(strings.TrimSpace(controlID))
+			if normalizedControlID != "" && parameterReference == "" && celAdmissionControlsRequiringParams[normalizedControlID] {
+				return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", normalizedControlID)
+			}
 			if err := isValidK8sObjectName(resolvedPolicyName); err != nil {
 				return fmt.Errorf("invalid policy name %s: %w", resolvedPolicyName, err)
 			}
@@ -183,6 +187,22 @@ var celAdmissionPolicyByControlID = map[string]string{
 	"C-0270": "kubescape-c-0270-deny-resources-with-cpu-limit-not-set",
 	"C-0271": "kubescape-c-0271-deny-resources-with-memory-limit-not-set",
 	"C-0280": "kubescape-c-0280-deny-access-to-csr-approval-subresource",
+}
+
+var celAdmissionControlsRequiringParams = map[string]bool{
+	"C-0001": true,
+	"C-0004": true,
+	"C-0012": true,
+	"C-0020": true,
+	"C-0046": true,
+	"C-0050": true,
+	"C-0076": true,
+	"C-0077": true,
+	"C-0078": true,
+	"C-0268": true,
+	"C-0269": true,
+	"C-0270": true,
+	"C-0271": true,
 }
 
 func resolvePolicyName(policyName, controlID string) (string, error) {

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -471,6 +471,28 @@ func TestCreatePolicyBindingCmdValidation(t *testing.T) {
 		err := cmd.Execute()
 		assert.NoError(t, err)
 	})
+
+	t.Run("known parameterized control requires parameter reference", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0012"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --parameter-reference")
+	})
+
+	t.Run("known parameterized control accepts parameter reference", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0001", "--parameter-reference", "basic-control-configuration"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("known non-parameterized control does not require parameter reference", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0016"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
 }
 
 func TestGetDeployLibraryCmd(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds validation to `kubescape vap create-policy-binding` so known parameterized CEL controls require `--parameter-reference`.

## Why

Several CEL policies in the Kubescape admission library reference `params.settings`. Generating a binding without `paramRef` creates an invalid or dangerous admission setup because the policy can evaluate with missing params.

## Changes

- Added `celAdmissionControlsRequiringParams`.
- Rejects known parameterized controls when `--parameter-reference` is omitted.
- Added tests for:
  - Parameterized control rejected without params.
  - Parameterized control accepted with params.
  - Non-parameterized control accepted without params.

## Test

```bash
go test ./cmd/vap
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to the policy binding command that normalizes control input and enforces providing a parameter reference for controls that require parameters, preventing invalid requests.

* **Tests**
  * Added tests covering missing parameter references (errors), successful binding when a parameter reference is provided, and successful binding for controls that do not require parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->