### PR TITLE
refactor(cmd): remove unreachable dead code from completion command

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -29,11 +29,6 @@ func GetCompletionCmd() *cobra.Command {
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
-			// Check if args array is not empty
-			if len(args) == 0 {
-				fmt.Println("No arguments provided.")
-				return
-			}
 
 			switch strings.ToLower(args[0]) {
 			case "bash":
@@ -44,8 +39,6 @@ func GetCompletionCmd() *cobra.Command {
 				cmd.Root().GenFishCompletion(os.Stdout, true)
 			case "powershell":
 				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-			default:
-				fmt.Printf("Invalid argument %s", args[0])
 			}
 		},
 	}


### PR DESCRIPTION
## Description
This PR removes redundant, unreachable dead code from the shell completion command in `cmd/completion/completion.go`. 

The completion command is configured using Cobra's built-in argument validation rules. Specifically, it strictly enforces that exactly 1 argument must be passed and that it must be one of the supported shells (`bash`, `zsh`, `fish`, or `powershell`). Because Cobra intercepts and rejects invalid inputs before the `Run` block ever executes, the manual checks inside the logic are mathematically impossible to hit.

### Changes Made
* **Removed lines 33-36:** The defensive validation check for `len(args) == 0` has been deleted, as Cobra guarantees exactly 1 argument is present.
* **Removed lines 47-48:** The `default:` case fallback within the shell switch block has been deleted, as Cobra prevents any unsupported shell strings from reaching this execution path.

## Why this is safe
No functional logic or behavior is changed. This is purely a cleanup effort to improve code readability, eliminate dead code branches, and rely correctly on framework-level constraints.

## Verification Results
* `go build ./...` completes successfully.
* `go test ./...` passes without regressions.

## Closes
Closes #2389 

<img width="1054" height="221" alt="image" src="https://github.com/user-attachments/assets/854284c5-b943-4aeb-8b86-cd215d4161ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal argument validation by removing redundant error handling logic, now relying on built-in framework validation for argument constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->