### PR TITLE
[ LFX 2026 ] Fixes bugs found before implementation of LFX 1982

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -3,6 +3,7 @@ package getter
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"time"
 
@@ -24,7 +25,7 @@ import (
 
 const (
 	securityExceptionGroup   = "kubescape.io"
-	securityExceptionVersion = "v1"
+	securityExceptionVersion = "v1beta1"
 )
 
 var (
@@ -153,7 +154,10 @@ func convertCRDObjectToPosturePolicies(
 		if !ok {
 			action = ""
 		}
-		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, "", action, expiresAt, reason, resources)
+		// frameworkName scopes the exception to a single framework; an empty value
+		// (field omitted) applies the exception framework-wide.
+		frameworkName, _ := item["frameworkName"].(string)
+		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, frameworkName, action, expiresAt, reason, resources)
 		if err != nil {
 			continue
 		}
@@ -187,17 +191,15 @@ func buildResourceDesignators(
 		designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
 	}
 
-	_, objectSelectorFound, err := unstructured.NestedFieldNoCopy(obj.Object, "spec", "match", "objectSelector")
+	// objectSelector constrains the exception to workloads carrying matching labels.
+	// matchLabels are flattened into every resource designator so the existing label
+	// comparator (opa-utils compareLabels) enforces them, AND-combined with the other
+	// match fields per the design doc. matchExpressions cannot be represented as
+	// key->value attributes, so they are best-effort for v1beta1: a warning is emitted
+	// and the rest of the exception still applies (partial application, never fail-closed).
+	objectSelectorLabels, err := objectSelectorMatchLabels(obj, kind)
 	if err != nil {
-		return nil, fmt.Errorf("read objectSelector: %w", err)
-	}
-	if objectSelectorFound {
-		logger.L().Warning("SecurityException CRD uses unsupported spec.match.objectSelector; skipping",
-			helpers.String("name", obj.GetName()),
-			helpers.String("namespace", namespace),
-			helpers.String("kind", kind),
-		)
-		return nil, fmt.Errorf("spec.match.objectSelector is not supported")
+		return nil, err
 	}
 
 	namespaceSelectorFound := false
@@ -284,7 +286,55 @@ func buildResourceDesignators(
 		designators = append(designators, map[string]string{identifiers.AttributeKind: "*"})
 	}
 
+	// AND objectSelector.matchLabels into every designator produced above.
+	if len(objectSelectorLabels) > 0 {
+		for _, designator := range designators {
+			for k, v := range objectSelectorLabels {
+				designator[k] = v
+			}
+		}
+	}
+
 	return designators, nil
+}
+
+// objectSelectorMatchLabels decodes spec.match.objectSelector and returns its
+// matchLabels as regex-escaped designator attributes (the label comparator treats
+// values as regexes). matchExpressions are not representable as key->value attributes
+// and are logged as best-effort rather than failing the exception.
+func objectSelectorMatchLabels(obj *unstructured.Unstructured, kind string) (map[string]string, error) {
+	selectorRaw, found, err := unstructured.NestedFieldCopy(obj.Object, "spec", "match", "objectSelector")
+	if err != nil {
+		return nil, fmt.Errorf("read objectSelector: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	selectorMap, ok := selectorRaw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("objectSelector has unexpected type")
+	}
+	labelSelector := metav1.LabelSelector{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(selectorMap, &labelSelector); err != nil {
+		return nil, fmt.Errorf("decode objectSelector: %w", err)
+	}
+
+	if len(labelSelector.MatchExpressions) > 0 {
+		logger.L().Warning("SecurityException spec.match.objectSelector.matchExpressions is best-effort for v1beta1 and is not applied; matchLabels (if any) still apply",
+			helpers.String("name", obj.GetName()),
+			helpers.String("namespace", obj.GetNamespace()),
+			helpers.String("kind", kind),
+		)
+	}
+
+	if len(labelSelector.MatchLabels) == 0 {
+		return nil, nil
+	}
+	escaped := make(map[string]string, len(labelSelector.MatchLabels))
+	for k, v := range labelSelector.MatchLabels {
+		escaped[k] = regexp.QuoteMeta(v)
+	}
+	return escaped, nil
 }
 
 // resolveNamespaceSelector returns namespace names matching a label selector.

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -81,6 +81,12 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 	for i := range seList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(&seList.Items[i], "SecurityException", g.k8sClient)
 		if convErr != nil {
+			// Partial application: skip this one CRD but keep the rest, and make the
+			// drop observable instead of silently swallowing it.
+			logger.L().Warning("skipping SecurityException that failed to convert to posture exceptions",
+				helpers.String("name", seList.Items[i].GetName()),
+				helpers.String("namespace", seList.Items[i].GetNamespace()),
+				helpers.Error(convErr))
 			continue
 		}
 		out = append(out, policies...)
@@ -93,6 +99,11 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 	for i := range cseList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(&cseList.Items[i], "ClusterSecurityException", g.k8sClient)
 		if convErr != nil {
+			// Partial application: skip this one CRD but keep the rest, and make the
+			// drop observable instead of silently swallowing it.
+			logger.L().Warning("skipping ClusterSecurityException that failed to convert to posture exceptions",
+				helpers.String("name", cseList.Items[i].GetName()),
+				helpers.Error(convErr))
 			continue
 		}
 		out = append(out, policies...)

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -207,7 +207,9 @@ func buildResourceDesignators(
 	// objectSelector constrains the exception to workloads carrying matching labels.
 	// matchLabels are flattened into every resource designator so the existing label
 	// comparator (opa-utils compareLabels) enforces them, AND-combined with the other
-	// match fields per the design doc. matchExpressions cannot be represented as
+	// match fields per the design doc. Note: matchLabels are matched against the
+	// resource's own top-level metadata.labels (workload.GetLabels()), not the
+	// pod-template/selector labels. matchExpressions cannot be represented as
 	// key->value attributes, so they are best-effort for v1beta1: a warning is emitted
 	// and the rest of the exception still applies (partial application, never fail-closed).
 	objectSelectorLabels, err := objectSelectorMatchLabels(obj, kind)

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -186,10 +186,12 @@ func buildResourceDesignators(
 ) ([]map[string]string, error) {
 	designators := make([]map[string]string, 0, 2)
 
+	// A namespaced SecurityException is implicitly scoped to its own namespace. That
+	// scope is carried per resource designator below (and as a fallback when no
+	// resources/objectSelector narrow it); it must NOT be added as a standalone
+	// designator here, or it would be OR'd with the narrower ones and widen the
+	// exception back to the whole namespace.
 	namespace := obj.GetNamespace()
-	if kind == "SecurityException" && namespace != "" {
-		designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
-	}
 
 	// objectSelector constrains the exception to workloads carrying matching labels.
 	// matchLabels are flattened into every resource designator so the existing label
@@ -282,8 +284,14 @@ func buildResourceDesignators(
 	}
 
 	// Ensure the exception has at least one scope designator, otherwise exception processor ignores it.
+	// A namespaced SecurityException with no narrowing falls back to its whole namespace;
+	// a cluster-scoped one falls back to all kinds.
 	if len(designators) == 0 && !namespaceSelectorFound {
-		designators = append(designators, map[string]string{identifiers.AttributeKind: "*"})
+		if kind == "SecurityException" && namespace != "" {
+			designators = append(designators, map[string]string{identifiers.AttributeNamespace: namespace})
+		} else {
+			designators = append(designators, map[string]string{identifiers.AttributeKind: "*"})
+		}
 	}
 
 	// AND objectSelector.matchLabels into every designator produced above.

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -21,7 +21,7 @@ func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
 	client := fake.NewSimpleDynamicClient(scheme,
 		&unstructured.Unstructured{
 			Object: map[string]any{
-				"apiVersion": "kubescape.io/v1",
+				"apiVersion": "kubescape.io/v1beta1",
 				"kind":       "SecurityException",
 				"metadata": map[string]any{
 					"name":      "se-a",
@@ -38,7 +38,7 @@ func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
 		},
 		&unstructured.Unstructured{
 			Object: map[string]any{
-				"apiVersion": "kubescape.io/v1",
+				"apiVersion": "kubescape.io/v1beta1",
 				"kind":       "ClusterSecurityException",
 				"metadata": map[string]any{
 					"name": "cse-a",
@@ -94,7 +94,7 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds,
 		&unstructured.Unstructured{
 			Object: map[string]any{
-				"apiVersion": "kubescape.io/v1",
+				"apiVersion": "kubescape.io/v1beta1",
 				"kind":       "ClusterSecurityException",
 				"metadata": map[string]any{
 					"name": "cse-staging",
@@ -125,7 +125,7 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 
 func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "ClusterSecurityException"})
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1beta1", Kind: "ClusterSecurityException"})
 	obj.SetName("cse-empty")
 	obj.SetUID("uid-cse")
 	obj.Object["spec"] = map[string]any{
@@ -140,26 +140,140 @@ func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 	assert.Equal(t, "*", policies[0].Resources[0].Attributes[identifiers.AttributeKind])
 }
 
-func TestConvertCRDObjectToPosturePolicies_ObjectSelectorIsRejected(t *testing.T) {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1", Kind: "SecurityException"})
-	obj.SetName("se-selector")
-	obj.SetNamespace("team-a")
-	obj.Object["spec"] = map[string]any{
-		"match": map[string]any{
-			"objectSelector": map[string]any{
-				"matchLabels": map[string]any{"app": "nginx"},
-			},
+func TestConvertCRDObjectToPosturePolicies_FrameworkName(t *testing.T) {
+	tests := []struct {
+		name          string
+		postureItem   map[string]any
+		wantFramework string
+	}{
+		{
+			name:          "frameworkName is carried into the posture policy",
+			postureItem:   map[string]any{"controlID": "C-0034", "frameworkName": "NSA", "action": "alert_only"},
+			wantFramework: "NSA",
 		},
-		"posture": []any{
-			map[string]any{"controlID": "C-0100", "action": "ignore"},
+		{
+			name:          "omitted frameworkName scopes the exception framework-wide",
+			postureItem:   map[string]any{"controlID": "C-0034", "action": "alert_only"},
+			wantFramework: "",
 		},
 	}
 
-	policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException", nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "spec.match.objectSelector is not supported")
-	assert.Nil(t, policies)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "SecurityException",
+				"metadata":   map[string]any{"name": "se-fw", "namespace": "team-a"},
+				"spec":       map[string]any{"posture": []any{tc.postureItem}},
+			}}
+
+			policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException", nil)
+			require.NoError(t, err)
+			require.Len(t, policies, 1)
+			assert.Equal(t, tc.wantFramework, policies[0].PosturePolicies[0].FrameworkName)
+		})
+	}
+}
+
+func TestBuildResourceDesignators_ObjectSelector(t *testing.T) {
+	tests := []struct {
+		name      string
+		kind      string
+		namespace string
+		selector  map[string]any
+		resources []map[string]any
+		want      []map[string]string
+	}{
+		{
+			name:      "matchLabels on namespaced SecurityException ANDs labels into the namespace scope",
+			kind:      "SecurityException",
+			namespace: "team-a",
+			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			want: []map[string]string{
+				{identifiers.AttributeNamespace: "team-a", "app": "nginx"},
+			},
+		},
+		{
+			name:      "matchLabels AND resources merge into the resource designator",
+			kind:      "ClusterSecurityException",
+			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			resources: []map[string]any{{"kind": "Deployment", "name": "web"}},
+			want: []map[string]string{
+				{
+					identifiers.AttributeKind: "Deployment",
+					identifiers.AttributeName: "web",
+					"app":                     "nginx",
+				},
+			},
+		},
+		{
+			name:      "label values are regex-escaped",
+			kind:      "SecurityException",
+			namespace: "team-a",
+			selector:  map[string]any{"matchLabels": map[string]any{"version": "1.25"}},
+			want: []map[string]string{
+				{identifiers.AttributeNamespace: "team-a", "version": `1\.25`},
+			},
+		},
+		{
+			name:      "matchExpressions are best-effort and do not fail or constrain the exception",
+			kind:      "SecurityException",
+			namespace: "team-a",
+			selector: map[string]any{
+				"matchExpressions": []any{
+					map[string]any{"key": "env", "operator": "In", "values": []any{"prod"}},
+				},
+			},
+			want: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+		},
+		{
+			name:      "matchLabels apply alongside ignored matchExpressions",
+			kind:      "SecurityException",
+			namespace: "team-a",
+			selector: map[string]any{
+				"matchLabels": map[string]any{"app": "nginx"},
+				"matchExpressions": []any{
+					map[string]any{"key": "env", "operator": "In", "values": []any{"prod"}},
+				},
+			},
+			want: []map[string]string{
+				{identifiers.AttributeNamespace: "team-a", "app": "nginx"},
+			},
+		},
+		{
+			name:     "matchLabels merge into the default cluster-wide scope",
+			kind:     "ClusterSecurityException",
+			selector: map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			want: []map[string]string{
+				{identifiers.AttributeKind: "*", "app": "nginx"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       tc.kind,
+				"metadata":   map[string]any{"name": "exception-a", "namespace": tc.namespace},
+				"spec": map[string]any{
+					"match":   map[string]any{"objectSelector": tc.selector},
+					"posture": []any{map[string]any{"controlID": "C-0001", "action": "ignore"}},
+				},
+			}}
+			if len(tc.resources) > 0 {
+				resources := make([]any, 0, len(tc.resources))
+				for _, res := range tc.resources {
+					resources = append(resources, res)
+				}
+				obj.Object["spec"].(map[string]any)["match"].(map[string]any)["resources"] = resources
+			}
+
+			got, err := buildResourceDesignators(obj, tc.kind, nil)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
 }
 
 func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
@@ -290,7 +404,7 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 				match["resources"] = resources
 			}
 			obj := &unstructured.Unstructured{Object: map[string]any{
-				"apiVersion": "kubescape.io/v1",
+				"apiVersion": "kubescape.io/v1beta1",
 				"kind":       tc.kind,
 				"metadata": map[string]any{
 					"name":      "exception-a",

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -123,6 +123,72 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 	assert.Equal(t, "ClusterSecurityException", exceptions[0].Attributes["securityExceptionKind"])
 }
 
+func TestCRDExceptionsGetter_PartialApplicationOnConversionError(t *testing.T) {
+	listKinds := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds,
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kubescape.io/v1beta1",
+			"kind":       "SecurityException",
+			"metadata":   map[string]any{"name": "se-good", "namespace": "team-a", "uid": "uid-good"},
+			"spec": map[string]any{
+				"posture": []any{map[string]any{"controlID": "C-0001", "action": "ignore"}},
+			},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kubescape.io/v1beta1",
+			"kind":       "SecurityException",
+			"metadata":   map[string]any{"name": "se-bad", "namespace": "team-a", "uid": "uid-bad"},
+			"spec": map[string]any{
+				// objectSelector is a string instead of an object -> conversion fails.
+				"match":   map[string]any{"objectSelector": "not-a-map"},
+				"posture": []any{map[string]any{"controlID": "C-0002", "action": "ignore"}},
+			},
+		}},
+	)
+
+	getter := &CRDExceptionsGetter{client: client}
+	exceptions, err := getter.GetExceptions("cluster-a")
+	require.NoError(t, err, "a single malformed CRD must not fail the whole getter")
+	require.Len(t, exceptions, 1, "the valid CRD must still be applied when another one fails to convert")
+	assert.Equal(t, "C-0001", exceptions[0].PosturePolicies[0].ControlID)
+}
+
+func TestBuildResourceDesignators_ObjectSelectorWithNamespaceSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging", Labels: map[string]string{"env": "staging"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging-2", Labels: map[string]string{"env": "staging"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod", Labels: map[string]string{"env": "prod"}}},
+	).Build()
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kubescape.io/v1beta1",
+		"kind":       "ClusterSecurityException",
+		"metadata":   map[string]any{"name": "cse-all"},
+		"spec": map[string]any{
+			"match": map[string]any{
+				"namespaceSelector": map[string]any{"matchLabels": map[string]any{"env": "staging"}},
+				"objectSelector":    map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+				"resources":         []any{map[string]any{"kind": "Deployment", "name": "web"}},
+			},
+			"posture": []any{map[string]any{"controlID": "C-0001", "action": "ignore"}},
+		},
+	}}
+
+	// objectSelector.matchLabels must merge into the namespace x resource cross product,
+	// AND-combined with both the resolved namespaces and the resource scope.
+	got, err := buildResourceDesignators(obj, "ClusterSecurityException", k8sClient)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []map[string]string{
+		{identifiers.AttributeNamespace: "staging", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web", "app": "nginx"},
+		{identifiers.AttributeNamespace: "staging-2", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web", "app": "nginx"},
+	}, got)
+}
+
 func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "kubescape.io", Version: "v1beta1", Kind: "ClusterSecurityException"})

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -175,6 +175,73 @@ func TestConvertCRDObjectToPosturePolicies_FrameworkName(t *testing.T) {
 	}
 }
 
+func TestBuildResourceDesignators_NamespacedScopeIsNotWidened(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []map[string]any
+		selector  map[string]any
+		want      []map[string]string
+	}{
+		{
+			name:      "resources narrow the scope without a bare-namespace designator",
+			resources: []map[string]any{{"kind": "Deployment", "name": "web"}},
+			want: []map[string]string{
+				{
+					identifiers.AttributeNamespace: "team-a",
+					identifiers.AttributeKind:      "Deployment",
+					identifiers.AttributeName:      "web",
+				},
+			},
+		},
+		{
+			name: "no narrowing falls back to the whole namespace",
+			want: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+		},
+		{
+			name:      "objectSelector AND resources is a strict intersection",
+			resources: []map[string]any{{"kind": "Deployment", "name": "web"}},
+			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			want: []map[string]string{
+				{
+					identifiers.AttributeNamespace: "team-a",
+					identifiers.AttributeKind:      "Deployment",
+					identifiers.AttributeName:      "web",
+					"app":                          "nginx",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match := map[string]any{}
+			if tc.selector != nil {
+				match["objectSelector"] = tc.selector
+			}
+			if len(tc.resources) > 0 {
+				resources := make([]any, 0, len(tc.resources))
+				for _, res := range tc.resources {
+					resources = append(resources, res)
+				}
+				match["resources"] = resources
+			}
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "SecurityException",
+				"metadata":   map[string]any{"name": "se-scoped", "namespace": "team-a"},
+				"spec": map[string]any{
+					"match":   match,
+					"posture": []any{map[string]any{"controlID": "C-0034", "action": "ignore"}},
+				},
+			}}
+
+			got, err := buildResourceDesignators(obj, "SecurityException", nil)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
+
 func TestBuildResourceDesignators_ObjectSelector(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -1,11 +1,18 @@
 package getter
 
-import "github.com/armosec/armoapi-go/armotypes"
+import (
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+)
+
+const exceptionKeySeparator = "/"
 
 var _ IExceptionsGetter = &MergedExceptionsGetter{}
 
 // MergedExceptionsGetter combines exceptions from a primary source and a secondary source.
-// Primary source failures are returned as errors; secondary source failures are ignored.
+// Primary source failures are returned as errors; secondary source failures are logged and ignored.
 type MergedExceptionsGetter struct {
 	primary   IExceptionsGetter
 	secondary IExceptionsGetter
@@ -31,6 +38,10 @@ func (g *MergedExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.
 
 	crdExceptions, err := g.secondary.GetExceptions(clusterName)
 	if err != nil {
+		// Secondary (CRD) failures must not break the scan, but a swallowed error hides
+		// version skew or RBAC gaps; surface it at Warning so it is observable.
+		logger.L().Warning("failed to get CRD security exceptions; continuing with primary exceptions only",
+			helpers.Error(err))
 		return exceptions, nil
 	}
 
@@ -38,8 +49,86 @@ func (g *MergedExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.
 		return exceptions, nil
 	}
 
-	merged := make([]armotypes.PostureExceptionPolicy, 0, len(exceptions)+len(crdExceptions))
-	merged = append(merged, exceptions...)
-	merged = append(merged, crdExceptions...)
-	return merged, nil
+	return deduplicateExceptions(exceptions, crdExceptions), nil
+}
+
+// deduplicateExceptions enforces the design review's precedence rule: cloud/file
+// (primary) exceptions are added first, and a CRD exception is appended only for the
+// control+workload designators not already covered by a primary exception. Partial
+// overlaps keep the non-overlapping designators of the CRD exception.
+func deduplicateExceptions(
+	cloudExceptions []armotypes.PostureExceptionPolicy,
+	crdExceptions []armotypes.PostureExceptionPolicy,
+) []armotypes.PostureExceptionPolicy {
+	if len(cloudExceptions) == 0 && len(crdExceptions) == 0 {
+		return []armotypes.PostureExceptionPolicy{}
+	}
+
+	covered := make(map[string]struct{}, len(cloudExceptions))
+	for _, cloud := range cloudExceptions {
+		for _, policy := range cloud.PosturePolicies {
+			if policy.ControlID == "" {
+				continue
+			}
+			for _, resource := range cloud.Resources {
+				covered[exceptionDedupKey(policy.ControlID, resource)] = struct{}{}
+			}
+		}
+	}
+
+	merged := make([]armotypes.PostureExceptionPolicy, 0, len(cloudExceptions)+len(crdExceptions))
+	merged = append(merged, cloudExceptions...)
+	if len(crdExceptions) == 0 {
+		return merged
+	}
+
+	for _, crd := range crdExceptions {
+		// Exceptions without resolvable control+workload keys can't be deduped; keep them.
+		if len(crd.Resources) == 0 || len(crd.PosturePolicies) == 0 {
+			merged = append(merged, crd)
+			continue
+		}
+		filteredResources := make([]identifiers.PortalDesignator, 0, len(crd.Resources))
+		for _, resource := range crd.Resources {
+			if !isResourceCovered(crd.PosturePolicies, resource, covered) {
+				filteredResources = append(filteredResources, resource)
+			}
+		}
+		if len(filteredResources) == 0 {
+			continue
+		}
+		filteredPolicy := crd
+		filteredPolicy.Resources = filteredResources
+		merged = append(merged, filteredPolicy)
+	}
+
+	return merged
+}
+
+func isResourceCovered(
+	policies []armotypes.PosturePolicy,
+	resource identifiers.PortalDesignator,
+	covered map[string]struct{},
+) bool {
+	for _, policy := range policies {
+		if policy.ControlID == "" {
+			continue
+		}
+		if _, found := covered[exceptionDedupKey(policy.ControlID, resource)]; found {
+			return true
+		}
+	}
+	return false
+}
+
+func exceptionDedupKey(controlID string, designator identifiers.PortalDesignator) string {
+	apiGroup := ""
+	if designator.Attributes != nil {
+		apiGroup = designator.Attributes[identifiers.AttributeApiGroup]
+	}
+	return controlID + exceptionKeySeparator +
+		designator.GetNamespace() + exceptionKeySeparator +
+		designator.GetName() + exceptionKeySeparator +
+		designator.GetKind() + exceptionKeySeparator +
+		apiGroup
 }

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,6 +77,118 @@ func TestMergedExceptionsGetter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Len(t, out, tc.wantLen)
+		})
+	}
+}
+
+// posturePolicy builds a posture exception scoping controlID to the given workloads.
+func posturePolicy(policyType, controlID string, workloads ...map[string]string) armotypes.PostureExceptionPolicy {
+	resources := make([]identifiers.PortalDesignator, 0, len(workloads))
+	for _, w := range workloads {
+		resources = append(resources, identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
+			Attributes:     w,
+		})
+	}
+	return armotypes.PostureExceptionPolicy{
+		PolicyType:      policyType,
+		Resources:       resources,
+		PosturePolicies: []armotypes.PosturePolicy{{ControlID: controlID}},
+	}
+}
+
+func nginx(namespace string) map[string]string {
+	return map[string]string{
+		identifiers.AttributeNamespace: namespace,
+		identifiers.AttributeKind:      "Deployment",
+		identifiers.AttributeName:      "nginx",
+	}
+}
+
+func redis(namespace string) map[string]string {
+	return map[string]string{
+		identifiers.AttributeNamespace: namespace,
+		identifiers.AttributeKind:      "Deployment",
+		identifiers.AttributeName:      "redis",
+	}
+}
+
+// TestMergedExceptionsGetter_Deduplication covers the design review's precedence rule:
+// cloud/file (primary) exceptions win on overlap, CRD (secondary) exceptions are kept
+// only for control+workload pairs not already covered, and partial overlaps keep the
+// non-overlapping designators.
+func TestMergedExceptionsGetter_Deduplication(t *testing.T) {
+	tests := []struct {
+		name  string
+		cloud []armotypes.PostureExceptionPolicy
+		crd   []armotypes.PostureExceptionPolicy
+		want  []armotypes.PostureExceptionPolicy
+	}{
+		{
+			name:  "full overlap drops the CRD exception",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
+			want:  []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+		},
+		{
+			name:  "no overlap keeps both exceptions",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", redis("production"))},
+			want: []armotypes.PostureExceptionPolicy{
+				posturePolicy("cloud", "C-0034", nginx("production")),
+				posturePolicy("crd", "C-0034", redis("production")),
+			},
+		},
+		{
+			name:  "different control on same workload is not an overlap",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0035", nginx("production"))},
+			want: []armotypes.PostureExceptionPolicy{
+				posturePolicy("cloud", "C-0034", nginx("production")),
+				posturePolicy("crd", "C-0035", nginx("production")),
+			},
+		},
+		{
+			name:  "partial overlap keeps only the non-overlapping designators",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"), redis("production"))},
+			want: []armotypes.PostureExceptionPolicy{
+				posturePolicy("cloud", "C-0034", nginx("production")),
+				posturePolicy("crd", "C-0034", redis("production")),
+			},
+		},
+		{
+			name:  "CRD exception without resolvable workload keys is kept",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   []armotypes.PostureExceptionPolicy{{PolicyType: "crd", PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}}}},
+			want: []armotypes.PostureExceptionPolicy{
+				posturePolicy("cloud", "C-0034", nginx("production")),
+				{PolicyType: "crd", PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}}},
+			},
+		},
+		{
+			name:  "only cloud exceptions",
+			cloud: []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+			crd:   nil,
+			want:  []armotypes.PostureExceptionPolicy{posturePolicy("cloud", "C-0034", nginx("production"))},
+		},
+		{
+			name:  "only CRD exceptions",
+			cloud: nil,
+			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
+			want:  []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			getter := NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: tc.cloud},
+				&exceptionsGetterStub{exceptions: tc.crd},
+			)
+			got, err := getter.GetExceptions("cluster-a")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/core/pkg/securityexception/exception_events.go
+++ b/core/pkg/securityexception/exception_events.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	securityExceptionAPIVersion = "kubescape.io/v1"
+	securityExceptionAPIVersion = "kubescape.io/v1beta1"
 	crdKindAttribute            = "securityExceptionKind"
 	crdNameAttribute            = "securityExceptionName"
 	crdNamespaceAttribute       = "securityExceptionNamespace"

--- a/core/pkg/securityexception/exception_events_test.go
+++ b/core/pkg/securityexception/exception_events_test.go
@@ -1,0 +1,87 @@
+package securityexception
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnstructuredForCRD(t *testing.T) {
+	ref := CRDReference{
+		Kind:      "SecurityException",
+		Name:      "se-a",
+		Namespace: "team-a",
+		UID:       "uid-1",
+	}
+
+	obj := UnstructuredForCRD(ref)
+
+	// The Event's involvedObject.apiVersion must match the version the Helm chart
+	// registers the CRD at, otherwise the reference dangles.
+	assert.Equal(t, "kubescape.io/v1beta1", obj.GetAPIVersion())
+	assert.Equal(t, "SecurityException", obj.GetKind())
+	assert.Equal(t, "se-a", obj.GetName())
+	assert.Equal(t, "team-a", obj.GetNamespace())
+	assert.Equal(t, "uid-1", string(obj.GetUID()))
+}
+
+func TestUnstructuredForCRD_ClusterScoped(t *testing.T) {
+	obj := UnstructuredForCRD(CRDReference{Kind: "ClusterSecurityException", Name: "cse-a"})
+
+	assert.Equal(t, "kubescape.io/v1beta1", obj.GetAPIVersion())
+	assert.Equal(t, "ClusterSecurityException", obj.GetKind())
+	assert.Equal(t, "cse-a", obj.GetName())
+	assert.Empty(t, obj.GetNamespace())
+	assert.Empty(t, string(obj.GetUID()))
+}
+
+func TestCRDReferenceAttributesRoundTrip(t *testing.T) {
+	ref := CRDReference{
+		Kind:      "SecurityException",
+		Name:      "se-a",
+		Namespace: "team-a",
+		UID:       "uid-1",
+	}
+
+	policy := armotypes.PostureExceptionPolicy{}
+	policy.Attributes = CRDReferenceAttributes(ref)
+
+	got, ok := CRDReferenceFromPolicy(policy)
+	require.True(t, ok)
+	assert.Equal(t, ref, got)
+}
+
+func TestCRDReferenceAttributesOmitsEmptyOptionalFields(t *testing.T) {
+	attrs := CRDReferenceAttributes(CRDReference{Kind: "ClusterSecurityException", Name: "cse-a"})
+
+	assert.Equal(t, "ClusterSecurityException", attrs[crdKindAttribute])
+	assert.Equal(t, "cse-a", attrs[crdNameAttribute])
+	assert.NotContains(t, attrs, crdNamespaceAttribute)
+	assert.NotContains(t, attrs, crdUIDAttribute)
+}
+
+func TestCRDReferenceFromPolicyNotCRDBacked(t *testing.T) {
+	withAttrs := func(attrs map[string]interface{}) armotypes.PostureExceptionPolicy {
+		policy := armotypes.PostureExceptionPolicy{}
+		policy.Attributes = attrs
+		return policy
+	}
+
+	tests := []struct {
+		name   string
+		policy armotypes.PostureExceptionPolicy
+	}{
+		{name: "nil attributes", policy: armotypes.PostureExceptionPolicy{}},
+		{name: "missing kind", policy: withAttrs(map[string]interface{}{crdNameAttribute: "se-a"})},
+		{name: "missing name", policy: withAttrs(map[string]interface{}{crdKindAttribute: "SecurityException"})},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := CRDReferenceFromPolicy(tc.policy)
+			assert.False(t, ok)
+		})
+	}
+}

--- a/deploy/crd/security-exception-crd.yaml
+++ b/deploy/crd/security-exception-crd.yaml
@@ -13,7 +13,7 @@ spec:
       - se
   scope: Namespaced
   versions:
-    - name: v1
+    - name: v1beta1
       served: true
       storage: true
       schema:


### PR DESCRIPTION
## Overview

The posture side of the SecurityException CRD (`CRDExceptionsGetter → convert → MergedExceptionsGetter`, already merged into `main` under kubescape/kubescape#1982) had a cluster of correctness bugs that made the feature inert or over-broad once exercised end-to-end. This PR fixes them together, since they all live in the same getter pipeline and share one test surface.

It resolves four filed issues plus one bug found during the work:

- **#2361** — version skew: the getter listed `kubescape.io/v1`, but the Helm chart ships the CRD at `v1beta1`, so the getter never saw the installed resource and the error was swallowed.
- **#2362** — `spec.posture[].frameworkName` was dropped during conversion, excepting a control across *all* frameworks.
- **#2363** — `spec.match.objectSelector` was rejected wholesale, silently discarding every posture entry in the CRD.
- **#2364** — cloud and CRD exceptions were concatenated with no precedence/dedup.
- **namespace-widening**  — a namespaced `SecurityException` scoped with `resources`/`objectSelector` also emitted a bare whole-namespace designator that OR'd away the narrowing.

**Current behavior**
- Getter queries `kubescape.io/v1` → `404 NotFound` on a Helm-installed cluster; `MergedExceptionsGetter` discards the error → posture exceptions silently do nothing.
- A posture entry's `frameworkName` is ignored → the control is excepted under every framework.
- Any `objectSelector` → the whole CRD's posture entries are dropped (only a `Warning` log).
- Cloud + CRD exceptions are appended unconditionally → overlapping control+workload pairs double-applied, winner undefined.
- A namespaced `SecurityException` scoped to `Deployment/web` is excepted across the **entire** namespace.

**New behavior**
- Getter, emitted Event `apiVersion`, and the stray standalone CRD manifest all use `v1beta1`; the previously-swallowed CRD getter error is logged at `Warning`.
- `frameworkName` is carried into `PosturePolicy.FrameworkName`; omitted → framework-wide (unchanged).
- `objectSelector.matchLabels` constrains the exception to matching workloads (AND-combined with `resources`/`namespaceSelector`); `matchExpressions` is best-effort for `v1beta1` (logged, never fail-closed).
- Cloud/file exceptions take precedence; CRD exceptions are appended only for control+workload designators not already covered (partial overlaps keep their non-overlapping designators).
- A namespaced `SecurityException` with `resources`/`objectSelector` is scoped to exactly those; the whole-namespace designator is only a fallback when nothing narrows it.

## Additional Information

**Where the fixes live**

- `core/cautils/getter/crdexceptionsgetter.go`
  - `securityExceptionVersion` → `v1beta1` (#2361).
  - Posture loop now reads `item["frameworkName"]` and plumbs it into the converter (#2362).
  - `objectSelectorMatchLabels` decodes `spec.match.objectSelector`, **regex-escapes** label values (the downstream comparator treats them as regexes — `1.25` would otherwise be a regex), and ANDs them into every designator; `matchExpressions` is logged and skipped, not fatal (#2363).
  - The bare-namespace designator was removed from the top of `buildResourceDesignators` and folded into the final fallback, namespace-aware (`{namespace}` for namespaced, `{kind:"*"}` for cluster-scoped) so it only applies when nothing else scopes the exception .
- `core/cautils/getter/mergedexceptionsgetter.go` — ports `deduplicateExceptions` / `isResourceCovered` / `exceptionDedupKey` (salvaged from the stalled #2317, adapted to the current `MergedExceptionsGetter` rather than re-adding a `primary` field to the getter). Cloud first; CRD per-designator dedup keyed on `controlID + namespace + name + kind + apiGroup`. Also logs the swallowed secondary error at `Warning` (#2361 hardening, #2364).
- `core/pkg/securityexception/exception_events.go` — Event `involvedObject.apiVersion` → `kubescape.io/v1beta1` (#2361).
- `deploy/crd/security-exception-crd.yaml` — stray standalone manifest version → `v1beta1` (#2361).

**Why `matchExpressions` is best-effort.** A designator can only express *"label key exists and its value matches this anchored regex"* — a positive, per-key AND (`opa-utils/exceptions/comparator.go:compareLabels` + `regexCompare`'s `^…$`). The negating operators `NotIn` and `DoesNotExist` need "value ≠ x" / "key absent", which RE2 (no negative lookahead) and a positive, key-must-exist comparator cannot represent. Rather than fail the whole exception, the supported parts (`matchLabels`, `resources`, namespace scope) apply and a single scoped `Warning` is emitted for the unrepresentable expressions.

**after this PR**: carry the raw `LabelSelector` on the exception and evaluate it with `labels.Selector.Matches(workloadLabels)` in the comparator at scan time. That supports every operator, stays always-fresh (no fetch-time snapshot / TOCTOU), and needs no extra API calls — at the cost of a cross-repo change (`armoapi-go` type + `opa-utils` comparator), which is the change #2363 deliberately deferred for the `v1beta1` milestone. The follow-up also explicitly rejects the design doc's fetch-time-resolution approach, which is getter-only but stale-by-construction. `In` and `Exists` are in fact already encodable as designator regexes (`(a|b)` / `.*`) and could be picked up in either this or the follow-up if desired.

**No opa-utils change required.** `objectSelector.matchLabels` rides the existing path: non-reserved designator keys route into the label bucket (`armoapi-go/identifiers/designators_methods.go`) and `compareLabels` matches them against workload labels (`opa-utils/exceptions/comparator.go`). The OR semantics of designators (`opa-utils/exceptions/exceptionprocessor.go:159-166`) are also what made the namespace-widening bug observable.

## How to Test

```bash
go test ./core/cautils/getter/... ./core/pkg/securityexception/...
```

All packages pass; `gofmt` and `go vet` are clean.

Regression tests added (table-driven, colocated with the code under test — no throwaway reproducer files):

| Test | Issue | What it pins down |
| --- | --- | --- |
| `TestCRDExceptionsGetter_GetExceptions` (fixtures now `v1beta1`) | #2361 | Getter lists the GroupVersion the chart ships; a regression to `v1` fails the fake client |
| `TestUnstructuredForCRD` / `_ClusterScoped` | #2361 | Emitted Event `apiVersion` is `kubescape.io/v1beta1` |
| `TestConvertCRDObjectToPosturePolicies_FrameworkName` | #2362 | `frameworkName` carried when set, empty (framework-wide) when omitted |
| `TestBuildResourceDesignators_ObjectSelector` | #2363 | matchLabels alone / AND resources / regex-escaping / matchExpressions best-effort / default cluster scope |
| `TestMergedExceptionsGetter_Deduplication` | #2364 | Full / partial / no overlap, different-control, no-key, single-source |
| `TestBuildResourceDesignators_NamespacedScopeIsNotWidened` | not filed | resources narrow without a bare-namespace designator; no-narrowing falls back to the whole namespace; objectSelector AND resources is a strict intersection |
| `TestCRDReferenceAttributesRoundTrip` / `_OmitsEmptyOptionalFields` / `TestCRDReferenceFromPolicyNotCRDBacked` | #2361 | CRD-reference attribute round-trip and negative cases |

## Examples

`buildResourceDesignators` for a namespaced `SecurityException` in `team-a` scoped to `Deployment/web` :

| Code state | Designators produced |
| --- | --- |
| **Before** | `[{namespace:team-a}, {namespace:team-a, kind:Deployment, name:web}]` — `[0]` excepts the whole namespace |
| **After (this PR)** | `[{namespace:team-a, kind:Deployment, name:web}]` — scoped exactly as written |

## Related issues/PRs

- Resolves #2361, #2362, #2363, #2364
- Resolves the namespace-widening
- Supersedes #2317 (its `deduplicateExceptions` logic is ported into the current `MergedExceptionsGetter`)
- **Follow-up after this lands:** full `objectSelector.matchExpressions` support via scan-time `LabelSelector` evaluation in the comparator. Tracks the cross-repo `armoapi-go`/`opa-utils` change intentionally out of scope here.
- Part of #1982

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SecurityException CRD schema updated to v1beta1
  * Exception deduplication now prevents overlapping coverage between CRD and primary exceptions
  * Framework names are preserved during security exception conversion

* **Bug Fixes**
  * Individual CRD conversion failures no longer block processing of remaining exceptions; warnings are logged instead

* **Tests**
  * Added comprehensive test coverage for exception handling, deduplication, and CRD reference management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->