### PR TITLE
fix(opaprocessor): stop processing after context cancellation

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -99,7 +99,10 @@ func (p *portForward) GetPortForwardLocalhost() string {
 }
 
 func (p *portForward) StopPortForwarder() {
-	p.stopChan <- struct{}{}
+	select {
+	case p.stopChan <- struct{}{}:
+	default:
+	}
 }
 
 func (p *portForward) StartPortForwarder() error {

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
@@ -223,5 +224,24 @@ func Test_GetPortForwardLocalhost(t *testing.T) {
 			result := pf.GetPortForwardLocalhost()
 			assert.Equal(t, tc.result+":"+getPortForwardingPort(), result)
 		})
+	}
+}
+func TestStopPortForwarder_Idempotent(t *testing.T) {
+	p := &portForward{
+		stopChan: make(chan struct{}, 1),
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		p.StopPortForwarder()
+		p.StopPortForwarder()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopPortForwarder blocked on repeated stop")
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -120,6 +120,10 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 
 	var processErrs []error
 	for _, toPin := range policies.Controls {
+		if err := ctx.Err(); err != nil {
+			processErrs = append(processErrs, err)
+			break
+		}
 		if progressListener != nil {
 			progressListener.ProgressJob(1, fmt.Sprintf("Control: %s", toPin.ControlID))
 		}
@@ -190,6 +194,10 @@ func (opap *OPAProcessor) processControl(ctx context.Context, control *reporthan
 
 	var ruleErrs []error
 	for i := range control.Rules {
+		if err := ctx.Err(); err != nil {
+			ruleErrs = append(ruleErrs, err)
+			break
+		}
 		resourceAssociatedRule, err := opap.processRule(ctx, &control.Rules[i], control.FixedInput)
 		if err != nil {
 			ruleErrs = append(ruleErrs, fmt.Errorf("rule %q: %w", control.Rules[i].Name, err))


### PR DESCRIPTION
## Summary

Improve cancellation handling in the OPA processor by stopping control and rule execution as soon as the parent context is cancelled.

Previously, processing could continue even after the parent context had expired or been cancelled, resulting in unnecessary work during shutdown or timeout scenarios. This update adds early context checks to ensure processing exits promptly when cancellation is detected.

## Changes

* added early `ctx.Err()` checks during control iteration
* stopped processing remaining controls after cancellation
* added cancellation checks during rule processing

## Testing

* go test ./core/pkg/opaprocessor/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed port forwarder stop operations to prevent blocking when called multiple times.

* **Improvements**
  * Port forwarding lifecycle is now more robust and resistant to edge cases.
  * Request processing now properly respects context cancellation and timeout signals, stopping immediately without waiting for ongoing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->