### PR TITLE
Fix index-out-of-range panic on image names without an organization

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -67,11 +67,20 @@ func getAttributesFromImage(imgName string) (Attributes, error) {
 		return Attributes{}, err
 	}
 
+	// canonicalImageName is registry/[path/...]/name[:tag]. The registry is always
+	// the first component, but the organization path in between is optional (a
+	// registry image can have no organization) and may span multiple segments, so
+	// don't assume a fixed three-token split. See #2391.
 	tokens := strings.Split(canonicalImageName, "/")
 	registry := tokens[0]
-	organization := tokens[1]
 
-	imageNameAndTag := strings.Split(tokens[2], ":")
+	organization := ""
+	nameAndTag := tokens[len(tokens)-1]
+	if len(tokens) > 2 {
+		organization = strings.Join(tokens[1:len(tokens)-1], "/")
+	}
+
+	imageNameAndTag := strings.Split(nameAndTag, ":")
 	imageName := imageNameAndTag[0]
 
 	// Intialize the image tag with default value

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -127,6 +127,39 @@ func TestGetAttributesFromImage(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// registry image with no organization path (previously panicked)
+			imageName: "myregistry.io/myimage:v1",
+			expectedAttributes: Attributes{
+				Registry:     "myregistry.io",
+				Organization: "",
+				ImageName:    "myimage",
+				ImageTag:     "v1",
+			},
+			expectedErr: nil,
+		},
+		{
+			// registry with a port, no organization, default tag
+			imageName: "localhost:5000/myimage",
+			expectedAttributes: Attributes{
+				Registry:     "localhost:5000",
+				Organization: "",
+				ImageName:    "myimage",
+				ImageTag:     "latest",
+			},
+			expectedErr: nil,
+		},
+		{
+			// multi-segment organization path
+			imageName: "gcr.io/team/sub/myimage:v2",
+			expectedAttributes: Attributes{
+				Registry:     "gcr.io",
+				Organization: "team/sub",
+				ImageName:    "myimage",
+				ImageTag:     "v2",
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview
`getAttributesFromImage` splits the normalized image name and reads `tokens[1]` and `tokens[2]` directly, assuming three slash-separated parts (`registry/organization/name:tag`). Registry images with no organization path, like `myregistry.io/image` or `localhost:5000/image`, normalize to two parts, so the scan panics with index out of range (#2391).

The fix takes the registry from the first part and name+tag from the last, treating anything in between as the organization (empty when there is none, joined when it spans multiple segments). The existing three-part behavior is unchanged.

## How to Test
`go test ./core/core/ -run TestGetAttributesFromImage`

I added cases for the no-organization, registry-with-port, and multi-segment-path forms; the first two reproduce the original panic on the old code.

## Related issues
Resolved #2391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canonical image name parsing to correctly handle registries without organization paths and multi-segment organization paths.

* **Tests**
  * Extended test coverage for image name parsing scenarios, including registries with ports and empty organization paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->