### PR TITLE
fix(diff): validate format input and clean up status handling

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -2,6 +2,8 @@ package diff
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -41,8 +43,10 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 			diffInfo.BaseFile = args[0]
 			diffInfo.HeadFile = args[1]
 
-			if err := shared.ValidateScanFormat(diffInfo.Format, []string{printer.PrettyFormat, printer.JsonFormat}); err != nil {
-				return err
+			// diff honors a single output format, so validate against the exact value rather than scan's comma-separated multi-format set.
+			supportedFormats := []string{printer.PrettyFormat, printer.JsonFormat}
+			if !slices.Contains(supportedFormats, diffInfo.Format) {
+				return fmt.Errorf("invalid format %q, supported formats: %s", diffInfo.Format, strings.Join(supportedFormats, ", "))
 			}
 
 			if diffInfo.SeverityThreshold != "" {

--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -1,7 +1,6 @@
 package diff
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/kubescape/go-logger"
@@ -9,6 +8,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/spf13/cobra"
 )
 
@@ -38,11 +38,12 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 		Example: diffCmdExamples,
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 2 {
-				return errors.New("two report files are required: <base-report.json> <head-report.json>")
-			}
 			diffInfo.BaseFile = args[0]
 			diffInfo.HeadFile = args[1]
+
+			if err := shared.ValidateScanFormat(diffInfo.Format, []string{printer.PrettyFormat, printer.JsonFormat}); err != nil {
+				return err
+			}
 
 			if diffInfo.SeverityThreshold != "" {
 				if err := shared.ValidateSeverity(diffInfo.SeverityThreshold); err != nil {

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -17,6 +17,7 @@ func TestGetDiffCmd_FormatValidation(t *testing.T) {
 		{"json", "json", false},
 		{"unsupported format is rejected", "yaml", true},
 		{"scan-only format is rejected", "sarif", true},
+		{"comma-separated multi-format is rejected", "json,pretty-printer", true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -1,0 +1,35 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDiffCmd_FormatValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		wantError bool
+	}{
+		{"default pretty-printer", "pretty-printer", false},
+		{"json", "json", false},
+		{"unsupported format is rejected", "yaml", true},
+		{"scan-only format is rejected", "sarif", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diffCmd := GetDiffCmd(&mocks.MockIKubescape{})
+			diffCmd.SetArgs([]string{"base.json", "head.json", "--format", tt.format})
+
+			err := diffCmd.Execute()
+			if tt.wantError {
+				assert.ErrorContains(t, err, "invalid format")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/core/core/diff.go
+++ b/core/core/diff.go
@@ -23,7 +23,7 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (int, error) {
 	}
 
 	switch diffInfo.Format {
-	case "json":
+	case printer.JsonFormat:
 		if err := diff.PrintJSON(w, cs); err != nil {
 			return 0, fmt.Errorf("writing JSON diff: %w", err)
 		}

--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -10,6 +10,10 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
+// statusAbsent marks a resource+control pair that is missing from one side of the diff
+// (it is not one of the apis.ScanningStatus values).
+const statusAbsent = "absent"
+
 // minimal structs for reading the v2 JSON scan output produced by jsonprinter.go
 type scanReport struct {
 	Results        []resultEntry  `json:"results"`
@@ -82,7 +86,7 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 
 	// walk head: find new and unchanged failures
 	for k, hc := range headMap {
-		if hc.Status.InnerStatus != "failed" {
+		if hc.Status.InnerStatus != string(apis.StatusFailed) {
 			continue
 		}
 		change := ControlChange{
@@ -90,12 +94,13 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 			ControlID:   k.controlID,
 			ControlName: hc.Name,
 			Severity:    headSev[k.controlID],
+			BaseStatus:  statusAbsent,
 			HeadStatus:  hc.Status.InnerStatus,
 		}
 		if bc, ok := baseMap[k]; ok {
 			change.BaseStatus = bc.Status.InnerStatus
 		}
-		if change.BaseStatus == "failed" {
+		if change.BaseStatus == string(apis.StatusFailed) {
 			cs.Unchanged = append(cs.Unchanged, change)
 		} else {
 			cs.New = append(cs.New, change)
@@ -104,12 +109,12 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 
 	// walk base: find resolved (was failed, now not failed or absent)
 	for k, bc := range baseMap {
-		if bc.Status.InnerStatus != "failed" {
+		if bc.Status.InnerStatus != string(apis.StatusFailed) {
 			continue
 		}
 		hc, inHead := headMap[k]
-		if !inHead || hc.Status.InnerStatus != "failed" {
-			headStatus := "absent"
+		if !inHead || hc.Status.InnerStatus != string(apis.StatusFailed) {
+			headStatus := statusAbsent
 			if inHead {
 				headStatus = hc.Status.InnerStatus
 			}
@@ -118,7 +123,7 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 				ControlID:   k.controlID,
 				ControlName: bc.Name,
 				Severity:    baseSev[k.controlID],
-				BaseStatus:  "failed",
+				BaseStatus:  string(apis.StatusFailed),
 				HeadStatus:  headStatus,
 			})
 		}

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -85,6 +85,8 @@ func TestCompute_NewResourceInHead(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, cs.New, 1)
 	assert.Equal(t, "res-new", cs.New[0].ResourceID)
+	// new-to-head failures have no base counterpart: BaseStatus is "absent", symmetric with HeadStatus
+	assert.Equal(t, "absent", cs.New[0].BaseStatus)
 }
 
 func TestCompute_RemovedResourceFromBase(t *testing.T) {


### PR DESCRIPTION
 ## Overview

  Addresses four quality/correctness issues in the `kubescape diff` command (#2433):

  1. **`--format` is now validated.** Previously any value was accepted and invalid
     formats silently fell through to the pretty printer. The flag is now validated
     in `RunE` against the supported set (`pretty-printer`, `json`) via
     `shared.ValidateScanFormat`, consistent with the `scan` command.
  2. **Removed unreachable code.** The `if len(args) < 2` check in `RunE` was dead —
     `cobra.ExactArgs(2)` already enforces the argument count. Removed it along with
     the now-unused `errors` import.
  3. **Typed status constants.** Bare `"failed"` string literals in the diff
     computation are replaced with `string(apis.StatusFailed)`.
  4. **Consistent `absent` status.** New-to-head failures previously left `baseStatus`
     as an empty string while resolved-in-base changes already set `headStatus` to
     `"absent"`. Both sides are now symmetric — new failures report
     `baseStatus: "absent"` in JSON output.

  > Note: the issue mentions a `"passed"` literal, but no `"passed"` literal exists in
  > the diff package — only `"failed"` was present, so item 3 only touched `"failed"`.

  ## Additional Information

  - The `"absent"` value is a diff-local sentinel (not one of the `apis.ScanningStatus`
    values), so it's defined as a local `statusAbsent` constant rather than reusing an
    `apis` constant.
  - The pretty printer does not emit `baseStatus`, so change only affects JSON output;
    no existing pretty-output behavior changes.

  ## How to Test

  ```bash
  go build ./...
  go test ./cmd/diff/... ./core/pkg/resultshandling/diff/...
   ```
  Manual check of format validation:

  ### rejected with an error listing supported formats
  kubescape diff base.json head.json --format yaml

  ### accepted
  kubescape diff base.json head.json --format json

  Related issues/PRs:

  - Resolved #2433

  Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests.
  - [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The diff command now rejects unsupported `--format` values, allowing only pretty-print and JSON.
  * Error messaging for invalid formats is now clearer and includes supported options.

* **Improvements**
  * Diff comparisons for resources that exist only in the head report now correctly mark the base side as **“absent”** for more accurate visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->