### PR TITLE
feat: add encrypted repo metadata workflow

### DIFF
--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -1,6 +1,9 @@
 package anonymizer
 
-import "github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+import (
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+)
 
 func Apply(resultsHandler *resultshandling.ResultsHandler) error {
 	return applyWithTransformer(
@@ -30,10 +33,22 @@ func applyWithTransformer(
 	return nil
 }
 
+// ApplyEncrypted anonymizes a scan session while encrypting
+// RepoContextMetadata using the supplied DEK.
+//
+// Resource identifiers, namespaces, annotations, source paths,
+// and other session data continue to use mapping-based
+// anonymization and remain irreversibly pseudonymized.
+//
+// Only repo context metadata is reversibly encrypted.
 func ApplyEncrypted(
 	resultsHandler *resultshandling.ResultsHandler,
 	dek []byte,
 ) error {
+	if err := reportcrypto.ValidateDEK(dek); err != nil {
+		return err
+	}
+
 	return applyWithTransformer(
 		resultsHandler,
 		NewEncryptionTransformer(dek),

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -3,15 +3,39 @@ package anonymizer
 import "github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 
 func Apply(resultsHandler *resultshandling.ResultsHandler) error {
+	return applyWithTransformer(
+		resultsHandler,
+		NewMappingTransformer(),
+	)
+}
+
+func applyWithTransformer(
+	resultsHandler *resultshandling.ResultsHandler,
+	transformer Transformer,
+) error {
 	if resultsHandler == nil || resultsHandler.ScanData == nil {
 		return nil
 	}
 
 	mapping := NewMapping()
 
-	if err := anonymizeSession(resultsHandler.ScanData, mapping); err != nil {
+	if err := anonymizeSession(
+		resultsHandler.ScanData,
+		mapping,
+		transformer,
+	); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func ApplyEncrypted(
+	resultsHandler *resultshandling.ResultsHandler,
+	dek []byte,
+) error {
+	return applyWithTransformer(
+		resultsHandler,
+		NewEncryptionTransformer(dek),
+	)
 }

--- a/core/pkg/anonymizer/anonymizer_test.go
+++ b/core/pkg/anonymizer/anonymizer_test.go
@@ -88,4 +88,36 @@ func TestApplyEncrypted(t *testing.T) {
 		"demo-repository",
 		decryptedRepo,
 	)
+
+	assert.Contains(
+		t,
+		repo.LastCommit.Message,
+		"ENC[AES256_GCM,",
+	)
+
+	decryptedMessage, err := reportcrypto.DecryptString(
+		repo.LastCommit.Message,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"demo commit",
+		decryptedMessage,
+	)
+}
+
+func TestApplyEncrypted_InvalidDEK(t *testing.T) {
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{},
+	}
+
+	err := ApplyEncrypted(
+		handler,
+		[]byte("bad"),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid DEK length")
 }

--- a/core/pkg/anonymizer/anonymizer_test.go
+++ b/core/pkg/anonymizer/anonymizer_test.go
@@ -3,8 +3,13 @@ package anonymizer
 import (
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApply(t *testing.T) {
@@ -30,4 +35,57 @@ func TestApply(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestApplyEncrypted(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{
+			Metadata: &reporthandlingv2.Metadata{
+				ContextMetadata: reporthandlingv2.ContextMetadata{
+					RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+						Repo:  "demo-repository",
+						Owner: "demo-owner",
+						LastCommit: reporthandling.LastCommit{
+							Message: "demo commit",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = ApplyEncrypted(
+		handler,
+		dek,
+	)
+	require.NoError(t, err)
+
+	repo := handler.ScanData.Metadata.ContextMetadata.RepoContextMetadata
+
+	assert.Contains(
+		t,
+		repo.Repo,
+		"ENC[AES256_GCM,",
+	)
+
+	assert.Contains(
+		t,
+		repo.Owner,
+		"ENC[AES256_GCM,",
+	)
+
+	decryptedRepo, err := reportcrypto.DecryptString(
+		repo.Repo,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"demo-repository",
+		decryptedRepo,
+	)
 }

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -15,7 +15,7 @@ import (
 
 // anonymizeSession rewrites sensitive resource identifiers and metadata while
 // preserving internal referential integrity across the full OPA session.
-func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) error {
+func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTransformer Transformer) error {
 	if session == nil {
 		return nil
 	}
@@ -114,7 +114,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping) error {
 		newResourceAttackTracks[newID] = attackTrack
 	}
 	session.ResourceAttackTracks = newResourceAttackTracks
-	repoTransformer := NewMappingTransformer()
+
 	if session.Metadata != nil {
 		if err := transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, repoTransformer); err != nil {
 			return err
@@ -372,11 +372,7 @@ func anonymizeLastCommit(commit *reporthandling.LastCommit, mapping *Mapping) {
 	}
 }
 
-func transformValue(
-	transformer Transformer,
-	prefix string,
-	value string,
-) (string, error) {
+func transformValue(transformer Transformer, prefix string, value string) (string, error) {
 	if value == "" {
 		return value, nil
 	}
@@ -387,10 +383,7 @@ func transformValue(
 	)
 }
 
-func transformRepoContextMetadata(
-	repo *reporthandlingv2.RepoContextMetadata,
-	transformer Transformer,
-) error {
+func transformRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, transformer Transformer) error {
 	if repo == nil {
 		return nil
 	}
@@ -465,10 +458,7 @@ func transformRepoContextMetadata(
 	return nil
 }
 
-func transformLastCommit(
-	commit *reporthandling.LastCommit,
-	transformer Transformer,
-) error {
+func transformLastCommit(commit *reporthandling.LastCommit, transformer Transformer) error {
 	if commit == nil {
 		return nil
 	}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -86,9 +86,10 @@ func TestResolveMappedID(t *testing.T) {
 func TestAnonymizeSession_NilSession(t *testing.T) {
 	mapping := NewMapping()
 
-	assert.NotPanics(t, func() {
-		anonymizeSession(nil, mapping)
-	})
+	require.NoError(
+		t,
+		anonymizeSession(nil, mapping, NewMappingTransformer()),
+	)
 }
 
 func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
@@ -112,7 +113,9 @@ func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
 	}
 
 	mapping := NewMapping()
-	anonymizeSession(session, mapping)
+
+	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	require.NoError(t, err)
 
 	for _, resource := range session.AllResources {
 		assert.NotEqual(t, "my-secret-pod", resource.GetName())
@@ -201,7 +204,8 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 	}
 
 	mapping := NewMapping()
-	anonymizeSession(session, mapping)
+	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	require.NoError(t, err)
 
 	var newID string
 	for id := range session.AllResources {
@@ -375,7 +379,8 @@ func TestAnonymizeSession_LabelHandling(t *testing.T) {
 			}
 
 			mapping := NewMapping()
-			anonymizeSession(session, mapping)
+			err := anonymizeSession(session, mapping, NewMappingTransformer())
+			require.NoError(t, err)
 
 			for _, resource := range session.AllResources {
 				workload, ok := resource.(workloadinterface.IWorkload)
@@ -560,7 +565,8 @@ func TestAnonymizeSession_Annotations(t *testing.T) {
 			mapping := NewMapping()
 
 			assert.NotPanics(t, func() {
-				anonymizeSession(session, mapping)
+				err := anonymizeSession(session, mapping, NewMappingTransformer())
+				require.NoError(t, err)
 			})
 
 			for _, resource := range session.AllResources {
@@ -628,7 +634,8 @@ func TestAnonymizeSession_RepoContextMetadata(t *testing.T) {
 	}
 
 	mapping := NewMapping()
-	anonymizeSession(session, mapping)
+	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	require.NoError(t, err)
 
 	for _, repo := range []*reporthandlingv2.RepoContextMetadata{
 		session.Metadata.ContextMetadata.RepoContextMetadata,

--- a/core/pkg/reportcrypto/crypto.go
+++ b/core/pkg/reportcrypto/crypto.go
@@ -18,6 +18,19 @@ const (
 	suffix    = "]"
 )
 
+// ValidateDEK validates that a DEK is suitable for AES-256-GCM.
+func ValidateDEK(dek []byte) error {
+	if len(dek) != dekSize {
+		return fmt.Errorf(
+			"invalid DEK length: got %d, want %d",
+			len(dek),
+			dekSize,
+		)
+	}
+
+	return nil
+}
+
 // GenerateDEK creates a random 256-bit Data Encryption Key.
 func GenerateDEK() ([]byte, error) {
 	dek := make([]byte, dekSize)
@@ -39,8 +52,8 @@ func formatCiphertext(nonce string, ciphertext string) string {
 //
 //	ENC[AES256_GCM,<base64 nonce>,<base64 ciphertext>]
 func EncryptString(plaintext string, dek []byte) (string, error) {
-	if len(dek) != dekSize {
-		return "", fmt.Errorf("invalid DEK length: got %d, want %d", len(dek), dekSize)
+	if err := ValidateDEK(dek); err != nil {
+		return "", err
 	}
 
 	block, err := aes.NewCipher(dek)
@@ -65,8 +78,8 @@ func EncryptString(plaintext string, dek []byte) (string, error) {
 
 // DecryptString decrypts a ciphertext produced by EncryptString.
 func DecryptString(ciphertext string, dek []byte) (string, error) {
-	if len(dek) != dekSize {
-		return "", fmt.Errorf("invalid DEK length: got %d, want %d", len(dek), dekSize)
+	if err := ValidateDEK(dek); err != nil {
+		return "", err
 	}
 
 	if !strings.HasPrefix(ciphertext, prefix) ||


### PR DESCRIPTION
Part of #1200

## Overview

Add an encrypted repo metadata workflow alongside the existing mapping-based anonymization flow.

This change introduces a reusable encryption path for `RepoContextMetadata` using the previously added `EncryptionTransformer` and AES-256-GCM encryption primitives. The existing anonymization behavior remains unchanged.

## Changes

- Refactor anonymization to inject repo metadata transformers
- Add `applyWithTransformer` helper to share transformation logic
- Add `ApplyEncrypted` entrypoint backed by `EncryptionTransformer`
- Reuse existing repo metadata transformation pipeline for encryption
- Add end-to-end tests covering encrypted repo metadata transformation
- Verify encrypted values can be decrypted back to their original contents

## Notes

This PR only makes the encrypted workflow available programmatically and does not yet wire it into the scan path or CLI options.

The existing `Apply()` behavior continues to use `MappingTransformer`, while `ApplyEncrypted()` uses `EncryptionTransformer` with a caller-provided DEK.

This lays the groundwork for future encrypted report workflows and DEK management integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted anonymization for repository metadata (names, owners, commit messages) using a Data Encryption Key.

* **Improvements**
  * Added DEK validation to enforce correct key length before encryption/decryption.

* **Bug Fixes**
  * Anonymization flow updated to a transformer-based pipeline with improved nil handling and error propagation.

* **Tests**
  * Added tests for encrypted anonymization and invalid-DEK handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->