### PR TITLE
feat: add SLSA build provenance attestation to release workflow

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -104,12 +104,13 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Attest build provenance
-        if: (github.event_name != 'workflow_dispatch' || inputs.skip_publish != 'true') && hashFiles('dist/**/*.tar.gz') != ''
+        if: (github.event_name != 'workflow_dispatch' || inputs.skip_publish != true) && hashFiles('dist/**/*.tar.gz') != ''
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             dist/**/*.tar.gz
             dist/**/kubescape
+            dist/**/kubescape.exe
             dist/**/ksserver
             dist/**/downloader
 

--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -104,7 +104,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Attest build provenance
-        if: github.event_name != 'workflow_dispatch' || inputs.skip_publish != true
+        if: (github.event_name != 'workflow_dispatch' || inputs.skip_publish != 'true') && hashFiles('dist/**/*.tar.gz') != ''
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |

--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -28,7 +28,7 @@ jobs:
       repository-projects: read
       statuses: read
       security-events: read
-      attestations: read
+      attestations: write
       artifact-metadata: read
     runs-on: ubuntu-large
     steps:
@@ -102,6 +102,16 @@ jobs:
           SECRET_KEY: ${{ secrets.SECRET_KEY_PROD }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Attest build provenance
+        if: github.event_name != 'workflow_dispatch' || inputs.skip_publish != true
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            dist/**/*.tar.gz
+            dist/**/kubescape
+            dist/**/ksserver
+            dist/**/downloader
 
       - name: Update new version in krew-index
         if: github.event_name != 'workflow_dispatch' || inputs.skip_publish != true


### PR DESCRIPTION
## Overview

Adds `actions/attest-build-provenance` to the release workflow so all kubescape binaries and archives get signed SLSA provenance attestation on every release. This mirrors the pattern already used in the helm-charts repo.

Before this change, released artifacts had no provenance attestation, making it impossible for users to verify that a downloaded binary was built from the official source code.

After this change, every release artifact gets a signed attestation that records the exact commit, workflow, and build environment used to produce it. Users can verify with:

```bash
gh attestation verify kubescape --owner kubescape
```

## Additional Information

The attestation covers all release artifacts:
- `dist/**/*.tar.gz` — compressed archives for all platforms
- `dist/**/kubescape` — CLI binaries
- `dist/**/ksserver` — server binaries
- `dist/**/downloader` — downloader binaries

Also updates `attestations` permission from `read` to `write` as required by the action.

## Related issues/PRs

* Resolved #1033

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to enable write access for attestations and added an automated build-provenance attestation step.
  * The attestation runs conditionally (skips manual/skip-publish cases) and only when build artifacts exist, improving release integrity, traceability, and confidence in published releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->