### PR TITLE
feat(opaprocessor): wire CEL language dispatch with stub evaluator

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -495,9 +495,17 @@ func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reportha
 	switch rule.RuleLanguage {
 	case reporthandling.RegoLanguage, reporthandling.RegoLanguage2:
 		return opap.runRegoOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
+	case reporthandling.CELLanguage:
+		return opap.runCELOnK8s(ctx, rule, k8sObjects, getRuleData)
 	default:
 		return nil, fmt.Errorf("rule: '%s', language '%v' not supported", rule.Name, rule.RuleLanguage)
 	}
+}
+
+// runCELOnK8s evaluates a CEL-based PolicyRule against k8s objects.
+// Stub: the CEL evaluator is added in follow-up PRs (kubescape/kubescape#2001).
+func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]interface{}, getRuleData func(*reporthandling.PolicyRule) string) ([]reporthandling.RuleResponse, error) {
+	return nil, fmt.Errorf("rule: '%s', CEL evaluation not yet implemented", rule.Name)
 }
 
 // runRegoOnK8s compiles an OPA PolicyRule and evaluates its against k8s

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -642,3 +642,30 @@ func TestMakeRegoDeps_InputIsolation(t *testing.T) {
 
 	assert.False(t, runtimeExists)
 }
+
+func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
+	opap := &OPAProcessor{}
+	getRuleData := func(r *reporthandling.PolicyRule) string { return r.Rule }
+
+	t.Run("CEL language routes to runCELOnK8s stub", func(t *testing.T) {
+		rule := &reporthandling.PolicyRule{
+			PortalBase:   armotypes.PortalBase{Name: "cel-test-rule"},
+			RuleLanguage: reporthandling.CELLanguage,
+		}
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CEL evaluation not yet implemented")
+		assert.Contains(t, err.Error(), "cel-test-rule")
+	})
+
+	t.Run("unknown language returns not-supported error", func(t *testing.T) {
+		rule := &reporthandling.PolicyRule{
+			PortalBase:   armotypes.PortalBase{Name: "mystery-rule"},
+			RuleLanguage: reporthandling.RuleLanguages("Mystery"),
+		}
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+		assert.Contains(t, err.Error(), "mystery-rule")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.299
+	github.com/kubescape/opa-utils v0.0.300
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1196,8 +1196,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.299 h1:67NYWCX6r2k2p0lKTb36dNmaje9iAxNvnd4icxL1LEg=
-github.com/kubescape/opa-utils v0.0.299/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.300 h1:dFO06j10NJUUMlAy4032yy8SVlvaOyOk3jYWQwlyaFg=
+github.com/kubescape/opa-utils v0.0.300/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.299
+	github.com/kubescape/opa-utils v0.0.300
 	github.com/kubescape/storage v0.0.258
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1204,8 +1204,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.299 h1:67NYWCX6r2k2p0lKTb36dNmaje9iAxNvnd4icxL1LEg=
-github.com/kubescape/opa-utils v0.0.299/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.300 h1:dFO06j10NJUUMlAy4032yy8SVlvaOyOk3jYWQwlyaFg=
+github.com/kubescape/opa-utils v0.0.300/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview

  Bumps opa-utils to v0.0.300 (which has the new `CELLanguage` constant from kubescape/opa-utils#175) and adds the `case
  reporthandling.CELLanguage:` branch in `runOPAOnSingleRule`. The new branch routes to a `runCELOnK8s` stub that just
  returns a "not yet implemented" error for now.

  So nothing actually evaluates CEL yet, this is just the wiring. The real evaluator comes in follow-up PRs

  Also added a small unit test covering the new CEL dispatch path and the existing not-supported error path.


## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added recognition for CEL (Common Expression Language) rules and improved rule-language dispatch behavior.

* **Bug Fixes**
  * CEL rules now return a clearer “not yet implemented” error instead of being treated as unsupported.

* **Tests**
  * Added unit tests covering CEL dispatch and error messaging, plus handling for unsupported rule languages.

* **Chores**
  * Updated an internal dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->