### PR TITLE
Fix relative path and Name typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,7 +208,7 @@ kubescape scan --exceptions examples/exceptions/exclude-kube-namespaces.json
 
 Objects with exceptions will be presented as `exclude` and not `fail`.
 
-[See more examples about exceptions.](/examples/exceptions/README.md)
+[See more examples about exceptions.](../examples/exceptions/README.md)
 
 #### Scan Helm charts
 
@@ -473,7 +473,7 @@ kubescape patch -i nginx:1.22 -a tcp://0.0.0.0:$BUILDKIT_PORT
 > **Note**  
 > Image patching can only fix OS-level vulnerabilities, not application-level ones.
 
-For more details, see the [Patch Command Documentation](/cmd/patch/README.md).
+For more details, see the [Patch Command Documentation](../cmd/patch/README.md).
 
 ## Validating Admission Policies (VAP)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,7 @@ sudo apt update
 sudo apt install kubescape
 ```
 
-For other Debian-based or RPM-based distributions, see the [OpenSUSE Build Service](https://software.opensuse.org/download.html?project=home%3Akubescape&package=kubescape).
+For other Debian-based or RPM-based distributions, see the [openSUSE Build Service](https://software.opensuse.org/download.html?project=home%3Akubescape&package=kubescape).
 
 ### Arch Linux
 


### PR DESCRIPTION
This is a really small and my first PR in this pr I fixed two things in Docs , 
Fixed broken absolute links: Updated the links in 
getting-started.md
 to use relative paths (../) so that they will resolve correctly when clicking through the GitHub documentation.
Corrected OS branding: Changed the capitalization from OpenSUSE to openSUSE in 
installation.md
 to match the official branding and the subsequent section header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation link references to improve consistency
  * Corrected capitalization in distribution naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->