### PR TITLE
fix: use filepath.Join instead of path.Join for filesystem paths

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -241,7 +240,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 				logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + resourcePath)
 				skipReason = "skipped: invalid resource path"
 			} else {
-				absolutePath = path.Join(h.localBasePath, relativePath)
+				absolutePath = filepath.Join(h.localBasePath, relativePath)
 				documentIndex = idx
 				if _, err := os.Stat(absolutePath); err != nil {
 					logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -207,14 +206,14 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 	for resourceID, result := range opaSessionObj.ResourcesResult {
 		if result.GetStatus(nil).IsFailed() {
 			resourceSource := opaSessionObj.ResourceSource[resourceID]
-			filepath := resourceSource.RelativePath
+			relPath := resourceSource.RelativePath
 
 			// Github Code Scanning considers results not associated to a file path meaningless and invalid when uploading
-			if filepath == "" && basePath == "" {
+			if relPath == "" && basePath == "" {
 				continue
 			}
 
-			rsrcAbsPath := path.Join(basePath, filepath)
+			rsrcAbsPath := filepath.Join(basePath, relPath)
 			locationResolver, err := locationresolver.NewFixPathLocationResolver(rsrcAbsPath)
 			if err != nil {
 				logger.L().Debug("failed to create location resolver, will use default location", helpers.Error(err))
@@ -231,8 +230,8 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 					}
 					location := sp.resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
 					sp.addRule(run, ctl)
-					r := sp.addResult(run, ctl, filepath, location)
-					collectFixes(ctx, r, ac, opaSessionObj, resourceID, filepath, rsrcAbsPath)
+					r := sp.addResult(run, ctl, relPath, location)
+					collectFixes(ctx, r, ac, opaSessionObj, resourceID, relPath, rsrcAbsPath)
 				}
 			}
 		}


### PR DESCRIPTION
## What

Replace two incorrect uses of `path.Join` with `filepath.Join` for filesystem path construction.

`path.Join` always uses forward slashes, which produces incorrect paths on Windows, where Kubescape is also expected to run. `filepath.Join` uses the OS-appropriate separator.

## Changes

- **`core/pkg/resultshandling/printer/v2/sarifprinter.go`** — `rsrcAbsPath` is an absolute local file path fed into the location resolver. Switched to `filepath.Join`. A local variable named `filepath` was shadowing the package in that loop, so it was renamed to `relPath`.
- **`core/pkg/fixhandler/fixhandler.go`** — `absolutePath` is passed straight to `os.Stat`, so it must be a real OS path. Switched to `filepath.Join`.
- Removed the now-unused `path` import from both files.

## Notes

- Both affected packages build cleanly.
- Bug fix only — no change to documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling in resource and SARIF scanning to work correctly across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->