### PR TITLE
refactor: eliminate package-level mutable state in workload command

### DIFF
--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -36,8 +36,6 @@ var (
 	ErrInvalidWorkloadIdentifier = errors.New("invalid workload identifier")
 )
 
-var namespace string
-
 // controlCmd represents the control command
 func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
 	workloadCmd := &cobra.Command{
@@ -75,7 +73,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			}
 			kind, name, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid input: %s", err.Error())
+				return fmt.Errorf("invalid input: %w", err)
 			}
 
 			setWorkloadScanInfo(scanInfo, kind, name)
@@ -96,7 +94,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			return nil
 		},
 	}
-	workloadCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Namespace of the workload. Default will be empty.")
+	workloadCmd.PersistentFlags().StringVarP(&scanInfo.Namespace, "namespace", "n", "", "Namespace of the workload. Default will be empty.")
 	workloadCmd.PersistentFlags().StringVar(&scanInfo.FilePath, "file-path", "", "Path to the workload file.")
 	workloadCmd.PersistentFlags().StringVar(&scanInfo.ChartPath, "chart-path", "", "Path to the helm chart the workload is part of. Must be used with --file-path.")
 
@@ -108,7 +106,7 @@ func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, kind string, name string) {
 	scanInfo.ScanImages = true
 
 	scanInfo.ScanObject = &objectsenvelopes.ScanObject{}
-	scanInfo.ScanObject.SetNamespace(namespace)
+	scanInfo.ScanObject.SetNamespace(scanInfo.Namespace)
 	scanInfo.ScanObject.SetKind(kind)
 	scanInfo.ScanObject.SetName(name)
 

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -80,13 +80,7 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 		t.Run(
 			tc.Description,
 			func(t *testing.T) {
-				prevNamespace := namespace
-				t.Cleanup(func() {
-					namespace = prevNamespace
-				})
-				namespace = tc.namespace
-
-				scanInfo := &cautils.ScanInfo{FilePath: tc.filePath}
+				scanInfo := &cautils.ScanInfo{FilePath: tc.filePath, Namespace: tc.namespace}
 				setWorkloadScanInfo(scanInfo, tc.kind, tc.name)
 
 				if scanInfo.ScanType != tc.want.ScanType {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -117,6 +117,7 @@ type ScanInfo struct {
 	CustomClusterName     string                       // Set the custom name of the cluster
 	ExcludedNamespaces    string                       // used for host scanner namespace
 	IncludeNamespaces     string                       //
+	Namespace             string                       // target namespace for workload scans
 	InputPatterns         []string                     // Yaml files input patterns
 	Silent                bool                         // Silent mode - Do not print progress logs
 	FailThreshold         float32                      // DEPRECATED - Failure score threshold


### PR DESCRIPTION
### Description
This PR removes the package-level global mutable variable `var namespace string` from `cmd/scan/workload.go` and encapsulates it within the thread-safe `ScanInfo` configuration struct.

Global mutable state is an anti-pattern in Go CLI commands that compromises test isolation and limits concurrent safety. Moving this state to the local context ensures thread safety, removes flaky test bleeding, and cleans up standard boilerplate configuration.

### Issue : #2378 
### Scope & Impact
- **Surgical Refactor:** Re-binds the `--namespace` Cobra flag directly to the localized `scanInfo` reference.
- **Backward Compatible:** CLI flags, behavior, and user inputs remain completely unchanged.
- **Files Changed:** - `core/cautils/scaninfo.go` (Added field)
  - `cmd/scan/workload.go` (Removed global var, bound flag to struct)
  - `cmd/scan/workload_test.go` (Removed global state cleanups)

### Verification
- Verified all tests pass cleanly in parallel without state bleed.
- Ran `go build` and `go vet` (Clean exit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace parameter now integrated into workload scans, letting users specify target namespaces for scans.

* **Bug Fixes**
  * Improved error messaging for invalid workload identifiers by wrapping errors to provide clearer context.

* **Tests**
  * Tests updated to use per-test namespace values, improving reliability of workload-scan behavior verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->