### PR TITLE
[fix] : Fall back to bundled defaults and surface degradation when control-inputs fetch fails

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -125,6 +125,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			}
 			enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
 			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo)
+			enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo)
 
 			return nil
 		},

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -143,6 +143,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
 			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo)
+			enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo)
 			return nil
 		},
 	}
@@ -208,6 +209,19 @@ func enforceCoverageThreshold(coverage cautils.ScanCoverage, totalControls int, 
 			helpers.String("fail-coverage-below", fmt.Sprintf("%.2f%%", scanInfo.FailCoverageThreshold)),
 		)
 	}
+}
+
+// enforcePolicyDegradation fails the scan if control configurations or
+// exceptions could not be loaded from their configured source and the scan
+// proceeded with bundled defaults instead.
+func enforcePolicyDegradation(coverage cautils.ScanCoverage, scanInfo *cautils.ScanInfo) {
+	if !scanInfo.FailOnDegradedConfig || len(coverage.PolicyDegradations) == 0 {
+		return
+	}
+	for _, d := range coverage.PolicyDegradations {
+		logger.L().Warning("policy input degraded, bundled defaults were used", helpers.String("component", d.Component), helpers.String("reason", d.Reason))
+	}
+	logger.L().Fatal("scan policy inputs were degraded", helpers.String("fail-on-degraded-config", "true"))
 }
 
 // enforceSeverityThresholds ensures that the scan results are below the defined severity threshold

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -96,6 +96,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1. Applies to 'scan framework', 'scan control', and '--view resource|control'")
 	scanCmd.PersistentFlags().Float32VarP(&scanInfo.ComplianceThreshold, "compliance-threshold", "", 0, "Compliance threshold is the percent below which the command fails and returns exit code 1. Applies to 'scan framework', 'scan control', and '--view resource|control'")
 	scanCmd.PersistentFlags().Float32Var(&scanInfo.FailCoverageThreshold, "fail-coverage-below", 0, "Minimum percentage of controls that must be evaluated (0 to disable). If coverage drops below this threshold the command returns exit code 1")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.FailOnDegradedConfig, "fail-on-degraded-config", false, "Fail the scan (exit code 1) if control configurations or exceptions could not be loaded from their configured source and bundled defaults were used instead")
 
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"`)
@@ -210,6 +211,7 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
 
 	enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), &scanInfo, terminateOnExceedingSeverity)
 	enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), &scanInfo)
+	enforcePolicyDegradation(results.GetData().ScanCoverage, &scanInfo)
 
 	return nil
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -90,6 +90,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
 			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo)
+			enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo)
 
 			return nil
 		},

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -64,6 +64,7 @@ type OPASessionObj struct {
 	ResourceToControlsMap map[string][]string                // map[<apigroup/apiversion/resource>] = [<control_IDs>]
 	ScanCoverage          ScanCoverage                       // runtime coverage gaps (failed GVR pulls + not-evaluated controls)
 	PartialGVRFailures    []PartialGVRPull                   // per-selector LIST failures for GVRs that were partially collected
+	PolicyDegradations    []PolicyDegradation                // policy inputs (control configurations, exceptions) served from a fallback
 	SessionID             string                             // SessionID
 	Policies              []reporthandling.Framework         // list of frameworks to scan
 	Exceptions            []armotypes.PostureExceptionPolicy // list of exceptions to apply on scan results

--- a/core/cautils/getter/defaultcontrolinputs.go
+++ b/core/cautils/getter/defaultcontrolinputs.go
@@ -1,0 +1,23 @@
+package getter
+
+import (
+	_ "embed"
+
+	"github.com/armosec/armoapi-go/armotypes"
+)
+
+//go:embed resources/default-config-inputs.json
+var defaultConfigInputsData []byte
+
+// DefaultControlInputs returns the bundled regolibrary default control
+// configurations. It is used as a fallback when the configured control
+// inputs source (Kubescape Cloud, ControlInput CRD, or the regolibrary
+// GitHub release) could not be reached, so config-dependent controls are
+// still evaluated against sane defaults instead of an empty configuration.
+func DefaultControlInputs() (map[string][]string, error) {
+	var customerConfig armotypes.CustomerConfig
+	if err := json.Unmarshal(defaultConfigInputsData, &customerConfig); err != nil {
+		return nil, err
+	}
+	return customerConfig.Settings.PostureControlInputs, nil
+}

--- a/core/cautils/getter/defaultcontrolinputs.go
+++ b/core/cautils/getter/defaultcontrolinputs.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	_ "embed"
+	encjson "encoding/json"
 
 	"github.com/armosec/armoapi-go/armotypes"
 )
@@ -16,7 +17,7 @@ var defaultConfigInputsData []byte
 // still evaluated against sane defaults instead of an empty configuration.
 func DefaultControlInputs() (map[string][]string, error) {
 	var customerConfig armotypes.CustomerConfig
-	if err := json.Unmarshal(defaultConfigInputsData, &customerConfig); err != nil {
+	if err := encjson.Unmarshal(defaultConfigInputsData, &customerConfig); err != nil {
 		return nil, err
 	}
 	return customerConfig.Settings.PostureControlInputs, nil

--- a/core/cautils/getter/defaultcontrolinputs.go
+++ b/core/cautils/getter/defaultcontrolinputs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 )
 
+//go:generate curl -sSfL https://github.com/kubescape/regolibrary/releases/latest/download/default-config-inputs.json -o resources/default-config-inputs.json
 //go:embed resources/default-config-inputs.json
 var defaultConfigInputsData []byte
 

--- a/core/cautils/getter/resources/default-config-inputs.json
+++ b/core/cautils/getter/resources/default-config-inputs.json
@@ -1,0 +1,117 @@
+{
+    "name": "default",
+    "attributes": {
+    },
+    "scope": {
+        "designatorType": "attributes",
+        "attributes": {}
+    },
+    "settings": {
+        "postureControlInputs": {
+            "imageRepositoryAllowList": [
+            ],
+            "trustedCosignPublicKeys": [],
+            "insecureCapabilities": [
+                "SETPCAP",
+                "NET_ADMIN",
+                "NET_RAW",
+                "SYS_MODULE",
+                "SYS_RAWIO",
+                "SYS_PTRACE",
+                "SYS_ADMIN",
+                "SYS_BOOT",
+                "MAC_OVERRIDE",
+                "MAC_ADMIN",
+                "PERFMON",
+                "ALL",
+                "BPF"
+            ],
+            "listOfDangerousArtifacts": [
+                "bin/bash",
+                "sbin/sh",
+                "bin/ksh",
+                "bin/tcsh",
+                "bin/zsh",
+                "usr/bin/scsh",
+                "bin/csh",
+                "bin/busybox",
+                "usr/bin/busybox"
+            ],
+            "publicRegistries": [],
+            "sensitiveInterfaces": [
+                "nifi",
+                "argo-server",
+                "weave-scope-app",
+                "kubeflow",
+                "kubernetes-dashboard",
+                "jenkins",
+                "prometheus-deployment"
+            ],
+            "max_critical_vulnerabilities": ["5"],
+            "max_high_vulnerabilities": ["10"],
+            "sensitiveKeyNames": [
+                "aws_secret_access_key",
+                "azure_batchai_storage_key",
+                "azure_batch_key",
+                "secret",
+                "key",
+                "password",
+                "pwd",
+                "token",
+                "jwt",
+                "bearer",
+                "credential"
+            ],
+            "sensitiveValues": [
+                "BEGIN \\w+ PRIVATE KEY",
+                "PRIVATE KEY",
+                "eyJhbGciO",
+                "JWT",
+                "Bearer",
+                "_key_",
+                "_secret_"
+            ],
+            "sensitiveKeyNamesAllowed": [],
+            "sensitiveValuesAllowed": [],
+            "servicesNames": [
+                "nifi-service",
+                "argo-server",
+                "minio",
+                "postgres",
+                "workflow-controller-metrics",
+                "weave-scope-app",
+                "kubernetes-dashboard"
+            ],
+            "untrustedRegistries": [],
+            "memory_request_max": [],
+            "memory_request_min": ["0"],
+            "memory_limit_max": [],
+            "memory_limit_min": ["0"],
+            "cpu_request_max": [],
+            "cpu_request_min": ["0"],
+            "cpu_limit_max": [],
+            "cpu_limit_min": ["0"],
+            "wlKnownNames": [
+                "coredns",
+                "kube-proxy",
+                "event-exporter-gke",
+                "kube-dns",
+                "17-default-backend",
+                "metrics-server",
+                "ca-audit",
+                "ca-dashboard-aggregator",
+                "ca-notification-server",
+                "ca-ocimage",
+                "ca-oracle",
+                "ca-posture",
+                "ca-rbac",
+                "ca-vuln-scan",
+                "ca-webhook",
+                "ca-websocket",
+                "clair-clair"
+            ],
+            "recommendedLabels": ["app", "tier", "phase", "version", "owner", "env"],
+            "k8sRecommendedLabels": ["app.kubernetes.io/name", "app.kubernetes.io/instance", "app.kubernetes.io/version", "app.kubernetes.io/component", "app.kubernetes.io/part-of", "app.kubernetes.io/managed-by", "app.kubernetes.io/created-by"]
+        }
+    }
+}

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -18,6 +18,20 @@ type ScanCoverage struct {
 	// partial data, but this field surfaces the gap so operators and CI/CD
 	// pipelines can detect incomplete scans without a false-green result.
 	PartialGVRPulls []PartialGVRPull `json:"partialGVRPulls,omitempty"`
+	// PolicyDegradations records policy inputs (control configurations,
+	// exceptions) that could not be loaded from their configured source and
+	// were served from a fallback so the scan could proceed.
+	PolicyDegradations []PolicyDegradation `json:"policyDegradations,omitempty"`
+}
+
+// PolicyDegradation records a policy input that could not be loaded from its
+// configured source (Kubescape Cloud, ControlInput CRD, regolibrary release,
+// or a local file) and was served from a fallback instead.
+type PolicyDegradation struct {
+	// Component identifies the degraded input, e.g. "controlInputs" or "exceptions".
+	Component string `json:"component"`
+	// Reason is the error returned by the configured source.
+	Reason string `json:"reason"`
 }
 
 // FailedGVRPull records a single GVR whose resources could not be collected.
@@ -63,9 +77,14 @@ type NotEvaluatedControl struct {
 //
 // partialPulls carries per-selector LIST failures for GVRs that were partially
 // collected; they are included as-is in ScanCoverage.PartialGVRPulls.
-func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull) ScanCoverage {
+//
+// policyDegradations carries policy inputs (control configurations,
+// exceptions) that were served from a fallback; they are included as-is in
+// ScanCoverage.PolicyDegradations.
+func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull, policyDegradations []PolicyDegradation) ScanCoverage {
 	coverage := ScanCoverage{
-		PartialGVRPulls: partialPulls,
+		PartialGVRPulls:    partialPulls,
+		PolicyDegradations: policyDegradations,
 	}
 
 	notEvaluated := make(map[string]NotEvaluatedControl, len(timedOutControls))

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildScanCoverage_EmptyInfoMap(t *testing.T) {
-	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil, nil)
+	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -17,7 +17,7 @@ func TestBuildScanCoverage_NoFailedGVRs(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusPassed},
 	}
-	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil)
+	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -32,7 +32,7 @@ func TestBuildScanCoverage_FailedGVRPopulated(t *testing.T) {
 	resourceToControlsMap := map[string][]string{
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, "networking.k8s.io/v1/networkpolicies", coverage.FailedGVRPulls[0].GVR)
 	assert.Equal(t, "RBAC denied", coverage.FailedGVRPulls[0].Error)
@@ -44,7 +44,7 @@ func TestBuildScanCoverage_NoResourceMap(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusSkipped},
 	}
-	coverage := BuildScanCoverage(infoMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 }
 
@@ -57,7 +57,7 @@ func TestBuildScanCoverage_AllGVRsFailedControlNotEvaluated(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies":      {"C-0001", "C-0002"},
 		"rbac.authorization.k8s.io/v1/clusterroles": {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 2)
 
@@ -84,7 +84,7 @@ func TestBuildScanCoverage_IgnoresResourceLevelEvalSkips(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 
 	// Only the GVR-keyed entry should be in FailedGVRPulls
 	assert.Len(t, coverage.FailedGVRPulls, 1)
@@ -108,9 +108,9 @@ func TestBuildScanCoverage_DeterministicOrder(t *testing.T) {
 		"m/v1/mthings": {"C-0002"},
 	}
 
-	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 	for i := 0; i < 10; i++ {
-		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 		assert.Equal(t, first, next)
 	}
 
@@ -133,7 +133,7 @@ func TestBuildScanCoverage_PartialGVRFailureControlStillEvaluated(t *testing.T) 
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Empty(t, coverage.NotEvaluatedControls)
@@ -152,7 +152,7 @@ func TestBuildScanCoverage_FailedGVRPullIsNotPhantomNotEvaluatedControl(t *testi
 			InnerInfo:   "failed to list resources",
 		},
 	}
-	coverage := BuildScanCoverage(infoMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil)
 
 	for _, ne := range coverage.NotEvaluatedControls {
 		assert.NotEqual(t, "networking.k8s.io/v1/networkpolicies", ne.ControlID)
@@ -168,7 +168,7 @@ func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
 		{GVR: "/v1/pods", Selector: "metadata.namespace==prod", Error: "RBAC denied for prod"},
 		{GVR: "core/v1/secrets", Selector: "metadata.name==prod-secret", Error: "forbidden"},
 	}
-	coverage := BuildScanCoverage(nil, nil, nil, partials)
+	coverage := BuildScanCoverage(nil, nil, nil, partials, nil)
 
 	assert.Len(t, coverage.PartialGVRPulls, 2)
 	assert.Equal(t, "/v1/pods", coverage.PartialGVRPulls[0].GVR)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -124,6 +124,7 @@ type ScanInfo struct {
 	ComplianceThreshold   float32                      // Compliance score threshold
 	FailThresholdSeverity string                       // Severity at and above which the command should fail
 	FailCoverageThreshold float32                      // Coverage threshold below which the command fails (0 = disabled)
+	FailOnDegradedConfig  bool                         // Fail the scan if control inputs or exceptions could not be loaded and a fallback was used
 	Submit                bool                         // Submit results to Kubescape Cloud BE
 	ScanID                string                       // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag                  // Deploy Kubescape K8s host scanner to collect data from certain controls

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -138,7 +138,7 @@ func TestAddInfoToMap_BuildScanCoverageRecognizesHostSensorFailure(t *testing.T)
 		expectedKey: {"C-0001"},
 	}
 
-	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil)
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
 
 	require.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, expectedKey, coverage.FailedGVRPulls[0].GVR)

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -93,7 +93,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	// rebuild ScanCoverage so controls that timed out during evaluation
 	// (recorded in TimedOutControls by markControlTimedOut) are reflected in
 	// NotEvaluatedControls alongside any collection-phase failures
-	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures)
+	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures, opap.PolicyDegradations)
 
 	// edit results
 	opap.updateResults(ctx)

--- a/core/pkg/opaprocessor/processorhandler_timeout_test.go
+++ b/core/pkg/opaprocessor/processorhandler_timeout_test.go
@@ -1,0 +1,114 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingRule is a genuinely CPU-bound Rego rule: it iterates the cartesian
+// product of two large arrays (10^10 combinations), with no I/O or custom
+// builtins involved. This proves that a context deadline interrupts
+// evaluation mid-computation (topdown checks for cancellation on every
+// expression evaluation), not just at an external blocking point.
+const blockingRule = `package armo_builtins
+
+deny[msga] {
+	a := numbers.range(1, 100000)
+	b := numbers.range(1, 100000)
+	x := a[_]
+	y := b[_]
+	x + y == -1
+	msga := {
+		"alertMessage": "should never be reached",
+		"packagename": "armo_builtins",
+		"alertScore": 1,
+		"fixPaths": [],
+		"failedPaths": [],
+		"alertObject": {"k8sApiObjects": [input[_]]}
+	}
+}
+`
+
+// TestProcess_ControlTimeout verifies that when ControlTimeout is set, a
+// control whose Rego evaluation never returns on its own is interrupted,
+// the overall scan still completes, and the timed-out control is recorded
+// in InfoMap as skipped/not-evaluated rather than stalling the scan.
+func TestProcess_ControlTimeout(t *testing.T) {
+	deployment := mocks.MockDevelopmentWithHostpath()
+
+	k8sResources := make(cautils.K8SResources)
+	k8sResources["apps/v1/deployments"] = workloadinterface.ListMetaIDs([]workloadinterface.IMetadata{deployment})
+
+	opaSessionObj := cautils.NewOPASessionObjMock()
+	opaSessionObj.K8SResources = k8sResources
+	opaSessionObj.AllResources[deployment.GetID()] = deployment
+	opaSessionObj.InfoMap = make(map[string]apis.StatusInfo)
+
+	const controlID = "C-TEST-TIMEOUT"
+	policies := &cautils.Policies{
+		Controls: map[string]reporthandling.Control{
+			controlID: {
+				PortalBase: armotypes.PortalBase{
+					Name: "blocking control",
+				},
+				ControlID: controlID,
+				Rules: []reporthandling.PolicyRule{
+					{
+						PortalBase: armotypes.PortalBase{
+							Name:       "blocking-rule",
+							Attributes: map[string]interface{}{},
+						},
+						Rule: blockingRule,
+						Match: []reporthandling.RuleMatchObjects{
+							{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"Deployment"},
+							},
+						},
+						RuleQuery:    "armo_builtins",
+						RuleLanguage: reporthandling.RegoLanguage,
+					},
+				},
+			},
+		},
+	}
+
+	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap.AllPolicies = policies
+	opap.ControlTimeout = 100 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() {
+		done <- opap.Process(context.Background(), policies, nil)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Process did not return: per-control timeout did not interrupt the blocking rule")
+	}
+
+	reason, ok := opap.TimedOutControls[controlID]
+	require.True(t, ok, "expected timed-out control to be recorded in TimedOutControls")
+	assert.Contains(t, reason, "timed out")
+
+	// mirrors the rebuild step performed by ProcessRulesListener after Process returns
+	coverage := cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opap.TimedOutControls, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations)
+	require.Len(t, coverage.NotEvaluatedControls, 1)
+	notEvaluated := coverage.NotEvaluatedControls[0]
+	assert.Equal(t, controlID, notEvaluated.ControlID)
+	assert.Contains(t, notEvaluated.Reason, "timed out")
+}

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -108,6 +108,7 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 			controlInputs = defaultInputs
 		} else {
 			logger.L().Ctx(ctx).Warning("failed to load bundled default control inputs", helpers.Error(defaultErr))
+			degradations = append(degradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: defaultErr.Error()})
 		}
 	} else {
 		logger.L().StopSuccess("Loaded account configurations")

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -54,19 +54,23 @@ func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyI
 	policyHandler.getters = &scanInfo.Getters
 
 	// get policies, exceptions and controls inputs
-	policies, exceptions, controlInputs, err := policyHandler.getPolicies(ctx, policyIdentifier)
+	policies, exceptions, controlInputs, degradations, err := policyHandler.getPolicies(ctx, policyIdentifier)
 	if err != nil {
 		return opaSessionObj, err
 	}
 
 	opaSessionObj.Policies = policies
 	opaSessionObj.Exceptions = exceptions
+	if controlInputs == nil {
+		controlInputs = map[string][]string{}
+	}
 	opaSessionObj.RegoInputData.PostureControlInputs = controlInputs
+	opaSessionObj.PolicyDegradations = degradations
 
 	return opaSessionObj, nil
 }
 
-func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier) (policies []reporthandling.Framework, exceptions []armotypes.PostureExceptionPolicy, controlInputs map[string][]string, err error) {
+func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier) (policies []reporthandling.Framework, exceptions []armotypes.PostureExceptionPolicy, controlInputs map[string][]string, degradations []cautils.PolicyDegradation, err error) {
 	ctx, span := otel.Tracer("").Start(ctx, "policyHandler.getPolicies")
 	defer span.End()
 
@@ -75,10 +79,10 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	// get policies
 	policies, err = policyHandler.getScanPolicies(ctx, policyIdentifier)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if len(policies) == 0 {
-		return nil, nil, nil, fmt.Errorf("failed to download policies: '%s'. Make sure the policy exist and you spelled it correctly. For more information, please feel free to contact ARMO team", strings.Join(policyIdentifierToSlice(policyIdentifier), ", "))
+		return nil, nil, nil, nil, fmt.Errorf("failed to download policies: '%s'. Make sure the policy exist and you spelled it correctly. For more information, please feel free to contact ARMO team", strings.Join(policyIdentifierToSlice(policyIdentifier), ", "))
 	}
 
 	logger.L().StopSuccess("Loaded policies")
@@ -87,6 +91,8 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	// get exceptions
 	if exceptions, err = policyHandler.getExceptions(); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load exceptions", helpers.Error(err))
+		degradations = append(degradations, cautils.PolicyDegradation{Component: "exceptions", Reason: err.Error()})
+		exceptions = []armotypes.PostureExceptionPolicy{}
 	} else {
 		logger.L().StopSuccess("Loaded exceptions")
 	}
@@ -96,11 +102,18 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	// get account configuration
 	if controlInputs, err = policyHandler.getControlInputs(); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
+		degradations = append(degradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: err.Error()})
+
+		if defaultInputs, defaultErr := getter.DefaultControlInputs(); defaultErr == nil {
+			controlInputs = defaultInputs
+		} else {
+			logger.L().Ctx(ctx).Warning("failed to load bundled default control inputs", helpers.Error(defaultErr))
+		}
 	} else {
 		logger.L().StopSuccess("Loaded account configurations")
 	}
 
-	return policies, exceptions, controlInputs, nil
+	return policies, exceptions, controlInputs, degradations, nil
 }
 
 // getScanPolicies - get policies from cache or downloads them. The function returns an error if the policies could not be downloaded.

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -35,7 +35,7 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	opaSessionObj.AllResources = allResources
 	opaSessionObj.ExternalResources = externalResources
 	opaSessionObj.ExcludedRules = excludedRulesMap
-	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, nil, opaSessionObj.PartialGVRFailures)
+	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, nil, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations)
 
 	if getErr != nil {
 		return getErr

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -376,7 +376,12 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 		fmt.Fprintf(pp.writer, "\nControls depending on these inputs were evaluated against default configuration, which may not reflect your environment.\n")
 	}
 
-	fmt.Fprintf(pp.writer, "\nTo fix this, ensure the scanning identity has list/get permissions on the missing resource types.\n")
+	if len(coverage.FailedGVRPulls) > 0 || len(coverage.PartialGVRPulls) > 0 {
+		fmt.Fprintf(pp.writer, "\nTo fix this, ensure the scanning identity has list/get permissions on the missing resource types.\n")
+	}
+	if len(coverage.PolicyDegradations) > 0 {
+		fmt.Fprintf(pp.writer, "\nTo fix this, ensure network access to the policy input source, or use --fail-on-degraded-config to fail the scan instead of using bundled defaults.\n")
+	}
 }
 
 func (p *PrettyPrinter) CloseWriter() {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -334,7 +334,7 @@ func isPrintSeparatorType(scanType cautils.ScanTypes) bool {
 // failures caused controls to be skipped or partial data was collected.
 // Nothing is printed on a clean scan.
 func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
-	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 {
+	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 && len(coverage.PolicyDegradations) == 0 {
 		return
 	}
 
@@ -366,6 +366,14 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 			fmt.Fprintf(pp.writer, "  • %s (selector: %q): %s\n", p.GVR, p.Selector, p.Error)
 		}
 		fmt.Fprintf(pp.writer, "\nControls depending on these resource types were evaluated against incomplete data.\n")
+	}
+
+	if len(coverage.PolicyDegradations) > 0 {
+		fmt.Fprintf(pp.writer, "\nThe following policy inputs could not be loaded and were served from bundled defaults:\n")
+		for _, d := range coverage.PolicyDegradations {
+			fmt.Fprintf(pp.writer, "  • %s: %s\n", d.Component, d.Reason)
+		}
+		fmt.Fprintf(pp.writer, "\nControls depending on these inputs were evaluated against default configuration, which may not reflect your environment.\n")
 	}
 
 	fmt.Fprintf(pp.writer, "\nTo fix this, ensure the scanning identity has list/get permissions on the missing resource types.\n")

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -133,7 +133,7 @@ func ConvertToPostureReportWithSeverityLabelsAndCoverage(report *reporthandlingv
 
 	// only attach coverage when there is something to show
 	var scanCoverage *cautils.ScanCoverage
-	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0) {
+	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0) {
 		scanCoverage = coverage
 	}
 


### PR DESCRIPTION
## Overview

When `getControlInputs()` failed, the error was logged and discarded, returning a nil `PostureControlInputs` map. That nil map became the OPA data document, making every `data.postureControlInputs.*` reference undefined in Rego. Every config-dependent control (C-0012, C-0001, C-0078, CPU/memory limits, sensitive-interface controls) evaluated as no violations -- indistinguishable from compliant. The scan returned exit 0 with an inflated score and no machine-readable trace of the failure.

**Future behavior:** On `getControlInputs()` failure, the scan falls back to the bundled regolibrary defaults and records a `PolicyDegradation` entry that surfaces in `ScanCoverage`, the printed report, and optionally fails the scan via `--fail-on-degraded-config`.

```go
// before -- nil map silently reaches NewOPAProcessor
if controlInputs, err = policyHandler.getControlInputs(); err != nil {
    logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
}
return policies, exceptions, controlInputs, nil

// after -- fallback to bundled defaults, degradation recorded
if controlInputs, err = policyHandler.getControlInputs(); err != nil {
    degradations = append(degradations, cautils.PolicyDegradation{
        Component: "control-inputs",
        Reason:    err.Error(),
    })
    controlInputs = getter.DefaultControlInputs()
}
```

## Additional Information

The core defect was the silence -- a nil map produced a green result with no machine-readable trace. The fix has three parts:

1. **Fallback** -- `default-config-inputs.json` is now bundled and embedded. `DefaultControlInputs()` parses it via the existing `armotypes.CustomerConfig` path. The network fetch exists to pick up account-level overrides; the bundled defaults are fully usable for air-gapped and rate-limited environments.

2. **Degradation recording** -- `PolicyDegradation{Component, Reason}` is added to `ScanCoverage` and `OPASessionObj`. Both `BuildScanCoverage` call sites thread it through. `printScanCoverage` surfaces it in the pretty printer with a note that affected controls were evaluated against bundled defaults. The JSON report attaches `ScanCoverage` when `PolicyDegradations` is non-empty.

3. **Strict mode** -- `--fail-on-degraded-config` (default false) lets compliance gates opt into a hard failure instead of a degraded scan. `enforcePolicyDegradation` is wired alongside the existing `enforceCoverageThreshold` calls in all scan entry points.

The exceptions swallow (`getExceptions()`) gets the same treatment -- fallback to empty slice and a recorded degradation -- fixing the mirror-image false-positive bug.

`CollectPolicies` also guards against `controlInputs == nil` reaching `NewOPAProcessor` as a defensive backstop.

## How to Test

```bash
# simulate air-gapped / rate-limited environment
# block github.com and run
kubescape scan framework nsa

# degradation appears in ScanCoverage, controls evaluate against bundled defaults
# exit code 0 (degraded but honest)

# strict mode
kubescape scan framework nsa --fail-on-degraded-config
# exit non-zero when control-inputs fetch fails
```

## Related issues/PRs

* Resolved #

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--fail-on-degraded-config` to make scans fail when policy inputs degrade and fall back to bundled defaults.
  * Scan results now include a dedicated “policy inputs” warning section with degraded components/reasons and remediation guidance.
* **Bug Fixes**
  * Policy input degradations are now included in generated posture reports and scan coverage payloads.
  * Improved reliability by enforcing per-control evaluation timeouts to prevent scan stalls.
* **Tests**
  * Added coverage for control-timeout behavior and updated coverage-building call sites to match the new degradation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->