### PR TITLE
fix(anonymizer): detect separator-less sensitive env variable names t…

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -272,6 +272,7 @@ func anonymizeUnstructuredReference(
 	ref["name"] = mapping.GetOrCreate("ref", name)
 }
 
+// isSensitiveEnvValue reports whether an env var value looks like a secret.
 func isSensitiveEnvValue(value string) bool {
 	value = strings.ToLower(value)
 
@@ -294,24 +295,22 @@ func isSensitiveEnvValue(value string) bool {
 	return false
 }
 
+// isSensitiveEnvName reports whether an env var name looks like a credential.
 func isSensitiveEnvName(name string) bool {
 	name = strings.ToLower(name)
 
-	// Normalize the name by removing common separators
+	// strip common separators so APIKEY matches api_key
 	normalized := name
 	for _, sep := range []string{"_", "-", ".", " "} {
 		normalized = strings.ReplaceAll(normalized, sep, "")
 	}
 
-	// Patterns are matched against the separator-normalized name
 	sensitivePatterns := []string{
 		"password",
 		"passwd",
 		"pwd",
 		"secret",
-		"secretkey",
 		"token",
-		"authtoken",
 		"apikey",
 		"accesskey",
 		"privatekey",

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -297,26 +297,36 @@ func isSensitiveEnvValue(value string) bool {
 func isSensitiveEnvName(name string) bool {
 	name = strings.ToLower(name)
 
+	// Normalize the name by removing common separators
+	normalized := name
+	for _, sep := range []string{"_", "-", ".", " "} {
+		normalized = strings.ReplaceAll(normalized, sep, "")
+	}
+
+	// Patterns are matched against the separator-normalized name
 	sensitivePatterns := []string{
 		"password",
 		"passwd",
 		"pwd",
 		"secret",
+		"secretkey",
 		"token",
-		"api_key",
-		"access_key",
+		"authtoken",
+		"apikey",
+		"accesskey",
+		"privatekey",
 		"credential",
-		"database_url",
-		"db_url",
-		"redis_url",
-		"mongo_uri",
-		"mongodb_uri",
+		"databaseurl",
+		"dburl",
+		"redisurl",
+		"mongouri",
+		"mongodburi",
 		"dsn",
-		"connection_string",
+		"connectionstring",
 	}
 
 	for _, pattern := range sensitivePatterns {
-		if strings.Contains(name, pattern) {
+		if strings.Contains(normalized, pattern) {
 			return true
 		}
 	}

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -793,7 +793,7 @@ func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
 }
 
 func TestAnonymizeUnstructuredEnv_LeaksApiKeyValue(t *testing.T) {
-	const secret = "AKIAIOSFODNN7EXAMPLE"
+	const secret = "AKIAIOSFODNN7EXAMPLE" //nolint:gosec // G101: AWS example access key ID, test fixture, not a real credential
 
 	container := map[string]interface{}{
 		"env": []interface{}{

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -763,3 +763,52 @@ func TestAnonymizeContainerList_InvalidType(t *testing.T) {
 		anonymizeContainerList(obj, "containers", mapping)
 	})
 }
+
+func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
+	cases := map[string]bool{
+		"API_KEY":          true,
+		"APIKEY":           true,
+		"ACCESS_KEY":       true,
+		"ACCESSKEY":        true,
+		"PRIVATEKEY":       true,
+		"PRIVATE_KEY":      true,
+		"SECRETKEY":        true,
+		"AUTHTOKEN":        true,
+		"AUTH_TOKEN":       true,
+		"app.api-key":      true,
+		"CREDENTIAL":       true,
+		"DATABASE_URL":     true,
+		"DATABASEURL":      true,
+		"CONNECTIONSTRING": true,
+		"NORMAL_ENV":       false,
+		"PORT":             false,
+		"LOG_LEVEL":        false,
+	}
+
+	for name, want := range cases {
+		if got := isSensitiveEnvName(name); got != want {
+			t.Errorf("isSensitiveEnvName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestAnonymizeUnstructuredEnv_LeaksApiKeyValue(t *testing.T) {
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+
+	container := map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{
+				"name":  "APIKEY",
+				"value": secret,
+			},
+		},
+	}
+
+	mapping := NewMapping()
+	anonymizeUnstructuredEnv(container, mapping)
+
+	got := container["env"].([]interface{})[0].(map[string]interface{})["value"].(string)
+	if got == secret {
+		t.Fatalf("env var APIKEY value was not anonymized; secret leaked into output")
+	}
+}


### PR DESCRIPTION
…o prevent credential leak

## Overview

The anonymizer could leak sensitive container environment variable values when the variable name used a separator-less credential naming convention (e.g. `APIKEY`, `ACCESSKEY`, `PRIVATEKEY`).

**Current behavior:** `isSensitiveEnvName()` matched names against patterns that embedded separators (`api_key`, `access_key`) using `strings.Contains`. As a result, separator-less variants did not match - `APIKEY` → `apikey` does not contain `api_key` - and keywords like `privatekey`, `secretkey`, and `authtoken` were not covered at all. When the value itself also didn't match any sensitive-value pattern, the original secret was emitted in clear text in the anonymized output.

**New behavior:** `isSensitiveEnvName()` now normalizes the name by stripping common separators (`_`, `-`, `.`, spaces) before matching, and the keyword list was rewritten in separator-less form and expanded (`apikey`, `accesskey`, `privatekey`, `secretkey`, `authtoken`, etc.). Sensitive credential names are now detected regardless of separator usage, so their values are correctly replaced via the anonymization mapping.

## Additional Information

The fix is scoped to name detection only; value-based detection (`isSensitiveEnvValue`) is unchanged. Both the typed (`anonymizeTypedEnv`) and unstructured (`anonymizeUnstructuredEnv`) code paths share `isSensitiveEnvName`, so both are covered.

## How to Test

```bash
# Unit tests for the package
go test ./core/pkg/anonymizer/ -v

# The specific reproduction case from the issue
go test ./core/pkg/anonymizer/ -run TestAnonymizeUnstructuredEnv_LeaksApiKeyValue -v

# Lint and build
golangci-lint run ./core/pkg/anonymizer/
make build
```

All tests pass, lint reports 0 issues, and the build succeeds. Two tests were added:
- `TestAnonymizeUnstructuredEnv_LeaksApiKeyValue` - the reproduction case from the issue (fails before the fix, passes after).
- `TestIsSensitiveEnvName_SeparatorlessVariants` - covers separator-less and separated variants plus negative cases (`PORT`, `LOG_LEVEL`).

## Related issues/PRs:

* Resolved #2357 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sensitive environment variables by normalizing names (case and common separators) and recognizing additional keyword variants to reduce accidental exposure of secrets.

* **Tests**
  * Added coverage for separatorless and variant formats of sensitive env names.
  * Added tests to ensure anonymization of unstructured environment entries prevents leakage of sensitive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->