### PR TITLE
Add CEL env builder for the VAP engine

### DIFF
--- a/core/pkg/opaprocessor/cel/env.go
+++ b/core/pkg/opaprocessor/cel/env.go
@@ -1,0 +1,72 @@
+// Package cel implements the CEL evaluation engine for Kubescape. It compiles
+// and evaluates ValidatingAdmissionPolicy (VAP) expressions offline, against
+// resources scanned from files, so that a VAP behaves the same way in a scan as
+// it does at live admission.
+package cel
+
+import (
+	"github.com/google/cel-go/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+)
+
+// newEnv builds the CEL environment used to compile and evaluate VAP
+// expressions offline.
+//
+// It extends apiserver's base env set rather than hand-picking CEL libraries.
+// The base set carries both the function library set (so quantity(), isIP(),
+// format.*, etc. exist) and the version gating that a real cluster applies to a
+// VAP. That is what guarantees a VAP behaves identically offline (in our scan)
+// and at live admission. Hand-assembling the libraries ourselves would risk a
+// function being present in one place and absent in the other, silently
+// breaking the equivalence guarantee. Always extend the base set; never replace
+// it.
+func newEnv() (*cel.Env, error) {
+	// Compatibility version pins the CEL feature/library set to what the
+	// apiserver guarantees, so scan and admission agree on what is available.
+	compatVersion := environment.DefaultCompatibilityVersion()
+
+	// The base set carries the apiserver CEL libraries, language settings and
+	// runtime cost limits. It declares no variables; we add the VAP variables
+	// on top of it.
+	baseEnvSet := environment.MustBaseEnvSet(compatVersion)
+
+	// Declare the VAP variables. They are declared dynamic because objects are
+	// bound from YAML as map[string]any rather than custom Go types.
+	//
+	//   - object    : the K8s resource being scanned.
+	//   - oldObject : declared here and bound to null offline, so a CREATE
+	//                 (request.operation=CREATE) has the same null oldObject it
+	//                 would have at live admission.
+	//   - params    : resolved from the control configuration; declared here so
+	//                 params.* references compile.
+	//   - request   : stubbed offline (operation=CREATE, empty userInfo);
+	//                 declared here so request.* references compile.
+	//   - variables : a dynamic selector so validations referencing
+	//                 variables.<name> compile; values are injected per-object
+	//                 at eval time.
+	//
+	// authorizer is deliberately NOT declared: it cannot be resolved offline, so
+	// a policy referencing authorizer should fail to compile and get skipped
+	// rather than produce a wrong verdict.
+	extended, err := baseEnvSet.Extend(environment.VersionedOptions{
+		// IntroducedVersion is required. Pinning it to the compatibility
+		// version itself means these variables are included at this version in
+		// both the NewExpressions and StoredExpressions environments.
+		IntroducedVersion: compatVersion,
+		EnvOptions: []cel.EnvOption{
+			cel.Variable("object", cel.DynType),
+			cel.Variable("oldObject", cel.DynType),
+			cel.Variable("params", cel.DynType),
+			cel.Variable("request", cel.DynType),
+			cel.Variable("variables", cel.DynType),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// StoredExpressions is the mode for compiling an already-authored policy
+	// (the VAP YAML we load from cel-admission-library), as opposed to
+	// NewExpressions which is used when validating a brand new policy.
+	return extended.Env(environment.StoredExpressions)
+}

--- a/core/pkg/opaprocessor/cel/env.go
+++ b/core/pkg/opaprocessor/cel/env.go
@@ -33,17 +33,26 @@ func newEnv() (*cel.Env, error) {
 	// Declare the VAP variables. They are declared dynamic because objects are
 	// bound from YAML as map[string]any rather than custom Go types.
 	//
-	//   - object    : the K8s resource being scanned.
-	//   - oldObject : declared here and bound to null offline, so a CREATE
-	//                 (request.operation=CREATE) has the same null oldObject it
-	//                 would have at live admission.
-	//   - params    : resolved from the control configuration; declared here so
-	//                 params.* references compile.
-	//   - request   : stubbed offline (operation=CREATE, empty userInfo);
-	//                 declared here so request.* references compile.
-	//   - variables : a dynamic selector so validations referencing
-	//                 variables.<name> compile; values are injected per-object
-	//                 at eval time.
+	//   - object          : the K8s resource being scanned.
+	//   - oldObject       : declared here and bound to null offline, so a CREATE
+	//                       (request.operation=CREATE) has the same null
+	//                       oldObject it would have at live admission.
+	//   - namespaceObject : the Namespace object the scanned resource lives in.
+	//                       A standard, first-class VAP variable; the apiserver
+	//                       binds it to the resource's namespace (null for
+	//                       cluster-scoped resources). Declared here so policies
+	//                       referencing namespaceObject.* compile; bound at eval
+	//                       time (the scanned resource's namespace object, or
+	//                       null when cluster-scoped). It is resolvable offline
+	//                       (unlike authorizer), so omitting it would silently
+	//                       skip common policies and break the parity guarantee.
+	//   - params          : resolved from the control configuration; declared
+	//                       here so params.* references compile.
+	//   - request         : stubbed offline (operation=CREATE, empty userInfo);
+	//                       declared here so request.* references compile.
+	//   - variables       : a dynamic selector so validations referencing
+	//                       variables.<name> compile; values are injected
+	//                       per-object at eval time.
 	//
 	// authorizer is deliberately NOT declared: it cannot be resolved offline, so
 	// a policy referencing authorizer should fail to compile and get skipped
@@ -56,6 +65,7 @@ func newEnv() (*cel.Env, error) {
 		EnvOptions: []cel.EnvOption{
 			cel.Variable("object", cel.DynType),
 			cel.Variable("oldObject", cel.DynType),
+			cel.Variable("namespaceObject", cel.DynType),
 			cel.Variable("params", cel.DynType),
 			cel.Variable("request", cel.DynType),
 			cel.Variable("variables", cel.DynType),

--- a/core/pkg/opaprocessor/cel/env_test.go
+++ b/core/pkg/opaprocessor/cel/env_test.go
@@ -1,0 +1,31 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewEnvCompilesObjectExpression is the smallest possible proof that the
+// env works: a literal expression referencing the declared "object" variable
+// compiles with no error.
+func TestNewEnvCompilesObjectExpression(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	_, issues := env.Compile(`object.metadata.name == "foo"`)
+	assert.NoError(t, issues.Err())
+}
+
+// TestNewEnvRejectsAuthorizer documents, as an executable test, that authorizer
+// is deliberately not declared: a policy referencing it must fail to compile
+// rather than silently produce a wrong verdict.
+func TestNewEnvRejectsAuthorizer(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+
+	_, issues := env.Compile(`authorizer.path("x").allowed()`)
+	assert.Error(t, issues.Err())
+}

--- a/core/pkg/opaprocessor/cel/env_test.go
+++ b/core/pkg/opaprocessor/cel/env_test.go
@@ -19,6 +19,19 @@ func TestNewEnvCompilesObjectExpression(t *testing.T) {
 	assert.NoError(t, issues.Err())
 }
 
+// TestNewEnvCompilesNamespaceObjectExpression guards against dropping the
+// namespaceObject variable: it is a standard, first-class VAP variable bound by
+// the apiserver to the resource's namespace, so a policy referencing it must
+// compile offline rather than fail and get silently skipped.
+func TestNewEnvCompilesNamespaceObjectExpression(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	_, issues := env.Compile(`namespaceObject.metadata.labels['environment'] == "prod"`)
+	assert.NoError(t, issues.Err())
+}
+
 // TestNewEnvRejectsAuthorizer documents, as an executable test, that authorizer
 // is deliberately not declared: a policy referencing it must fail to compile
 // rather than silently produce a wrong verdict.

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/enescakir/emoji v1.0.0
 	github.com/francoispqt/gojay v1.2.13
 	github.com/go-git/go-git/v5 v5.19.1
+	github.com/google/cel-go v0.28.1
 	github.com/google/go-containerregistry v0.21.2
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
@@ -65,6 +66,7 @@ require (
 	helm.sh/helm/v3 v3.20.2
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
+	k8s.io/apiserver v0.35.1
 	k8s.io/client-go v0.35.2
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/kustomize/api v0.20.1
@@ -151,6 +153,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 // indirect
 	github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aquasecurity/go-pep440-version v0.0.1 // indirect
 	github.com/aquasecurity/go-version v0.0.1 // indirect
@@ -593,7 +596,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/gorm v1.31.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
-	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/cli-runtime v0.35.1 // indirect
 	k8s.io/component-base v0.35.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/anubhav06/copa-grype v1.0.3-alpha.1 h1:hXuFSOVekcPFENdUdvMyGx+SvIh0vIgzY+j1pnkoJaw=
 github.com/anubhav06/copa-grype v1.0.3-alpha.1/go.mod h1:JhE+hPD6XOcS2dfgw8MwOQVCUlIQUHN+XiwBItxFIfM=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -889,6 +891,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/certificate-transparency-go v1.3.2 h1:9ahSNZF2o7SYMaKaXhAumVEzXB2QaayzII9C8rv7v+A=
 github.com/google/certificate-transparency-go v1.3.2/go.mod h1:H5FpMUaGa5Ab2+KCYsxg6sELw3Flkl7pGZzWdBoYLXs=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=


### PR DESCRIPTION
## Overview

So this PR is the first real piece of the CEL engine. I added a new package at `core/pkg/opaprocessor/cel/` with just one file, `env.go`, that has a `newEnv()` function.  All it does is build the CEL environment we'll compile and run VAP expressions against later. Instead of picking the CEL libraries myself I just extend  apiserver's base env set, because that way the functions and version rules match what an actual cluster uses on a VAP, so a policy behaves the same in our scan as it does at admission. On top of that I declare the variables from issue #2001, which are object, oldObject, params, request and variables. I left out authorizer on  purpose since there's no way to fill it in offline, so any policy using it just won't compile and gets skipped later instead of giving a wrong result. I also added the `google/cel-go` dependency here since this is the first file that actually imports it. And there's a small test file that compiles a basic expression to prove the env works, plus one that checks the authorizer case fails like it should.  

## How to Test

`go test -v ./core/pkg/opaprocessor/cel/...`

<img width="772" height="180" alt="image" src="https://github.com/user-attachments/assets/04b4c90d-e251-4703-ad6d-84f90b79f572" />

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Common Expression Language (CEL) support for offline compilation and evaluation of ValidatingAdmissionPolicy expressions in Kubescape.

* **Tests**
  * Added unit tests to ensure the CEL environment compiles expressions using supported variables and rejects expressions that reference unsupported constructs.

* **Chores**
  * Updated Go module dependencies to align with the required CEL and Kubernetes API server versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->