### PR TITLE
fix(portforwarder): avoid blocking on repeated stop signals

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -99,7 +99,10 @@ func (p *portForward) GetPortForwardLocalhost() string {
 }
 
 func (p *portForward) StopPortForwarder() {
-	p.stopChan <- struct{}{}
+	select {
+	case p.stopChan <- struct{}{}:
+	default:
+	}
 }
 
 func (p *portForward) StartPortForwarder() error {

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
@@ -223,5 +224,24 @@ func Test_GetPortForwardLocalhost(t *testing.T) {
 			result := pf.GetPortForwardLocalhost()
 			assert.Equal(t, tc.result+":"+getPortForwardingPort(), result)
 		})
+	}
+}
+func TestStopPortForwarder_Idempotent(t *testing.T) {
+	p := &portForward{
+		stopChan: make(chan struct{}, 1),
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		p.StopPortForwarder()
+		p.StopPortForwarder()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopPortForwarder blocked on repeated stop")
 	}
 }


### PR DESCRIPTION
## Summary

Makes `StopPortForwarder()` safe to call multiple times by preventing blocking on repeated stop signals.

## Problem

`StopPortForwarder()` previously wrote directly to a buffered stop channel:

```go
p.stopChan <- struct{}{}
```

Because the channel buffer size is 1, calling stop more than once could block if the signal was already sent but not yet consumed.

## Changes 

* Replaced the direct channel send with a non-blocking `select`
* Preserved existing shutdown behavior without introducing functional changes
* Added regression test coverage for repeated stop calls
* Improved shutdown reliability by preventing repeated cleanup or stop paths from hanging

## Testing

Added a regression test to verify repeated `StopPortForwarder()` calls do not block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential blocking issue in port forwarder shutdown mechanism, ensuring stop operations complete reliably without delays.

* **Tests**
  * Added concurrency test to validate port forwarder shutdown behavior, verifying correct operation when called multiple times and confirming non-blocking execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->