### PR TITLE
feat(report): add encrypted report decryption

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -26,20 +26,54 @@ func GetDecryptCommand() *cobra.Command {
 				)
 			}
 
-			var report reporthandlingv2.PostureReport
+			var report map[string]json.RawMessage
 
-			if err := json.Unmarshal(data, &report); err != nil {
+			if err := json.Unmarshal(
+				data,
+				&report,
+			); err != nil {
 				return fmt.Errorf(
 					"failed to parse report: %w",
 					err,
 				)
 			}
 
+			metadataRaw, ok := report["metadata"]
+			if !ok {
+				return fmt.Errorf(
+					"report metadata not found",
+				)
+			}
+
+			var metadata reporthandlingv2.Metadata
+
+			if err := json.Unmarshal(
+				metadataRaw,
+				&metadata,
+			); err != nil {
+				return fmt.Errorf(
+					"failed to parse metadata: %w",
+					err,
+				)
+			}
+
 			if err := reportcrypto.DecryptMetadataFromEnv(
-				&report.Metadata,
+				&metadata,
 			); err != nil {
 				return err
 			}
+
+			updatedMetadata, err := json.Marshal(
+				metadata,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to marshal metadata: %w",
+					err,
+				)
+			}
+
+			report["metadata"] = updatedMetadata
 
 			encoder := json.NewEncoder(os.Stdout)
 			encoder.SetIndent("", "  ")

--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -1,0 +1,50 @@
+package decrypt
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/spf13/cobra"
+)
+
+func GetDecryptCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "decrypt <report.json>",
+		Short: "Decrypt encrypted Kubescape reports",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf(
+					"failed to read report %q: %w",
+					args[0],
+					err,
+				)
+			}
+
+			var report reporthandlingv2.PostureReport
+
+			if err := json.Unmarshal(data, &report); err != nil {
+				return fmt.Errorf(
+					"failed to parse report: %w",
+					err,
+				)
+			}
+
+			if err := reportcrypto.DecryptMetadataFromEnv(
+				&report.Metadata,
+			); err != nil {
+				return err
+			}
+
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+
+			return encoder.Encode(report)
+		},
+	}
+}

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -11,118 +11,164 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecryptCommand_PreservesUnknownFields(t *testing.T) {
-	dek, err := reportcrypto.GenerateDEK()
-	require.NoError(t, err)
-
-	masterKey := []byte("12345678901234567890123456789012")
-
-	encryptedRepo, err := reportcrypto.EncryptString(
-		"kubescape",
-		dek,
-	)
-	require.NoError(t, err)
-
-	wrappedDEK, err := reportcrypto.WrapDEK(
-		dek,
-		masterKey,
-	)
-	require.NoError(t, err)
-
-	report := map[string]any{
-		"resourceLabels": map[string]any{
-			"team": "platform",
-		},
-		"scanCoverage": map[string]any{
-			"all": true,
-		},
-		"metadata": map[string]any{
-			"targetMetadata": map[string]any{
-				"gitRepoContextMetadata": map[string]any{
-					"repo": encryptedRepo,
-				},
-			},
-			"encryptionMetadata": map[string]any{
-				"encryptedDEK": wrappedDEK,
-			},
+func TestDecryptCommand(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "preserves unknown fields",
 		},
 	}
 
-	data, err := json.Marshal(report)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dek, err := reportcrypto.GenerateDEK()
+			require.NoError(t, err)
 
-	tmp, err := os.CreateTemp("", "encrypted-*.json")
-	require.NoError(t, err)
+			masterKey := []byte(
+				"12345678901234567890123456789012",
+			)
 
-	defer os.Remove(tmp.Name())
+			encryptedRepo, err :=
+				reportcrypto.EncryptString(
+					"kubescape",
+					dek,
+				)
+			require.NoError(t, err)
 
-	_, err = tmp.Write(data)
-	require.NoError(t, err)
+			wrappedDEK, err :=
+				reportcrypto.WrapDEK(
+					dek,
+					masterKey,
+				)
+			require.NoError(t, err)
 
-	require.NoError(t, tmp.Close())
+			report := map[string]any{
+				"resourceLabels": map[string]any{
+					"team": "platform",
+				},
+				"scanCoverage": map[string]any{
+					"all": true,
+				},
+				"metadata": map[string]any{
+					"targetMetadata": map[string]any{
+						"gitRepoContextMetadata": map[string]any{
+							"repo": encryptedRepo,
+						},
+					},
+					"encryptionMetadata": map[string]any{
+						"encryptedDEK": wrappedDEK,
+					},
+				},
+			}
 
-	t.Setenv(
-		"KUBESCAPE_MASTER_KEY",
-		string(masterKey),
-	)
+			data, err := json.Marshal(report)
+			require.NoError(t, err)
 
-	oldStdout := os.Stdout
+			tmp, err := os.CreateTemp(
+				"",
+				"encrypted-*.json",
+			)
+			require.NoError(t, err)
 
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
+			defer os.Remove(tmp.Name())
 
-	os.Stdout = w
+			_, err = tmp.Write(data)
+			require.NoError(t, err)
 
-	cmd := GetDecryptCommand()
+			require.NoError(
+				t,
+				tmp.Close(),
+			)
 
-	err = cmd.RunE(
-		cmd,
-		[]string{tmp.Name()},
-	)
+			t.Setenv(
+				"KUBESCAPE_MASTER_KEY",
+				string(masterKey),
+			)
 
-	require.NoError(t, err)
+			oldStdout := os.Stdout
 
-	require.NoError(t, w.Close())
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
 
-	os.Stdout = oldStdout
+			os.Stdout = w
 
-	var buf bytes.Buffer
+			defer func() {
+				os.Stdout = oldStdout
+			}()
 
-	_, err = buf.ReadFrom(r)
-	require.NoError(t, err)
+			defer func() {
+				_ = w.Close()
+			}()
 
-	var output map[string]any
+			cmd := GetDecryptCommand()
 
-	err = json.Unmarshal(
-		buf.Bytes(),
-		&output,
-	)
-	require.NoError(t, err)
+			err = cmd.RunE(
+				cmd,
+				[]string{tmp.Name()},
+			)
 
-	assert.Contains(
-		t,
-		output,
-		"resourceLabels",
-	)
+			require.NoError(t, err)
 
-	assert.Contains(
-		t,
-		output,
-		"scanCoverage",
-	)
+			require.NoError(
+				t,
+				w.Close(),
+			)
 
-	metadata :=
-		output["metadata"].(map[string]any)
+			var buf bytes.Buffer
 
-	targetMetadata :=
-		metadata["targetMetadata"].(map[string]any)
+			_, err = buf.ReadFrom(r)
+			require.NoError(t, err)
 
-	repoMetadata :=
-		targetMetadata["gitRepoContextMetadata"].(map[string]any)
+			var output map[string]any
 
-	assert.Equal(
-		t,
-		"kubescape",
-		repoMetadata["repo"],
-	)
+			err = json.Unmarshal(
+				buf.Bytes(),
+				&output,
+			)
+			require.NoError(t, err)
+
+			assert.Contains(
+				t,
+				output,
+				"resourceLabels",
+			)
+
+			assert.Contains(
+				t,
+				output,
+				"scanCoverage",
+			)
+
+			metadata, ok :=
+				output["metadata"].(map[string]any)
+			require.True(
+				t,
+				ok,
+				"metadata should be an object",
+			)
+
+			targetMetadata, ok :=
+				metadata["targetMetadata"].(map[string]any)
+			require.True(
+				t,
+				ok,
+				"targetMetadata should be an object",
+			)
+
+			repoMetadata, ok :=
+				targetMetadata["gitRepoContextMetadata"].(map[string]any)
+			require.True(
+				t,
+				ok,
+				"gitRepoContextMetadata should be an object",
+			)
+
+			assert.Equal(
+				t,
+				"kubescape",
+				repoMetadata["repo"],
+			)
+		})
+	}
 }

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -1,0 +1,128 @@
+package decrypt
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptCommand_PreservesUnknownFields(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey := []byte("12345678901234567890123456789012")
+
+	encryptedRepo, err := reportcrypto.EncryptString(
+		"kubescape",
+		dek,
+	)
+	require.NoError(t, err)
+
+	wrappedDEK, err := reportcrypto.WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	report := map[string]any{
+		"resourceLabels": map[string]any{
+			"team": "platform",
+		},
+		"scanCoverage": map[string]any{
+			"all": true,
+		},
+		"metadata": map[string]any{
+			"targetMetadata": map[string]any{
+				"gitRepoContextMetadata": map[string]any{
+					"repo": encryptedRepo,
+				},
+			},
+			"encryptionMetadata": map[string]any{
+				"encryptedDEK": wrappedDEK,
+			},
+		},
+	}
+
+	data, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	tmp, err := os.CreateTemp("", "encrypted-*.json")
+	require.NoError(t, err)
+
+	defer os.Remove(tmp.Name())
+
+	_, err = tmp.Write(data)
+	require.NoError(t, err)
+
+	require.NoError(t, tmp.Close())
+
+	t.Setenv(
+		"KUBESCAPE_MASTER_KEY",
+		string(masterKey),
+	)
+
+	oldStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	cmd := GetDecryptCommand()
+
+	err = cmd.RunE(
+		cmd,
+		[]string{tmp.Name()},
+	)
+
+	require.NoError(t, err)
+
+	require.NoError(t, w.Close())
+
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	var output map[string]any
+
+	err = json.Unmarshal(
+		buf.Bytes(),
+		&output,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(
+		t,
+		output,
+		"resourceLabels",
+	)
+
+	assert.Contains(
+		t,
+		output,
+		"scanCoverage",
+	)
+
+	metadata :=
+		output["metadata"].(map[string]any)
+
+	targetMetadata :=
+		metadata["targetMetadata"].(map[string]any)
+
+	repoMetadata :=
+		targetMetadata["gitRepoContextMetadata"].(map[string]any)
+
+	assert.Equal(
+		t,
+		"kubescape",
+		repoMetadata["repo"],
+	)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/cmd/completion"
 	"github.com/kubescape/kubescape/v3/cmd/config"
+	"github.com/kubescape/kubescape/v3/cmd/decrypt"
 	"github.com/kubescape/kubescape/v3/cmd/diff"
 	"github.com/kubescape/kubescape/v3/cmd/download"
 	"github.com/kubescape/kubescape/v3/cmd/fix"
@@ -91,6 +92,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 	rootCmd.PersistentFlags().StringVarP(&rootInfo.KubeContext, "kube-context", "", "", "Kube context. Default will use the current-context")
 	// Supported commands
 	rootCmd.AddCommand(scan.GetScanCommand(ks))
+	rootCmd.AddCommand(decrypt.GetDecryptCommand())
 	rootCmd.AddCommand(download.GetDownloadCmd(ks))
 	rootCmd.AddCommand(list.GetListCmd(ks))
 	rootCmd.AddCommand(completion.GetCompletionCmd())

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/meta"
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/spf13/cobra"
 )
@@ -48,33 +49,74 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Example: scanCmdExamples,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scanInfo.FailThresholdSeverity != "" {
-				if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+				if err := shared.ValidateSeverity(
+					scanInfo.FailThresholdSeverity,
+				); err != nil {
 					return err
 				}
 			}
-			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+
+			if f := cmd.Flags().Lookup("format"); f != nil &&
+				f.Changed &&
+				scanInfo.Format == "" {
+
+				return fmt.Errorf(
+					"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif",
+				)
 			}
-			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
+
+			if err := shared.ValidateScanFormat(
+				scanInfo.Format,
+				shared.ScanFormats,
+			); err != nil {
 				return err
 			}
+
+			if scanInfo.EncryptionEnabled {
+
+				if _, err := reportcrypto.GetMasterKeyFromEnv(); err != nil {
+					return err
+				}
+			}
+
 			requestedView := scanInfo.View
+
 			if err := validateFrameworkScanInfo(&scanInfo); err != nil {
 				return err
 			}
+
 			scanInfo.View = requestedView
+
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				setSecurityViewScanInfo(args, &scanInfo)
 
 				if err := securityScan(scanInfo, ks); err != nil {
 					logger.L().Fatal(err.Error())
 				}
-			} else if len(args) == 0 || (args[0] != "framework" && args[0] != "control") {
-				if err := getFrameworkCmd(ks, &scanInfo).RunE(cmd, append([]string{strings.Join(getter.NativeFrameworks, ",")}, args...)); err != nil {
+			} else if len(args) == 0 ||
+				(args[0] != "framework" && args[0] != "control") {
+
+				if err := getFrameworkCmd(
+					ks,
+					&scanInfo,
+				).RunE(
+					cmd,
+					append(
+						[]string{
+							strings.Join(
+								getter.NativeFrameworks,
+								",",
+							),
+						},
+						args...,
+					),
+				); err != nil {
 					logger.L().Fatal(err.Error())
 				}
 			} else {
-				return fmt.Errorf("kubescape did not do anything")
+				return fmt.Errorf(
+					"kubescape did not do anything",
+				)
 			}
 
 			return nil
@@ -116,7 +158,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
-	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers (namespace, resource names, container names, images) in results")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers using irreversible pseudonymization")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Use reversible encryption for repository metadata instead of pseudonymization")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -74,7 +74,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 			if scanInfo.EncryptionEnabled {
 
-				if _, err := reportcrypto.GetMasterKeyFromEnv(); err != nil {
+				if _, err := reportcrypto.GetMasterKeyFromEnv("encryption"); err != nil {
 					return err
 				}
 			}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -100,16 +100,17 @@ type PolicyIdentifier struct {
 }
 
 type ScanInfo struct {
-	Getters                                            // TODO - remove from object
-	PolicyIdentifier      []PolicyIdentifier           // TODO - remove from object
-	UseExceptions         string                       // Load file with exceptions configuration
-	ControlsInputs        string                       // Load file with inputs for controls
-	AttackTracks          string                       // Load file with attack tracks
-	UseFrom               []string                     // Load framework from local file (instead of download). Use when running offline
-	UseDefault            bool                         // Load framework from cached file (instead of download). Use when running offline
-	UseArtifactsFrom      string                       // Load artifacts from local path. Use when running offline
-	VerboseMode           bool                         // Display all the input resources and not only failed resources
-	Hide                  bool                         // Hide sensitive identifiers (names, namespaces, images) in results
+	Getters                                  // TODO - remove from object
+	PolicyIdentifier      []PolicyIdentifier // TODO - remove from object
+	UseExceptions         string             // Load file with exceptions configuration
+	ControlsInputs        string             // Load file with inputs for controls
+	AttackTracks          string             // Load file with attack tracks
+	UseFrom               []string           // Load framework from local file (instead of download). Use when running offline
+	UseDefault            bool               // Load framework from cached file (instead of download). Use when running offline
+	UseArtifactsFrom      string             // Load artifacts from local path. Use when running offline
+	VerboseMode           bool               // Display all the input resources and not only failed resources
+	Hide                  bool               // Hide sensitive identifiers (names, namespaces, images) in results
+	EncryptionEnabled     bool
 	View                  string                       //
 	Format                string                       // Format results (table, json, junit ...)
 	Output                string                       // Store results in an output file, Output file name

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils"
 	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor"
 	"github.com/kubescape/kubescape/v3/core/pkg/policyhandler"
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	"github.com/kubescape/kubescape/v3/core/pkg/resourcehandler"
 	"github.com/kubescape/kubescape/v3/core/pkg/resourcesprioritization"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
@@ -279,9 +280,55 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)
 
-	if scanInfo.Hide {
-		if err := anonymizer.Apply(resultsHandling); err != nil {
-			return nil, fmt.Errorf("failed to hide sensitive fields: %w", err)
+	if scanInfo.EncryptionEnabled {
+
+		masterKey, err := reportcrypto.GetMasterKeyFromEnv()
+		if err != nil {
+			return nil, err
+		}
+
+		dek, err := reportcrypto.GenerateDEK()
+		if err != nil {
+			for i := range masterKey {
+				masterKey[i] = 0
+			}
+
+			return nil, fmt.Errorf(
+				"failed to generate encryption key",
+			)
+		}
+
+		err = anonymizer.ApplyEncrypted(
+			resultsHandling,
+			dek,
+			masterKey,
+		)
+
+		// best-effort memory cleanup
+		for i := range dek {
+			dek[i] = 0
+		}
+
+		for i := range masterKey {
+			masterKey[i] = 0
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to encrypt sensitive fields: %w",
+				err,
+			)
+		}
+
+	} else if scanInfo.Hide {
+
+		if err := anonymizer.Apply(
+			resultsHandling,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"failed to hide sensitive fields: %w",
+				err,
+			)
 		}
 	}
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -282,7 +282,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 
 	if scanInfo.EncryptionEnabled {
 
-		masterKey, err := reportcrypto.GetMasterKeyFromEnv()
+		masterKey, err := reportcrypto.GetMasterKeyFromEnv("encryption")
 		if err != nil {
 			return nil, err
 		}
@@ -298,11 +298,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 			)
 		}
 
-		err = anonymizer.ApplyEncrypted(
-			resultsHandling,
-			dek,
-			masterKey,
-		)
+		err = anonymizer.ApplyEncrypted(resultsHandling, dek, masterKey)
 
 		// best-effort memory cleanup
 		for i := range dek {

--- a/core/pkg/reportcrypto/crypto.go
+++ b/core/pkg/reportcrypto/crypto.go
@@ -150,19 +150,25 @@ func ValidateMasterKey(masterKey []byte) error {
 
 // GetMasterKeyFromEnv loads and validates the master key
 // from the KUBESCAPE_MASTER_KEY environment variable.
-func GetMasterKeyFromEnv() ([]byte, error) {
-	masterKey := os.Getenv("KUBESCAPE_MASTER_KEY")
+func GetMasterKeyFromEnv(operation string) ([]byte, error) {
+
+	masterKey := os.Getenv(
+		"KUBESCAPE_MASTER_KEY",
+	)
 
 	if masterKey == "" {
-		return nil, errors.New(
-			"encryption enabled but KUBESCAPE_MASTER_KEY is not configured",
+		return nil, fmt.Errorf(
+			"%s requires KUBESCAPE_MASTER_KEY to be configured",
+			operation,
 		)
 	}
 
 	keyBytes := []byte(masterKey)
 
-	if err := ValidateMasterKey(keyBytes); err != nil {
-		return nil, errors.New(
+	if err := ValidateMasterKey(
+		keyBytes,
+	); err != nil {
+		return nil, fmt.Errorf(
 			"invalid KUBESCAPE_MASTER_KEY configuration",
 		)
 	}

--- a/core/pkg/reportcrypto/crypto.go
+++ b/core/pkg/reportcrypto/crypto.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -145,4 +146,26 @@ func ValidateMasterKey(masterKey []byte) error {
 	}
 
 	return nil
+}
+
+// GetMasterKeyFromEnv loads and validates the master key
+// from the KUBESCAPE_MASTER_KEY environment variable.
+func GetMasterKeyFromEnv() ([]byte, error) {
+	masterKey := os.Getenv("KUBESCAPE_MASTER_KEY")
+
+	if masterKey == "" {
+		return nil, errors.New(
+			"encryption enabled but KUBESCAPE_MASTER_KEY is not configured",
+		)
+	}
+
+	keyBytes := []byte(masterKey)
+
+	if err := ValidateMasterKey(keyBytes); err != nil {
+		return nil, errors.New(
+			"invalid KUBESCAPE_MASTER_KEY configuration",
+		)
+	}
+
+	return keyBytes, nil
 }

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -1,0 +1,211 @@
+package reportcrypto
+
+import (
+	"fmt"
+
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+// DEKFromMetadata extracts and unwraps the DEK stored in
+// EncryptionMetadata using the supplied master key.
+//
+// This is the first step of the decryption workflow:
+//
+//	EncryptionMetadata.EncryptedDEK
+//	          ↓
+//	     UnwrapDEK()
+//	          ↓
+//	           DEK
+func DEKFromMetadata(
+	metadata *reporthandlingv2.Metadata,
+	masterKey []byte,
+) ([]byte, error) {
+
+	if metadata == nil {
+		return nil, fmt.Errorf("metadata is nil")
+	}
+
+	if metadata.EncryptionMetadata == nil {
+		return nil, fmt.Errorf("encryption metadata not found")
+	}
+
+	if metadata.EncryptionMetadata.EncryptedDEK == "" {
+		return nil, fmt.Errorf("encrypted DEK not found")
+	}
+
+	return UnwrapDEK(
+		metadata.EncryptionMetadata.EncryptedDEK,
+		masterKey,
+	)
+}
+
+// DecryptRepoContextMetadata decrypts all repository context fields
+// previously encrypted by ApplyEncrypted.
+//
+// This operation mutates the supplied metadata object in place.
+//
+// Current fields:
+//
+//   - Repo
+//   - Owner
+//   - Branch
+//   - RemoteURL
+//   - LastCommit.Message
+//
+// Additional fields can be added as encryption coverage expands.
+func DecryptRepoContextMetadata(
+	metadata *reporthandlingv2.Metadata,
+	masterKey []byte,
+) error {
+
+	dek, err := DEKFromMetadata(
+		metadata,
+		masterKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		for i := range dek {
+			dek[i] = 0
+		}
+	}()
+
+	repoMetadata :=
+		metadata.ContextMetadata.RepoContextMetadata
+
+	if repoMetadata == nil {
+		return nil
+	}
+
+	if repoMetadata.Repo != "" {
+		repoMetadata.Repo, err =
+			DecryptString(repoMetadata.Repo, dek)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt repo: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.Owner != "" {
+		repoMetadata.Owner, err =
+			DecryptString(repoMetadata.Owner, dek)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt owner: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.Branch != "" {
+		repoMetadata.Branch, err =
+			DecryptString(repoMetadata.Branch, dek)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt branch: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.DefaultBranch != "" {
+		repoMetadata.DefaultBranch, err =
+			DecryptString(
+				repoMetadata.DefaultBranch,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt default branch: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.RemoteURL != "" {
+		repoMetadata.RemoteURL, err =
+			DecryptString(repoMetadata.RemoteURL, dek)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt remoteURL: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.LocalRootPath != "" {
+		repoMetadata.LocalRootPath, err =
+			DecryptString(
+				repoMetadata.LocalRootPath,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt localRootPath: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.LastCommit.Hash != "" {
+		repoMetadata.LastCommit.Hash, err =
+			DecryptString(
+				repoMetadata.LastCommit.Hash,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt commit hash: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.LastCommit.CommitterName != "" {
+		repoMetadata.LastCommit.CommitterName, err =
+			DecryptString(
+				repoMetadata.LastCommit.CommitterName,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt committer name: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.LastCommit.CommitterEmail != "" {
+		repoMetadata.LastCommit.CommitterEmail, err =
+			DecryptString(
+				repoMetadata.LastCommit.CommitterEmail,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt committer email: %w",
+				err,
+			)
+		}
+	}
+
+	if repoMetadata.LastCommit.Message != "" {
+		repoMetadata.LastCommit.Message, err =
+			DecryptString(
+				repoMetadata.LastCommit.Message,
+				dek,
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt commit message: %w",
+				err,
+			)
+		}
+	}
+
+	return nil
+}

--- a/core/pkg/reportcrypto/decrypt_env.go
+++ b/core/pkg/reportcrypto/decrypt_env.go
@@ -8,7 +8,7 @@ func DecryptMetadataFromEnv(
 	metadata *reporthandlingv2.Metadata,
 ) error {
 
-	masterKey, err := GetMasterKeyFromEnv()
+	masterKey, err := GetMasterKeyFromEnv("decryption")
 	if err != nil {
 		return err
 	}

--- a/core/pkg/reportcrypto/decrypt_env.go
+++ b/core/pkg/reportcrypto/decrypt_env.go
@@ -1,0 +1,26 @@
+package reportcrypto
+
+import (
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+func DecryptMetadataFromEnv(
+	metadata *reporthandlingv2.Metadata,
+) error {
+
+	masterKey, err := GetMasterKeyFromEnv()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		for i := range masterKey {
+			masterKey[i] = 0
+		}
+	}()
+
+	return DecryptRepoContextMetadata(
+		metadata,
+		masterKey,
+	)
+}

--- a/core/pkg/reportcrypto/decrypt_test.go
+++ b/core/pkg/reportcrypto/decrypt_test.go
@@ -1,0 +1,253 @@
+package reportcrypto
+
+import (
+	"testing"
+
+	reporthandling "github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptRepoContextMetadata_RoundTrip(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedRepo, err := EncryptString(
+		"demo-repository",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedOwner, err := EncryptString(
+		"demo-owner",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedBranch, err := EncryptString(
+		"main",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedRemoteURL, err := EncryptString(
+		"https://github.com/example/repo",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedLocalRootPath, err := EncryptString(
+		"/home/user/repository",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedCommitHash, err := EncryptString(
+		"abc123def456",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedCommitMessage, err := EncryptString(
+		"initial commit",
+		dek,
+	)
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+				Repo:          encryptedRepo,
+				Owner:         encryptedOwner,
+				Branch:        encryptedBranch,
+				RemoteURL:     encryptedRemoteURL,
+				LocalRootPath: encryptedLocalRootPath,
+				LastCommit: reporthandling.LastCommit{
+					Hash:    encryptedCommitHash,
+					Message: encryptedCommitMessage,
+				},
+			},
+		},
+		EncryptionMetadata: &reporthandlingv2.EncryptionMetadata{
+			Version:      "v1",
+			DEKAlgorithm: "AES256_GCM",
+			KEKAlgorithm: "AES256_GCM",
+			EncryptedDEK: wrappedDEK,
+		},
+	}
+
+	err = DecryptRepoContextMetadata(
+		metadata,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	repoMetadata :=
+		metadata.ContextMetadata.RepoContextMetadata
+
+	assert.Equal(
+		t,
+		"demo-repository",
+		repoMetadata.Repo,
+	)
+
+	assert.Equal(
+		t,
+		"demo-owner",
+		repoMetadata.Owner,
+	)
+
+	assert.Equal(
+		t,
+		"main",
+		repoMetadata.Branch,
+	)
+
+	assert.Equal(
+		t,
+		"https://github.com/example/repo",
+		repoMetadata.RemoteURL,
+	)
+
+	assert.Equal(
+		t,
+		"/home/user/repository",
+		repoMetadata.LocalRootPath,
+	)
+
+	assert.Equal(
+		t,
+		"abc123def456",
+		repoMetadata.LastCommit.Hash,
+	)
+
+	assert.Equal(
+		t,
+		"initial commit",
+		repoMetadata.LastCommit.Message,
+	)
+}
+
+func TestDecryptRepoContextMetadata_WrongMasterKey(
+	t *testing.T,
+) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrongMasterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedRepo, err := EncryptString(
+		"demo-repository",
+		dek,
+	)
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+				Repo: encryptedRepo,
+			},
+		},
+		EncryptionMetadata: &reporthandlingv2.EncryptionMetadata{
+			EncryptedDEK: wrappedDEK,
+		},
+	}
+
+	err = DecryptRepoContextMetadata(
+		metadata,
+		wrongMasterKey,
+	)
+
+	require.Error(t, err)
+}
+
+func TestDEKFromMetadata_InvalidMasterKey(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		EncryptionMetadata: &reporthandlingv2.EncryptionMetadata{
+			EncryptedDEK: wrappedDEK,
+		},
+	}
+
+	_, err = DEKFromMetadata(
+		metadata,
+		[]byte("bad"),
+	)
+
+	require.Error(t, err)
+}
+
+func TestDEKFromMetadata_NoEncryptionMetadata(t *testing.T) {
+	metadata := &reporthandlingv2.Metadata{}
+
+	_, err := DEKFromMetadata(
+		metadata,
+		make([]byte, 32),
+	)
+
+	require.Error(t, err)
+
+	assert.Contains(
+		t,
+		err.Error(),
+		"encryption metadata not found",
+	)
+}
+
+func TestDecryptRepoContextMetadata_NoRepoMetadata(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(
+		dek,
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		EncryptionMetadata: &reporthandlingv2.EncryptionMetadata{
+			EncryptedDEK: wrappedDEK,
+		},
+	}
+
+	err = DecryptRepoContextMetadata(
+		metadata,
+		masterKey,
+	)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Part of : #1200 

## Overview

This PR adds support for decrypting encrypted Kubescape reports and completes the initial report encryption workflow.

Users can now generate encrypted reports using `--encrypt` and later restore encrypted repository metadata using the new `kubescape decrypt` command.

## Changes

### Encryption

* Added `--encrypt` scan flag
* Added validation for `KUBESCAPE_MASTER_KEY`
* Added DEK generation during scan execution
* Added encryption flow integration into report generation
* Added support for loading and validating master keys from environment variables

### Decryption

Added a new command:

```bash
kubescape decrypt <report.json>
```

The command:

* Reads an encrypted report from disk
* Loads the master key from `KUBESCAPE_MASTER_KEY`
* Unwraps the encrypted DEK stored in report metadata
* Decrypts encrypted repository metadata
* Outputs the decrypted report as JSON

### Repository Metadata Decryption

Added support for decrypting:

* Repo
* Owner
* Branch
* DefaultBranch
* RemoteURL
* LocalRootPath
* LastCommit.Hash
* LastCommit.CommitterName
* LastCommit.CommitterEmail
* LastCommit.Message

### Tests

Added unit tests covering:

* Encryption/decryption round-trip
* Wrong master key handling
* Invalid master key handling
* Missing encryption metadata
* Missing repository metadata

## How to Test

Set a valid 32-byte master key:

```bash
export KUBESCAPE_MASTER_KEY="12345678901234567890123456789012"
```

Generate an encrypted report:

```bash
kubescape scan <target> \
  --encrypt \
  --format json \
  -o encrypted.json
```

Verify encrypted repository metadata is present:

```bash
grep 'ENC\[AES256_GCM' encrypted.json
```

Decrypt the report:

```bash
kubescape decrypt encrypted.json > decrypted.json
```

Verify repository metadata is restored:

```bash
grep '"repo"' decrypted.json
grep '"owner"' decrypted.json
grep '"branch"' decrypted.json
grep '"remoteURL"' decrypted.json
```

## Validation

Validated end-to-end encryption and decryption flow:

```text
scan
  ↓
encrypt
  ↓
encrypted report
  ↓
decrypt
  ↓
original repository metadata restored
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `decrypt` command to output pretty-printed, decrypted report JSON.
  * Added `--encrypt` to the scan command to enable reversible repository metadata encryption.
  * Encryption mode now pulls the required master key from the environment and decrypts repository-context metadata on demand.

* **Bug Fixes**
  * Ensure the `decrypt` command preserves unknown/unrelated fields in report JSON.

* **Tests**
  * Added tests for decryption, encryption-metadata requirements, and error handling (including round-trip behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->