### PR TITLE
Feat/opa cosign context propagation

### DIFF
--- a/core/pkg/opaprocessor/cosign_verify.go
+++ b/core/pkg/opaprocessor/cosign_verify.go
@@ -44,7 +44,9 @@ type VerifyCommand struct {
 
 // Exec runs the verification command
 func verify(ctx context.Context, img string, key string) (bool, error) {
-
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("context canceled before verification: %w", err)
+	}
 	co := &cosign.CheckOpts{}
 	var ociremoteOpts []ociremote.Option
 	attachment := ""
@@ -66,10 +68,16 @@ func verify(ctx context.Context, img string, key string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("resolving attachment type %s for image %s: %w", attachment, img, err)
 	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("context canceled before Rekor public key retrieval: %w", err)
+	}
 
 	co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
 	if err != nil {
 		return false, fmt.Errorf("getting Rekor public keys: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("context canceled before signature verification: %w", err)
 	}
 
 	_, _, err = cosign.VerifyImageSignatures(ctx, ref, co)

--- a/core/pkg/opaprocessor/cosign_verify_test.go
+++ b/core/pkg/opaprocessor/cosign_verify_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_verify(t *testing.T) {
@@ -56,4 +58,34 @@ func Test_verify(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "verify(%v, %v)", tt.args.img, tt.args.key)
 		})
 	}
+}
+
+func TestVerify_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := verify(
+		ctx,
+		"quay.io/kubescape/kubescape:v3.0.3",
+		"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbgIMZrMTTlEFDLEeZXz+4R/908BG\nEeO70x6oMN7E4JQgzgbCB5rinqhK5t7dB61saVKQTb4P2NGtjPjXVbSTwQ==\n-----END PUBLIC KEY-----\n",
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestVerify_DeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	time.Sleep(time.Millisecond)
+
+	_, err := verify(
+		ctx,
+		"quay.io/kubescape/kubescape:v3.0.3",
+		"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbgIMZrMTTlEFDLEeZXz+4R/908BG\nEeO70x6oMN7E4JQgzgbCB5rinqhK5t7dB61saVKQTb4P2NGtjPjXVbSTwQ==\n-----END PUBLIC KEY-----\n",
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }


### PR DESCRIPTION
## Summary

This PR adds a small fix to make Cosign verification stop early when the OPA context is cancelled or times out.

## What changed

* Added early `ctx.Err()` checks inside `verify()`
* Stop verification before expensive Rekor and Cosign calls when the context is cancelled
* Prevent unnecessary work after scan cancellation or timeout
* Added tests for cancelled contexts
* Added tests for expired deadlines

## Tests

Added cancellation and deadline-focused tests to verify fail-fast behavior during verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context cancellation detection during signature verification with more specific error messages at each checkpoint.

* **Tests**
  * Added test coverage for context cancellation and timeout scenarios during the verification process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->