### PR TITLE
reportcrypto: add DEK wrapping support

### DIFF
--- a/core/pkg/reportcrypto/dek.go
+++ b/core/pkg/reportcrypto/dek.go
@@ -1,0 +1,57 @@
+package reportcrypto
+
+import (
+	"encoding/base64"
+)
+
+// WrapDEK encrypts a DEK using the provided master key
+// and returns a base64-encoded encrypted representation
+// suitable for storing in report metadata.
+func WrapDEK(
+	dek []byte,
+	masterKey []byte,
+) (string, error) {
+
+	if err := ValidateDEK(dek); err != nil {
+		return "", err
+	}
+
+	encryptedDEK, err := EncryptString(
+		base64.StdEncoding.EncodeToString(dek),
+		masterKey,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return encryptedDEK, nil
+}
+
+// UnwrapDEK decrypts a wrapped DEK using the provided
+// master key and returns the original DEK bytes.
+func UnwrapDEK(
+	wrappedDEK string,
+	masterKey []byte,
+) ([]byte, error) {
+
+	dekString, err := DecryptString(
+		wrappedDEK,
+		masterKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	dek, err := base64.StdEncoding.DecodeString(
+		dekString,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ValidateDEK(dek); err != nil {
+		return nil, err
+	}
+
+	return dek, nil
+}

--- a/core/pkg/reportcrypto/dek.go
+++ b/core/pkg/reportcrypto/dek.go
@@ -2,7 +2,22 @@ package reportcrypto
 
 import (
 	"encoding/base64"
+	"fmt"
 )
+
+// validateMasterKey validates that a master key is suitable
+// for wrapping and unwrapping DEKs.
+func validateMasterKey(masterKey []byte) error {
+	if len(masterKey) != dekSize {
+		return fmt.Errorf(
+			"invalid master key length: got %d, want %d",
+			len(masterKey),
+			dekSize,
+		)
+	}
+
+	return nil
+}
 
 // WrapDEK encrypts a DEK using the provided master key
 // and returns a base64-encoded encrypted representation
@@ -13,6 +28,10 @@ func WrapDEK(
 ) (string, error) {
 
 	if err := ValidateDEK(dek); err != nil {
+		return "", err
+	}
+
+	if err := validateMasterKey(masterKey); err != nil {
 		return "", err
 	}
 
@@ -33,6 +52,10 @@ func UnwrapDEK(
 	wrappedDEK string,
 	masterKey []byte,
 ) ([]byte, error) {
+
+	if err := validateMasterKey(masterKey); err != nil {
+		return nil, err
+	}
 
 	dekString, err := DecryptString(
 		wrappedDEK,

--- a/core/pkg/reportcrypto/dek_test.go
+++ b/core/pkg/reportcrypto/dek_test.go
@@ -57,3 +57,66 @@ func TestUnwrapDEKWrongMasterKey(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, unwrappedDEK)
 }
+
+func TestWrapDEKInvalidDEK(t *testing.T) {
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		[]byte("invalid-dek"),
+		masterKey,
+	)
+
+	assert.Error(t, err)
+	assert.Empty(t, wrappedDEK)
+}
+
+func TestWrapDEKInvalidMasterKey(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		[]byte("invalid-master-key"),
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "master key")
+	assert.Empty(t, wrappedDEK)
+}
+
+func TestUnwrapDEKMalformedCiphertext(t *testing.T) {
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	dek, err := UnwrapDEK(
+		"malformed-ciphertext",
+		masterKey,
+	)
+
+	assert.Error(t, err)
+	assert.Nil(t, dek)
+}
+
+func TestUnwrapDEKInvalidMasterKey(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	unwrappedDEK, err := UnwrapDEK(
+		wrappedDEK,
+		[]byte("invalid-master-key"),
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "master key")
+	assert.Nil(t, unwrappedDEK)
+}

--- a/core/pkg/reportcrypto/dek_test.go
+++ b/core/pkg/reportcrypto/dek_test.go
@@ -1,0 +1,59 @@
+package reportcrypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapAndUnwrapDEK(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	unwrappedDEK, err := UnwrapDEK(
+		wrappedDEK,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		dek,
+		unwrappedDEK,
+	)
+}
+
+func TestUnwrapDEKWrongMasterKey(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrongMasterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	unwrappedDEK, err := UnwrapDEK(
+		wrappedDEK,
+		wrongMasterKey,
+	)
+
+	assert.Error(t, err)
+	assert.Nil(t, unwrappedDEK)
+}


### PR DESCRIPTION
Part of #1200 

## Overview
Add support for wrapping and unwrapping Data Encryption Keys (DEKs) using AES-256-GCM.

This change introduces reusable primitives that allow a generated DEK to be encrypted with a master key before being stored in report metadata. The wrapped DEK can later be recovered using the same master key.

## Changes

* Add `WrapDEK` helper for encrypting DEKs with a master key
* Add `UnwrapDEK` helper for recovering DEKs from wrapped ciphertext
* Reuse existing AES-256-GCM encryption primitives
* Add tests covering:

  * successful wrap/unwrap roundtrip
  * unwrap failure with an incorrect master key
## Related Notes

Upcoming report encryption work requires storing an encrypted DEK alongside report metadata. This PR introduces the cryptographic building blocks needed for that workflow while keeping report generation and metadata integration as a follow-up change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added DEK wrap/unwrap support to handle encrypted key storage and retrieval.
* **Tests**
  * Added comprehensive tests verifying wrap/unwrap behavior and error handling for invalid or mismatched keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->