### PR TITLE
Fail closed on repo metadata transformation errors

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -231,9 +231,8 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	resultsHandling.SetData(scanData)
 
 	if scanInfo.Hide {
-		/* logger.L().Info("anonymizer hook triggered")  //used for debuging pipeline right now will be removed in suceeding phase */
 		if err := anonymizer.Apply(resultsHandling); err != nil {
-			logger.L().Warning("failed to hide sensitive fields", helpers.Error(err))
+			return nil, fmt.Errorf("failed to hide sensitive fields: %w", err)
 		}
 	}
 

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -9,7 +9,9 @@ func Apply(resultsHandler *resultshandling.ResultsHandler) error {
 
 	mapping := NewMapping()
 
-	anonymizeSession(resultsHandler.ScanData, mapping)
+	if err := anonymizeSession(resultsHandler.ScanData, mapping); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -15,9 +15,9 @@ import (
 
 // anonymizeSession rewrites sensitive resource identifiers and metadata while
 // preserving internal referential integrity across the full OPA session.
-func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
+func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) error {
 	if session == nil {
-		return
+		return nil
 	}
 
 	idMapping := make(map[string]string)
@@ -116,17 +116,28 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 	session.ResourceAttackTracks = newResourceAttackTracks
 	repoTransformer := NewMappingTransformer()
 	if session.Metadata != nil {
-		transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, repoTransformer)
+		if err := transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, repoTransformer); err != nil {
+			return err
+		}
 	}
 
 	if session.Report != nil {
 
-		transformRepoContextMetadata(session.Report.Metadata.ContextMetadata.RepoContextMetadata, repoTransformer)
+		if err := transformRepoContextMetadata(
+			session.Report.Metadata.ContextMetadata.RepoContextMetadata,
+			repoTransformer,
+		); err != nil {
+			return err
+		}
 
 		for controlID, control := range session.Report.SummaryDetails.Controls {
 			remappedResourceIDs := control.ResourceIDs
 
-			originalResourceIDs := make(map[string]apis.ScanningStatus, len(control.ResourceIDs.All()))
+			originalResourceIDs := make(
+				map[string]apis.ScanningStatus,
+				len(control.ResourceIDs.All()),
+			)
+
 			for resourceID, status := range control.ResourceIDs.All() {
 				originalResourceIDs[resourceID] = status
 			}
@@ -134,14 +145,24 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) {
 			remappedResourceIDs.Clear()
 
 			for oldID, status := range originalResourceIDs {
-				newID := resolveMappedID(mapping, idMapping, oldID, "ref")
-				remappedResourceIDs.Append(status, newID)
+				newID := resolveMappedID(
+					mapping,
+					idMapping,
+					oldID,
+					"ref",
+				)
+
+				remappedResourceIDs.Append(
+					status,
+					newID,
+				)
 			}
 
 			control.ResourceIDs = remappedResourceIDs
 			session.Report.SummaryDetails.Controls[controlID] = control
 		}
 	}
+	return nil
 }
 
 // resolveMappedID preserves referential integrity when IDs are rewritten during
@@ -355,50 +376,105 @@ func transformValue(
 	transformer Transformer,
 	prefix string,
 	value string,
-) string {
+) (string, error) {
 	if value == "" {
-		return value
+		return value, nil
 	}
 
-	transformed, err := transformer.Transform(prefix, value)
-	if err != nil {
-		return ""
-	}
-
-	return transformed
+	return transformer.Transform(
+		prefix,
+		value,
+	)
 }
 
 func transformRepoContextMetadata(
 	repo *reporthandlingv2.RepoContextMetadata,
 	transformer Transformer,
-) {
+) error {
 	if repo == nil {
-		return
+		return nil
 	}
 
-	repo.Repo = transformValue(transformer, "git", repo.Repo)
-	repo.Owner = transformValue(transformer, "git", repo.Owner)
-	repo.Branch = transformValue(transformer, "git", repo.Branch)
-	repo.DefaultBranch = transformValue(transformer, "git", repo.DefaultBranch)
-	repo.RemoteURL = transformValue(transformer, "git", repo.RemoteURL)
-	repo.LocalRootPath = transformValue(transformer, "git", repo.LocalRootPath)
+	var err error
 
-	transformLastCommit(
-		&repo.LastCommit,
-		transformer,
-	)
+	repo.Repo, err = transformValue(transformer, "git", repo.Repo)
+	if err != nil {
+		return err
+	}
+
+	repo.Owner, err = transformValue(transformer, "git", repo.Owner)
+	if err != nil {
+		return err
+	}
+
+	repo.Branch, err = transformValue(transformer, "git", repo.Branch)
+	if err != nil {
+		return err
+	}
+
+	repo.DefaultBranch, err = transformValue(transformer, "git", repo.DefaultBranch)
+	if err != nil {
+		return err
+	}
+
+	repo.RemoteURL, err = transformValue(transformer, "git", repo.RemoteURL)
+	if err != nil {
+		return err
+	}
+
+	repo.LocalRootPath, err = transformValue(transformer, "git", repo.LocalRootPath)
+	if err != nil {
+		return err
+	}
+
+	return transformLastCommit(&repo.LastCommit, transformer)
 }
 
 func transformLastCommit(
 	commit *reporthandling.LastCommit,
 	transformer Transformer,
-) {
+) error {
 	if commit == nil {
-		return
+		return nil
 	}
 
-	commit.Hash = transformValue(transformer, "git", commit.Hash)
-	commit.CommitterName = transformValue(transformer, "git", commit.CommitterName)
-	commit.CommitterEmail = transformValue(transformer, "git", commit.CommitterEmail)
-	commit.Message = transformValue(transformer, "git", commit.Message)
+	var err error
+
+	commit.Hash, err = transformValue(
+		transformer,
+		"git",
+		commit.Hash,
+	)
+	if err != nil {
+		return err
+	}
+
+	commit.CommitterName, err = transformValue(
+		transformer,
+		"git",
+		commit.CommitterName,
+	)
+	if err != nil {
+		return err
+	}
+
+	commit.CommitterEmail, err = transformValue(
+		transformer,
+		"git",
+		commit.CommitterEmail,
+	)
+	if err != nil {
+		return err
+	}
+
+	commit.Message, err = transformValue(
+		transformer,
+		"git",
+		commit.Message,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -395,39 +395,74 @@ func transformRepoContextMetadata(
 		return nil
 	}
 
+	repoCopy := *repo
+
 	var err error
 
-	repo.Repo, err = transformValue(transformer, "git", repo.Repo)
+	repoCopy.Repo, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.Repo,
+	)
 	if err != nil {
 		return err
 	}
 
-	repo.Owner, err = transformValue(transformer, "git", repo.Owner)
+	repoCopy.Owner, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.Owner,
+	)
 	if err != nil {
 		return err
 	}
 
-	repo.Branch, err = transformValue(transformer, "git", repo.Branch)
+	repoCopy.Branch, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.Branch,
+	)
 	if err != nil {
 		return err
 	}
 
-	repo.DefaultBranch, err = transformValue(transformer, "git", repo.DefaultBranch)
+	repoCopy.DefaultBranch, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.DefaultBranch,
+	)
 	if err != nil {
 		return err
 	}
 
-	repo.RemoteURL, err = transformValue(transformer, "git", repo.RemoteURL)
+	repoCopy.RemoteURL, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.RemoteURL,
+	)
 	if err != nil {
 		return err
 	}
 
-	repo.LocalRootPath, err = transformValue(transformer, "git", repo.LocalRootPath)
+	repoCopy.LocalRootPath, err = transformValue(
+		transformer,
+		"git",
+		repoCopy.LocalRootPath,
+	)
 	if err != nil {
 		return err
 	}
 
-	return transformLastCommit(&repo.LastCommit, transformer)
+	if err := transformLastCommit(
+		&repoCopy.LastCommit,
+		transformer,
+	); err != nil {
+		return err
+	}
+
+	*repo = repoCopy
+
+	return nil
 }
 
 func transformLastCommit(
@@ -438,43 +473,47 @@ func transformLastCommit(
 		return nil
 	}
 
+	commitCopy := *commit
+
 	var err error
 
-	commit.Hash, err = transformValue(
+	commitCopy.Hash, err = transformValue(
 		transformer,
 		"git",
-		commit.Hash,
+		commitCopy.Hash,
 	)
 	if err != nil {
 		return err
 	}
 
-	commit.CommitterName, err = transformValue(
+	commitCopy.CommitterName, err = transformValue(
 		transformer,
 		"git",
-		commit.CommitterName,
+		commitCopy.CommitterName,
 	)
 	if err != nil {
 		return err
 	}
 
-	commit.CommitterEmail, err = transformValue(
+	commitCopy.CommitterEmail, err = transformValue(
 		transformer,
 		"git",
-		commit.CommitterEmail,
+		commitCopy.CommitterEmail,
 	)
 	if err != nil {
 		return err
 	}
 
-	commit.Message, err = transformValue(
+	commitCopy.Message, err = transformValue(
 		transformer,
 		"git",
-		commit.Message,
+		commitCopy.Message,
 	)
 	if err != nil {
 		return err
 	}
+
+	*commit = commitCopy
 
 	return nil
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -3,6 +3,8 @@ package anonymizer
 import (
 	"testing"
 
+	"errors"
+
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -18,6 +20,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingTransformer struct{}
+
+func (f *failingTransformer) Transform(prefix string, value string) (string, error) {
+	return "", errors.New("transform failed")
+}
 
 type metadataOnly struct{}
 
@@ -769,4 +777,20 @@ func TestTransformRepoContextMetadata_EncryptionTransformer(
 		"demo-repository",
 		decryptedRepo,
 	)
+}
+
+func TestTransformRepoContextMetadata_Error(
+	t *testing.T,
+) {
+	repo := &reporthandlingv2.RepoContextMetadata{
+		Repo: "demo-repository",
+	}
+
+	err := transformRepoContextMetadata(
+		repo,
+		&failingTransformer{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transform failed")
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -695,10 +695,11 @@ func TestTransformRepoContextMetadata(t *testing.T) {
 		},
 	}
 
-	transformRepoContextMetadata(
+	err := transformRepoContextMetadata(
 		repo,
 		NewMappingTransformer(),
 	)
+	require.NoError(t, err)
 
 	assert.NotEqual(t, "demo-repository", repo.Repo)
 	assert.NotEqual(t, "demo-owner", repo.Owner)
@@ -749,10 +750,11 @@ func TestTransformRepoContextMetadata_EncryptionTransformer(
 		},
 	}
 
-	transformRepoContextMetadata(
+	err = transformRepoContextMetadata(
 		repo,
 		transformer,
 	)
+	require.NoError(t, err)
 
 	assert.Contains(t, repo.Repo, "ENC[AES256_GCM,")
 	assert.Contains(t, repo.Owner, "ENC[AES256_GCM,")
@@ -783,7 +785,12 @@ func TestTransformRepoContextMetadata_Error(
 	t *testing.T,
 ) {
 	repo := &reporthandlingv2.RepoContextMetadata{
-		Repo: "demo-repository",
+		Repo:          "demo-repository",
+		Owner:         "demo-owner",
+		Branch:        "feature/demo-work",
+		DefaultBranch: "main",
+		RemoteURL:     "https://github.com/demo-owner/demo-repository",
+		LocalRootPath: "/workspace/demo-repository",
 	}
 
 	err := transformRepoContextMetadata(
@@ -793,4 +800,18 @@ func TestTransformRepoContextMetadata_Error(
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transform failed")
+	assert.Equal(t, "demo-repository", repo.Repo)
+	assert.Equal(t, "demo-owner", repo.Owner)
+	assert.Equal(t, "feature/demo-work", repo.Branch)
+	assert.Equal(t, "main", repo.DefaultBranch)
+	assert.Equal(
+		t,
+		"https://github.com/demo-owner/demo-repository",
+		repo.RemoteURL,
+	)
+	assert.Equal(
+		t,
+		"/workspace/demo-repository",
+		repo.LocalRootPath,
+	)
 }


### PR DESCRIPTION
Part of #1200
## Overview

Propagate transformer errors during repo metadata transformation instead of silently masking failures.

### Changes

* Update repo metadata transformation helpers to return errors
* Propagate transformation failures through `anonymizeSession` and `Apply`
* Add coverage for transformer failure scenarios
* Preserve existing anonymization behavior for successful transformations

This change ensures repo metadata transformations fail closed. Future transformer implementations (for example encryption-based transformers) can now surface errors instead of silently producing incomplete output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymization now surfaces errors from session processing and metadata transformation instead of suppressing them; failed anonymization now aborts the scan step rather than logging and continuing.

* **Tests**
  * Added tests verifying metadata transformation error handling and that transformation failures are reported and do not mutate original metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->