### PR TITLE
fix(opaprocessor): count timed-out controls as 0 in compliance score

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -431,11 +431,10 @@ func (opap *OPAProcessor) reweightComplianceScores() {
 	var sum float32
 	var count int
 	for ctrlID := range opap.Report.SummaryDetails.Controls {
-		if _, ok := opap.TimedOutControls[ctrlID]; ok {
-			continue
+		if _, ok := opap.TimedOutControls[ctrlID]; !ok {
+			ctrl := opap.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
+			sum += ctrl.GetComplianceScore()
 		}
-		ctrl := opap.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
-		sum += ctrl.GetComplianceScore()
 		count++
 	}
 	if count > 0 {
@@ -447,11 +446,10 @@ func (opap *OPAProcessor) reweightComplianceScores() {
 		var fsum float32
 		var fcount int
 		for ctrlID := range opap.Report.SummaryDetails.Frameworks[i].Controls {
-			if _, ok := opap.TimedOutControls[ctrlID]; ok {
-				continue
+			if _, ok := opap.TimedOutControls[ctrlID]; !ok {
+				ctrl := opap.Report.SummaryDetails.Frameworks[i].Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
+				fsum += ctrl.GetComplianceScore()
 			}
-			ctrl := opap.Report.SummaryDetails.Frameworks[i].Controls.GetControl(reportsummary.EControlCriteriaID, ctrlID)
-			fsum += ctrl.GetComplianceScore()
 			fcount++
 		}
 		if fcount > 0 {

--- a/core/pkg/opaprocessor/processorhandler_timeout_test.go
+++ b/core/pkg/opaprocessor/processorhandler_timeout_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/score"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,4 +140,30 @@ func TestProcess_ControlTimeout(t *testing.T) {
 	assert.Equal(t, float32(0), coverage.CoverageScore)
 	assert.Equal(t, 0, coverage.EvaluatedControls)
 	assert.True(t, coverage.Degraded)
+}
+
+// TestReweightComplianceScores_TimedOutControlCountsAsFailed verifies that a
+// timed-out control is counted as 0 within a full denominator (fail-closed),
+// so it cannot inflate ComplianceScore above the value a genuine failure would
+// produce. A high per-control score on the timed-out control (e.g. from partial
+// data) must not leak into the aggregate.
+func TestReweightComplianceScores_TimedOutControlCountsAsFailed(t *testing.T) {
+	passScore := float32(100)
+	slowScore := float32(100)
+
+	opaSessionObj := cautils.NewOPASessionObjMock()
+	opaSessionObj.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-PASS": reportsummary.ControlSummary{ControlID: "C-PASS", ComplianceScore: &passScore},
+		"C-SLOW": reportsummary.ControlSummary{ControlID: "C-SLOW", ComplianceScore: &slowScore},
+	}
+
+	opap := NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap.TimedOutControls["C-SLOW"] = "control evaluation timed out"
+
+	opap.reweightComplianceScores()
+
+	// (100 + 0) / 2 == 50: identical to C-SLOW genuinely failing (score 0), and
+	// strictly below the 100 produced by excluding it from the denominator.
+	assert.Equal(t, float32(50), opaSessionObj.Report.SummaryDetails.ComplianceScore)
+	assert.Less(t, opaSessionObj.Report.SummaryDetails.ComplianceScore, float32(100))
 }


### PR DESCRIPTION
## Overview

`reweightComplianceScores` excluded timed-out controls from both the numerator and denominator of the compliance score, treating them as if they were never in scope. This made `--compliance-threshold` fail-open: a scan where slow failing controls timed out could pass a threshold it would otherwise fail.

```go
// before -- timed-out controls excluded from denominator entirely
for ctrlID := range opap.Report.SummaryDetails.Controls {
    if _, ok := opap.TimedOutControls[ctrlID]; ok {
        continue // dropped from BOTH sum and count
    }
    sum += ctrl.GetComplianceScore(); count++
}

// after -- timed-out controls stay in denominator, counted as 0
for ctrlID := range opap.Report.SummaryDetails.Controls {
    if _, ok := opap.TimedOutControls[ctrlID]; !ok {
        sum += ctrl.GetComplianceScore()
    }
    count++ // always increments
}
```

Numeric example: 100 controls, `--compliance-threshold 90`. True posture: 85 pass / 15 fail = 85%, gate should fail. 12 of the 15 failing controls time out. Before fix: excluded from denominator, 85/88 = 96.6%, gate passes (exit 0). After fix: counted as 0, 85/100 = 85%, gate correctly fails (exit 1).

## Additional Information

Regression introduced in `741b2431`. The pre-existing `scorewrapper.Calculate()` path was fail-closed -- skipped controls contributed 0 within a full denominator. `reweightComplianceScores` overwrote that with an exclusion-based average, converting unevaluated controls from "0% (counts against you)" to "excluded (free pass)".

The fix applies to both the top-level `SummaryDetails.ComplianceScore` loop and the per-framework `Frameworks[i].ComplianceScore` loop. Timed-out controls are still marked `StatusSkipped` and still appear in `NotEvaluatedControls` via the coverage report -- only the denominator exclusion is removed.

Slow controls correlate with the most expensive security-relevant checks (RBAC graph analysis, cluster-wide correlation, host-sensor data). The controls most likely to time out are exactly the ones whose silent removal from the compliance denominator is most dangerous.

## How to Test

```bash
kubescape scan framework nsa --control-timeout 3s --compliance-threshold 90
```

Before fix: timed-out failing controls excluded from denominator, compliance score inflated, gate passes even when true posture is below threshold.

After fix: timed-out controls counted as 0 in denominator, compliance score reflects true posture, gate correctly fails.

Unit test added: `TestReweightComplianceScores_TimedOutControlCountsAsFailed` -- two controls both at 100 per-control score, one times out. Asserts aggregate is 50 (identical to the timed-out control genuinely failing) and strictly below the 100 the old exclusion produced.

## Related issues/PRs

* Resolved #2423 
* Regression from #2404

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compliance score calculation to properly account for timed-out controls. Timed-out controls now correctly contribute a zero compliance score to the overall compliance assessment, preventing inflated compliance scores when controls fail to complete evaluation.

* **Tests**
  * Added test case to verify timed-out controls are correctly counted as failed assessments in compliance score calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->