### PR TITLE
fix(hostsensorutils): normalize infoMap keys using ResourceGroupToString

### DIFF
--- a/core/pkg/hostsensorutils/utils.go
+++ b/core/pkg/hostsensorutils/utils.go
@@ -8,9 +8,10 @@ import (
 
 func addInfoToMap(resource hostsensor.HostSensorResource, infoMap map[string]apis.StatusInfo, err error) {
 	group, version := k8sinterface.SplitApiVersion(hostsensor.MapHostSensorResourceToApiGroup(resource))
-	r := k8sinterface.JoinResourceTriplets(group, version, resource.String())
-	infoMap[r] = apis.StatusInfo{
-		InnerStatus: apis.StatusSkipped,
-		InnerInfo:   err.Error(),
+	for _, r := range k8sinterface.ResourceGroupToString(group, version, resource.String()) {
+		infoMap[r] = apis.StatusInfo{
+			InnerStatus: apis.StatusSkipped,
+			InnerInfo:   err.Error(),
+		}
 	}
 }

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -3,14 +3,50 @@ package hostsensorutils
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/hostsensor"
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+// fakeHostSensorDiscovery returns a discovery.DiscoveryInterface whose
+// ServerPreferredResources reports the host-sensor CRDs as the cluster would.
+// This lets IsKindKubernetes/ResourceGroupToString normalize host-sensor
+// kinds the same way they do against a real cluster.
+type fakeHostSensorDiscovery struct {
+	*fakediscovery.FakeDiscovery
+}
+
+func (f *fakeHostSensorDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return []*metav1.APIResourceList{
+		{
+			GroupVersion: "hostdata.kubescape.cloud/v1beta0",
+			APIResources: []metav1.APIResource{
+				{Name: "kubeletinfos", Kind: "KubeletInfo", Namespaced: false, Verbs: metav1.Verbs{"get", "list"}},
+				{Name: "cniinfos", Kind: "CNIInfo", Namespaced: false, Verbs: metav1.Verbs{"get", "list"}},
+			},
+		},
+	}, nil
+}
+
+func TestMain(m *testing.M) {
+	// Register host-sensor CRDs into k8sinterface's global discovery mapping
+	// so that ResourceGroupToString normalizes "KubeletInfo"/"CNIInfo" to their
+	// plural lowercase CRD names ("kubeletinfos"/"cniinfos"), matching what
+	// happens against a real cluster where these CRDs are installed.
+	k8sinterface.InitializeMapResources(&fakeHostSensorDiscovery{
+		FakeDiscovery: &fakediscovery.FakeDiscovery{Fake: &k8stesting.Fake{}},
+	})
+	os.Exit(m.Run())
+}
 
 func TestAddInfoToMap(t *testing.T) {
 	t.Parallel()
@@ -27,6 +63,8 @@ func TestAddInfoToMap(t *testing.T) {
 		Expected map[string]apis.StatusInfo
 	}{
 		{
+			// KubeletConfiguration is not a registered CRD kind, so
+			// ResourceGroupToString falls back to the raw group/version/kind triplet.
 			Resource: hostsensor.KubeletConfiguration,
 			Err:      testErr,
 			Expected: map[string]apis.StatusInfo{
@@ -37,10 +75,24 @@ func TestAddInfoToMap(t *testing.T) {
 			},
 		},
 		{
+			// CNIInfo is registered as the "cniinfos" CRD (see TestMain), so
+			// ResourceGroupToString normalizes the key to its plural lowercase form.
 			Resource: hostsensor.CNIInfo,
 			Err:      testErr,
 			Expected: map[string]apis.StatusInfo{
-				"hostdata.kubescape.cloud/v1beta0/CNIInfo": {
+				"hostdata.kubescape.cloud/v1beta0/cniinfos": {
+					InnerStatus: apis.StatusSkipped,
+					InnerInfo:   testErr.Error(),
+				},
+			},
+		},
+		{
+			// KubeletInfo is registered as the "kubeletinfos" CRD (see TestMain), so
+			// ResourceGroupToString normalizes the key to its plural lowercase form.
+			Resource: hostsensor.KubeletInfo,
+			Err:      testErr,
+			Expected: map[string]apis.StatusInfo{
+				"hostdata.kubescape.cloud/v1beta0/kubeletinfos": {
 					InnerStatus: apis.StatusSkipped,
 					InnerInfo:   testErr.Error(),
 				},
@@ -60,8 +112,6 @@ func TestAddInfoToMap(t *testing.T) {
 		tc := toPin
 
 		t.Run(fmt.Sprintf("should expect a status for resource %s", tc.Resource), func(t *testing.T) {
-			t.Parallel()
-
 			result := make(map[string]apis.StatusInfo, 1)
 			addInfoToMap(tc.Resource, result, tc.Err)
 
@@ -70,37 +120,32 @@ func TestAddInfoToMap(t *testing.T) {
 	}
 }
 
-// TestAddInfoToMap_KeysMatchResourceGroupToString is a regression test for the
-// bug where addInfoToMap used JoinResourceTriplets while collectHostResources
-// used ResourceGroupToString, causing a key mismatch that silently dropped
-// host-sensor CRD pull failures from scan coverage.
-func TestAddInfoToMap_KeysMatchResourceGroupToString(t *testing.T) {
-	t.Parallel()
+// TestAddInfoToMap_BuildScanCoverageRecognizesHostSensorFailure is a regression
+// test for the bug where addInfoToMap used JoinResourceTriplets while
+// collectHostResources used ResourceGroupToString, producing different keys
+// for the same CRD ("KubeletInfo" vs "kubeletinfos"). BuildScanCoverage only
+// surfaces an InfoMap entry as a FailedGVRPull/NotEvaluatedControl when its
+// key matches ResourceToControlsMap, so the mismatch silently dropped
+// host-sensor pull failures from scan coverage.
+func TestAddInfoToMap_BuildScanCoverageRecognizesHostSensorFailure(t *testing.T) {
 	testErr := errors.New("failed to list CRDs")
 
-	for _, resource := range []hostsensor.HostSensorResource{
-		hostsensor.KubeletInfo,
-		hostsensor.KubeletConfiguration,
-		hostsensor.CNIInfo,
-	} {
-		resource := resource
-		t.Run(string(resource), func(t *testing.T) {
-			t.Parallel()
-			group, version := k8sinterface.SplitApiVersion(hostsensor.MapHostSensorResourceToApiGroup(resource))
-			expectedKeys := k8sinterface.ResourceGroupToString(group, version, resource.String())
+	infoMap := make(map[string]apis.StatusInfo)
+	addInfoToMap(hostsensor.KubeletInfo, infoMap, testErr)
 
-			result := make(map[string]apis.StatusInfo)
-			addInfoToMap(resource, result, testErr)
-
-			require.Len(t, result, len(expectedKeys))
-			for _, key := range expectedKeys {
-				info, ok := result[key]
-				require.True(t, ok, "key %q not found in infoMap", key)
-				assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
-				assert.Equal(t, testErr.Error(), info.InnerInfo)
-			}
-		})
+	const expectedKey = "hostdata.kubescape.cloud/v1beta0/kubeletinfos"
+	resourceToControlsMap := map[string][]string{
+		expectedKey: {"C-0001"},
 	}
+
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+
+	require.Len(t, coverage.FailedGVRPulls, 1)
+	assert.Equal(t, expectedKey, coverage.FailedGVRPulls[0].GVR)
+	assert.Equal(t, testErr.Error(), coverage.FailedGVRPulls[0].Error)
+
+	require.Len(t, coverage.NotEvaluatedControls, 1)
+	assert.Equal(t, "C-0001", coverage.NotEvaluatedControls[0].ControlID)
 }
 
 func TestMapHostSensorResourceToApiGroup(t *testing.T) {

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/k8s-interface/hostsensor"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,39 @@ func TestAddInfoToMap(t *testing.T) {
 			addInfoToMap(tc.Resource, result, tc.Err)
 
 			require.EqualValues(t, tc.Expected, result)
+		})
+	}
+}
+
+// TestAddInfoToMap_KeysMatchResourceGroupToString is a regression test for the
+// bug where addInfoToMap used JoinResourceTriplets while collectHostResources
+// used ResourceGroupToString, causing a key mismatch that silently dropped
+// host-sensor CRD pull failures from scan coverage.
+func TestAddInfoToMap_KeysMatchResourceGroupToString(t *testing.T) {
+	t.Parallel()
+	testErr := errors.New("failed to list CRDs")
+
+	for _, resource := range []hostsensor.HostSensorResource{
+		hostsensor.KubeletInfo,
+		hostsensor.KubeletConfiguration,
+		hostsensor.CNIInfo,
+	} {
+		resource := resource
+		t.Run(string(resource), func(t *testing.T) {
+			t.Parallel()
+			group, version := k8sinterface.SplitApiVersion(hostsensor.MapHostSensorResourceToApiGroup(resource))
+			expectedKeys := k8sinterface.ResourceGroupToString(group, version, resource.String())
+
+			result := make(map[string]apis.StatusInfo)
+			addInfoToMap(resource, result, testErr)
+
+			require.Len(t, result, len(expectedKeys))
+			for _, key := range expectedKeys {
+				info, ok := result[key]
+				require.True(t, ok, "key %q not found in infoMap", key)
+				assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
+				assert.Equal(t, testErr.Error(), info.InnerInfo)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Overview

**Current behavior:** `addInfoToMap` in `core/pkg/hostsensorutils/utils.go` built InfoMap keys using `JoinResourceTriplets`, producing singular/capitalized keys like `hostdata.kubescape.cloud/v1beta0/KubeletInfo`. The success path in `collectHostResources` uses `ResourceGroupToString`, which normalizes CRD kinds to plural lowercase (`hostdata.kubescape.cloud/v1beta0/kubeletinfos`). The key mismatch meant `BuildScanCoverage` silently dropped all host-sensor CRD pull failures since the keys never matched `ResourceToControlsMap`. Affected controls showed as covered/passing instead of `NotEvaluated`.

```go
// before -- wrong key, no normalization
r := k8sinterface.JoinResourceTriplets(group, version, resource.String())
// produces: hostdata.kubescape.cloud/v1beta0/KubeletInfo
infoMap[r] = apis.StatusInfo{InnerStatus: apis.StatusSkipped, InnerInfo: err.Error()}
```

**Future behavior:** `addInfoToMap` now uses `ResourceGroupToString` in a for loop, matching exactly what the success path uses. Host-sensor collection failures are correctly keyed, picked up by `BuildScanCoverage`, and surfaced as `NotEvaluated` controls.

```go
// after -- normalized key, matches success path and ResourceToControlsMap
for _, r := range k8sinterface.ResourceGroupToString(group, version, resource.String()) {
    infoMap[r] = apis.StatusInfo{InnerStatus: apis.StatusSkipped, InnerInfo: err.Error()}
}
```

## Additional Information

The divergence was introduced by commit `d091a24d` which normalized the success path and `ResourceToControlsMap` to the plural CRD form but left `addInfoToMap` on the old `JoinResourceTriplets` form. Before CRD-based collection, both paths produced the same singular key and matched -- so this was a silent regression.

Affected call chain:
- `utils.go` -- `addInfoToMap()` (root cause, 1 line changed)
- `hostsensorcollectcrds.go` -- `CollectResources()` (callers, unchanged)
- `scancoverage.go:75` -- `BuildScanCoverage()` (was silently dropping mismatched keys)
- `processorhandlerutils.go:186` -- `mapControlToInfo()` (was missing skip status on affected controls)

## How to Test

1. Deploy the Kubescape operator + node-agent so host-data CRDs are registered (`kubectl get crd | grep hostdata.kubescape.cloud`)
2. Induce a host-resource collection failure -- scan before the node-agent has populated `KubeletInfo` on all nodes, or revoke `list` on one CRD type
3. Run a CIS/host-scanning framework scan

Before fix: `scanCoverage.failedGVRPulls` and `notEvaluatedControls` are empty despite the collection failure. Affected controls show as covered.

After fix: the failed host GVR appears in `failedGVRPulls` and dependent controls appear in `notEvaluatedControls`, identical to how a K8s GVR pull failure is handled.

## Related issues/PRs

* Resolved #2354 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure resource-status entries are recorded consistently so scan failures from host-sensor resources are correctly recognized and reported.

* **Tests**
  * Added regression test to confirm resource-status key handling and that host-sensor failures surface in scan results rather than being dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->