### PR TITLE
fix: anonymize LocalRootPath in hidden report output

### DIFF
--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -378,5 +378,9 @@ func anonymizeRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, ma
 		repo.RemoteURL = mapping.GetOrCreate("git", repo.RemoteURL)
 	}
 
+	if repo.LocalRootPath != "" {
+		repo.LocalRootPath = mapping.GetOrCreate("git", repo.LocalRootPath)
+	}
+
 	anonymizeLastCommit(&repo.LastCommit, mapping)
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -638,7 +638,17 @@ func TestAnonymizeSession_RepoContextMetadata(t *testing.T) {
 		assert.NotEqual(t, "main", repo.DefaultBranch)
 		assert.NotEqual(t, "https://github.com/jijo-OO7/kubescape", repo.RemoteURL)
 
-		assert.Equal(t, "/home/devjijo/work/kubescape", repo.LocalRootPath)
+		assert.NotEqual(
+			t,
+			"/home/devjijo/work/kubescape",
+			repo.LocalRootPath,
+		)
+
+		assert.Contains(
+			t,
+			repo.LocalRootPath,
+			"git-",
+		)
 
 		assert.Contains(t, repo.Repo, "git-")
 		assert.Contains(t, repo.Owner, "git-")


### PR DESCRIPTION
Part of: #1200

## Overview

This PR fixes a remaining information leak in hidden scan output by anonymizing `RepoContextMetadata.LocalRootPath` through the existing anonymization pipeline when `--hide` is enabled.

## Changes

* extend `anonymizeRepoContextMetadata()` to anonymize `LocalRootPath`
* reuse the existing `git` anonymization mapping used for repository metadata fields such as `Repo`, `Owner`, `Branch`, `DefaultBranch`, and `RemoteURL`
* add regression test coverage validating that `LocalRootPath` is anonymized when session anonymization is applied

## Additional Information

`LocalRootPath` was previously left out of `anonymizeRepoContextMetadata()`, causing local filesystem paths to remain visible in hidden output while other repository metadata was anonymized.

This change brings `LocalRootPath` in line with the existing repository metadata anonymization behavior and closes the remaining leak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved repository metadata anonymization to include local repository path information, providing enhanced privacy protection during session anonymization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->