### PR TITLE
 fix(httphandler): surface async scan failures via Results endpoint

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -210,9 +211,20 @@ func (handler *HTTPHandler) Results(w http.ResponseWriter, r *http.Request) {
 		logger.L().Info("requesting results", helpers.String("ID", resultsQueryParams.ScanID))
 
 		if res, err := readResultsFile(resultsQueryParams.ScanID); err != nil {
-			logger.L().Info("scan result not found", helpers.String("ID", resultsQueryParams.ScanID))
-			w.WriteHeader(http.StatusNoContent)
-			response.Response = err.Error()
+			var scanFailed *ScanFailedError
+			if errors.As(err, &scanFailed) {
+				logger.L().Info("scan failed", helpers.String("ID", resultsQueryParams.ScanID), helpers.String("reason", scanFailed.Message))
+				w.WriteHeader(http.StatusInternalServerError)
+				response.Type = utilsapisv1.ErrorScanResponseType
+				response.Response = scanFailed.Message
+				if !resultsQueryParams.KeepResults && !isLatestFallback {
+					defer removeResultsFile(resultsQueryParams.ScanID)
+				}
+			} else {
+				logger.L().Info("scan result not found", helpers.String("ID", resultsQueryParams.ScanID))
+				w.WriteHeader(http.StatusNoContent)
+				response.Response = err.Error()
+			}
 		} else {
 			logger.L().Info("scan result found", helpers.String("ID", resultsQueryParams.ScanID))
 			w.WriteHeader(http.StatusOK)

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -95,7 +95,7 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 			pr := result.GetResults()
 
 			if err := store.StorePostureReportResults(ctx, pr); err != nil {
-				return nil, err
+				return nil, writeScanErrorToFile(err, scanID)
 			}
 		} else {
 			logger.L().Debug("storage is not initialized - skipping storing results")
@@ -129,6 +129,18 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 
 	extensions := []string{"", ".json"}
 
+	// Failed artifacts win over success artifacts. HandleResults writes the
+	// JSON output before later failure points (e.g. StorePostureReportResults),
+	// so when both files exist the failed one is the source of truth and the
+	// success file is stale data that must not mask the failure.
+	for _, ext := range extensions {
+		path := filepath.Join(FailedOutputDir, cleanID+ext)
+		f, err := os.ReadFile(path)
+		if err == nil {
+			return nil, &ScanFailedError{Message: string(f)}
+		}
+	}
+
 	for _, ext := range extensions {
 		path := filepath.Join(OutputDir, cleanID+ext)
 		f, err := os.ReadFile(path)
@@ -136,14 +148,6 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 			postureReport := &reporthandlingv2.PostureReport{}
 			err = json.Unmarshal(f, postureReport)
 			return postureReport, err
-		}
-	}
-
-	for _, ext := range extensions {
-		path := filepath.Join(FailedOutputDir, cleanID+ext)
-		f, err := os.ReadFile(path)
-		if err == nil {
-			return nil, &ScanFailedError{Message: string(f)}
 		}
 	}
 

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -85,7 +85,7 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 		return nil, writeScanErrorToFile(err, scanID)
 	}
 	if err := result.HandleResults(ctx, scanInfo); err != nil {
-		return nil, err
+		return nil, writeScanErrorToFile(err, scanID)
 	}
 
 	if !skipPersistence {
@@ -107,6 +107,18 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 	return nil, nil
 }
 
+// ScanFailedError carries the plaintext error written by writeScanErrorToFile.
+// readResultsFile returns this when the only artifact for a scan ID is under
+// FailedOutputDir, so the Results handler can surface the real scan failure
+// instead of a JSON parse error.
+type ScanFailedError struct {
+	Message string
+}
+
+func (e *ScanFailedError) Error() string {
+	return e.Message
+}
+
 func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 	parsedUUID, err := uuid.Parse(fileID)
 	if err != nil {
@@ -115,20 +127,26 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 	}
 	cleanID := parsedUUID.String()
 
-	dirs := []string{OutputDir, FailedOutputDir}
 	extensions := []string{"", ".json"}
 
-	for _, dir := range dirs {
-		for _, ext := range extensions {
-			path := filepath.Join(dir, cleanID+ext)
-			f, err := os.ReadFile(path)
-			if err == nil {
-				postureReport := &reporthandlingv2.PostureReport{}
-				err = json.Unmarshal(f, postureReport)
-				return postureReport, err
-			}
+	for _, ext := range extensions {
+		path := filepath.Join(OutputDir, cleanID+ext)
+		f, err := os.ReadFile(path)
+		if err == nil {
+			postureReport := &reporthandlingv2.PostureReport{}
+			err = json.Unmarshal(f, postureReport)
+			return postureReport, err
 		}
 	}
+
+	for _, ext := range extensions {
+		path := filepath.Join(FailedOutputDir, cleanID+ext)
+		f, err := os.ReadFile(path)
+		if err == nil {
+			return nil, &ScanFailedError{Message: string(f)}
+		}
+	}
+
 	return nil, fmt.Errorf("file %s not found", cleanID)
 }
 


### PR DESCRIPTION
## Overview
 So basically I was poking around the in-cluster operator's HTTP handler and found this weird thing. When you POST a scan without wait=true, the scan runs in the background. If it fails, the code dumps the error message as plain text into the ./failed/<scanID> file. Cool.

But then when you poll /v1/results later, the read function just blindly tries to json.Unmarshal whatever file it finds. So it reads the plaintext error, fails to parse it as JSON, and the handler returns 204 No Content with some random JSON parse error in the body. The actual reason the scan failed is just gone.

And the 204 part is what really bugged me. Most HTTP clients don't even read the body of a 204 response, and 204 is in the 2xx range so CI pipelines treat it as success. Meaning a scan that actually failed gets reported as passing. That's pretty bad for anyone using this in a compliance pipeline.

My fix is small. I made readResultsFile check the failed directory separately and return a typed ScanFailedError that carries the plaintext message. The Results handler now checks for that error and responds with 500 plus ErrorScanResponseType and the real failure text. I also noticed result.HandleResults failures weren't being written to the failed dir at all, so I added that too.

Ran the existing tests and they still pass. Nothing fancy, just making the failure path actually tell you what went wrong.

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Distinguish failed scans from missing results; failed scans now return HTTP 500 with failure details instead of 204 No Content.
  * Preserve and surface plaintext failure information for clearer error responses.
  * Conditional cleanup of result files now respects "keep results" and fallback cases.

* **Chores**
  * Improved result-file lookup order to prefer failure artifacts and enhance recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape/pull/2339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->