### PR TITLE
fix(resourcehandler): fail fast on cancelled contexts after resource pulls

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -416,6 +416,15 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors)
+			if err := ctx.Err(); err != nil {
+				mu.Lock()
+				failedQueries[qr.GroupVersionResourceTriplet] = queryFailure{
+					gvr: qr.GroupVersionResourceTriplet,
+					err: err,
+				}
+				mu.Unlock()
+				return
+			}
 
 			if len(selectorErrs) > 0 {
 				mu.Lock()

--- a/core/pkg/resourcehandler/k8sresources_context_test.go
+++ b/core/pkg/resourcehandler/k8sresources_context_test.go
@@ -192,3 +192,48 @@ func TestScanInfo_ScanTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestPullResources_PostPullContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{
+			DynamicClient: &mockDynamicClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					cancel()
+
+					return &unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{},
+						},
+					}, nil
+				},
+			},
+		},
+	}
+
+	qrs := QueryableResources{
+		"//v1/pods": QueryableResource{
+			GroupVersionResourceTriplet: "//v1/pods",
+		},
+	}
+
+	k8sResources, allResources, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{})
+
+	ids, ok := k8sResources["//v1/pods"]
+	assert.True(t, ok)
+	assert.Empty(t, ids)
+
+	assert.Empty(t, allResources)
+	assert.NotEmpty(t, failedQueries)
+
+	hasCanceled := false
+	for _, f := range failedQueries {
+		if errors.Is(f.err, context.Canceled) {
+			hasCanceled = true
+			break
+		}
+	}
+
+	assert.True(t, hasCanceled)
+}


### PR DESCRIPTION
## Summary

Adds a post-fetch `ctx.Err()` check after `pullSingleResource()` to stop unnecessary resource processing when cancellation occurs immediately after resource retrieval.

## Changes

* Added a post-fetch cancellation check
* Stopped selector handling and aggregation work after cancellation
* Added regression test coverage for post-retrieval cancellation
* Reduced unnecessary post-cancellation processing
* Improved shutdown responsiveness during concurrent scans

## Testing

Added regression coverage for cancellation immediately after resource retrieval and verified existing context cancellation tests continue to pass.
