### PR TITLE
fix: return error when related RBAC objects share the same category

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -399,6 +399,9 @@ func getRoleAndRoleBindingFromRelatedObjects(relatedObjects []workloadinterface.
 			return nil, nil, fmt.Errorf("unknown related object kind %s", relatedObjects[i].GetKind())
 		}
 	}
+	if role == nil || roleBinding == nil {
+		return nil, nil, fmt.Errorf("%w: both related objects belong to the same RBAC category", ErrIncompleteRelatedObjects)
+	}
 	return role, roleBinding, nil
 }
 

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -641,4 +642,102 @@ func TestMergeMaps(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestGetRoleAndRoleBindingFromRelatedObjects_SameCategory(t *testing.T) {
+	testCases := []struct {
+		name           string
+		relatedObjects []workloadinterface.IMetadata
+	}{
+		{
+			name: "two Role objects",
+			relatedObjects: []workloadinterface.IMetadata{
+				&FakeMetadata{Kind: "Role", Name: "role-a", Namespace: "ns"},
+				&FakeMetadata{Kind: "Role", Name: "role-b", Namespace: "ns"},
+			},
+		},
+		{
+			name: "two RoleBinding objects",
+			relatedObjects: []workloadinterface.IMetadata{
+				&FakeMetadata{Kind: "RoleBinding", Name: "rb-a", Namespace: "ns"},
+				&FakeMetadata{Kind: "RoleBinding", Name: "rb-b", Namespace: "ns"},
+			},
+		},
+		{
+			name: "two ClusterRole objects",
+			relatedObjects: []workloadinterface.IMetadata{
+				&FakeMetadata{Kind: "ClusterRole", Name: "cr-a"},
+				&FakeMetadata{Kind: "ClusterRole", Name: "cr-b"},
+			},
+		},
+		{
+			name: "two ClusterRoleBinding objects",
+			relatedObjects: []workloadinterface.IMetadata{
+				&FakeMetadata{Kind: "ClusterRoleBinding", Name: "crb-a"},
+				&FakeMetadata{Kind: "ClusterRoleBinding", Name: "crb-b"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, roleBinding, err := getRoleAndRoleBindingFromRelatedObjects(tc.relatedObjects)
+			assert.True(t, errors.Is(err, ErrIncompleteRelatedObjects))
+			assert.Nil(t, role)
+			assert.Nil(t, roleBinding)
+		})
+	}
+}
+
+func TestStorePostureReportResults_SkipsSameCategoryRBACObjects(t *testing.T) {
+	store := NewFakeAPIServerStorage("kubescape")
+	ctx := context.Background()
+
+	sameCategoryObj := map[string]any{
+		"kind":      "ServiceAccount",
+		"name":      "my-sa",
+		"namespace": "default",
+		"relatedObjects": []any{
+			map[string]any{
+				"kind":       "Role",
+				"name":       "role-a",
+				"namespace":  "default",
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+			},
+			map[string]any{
+				"kind":       "Role",
+				"name":       "role-b",
+				"namespace":  "default",
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+			},
+		},
+	}
+
+	podObj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "test-pod",
+			"namespace": "default",
+		},
+	}
+
+	pr := &v2.PostureReport{
+		Resources: []reporthandling.Resource{
+			{ResourceID: "same-category-resource-id", Object: sameCategoryObj},
+			{ResourceID: "pod-resource-id", Object: podObj},
+		},
+		Results: []resourcesresults.Result{
+			{ResourceID: "same-category-resource-id"},
+			{ResourceID: "pod-resource-id"},
+		},
+	}
+
+	err := store.StorePostureReportResults(ctx, pr)
+	assert.NoError(t, err)
+
+	summaries, listErr := store.StorageClient.WorkloadConfigurationScanSummaries("default").List(ctx, metav1.ListOptions{})
+	assert.NoError(t, listErr)
+	assert.Len(t, summaries.Items, 1)
+	assert.Equal(t, "pod-test-pod", summaries.Items[0].Name)
 }


### PR DESCRIPTION
## Overview

`getRoleAndRoleBindingFromRelatedObjects` dispatches two related objects by kind into `role` and `roleBinding`. PR #2392 added a guard for the case where the slice does not contain exactly 2 objects, but did not guard against both objects falling into the same RBAC category.

If both objects are `Role`/`ClusterRole` (or both `RoleBinding`/ `ClusterRoleBinding`), the switch overwrites the same variable twice and the other stays nil with no error returned. `GetWorkloadScanK8sResourceName` then passes the nil interface into `RoleBindingResourceToSlug`, which panics on the nil receiver. In server mode the HTTP layer recovers the
panic as a 500, but the scan result for that workload is permanently lost with no retry, silently degrading RBAC coverage reporting.

This adds a nil-check after the dispatch loop that returns an error wrapping `ErrIncompleteRelatedObjects`, which `StorePostureReportResults` already skips gracefully, the same way it handles the `len != 2` case.

## How to Test

```bash
go test -v ./httphandler/...
```

Key new tests:

- `TestGetRoleAndRoleBindingFromRelatedObjects_SameCategory` covers two Role, two RoleBinding, two ClusterRole, and two ClusterRoleBinding cases, each asserting `errors.Is(err, ErrIncompleteRelatedObjects)`
- `TestStorePostureReportResults_SkipsSameCategoryRBACObjects` is an integration test that feeds a same-category RBAC resource alongside a normal Pod and confirms the scan continues without panicking, storing only the Pod result

## Related issues/PRs

* Resolved #2421

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for RBAC objects to ensure both role and binding objects are identified before processing. Returns an error if either object is missing, preventing incomplete data from being stored.

* **Tests**
  * Added comprehensive test coverage for RBAC object validation, including scenarios with incomplete object pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->