### PR TITLE
fix(list): emit JSON objects for list controls --format json

### DIFF
--- a/core/core/list.go
+++ b/core/core/list.go
@@ -115,19 +115,31 @@ func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]met
 	return entries, nil
 }
 
-// parseControlEntry converts a pipe-delimited "id|name|fw1, fw2" string from
-// IPolicyGetter.ListControls into a typed ControlListEntry.
+// parseControlEntry converts a pipe-delimited "id|name|fw1, fw2" string into a ControlListEntry.
 func parseControlEntry(pipe string) metav1.ControlListEntry {
-	parts := strings.SplitN(pipe, "|", 3)
 	entry := metav1.ControlListEntry{Frameworks: []string{}}
-	if len(parts) > 0 {
-		entry.ID = parts[0]
+	if pipe == "" {
+		return entry
 	}
-	if len(parts) > 1 {
-		entry.Name = parts[1]
+
+	first := strings.Index(pipe, "|")
+	if first == -1 {
+		entry.ID = pipe
+		return entry
 	}
-	if len(parts) > 2 && parts[2] != "" {
-		for _, fw := range strings.Split(parts[2], ", ") {
+	entry.ID = pipe[:first]
+
+	rest := pipe[first+1:]
+	last := strings.LastIndex(rest, "|")
+	if last == -1 {
+		entry.Name = rest
+		return entry
+	}
+
+	entry.Name = rest[:last]
+	frameworksRaw := rest[last+1:]
+	if frameworksRaw != "" {
+		for _, fw := range strings.Split(frameworksRaw, ",") {
 			if fw = strings.TrimSpace(fw); fw != "" {
 				entry.Frameworks = append(entry.Frameworks, fw)
 			}

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -16,8 +16,9 @@ import (
 	"github.com/maruel/natural"
 )
 
+// listFunc handles targets whose output is a flat []string (frameworks, exceptions).
+// "controls" is handled separately via listAndFormatControls because it produces typed structs.
 var listFunc = map[string]func(context.Context, *metav1.ListPolicies) ([]string, error){
-	"controls":   listControls,
 	"frameworks": listFrameworks,
 	"exceptions": listExceptions,
 }
@@ -28,16 +29,20 @@ var listFormatFunc = map[string]func(context.Context, string, []string){
 }
 
 func ListSupportActions() []string {
-	commands := []string{}
+	commands := []string{"controls"}
 	for key := range listFunc {
 		commands = append(commands, key)
 	}
 
-	// Sort the keys
 	sort.Strings(commands)
 	return commands
 }
+
 func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) error {
+	if listPolicies.Target == "controls" {
+		return ks.listAndFormatControls(listPolicies)
+	}
+
 	if policyListerFunc, ok := listFunc[listPolicies.Target]; ok {
 		policies, err := policyListerFunc(ks.Context(), listPolicies)
 		if err != nil {
@@ -56,11 +61,36 @@ func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) error {
 	return fmt.Errorf("unknown command to download")
 }
 
+func (ks *Kubescape) listAndFormatControls(listPolicies *metav1.ListPolicies) error {
+	entries, err := listControls(ks.Context(), listPolicies)
+	if err != nil {
+		return err
+	}
+	entries = naturalSortControls(entries)
+
+	switch listPolicies.Format {
+	case "pretty-print":
+		prettyPrintControls(ks.Context(), entries)
+	case "json":
+		jsonControlsFormat(entries)
+	default:
+		return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'", listPolicies.Format)
+	}
+	return nil
+}
+
 func naturalSortPolicies(policies []string) []string {
 	sort.Slice(policies, func(i, j int) bool {
 		return natural.Less(policies[i], policies[j])
 	})
 	return policies
+}
+
+func naturalSortControls(entries []metav1.ControlListEntry) []metav1.ControlListEntry {
+	sort.Slice(entries, func(i, j int) bool {
+		return natural.Less(entries[i].ID, entries[j].ID)
+	})
+	return entries
 }
 
 func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
@@ -70,11 +100,40 @@ func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 	return listFrameworksNames(policyGetter), nil
 }
 
-func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
+func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]metav1.ControlListEntry, error) {
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
 
 	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil)
-	return policyGetter.ListControls()
+	pipes, err := policyGetter.ListControls()
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]metav1.ControlListEntry, 0, len(pipes))
+	for _, pipe := range pipes {
+		entries = append(entries, parseControlEntry(pipe))
+	}
+	return entries, nil
+}
+
+// parseControlEntry converts a pipe-delimited "id|name|fw1, fw2" string from
+// IPolicyGetter.ListControls into a typed ControlListEntry.
+func parseControlEntry(pipe string) metav1.ControlListEntry {
+	parts := strings.SplitN(pipe, "|", 3)
+	entry := metav1.ControlListEntry{Frameworks: []string{}}
+	if len(parts) > 0 {
+		entry.ID = parts[0]
+	}
+	if len(parts) > 1 {
+		entry.Name = parts[1]
+	}
+	if len(parts) > 2 && parts[2] != "" {
+		for _, fw := range strings.Split(parts[2], ", ") {
+			if fw = strings.TrimSpace(fw); fw != "" {
+				entry.Frameworks = append(entry.Frameworks, fw)
+			}
+		}
+	}
+	return entry
 }
 
 func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
@@ -94,11 +153,6 @@ func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 }
 
 func prettyPrintListFormat(ctx context.Context, targetPolicy string, policies []string) {
-	if targetPolicy == "controls" {
-		prettyPrintControls(ctx, policies)
-		return
-	}
-
 	policyTable := table.NewWriter()
 	policyTable.SetOutputMirror(printer.GetWriter(ctx, ""))
 
@@ -121,7 +175,13 @@ func jsonListFormat(_ context.Context, _ string, policies []string) {
 	fmt.Printf("%s\n", j)
 }
 
-func prettyPrintControls(ctx context.Context, policies []string) {
+func jsonControlsFormat(entries []metav1.ControlListEntry) {
+	j, _ := json.MarshalIndent(entries, "", "  ")
+
+	fmt.Printf("%s\n", j)
+}
+
+func prettyPrintControls(ctx context.Context, entries []metav1.ControlListEntry) {
 	controlsTable := table.NewWriter()
 	controlsTable.SetOutputMirror(printer.GetWriter(ctx, ""))
 
@@ -132,7 +192,7 @@ func prettyPrintControls(ctx context.Context, policies []string) {
 	controlsTable.Style().Box = table.StyleBoxRounded
 	controlsTable.SetColumnConfigs([]table.ColumnConfig{{Number: 1, Align: text.AlignRight}})
 
-	controlRows := generateControlRows(policies)
+	controlRows := generateControlRows(entries)
 
 	short := utils.CheckShortTerminalWidth(controlRows, table.Row{"Control ID", "Control name", "Docs", "Frameworks"})
 	if short {
@@ -146,31 +206,13 @@ func prettyPrintControls(ctx context.Context, policies []string) {
 	controlsTable.Render()
 }
 
-func generateControlRows(policies []string) []table.Row {
-	rows := make([]table.Row, 0, len(policies))
+func generateControlRows(entries []metav1.ControlListEntry) []table.Row {
+	rows := make([]table.Row, 0, len(entries))
 
-	for _, control := range policies {
-
-		idAndControlAndFrameworks := strings.Split(control, "|")
-
-		var id, control, framework string
-
-		switch len(idAndControlAndFrameworks) {
-		case 0:
-			continue
-		case 1:
-			id = idAndControlAndFrameworks[0]
-		case 2:
-			id, control = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1]
-		default:
-			id, control, framework = idAndControlAndFrameworks[0], idAndControlAndFrameworks[1], idAndControlAndFrameworks[2]
-		}
-
-		docs := cautils.GetControlLink(id)
-
-		currentRow := table.Row{id, control, docs, strings.ReplaceAll(framework, " ", "\n")}
-
-		rows = append(rows, currentRow)
+	for _, entry := range entries {
+		docs := cautils.GetControlLink(entry.ID)
+		frameworks := strings.Join(entry.Frameworks, "\n")
+		rows = append(rows, table.Row{entry.ID, entry.Name, docs, frameworks})
 	}
 
 	return rows

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -29,7 +29,6 @@ func TestNonEmptyListOfPolicies(t *testing.T) {
 	got, _ := io.ReadAll(r)
 	os.Stdout = rescueStdout
 
-	// got := buf.String()
 	want := `[
   "policy1",
   "policy2",
@@ -138,7 +137,7 @@ func TestShortFormatControlRows_ReturnsListOfRowsWithFormattedString(t *testing.
 	assert.Equal(t, want, got)
 }
 
-// The function formats the control rows correctly, replacing newlines in the frameworks column with line breaks.
+// The function formats the control rows correctly, replacing newlines in the frameworks column with spaces.
 func TestShortFormatControlRows_FormatsControlRowsCorrectly(t *testing.T) {
 	controlRows := []table.Row{
 		{"ID1", "Control 1", "Docs 1", "Framework\n1"},
@@ -185,110 +184,197 @@ func TestShortFormatControlRows_HandlesControlRowWithEmptyControlName(t *testing
 	assert.Equal(t, want, got)
 }
 
-// Generates rows for each policy with ID, control, documentation, and framework
+func TestParseControlEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		pipe string
+		want metav1.ControlListEntry
+	}{
+		{
+			name: "full entry with multiple frameworks",
+			pipe: "C-0001|Forbidden Container Registries|NSA, AllControls, MITRE",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Name:       "Forbidden Container Registries",
+				Frameworks: []string{"NSA", "AllControls", "MITRE"},
+			},
+		},
+		{
+			name: "entry with single framework",
+			pipe: "C-0001|Name|NSA",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Name:       "Name",
+				Frameworks: []string{"NSA"},
+			},
+		},
+		{
+			name: "entry with empty frameworks field",
+			pipe: "C-0001|Name|",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Name:       "Name",
+				Frameworks: []string{},
+			},
+		},
+		{
+			name: "entry without frameworks field",
+			pipe: "C-0001|Name",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Name:       "Name",
+				Frameworks: []string{},
+			},
+		},
+		{
+			name: "entry with only ID",
+			pipe: "C-0001",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Frameworks: []string{},
+			},
+		},
+		{
+			name: "empty string",
+			pipe: "",
+			want: metav1.ControlListEntry{
+				Frameworks: []string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseControlEntry(tt.pipe)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Generates rows for each entry with ID, name, documentation link, and frameworks.
 func TestGenerateControlRowsWithAllFields(t *testing.T) {
-	policies := []string{
-		"1|Control 1|Framework 1",
-		"2|Control 2|Framework 2",
-		"3|Control 3|Framework 3",
+	entries := []metav1.ControlListEntry{
+		{ID: "1", Name: "Control 1", Frameworks: []string{"NSA", "MITRE"}},
+		{ID: "2", Name: "Control 2", Frameworks: []string{"AllControls"}},
+		{ID: "3", Name: "Control 3", Frameworks: []string{}},
 	}
 
 	want := []table.Row{
-		{"1", "Control 1", "https://hub.armosec.io/docs/1", "Framework\n1"},
-		{"2", "Control 2", "https://hub.armosec.io/docs/2", "Framework\n2"},
-		{"3", "Control 3", "https://hub.armosec.io/docs/3", "Framework\n3"},
+		{"1", "Control 1", "https://hub.armosec.io/docs/1", "NSA\nMITRE"},
+		{"2", "Control 2", "https://hub.armosec.io/docs/2", "AllControls"},
+		{"3", "Control 3", "https://hub.armosec.io/docs/3", ""},
 	}
 
-	got := generateControlRows(policies)
+	got := generateControlRows(entries)
 
 	assert.Equal(t, want, got)
 }
 
-// Handles policies with no '|' characters in the string
-func TestGenerateControlRowsHandlesPoliciesWithEmptyStringOrNoPipesOrOnePipeMissing(t *testing.T) {
-	policies := []string{
-		"",
-		"1",
-		"2|Control 2|Framework 2",
-		"3|Control 3|Framework 3|Extra 3",
-		"4||Framework 4",
-		"|",
-		"5|Control 5||Extra 5",
+// Handles entries with missing or empty fields.
+func TestGenerateControlRowsHandlesMissingFields(t *testing.T) {
+	entries := []metav1.ControlListEntry{
+		{ID: "", Name: "", Frameworks: []string{}},
+		{ID: "1", Name: "", Frameworks: []string{}},
+		{ID: "2", Name: "Control 2", Frameworks: []string{"NSA", "MITRE"}},
 	}
 
-	expectedRows := []table.Row{
+	want := []table.Row{
 		{"", "", "https://hub.armosec.io/docs/", ""},
 		{"1", "", "https://hub.armosec.io/docs/1", ""},
-		{"2", "Control 2", "https://hub.armosec.io/docs/2", "Framework\n2"},
-		{"3", "Control 3", "https://hub.armosec.io/docs/3", "Framework\n3"},
-		{"4", "", "https://hub.armosec.io/docs/4", "Framework\n4"},
-		{"", "", "https://hub.armosec.io/docs/", ""},
-		{"5", "Control 5", "https://hub.armosec.io/docs/5", ""},
+		{"2", "Control 2", "https://hub.armosec.io/docs/2", "NSA\nMITRE"},
 	}
 
-	rows := generateControlRows(policies)
+	got := generateControlRows(entries)
 
-	assert.Equal(t, expectedRows, rows)
+	assert.Equal(t, want, got)
 }
 
-// The function generates a table with the correct headers and rows based on the input policies.
-func TestGenerateTableWithCorrectHeadersAndRows(t *testing.T) {
-	// Arrange
-	ctx := context.Background()
-	policies := []string{
-		"1|Control 1|Framework 1",
-		"2|Control 2|Framework 2",
-		"3|Control 3|Framework 3",
+// jsonControlsFormat emits a JSON array of objects, not pipe-delimited strings.
+func TestJsonControlsFormat(t *testing.T) {
+	entries := []metav1.ControlListEntry{
+		{ID: "C-0001", Name: "Forbidden Container Registries", Frameworks: []string{}},
+		{ID: "C-0002", Name: "Prevent containers from allowing command execution", Frameworks: []string{"NSA", "AllControls", "MITRE"}},
 	}
 
-	// Redirect stdout to a buffer
 	rescueStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	prettyPrintControls(ctx, policies)
+	jsonControlsFormat(entries)
 
 	w.Close()
 	got, _ := io.ReadAll(r)
 	os.Stdout = rescueStdout
 
-	// got := buf.String()
+	// Verify it is valid JSON that unmarshals into typed objects (not strings).
+	var result []metav1.ControlListEntry
+	assert.NoError(t, json.Unmarshal(got, &result))
+	assert.Len(t, result, 2)
+
+	assert.Equal(t, "C-0001", result[0].ID)
+	assert.Equal(t, "Forbidden Container Registries", result[0].Name)
+	assert.Equal(t, []string{}, result[0].Frameworks)
+
+	assert.Equal(t, "C-0002", result[1].ID)
+	assert.Equal(t, []string{"NSA", "AllControls", "MITRE"}, result[1].Frameworks)
+
+	// Verify the raw output contains object keys, not pipe-delimited strings.
+	assert.Contains(t, string(got), `"id"`)
+	assert.Contains(t, string(got), `"name"`)
+	assert.Contains(t, string(got), `"frameworks"`)
+	assert.NotContains(t, string(got), "|")
+}
+
+// The function generates a table with the correct headers and rows based on the input entries.
+func TestGenerateTableWithCorrectHeadersAndRows(t *testing.T) {
+	ctx := context.Background()
+	entries := []metav1.ControlListEntry{
+		{ID: "1", Name: "Control 1", Frameworks: []string{"NSA"}},
+		{ID: "2", Name: "Control 2", Frameworks: []string{"MITRE"}},
+		{ID: "3", Name: "Control 3", Frameworks: []string{"NSA", "MITRE"}},
+	}
+
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	prettyPrintControls(ctx, entries)
+
+	w.Close()
+	got, _ := io.ReadAll(r)
+	os.Stdout = rescueStdout
+
 	want := `╭────────────┬──────────────┬───────────────────────────────┬────────────╮
 │ Control ID │ Control name │ Docs                          │ Frameworks │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          1 │ Control 1    │ https://hub.armosec.io/docs/1 │ Framework  │
-│            │              │                               │ 1          │
+│          1 │ Control 1    │ https://hub.armosec.io/docs/1 │ NSA        │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          2 │ Control 2    │ https://hub.armosec.io/docs/2 │ Framework  │
-│            │              │                               │ 2          │
+│          2 │ Control 2    │ https://hub.armosec.io/docs/2 │ MITRE      │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ Framework  │
-│            │              │                               │ 3          │
+│          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ NSA        │
+│            │              │                               │ MITRE      │
 ╰────────────┴──────────────┴───────────────────────────────┴────────────╯
 `
 
 	assert.Equal(t, want, string(got))
 }
 
-func TestGenerateTableWithMalformedPoliciesAndPrettyPrintHeadersAndRows(t *testing.T) {
-	// Arrange
+func TestGenerateTableWithPartialEntriesAndPrettyPrintHeadersAndRows(t *testing.T) {
 	ctx := context.Background()
-	policies := []string{
-		"",
-		"1",
-		"2|Control 2|Framework 2",
-		"3|Control 3|Framework 3|Extra 3",
-		"4||Framework 4",
-		"|",
-		"5|Control 5||Extra 5",
+	entries := []metav1.ControlListEntry{
+		{ID: "", Name: "", Frameworks: []string{}},
+		{ID: "1", Name: "", Frameworks: []string{}},
+		{ID: "2", Name: "Control 2", Frameworks: []string{"NSA"}},
+		{ID: "3", Name: "Control 3", Frameworks: []string{"MITRE"}},
+		{ID: "4", Name: "", Frameworks: []string{"NSA"}},
+		{ID: "", Name: "", Frameworks: []string{}},
+		{ID: "5", Name: "Control 5", Frameworks: []string{}},
 	}
 
-	// Redirect stdout to a buffer
 	rescueStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	prettyPrintControls(ctx, policies)
+	prettyPrintControls(ctx, entries)
 
 	w.Close()
 	got, _ := io.ReadAll(r)
@@ -302,14 +388,11 @@ func TestGenerateTableWithMalformedPoliciesAndPrettyPrintHeadersAndRows(t *testi
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
 │          1 │              │ https://hub.armosec.io/docs/1 │            │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          2 │ Control 2    │ https://hub.armosec.io/docs/2 │ Framework  │
-│            │              │                               │ 2          │
+│          2 │ Control 2    │ https://hub.armosec.io/docs/2 │ NSA        │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ Framework  │
-│            │              │                               │ 3          │
+│          3 │ Control 3    │ https://hub.armosec.io/docs/3 │ MITRE      │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
-│          4 │              │ https://hub.armosec.io/docs/4 │ Framework  │
-│            │              │                               │ 4          │
+│          4 │              │ https://hub.armosec.io/docs/4 │ NSA        │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤
 │            │              │ https://hub.armosec.io/docs/  │            │
 ├────────────┼──────────────┼───────────────────────────────┼────────────┤

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -241,6 +241,15 @@ func TestParseControlEntry(t *testing.T) {
 				Frameworks: []string{},
 			},
 		},
+		{
+			name: "control name containing pipe characters",
+			pipe: "C-0001|Name|with|pipe|NSA, MITRE",
+			want: metav1.ControlListEntry{
+				ID:         "C-0001",
+				Name:       "Name|with|pipe",
+				Frameworks: []string{"NSA", "MITRE"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/meta/datastructures/v1/listpolicies.go
+++ b/core/meta/datastructures/v1/listpolicies.go
@@ -11,3 +11,10 @@ type ListResponse struct {
 	Names []string
 	IDs   []string
 }
+
+// ControlListEntry is a single row emitted by "kubescape list controls --format json".
+type ControlListEntry struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Frameworks []string `json:"frameworks"`
+}


### PR DESCRIPTION
## Overview
`kubescape list controls --format json` was emitting a JSON array of pipe-delimited strings (`"C-0001|name|NSA, MITRE"`) instead of structured objects. This meant consumers had to do two layers of string-splitting on output that came from a JSON parser, and `jq '.[].id'` returned null for every entry.

This PR fixes the output to be an array of proper JSON objects:
```json
[
  {"id": "C-0001", "name": "Forbidden Container Registries", "frameworks": []},
  {"id": "C-0002", "name": "Prevent containers from allowing command execution", "frameworks": ["NSA", "AllControls", "MITRE"]}
]
```
`list frameworks` and `list exceptions` are unaffected.

## Additional Information
`IPolicyGetter.ListControls()` is intentionally unchanged — the pipe strings are converted to typed `ControlListEntry` structs in a single `parseControlEntry()` helper inside `core/core/list.go`, keeping the blast radius small. A full interface-layer fix (changing `ListControls()` to return structs directly, which would also require updating `github.com/kubescape/backend`) is a natural follow-up once this lands.

## How to Test
```bash
kubescape list controls --format json | jq '.[0]'
# should print: { "id": "...", "name": "...", "frameworks": [...] }

kubescape list controls --format json | jq '.[].id'
# should print control IDs, not null
```

## Related issues/PRs
* Resolved #2399 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `kubescape list controls` with richer, structured control output for both table and JSON formats.
  * Added direct documentation links per control in the listings.
* **Improvements**
  * Updated control formatting to render framework information more consistently and clearly.
  * JSON output now provides structured objects (easier to consume programmatically).
* **Tests**
  * Expanded coverage for control parsing, row generation, and JSON/table formatting behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->