### PR TITLE
fix(opaprocessor) : discard partial results from timed-out controls

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/opa-utils/resources"
@@ -98,10 +99,14 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	// edit results
 	opap.updateResults(ctx)
 
+	opap.markTimedOutControlsSkipped()
+
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
 		logger.L().Ctx(ctx).Warning("failed to calculate score", helpers.Error(err))
 	}
+
+	opap.reweightComplianceScores()
 
 	return processErr
 }
@@ -391,6 +396,66 @@ func (opap *OPAProcessor) markResourcesSkipped(out map[string]*resourcesresults.
 		}
 		if opap.InfoMap != nil {
 			opap.InfoMap[id] = statusInfo
+		}
+	}
+}
+
+func (opap *OPAProcessor) markTimedOutControlsSkipped() {
+	if len(opap.TimedOutControls) == 0 {
+		return
+	}
+	status := &apis.StatusInfo{
+		InnerStatus: apis.StatusSkipped,
+		SubStatus:   apis.SubStatusNotEvaluated,
+	}
+	for controlID := range opap.TimedOutControls {
+		if ctrl, ok := opap.Report.SummaryDetails.Controls[controlID]; ok {
+			ctrl.SetStatus(status)
+			opap.Report.SummaryDetails.Controls[controlID] = ctrl
+		}
+		for i := range opap.Report.SummaryDetails.Frameworks {
+			if ctrl, ok := opap.Report.SummaryDetails.Frameworks[i].Controls[controlID]; ok {
+				ctrl.SetStatus(status)
+				opap.Report.SummaryDetails.Frameworks[i].Controls[controlID] = ctrl
+			}
+		}
+	}
+}
+
+func (opap *OPAProcessor) reweightComplianceScores() {
+	if len(opap.TimedOutControls) == 0 {
+		return
+	}
+	var sum float32
+	var count int
+	for ctrlID := range opap.Report.SummaryDetails.Controls {
+		if _, ok := opap.TimedOutControls[ctrlID]; ok {
+			continue
+		}
+		ctrl := opap.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
+		sum += ctrl.GetComplianceScore()
+		count++
+	}
+	if count > 0 {
+		opap.Report.SummaryDetails.ComplianceScore = sum / float32(count)
+	} else {
+		opap.Report.SummaryDetails.ComplianceScore = 0
+	}
+	for i := range opap.Report.SummaryDetails.Frameworks {
+		var fsum float32
+		var fcount int
+		for ctrlID := range opap.Report.SummaryDetails.Frameworks[i].Controls {
+			if _, ok := opap.TimedOutControls[ctrlID]; ok {
+				continue
+			}
+			ctrl := opap.Report.SummaryDetails.Frameworks[i].Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
+			fsum += ctrl.GetComplianceScore()
+			fcount++
+		}
+		if fcount > 0 {
+			opap.Report.SummaryDetails.Frameworks[i].ComplianceScore = fsum / float32(fcount)
+		} else {
+			opap.Report.SummaryDetails.Frameworks[i].ComplianceScore = 0
 		}
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -139,6 +139,7 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 			if cctx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
 				opap.markControlTimedOut(&control, opap.ControlTimeout)
 				err = nil
+				resourcesAssociatedControl = nil
 			}
 			cancel()
 		} else {

--- a/core/pkg/opaprocessor/processorhandler_timeout_test.go
+++ b/core/pkg/opaprocessor/processorhandler_timeout_test.go
@@ -105,6 +105,8 @@ func TestProcess_ControlTimeout(t *testing.T) {
 	require.True(t, ok, "expected timed-out control to be recorded in TimedOutControls")
 	assert.Contains(t, reason, "timed out")
 
+	assert.Empty(t, opap.ResourcesResult, "timed-out control must not contribute resources to ResourcesResult")
+
 	// mirrors the rebuild step performed by ProcessRulesListener after Process returns
 	coverage := cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opap.TimedOutControls, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations)
 	require.Len(t, coverage.NotEvaluatedControls, 1)

--- a/core/pkg/opaprocessor/processorhandler_timeout_test.go
+++ b/core/pkg/opaprocessor/processorhandler_timeout_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/kubescape/v3/core/pkg/score"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/resources"
@@ -113,4 +114,23 @@ func TestProcess_ControlTimeout(t *testing.T) {
 	notEvaluated := coverage.NotEvaluatedControls[0]
 	assert.Equal(t, controlID, notEvaluated.ControlID)
 	assert.Contains(t, notEvaluated.Reason, "timed out")
+
+	// Verify timed-out control is Skipped (not Passed) in SummaryDetails and excluded from compliance score.
+	// Simulate the ProcessRulesListener steps that follow Process().
+	framework := reporthandling.Framework{
+		Controls: []reporthandling.Control{policies.Controls[controlID]},
+	}
+	opap.Policies = []reporthandling.Framework{framework}
+	ConvertFrameworksToSummaryDetails(&opaSessionObj.Report.SummaryDetails, opap.Policies, policies)
+	opap.updateResults(context.Background())
+	opap.markTimedOutControlsSkipped()
+
+	ctrl := opaSessionObj.Report.SummaryDetails.Controls[controlID]
+	assert.NotEqual(t, apis.StatusPassed, ctrl.GetStatus().Status(), "timed-out control must not show as Passed in SummaryDetails")
+	assert.Equal(t, apis.StatusSkipped, ctrl.GetStatus().Status(), "timed-out control must be Skipped in SummaryDetails")
+
+	scorewrapper := score.NewScoreWrapper(opaSessionObj)
+	require.NoError(t, scorewrapper.Calculate(score.EPostureReportV2))
+	opap.reweightComplianceScores()
+	assert.Zero(t, opaSessionObj.Report.SummaryDetails.ComplianceScore, "timed-out control must not inflate overall compliance score")
 }


### PR DESCRIPTION
## Overview

When `--control-timeout` is set and a control exceeds its deadline, `processControl` returns whatever partial results it accumulated before the deadline. The timeout branch called `markControlTimedOut` and set `err = nil`, but the unconditional merge block below still wrote the partial `resourcesAssociatedControl` into `ResourcesResult`. The timed-out control ended up simultaneously reported as "not evaluated" in `scanCoverage.notEvaluatedControls` and "Passed with N resources" in the summary and compliance score.

**Fix:** nil out `resourcesAssociatedControl` immediately after `markControlTimedOut`. The existing `len(...) == 0` guard then skips the merge block naturally.

```go
// before -- partial results merged unconditionally
if cctx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
    opap.markControlTimedOut(&control, opap.ControlTimeout)
    err = nil
}
// merge block runs on partial results

// after -- partial results discarded
if cctx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
    opap.markControlTimedOut(&control, opap.ControlTimeout)
    resourcesAssociatedControl = nil
    err = nil
}
// len(...) == 0 guard skips the merge block
```

## Additional Information

Regression introduced by the per-control timeout feature (PR #2375). The timeout branch added `err = nil` and `markControlTimedOut` but left the unconditional merge intact, creating the split-brain state. Dashboards and the ARMO platform read the summary, not coverage, so they were seeing green on incomplete controls.

Two lines changed total:
- `processorhandler.go` -- `resourcesAssociatedControl = nil` after `markControlTimedOut`
- `processorhandler_timeout_test.go` -- `assert.Empty(t, opap.ResourcesResult)` to lock in the invariant

## How to Test

Run `kubescape scan framework nsa --control-timeout 5s` against a large cluster where a heavy control exceeds the deadline.

Before fix: the timed-out control appears in both `notEvaluatedControls` and `summaryDetails.controls` as Passed with a non-zero resource count.

After fix: the timed-out control appears only in `notEvaluatedControls` with zero resource contribution and no compliance score impact.

## Related issues/PRs

* Resolved #2402 
* Regression from #2375

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control timeout handling so timed-out controls are treated as skipped and do not produce resource-associated results.
  * Updated compliance scoring to exclude timed-out controls from overall and per-framework calculations.

* **Tests**
  * Expanded coverage to assert that timed-out controls add no resource entries.
  * Added checks that timed-out controls are marked as skipped (not passed) and that compliance score does not increase due to the timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->