### PR TITLE
fix(storage): skip orphaned RoleBinding instead of aborting scan persistence

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/armosec/utils-k8s-go/wlid"
@@ -27,6 +28,9 @@ import (
 )
 
 var storageInstance *APIServerStore
+
+// ErrIncompleteRelatedObjects is returned when a RegoResponseVector lacks the expected Role+RoleBinding pair (e.g. orphaned binding).
+var ErrIncompleteRelatedObjects = stderrors.New("incomplete related objects")
 
 type PostureRepository interface {
 	GetWorkloadConfigurationScanResult(ctx context.Context, name, namespace string) (*v1beta1.WorkloadConfigurationScan, error)
@@ -67,22 +71,22 @@ func (a *APIServerStore) StorePostureReportResults(ctx context.Context, pr *v2.P
 	for i := range pr.Results {
 		workloadScan, err := a.BuildWorkloadConfigurationScan(ctx, pr, &pr.Results[i])
 		if err != nil {
-			logger.L().Ctx(ctx).Warning("skipping result with incomplete related objects", helpers.Error(err), helpers.String("resourceID", pr.Results[i].ResourceID))
-			continue
+			if stderrors.Is(err, ErrIncompleteRelatedObjects) {
+				logger.L().Ctx(ctx).Warning("skipping result with incomplete related objects", helpers.Error(err), helpers.String("resourceID", pr.Results[i].ResourceID))
+				continue
+			}
+			return err
 		}
 
-		// Only store full WorkloadConfigurationScan when continuousPostureScan is enabled
 		if a.continuousPostureScan {
 			if err := a.StoreWorkloadConfigurationScanResult(ctx, workloadScan); err != nil {
 				return err
 			}
 		}
 
-		// Always store summaries for headlamp plugin
 		if _, err := a.StoreWorkloadConfigurationScanResultSummary(ctx, workloadScan); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }
@@ -381,7 +385,7 @@ func getRelatedObjects(resource *reporthandling.Resource) []workloadinterface.IM
 
 func getRoleAndRoleBindingFromRelatedObjects(relatedObjects []workloadinterface.IMetadata) (role workloadinterface.IMetadata, roleBinding workloadinterface.IMetadata, err error) {
 	if len(relatedObjects) != 2 {
-		return nil, nil, fmt.Errorf("expected 2 related objects, got %d", len(relatedObjects))
+		return nil, nil, fmt.Errorf("%w: expected 2, got %d", ErrIncompleteRelatedObjects, len(relatedObjects))
 	}
 
 	for i := range relatedObjects {

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -67,7 +67,8 @@ func (a *APIServerStore) StorePostureReportResults(ctx context.Context, pr *v2.P
 	for i := range pr.Results {
 		workloadScan, err := a.BuildWorkloadConfigurationScan(ctx, pr, &pr.Results[i])
 		if err != nil {
-			return err
+			logger.L().Ctx(ctx).Warning("skipping result with incomplete related objects", helpers.Error(err), helpers.String("resourceID", pr.Results[i].ResourceID))
+			continue
 		}
 
 		// Only store full WorkloadConfigurationScan when continuousPostureScan is enabled

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -11,12 +11,15 @@ import (
 	"github.com/kubescape/k8s-interface/names"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	v2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewFakeAPIServerStorage(namespace string) *APIServerStore {
@@ -511,6 +514,57 @@ func Test_RoleBindingResourceTripletToSlug(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedSlugs, slugs)
 		})
 	}
+}
+
+func TestStorePostureReportResults_SkipsOrphanedRoleBinding(t *testing.T) {
+	store := NewFakeAPIServerStorage("kubescape")
+	ctx := context.Background()
+
+	// RegoResponseVector with only 1 related object (RoleBinding, no Role) — simulates an
+	// orphaned binding whose referenced Role/ClusterRole has been deleted.
+	orphanObj := map[string]interface{}{
+		"kind":      "ServiceAccount",
+		"name":      "my-sa",
+		"namespace": "default",
+		"relatedObjects": []interface{}{
+			map[string]interface{}{
+				"kind":       "RoleBinding",
+				"name":       "orphan-binding",
+				"namespace":  "default",
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+			},
+		},
+	}
+
+	// Normal Pod resource — should be persisted regardless of the orphaned binding above.
+	podObj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "test-pod",
+			"namespace": "default",
+		},
+	}
+
+	pr := &v2.PostureReport{
+		Resources: []reporthandling.Resource{
+			{ResourceID: "orphan-resource-id", Object: orphanObj},
+			{ResourceID: "pod-resource-id", Object: podObj},
+		},
+		Results: []resourcesresults.Result{
+			{ResourceID: "orphan-resource-id"},
+			{ResourceID: "pod-resource-id"},
+		},
+	}
+
+	err := store.StorePostureReportResults(ctx, pr)
+	assert.NoError(t, err)
+
+	// The Pod summary must be stored; the orphaned binding must be skipped, not abort the run.
+	summaries, listErr := store.StorageClient.WorkloadConfigurationScanSummaries("default").List(ctx, metav1.ListOptions{})
+	assert.NoError(t, listErr)
+	assert.Len(t, summaries.Items, 1)
+	assert.Equal(t, "pod-test-pod", summaries.Items[0].Name)
 }
 
 func TestMergeMaps(t *testing.T) {

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -567,6 +567,23 @@ func TestStorePostureReportResults_SkipsOrphanedRoleBinding(t *testing.T) {
 	assert.Equal(t, "pod-test-pod", summaries.Items[0].Name)
 }
 
+func TestStorePostureReportResults_NonRecoverableError(t *testing.T) {
+	store := NewFakeAPIServerStorage("kubescape")
+	ctx := context.Background()
+
+	// Result whose ResourceID has no matching entry in Resources — this is a non-recoverable
+	// build error (findResourceInReport fails) and must not be silently skipped.
+	pr := &v2.PostureReport{
+		Resources: []reporthandling.Resource{},
+		Results: []resourcesresults.Result{
+			{ResourceID: "missing-resource-id"},
+		},
+	}
+
+	err := store.StorePostureReportResults(ctx, pr)
+	assert.Error(t, err)
+}
+
 func TestMergeMaps(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Overview
Current behavior: When persisting scan results to in-cluster storage, a single orphaned RoleBinding (one whose referenced Role/ClusterRole has been deleted) causes `StorePostureReportResults` to abort entirely. The `RegoResponseVector` for the orphaned binding carries only 1 related object instead of the expected 2, which triggers "expected 2 related objects, got 1" in `getRoleAndRoleBindingFromRelatedObjects`. The previous `return err` in the results loop means no subsequent scan results are persisted — not just the offending one.

New behavior: The incomplete result is logged as a warning (with its resourceID) and skipped. The rest of the scan results are persisted normally.

## How to Test
1. Create an orphaned binding in your cluster:
kubectl create clusterrole tmp-role --verb=get --resource=pods
kubectl create rolebinding tmp-orphan --clusterrole=tmp-role --serviceaccount=default:default -n default
kubectl delete clusterrole tmp-role

2. Trigger an in-cluster scan via the operator (`v1/triggerAction`, `kubescapeScan`).
3. Confirm the scan completes and `WorkloadConfigurationScans`/summaries are written for all other resources. The orphaned binding emits a warning log and is skipped rather than aborting the run.

Unit test added: `TestStorePostureReportResults_SkipsOrphanedRoleBinding` in `httphandler/storage/apiserver_test.go`.

## Related issues/PRs
* Resolved #2383

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of posture reporting: if a result includes incomplete related data, the system now logs a warning and skips that specific item instead of failing the entire operation.

* **Tests**
  * Added coverage to ensure orphaned/incomplete related objects are skipped successfully.
  * Added coverage to ensure non-recoverable mismatches in reported resource mappings still return an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->