### PR TITLE
fix(httphandler): log persistence failure as warning, return valid result

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -94,8 +94,13 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 		if store != nil && config.GetAccount() == "" {
 			pr := result.GetResults()
 
+			// StorePostureReportResults persists to the operator storage backend
+			// (CRD/ConfigMap). This runs after HandleResults has already written
+			// the valid JSON to OutputDir, so a failure here is a persistence
+			// problem, not a scan failure. Log it and let the poller read the
+			// valid result rather than overwriting it with a failed artifact.
 			if err := store.StorePostureReportResults(ctx, pr); err != nil {
-				return nil, writeScanErrorToFile(err, scanID)
+				logger.L().Ctx(ctx).Error("failed to persist scan results to storage", helpers.String("scanID", scanID), helpers.Error(err))
 			}
 		} else {
 			logger.L().Debug("storage is not initialized - skipping storing results")


### PR DESCRIPTION
## Overview


  This is the fix for #2341.

  The issue was that StorePostureReportResults failing after a successful scan was being treated the same as an actual
  scan failure. The scan ran fine, OPA did its job, the report was already written to disk by HandleResults, but a
  storage hiccup would overwrite all that with a failed artifact and the poller would get ErrorScanResponseType with a
  storage error. No way to tell if the cluster was actually misconfigured or if etcd just had a bad moment.

  The fix is simple. StorePostureReportResults is a persistence step, not a scan step. If it fails, I log the error and
  move on. The valid JSON result is already sitting on disk from HandleResults, so the poller reads that and gets the
  real scan results. The storage failure shows up in the operator logs where it belongs.

  Now the two failure modes are actually distinct:
  - Scan fails → failed artifact written → poller gets 500 + ErrorScanResponseType
  - Persistence fails → error logged → poller gets the valid result


## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan operation resilience by preventing storage backend failures from incorrectly marking scans as failed. Scan results now complete successfully even when experiencing persistence issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->