### PR TITLE
fix(diff): move --fail-on-new exit to cmd layer so output writer is closed

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -49,7 +50,17 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 				}
 			}
 
-			return ks.Diff(&diffInfo)
+			newFailures, err := ks.Diff(&diffInfo)
+			if err != nil {
+				return err
+			}
+
+			if diffInfo.FailOnNew && newFailures > 0 {
+				logger.L().Fatal(fmt.Sprintf("found %d new failure(s) at or above severity threshold %q",
+					newFailures, severityLabel(diffInfo.SeverityThreshold)))
+			}
+
+			return nil
 		},
 	}
 
@@ -59,4 +70,11 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 	diffCmd.Flags().StringVarP(&diffInfo.Output, "output", "o", "", "Output file; defaults to stdout")
 
 	return diffCmd
+}
+
+func severityLabel(s string) string {
+	if s == "" {
+		return "all"
+	}
+	return s
 }

--- a/core/core/diff.go
+++ b/core/core/diff.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubescape/go-logger"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/diff"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 )
 
-func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) error {
+// Diff writes the diff between the two scan reports and returns the number of new failures at or above the severity threshold; the caller decides whether to exit 1.
+func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (int, error) {
 	cs, err := diff.Compute(diffInfo.BaseFile, diffInfo.HeadFile)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	w := printer.GetWriter(context.Background(), diffInfo.Output)
@@ -25,26 +25,11 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) error {
 	switch diffInfo.Format {
 	case "json":
 		if err := diff.PrintJSON(w, cs); err != nil {
-			return fmt.Errorf("writing JSON diff: %w", err)
+			return 0, fmt.Errorf("writing JSON diff: %w", err)
 		}
 	default:
 		diff.PrintPretty(w, cs)
 	}
 
-	if diffInfo.FailOnNew {
-		filtered := diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)
-		if len(filtered) > 0 {
-			logger.L().Fatal(fmt.Sprintf("found %d new failure(s) at or above severity threshold %q",
-				len(filtered), severityLabel(diffInfo.SeverityThreshold)))
-		}
-	}
-
-	return nil
-}
-
-func severityLabel(s string) string {
-	if s == "" {
-		return "all"
-	}
-	return s
+	return len(diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)), nil
 }

--- a/core/core/diff_test.go
+++ b/core/core/diff_test.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeReport writes raw scan-report JSON to a temp file and returns its path.
+func writeReport(t *testing.T, json string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "report-*.json")
+	require.NoError(t, err)
+	_, err = f.WriteString(json)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// TestDiff_ReturnsNewFailureCount verifies that Diff returns the number of new failures at or above the severity threshold.
+func TestDiff_ReturnsNewFailureCount(t *testing.T) {
+	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+	head := writeReport(t, `{
+		"results":[{"resourceID":"res1","controls":[
+			{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}},
+			{"controlID":"C-LOW","name":"Low","status":{"status":"failed"}}
+		]}],
+		"summaryDetails":{"controls":{
+			"C-HIGH":{"scoreFactor":7.0},
+			"C-LOW":{"scoreFactor":2.0}
+		}}
+	}`)
+
+	ks := NewKubescape(context.Background())
+	outDir := t.TempDir()
+
+	t.Run("no threshold counts all new failures", func(t *testing.T) {
+		count, err := ks.Diff(&metav1.DiffInfo{
+			BaseFile: base,
+			HeadFile: head,
+			Format:   "json",
+			Output:   filepath.Join(outDir, "all.json"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("high threshold counts only high+ new failures", func(t *testing.T) {
+		out := filepath.Join(outDir, "high.json")
+		count, err := ks.Diff(&metav1.DiffInfo{
+			BaseFile:          base,
+			HeadFile:          head,
+			Format:            "json",
+			SeverityThreshold: "high",
+			Output:            out,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+
+		// The deferred writer close must have run: the output file is present and non-empty.
+		data, err := os.ReadFile(out)
+		require.NoError(t, err)
+		assert.NotEmpty(t, data)
+	})
+
+	t.Run("no new failures returns zero", func(t *testing.T) {
+		count, err := ks.Diff(&metav1.DiffInfo{
+			BaseFile: head,
+			HeadFile: head,
+			Format:   "json",
+			Output:   filepath.Join(outDir, "same.json"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+}

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -26,8 +26,8 @@ type IKubescape interface {
 	// fix
 	Fix(fixInfo *metav1.FixInfo) error
 
-	// diff
-	Diff(diffInfo *metav1.DiffInfo) error
+	// diff returns the number of new failures at or above the configured severity threshold.
+	Diff(diffInfo *metav1.DiffInfo) (int, error)
 
 	// patch
 	Patch(patchInfo *metav1.PatchInfo, scanInfo *cautils.ScanInfo) (bool, error)

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -44,8 +44,8 @@ func (m *MockIKubescape) Fix(_ *metav1.FixInfo) error {
 	return nil
 }
 
-func (m *MockIKubescape) Diff(_ *metav1.DiffInfo) error {
-	return nil
+func (m *MockIKubescape) Diff(_ *metav1.DiffInfo) (int, error) {
+	return 0, nil
 }
 
 func (m *MockIKubescape) Patch(_ *metav1.PatchInfo, _ *cautils.ScanInfo) (bool, error) {


### PR DESCRIPTION

## Overview
  `kubescape diff --fail-on-new` terminated the process by calling `logger.L().Fatal`
  (which runs `os.Exit`) from **inside** the core `Diff` method, while a
  `defer w.Close()` on the output writer was still pending. `os.Exit` does not run
  deferred calls, so when `--output <file>` was used the output file was never closed.
  Placing the process-terminating exit inside the exported `IKubescape.Diff` method
  is also a layering violation — every other command (e.g. `scan`) performs its
  CI fail-gate exit in the cmd layer, after the core method returns and its writer
  is closed.

  **Current behavior:** `Diff` writes the diff and, on new failures, calls `Fatal`
  internally — skipping the deferred output close.

  **New behavior:** `Diff` returns the number of new failures at or above the
  severity threshold and never terminates the process, so its deferred close always
  runs. `cmd/diff` decides whether to exit 1, mirroring `cmd/scan/scan.go`.

  ## Additional Information
  - `IKubescape.Diff` signature changes from `(diffInfo) error` to `(diffInfo) (int, error)`;
    the generated mock in `core/mocks/cmd_mocks.go` is updated to match.
  - The `severityLabel` helper moved alongside the gate into the cmd layer.
  - Scope is limited to this layering fix. Unrelated cleanups in the diff command
    (e.g. `--format` validation, dead-code removal) are intentionally left for a
    follow-up PR.

  ## How to Test
  1. `kubescape scan --format json --output base.json .`
  2. Introduce a change that creates a new failing control.
  3. `kubescape scan --format json --output head.json .`
  4. `kubescape diff base.json head.json --fail-on-new --output diff.json`
  5. The command exits 1, and `diff.json` is fully written/closed.

  Unit tests:
  go test ./cmd/diff/... ./core/core/... ./core/pkg/resultshandling/diff/...

  ## Related issues/PRs:
  * Resolved #2432 

  ## Checklist before requesting a review
  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests.
  - [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced diff functionality to report the count of newly detected failures
  * Severity threshold now properly filters which failures are counted as new
  * `--fail-on-new` flag behavior refined to use updated failure detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->