### PR TITLE
fix: restrict config.json permissions to owner-only

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -343,8 +343,17 @@ func updateConfigFile(configObj *ConfigObj) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-
-	return os.WriteFile(fullPath, configObj.Config(), 0600)
+	// Tighten permissions on pre-existing directory in case it was
+	// created with broader permissions by an older version.
+	if err := os.Chmod(dir, 0700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(fullPath, configObj.Config(), 0600); err != nil {
+		return err
+	}
+	// Tighten permissions on pre-existing file in case it was created
+	// with broader permissions by an older version.
+	return os.Chmod(fullPath, 0600)
 }
 
 func (c *ClusterConfig) GenerateAccountID() (string, error) {

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -340,11 +340,11 @@ func existsConfigFile() bool {
 func updateConfigFile(configObj *ConfigObj) error {
 	fullPath := ConfigFileFullPath()
 	dir := filepath.Dir(fullPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 
-	return os.WriteFile(fullPath, configObj.Config(), 0664) //nolint:gosec
+	return os.WriteFile(fullPath, configObj.Config(), 0600)
 }
 
 func (c *ClusterConfig) GenerateAccountID() (string, error) {


### PR DESCRIPTION
## Overview

`updateConfigFile` was writing `~/.kubescape/config.json` with mode `0664` and the parent directory with `0755`. The config file includes `accessKey` in plaintext, so any local user on a shared host or jump box could read the tenant credential without any privileges.

Changed file mode to `0600` and directory mode to `0700` so only the owner can read or traverse the kubescape config directory. Also removed the `//nolint:gosec` annotation that was silencing the linter on this line.

## How to Test

```bash
kubescape scan framework nsa .
stat ~/.kubescape/config.json  # should show -rw-------
stat ~/.kubescape/             # should show drwx------
```


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by applying more restrictive filesystem permissions to the configuration directory and cached config file, and ensuring existing files/directories are tightened to prevent unauthorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->