### PR TITLE
fix(resourcehandler): merge host-sensor infoMap instead of replacing it

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -159,8 +159,8 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 				// using hostSensor mock
 				cautils.SetInfoMapForResources("failed to init host scanner", hostResources, sessionObj.InfoMap)
 			} else {
-				if len(infoMap) > 0 {
-					sessionObj.InfoMap = infoMap
+				for k, v := range infoMap {
+					sessionObj.InfoMap[k] = v
 				}
 			}
 			cautils.StopSpinner()

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -266,4 +266,7 @@ func TestGetResources_HostSensorInfoMapMerged(t *testing.T) {
 
 	_, ok := sessionObj.InfoMap[preSeededGVR]
 	assert.True(t, ok, "GVR pull-failure entry must survive host-sensor collection; host infoMap must be merged, not replace sessionObj.InfoMap")
+
+	_, ok = sessionObj.InfoMap["KubeletInfo"]
+	assert.True(t, ok, "host-sensor infoMap entries must be present in sessionObj.InfoMap after merge")
 }

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -206,4 +209,61 @@ func TestGetResources_ScanAbortedOnContextCancellation(t *testing.T) {
 	assert.True(t,
 		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
 		"error should wrap the context error so callers can use errors.Is(err, context.DeadlineExceeded)")
+}
+
+type stubHostSensor struct {
+	infoMap map[string]apis.StatusInfo
+}
+
+func (s *stubHostSensor) Init(_ context.Context) error { return nil }
+func (s *stubHostSensor) TearDown() error              { return nil }
+func (s *stubHostSensor) CollectResources(_ context.Context) ([]hostsensor.HostSensorDataEnvelope, map[string]apis.StatusInfo, error) {
+	return nil, s.infoMap, nil
+}
+
+// TestGetResources_HostSensorInfoMapMerged is a regression test for the bug
+// where the host-sensor infoMap replaced sessionObj.InfoMap wholesale instead
+// of being merged into it, silently discarding GVR pull-failure entries that
+// recordFailedQueryStatuses had written earlier.
+func TestGetResources_HostSensorInfoMapMerged(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{}, nil
+		},
+	}
+	handler.hostSensorHandler = &stubHostSensor{
+		infoMap: map[string]apis.StatusInfo{
+			"KubeletInfo": {InnerStatus: apis.StatusSkipped, InnerInfo: "node-1: connection refused"},
+		},
+	}
+
+	rule := mockRule("host-sensor-rule", nil, "")
+	rule.Match = []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{""},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"KubeletInfo"},
+	}}
+	control := mockControl("host-control", nil)
+	control.Rules = []reporthandling.PolicyRule{rule}
+	framework := mockFramework("host-framework", nil)
+	framework.Controls = []reporthandling.Control{control}
+
+	scanInfo := &cautils.ScanInfo{}
+	scanInfo.HostSensorEnabled.SetBool(true)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	const preSeededGVR = "/v1/networkpolicies"
+	sessionObj.InfoMap[preSeededGVR] = apis.StatusInfo{
+		InnerInfo:   "networkpolicies is forbidden",
+		InnerStatus: apis.StatusSkipped,
+		SubStatus:   apis.SubStatusNotEvaluated,
+	}
+
+	_, _, _, _, _ = handler.GetResources(context.Background(), sessionObj, scanInfo)
+
+	_, ok := sessionObj.InfoMap[preSeededGVR]
+	assert.True(t, ok, "GVR pull-failure entry must survive host-sensor collection; host infoMap must be merged, not replace sessionObj.InfoMap")
 }


### PR DESCRIPTION
## Overview

**Current behavior:** When host scanning is enabled, `GetResources()` in `k8sresources.go` overwrites `sessionObj.InfoMap` wholesale with the result of `collectHostResources`. By that point, `recordFailedQueryStatuses` has already written GVR pull-failure entries into the same map. The overwrite discards all of them.

```go
// before — destructive assignment
if len(infoMap) > 0 {
    sessionObj.InfoMap = infoMap
}
```

`BuildScanCoverage` is called immediately after `GetResources` returns and reads from the now-clobbered map. Since the GVR failure keys are gone, it returns empty `failedGVRPulls` and `notEvaluatedControls`, making the scan report full coverage even when entire resource types were never collected due to RBAC restrictions.

**Future behavior:** `sessionObj.InfoMap` is merged instead of replaced. All GVR pull-failure entries written before the host-sensor block survive, and host-sensor statuses are still added on top. `BuildScanCoverage` now correctly surfaces incomplete coverage.

```go
// after -- merge
for k, v := range infoMap {
    sessionObj.InfoMap[k] = v
}
```

## Additional Information

`sessionObj.InfoMap` is a shared accumulator used for two purposes: GVR-level pull failures (keyed by GVR string, e.g. `v1/networkpolicies`) and resource-level eval skips. The host-sensor block was treating it as if it owns the map, which was fine before `BuildScanCoverage` and `recordFailedQueryStatuses` started populating it pre-host-block. This is a regression from those PRs, not the original host-sensor code.

Affected call chain:
- `k8sresources.go:99` -- `recordFailedQueryStatuses()` writes GVR failure entries
- `k8sresources.go:163` -- host-sensor block overwrites the map (the fix is here)
- `handlerpullresources.go:38` -- `BuildScanCoverage()` reads the now-clobbered map
- `scancoverage.go:60` -- `BuildScanCoverage()` finds no GVR keys, reports full coverage
- `processorhandlerutils.go:186` -- `mapControlToInfo()` loses per-control skip reasons

The trigger is common: any cluster where the service account lacks `list` on at least one scanned GVR and host scanning is enabled. On managed clusters this is routine.

## How to Test

1. Run Kubescape against a cluster where the service account lacks `list` on at least one GVR (e.g. `networkpolicies` or `roles`)
2. Enable host scanning via `--enable-host-scan`
3. Ensure at least one host-sensor query fails so `collectHostResources` returns a non-empty `infoMap`
4. Check `ScanCoverage` in the JSON report

Before fix: `failedGVRPulls` and `notEvaluatedControls` are empty despite RBAC blocking entire resource types.

After fix: both fields correctly list the blocked GVRs and their dependent controls.

Disabling host scanning and re-running should show the same gaps with or without this fix, confirming the host block was the cause.

## Related issues/PRs

* Resolved #2348

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host scanner enrichment now preserves previously collected session data by merging new host info into existing records instead of overwriting them, preventing loss of earlier diagnostics and improving data continuity during scans.

* **Tests**
  * Added a regression test to verify host-scanner info merging behavior and ensure pre-existing session entries remain intact after enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->