### PR TITLE
Add security-severity to SARIF rules for Code Scanning

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -90,7 +90,8 @@ func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) {
 
 // addRule adds a rule description to the scan run based on the given control summary
 func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IControlSummary) {
-	controlSARIFSeverity := string(scoreFactorToSARIFSeverityLevel(control.GetScoreFactor()))
+	scoreFactor := control.GetScoreFactor()
+	controlSARIFSeverity := string(scoreFactorToSARIFSeverityLevel(scoreFactor))
 
 	configuration := sarif.NewReportingConfiguration().WithLevel(controlSARIFSeverity)
 
@@ -98,7 +99,13 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 		WithDefaultConfiguration(configuration).
 		WithShortDescription(sarif.NewMultiformatMessageString(control.GetName())).
 		WithFullDescription(sarif.NewMultiformatMessageString(control.GetDescription())).
-		WithHelp(sarif.NewMultiformatMessageString(sp.generateRemediationMessage(control)))
+		WithHelp(sarif.NewMultiformatMessageString(sp.generateRemediationMessage(control))).
+		// security-severity lets GitHub Code Scanning render and filter findings by
+		// severity. It mirrors the CVSS-style score band already used to pick the
+		// SARIF level above, formatted as grype does it. See #2394.
+		WithProperties(sarif.Properties{
+			"security-severity": fmt.Sprintf("%.1f", scoreFactor),
+		})
 }
 
 // addResult adds a result of checking a rule to the scan run based on the given control summary

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -228,6 +228,31 @@ func TestAddFix_AddsNewFixToResult(t *testing.T) {
 	assert.Equal(t, expectedFix, result.Fixes[0])
 }
 
+// TestAddRule_SetsSecuritySeverity is the regression test for
+// kubescape/kubescape#2394: SARIF rules omitted properties["security-severity"],
+// so GitHub Code Scanning had no severity to display or filter on. The value must
+// mirror the control's score factor, formatted the same way grype emits it.
+func TestAddRule_SetsSecuritySeverity(t *testing.T) {
+	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+
+	control := &reportsummary.ControlSummary{
+		ControlID:   "C-0001",
+		Name:        "Test control",
+		Description: "a test control",
+		Remediation: "do the thing",
+		ScoreFactor: 8.5,
+	}
+
+	sp := NewSARIFPrinter()
+	sp.addRule(run, control)
+
+	require.Len(t, run.Tool.Driver.Rules, 1)
+	rule := run.Tool.Driver.Rules[0]
+	require.NotNil(t, rule.Properties, "rule properties must be set")
+	assert.Equal(t, "8.5", rule.Properties["security-severity"],
+		"security-severity must mirror the control score factor")
+}
+
 func TestPrintConfigurationScan_MissingControl(t *testing.T) {
 	resourceID := "apps/v1/Deployment/default/my-deployment"
 


### PR DESCRIPTION
## Overview
GitHub Code Scanning reads `properties["security-severity"]` on each SARIF rule to display and filter findings by severity. The SARIF printer never set it, so uploaded findings show up with no severity (#2394).

`addRule` now sets it from the control score factor, formatted to one decimal place (the convention grype already uses in its SARIF output). That score factor is the same value the printer uses to pick the SARIF `level`, so the two stay consistent.

## How to Test
`go test ./core/pkg/resultshandling/printer/v2/ -run TestAddRule_SetsSecuritySeverity`

The new test asserts the emitted rule carries `security-severity` matching the control score.

## Related issues
Resolved #2394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SARIF reports now include security severity information for each rule.

* **Tests**
  * Added test to validate security severity field in SARIF output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->