### PR TITLE
test: add missing unit tests for cautils session initialization and scan scope

### DIFF
--- a/core/cautils/datastructures_test.go
+++ b/core/cautils/datastructures_test.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -161,4 +162,21 @@ func TestSetTopWorkloads_Idempotent(t *testing.T) {
 	obj.SetTopWorkloads()
 
 	assert.Len(t, obj.TopWorkloadsByScore, firstLen)
+}
+
+func TestNewOPASessionObj(t *testing.T) {
+	ctx := context.Background()
+	frameworks := []reporthandling.Framework{}
+	k8sResources := K8SResources{"group/version/kind": []string{"id1", "id2"}}
+	scanInfo := &ScanInfo{
+		ScanID:           "test-scan-id",
+		OmitRawResources: true,
+		TriggeredByCLI:   true,
+	}
+	sessionObj := NewOPASessionObj(ctx, frameworks, k8sResources, scanInfo)
+	assert.NotNil(t, sessionObj)
+	assert.Equal(t, "test-scan-id", sessionObj.SessionID)
+	assert.Equal(t, true, sessionObj.OmitRawResources)
+	assert.Equal(t, true, sessionObj.TriggeredByCLI)
+	assert.Equal(t, k8sResources, sessionObj.K8SResources)
 }

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -294,4 +295,46 @@ func TestIsRuleKubescapeVersionCompatible(t *testing.T) {
 	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
 	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
 	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+}
+
+func TestGetScanningScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata reporthandlingv2.ContextMetadata
+		expected reporthandling.ScanningScopeType
+	}{
+		{
+			name: "ScopeFile without cluster context",
+			metadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: nil,
+			},
+			expected: reporthandling.ScopeFile,
+		},
+		{
+			name: "ScopeCluster with cluster context but no cloud metadata",
+			metadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: &reporthandlingv2.ClusterMetadata{
+					CloudMetadata: nil,
+				},
+			},
+			expected: reporthandling.ScopeCluster,
+		},
+		{
+			name: "CloudProvider matching provider string",
+			metadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: &reporthandlingv2.ClusterMetadata{
+					CloudMetadata: &reporthandlingv2.CloudMetadata{
+						CloudProvider: "gke",
+					},
+				},
+			},
+			expected: reporthandling.ScanningScopeType("gke"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetScanningScope(tt.metadata))
+		})
+	}
 }


### PR DESCRIPTION
### What this PR does:
This PR enhances test coverage within the core/cautils package by introducing tests for previously uncovered foundational methods:

NewOPASessionObj: Adds TestNewOPASessionObj in datastructures_test.go. This tests the actual production initialization (rather than the mock), creating a local context and mock K8SResources map to assert that the session object successfully transfers essential metadata flags (like OmitRawResources and TriggeredByCLI) without panicking.

GetScanningScope: Adds TestGetScanningScope in datastructuresmethods_test.go. This table-driven test evaluates the extraction of scan scopes by verifying the safe fallback to ScopeFile (when cluster metadata is nil), fallback to ScopeCluster (when cloud metadata is missing), and the proper extraction of customized cloud provider scopes (e.g., gke).
### Which issue(s) this PR fixes:
Fixes #2435

Special notes for your reviewer: This PR contains two distinct commits. Because these tests evaluate entirely different functionalities and live in different test files (datastructures_test.go and datastructuresmethods_test.go), I kept them in separate commits to maintain clean modularity and make the review process easier. Both tests are completely isolated and backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit coverage to validate OPA session object initialization (ensuring key fields are set as expected).
  * Expanded scanning scope determination tests using table-driven scenarios for different combinations of cluster and cloud metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->