### PR TITLE
fix(offline): dynamically populate allcontrols framework and fix loadpolicy search

### DIFF
--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -47,7 +47,14 @@ func (drp *DownloadReleasedPolicy) GetFramework(name string) (*reporthandling.Fr
 	if err != nil {
 		return nil, err
 	}
-	return framework, err
+	if framework != nil && strings.EqualFold(framework.Name, "allcontrols") {
+		controls, err := drp.gs.GetOPAControls()
+		if err != nil {
+			return nil, err
+		}
+		framework.Controls = controls
+	}
+	return framework, nil
 }
 
 func (drp *DownloadReleasedPolicy) GetFrameworks() ([]reporthandling.Framework, error) {
@@ -55,7 +62,16 @@ func (drp *DownloadReleasedPolicy) GetFrameworks() ([]reporthandling.Framework, 
 	if err != nil {
 		return nil, err
 	}
-	return frameworks, err
+	for i := range frameworks {
+		if strings.EqualFold(frameworks[i].Name, "allcontrols") {
+			controls, err := drp.gs.GetOPAControls()
+			if err != nil {
+				return nil, err
+			}
+			frameworks[i].Controls = controls
+		}
+	}
+	return frameworks, nil
 }
 
 func (drp *DownloadReleasedPolicy) ListFrameworks() ([]string, error) {

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -59,35 +60,30 @@ func (lp *LoadPolicy) GetControl(controlID string) (*reporthandling.Control, err
 		return nil, ErrIDRequired
 	}
 
-	// NOTE: this assumes that only the first path contains either a valid control descriptor or a framework descriptor
-	filePath := lp.filePath()
-	buf, err := os.ReadFile(filePath)
-
-	if err != nil {
-		return nil, err
-	}
-
-	// check if the file is a control descriptor: a ControlID field is populated.
-	var control reporthandling.Control
-	if err = json.Unmarshal(buf, &control); err == nil && control.ControlID != "" {
-		if strings.EqualFold(controlID, control.ControlID) {
-			return &control, nil
+	for _, filePath := range lp.filePaths {
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
 		}
 
-		return nil, fmt.Errorf("controlID: %s: %w", controlID, ErrControlNotMatching)
-	}
+		// check if the file is a control descriptor: a ControlID field is populated.
+		var control reporthandling.Control
+		if err = json.Unmarshal(buf, &control); err == nil && control.ControlID != "" {
+			if strings.EqualFold(controlID, control.ControlID) {
+				return &control, nil
+			}
+			continue
+		}
 
-	// check if the file is a framework descriptor
-	var framework reporthandling.Framework
-	if err = json.Unmarshal(buf, &framework); err != nil {
-		return nil, err
-	}
-
-	for _, toPin := range framework.Controls {
-		ctrl := toPin
-
-		if strings.EqualFold(ctrl.ControlID, controlID) {
-			return &ctrl, nil
+		// check if the file is a framework descriptor
+		var framework reporthandling.Framework
+		if err = json.Unmarshal(buf, &framework); err == nil {
+			for _, toPin := range framework.Controls {
+				ctrl := toPin
+				if strings.EqualFold(ctrl.ControlID, controlID) {
+					return &ctrl, nil
+				}
+			}
 		}
 	}
 
@@ -174,27 +170,77 @@ func (lp *LoadPolicy) ListFrameworks() ([]string, error) {
 	return frameworkNames, nil
 }
 
-// ListControls returns the list of controls for this framework.
-//
-// At this moment, controls are listed for one single configured framework.
+// ListControls returns the list of controls in the format "id|name|frameworks".
 func (lp *LoadPolicy) ListControls() ([]string, error) {
-	controlIDs := make([]string, 0, 100)
-	filePath := lp.filePath()
-	buf, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
+	type controlInfo struct {
+		id         string
+		name       string
+		frameworks []string
 	}
 
-	var framework reporthandling.Framework
-	if err = json.Unmarshal(buf, &framework); err != nil {
-		return nil, err
+	controlsMap := make(map[string]*controlInfo)
+	var orderedIDs []string
+
+	for _, filePath := range lp.filePaths {
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		// check if the file is a control descriptor: a ControlID field is populated.
+		var control reporthandling.Control
+		if err = json.Unmarshal(buf, &control); err == nil && control.ControlID != "" {
+			info, exists := controlsMap[control.ControlID]
+			if !exists {
+				info = &controlInfo{id: control.ControlID}
+				controlsMap[control.ControlID] = info
+				orderedIDs = append(orderedIDs, control.ControlID)
+			}
+			if info.name == "" {
+				info.name = control.Name
+			}
+			continue
+		}
+
+		// check if the file is a framework descriptor
+		var framework reporthandling.Framework
+		if err = json.Unmarshal(buf, &framework); err == nil && framework.Name != "" {
+			isAllControls := strings.EqualFold(framework.Name, "allcontrols")
+			for _, ctrl := range framework.Controls {
+				info, exists := controlsMap[ctrl.ControlID]
+				if !exists {
+					info = &controlInfo{id: ctrl.ControlID}
+					controlsMap[ctrl.ControlID] = info
+					orderedIDs = append(orderedIDs, ctrl.ControlID)
+				}
+				if info.name == "" {
+					info.name = ctrl.Name
+				}
+				if !isAllControls {
+					found := false
+					for _, fw := range info.frameworks {
+						if strings.EqualFold(fw, framework.Name) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						info.frameworks = append(info.frameworks, framework.Name)
+					}
+				}
+			}
+		}
 	}
 
-	for _, ctrl := range framework.Controls {
-		controlIDs = append(controlIDs, ctrl.ControlID)
+	results := make([]string, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		info := controlsMap[id]
+		sort.Strings(info.frameworks)
+		entry := fmt.Sprintf("%s|%s|%s", info.id, info.name, strings.Join(info.frameworks, ", "))
+		results = append(results, entry)
 	}
 
-	return controlIDs, nil
+	return results, nil
 }
 
 // GetExceptions retrieves configured exceptions.

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -273,7 +273,7 @@ func TestLoadPolicy(t *testing.T) {
 			controlIDs, err := p.ListControls()
 			require.NoError(t, err)
 			require.Greater(t, len(controlIDs), 0)
-			require.Equal(t, testControl, controlIDs[0])
+			require.Equal(t, fmt.Sprintf("%s|Access container service account|%s", testControl, testFramework), controlIDs[0])
 		})
 	})
 


### PR DESCRIPTION
Fixes #2337

### Description
This PR resolves the issue where offline scans of controls fail because `allcontrols.json` was missing most of the regolibrary's controls. 

### Changes
1. **Dynamically populate `"allcontrols"` framework on download:** Updated `core/cautils/getter/downloadreleasedpolicy.go` to intercept `"allcontrols"` framework queries and populate them dynamically with all 265 controls available from `drp.gs.GetOPAControls()`.
2. **Support multiple policy files in `LoadPolicy.GetControl`:** Updated `core/cautils/getter/loadpolicy.go` to iterate over all file paths provided to `LoadPolicy` rather than assuming a single file at index 0. This ensures any control inside downloaded artifacts is correctly matched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve "all controls" when requesting the special "allcontrols" framework
  * Search for and aggregate controls across all configured policy paths, deduplicating sources

* **Bug Fixes / Robustness**
  * Tolerate unreadable or malformed policy files and apply case-insensitive control matching
  * Fail-fast on control-fetch errors for "allcontrols" to avoid inconsistent results

* **Tests**
  * Updated control-listing test to expect the composite id|name|frameworks format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->