### PR TITLE
fix: prevent silent output overwrite when multiple formats share one path

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -230,7 +230,10 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 
 	scanInfo.SetScanType(cautils.ScanTypeImage)
 
-	outputPrinters := GetOutputPrinters(scanInfo, ks.Context(), "")
+	outputPrinters, err := GetOutputPrinters(scanInfo, ks.Context(), "")
+	if err != nil {
+		return false, err
+	}
 
 	uiPrinter := GetUIPrinter(ks.Context(), scanInfo, "")
 

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -140,7 +140,10 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	// ===================== Results Handling =====================
 
 	scanInfo.SetScanType(cautils.ScanTypeImage)
-	outputPrinters := GetOutputPrinters(scanInfo, ks.Context(), "")
+	outputPrinters, err := GetOutputPrinters(scanInfo, ks.Context(), "")
+	if err != nil {
+		return false, err
+	}
 	uiPrinter := GetUIPrinter(ks.Context(), scanInfo, "")
 	resultsHandler := resultshandling.NewResultsHandler(nil, outputPrinters, uiPrinter)
 	resultsHandler.ImageScanData = []cautils.ImageScanData{*scanResultsPatched}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -39,7 +39,7 @@ type componentInterfaces struct {
 	outputPrinters    []printer.IPrinter
 }
 
-func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInterfaces {
+func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentInterfaces, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "setup interfaces")
 	defer span.End()
 
@@ -95,7 +95,10 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 	reportHandler := getReporter(ctx, tenantConfig, scanInfo.ScanID, scanInfo.Submit, scanInfo.FrameworkScan, *scanInfo)
 
 	// setup printers
-	outputPrinters := GetOutputPrinters(scanInfo, ctx, tenantConfig.GetContextName())
+	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, tenantConfig.GetContextName())
+	if err != nil {
+		return componentInterfaces{}, err
+	}
 
 	uiPrinter := GetUIPrinter(ctx, scanInfo, tenantConfig.GetContextName())
 
@@ -108,10 +111,10 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) componentInt
 		outputPrinters:    outputPrinters,
 		uiPrinter:         uiPrinter,
 		hostSensorHandler: hostSensorHandler,
-	}
+	}, nil
 }
 
-func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterName string) []printer.IPrinter {
+func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterName string) ([]printer.IPrinter, error) {
 	formats := scanInfo.Formats()
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
@@ -119,7 +122,7 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
-			logger.L().Ctx(ctx).Fatal(err.Error())
+			return nil, err
 		}
 
 		if usesPrettyPrinter && containPrettyPrinter {
@@ -128,7 +131,7 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 
 		if path := resolvedOutputPath(format, scanInfo.Output); path != "" {
 			if existing, collision := resolvedPaths[path]; collision {
-				logger.L().Ctx(ctx).Fatal(fmt.Sprintf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path))
+				return nil, fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path)
 			}
 			resolvedPaths[path] = format
 		}
@@ -142,7 +145,7 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 		}
 	}
 
-	return outputPrinters
+	return outputPrinters, nil
 }
 
 func resolvedOutputPath(format, outputFile string) string {
@@ -160,19 +163,19 @@ func resolvedOutputPath(format, outputFile string) string {
 func fileExtForFormat(format string) string {
 	switch format {
 	case printer.JsonFormat:
-		return ".json"
+		return printer.JsonOutputExt
 	case printer.JunitResultFormat:
-		return ".xml"
+		return printer.JunitOutputExt
 	case printer.SARIFFormat:
-		return ".sarif"
+		return printer.SARIFOutputExt
 	case printer.HtmlFormat:
-		return ".html"
+		return printer.HtmlOutputExt
 	case printer.PdfFormat:
-		return ".pdf"
+		return printer.PdfOutputExt
 	case printer.PrometheusFormat:
-		return ".txt"
+		return printer.PrometheusOutputExt
 	default:
-		return ".txt"
+		return printer.PrettyOutputExt
 	}
 }
 
@@ -184,7 +187,11 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	scanInfo.Init(ctxInit) // initialize scan info
 	defer scanInfo.Cleanup()
 
-	interfaces := getInterfaces(ctxInit, scanInfo)
+	interfaces, err := getInterfaces(ctxInit, scanInfo)
+	if err != nil {
+		spanInit.End()
+		return nil, err
+	}
 	interfaces.report.SetTenantConfig(interfaces.tenantConfig)
 
 	// Only create DownloadReleasedPolicy if not in air-gapped mode

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -113,6 +115,7 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	formats := scanInfo.Formats()
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
+	resolvedPaths := make(map[string]string)
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
@@ -121,6 +124,13 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 
 		if usesPrettyPrinter && containPrettyPrinter {
 			continue
+		}
+
+		if path := resolvedOutputPath(format, scanInfo.Output); path != "" {
+			if existing, collision := resolvedPaths[path]; collision {
+				logger.L().Ctx(ctx).Fatal(fmt.Sprintf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path))
+			}
+			resolvedPaths[path] = format
 		}
 
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo, clusterName)
@@ -133,6 +143,37 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	}
 
 	return outputPrinters
+}
+
+func resolvedOutputPath(format, outputFile string) string {
+	if outputFile == "" {
+		return ""
+	}
+	ext := fileExtForFormat(format)
+	trimmed := strings.TrimSpace(outputFile)
+	if ext != "" && filepath.Ext(trimmed) != ext {
+		return trimmed + ext
+	}
+	return trimmed
+}
+
+func fileExtForFormat(format string) string {
+	switch format {
+	case printer.JsonFormat:
+		return ".json"
+	case printer.JunitResultFormat:
+		return ".xml"
+	case printer.SARIFFormat:
+		return ".sarif"
+	case printer.HtmlFormat:
+		return ".html"
+	case printer.PdfFormat:
+		return ".pdf"
+	case printer.PrometheusFormat:
+		return ".txt"
+	default:
+		return ".txt"
+	}
 }
 
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -146,11 +146,11 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 }
 
 func resolvedOutputPath(format, outputFile string) string {
-	if outputFile == "" {
+	trimmed := strings.TrimSpace(outputFile)
+	if trimmed == "" {
 		return ""
 	}
 	ext := fileExtForFormat(format)
-	trimmed := strings.TrimSpace(outputFile)
 	if ext != "" && filepath.Ext(trimmed) != ext {
 		return trimmed + ext
 	}

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -16,10 +16,24 @@ func TestGetOutputPrinters(t *testing.T) {
 		Format:   "json,junit,html",
 	}
 
-	outputPrinters := GetOutputPrinters(scanInfo, ctx, "test-cluster")
+	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, "test-cluster")
 
+	assert.NoError(t, err)
 	assert.NotNil(t, outputPrinters)
 	assert.Equal(t, 3, len(outputPrinters))
+}
+
+func TestGetOutputPrintersCollisionReturnsError(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{
+		ScanType: cautils.ScanTypeControl,
+		Format:   "prometheus,pretty-printer",
+		Output:   "report",
+	}
+
+	_, err := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "output path collision")
 }
 
 func TestIsPrioritizationScanType(t *testing.T) {
@@ -203,8 +217,9 @@ func TestGetOutputPrintersDeduplicatesPrettyPrinterFallback(t *testing.T) {
 				ScanType: tt.scanType,
 			}
 
-			got := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
+			got, err := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
 
+			assert.NoError(t, err)
 			assert.Len(t, got, tt.expectedLen)
 		})
 	}

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -24,6 +24,16 @@ const (
 	SARIFFormat       string = "sarif"
 )
 
+const (
+	JsonOutputExt       = ".json"
+	JunitOutputExt      = ".xml"
+	SARIFOutputExt      = ".sarif"
+	HtmlOutputExt       = ".html"
+	PdfOutputExt        = ".pdf"
+	PrometheusOutputExt = ".txt"
+	PrettyOutputExt     = ".txt"
+)
+
 type IPrinter interface {
 	PrintNextSteps()
 	ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	htmlOutputFile = "report"
-	htmlOutputExt  = ".html"
 )
 
 //go:embed html/report.gohtml
@@ -45,15 +44,15 @@ func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
 	outputFile = strings.TrimSpace(outputFile)
 	if outputFile == "" {
 		// Raw HTML markup must never fall back to stdout on a TTY.
-		outputFile = htmlOutputFile + htmlOutputExt
+		outputFile = htmlOutputFile + printer.HtmlOutputExt
 		logger.L().Info("no --output specified for html format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(outputFile) != htmlOutputExt {
-		outputFile = outputFile + htmlOutputExt
+	} else if filepath.Ext(outputFile) != printer.HtmlOutputExt {
+		outputFile = outputFile + printer.HtmlOutputExt
 	}
 	// HTML must never fall back to stdout on file-create errors either
 	// (e.g. read-only cwd) — use the no-stdout-fallback helper.
-	hp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+htmlOutputExt)
+	hp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+printer.HtmlOutputExt)
 }
 
 func (hp *HtmlPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	jsonOutputFile = "report"
-	jsonOutputExt  = ".json"
 )
 
 var _ printer.IPrinter = &JsonPrinter{}
@@ -40,8 +39,8 @@ func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = jsonOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != jsonOutputExt {
-			outputFile = outputFile + jsonOutputExt
+		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JsonOutputExt {
+			outputFile = outputFile + printer.JsonOutputExt
 		}
 	}
 	jp.writer = printer.GetWriter(ctx, outputFile)

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	junitOutputFile = "report"
-	junitOutputExt  = ".xml"
 )
 
 var _ printer.IPrinter = &JunitPrinter{}
@@ -104,8 +103,8 @@ func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = junitOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != junitOutputExt {
-			outputFile = outputFile + junitOutputExt
+		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JunitOutputExt {
+			outputFile = outputFile + printer.JunitOutputExt
 		}
 	}
 	jp.writer = printer.GetWriter(ctx, outputFile)

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	pdfOutputFile = "report"
-	pdfOutputExt  = ".pdf"
 )
 
 var _ printer.IPrinter = &PdfPrinter{}
@@ -39,16 +38,16 @@ func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
 	if outputFile == "" {
 		// Binary PDF must never fall back to stdout: it corrupts TTYs and
 		// is rarely what the user intended. Default to ./report.pdf.
-		outputFile = pdfOutputFile + pdfOutputExt
+		outputFile = pdfOutputFile + printer.PdfOutputExt
 		logger.L().Info("no --output specified for pdf format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(outputFile) != pdfOutputExt {
-		outputFile = outputFile + pdfOutputExt
+	} else if filepath.Ext(outputFile) != printer.PdfOutputExt {
+		outputFile = outputFile + printer.PdfOutputExt
 	}
 	// PDF must never fall back to stdout on file-create errors either
 	// (e.g. read-only cwd) — use the no-stdout-fallback helper, which
 	// falls back to a temp file rather than corrupting the TTY.
-	pp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+pdfOutputExt)
+	pp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+printer.PdfOutputExt)
 }
 
 func (pp *PdfPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -22,6 +23,11 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+const (
+	prettyOutputFile = "report"
+	prettyOutputExt  = ".txt"
 )
 
 var _ printer.IPrinter = &PrettyPrinter{}
@@ -184,17 +190,22 @@ func (pp *PrettyPrinter) printHeader(opaSessionObj *cautils.OPASessionObj) {
 }
 
 func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
-	// PrettyPrinter should accept Stdout at least by its full name (path)
-	// and follow the common behavior of outputting to a default filename
-	// otherwise
 	if outputFile == os.Stdout.Name() {
 		pp.writer = printer.GetWriter(ctx, "")
 		pp.SetMainPrinter()
 		return
 	}
 
-	pp.writer = printer.GetWriter(ctx, outputFile)
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = prettyOutputFile
+		}
+		if filepath.Ext(strings.TrimSpace(outputFile)) != prettyOutputExt {
+			outputFile = outputFile + prettyOutputExt
+		}
+	}
 
+	pp.writer = printer.GetWriter(ctx, outputFile)
 	pp.SetMainPrinter()
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -197,10 +197,11 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
 	}
 
 	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
+		outputFile = strings.TrimSpace(outputFile)
+		if outputFile == "" {
 			outputFile = prettyOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != prettyOutputExt {
+		if filepath.Ext(outputFile) != prettyOutputExt {
 			outputFile = outputFile + prettyOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	prettyOutputFile = "report"
-	prettyOutputExt  = ".txt"
 )
 
 var _ printer.IPrinter = &PrettyPrinter{}
@@ -201,8 +200,8 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if outputFile == "" {
 			outputFile = prettyOutputFile
 		}
-		if filepath.Ext(outputFile) != prettyOutputExt {
-			outputFile = outputFile + prettyOutputExt
+		if filepath.Ext(outputFile) != printer.PrettyOutputExt {
+			outputFile = outputFile + printer.PrettyOutputExt
 		}
 	}
 

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -12,6 +14,11 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+)
+
+const (
+	prometheusOutputFile = "report"
+	prometheusOutputExt  = ".txt"
 )
 
 var _ printer.IPrinter = &PrometheusPrinter{}
@@ -32,6 +39,14 @@ func (pp *PrometheusPrinter) PrintNextSteps() {
 }
 
 func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = prometheusOutputFile
+		}
+		if filepath.Ext(strings.TrimSpace(outputFile)) != prometheusOutputExt {
+			outputFile = outputFile + prometheusOutputExt
+		}
+	}
 	pp.writer = printer.GetWriter(ctx, outputFile)
 }
 

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -40,10 +40,11 @@ func (pp *PrometheusPrinter) PrintNextSteps() {
 
 func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
+		outputFile = strings.TrimSpace(outputFile)
+		if outputFile == "" {
 			outputFile = prometheusOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != prometheusOutputExt {
+		if filepath.Ext(outputFile) != prometheusOutputExt {
 			outputFile = outputFile + prometheusOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	prometheusOutputFile = "report"
-	prometheusOutputExt  = ".txt"
 )
 
 var _ printer.IPrinter = &PrometheusPrinter{}
@@ -44,8 +43,8 @@ func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if outputFile == "" {
 			outputFile = prometheusOutputFile
 		}
-		if filepath.Ext(outputFile) != prometheusOutputExt {
-			outputFile = outputFile + prometheusOutputExt
+		if filepath.Ext(outputFile) != printer.PrometheusOutputExt {
+			outputFile = outputFile + printer.PrometheusOutputExt
 		}
 	}
 	pp.writer = printer.GetWriter(ctx, outputFile)

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -30,20 +30,27 @@ func TestNewPrometheusPrinter(t *testing.T) {
 }
 
 func TestSetWriter(t *testing.T) {
-	// Test case 1: Empty outputFile
 	outputFile := ""
 	promPrinter := &PrometheusPrinter{}
 	promPrinter.SetWriter(context.Background(), outputFile)
 	assert.Equal(t, os.Stdout, promPrinter.writer)
 
-	// Test case 2: Valid outputFile
-	outputFile = filepath.Join(os.TempDir(), "test.log")
+	base := filepath.Join(t.TempDir(), "test-prom")
 	promPrinter = &PrometheusPrinter{}
-	promPrinter.SetWriter(context.Background(), outputFile)
-	f, err := os.Open(outputFile)
+	promPrinter.SetWriter(context.Background(), base)
+	expectedPath := base + prometheusOutputExt
+	f, err := os.Open(expectedPath)
 	assert.NoError(t, err)
 	defer f.Close()
-	assert.NotNil(t, promPrinter.writer)
+	assert.Equal(t, expectedPath, promPrinter.writer.Name())
+
+	withExt := filepath.Join(t.TempDir(), "test-prom"+prometheusOutputExt)
+	promPrinter = &PrometheusPrinter{}
+	promPrinter.SetWriter(context.Background(), withExt)
+	f2, err := os.Open(withExt)
+	assert.NoError(t, err)
+	defer f2.Close()
+	assert.Equal(t, withExt, promPrinter.writer.Name())
 }
 
 func TestScore(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
@@ -38,13 +39,13 @@ func TestSetWriter(t *testing.T) {
 	base := filepath.Join(t.TempDir(), "test-prom")
 	promPrinter = &PrometheusPrinter{}
 	promPrinter.SetWriter(context.Background(), base)
-	expectedPath := base + prometheusOutputExt
+	expectedPath := base + printer.PrometheusOutputExt
 	f, err := os.Open(expectedPath)
 	assert.NoError(t, err)
 	defer f.Close()
 	assert.Equal(t, expectedPath, promPrinter.writer.Name())
 
-	withExt := filepath.Join(t.TempDir(), "test-prom"+prometheusOutputExt)
+	withExt := filepath.Join(t.TempDir(), "test-prom"+printer.PrometheusOutputExt)
 	promPrinter = &PrometheusPrinter{}
 	promPrinter.SetWriter(context.Background(), withExt)
 	f2, err := os.Open(withExt)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	sarifOutputFile = "report"
-	sarifOutputExt  = ".sarif"
 
 	toolName    = "kubescape"
 	toolInfoURI = "https://armosec.io"
@@ -80,8 +79,8 @@ func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = sarifOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != sarifOutputExt {
-			outputFile = outputFile + sarifOutputExt
+		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.SARIFOutputExt {
+			outputFile = outputFile + printer.SARIFOutputExt
 		}
 	}
 	sp.writer = printer.GetWriter(ctx, outputFile)


### PR DESCRIPTION
## Overview

`PrometheusPrinter` and `PrettyPrinter` were writing to the raw `--output` path with no file extension. All other printers (JSON, SARIF, JUnit, PDF, HTML) append their own extension so they resolve to distinct files. When two formats resolved to the same final path, each printer independently truncated and overwrote the previous output with no error or warning. The scan completed with exit code 0 and the earlier format's results were silently lost.

Two changes fix this:

- `PrometheusPrinter.SetWriter` and `PrettyPrinter.SetWriter` now append a `.txt` extension when the output path has none, matching the pattern already used by all other printers.
- `GetOutputPrinters` in `scan.go` now computes each format's resolved output path before constructing the printer and fails fast with a clear error if two formats would write to the same file.

## How to Test

```bash
go test -v ./core/... ./core/pkg/resultshandling/printer/v2/...
```

To reproduce the original bug before the fix:

```bash
kubescape scan framework nsa . --format json,prometheus --output report.json
# before: both resolve to report.json, prometheus silently overwrites json
# after:  json -> report.json, prometheus -> report.txt
```

## Additional Information

`resolvedOutputPath` and `fileExtForFormat` are unexported helpers in `scan.go` that mirror the extension logic from each printer's `SetWriter`so collision detection stays in sync with the actual file resolution.

## Related issues/PRs

* Resolved #2413

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Output file handling now trims whitespace, normalizes filenames per report format, and appends the correct extension when missing
  * Detects and returns an error when different report formats resolve to the same output path
  * More consistent extension behavior across HTML, JSON, JUnit XML, PDF, and SARIF printers
  * Scanner/image/patch setup now stops early and surfaces printer initialization failures
* **Tests**
  * Expanded assertions for Prometheus output filename normalization
  * Added coverage for output-path collision errors and updated existing `GetOutputPrinters` tests to handle errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->