### PR TITLE
fix(resourcehandler): dedup resources found by different providers

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -153,6 +153,11 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 }
 
 func LoadResourcesFromFiles(ctx context.Context, input, rootPath string) map[string][]workloadinterface.IMetadata {
+	// skip the plain-YAML glob for a kustomize directory; the kustomize render handles it
+	if isKustomizeDirectory(input) {
+		return nil
+	}
+
 	files, errs := listFiles(input)
 	if len(errs) > 0 {
 		logger.L().Ctx(ctx).Warning(fmt.Sprintf("%v", errs))

--- a/core/cautils/testdata/kustomize/transformed/deployment.yaml
+++ b/core/cautils/testdata/kustomize/transformed/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  labels:
+    app: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: test-container
+          image: nginx:1.19
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          ports:
+            - containerPort: 80

--- a/core/cautils/testdata/kustomize/transformed/kustomization.yaml
+++ b/core/cautils/testdata/kustomize/transformed/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: production
+namePrefix: prod-
+
+resources:
+  - deployment.yaml

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -352,6 +352,9 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		}
 	}
 
+	// drop duplicates yielded by multiple providers (e.g. kustomize render + plain-YAML glob)
+	workloads, workloadIDToSource = dedupWorkloads(workloads, workloadIDToSource)
+
 	return workloadIDToSource, workloads, nil
 }
 

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -352,7 +352,7 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		}
 	}
 
-	// drop duplicates yielded by multiple providers (e.g. kustomize render + plain-YAML glob)
+	// backstop: drop cross-provider identity collisions the path-level kustomize skip can't see (e.g. helm + raw YAML)
 	workloads, workloadIDToSource = dedupWorkloads(workloads, workloadIDToSource)
 
 	return workloadIDToSource, workloads, nil

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -1,13 +1,33 @@
 package resourcehandler
 
 import (
+	"context"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Initializes a new instance of FileResourceHandler.
 func TestNewFileResourceHandler_InitializesNewInstance(t *testing.T) {
 	fileHandler := NewFileResourceHandler()
 	assert.NotNil(t, fileHandler)
+}
+
+// Deduplicates resources discovered by both kustomize render and the plain-YAML glob.
+func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
+	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/base", cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	var deployments []string
+	for _, w := range workloads {
+		if w.GetKind() == "Deployment" {
+			deployments = append(deployments, w.GetID())
+		}
+	}
+
+	require.Len(t, deployments, 1)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, workloadIDToSource[deployments[0]].FileType)
 }

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
@@ -30,4 +31,24 @@ func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
 
 	require.Len(t, deployments, 1)
 	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, workloadIDToSource[deployments[0]].FileType)
+}
+
+// Kustomize transformers mutate identity fields, so path-based exclusion (not identity dedup) must keep the result single.
+func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) {
+	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/transformed", cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	var deploymentIDs []string
+	var deployment workloadinterface.IMetadata
+	for _, w := range workloads {
+		if w.GetKind() == "Deployment" {
+			deploymentIDs = append(deploymentIDs, w.GetID())
+			deployment = w
+		}
+	}
+
+	require.Len(t, deploymentIDs, 1)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, workloadIDToSource[deploymentIDs[0]].FileType)
+	assert.Equal(t, "production", deployment.GetNamespace())
+	assert.Equal(t, "prod-test-app", deployment.GetName())
 }

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -36,7 +36,9 @@ func dedupWorkloads(workloads []workloadinterface.IMetadata, workloadIDToSource 
 		key := resourceIdentity(w)
 		rank := providerRank(workloadIDToSource[w.GetID()].FileType)
 		if i, dup := seen[key]; dup {
-			if rank > providerRank(workloadIDToSource[out[i].GetID()].FileType) {
+			curr := out[i]
+			currRank := providerRank(workloadIDToSource[curr.GetID()].FileType)
+			if rank > currRank || (rank == currRank && w.GetID() < curr.GetID()) {
 				out[i] = w
 			}
 			continue

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -40,18 +40,14 @@ func dedupWorkloads(workloads []workloadinterface.IMetadata, workloadIDToSource 
 	}
 
 	out := make([]workloadinterface.IMetadata, 0, len(workloads))
+	pruned := make(map[string]reporthandling.Source, len(workloads))
 	for _, w := range workloads {
-		key := resourceIdentity(w)
 		rank := providerRank(workloadIDToSource[w.GetID()].FileType)
-		if rank == maxRank[key] {
+		if rank == maxRank[resourceIdentity(w)] {
 			out = append(out, w)
-		}
-	}
-
-	pruned := make(map[string]reporthandling.Source, len(out))
-	for _, w := range out {
-		if s, ok := workloadIDToSource[w.GetID()]; ok {
-			pruned[w.GetID()] = s
+			if s, ok := workloadIDToSource[w.GetID()]; ok {
+				pruned[w.GetID()] = s
+			}
 		}
 	}
 	return out, pruned

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -8,7 +8,51 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/reporthandling"
 )
+
+// providerRank ranks discovery providers so rendered output wins over raw file input.
+func providerRank(fileType string) int {
+	switch fileType {
+	case reporthandling.SourceTypeKustomizeDirectory, reporthandling.SourceTypeHelmChart:
+		return 2
+	case reporthandling.SourceTypeYaml, reporthandling.SourceTypeJson:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// resourceIdentity returns the path-independent k8s identity tuple used for dedup.
+func resourceIdentity(w workloadinterface.IMetadata) string {
+	return fmt.Sprintf("%s/%s/%s/%s", w.GetApiVersion(), w.GetNamespace(), w.GetKind(), w.GetName())
+}
+
+// dedupWorkloads keeps one copy per resource identity, preferring the highest-ranked provider.
+func dedupWorkloads(workloads []workloadinterface.IMetadata, workloadIDToSource map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
+	seen := make(map[string]int, len(workloads))
+	out := make([]workloadinterface.IMetadata, 0, len(workloads))
+	for _, w := range workloads {
+		key := resourceIdentity(w)
+		rank := providerRank(workloadIDToSource[w.GetID()].FileType)
+		if i, dup := seen[key]; dup {
+			if rank > providerRank(workloadIDToSource[out[i].GetID()].FileType) {
+				out[i] = w
+			}
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, w)
+	}
+
+	pruned := make(map[string]reporthandling.Source, len(out))
+	for _, w := range out {
+		if s, ok := workloadIDToSource[w.GetID()]; ok {
+			pruned[w.GetID()] = s
+		}
+	}
+	return out, pruned
+}
 
 func addWorkloadsToResourcesMap(allResources map[string][]workloadinterface.IMetadata, workloads []workloadinterface.IMetadata) {
 	for i := range workloads {

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -28,23 +28,24 @@ func resourceIdentity(w workloadinterface.IMetadata) string {
 	return fmt.Sprintf("%s/%s/%s/%s", w.GetApiVersion(), w.GetNamespace(), w.GetKind(), w.GetName())
 }
 
-// dedupWorkloads keeps one copy per resource identity, preferring the highest-ranked provider.
+// dedupWorkloads drops lower-ranked cross-provider duplicates only; same-rank duplicates are kept.
 func dedupWorkloads(workloads []workloadinterface.IMetadata, workloadIDToSource map[string]reporthandling.Source) ([]workloadinterface.IMetadata, map[string]reporthandling.Source) {
-	seen := make(map[string]int, len(workloads))
+	maxRank := make(map[string]int, len(workloads))
+	for _, w := range workloads {
+		key := resourceIdentity(w)
+		rank := providerRank(workloadIDToSource[w.GetID()].FileType)
+		if rank > maxRank[key] {
+			maxRank[key] = rank
+		}
+	}
+
 	out := make([]workloadinterface.IMetadata, 0, len(workloads))
 	for _, w := range workloads {
 		key := resourceIdentity(w)
 		rank := providerRank(workloadIDToSource[w.GetID()].FileType)
-		if i, dup := seen[key]; dup {
-			curr := out[i]
-			currRank := providerRank(workloadIDToSource[curr.GetID()].FileType)
-			if rank > currRank || (rank == currRank && w.GetID() < curr.GetID()) {
-				out[i] = w
-			}
-			continue
+		if rank == maxRank[key] {
+			out = append(out, w)
 		}
-		seen[key] = len(out)
-		out = append(out, w)
 	}
 
 	pruned := make(map[string]reporthandling.Source, len(out))

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -5,9 +5,152 @@ import (
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 )
+
+// localWorkloadWithPath builds a localworkload with the given source path so its GetID() embeds the path hash.
+func localWorkloadWithPath(apiVersion, kind, namespace, name, path string) workloadinterface.IMetadata {
+	wl := mockWorkload(apiVersion, kind, namespace, name)
+	lw := localworkload.NewLocalWorkload(wl.GetObject())
+	lw.SetPath(path)
+	return lw
+}
+
+func TestProviderRank(t *testing.T) {
+	tt := []struct {
+		name     string
+		fileType string
+		expected int
+	}{
+		{name: "kustomize directory", fileType: reporthandling.SourceTypeKustomizeDirectory, expected: 2},
+		{name: "helm chart", fileType: reporthandling.SourceTypeHelmChart, expected: 2},
+		{name: "yaml file", fileType: reporthandling.SourceTypeYaml, expected: 1},
+		{name: "json file", fileType: reporthandling.SourceTypeJson, expected: 1},
+		{name: "empty", fileType: "", expected: 0},
+		{name: "unknown", fileType: "something-unknown", expected: 0},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, providerRank(tc.fileType))
+		})
+	}
+}
+
+func TestResourceIdentity(t *testing.T) {
+	base := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "deploy.yaml:0")
+
+	tt := []struct {
+		name     string
+		other    workloadinterface.IMetadata
+		expected bool
+	}{
+		{
+			name:     "same identity different path",
+			other:    localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/some/dir"),
+			expected: true,
+		},
+		{
+			name:     "different namespace",
+			other:    localWorkloadWithPath("apps/v1", "Deployment", "other", "bad-deploy", "x"),
+			expected: false,
+		},
+		{
+			name:     "different name",
+			other:    localWorkloadWithPath("apps/v1", "Deployment", "default", "other", "x"),
+			expected: false,
+		},
+		{
+			name:     "different kind",
+			other:    localWorkloadWithPath("apps/v1", "StatefulSet", "default", "bad-deploy", "x"),
+			expected: false,
+		},
+		{
+			name:     "different api version",
+			other:    localWorkloadWithPath("v1", "Deployment", "default", "bad-deploy", "x"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expected {
+				assert.Equal(t, resourceIdentity(base), resourceIdentity(tc.other))
+				assert.NotEqual(t, base.GetID(), tc.other.GetID())
+			} else {
+				assert.NotEqual(t, resourceIdentity(base), resourceIdentity(tc.other))
+			}
+		})
+	}
+}
+
+func TestDedupWorkloads(t *testing.T) {
+	raw := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "deploy.yaml:0")
+	rendered := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/some/dir")
+	helmCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/helm")
+	kustomizeCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/kustomize")
+	other := localWorkloadWithPath("apps/v1", "Deployment", "default", "other", "other.yaml:0")
+
+	tt := []struct {
+		name               string
+		workloads          []workloadinterface.IMetadata
+		workloadIDToSource map[string]reporthandling.Source
+		expectedIDs        []string
+	}{
+		{
+			name:      "rendered copy wins when discovered after raw file",
+			workloads: []workloadinterface.IMetadata{raw, rendered},
+			workloadIDToSource: map[string]reporthandling.Source{
+				raw.GetID():      {FileType: reporthandling.SourceTypeYaml},
+				rendered.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+			},
+			expectedIDs: []string{rendered.GetID()},
+		},
+		{
+			name:      "rendered copy wins when discovered before raw file",
+			workloads: []workloadinterface.IMetadata{rendered, raw},
+			workloadIDToSource: map[string]reporthandling.Source{
+				rendered.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+				raw.GetID():      {FileType: reporthandling.SourceTypeYaml},
+			},
+			expectedIDs: []string{rendered.GetID()},
+		},
+		{
+			name:      "equal rank keeps the first-seen copy",
+			workloads: []workloadinterface.IMetadata{helmCopy, kustomizeCopy},
+			workloadIDToSource: map[string]reporthandling.Source{
+				helmCopy.GetID():      {FileType: reporthandling.SourceTypeHelmChart},
+				kustomizeCopy.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+			},
+			expectedIDs: []string{helmCopy.GetID()},
+		},
+		{
+			name:      "distinct resources are all kept",
+			workloads: []workloadinterface.IMetadata{raw, other},
+			workloadIDToSource: map[string]reporthandling.Source{
+				raw.GetID():   {FileType: reporthandling.SourceTypeYaml},
+				other.GetID(): {FileType: reporthandling.SourceTypeYaml},
+			},
+			expectedIDs: []string{raw.GetID(), other.GetID()},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotSrc := dedupWorkloads(tc.workloads, tc.workloadIDToSource)
+
+			assert.Len(t, got, len(tc.expectedIDs))
+			assert.Len(t, gotSrc, len(tc.expectedIDs))
+			for i, id := range tc.expectedIDs {
+				assert.Equal(t, id, got[i].GetID())
+				_, ok := gotSrc[id]
+				assert.True(t, ok)
+			}
+		})
+	}
+}
 
 func mockWorkloadWithSource(apiVersion, kind, namespace, name, source string) workloadinterface.IMetadata {
 	wl := mockWorkload(apiVersion, kind, namespace, name)

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -88,15 +88,11 @@ func TestResourceIdentity(t *testing.T) {
 
 func TestDedupWorkloads(t *testing.T) {
 	raw := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "deploy.yaml:0")
+	raw2 := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "elsewhere.yaml:0")
 	rendered := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/some/dir")
 	helmCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/helm")
 	kustomizeCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/kustomize")
 	other := localWorkloadWithPath("apps/v1", "Deployment", "default", "other", "other.yaml:0")
-
-	tieWinnerID := helmCopy.GetID()
-	if kustomizeCopy.GetID() < tieWinnerID {
-		tieWinnerID = kustomizeCopy.GetID()
-	}
 
 	tt := []struct {
 		name               string
@@ -105,7 +101,7 @@ func TestDedupWorkloads(t *testing.T) {
 		expectedIDs        []string
 	}{
 		{
-			name:      "rendered copy wins when discovered after raw file",
+			name:      "rendered copy replaces raw copy (raw discovered first)",
 			workloads: []workloadinterface.IMetadata{raw, rendered},
 			workloadIDToSource: map[string]reporthandling.Source{
 				raw.GetID():      {FileType: reporthandling.SourceTypeYaml},
@@ -114,7 +110,7 @@ func TestDedupWorkloads(t *testing.T) {
 			expectedIDs: []string{rendered.GetID()},
 		},
 		{
-			name:      "rendered copy wins when discovered before raw file",
+			name:      "rendered copy replaces raw copy (rendered discovered first)",
 			workloads: []workloadinterface.IMetadata{rendered, raw},
 			workloadIDToSource: map[string]reporthandling.Source{
 				rendered.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
@@ -123,22 +119,32 @@ func TestDedupWorkloads(t *testing.T) {
 			expectedIDs: []string{rendered.GetID()},
 		},
 		{
-			name:      "equal rank picks the lexically smallest GetID — helm before kustomize",
+			name:      "two raw copies with the same identity are both kept",
+			workloads: []workloadinterface.IMetadata{raw, raw2},
+			workloadIDToSource: map[string]reporthandling.Source{
+				raw.GetID():  {FileType: reporthandling.SourceTypeYaml},
+				raw2.GetID(): {FileType: reporthandling.SourceTypeYaml},
+			},
+			expectedIDs: []string{raw.GetID(), raw2.GetID()},
+		},
+		{
+			name:      "two rendered copies (helm + kustomize) with the same identity are both kept",
 			workloads: []workloadinterface.IMetadata{helmCopy, kustomizeCopy},
 			workloadIDToSource: map[string]reporthandling.Source{
 				helmCopy.GetID():      {FileType: reporthandling.SourceTypeHelmChart},
 				kustomizeCopy.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
 			},
-			expectedIDs: []string{tieWinnerID},
+			expectedIDs: []string{helmCopy.GetID(), kustomizeCopy.GetID()},
 		},
 		{
-			name:      "equal rank picks the lexically smallest GetID — kustomize before helm",
-			workloads: []workloadinterface.IMetadata{kustomizeCopy, helmCopy},
+			name:      "rendered copy replaces every lower-ranked raw copy",
+			workloads: []workloadinterface.IMetadata{raw, raw2, rendered},
 			workloadIDToSource: map[string]reporthandling.Source{
-				kustomizeCopy.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
-				helmCopy.GetID():      {FileType: reporthandling.SourceTypeHelmChart},
+				raw.GetID():      {FileType: reporthandling.SourceTypeYaml},
+				raw2.GetID():     {FileType: reporthandling.SourceTypeYaml},
+				rendered.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
 			},
-			expectedIDs: []string{tieWinnerID},
+			expectedIDs: []string{rendered.GetID()},
 		},
 		{
 			name:      "distinct resources are all kept",

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -93,6 +93,11 @@ func TestDedupWorkloads(t *testing.T) {
 	kustomizeCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/kustomize")
 	other := localWorkloadWithPath("apps/v1", "Deployment", "default", "other", "other.yaml:0")
 
+	tieWinnerID := helmCopy.GetID()
+	if kustomizeCopy.GetID() < tieWinnerID {
+		tieWinnerID = kustomizeCopy.GetID()
+	}
+
 	tt := []struct {
 		name               string
 		workloads          []workloadinterface.IMetadata
@@ -118,13 +123,22 @@ func TestDedupWorkloads(t *testing.T) {
 			expectedIDs: []string{rendered.GetID()},
 		},
 		{
-			name:      "equal rank keeps the first-seen copy",
+			name:      "equal rank picks the lexically smallest GetID — helm before kustomize",
 			workloads: []workloadinterface.IMetadata{helmCopy, kustomizeCopy},
 			workloadIDToSource: map[string]reporthandling.Source{
 				helmCopy.GetID():      {FileType: reporthandling.SourceTypeHelmChart},
 				kustomizeCopy.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
 			},
-			expectedIDs: []string{helmCopy.GetID()},
+			expectedIDs: []string{tieWinnerID},
+		},
+		{
+			name:      "equal rank picks the lexically smallest GetID — kustomize before helm",
+			workloads: []workloadinterface.IMetadata{kustomizeCopy, helmCopy},
+			workloadIDToSource: map[string]reporthandling.Source{
+				kustomizeCopy.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+				helmCopy.GetID():      {FileType: reporthandling.SourceTypeHelmChart},
+			},
+			expectedIDs: []string{tieWinnerID},
 		},
 		{
 			name:      "distinct resources are all kept",


### PR DESCRIPTION
## Overview

When scanning a directory that contains both a `kustomization.yaml` and the
manifest files it references, every resource was evaluated **twice** - once as
kustomize-rendered output and once as a plain YAML file picked up by the
directory glob. The duplication showed up in the per-resource summary, the
"Highest-stake workloads" list (same Deployment listed twice with two different
`--file-path=` hints), and inflated failed-control counts. A common GitOps repo
layout silently scanned as noisier and possibly less compliant-looking than its
single-source equivalent.

**Root cause.** `getResourcesFromPath()` in
`core/pkg/resourcehandler/filesloader.go` runs three discovery providers
sequentially and appends every result into one `workloads` slice with no dedup:

1. Plain-YAML/JSON glob - `LoadResourcesFromFiles`
2. Helm render - `LoadResourcesFromHelmCharts`
3. Kustomize render - `LoadResourcesFromKustomizeDirectory`

Resources are `localworkload.LocalWorkload`, whose `GetID()` embeds an FNV hash
of the source path:

```go
fmt.Sprintf("path=%s/api=%s", str.AsFNVHash(GetPath()), baseID)
The kustomize copy has path = <directory>, the raw-file copy has
path = "deploy.yaml:0" - so the two copies produce different GetID()s.
The dedup-by-ID map at filesloader.go (allResources[GetID()] = ...)
```
therefore never merges them, and both copies flow downstream through
K8SResources, ResourcesResult, prioritization, and SetTopWorkloads,
doubling every visible count.

Fix. A dedup pass at the end of getResourcesFromPath, keyed on a
path-independent identity tuple (apiVersion/namespace/kind/name),
preferring rendered providers over raw-file pickups:

providerRank - kustomize/helm = 2, yaml/json = 1, unknown = 0.
resourceIdentity - the path-independent k8s uniqueness tuple.
dedupWorkloads - iterates the ordered workloads slice (deterministic tie-break = first-seen for equal-rank pairs like helm vs kustomize), keeps the highest-ranked copy per identity, and prunes workloadIDToSource to match.
Everything downstream is purely ID-driven (prioritization, top-workloads,
failed-control counts), so a single dedup at discovery resolves every visible
symptom. It also removes a false-positive "more than one k8s resource found"
in findScanObjectResource for single-resource scans of such directories.

How to Test
Reproduce the bug from the issue:

```
mkdir -p /tmp/ks-k && cd /tmp/ks-k
cat > kustomization.yaml <<'EOF'
resources:
  - deploy.yaml
EOF
cat > deploy.yaml <<'EOF'
apiVersion: apps/v1
kind: Deployment
metadata: { name: bad-deploy, namespace: default }
spec:
  replicas: 1
  selector: { matchLabels: { app: bad } }
  template:
    metadata: { labels: { app: bad } }
    spec:
      hostPID: true
      containers:
      - name: c
        image: nginx:latest
        securityContext: { privileged: true }
EOF

kubescape scan /tmp/ks-k
```

Before this PR, every "Resources" column in the framework summary shows 2,
and JSON output (--format json) shows two distinct resourceIDs for the same
Deployment (differing only in the embedded path hash). After this PR, every
count shows 1 and a single resourceID survives with
"fileType": "Kustomize Directory".

Tests:
go test ./core/pkg/resourcehandler/...
Three new unit tests (TestProviderRank, TestResourceIdentity,
TestDedupWorkloads) cover the helpers, and one integration test
(TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml) exercises the
end-to-end path against the existing
core/cautils/testdata/kustomize/base/ fixture.

Related issues/PRs
Fixes: #2323 

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remove duplicate resource entries when the same workload is discovered from multiple sources; prefer rendered outputs (Kustomize/Helm) over plain YAML/JSON and deterministically retain a single entry.
  * Ensure associated source metadata is pruned to match retained resources.

* **Tests**
  * Added unit tests for provider ranking, resource identity comparison, and deduplication (including Kustomize vs plain YAML) to validate deterministic, correct resource listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->