### PR TITLE
fix(resourcehandler): trim spaces from namespaces in field selectors

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -58,6 +58,7 @@ func (is *IncludeSelector) GetClusterScope(resource *schema.GroupVersionResource
 func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
 	fieldSelectors := ""
 	for _, n := range strings.Split(es.namespace, FieldSelectorsSeparator) {
+		n = strings.TrimSpace(n)
 		if n != "" {
 			fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespacesSelector(resource.Resource, n, FieldSelectorsNotEqualsOperator))
 		}
@@ -69,6 +70,7 @@ func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource) []string {
 	fieldSelectors := []string{}
 	for _, n := range strings.Split(is.namespace, FieldSelectorsSeparator) {
+		n = strings.TrimSpace(n)
 		if n == "" {
 			continue
 		}

--- a/core/pkg/resourcehandler/fieldselector_test.go
+++ b/core/pkg/resourcehandler/fieldselector_test.go
@@ -30,6 +30,11 @@ func TestExcludedNamespacesSelectors(t *testing.T) {
 	selectors2 := es.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "namespaces"})
 	assert.Equal(t, 1, len(selectors2))
 	assert.Equal(t, "metadata.name!=default,metadata.name!=ingress", selectors2[0])
+
+	esSpace := NewExcludeSelector("default, ingress")
+	selectorsSpace := esSpace.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"})
+	assert.Equal(t, 1, len(selectorsSpace))
+	assert.Equal(t, "metadata.namespace!=default,metadata.namespace!=ingress", selectorsSpace[0])
 }
 
 func TestIncludeNamespacesSelectors(t *testing.T) {
@@ -45,6 +50,12 @@ func TestIncludeNamespacesSelectors(t *testing.T) {
 	assert.Equal(t, 2, len(selectors2))
 	assert.Equal(t, "metadata.name==default", selectors2[0])
 	assert.Equal(t, "metadata.name==ingress", selectors2[1])
+
+	isSpace := NewIncludeSelector("default, ingress")
+	selectorsSpace := isSpace.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"})
+	assert.Equal(t, 2, len(selectorsSpace))
+	assert.Equal(t, "metadata.namespace==default", selectorsSpace[0])
+	assert.Equal(t, "metadata.namespace==ingress", selectorsSpace[1])
 
 	// Cluster-scoped resources must collapse to a single unfiltered query
 	// regardless of how many namespaces were included; otherwise


### PR DESCRIPTION
## Overview
**Current Behavior:** 
When passing a comma-separated list of namespaces with spaces (e.g. `--exclude-namespaces "ns-a, ns-b"`), the spaces are not trimmed in `fieldselector.go`. This results in the Kubernetes API attempting to match a namespace with a leading space (like `" ns-b"`), which silently fails and incorrectly includes resources from `ns-b` in the scan.

**Future Behavior:** 
The split namespace strings are now wrapped in `strings.TrimSpace()` before being evaluated in `GetNamespacesSelectors` for both `ExcludeSelector` and `IncludeSelector`. Any trailing or leading whitespace is correctly stripped out, ensuring the Kubernetes field selector matches the correct namespace names regardless of user input spacing.

## Additional Information
> Reconciles the behavior of `fieldselector.go` with `opaprocessor/processorhandler.go` and `scaninfo.go`, which already trim namespaces consistently.

## How to Test
> Run unit tests to verify the added test cases pass:
> `go test ./core/pkg/resourcehandler/...`
> 
> You can also test manually using the CLI:
> `kubescape scan --exclude-namespaces "kube-system, kube-public"` (with a space after the comma). Resources from `kube-public` should now be correctly excluded.

## Related issues/PRs:
* Resolved #2275 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace selector parsing to consistently handle whitespace around namespace entries, ensuring selectors function correctly even when input contains leading or trailing spaces.

* **Tests**
  * Enhanced test coverage for namespace selectors with whitespace-separated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->