### PR TITLE
Add encryption transformer integration tests

### DIFF
--- a/core/pkg/anonymizer/encryptiontransformer.go
+++ b/core/pkg/anonymizer/encryptiontransformer.go
@@ -1,0 +1,32 @@
+package anonymizer
+
+import "github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+
+// EncryptionTransformer implements Transformer using AES-256-GCM encryption.
+//
+// Unlike MappingTransformer, which produces deterministic pseudonyms,
+// EncryptionTransformer produces reversible ciphertext suitable for
+// encrypted report workflows.
+type EncryptionTransformer struct {
+	dek []byte
+}
+
+func NewEncryptionTransformer(
+	dek []byte,
+) *EncryptionTransformer {
+	return &EncryptionTransformer{
+		dek: dek,
+	}
+}
+
+// Transform encrypts the provided value using the configured DEK and
+// returns a SOPS-inspired ENC[AES256_GCM,...] ciphertext representation.
+func (t *EncryptionTransformer) Transform(
+	prefix string,
+	value string,
+) (string, error) {
+	return reportcrypto.EncryptString(
+		value,
+		t.dek,
+	)
+}

--- a/core/pkg/anonymizer/encryptiontransformer_test.go
+++ b/core/pkg/anonymizer/encryptiontransformer_test.go
@@ -1,0 +1,69 @@
+package anonymizer
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptionTransformer_Transform(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	plaintext := "/workspace/demo-repository"
+
+	ciphertext, err := transformer.Transform(
+		"git",
+		plaintext,
+	)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, plaintext, ciphertext)
+	assert.Contains(t, ciphertext, "ENC[AES256_GCM,")
+
+	decrypted, err := reportcrypto.DecryptString(
+		ciphertext,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestEncryptionTransformer_UniqueCiphertexts(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	ciphertext1, err := transformer.Transform(
+		"git",
+		"demo-repository",
+	)
+	require.NoError(t, err)
+
+	ciphertext2, err := transformer.Transform(
+		"git",
+		"demo-repository",
+	)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ciphertext1, ciphertext2)
+}
+
+func TestEncryptionTransformer_InvalidDEK(t *testing.T) {
+	transformer := NewEncryptionTransformer(
+		[]byte("short-key"),
+	)
+
+	_, err := transformer.Transform(
+		"git",
+		"demo-repository",
+	)
+
+	assert.Error(t, err)
+}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
@@ -15,6 +16,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type metadataOnly struct{}
@@ -713,4 +715,58 @@ func TestTransformRepoContextMetadata(t *testing.T) {
 	assert.Contains(t, repo.LastCommit.CommitterName, "git-")
 	assert.Contains(t, repo.LastCommit.CommitterEmail, "git-")
 	assert.Contains(t, repo.LastCommit.Message, "git-")
+}
+
+func TestTransformRepoContextMetadata_EncryptionTransformer(
+	t *testing.T,
+) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	repo := &reporthandlingv2.RepoContextMetadata{
+		Provider:      "github",
+		Repo:          "demo-repository",
+		Owner:         "demo-owner",
+		Branch:        "feature/demo-work",
+		DefaultBranch: "main",
+		RemoteURL:     "https://github.com/demo-owner/demo-repository",
+		LocalRootPath: "/workspace/demo-repository",
+		LastCommit: reporthandling.LastCommit{
+			Hash:           "demo-commit-hash",
+			CommitterName:  "Demo User",
+			CommitterEmail: "demo@example.com",
+			Message:        "demo commit message",
+		},
+	}
+
+	transformRepoContextMetadata(
+		repo,
+		transformer,
+	)
+
+	assert.Contains(t, repo.Repo, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.Owner, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.Branch, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.DefaultBranch, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.RemoteURL, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.LocalRootPath, "ENC[AES256_GCM,")
+
+	assert.Contains(t, repo.LastCommit.Hash, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.LastCommit.CommitterName, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.LastCommit.CommitterEmail, "ENC[AES256_GCM,")
+	assert.Contains(t, repo.LastCommit.Message, "ENC[AES256_GCM,")
+
+	decryptedRepo, err := reportcrypto.DecryptString(
+		repo.Repo,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"demo-repository",
+		decryptedRepo,
+	)
 }

--- a/core/pkg/reportcrypto/crypto.go
+++ b/core/pkg/reportcrypto/crypto.go
@@ -29,6 +29,11 @@ func GenerateDEK() ([]byte, error) {
 	return dek, nil
 }
 
+// formatCiphertext builds the canonical ENC[AES256_GCM,...] envelope.
+func formatCiphertext(nonce string, ciphertext string) string {
+	return fmt.Sprintf("%s%s,%s%s", prefix, nonce, ciphertext, suffix)
+}
+
 // EncryptString encrypts plaintext using AES-256-GCM and returns
 // a SOPS-inspired ciphertext representation:
 //
@@ -55,11 +60,7 @@ func EncryptString(plaintext string, dek []byte) (string, error) {
 
 	ciphertext := gcm.Seal(nil, nonce, []byte(plaintext), nil)
 
-	return fmt.Sprintf(
-		"ENC[AES256_GCM,%s,%s]",
-		base64.StdEncoding.EncodeToString(nonce),
-		base64.StdEncoding.EncodeToString(ciphertext),
-	), nil
+	return formatCiphertext(base64.StdEncoding.EncodeToString(nonce), base64.StdEncoding.EncodeToString(ciphertext)), nil
 }
 
 // DecryptString decrypts a ciphertext produced by EncryptString.


### PR DESCRIPTION
Part of #1200 
## Overview
This PR adds the first encryption-backed transformer implementation and validates the existing transformer abstraction with end-to-end tests.

### Changes

* Add `EncryptionTransformer` backed by `reportcrypto`
* Add unit tests for `EncryptionTransformer`
* Add integration tests covering encrypted `RepoContextMetadata` transformation and decryption round-trip validation
* Reuse shared ciphertext envelope formatting to keep encryption and decryption logic aligned

### Notes

This PR does not change production behavior. It focuses on validating the encryption transformer implementation and strengthening the encrypted-report foundation introduced in previous work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to encrypt sensitive data fields using a data-encryption key
  * Encrypted data can be decrypted back to original values using the same key

* **Tests**
  * Added comprehensive unit tests validating encryption functionality with various data types and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->