### PR TITLE
backend: ksinit: add success case for `CreateKsObjectConnection`

### DIFF
--- a/pkg/ksinit/ksinit_test.go
+++ b/pkg/ksinit/ksinit_test.go
@@ -54,3 +54,31 @@ func TestCreateKsObjectConnectionReturnsKubeconfigErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateKsObjectConnectionSuccess(t *testing.T) {
+	validKubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user: {}`
+
+	configPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(configPath, []byte(validKubeconfig), 0600))
+	t.Setenv("KUBECONFIG", configPath)
+
+	got, err := CreateKsObjectConnection("default", time.Second)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}


### PR DESCRIPTION
**Description:**
**What this PR does:**
This PR enhances the test coverage in `pkg/ksinit` by introducing `TestCreateKsObjectConnectionSuccess`.
Currently, the test suite only validates error states (like missing config files or empty paths). This new test stubs a minimal, valid `kubeconfig` YAML inside a temporary directory and asserts that `CreateKsObjectConnection` properly validates the configuration and generates a connection instance without throwing an error.
**Which issue(s) this PR fixes:**
Fixes #2428 
**Special notes for your reviewer:**
This is an isolated test case appended to `ksinit_test.go` to provide a complete success execution path. No existing tests or core features were altered.
**Screenshot**
<img width="1030" height="89" alt="image" src="https://github.com/user-attachments/assets/fc45bbab-0c18-4a24-8405-b0dbbf865090" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new unit test to verify successful kubeconfig-based connection initialization, including handling of a valid temporary kubeconfig file and ensuring a non-nil connection is returned.

*Note: This release contains no user-visible changes.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->