### PR TITLE
fix: read severity from summaryDetails instead of missing controls field

### DIFF
--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
 // minimal structs for reading the v2 JSON scan output produced by jsonprinter.go
@@ -159,26 +161,11 @@ func buildSeverityMap(r *scanReport) map[string]string {
 	for id, cs := range r.SummaryDetails.Controls {
 		sev := cs.Severity
 		if sev == "" {
-			sev = scoreToSeverity(cs.ScoreFactor)
+			sev = apis.ControlSeverityToString(cs.ScoreFactor)
 		}
 		m[id] = sev
 	}
 	return m
-}
-
-func scoreToSeverity(f float32) string {
-	switch {
-	case f >= 9:
-		return "Critical"
-	case f >= 7:
-		return "High"
-	case f >= 4:
-		return "Medium"
-	case f >= 1:
-		return "Low"
-	default:
-		return ""
-	}
 }
 
 // severityRank maps severity strings to comparable ints (higher = more severe).

--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -10,7 +10,8 @@ import (
 
 // minimal structs for reading the v2 JSON scan output produced by jsonprinter.go
 type scanReport struct {
-	Results []resultEntry `json:"results"`
+	Results        []resultEntry  `json:"results"`
+	SummaryDetails summaryDetails `json:"summaryDetails"`
 }
 
 type resultEntry struct {
@@ -22,11 +23,19 @@ type controlEntry struct {
 	ControlID string     `json:"controlID"`
 	Name      string     `json:"name"`
 	Status    statusInfo `json:"status"`
-	Severity  string     `json:"severity"`
 }
 
 type statusInfo struct {
 	InnerStatus string `json:"status"`
+}
+
+type summaryDetails struct {
+	Controls map[string]controlSummary `json:"controls"`
+}
+
+type controlSummary struct {
+	ScoreFactor float32 `json:"scoreFactor"`
+	Severity    string  `json:"severity"`
 }
 
 // ControlChange represents a single resource+control pair whose status changed (or stayed failed).
@@ -64,6 +73,8 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 
 	baseMap := buildMap(base)
 	headMap := buildMap(head)
+	baseSev := buildSeverityMap(base)
+	headSev := buildSeverityMap(head)
 
 	cs := &ChangeSet{}
 
@@ -76,7 +87,7 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 			ResourceID:  k.resourceID,
 			ControlID:   k.controlID,
 			ControlName: hc.Name,
-			Severity:    hc.Severity,
+			Severity:    headSev[k.controlID],
 			HeadStatus:  hc.Status.InnerStatus,
 		}
 		if bc, ok := baseMap[k]; ok {
@@ -104,7 +115,7 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 				ResourceID:  k.resourceID,
 				ControlID:   k.controlID,
 				ControlName: bc.Name,
-				Severity:    bc.Severity,
+				Severity:    baseSev[k.controlID],
 				BaseStatus:  "failed",
 				HeadStatus:  headStatus,
 			})
@@ -141,6 +152,33 @@ func buildMap(r *scanReport) map[key]controlEntry {
 		}
 	}
 	return m
+}
+
+func buildSeverityMap(r *scanReport) map[string]string {
+	m := make(map[string]string, len(r.SummaryDetails.Controls))
+	for id, cs := range r.SummaryDetails.Controls {
+		sev := cs.Severity
+		if sev == "" {
+			sev = scoreToSeverity(cs.ScoreFactor)
+		}
+		m[id] = sev
+	}
+	return m
+}
+
+func scoreToSeverity(f float32) string {
+	switch {
+	case f >= 9:
+		return "Critical"
+	case f >= 7:
+		return "High"
+	case f >= 4:
+		return "Medium"
+	case f >= 1:
+		return "Low"
+	default:
+		return ""
+	}
 }
 
 // severityRank maps severity strings to comparable ints (higher = more severe).

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -30,13 +30,20 @@ func makeResult(resourceID string, controls ...controlEntry) resultEntry {
 	return resultEntry{ResourceID: resourceID, AssociatedControls: controls}
 }
 
-func makeControl(id, name, status, severity string) controlEntry {
-	return controlEntry{ControlID: id, Name: name, Status: statusInfo{InnerStatus: status}, Severity: severity}
+func makeControl(id, name, status string) controlEntry {
+	return controlEntry{ControlID: id, Name: name, Status: statusInfo{InnerStatus: status}}
 }
 
 func TestCompute_NewFailure(t *testing.T) {
-	base := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "passed", "High")))
-	head := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed", "High")))
+	sum := summaryDetails{Controls: map[string]controlSummary{"C-001": {ScoreFactor: 7.0}}}
+	base := scanReport{
+		Results:        []resultEntry{makeResult("res1", makeControl("C-001", "Control 1", "passed"))},
+		SummaryDetails: sum,
+	}
+	head := scanReport{
+		Results:        []resultEntry{makeResult("res1", makeControl("C-001", "Control 1", "failed"))},
+		SummaryDetails: sum,
+	}
 
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
 	require.NoError(t, err)
@@ -48,8 +55,8 @@ func TestCompute_NewFailure(t *testing.T) {
 }
 
 func TestCompute_Resolved(t *testing.T) {
-	base := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed", "Medium")))
-	head := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "passed", "Medium")))
+	base := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed")))
+	head := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "passed")))
 
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
 	require.NoError(t, err)
@@ -59,8 +66,8 @@ func TestCompute_Resolved(t *testing.T) {
 }
 
 func TestCompute_Unchanged(t *testing.T) {
-	base := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed", "Low")))
-	head := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed", "Low")))
+	base := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed")))
+	head := makeReport(makeResult("res1", makeControl("C-001", "Control 1", "failed")))
 
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
 	require.NoError(t, err)
@@ -72,7 +79,7 @@ func TestCompute_Unchanged(t *testing.T) {
 func TestCompute_NewResourceInHead(t *testing.T) {
 	// resource not in base at all but failing in head
 	base := makeReport()
-	head := makeReport(makeResult("res-new", makeControl("C-002", "Control 2", "failed", "Critical")))
+	head := makeReport(makeResult("res-new", makeControl("C-002", "Control 2", "failed")))
 
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
 	require.NoError(t, err)
@@ -82,7 +89,7 @@ func TestCompute_NewResourceInHead(t *testing.T) {
 
 func TestCompute_RemovedResourceFromBase(t *testing.T) {
 	// resource was failing in base but absent in head
-	base := makeReport(makeResult("res-old", makeControl("C-001", "Control 1", "failed", "High")))
+	base := makeReport(makeResult("res-old", makeControl("C-001", "Control 1", "failed")))
 	head := makeReport()
 
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
@@ -115,4 +122,95 @@ func TestFilterBySeverity(t *testing.T) {
 
 	result = FilterBySeverity(changes, "Critical")
 	assert.Len(t, result, 1)
+}
+
+func TestCompute_SeverityFromSummaryDetails(t *testing.T) {
+	tests := []struct {
+		name        string
+		scoreFactor float32
+		wantSev     string
+	}{
+		{"critical", 9.5, "Critical"},
+		{"high", 7.0, "High"},
+		{"medium", 5.0, "Medium"},
+		{"low", 2.0, "Low"},
+		{"unknown_zero", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sum := summaryDetails{Controls: map[string]controlSummary{
+				"C-001": {ScoreFactor: tt.scoreFactor},
+			}}
+			head := scanReport{
+				Results:        []resultEntry{makeResult("res1", makeControl("C-001", "Control 1", "failed"))},
+				SummaryDetails: sum,
+			}
+			base := scanReport{}
+
+			cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
+			require.NoError(t, err)
+			require.Len(t, cs.New, 1)
+			assert.Equal(t, tt.wantSev, cs.New[0].Severity)
+		})
+	}
+}
+
+func TestCompute_SeverityStringFieldTakesPrecedence(t *testing.T) {
+	sum := summaryDetails{Controls: map[string]controlSummary{
+		"C-001": {ScoreFactor: 9.5, Severity: "High"},
+	}}
+	head := scanReport{
+		Results:        []resultEntry{makeResult("res1", makeControl("C-001", "Control 1", "failed"))},
+		SummaryDetails: sum,
+	}
+	base := scanReport{}
+
+	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
+	require.NoError(t, err)
+	require.Len(t, cs.New, 1)
+	assert.Equal(t, "High", cs.New[0].Severity)
+}
+
+func TestFilterBySeverity_BelowThresholdReturnsEmpty(t *testing.T) {
+	changes := []ControlChange{
+		{ControlID: "C-001", Severity: "Low"},
+		{ControlID: "C-002", Severity: "Medium"},
+	}
+
+	result := FilterBySeverity(changes, "High")
+	assert.Empty(t, result)
+}
+
+func TestFilterBySeverity_CIGate(t *testing.T) {
+	sum := summaryDetails{Controls: map[string]controlSummary{
+		"C-HIGH":     {ScoreFactor: 7.0},
+		"C-CRITICAL": {ScoreFactor: 9.5},
+		"C-MEDIUM":   {ScoreFactor: 5.0},
+		"C-LOW":      {ScoreFactor: 2.0},
+	}}
+	head := scanReport{
+		Results: []resultEntry{
+			makeResult("res1",
+				makeControl("C-HIGH", "High Control", "failed"),
+				makeControl("C-CRITICAL", "Critical Control", "failed"),
+				makeControl("C-MEDIUM", "Medium Control", "failed"),
+				makeControl("C-LOW", "Low Control", "failed"),
+			),
+		},
+		SummaryDetails: sum,
+	}
+	base := scanReport{}
+
+	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
+	require.NoError(t, err)
+	require.Len(t, cs.New, 4)
+
+	gate := FilterBySeverity(cs.New, "high")
+	assert.Len(t, gate, 2)
+
+	controlIDs := make([]string, len(gate))
+	for i, c := range gate {
+		controlIDs[i] = c.ControlID
+	}
+	assert.ElementsMatch(t, []string{"C-HIGH", "C-CRITICAL"}, controlIDs)
 }

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -134,7 +134,7 @@ func TestCompute_SeverityFromSummaryDetails(t *testing.T) {
 		{"high", 7.0, "High"},
 		{"medium", 5.0, "Medium"},
 		{"low", 2.0, "Low"},
-		{"unknown_zero", 0, ""},
+		{"unknown_zero", 0, "Unknown"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -155,9 +155,9 @@ func TestCompute_SeverityFromSummaryDetails(t *testing.T) {
 	}
 }
 
-func TestCompute_SeverityStringFieldTakesPrecedence(t *testing.T) {
+func TestCompute_SeverityStringFromCurrentReport(t *testing.T) {
 	sum := summaryDetails{Controls: map[string]controlSummary{
-		"C-001": {ScoreFactor: 9.5, Severity: "High"},
+		"C-001": {ScoreFactor: 9.5, Severity: "Critical"},
 	}}
 	head := scanReport{
 		Results:        []resultEntry{makeResult("res1", makeControl("C-001", "Control 1", "failed"))},
@@ -168,7 +168,7 @@ func TestCompute_SeverityStringFieldTakesPrecedence(t *testing.T) {
 	cs, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
 	require.NoError(t, err)
 	require.Len(t, cs.New, 1)
-	assert.Equal(t, "High", cs.New[0].Severity)
+	assert.Equal(t, "Critical", cs.New[0].Severity)
 }
 
 func TestFilterBySeverity_BelowThresholdReturnsEmpty(t *testing.T) {


### PR DESCRIPTION
## Overview

`--severity-threshold` and `--fail-on-new` in `kubescape diff` had no effect. The `controlEntry` struct was reading `Severity` from `json:"severity"` at the `results[].controls[]` level, but kubescape scan never writes a severity field there. Severity lives in `summaryDetails.controls[<controlID>].scoreFactor` in the actual JSON output. Because of this `controlEntry.Severity` was always an empty string after decoding, `severityRank("")` returned 0, and `FilterBySeverity` dropped every change, meaning the CI gate silently passed even when new critical failures existed.

The fix adds `summaryDetails` parsing to `diff.go`, builds a `controlID -> severity` map from the correct location, and removes the dead `Severity` field from `controlEntry` since the JSON at `results[].controls[]` never populated it.

## How to Test

```bash
go test -v ./core/pkg/resultshandling/diff/...
```

All 12 tests should pass. Key new tests:

- `TestCompute_SeverityFromSummaryDetails` verifies severity is correctly read from `summaryDetails.controls` across all severity bands
- `TestFilterBySeverity_CIGate` runs an end-to-end check with 4 new failures (critical, high, medium, low) and asserts that
  `FilterBySeverity(cs.New, "high")` returns exactly 2

## Additional Information

The fallback `scoreToSeverity(scoreFactor)` handles older report files that do not have a pre-computed severity string, so the fix is backward compatible.

## Related issues/PRs

* Resolved #2411

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diff computations now pull severity from scan summary details rather than per-control fields, resulting in correct severity assignment for new failures and resolved controls.
* **Refactor**
  * Severity derivation is more consistent, including reliable fallback from score factors when an explicit severity value isn’t available.
* **Tests**
  * Added and expanded test cases to validate summary-driven severity mapping, fallback behavior, and severity filtering/gating expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->