### PR TITLE
Set HTTP timeouts on the scan listener server

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -37,6 +38,14 @@ func SetupHTTPListener() error {
 	}
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
+		// Bound slow-client (slowloris-style) resource exhaustion. Scan requests are
+		// handled asynchronously (the handler returns immediately and results are
+		// polled), so these bounds do not cap scan duration. See #2277.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 	if keyPair != nil {
 		server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*keyPair}}

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -38,12 +38,11 @@ func SetupHTTPListener() error {
 	}
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
-		// Bound slow-client (slowloris-style) resource exhaustion. Scan requests are
-		// handled asynchronously (the handler returns immediately and results are
-		// polled), so these bounds do not cap scan duration. See #2277.
+		// ReadHeaderTimeout defends against slowloris-style attacks without
+		// capping handler duration. ReadTimeout and WriteTimeout are left at 0
+		// because the synchronous scan path (POST /v1/scan?wait=true) blocks
+		// until the scan finishes, which can take minutes. See #2277.
 		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}


### PR DESCRIPTION
## Overview
The httphandler scan server is created with no Read/Write/Idle timeouts and no header size limit, so a slow client can hold a connection open indefinitely and tie up server resources (the slowloris pattern in #2277).

This adds `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, `IdleTimeout` and `MaxHeaderBytes` on the server. Scan requests are handled asynchronously (the handler returns right away and clients poll `/v1/results`), so these bounds do not cap how long a scan itself can run.

## How to Test
`cd httphandler && go build ./...` builds clean. The change only sets fields on the `http.Server` struct; handler behavior is unchanged.

## Related issues
Resolved #2277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced HTTP server configuration to better handle slow or idle clients by adding header/time limits and a maximum header size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->