### PR TITLE
fix(scan): reject invalid format values before scanning

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -65,6 +65,9 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
+				return err
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -79,6 +79,9 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
+				return err
+			}
 			if err := validateFrameworkScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -52,6 +52,9 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
 			}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ImageScanFormats); err != nil {
+				return err
+			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -69,6 +69,20 @@ func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
 	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, sarif", err.Error())
 }
 
+func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parent := &cobra.Command{}
+	parent.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "", "")
+	parent.AddCommand(cmd)
+	assert.NoError(t, parent.PersistentFlags().Set("format", "xml"))
+
+	err := cmd.RunE(cmd, []string{"nginx"})
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, sarif`)
+}
+
 func TestGetImageCmd_RunE_Success(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	scanInfo := cautils.ScanInfo{}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -55,6 +55,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
+				return err
+			}
 			requestedView := scanInfo.View
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {
 				return err

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -379,6 +379,16 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
+func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+
+	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
+
+	err := cmd.RunE(cmd, []string{"."})
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif`)
+}
+
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -67,6 +67,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
 			}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
+				return err
+			}
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -3,11 +3,18 @@ package shared
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
+)
+
+// ScanFormats and ImageScanFormats list the output formats supported by the scan commands.
+var (
+	ScanFormats      = []string{"pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"}
+	ImageScanFormats = []string{"pretty-printer", "json", "sarif"}
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))
@@ -40,6 +47,20 @@ func ValidateSeverity(severity string) error {
 	}
 	return ErrUnknownSeverity
 
+}
+
+// ValidateScanFormat returns an error if any comma-separated entry in format is not a supported format.
+func ValidateScanFormat(format string, supported []string) error {
+	for _, f := range strings.Split(format, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if !slices.Contains(supported, f) {
+			return fmt.Errorf("invalid format %q, supported formats: %s", f, strings.Join(supported, ", "))
+		}
+	}
+	return nil
 }
 
 // TerminateOnExceedingSeverity terminates the program if the result exceeds the severity threshold

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
 // ScanFormats and ImageScanFormats list the output formats supported by the scan commands.
+// They are built from the printer.*Format constants to keep a single source of truth.
 var (
-	ScanFormats      = []string{"pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"}
-	ImageScanFormats = []string{"pretty-printer", "json", "sarif"}
+	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat}
+	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat}
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))
@@ -51,14 +53,21 @@ func ValidateSeverity(severity string) error {
 
 // ValidateScanFormat returns an error if any comma-separated entry in format is not a supported format.
 func ValidateScanFormat(format string, supported []string) error {
+	var entries int
 	for _, f := range strings.Split(format, ",") {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
 		}
+		entries++
 		if !slices.Contains(supported, f) {
 			return fmt.Errorf("invalid format %q, supported formats: %s", f, strings.Join(supported, ", "))
 		}
+	}
+	// Reject separator/whitespace-only input (e.g. "," or " ") that resolves to no format.
+	// A truly empty value is left to the caller's "format cannot be empty" check.
+	if entries == 0 && strings.TrimSpace(format) != "" {
+		return fmt.Errorf("invalid format %q, supported formats: %s", format, strings.Join(supported, ", "))
 	}
 	return nil
 }

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -110,6 +110,8 @@ func TestValidateScanFormat(t *testing.T) {
 		{"valid comma-separated formats", "json,html,junit", ScanFormats, false},
 		{"comma-separated with whitespace and empty entry", "json, ,html", ScanFormats, false},
 		{"empty string is not an invalid format", "", ScanFormats, false},
+		{"separator-only input is rejected", ",", ScanFormats, true},
+		{"whitespace-and-separator-only input is rejected", " , ", ScanFormats, true},
 		{"invalid format", "xml", ScanFormats, true},
 		{"mixed valid and invalid formats", "json,xml", ScanFormats, true},
 		{"valid image format", "sarif", ImageScanFormats, false},

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -98,6 +98,38 @@ func TestTerminateOnExceedingSeverity(t *testing.T) {
 	}
 }
 
+func TestValidateScanFormat(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Format      string
+		Supported   []string
+		WantErr     bool
+	}{
+		{"valid single format", "json", ScanFormats, false},
+		{"valid default format", "pretty-printer", ScanFormats, false},
+		{"valid comma-separated formats", "json,html,junit", ScanFormats, false},
+		{"comma-separated with whitespace and empty entry", "json, ,html", ScanFormats, false},
+		{"empty string is not an invalid format", "", ScanFormats, false},
+		{"invalid format", "xml", ScanFormats, true},
+		{"mixed valid and invalid formats", "json,xml", ScanFormats, true},
+		{"valid image format", "sarif", ImageScanFormats, false},
+		{"format unsupported for image scanning", "junit", ImageScanFormats, true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			err := ValidateScanFormat(testCase.Format, testCase.Supported)
+			if testCase.WantErr {
+				if err == nil {
+					t.Errorf("expected an error for format %q, got nil", testCase.Format)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error for format %q, got: %v", testCase.Format, err)
+			}
+		})
+	}
+}
+
 func TestValidateSeverity(t *testing.T) {
 	testCases := []struct {
 		Description string


### PR DESCRIPTION
## Overview

When an invalid `--format` value (e.g. `xml`) is passed to `kubescape scan` or any of its subcommands, the tool currently emits a warning and **silently falls back to `pretty-printer`**, running the entire scan to completion instead of failing - silently ignoring what the user asked for.

**Current behavior:**
```
$ kubescape scan --format xml
{"level":"warn","msg":"Invalid format \"xml\", default format \"pretty-printer\" is applied"}
{"level":"info","msg":"Initialized scanner"}
... (full scan continues and completes)
```

**New behavior** (fails fast, before any scan work, matching `kubescape list`):
```
$ kubescape scan --format xml
Error: invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif
```

The root cause was that the existing `RunE` checks only rejected *empty* format strings; any non-empty invalid value passed through, and the real rejection happened deep inside `NewPrinter()` which only warned and fell back.

This PR adds a `ValidateScanFormat()` helper in `cmd/shared/scan.go` (alongside the existing `ValidateSeverity()`) and calls it early in the `RunE` of all five affected commands, before any scan work begins. This follows the same early-validation pattern already used by `cmd/patch`.

## Additional Information

- The `--format` flag accepts comma-separated multiple formats (e.g. `--format json,html,junit`), so `ValidateScanFormat()` splits on commas, trims whitespace, and validates each entry - rejecting the first unsupported one.
- The empty-format case is left to the existing `"format cannot be empty"` check, so its message is unchanged.
- `scan image` validates against the smaller supported subset (`pretty-printer, json, sarif`).
- `NewPrinter()` / `ValidatePrinter()` were intentionally left untouched as defense-in-depth - they remain reachable via the HTTP server / SDK paths and their existing tests depend on the fallback.

## How to Test

```bash
# Build
go build ./...

# Each of these should now error immediately, before "Initialized scanner":
kubescape scan --format xml .
kubescape scan framework nsa --format xml
kubescape scan control C-0057 --format xml
kubescape scan workload deploy/nginx --format xml
kubescape scan image nginx --format xml        # -> image subset message

# Regression - valid formats still scan normally (no false rejection):
kubescape scan --format json .
kubescape scan --format json,html,junit -o result .
kubescape scan .                               # default pretty-printer

# Unit tests
go test ./cmd/scan/... ./cmd/shared/...
```

## Related issues/PRs:

* Resolved #2320 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan commands now validate requested output formats against supported options earlier in execution, producing clear errors for unsupported or malformed format values.

* **Tests**
  * Added unit tests covering format validation and error messages for scan, image and workload command flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->