### PR TITLE
fix(httphandler): add panic recovery to scan execution goroutine

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -34,11 +34,15 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 		if r := recover(); r != nil {
 			err := fmt.Errorf("scan panicked: %v", r)
 			logger.L().Ctx(scanReq.ctx).Error("scan panic recovered", helpers.String("ID", scanReq.scanID), helpers.Error(err))
-			writeScanErrorToFile(err, scanReq.scanID)
+			responseMsg := err.Error()
+			if persistErr := writeScanErrorToFile(err, scanReq.scanID); persistErr != nil {
+				logger.L().Ctx(scanReq.ctx).Error("failed to persist panic error to file", helpers.String("ID", scanReq.scanID), helpers.Error(persistErr))
+				responseMsg = persistErr.Error()
+			}
 			handler.state.setNotBusy(scanReq.scanID)
 			if scanReq.scanQueryParams.ReturnResults {
 				response.Type = utilsapisv1.ErrorScanResponseType
-				response.Response = err.Error()
+				response.Response = responseMsg
 				select {
 				case scanReq.resp <- response:
 				default:

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -30,6 +30,23 @@ var scanImpl = scan // Override for testing
 func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	response := &utilsmetav1.Response{}
 
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("scan panicked: %v", r)
+			logger.L().Ctx(scanReq.ctx).Error("scan panic recovered", helpers.String("ID", scanReq.scanID), helpers.Error(err))
+			writeScanErrorToFile(err, scanReq.scanID)
+			handler.state.setNotBusy(scanReq.scanID)
+			if scanReq.scanQueryParams.ReturnResults {
+				response.Type = utilsapisv1.ErrorScanResponseType
+				response.Response = err.Error()
+				select {
+				case scanReq.resp <- response:
+				default:
+				}
+			}
+		}
+	}()
+
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
 	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -269,3 +269,39 @@ func TestScan_WhenScanFails_Returns500WithErrorType(t *testing.T) {
 		t.Errorf("Scan failure: response.Response is empty; want scan error message")
 	}
 }
+
+func TestScan_WhenScanPanics_RecoversAndReturns500(t *testing.T) {
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		panic("boom")
+	}
+
+	h := NewHTTPHandler(false)
+	rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+	w := httptest.NewRecorder()
+
+	// Must not crash the test process — the panic recovery in executeScan must
+	// contain the failure to a single scan and keep the operator alive.
+	h.Scan(w, rq)
+
+	rs := w.Result()
+	if rs.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Scan panic: HTTP status = %d; want %d", rs.StatusCode, http.StatusInternalServerError)
+	}
+
+	var resp utilsmetav1.Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode Scan panic response: %v", err)
+	}
+	if resp.Type != utilsapisv1.ErrorScanResponseType {
+		t.Errorf("Scan panic: response.Type = %q; want %q", resp.Type, utilsapisv1.ErrorScanResponseType)
+	}
+	if resp.Response == "" {
+		t.Errorf("Scan panic: response.Response is empty; want panic message")
+	}
+
+	// The scan slot must be released so the operator is not stuck busy forever.
+	if h.state.isBusy("") {
+		t.Errorf("Scan panic: handler state is still busy after recovery; scan slot must be released")
+	}
+}


### PR DESCRIPTION
## Overview

**Current behavior:** `watchForScan` runs in a long-lived background goroutine that processes scans sequentially. Neither `watchForScan` nor `executeScan` had any panic recovery. The `defer handler.recover(...)` in the HTTP `Scan` handler runs in the request goroutine -- Go's `recover()` cannot catch panics from a different goroutine. Any panic inside `scanImpl` (e.g. the nil-pointer printer panics from commit `e03e4249`) crashed the entire operator process instead of failing just that one scan.

```go
// before -- no recovery in the scan goroutine
func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
    _, err := scanImpl(scanReq.ctx, ...)
    ...
    handler.state.setNotBusy(scanReq.scanID)
}
```

**Future behavior:** A deferred panic recovery at the top of `executeScan` converts any panic into a normal failed-scan outcome. The `watchForScan` loop stays alive and continues processing subsequent scans.

```go
// after -- panic is caught, contained, and surfaced as a scan failure
func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
    defer func() {
        if r := recover(); r != nil {
            err := fmt.Errorf("scan panic: %v", r)
            writeScanErrorToFile(err, scanReq.scanID)
            handler.state.setNotBusy(scanReq.scanID)
            select {
            case scanReq.resp <- &v1.ScanResponse{Type: v1.ErrorScanResponseType}:
            default:
            }
        }
    }()
    _, err := scanImpl(scanReq.ctx, ...)
    ...
    handler.state.setNotBusy(scanReq.scanID)
}
```

## Additional Information

The existing `defer handler.recover(...)` in the `Scan()` HTTP handler gives a false sense of safety. It only protects the request goroutine, not the background worker goroutine where the scan actually runs. This is a concurrency architecture gap, not a missing line.

The fix is consistent with existing failed-scan handling:
- `writeScanErrorToFile` surfaces the failure through `/v1/results` as `ScanFailedError`, same as other scan errors
- `setNotBusy` releases the scan slot so the operator does not get stuck in a busy state
- The non-blocking `select` on `scanReq.resp` mirrors the pattern already used at the bottom of `executeScan`

This is not hypothetical -- commit `e03e4249` fixed nil-pointer panics in SARIF, HTML, and JUnit printers that run inside `HandleResults` inside `scanImpl` inside `executeScan`. Any similar future panic in that path is now contained to the single scan.

Affected file: `httphandler/handlerequests/v1/requestshandlerutils.go` -- `executeScan()`

## How to Test

1. Deploy the Kubescape in-cluster operator
2. Inject a panic into `scanImpl` or trigger the printer condition from `e03e4249` (a control present in results but missing from summary details)
3. Trigger a scan via `POST /v1/scan`

Before fix: operator process terminates, pod CrashLoopBackOffs, scan ID stays stuck as busy.

After fix: `/v1/results` returns `ErrorScanResponseType` for the failed scan, operator stays running, subsequent scans execute normally.

## Related issues/PRs

* Resolved #2350 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scans that encounter unexpected failures are now recovered, recorded, and no longer leave scan slots stuck as busy. If result reporting is enabled, users receive an explicit error response for failed scans.

* **Tests**
  * Added a unit test to verify panic recovery: handler returns HTTP 500 with an error response and releases the scan slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->