### PR TITLE
Fix nil pointer panic on image scan when ScanData is nil

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -77,7 +77,7 @@ func (rh *ResultsHandler) GetResults() *reporthandlingv2.PostureReport {
 
 // HandleResults handles all necessary actions for the scan results
 func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.ScanInfo) error {
-	if len(rh.ScanData.VAPPolicies) > 0 {
+	if rh.ScanData != nil && len(rh.ScanData.VAPPolicies) > 0 {
 		index := vapreconcile.BuildIndex(rh.ScanData.VAPPolicies, rh.ScanData.VAPBindings)
 		vapreconcile.EnrichSummary(rh.ScanData.Report.SummaryDetails.Controls, index)
 	}

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -61,6 +61,33 @@ func TestResultsHandlerHandleResultsPrintsResultsToUI(t *testing.T) {
 	}
 }
 
+// TestResultsHandlerHandleResultsImageScanNilScanData reproduces issue #2430:
+// image scans construct the handler with a nil ScanData (only ImageScanData is
+// set), so HandleResults must not dereference ScanData. Before the fix this
+// panicked with a nil pointer dereference in the VAP-reconcile block.
+func TestResultsHandlerHandleResultsImageScanNilScanData(t *testing.T) {
+	uiPrinter := &SpyPrinter{}
+	outputPrinter := &SpyPrinter{}
+
+	// Mirror core.ScanImage: nil reporter, nil ScanData, only ImageScanData.
+	rh := NewResultsHandler(nil, []printer.IPrinter{outputPrinter}, uiPrinter)
+	rh.ImageScanData = []cautils.ImageScanData{{}}
+
+	assert.Nil(t, rh.ScanData)
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = rh.HandleResults(context.Background(), &cautils.ScanInfo{})
+	})
+	assert.NoError(t, err)
+
+	// Results are still printed even though ScanData is nil...
+	assert.Equal(t, 1, uiPrinter.ActionPrintCalls)
+	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
+	// ...but the compliance score is skipped, as it requires ScanData.
+	assert.Equal(t, 0, outputPrinter.ScoreCalls)
+}
+
 func TestValidatePrinter(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Fixes #2430

kubescape scan image crashed with a nil pointer dereference panic at core/pkg/resultshandling/results.go:80, because HandleResults dereferenced rh.ScanData unconditionally in the VAP-reconcile block, while image scans intentionally construct the handler with a nil ScanData (they populate ImageScanData instead). This was introduced in PR #2307 ("Feat/vap enforcement reconcile", commit d4d4d38b, 2026-05-22) and first shipped in v4.0.9 (2026-05-29) — image scanning worked in v3.x and through v4.0.8. The fix adds the same rh.ScanData != nil guard already used elsewhere in the function, so posture scans keep VAP enforcement unchanged and image scans no longer crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in results processing when scan data was absent in an image-scan scenario.
  * Updated/added coverage to ensure processing doesn’t panic and that compliance-score output is skipped when it requires non-missing scan data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->