### PR TITLE
feat(opaprocessor): add per-control evaluation timeout

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -139,6 +139,10 @@ func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
 		return ErrOmitRawResourcesOrSubmit
 	}
 
+	if err := validateControlTimeout(scanInfo); err != nil {
+		return err
+	}
+
 	if err := shared.ValidateSeverity(severity); severity != "" && err != nil {
 		return err
 	}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -42,6 +42,7 @@ var (
 
 	ErrSecurityViewNotSupported = errors.New("security view is not supported for framework scan")
 	ErrBadThreshold             = errors.New("bad argument: out of range threshold")
+	ErrControlTimeoutTooHigh    = errors.New("--control-timeout must be lower than --scan-timeout")
 	ErrKeepLocalOrSubmit        = errors.New("you can use `keep-local` or `submit`, but not both")
 	ErrOmitRawResourcesOrSubmit = errors.New("you can use `omit-raw-resources` or `submit`, but not both")
 )
@@ -246,6 +247,9 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if scanInfo.Submit && scanInfo.OmitRawResources {
 		return ErrOmitRawResourcesOrSubmit
 	}
+	if err := validateControlTimeout(scanInfo); err != nil {
+		return err
+	}
 	severity := scanInfo.FailThresholdSeverity
 	if err := shared.ValidateSeverity(severity); severity != "" && err != nil {
 		return err
@@ -253,6 +257,16 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 
 	// Validate the user's credentials
 	return cautils.ValidateAccountID(scanInfo.AccountID)
+}
+
+// validateControlTimeout ensures --control-timeout, when set alongside
+// --scan-timeout, leaves room for at least one control to be evaluated
+// before the overall scan deadline expires.
+func validateControlTimeout(scanInfo *cautils.ScanInfo) error {
+	if scanInfo.ControlTimeout > 0 && scanInfo.ScanTimeout > 0 && scanInfo.ControlTimeout >= scanInfo.ScanTimeout {
+		return ErrControlTimeoutTooHigh
+	}
+	return nil
 }
 
 // validateThresholdsOnly validates only the numeric threshold ranges
@@ -269,5 +283,5 @@ func validateThresholdsOnly(scanInfo *cautils.ScanInfo) error {
 	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
 		return ErrBadThreshold
 	}
-	return nil
+	return validateControlTimeout(scanInfo)
 }

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -119,6 +119,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")
+	scanCmd.PersistentFlags().DurationVar(&scanInfo.ControlTimeout, "control-timeout", 0, "Maximum duration for evaluating a single control (e.g. 30s, 1m). 0 means no timeout. Controls that exceed this are marked as not evaluated and the scan continues. Must be lower than --scan-timeout when both are set.")
 
 	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
 	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -47,10 +47,13 @@ type NotEvaluatedControl struct {
 }
 
 // BuildScanCoverage derives a ScanCoverage from the InfoMap,
-// ResourceToControlsMap, and any partial GVR pull failures on the session.
+// ResourceToControlsMap, timedOutControls, and any partial GVR pull failures
+// on the session.
 //
 // A control is considered NotEvaluated when every GVR listed in
-// ResourceToControlsMap for that control appears in InfoMap as a pull failure.
+// ResourceToControlsMap for that control appears in InfoMap as a pull failure,
+// or when it appears in timedOutControls because its evaluation was aborted
+// (e.g. by exceeding --control-timeout).
 // Controls with at least one successfully fetched GVR are not included.
 //
 // InfoMap is mixed-purpose: it holds whole-GVR pull failures (keyed by GVR
@@ -60,27 +63,28 @@ type NotEvaluatedControl struct {
 //
 // partialPulls carries per-selector LIST failures for GVRs that were partially
 // collected; they are included as-is in ScanCoverage.PartialGVRPulls.
-func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, partialPulls []PartialGVRPull) ScanCoverage {
+func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull) ScanCoverage {
 	coverage := ScanCoverage{
 		PartialGVRPulls: partialPulls,
 	}
 
-	if len(infoMap) == 0 {
-		return coverage
-	}
+	notEvaluated := make(map[string]NotEvaluatedControl, len(timedOutControls))
 
-	notEvaluated := make(map[string]NotEvaluatedControl)
-
-	// eval-phase: controls whose evaluation was aborted (e.g. --control-timeout)
-	// are recorded directly in InfoMap keyed by controlID with SubStatusNotEvaluated.
-	for controlID, statusInfo := range infoMap {
-		if statusInfo.InnerStatus != apis.StatusSkipped || statusInfo.SubStatus != apis.SubStatusNotEvaluated {
-			continue
-		}
+	for controlID, reason := range timedOutControls {
 		notEvaluated[controlID] = NotEvaluatedControl{
 			ControlID: controlID,
-			Reason:    statusInfo.InnerInfo,
+			Reason:    reason,
 		}
+	}
+
+	if len(infoMap) == 0 {
+		for _, ne := range notEvaluated {
+			coverage.NotEvaluatedControls = append(coverage.NotEvaluatedControls, ne)
+		}
+		sort.Slice(coverage.NotEvaluatedControls, func(i, j int) bool {
+			return coverage.NotEvaluatedControls[i].ControlID < coverage.NotEvaluatedControls[j].ControlID
+		})
+		return coverage
 	}
 
 	if len(resourceToControlsMap) > 0 {

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -36,11 +36,14 @@ type PartialGVRPull struct {
 	Error    string `json:"error"`
 }
 
-// NotEvaluatedControl records a control that was skipped because every GVR it
-// depends on failed to pull.
+// NotEvaluatedControl records a control that was not evaluated, either
+// because every GVR it depends on failed to pull (MissingGVRs is set) or
+// because its evaluation was aborted during the OPA processing phase, e.g.
+// by exceeding --control-timeout (Reason is set).
 type NotEvaluatedControl struct {
 	ControlID   string   `json:"controlID"`
-	MissingGVRs []string `json:"missingGVRs"`
+	MissingGVRs []string `json:"missingGVRs,omitempty"`
+	Reason      string   `json:"reason,omitempty"`
 }
 
 // BuildScanCoverage derives a ScanCoverage from the InfoMap,
@@ -62,71 +65,91 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 		PartialGVRPulls: partialPulls,
 	}
 
-	if len(infoMap) == 0 || len(resourceToControlsMap) == 0 {
+	if len(infoMap) == 0 {
 		return coverage
 	}
 
-	// collect failed GVR pulls from InfoMap, filtering out resource-level
-	// eval skips by requiring the key to be a known GVR
-	for gvr, statusInfo := range infoMap {
-		if statusInfo.InnerStatus != apis.StatusSkipped {
+	notEvaluated := make(map[string]NotEvaluatedControl)
+
+	// eval-phase: controls whose evaluation was aborted (e.g. --control-timeout)
+	// are recorded directly in InfoMap keyed by controlID with SubStatusNotEvaluated.
+	for controlID, statusInfo := range infoMap {
+		if statusInfo.InnerStatus != apis.StatusSkipped || statusInfo.SubStatus != apis.SubStatusNotEvaluated {
 			continue
 		}
-		if _, isGVR := resourceToControlsMap[gvr]; !isGVR {
-			continue
+		notEvaluated[controlID] = NotEvaluatedControl{
+			ControlID: controlID,
+			Reason:    statusInfo.InnerInfo,
 		}
-		coverage.FailedGVRPulls = append(coverage.FailedGVRPulls, FailedGVRPull{
-			GVR:   gvr,
-			Error: statusInfo.InnerInfo,
+	}
+
+	if len(resourceToControlsMap) > 0 {
+		// collect failed GVR pulls from InfoMap, filtering out resource-level
+		// eval skips by requiring the key to be a known GVR
+		for gvr, statusInfo := range infoMap {
+			if statusInfo.InnerStatus != apis.StatusSkipped {
+				continue
+			}
+			if _, isGVR := resourceToControlsMap[gvr]; !isGVR {
+				continue
+			}
+			coverage.FailedGVRPulls = append(coverage.FailedGVRPulls, FailedGVRPull{
+				GVR:   gvr,
+				Error: statusInfo.InnerInfo,
+			})
+		}
+
+		if len(coverage.FailedGVRPulls) > 0 {
+			// build a set of failed GVRs for fast lookup
+			failedGVRs := make(map[string]struct{}, len(coverage.FailedGVRPulls))
+			for _, f := range coverage.FailedGVRPulls {
+				failedGVRs[f.GVR] = struct{}{}
+			}
+
+			// invert ResourceToControlsMap: controlID -> set of GVRs it depends on
+			controlToGVRs := make(map[string]map[string]struct{})
+			for gvr, controlIDs := range resourceToControlsMap {
+				for _, controlID := range controlIDs {
+					if _, ok := controlToGVRs[controlID]; !ok {
+						controlToGVRs[controlID] = make(map[string]struct{})
+					}
+					controlToGVRs[controlID][gvr] = struct{}{}
+				}
+			}
+
+			// a control is not-evaluated only when ALL its GVRs are in the failed set
+			for controlID, gvrSet := range controlToGVRs {
+				if _, ok := notEvaluated[controlID]; ok {
+					continue
+				}
+				missingGVRs := make([]string, 0, len(gvrSet))
+				allFailed := true
+				for gvr := range gvrSet {
+					if _, failed := failedGVRs[gvr]; failed {
+						missingGVRs = append(missingGVRs, gvr)
+					} else {
+						allFailed = false
+						break
+					}
+				}
+				if allFailed && len(missingGVRs) == len(gvrSet) {
+					sort.Strings(missingGVRs)
+					notEvaluated[controlID] = NotEvaluatedControl{
+						ControlID:   controlID,
+						MissingGVRs: missingGVRs,
+					}
+				}
+			}
+		}
+
+		sort.Slice(coverage.FailedGVRPulls, func(i, j int) bool {
+			return coverage.FailedGVRPulls[i].GVR < coverage.FailedGVRPulls[j].GVR
 		})
 	}
 
-	if len(coverage.FailedGVRPulls) == 0 {
-		return coverage
+	for _, ne := range notEvaluated {
+		coverage.NotEvaluatedControls = append(coverage.NotEvaluatedControls, ne)
 	}
-
-	// build a set of failed GVRs for fast lookup
-	failedGVRs := make(map[string]struct{}, len(coverage.FailedGVRPulls))
-	for _, f := range coverage.FailedGVRPulls {
-		failedGVRs[f.GVR] = struct{}{}
-	}
-
-	// invert ResourceToControlsMap: controlID -> set of GVRs it depends on
-	controlToGVRs := make(map[string]map[string]struct{})
-	for gvr, controlIDs := range resourceToControlsMap {
-		for _, controlID := range controlIDs {
-			if _, ok := controlToGVRs[controlID]; !ok {
-				controlToGVRs[controlID] = make(map[string]struct{})
-			}
-			controlToGVRs[controlID][gvr] = struct{}{}
-		}
-	}
-
-	// a control is not-evaluated only when ALL its GVRs are in the failed set
-	for controlID, gvrSet := range controlToGVRs {
-		missingGVRs := make([]string, 0, len(gvrSet))
-		allFailed := true
-		for gvr := range gvrSet {
-			if _, failed := failedGVRs[gvr]; failed {
-				missingGVRs = append(missingGVRs, gvr)
-			} else {
-				allFailed = false
-				break
-			}
-		}
-		if allFailed && len(missingGVRs) == len(gvrSet) {
-			sort.Strings(missingGVRs)
-			coverage.NotEvaluatedControls = append(coverage.NotEvaluatedControls, NotEvaluatedControl{
-				ControlID:   controlID,
-				MissingGVRs: missingGVRs,
-			})
-		}
-	}
-
-	// stable, deterministic output for JSON / golden tests
-	sort.Slice(coverage.FailedGVRPulls, func(i, j int) bool {
-		return coverage.FailedGVRPulls[i].GVR < coverage.FailedGVRPulls[j].GVR
-	})
 	sort.Slice(coverage.NotEvaluatedControls, func(i, j int) bool {
 		return coverage.NotEvaluatedControls[i].ControlID < coverage.NotEvaluatedControls[j].ControlID
 	})

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildScanCoverage_EmptyInfoMap(t *testing.T) {
-	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil)
+	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -17,7 +17,7 @@ func TestBuildScanCoverage_NoFailedGVRs(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusPassed},
 	}
-	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil)
+	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -32,7 +32,7 @@ func TestBuildScanCoverage_FailedGVRPopulated(t *testing.T) {
 	resourceToControlsMap := map[string][]string{
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, "networking.k8s.io/v1/networkpolicies", coverage.FailedGVRPulls[0].GVR)
 	assert.Equal(t, "RBAC denied", coverage.FailedGVRPulls[0].Error)
@@ -44,7 +44,7 @@ func TestBuildScanCoverage_NoResourceMap(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusSkipped},
 	}
-	coverage := BuildScanCoverage(infoMap, nil, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 }
 
@@ -57,7 +57,7 @@ func TestBuildScanCoverage_AllGVRsFailedControlNotEvaluated(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies":      {"C-0001", "C-0002"},
 		"rbac.authorization.k8s.io/v1/clusterroles": {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 2)
 
@@ -84,7 +84,7 @@ func TestBuildScanCoverage_IgnoresResourceLevelEvalSkips(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 
 	// Only the GVR-keyed entry should be in FailedGVRPulls
 	assert.Len(t, coverage.FailedGVRPulls, 1)
@@ -108,9 +108,9 @@ func TestBuildScanCoverage_DeterministicOrder(t *testing.T) {
 		"m/v1/mthings": {"C-0002"},
 	}
 
-	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 	for i := 0; i < 10; i++ {
-		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 		assert.Equal(t, first, next)
 	}
 
@@ -133,9 +133,30 @@ func TestBuildScanCoverage_PartialGVRFailureControlStillEvaluated(t *testing.T) 
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 1)
+	assert.Empty(t, coverage.NotEvaluatedControls)
+}
+
+func TestBuildScanCoverage_FailedGVRPullIsNotPhantomNotEvaluatedControl(t *testing.T) {
+	// recordFailedQueryStatuses writes failed GVR pulls into InfoMap keyed by
+	// GVR string using the same status pair as a timed-out control
+	// (StatusSkipped + SubStatusNotEvaluated). Without resourceToControlsMap,
+	// BuildScanCoverage must not surface this as a NotEvaluatedControl with the
+	// GVR string as ControlID.
+	infoMap := map[string]apis.StatusInfo{
+		"networking.k8s.io/v1/networkpolicies": {
+			InnerStatus: apis.StatusSkipped,
+			SubStatus:   apis.SubStatusNotEvaluated,
+			InnerInfo:   "failed to list resources",
+		},
+	}
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil)
+
+	for _, ne := range coverage.NotEvaluatedControls {
+		assert.NotEqual(t, "networking.k8s.io/v1/networkpolicies", ne.ControlID)
+	}
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
 
@@ -147,7 +168,7 @@ func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
 		{GVR: "/v1/pods", Selector: "metadata.namespace==prod", Error: "RBAC denied for prod"},
 		{GVR: "core/v1/secrets", Selector: "metadata.name==prod-secret", Error: "forbidden"},
 	}
-	coverage := BuildScanCoverage(nil, nil, partials)
+	coverage := BuildScanCoverage(nil, nil, nil, partials)
 
 	assert.Len(t, coverage.PartialGVRPulls, 2)
 	assert.Equal(t, "/v1/pods", coverage.PartialGVRPulls[0].GVR)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -142,6 +142,7 @@ type ScanInfo struct {
 	ScanImages            bool
 	UseDefaultMatchers    bool
 	ScanTimeout           time.Duration // Maximum duration for the entire scan (0 = no timeout)
+	ControlTimeout        time.Duration // Maximum duration for evaluating a single control (0 = no timeout)
 	ChartPath             string
 	FilePath              string
 	HelmValueFiles        []string // -f / --values: paths to Helm values YAML files (repeatable)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -205,6 +205,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
 	var exceptionRecorder = newSecurityExceptionEventRecorder()
 	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, exceptionRecorder)
+	reportResults.ControlTimeout = scanInfo.ControlTimeout
 	if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
 		logger.L().Ctx(ctxOpa).Error("failed to process rules", helpers.Error(err))
 		return resultsHandling, fmt.Errorf("%w", err)

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -138,7 +138,7 @@ func TestAddInfoToMap_BuildScanCoverageRecognizesHostSensorFailure(t *testing.T)
 		expectedKey: {"C-0001"},
 	}
 
-	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil)
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
 
 	require.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, expectedKey, coverage.FailedGVRPulls[0].GVR)

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -54,6 +54,9 @@ type OPAProcessor struct {
 	// control. If exceeded, the control is recorded as not evaluated instead
 	// of stalling or aborting the whole scan.
 	ControlTimeout time.Duration
+	// TimedOutControls maps controlID to the reason its evaluation was
+	// aborted after exceeding ControlTimeout.
+	TimedOutControls map[string]string
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -71,6 +74,7 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		includeNamespaces:      split(includeNamespaces),
 		printEnabled:           enableRegoPrint,
 		compiledModules:        make(map[string]*ast.Compiler),
+		TimedOutControls:       make(map[string]string),
 	}
 }
 
@@ -87,9 +91,9 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	}
 
 	// rebuild ScanCoverage so controls that timed out during evaluation
-	// (recorded in InfoMap by markControlTimedOut) are reflected in
+	// (recorded in TimedOutControls by markControlTimedOut) are reflected in
 	// NotEvaluatedControls alongside any collection-phase failures
-	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.PartialGVRFailures)
+	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures)
 
 	// edit results
 	opap.updateResults(ctx)
@@ -382,18 +386,14 @@ func (opap *OPAProcessor) markResourcesSkipped(out map[string]*resourcesresults.
 	}
 }
 
-// markControlTimedOut records in opap.InfoMap that a control's evaluation was
-// aborted after exceeding ControlTimeout, so it surfaces as a not-evaluated
-// control instead of silently stalling the scan.
+// markControlTimedOut records in opap.TimedOutControls that a control's
+// evaluation was aborted after exceeding ControlTimeout, so it surfaces as a
+// not-evaluated control instead of silently stalling the scan.
 func (opap *OPAProcessor) markControlTimedOut(control *reporthandling.Control, timeout time.Duration) {
-	if opap.InfoMap == nil {
-		return
+	if opap.TimedOutControls == nil {
+		opap.TimedOutControls = make(map[string]string)
 	}
-	opap.InfoMap[control.ControlID] = apis.StatusInfo{
-		InnerStatus: apis.StatusSkipped,
-		SubStatus:   apis.SubStatusNotEvaluated,
-		InnerInfo:   fmt.Sprintf("control evaluation timed out after %s", timeout),
-	}
+	opap.TimedOutControls[control.ControlID] = fmt.Sprintf("control evaluation timed out after %s", timeout)
 }
 
 // appendPaths appends the failedPaths, fixPaths and fixCommand to the paths slice with the resourceID

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -49,6 +50,10 @@ type OPAProcessor struct {
 	printEnabled           bool
 	compiledModules        map[string]*ast.Compiler
 	compiledMu             sync.RWMutex
+	// ControlTimeout, when non-zero, bounds the evaluation time of a single
+	// control. If exceeded, the control is recorded as not evaluated instead
+	// of stalling or aborting the whole scan.
+	ControlTimeout time.Duration
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -81,6 +86,11 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 		logger.L().Ctx(ctx).Warning(processErr.Error())
 	}
 
+	// rebuild ScanCoverage so controls that timed out during evaluation
+	// (recorded in InfoMap by markControlTimedOut) are reflected in
+	// NotEvaluatedControls alongside any collection-phase failures
+	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.PartialGVRFailures)
+
 	// edit results
 	opap.updateResults(ctx)
 
@@ -112,7 +122,21 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 
 		control := toPin
 
-		resourcesAssociatedControl, err := opap.processControl(ctx, &control)
+		var resourcesAssociatedControl map[string]resourcesresults.ResourceAssociatedControl
+		var err error
+
+		if opap.ControlTimeout > 0 {
+			cctx, cancel := context.WithTimeout(ctx, opap.ControlTimeout)
+			resourcesAssociatedControl, err = opap.processControl(cctx, &control)
+			if cctx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+				opap.markControlTimedOut(&control, opap.ControlTimeout)
+				err = nil
+			}
+			cancel()
+		} else {
+			resourcesAssociatedControl, err = opap.processControl(ctx, &control)
+		}
+
 		if err != nil {
 			processErrs = append(processErrs, fmt.Errorf("control %q: %w", control.ControlID, err))
 		}
@@ -355,6 +379,20 @@ func (opap *OPAProcessor) markResourcesSkipped(out map[string]*resourcesresults.
 		if opap.InfoMap != nil {
 			opap.InfoMap[id] = statusInfo
 		}
+	}
+}
+
+// markControlTimedOut records in opap.InfoMap that a control's evaluation was
+// aborted after exceeding ControlTimeout, so it surfaces as a not-evaluated
+// control instead of silently stalling the scan.
+func (opap *OPAProcessor) markControlTimedOut(control *reporthandling.Control, timeout time.Duration) {
+	if opap.InfoMap == nil {
+		return
+	}
+	opap.InfoMap[control.ControlID] = apis.StatusInfo{
+		InnerStatus: apis.StatusSkipped,
+		SubStatus:   apis.SubStatusNotEvaluated,
+		InnerInfo:   fmt.Sprintf("control evaluation timed out after %s", timeout),
 	}
 }
 

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -35,7 +35,7 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	opaSessionObj.AllResources = allResources
 	opaSessionObj.ExternalResources = externalResources
 	opaSessionObj.ExcludedRules = excludedRulesMap
-	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opaSessionObj.PartialGVRFailures)
+	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, nil, opaSessionObj.PartialGVRFailures)
 
 	if getErr != nil {
 		return getErr

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -350,9 +350,13 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 	}
 
 	if len(coverage.NotEvaluatedControls) > 0 {
-		fmt.Fprintf(pp.writer, "\nThe following controls were NOT evaluated (all required resource types failed to pull):\n")
+		fmt.Fprintf(pp.writer, "\nThe following controls were NOT evaluated:\n")
 		for _, c := range coverage.NotEvaluatedControls {
-			fmt.Fprintf(pp.writer, "  • %s (missing: %s)\n", c.ControlID, strings.Join(c.MissingGVRs, ", "))
+			if c.Reason != "" {
+				fmt.Fprintf(pp.writer, "  • %s (%s)\n", c.ControlID, c.Reason)
+			} else {
+				fmt.Fprintf(pp.writer, "  • %s (missing: %s)\n", c.ControlID, strings.Join(c.MissingGVRs, ", "))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Overview

Kubescape had a whole-scan timeout (`--scan-timeout`) but no per-control evaluation budget. `OPAProcessor.Process` iterates controls sequentially with a single shared context and zero per-control deadline enforcement. One slow Rego rule -- a quadratic RBAC cross-product on a large cluster, a cosign builtin doing network calls, or any future rule regression -- stalls the entire loop. The 200+ other controls never run. Using `--scan-timeout` as a workaround cancels the shared context and kills every remaining control at once, yielding no partial results and no indication of which control was the offender.

**Future behavior:** `--control-timeout` wraps each `processControl` call with `context.WithTimeout`. On `DeadlineExceeded`, the timed-out control is recorded in a dedicated `TimedOutControls` map and surfaced in `NotEvaluatedControls` via a post-eval `ScanCoverage` rebuild. The other controls complete normally. One bad rule no longer destroys an entire scan.

## Problem

- One slow control stalls the entire sequential OPA processor loop indefinitely
- `--scan-timeout` as a workaround kills all remaining controls on expiry -- no partial results, no named offender
- In operator mode there is no timeout at all -- the scan goroutine occupies the busy-state slot until the pod restarts
- The scan-coverage subsystem (`NotEvaluatedControls`, `--fail-coverage-below`) had vocabulary for collection-phase gaps but no eval-phase equivalent -- a hung-then-killed scan could claim full coverage

## Solution

```go
// Process() -- per-control timeout wrapping
if opap.ControlTimeout > 0 {
    cctx, cancel := context.WithTimeout(ctx, opap.ControlTimeout)
    err = opap.processControl(cctx, control, resourcesMap)
    cancel()
    if cctx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
        opap.markControlTimedOut(control, opap.ControlTimeout)
        continue
    }
}
```

`markControlTimedOut` writes into a dedicated `TimedOutControls map[string]string` field on `OPAProcessor` (keyed by control ID, value is the timeout reason). `BuildScanCoverage` consumes it directly in a separate pass -- completely decoupled from InfoMap to avoid the status-pair collision with `recordFailedQueryStatuses` (which writes `StatusSkipped + SubStatusNotEvaluated` keyed by GVR string for failed GVR pulls).

`ProcessRulesListener` rebuilds `ScanCoverage` after `Process` returns, passing `TimedOutControls` into `BuildScanCoverage` so timed-out controls appear in `NotEvaluatedControls` alongside collection-phase failures. The collection-phase call site passes `nil` for `timedOutControls` since no controls have run at that point.

Parent context cancellation (scan-level abort / SIGINT) is distinguished from per-control deadline via `ctx.Err()` vs `cctx.Err()` -- whole-scan cancellation still aborts promptly. Validation rejects `ControlTimeout >= ScanTimeout` when both are set.

## How to Test

```bash
kubescape scan framework nsa --control-timeout 5s
```

On a large cluster with a slow control, the scan completes with the offending control listed under `NOT evaluated` in the coverage report with the timeout reason. All other controls run normally.

Unit tests:
- `TestProcess_ControlTimeout` -- CPU-bound pure-Rego rule (cartesian product over two 100k-element arrays, no I/O, no builtins) proves the deadline fires mid-computation via topdown's per-expression cancellation check. Asserts scan completes, control lands in `TimedOutControls` and `NotEvaluatedControls` with the timeout reason.
- `TestBuildScanCoverage_FailedGVRPullIsNotPhantomNotEvaluatedControl` -- seeds InfoMap with a real `recordFailedQueryStatuses`-style entry (`StatusSkipped + SubStatusNotEvaluated` keyed by GVR string) and asserts no GVR string appears as a `ControlID` in `NotEvaluatedControls`. Regression test for the phantom control bug.

## Related issues/PRs

* Resolved #

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to set a per-control evaluation timeout.

* **Improvements**
  * Controls that exceed their timeout are marked as not evaluated while the scan continues.
  * Reporting now shows per-control reasons for not-evaluated entries when applicable.

* **Validation**
  * Prevents a control timeout from leaving no time before the overall scan deadline.

* **Tests**
  * Updated and added tests to cover timeout and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->