### PR TITLE
test(opaprocessor): improve temporary resource cleanup

### DIFF
--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -47,41 +47,55 @@ func unzipAllResourcesTestDataAndSetVar(zipFilePath, destFilePath string) error 
 	if err != nil {
 		return err
 	}
+	defer archive.Close()
 
 	os.RemoveAll(destFilePath)
 
-	f := archive.File[0]
-	dstFile, err := os.OpenFile(destFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-	if err != nil {
-		return err
+	if len(archive.File) == 0 {
+		return fmt.Errorf("archive contains no files")
 	}
+
+	f := archive.File[0]
 
 	fileInArchive, err := f.Open()
 	if err != nil {
 		return err
 	}
 
-	_, err = io.Copy(dstFile, fileInArchive) //nolint:gosec
+	dstFile, err := os.OpenFile(
+		destFilePath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		f.Mode(),
+	)
 	if err != nil {
-		dstFile.Close()
 		fileInArchive.Close()
-		archive.Close()
+		return err
+	}
+	defer dstFile.Close()
+	const maxUncompressedTestDataSize = 500 * 1024 * 1024 // 500 MB
+
+	limitedReader := io.LimitReader(fileInArchive, maxUncompressedTestDataSize+1)
+
+	written, err := io.Copy(dstFile, limitedReader)
+	if err != nil {
 		return err
 	}
 
-	dstFile.Close()
+	if written > maxUncompressedTestDataSize {
+		return fmt.Errorf("test archive exceeds maximum allowed size")
+	}
 	fileInArchive.Close()
-	archive.Close()
 
 	file, err := os.Open(destFilePath)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	defer file.Close()
+
 	allResourcesMockData, err = io.ReadAll(file)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	file.Close()
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Refactor temporary resource cleanup handling in `unzipAllResourcesTestDataAndSetVar` to improve test resource lifecycle management and reduce repetitive manual cleanup logic.

Closes #2387

## Changes

* improved temporary resource lifecycle handling in test helpers
* simplified archive and file cleanup flow
* reduced duplicated manual cleanup logic
* improved readability and maintainability of test setup code

## Testing

* `go test ./core/pkg/opaprocessor/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved ZIP extraction test utilities with safer resource cleanup using deferred closes
  * Added validation that ZIP archives contain at least one file and enforced a strict extraction size cap (500MB+1 byte)
  * Strengthened error handling to avoid panics and return clear errors on failures during archive and file operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->