### PR TITLE
Add offline request stub for the CEL engine

### DIFF
--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -44,13 +44,11 @@ func stubBindings(obj, namespaceObject map[string]any) map[string]any {
 // key that is absent from this map is a runtime error rather than null. At
 // live admission every one of these fields is set, so a VAP reading e.g.
 // request.resource.resource passes on a cluster but would error offline if we
-// left the key out. We mirror apiserver's BuildRequestType field set exactly
-// (k8s.io/apiserver/pkg/admission/plugin/cel/compile.go): kind, resource,
+// left the key out. So every field a real AdmissionRequest exposes is present
+// here, with a zero value where we have nothing real, so any field a policy
+// selects resolves instead of blowing up at eval time: kind, resource,
 // subResource, requestKind, requestResource, requestSubResource, name,
-// namespace, operation, userInfo, dryRun, options. uid is intentionally
-// omitted because apiserver omits it too (its comment: "not needed for
-// in-process admission review"), so a VAP reading request.uid errors at
-// admission as well and we keep parity by not inventing it.
+// namespace, operation, userInfo, dryRun, options, uid.
 //
 // Known gaps (issue #2001), present-but-zero so selection never errors:
 //   - userInfo carries no identity (offline we don't know the requester), so
@@ -72,6 +70,7 @@ func stubRequest(obj map[string]any) map[string]any {
 	gvr := map[string]any{"group": group, "version": version, "resource": ""}
 
 	return map[string]any{
+		"uid":                "",
 		"kind":               gvk,
 		"resource":           gvr,
 		"subResource":        "",
@@ -89,7 +88,10 @@ func stubRequest(obj map[string]any) map[string]any {
 			"groups":   []any{},
 			"extra":    map[string]any{},
 		},
-		"dryRun":  true,
+		// dryRun is false: we model a real CREATE (e.g. kubectl apply), which
+		// is the case the scan/admission parity claim is about. A policy that
+		// gates on request.dryRun then sees what it would at a real admission.
+		"dryRun":  false,
 		"options": map[string]any{},
 	}
 }

--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -1,0 +1,108 @@
+package cel
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// operationCreate is the admission operation we report offline. Kubescape
+// scans files rather than reacting to live API calls, so every resource is
+// treated as a fresh CREATE: that is what gives us CREATE-parity with live
+// admission (request.operation=CREATE, oldObject=null).
+const operationCreate = "CREATE"
+
+// stubBindings returns the activation entries the offline stub layer owns:
+// the stubbed request, the null oldObject, and the namespaceObject. PR #6's
+// evaluator merges these with the object, params and variables bindings to
+// form the full activation for one resource.
+//
+//   - obj is the K8s resource being scanned (bound to "object" elsewhere).
+//   - namespaceObject is the resource's Namespace object, or nil when the
+//     scan does not have it. For a cluster-scoped resource it is ignored and
+//     namespaceObject binds to null, matching how the apiserver binds it.
+//
+// oldObject and namespaceObject are bound to nil (CEL null) rather than left
+// absent: the variables are declared on the env (see env.go), and a declared
+// variable that is missing from the activation would error at eval time
+// instead of evaluating as null.
+func stubBindings(obj, namespaceObject map[string]any) map[string]any {
+	return map[string]any{
+		"request":         stubRequest(obj),
+		"oldObject":       nil,
+		"namespaceObject": stubNamespaceObject(obj, namespaceObject),
+	}
+}
+
+// stubRequest builds the "request" variable the way Kubernetes would during
+// admission of a fresh CREATE. Because Kubescape is scanning files rather
+// than reacting to a live API call, operation is always CREATE and userInfo
+// is empty.
+//
+// Known gap (issue #2001): request.userInfo and authorizer cannot be
+// populated meaningfully offline. userInfo is present but empty so that
+// expressions referencing request.userInfo.* still evaluate; checks that
+// depend on the requesting user being known are a documented limitation, not
+// a correctness claim.
+func stubRequest(obj map[string]any) map[string]any {
+	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
+	kind, _, _ := unstructured.NestedString(obj, "kind")
+	apiVersion, _, _ := unstructured.NestedString(obj, "apiVersion")
+	group, version := splitAPIVersion(apiVersion)
+
+	return map[string]any{
+		"operation": operationCreate,
+		"name":      name,
+		"namespace": namespace,
+		// kind is a GroupVersionKind; some VAPs read request.kind.kind.
+		"kind": map[string]any{
+			"group":   group,
+			"version": version,
+			"kind":    kind,
+		},
+		"dryRun": true,
+		// Empty UserInfo: present so request.userInfo.* compiles and
+		// evaluates, but carries no identity (see the doc note above).
+		"userInfo": map[string]any{
+			"username": "",
+			"uid":      "",
+			"groups":   []any{},
+			"extra":    map[string]any{},
+		},
+	}
+}
+
+// stubNamespaceObject resolves the value bound to "namespaceObject".
+//
+// It is the resource's Namespace object for a namespaced resource, and null
+// for a cluster-scoped one — matching the apiserver. When the resource is
+// namespaced but the scan does not have the Namespace object (namespaceObject
+// is nil), it also binds to null; policies that read namespaceObject.* then
+// see an absent namespace rather than failing to evaluate.
+func stubNamespaceObject(obj, namespaceObject map[string]any) any {
+	if !isNamespaced(obj) {
+		return nil
+	}
+	if namespaceObject == nil {
+		return nil
+	}
+	return namespaceObject
+}
+
+// isNamespaced reports whether the resource carries a non-empty
+// metadata.namespace. Cluster-scoped resources (Namespace, ClusterRole, …)
+// have none.
+func isNamespaced(obj map[string]any) bool {
+	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
+	return namespace != ""
+}
+
+// splitAPIVersion splits a K8s apiVersion ("apps/v1", "v1") into its group
+// and version. The core group has an empty group string ("v1" -> "", "v1").
+func splitAPIVersion(apiVersion string) (group, version string) {
+	if i := strings.Index(apiVersion, "/"); i >= 0 {
+		return apiVersion[:i], apiVersion[i+1:]
+	}
+	return "", apiVersion
+}

--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -39,11 +39,25 @@ func stubBindings(obj, namespaceObject map[string]any) map[string]any {
 // than reacting to a live API call, operation is always CREATE and userInfo
 // is empty.
 //
-// Known gap (issue #2001): request.userInfo and authorizer cannot be
-// populated meaningfully offline. userInfo is present but empty so that
-// expressions referencing request.userInfo.* still evaluate; checks that
-// depend on the requesting user being known are a documented limitation, not
-// a correctness claim.
+// The whole AdmissionRequest shape is populated, not just the fields we have
+// real values for. request is declared cel.DynType on the env, so selecting a
+// key that is absent from this map is a runtime error rather than null. At
+// live admission every one of these fields is set, so a VAP reading e.g.
+// request.resource.resource passes on a cluster but would error offline if we
+// left the key out. We mirror apiserver's BuildRequestType field set exactly
+// (k8s.io/apiserver/pkg/admission/plugin/cel/compile.go): kind, resource,
+// subResource, requestKind, requestResource, requestSubResource, name,
+// namespace, operation, userInfo, dryRun, options. uid is intentionally
+// omitted because apiserver omits it too (its comment: "not needed for
+// in-process admission review"), so a VAP reading request.uid errors at
+// admission as well and we keep parity by not inventing it.
+//
+// Known gaps (issue #2001), present-but-zero so selection never errors:
+//   - userInfo carries no identity (offline we don't know the requester), so
+//     checks depending on the requesting user are a documented limitation.
+//   - resource/requestResource carry the group and version but an empty
+//     resource (plural) name: resolving the GVR plural offline needs a
+//     RESTMapper we don't have, so it stays the zero value.
 func stubRequest(obj map[string]any) map[string]any {
 	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
 	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
@@ -51,25 +65,32 @@ func stubRequest(obj map[string]any) map[string]any {
 	apiVersion, _, _ := unstructured.NestedString(obj, "apiVersion")
 	group, version := splitAPIVersion(apiVersion)
 
+	// kind is a GroupVersionKind; resource is a GroupVersionResource. They
+	// share group/version. requestKind/requestResource equal kind/resource
+	// when no API conversion is involved, which is always the case offline.
+	gvk := map[string]any{"group": group, "version": version, "kind": kind}
+	gvr := map[string]any{"group": group, "version": version, "resource": ""}
+
 	return map[string]any{
-		"operation": operationCreate,
-		"name":      name,
-		"namespace": namespace,
-		// kind is a GroupVersionKind; some VAPs read request.kind.kind.
-		"kind": map[string]any{
-			"group":   group,
-			"version": version,
-			"kind":    kind,
-		},
-		"dryRun": true,
-		// Empty UserInfo: present so request.userInfo.* compiles and
-		// evaluates, but carries no identity (see the doc note above).
+		"kind":               gvk,
+		"resource":           gvr,
+		"subResource":        "",
+		"requestKind":        gvk,
+		"requestResource":    gvr,
+		"requestSubResource": "",
+		"name":               name,
+		"namespace":          namespace,
+		"operation":          operationCreate,
+		// Empty UserInfo: present so request.userInfo.* evaluates, but
+		// carries no identity (see the doc note above).
 		"userInfo": map[string]any{
 			"username": "",
 			"uid":      "",
 			"groups":   []any{},
 			"extra":    map[string]any{},
 		},
+		"dryRun":  true,
+		"options": map[string]any{},
 	}
 }
 

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -35,7 +35,8 @@ func TestStubRequest(t *testing.T) {
 	assert.Equal(t, operationCreate, req["operation"])
 	assert.Equal(t, "nginx", req["name"])
 	assert.Equal(t, "production", req["namespace"])
-	assert.Equal(t, true, req["dryRun"])
+	// dryRun models a real CREATE, not a dry run.
+	assert.Equal(t, false, req["dryRun"])
 
 	// userInfo must exist but carry no identity.
 	userInfo, ok := req["userInfo"].(map[string]any)
@@ -59,7 +60,7 @@ func TestStubRequestHasFullAdmissionRequestShape(t *testing.T) {
 	req := stubRequest(namespacedPod())
 
 	for _, key := range []string{
-		"kind", "resource", "subResource", "requestKind", "requestResource",
+		"uid", "kind", "resource", "subResource", "requestKind", "requestResource",
 		"requestSubResource", "name", "namespace", "operation", "userInfo",
 		"dryRun", "options",
 	} {
@@ -97,6 +98,7 @@ func TestStubRequestSelectableAgainstEnv(t *testing.T) {
 		"request.operation == 'CREATE'",
 		"request.name == 'nginx'",
 		"request.namespace == 'production'",
+		"request.uid == ''",
 		"request.kind.kind == 'Pod'",
 		"request.resource.resource == ''",
 		"request.resource.group == ''",
@@ -106,7 +108,7 @@ func TestStubRequestSelectableAgainstEnv(t *testing.T) {
 		"request.requestSubResource == ''",
 		"request.userInfo.username == ''",
 		"size(request.userInfo.groups) == 0",
-		"request.dryRun == true",
+		"request.dryRun == false",
 	}
 
 	for _, expr := range exprs {

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -3,6 +3,8 @@ package cel
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -30,52 +32,93 @@ func clusterScopedRole() map[string]any {
 func TestStubRequest(t *testing.T) {
 	req := stubRequest(namespacedPod())
 
-	if got := req["operation"]; got != operationCreate {
-		t.Errorf("operation = %v, want %q", got, operationCreate)
-	}
-	if got := req["name"]; got != "nginx" {
-		t.Errorf("name = %v, want %q", got, "nginx")
-	}
-	if got := req["namespace"]; got != "production" {
-		t.Errorf("namespace = %v, want %q", got, "production")
-	}
+	assert.Equal(t, operationCreate, req["operation"])
+	assert.Equal(t, "nginx", req["name"])
+	assert.Equal(t, "production", req["namespace"])
+	assert.Equal(t, true, req["dryRun"])
 
 	// userInfo must exist but carry no identity.
 	userInfo, ok := req["userInfo"].(map[string]any)
-	if !ok {
-		t.Fatalf("userInfo is %T, want map[string]any", req["userInfo"])
-	}
-	if got := userInfo["username"]; got != "" {
-		t.Errorf("userInfo.username = %v, want empty", got)
-	}
-	if groups, ok := userInfo["groups"].([]any); !ok || len(groups) != 0 {
-		t.Errorf("userInfo.groups = %v, want empty slice", userInfo["groups"])
-	}
+	require.True(t, ok, "userInfo should be a map")
+	assert.Equal(t, "", userInfo["username"])
+	assert.Empty(t, userInfo["groups"])
 
 	// kind is a GroupVersionKind; core-group resources have an empty group.
 	kind, ok := req["kind"].(map[string]any)
-	if !ok {
-		t.Fatalf("kind is %T, want map[string]any", req["kind"])
+	require.True(t, ok, "kind should be a map")
+	assert.Equal(t, "", kind["group"])
+	assert.Equal(t, "v1", kind["version"])
+	assert.Equal(t, "Pod", kind["kind"])
+}
+
+// TestStubRequestHasFullAdmissionRequestShape guards the blocker matthyx
+// flagged: because request is cel.DynType, any AdmissionRequest field a VAP
+// selects must exist on the stub or evaluation errors offline while passing at
+// admission. Keep this aligned with apiserver's BuildRequestType field set.
+func TestStubRequestHasFullAdmissionRequestShape(t *testing.T) {
+	req := stubRequest(namespacedPod())
+
+	for _, key := range []string{
+		"kind", "resource", "subResource", "requestKind", "requestResource",
+		"requestSubResource", "name", "namespace", "operation", "userInfo",
+		"dryRun", "options",
+	} {
+		_, ok := req[key]
+		assert.Truef(t, ok, "request is missing field %q", key)
 	}
-	if got := kind["group"]; got != "" {
-		t.Errorf("kind.group = %v, want empty (core group)", got)
-	}
-	if got := kind["version"]; got != "v1" {
-		t.Errorf("kind.version = %v, want %q", got, "v1")
-	}
-	if got := kind["kind"]; got != "Pod" {
-		t.Errorf("kind.kind = %v, want %q", got, "Pod")
-	}
+
+	// resource is a GroupVersionResource: group/version are real, the plural
+	// resource name is the zero value (can't resolve a GVR plural offline).
+	resource, ok := req["resource"].(map[string]any)
+	require.True(t, ok, "resource should be a map")
+	assert.Equal(t, "", resource["group"])
+	assert.Equal(t, "v1", resource["version"])
+	assert.Equal(t, "", resource["resource"])
 }
 
 func TestStubRequestGroupedAPIVersion(t *testing.T) {
 	req := stubRequest(clusterScopedRole())
 	kind := req["kind"].(map[string]any)
-	if got := kind["group"]; got != "rbac.authorization.k8s.io" {
-		t.Errorf("kind.group = %v, want %q", got, "rbac.authorization.k8s.io")
+	assert.Equal(t, "rbac.authorization.k8s.io", kind["group"])
+	assert.Equal(t, "v1", kind["version"])
+}
+
+// TestStubRequestSelectableAgainstEnv is the strongest form of the
+// full-shape guarantee: it compiles and evaluates selections into every
+// request field against the real env. A missing key would surface here as an
+// eval error, exactly the offline/admission mismatch we are avoiding.
+func TestStubRequestSelectableAgainstEnv(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+
+	activation := map[string]any{"request": stubRequest(namespacedPod())}
+
+	exprs := []string{
+		"request.operation == 'CREATE'",
+		"request.name == 'nginx'",
+		"request.namespace == 'production'",
+		"request.kind.kind == 'Pod'",
+		"request.resource.resource == ''",
+		"request.resource.group == ''",
+		"request.subResource == ''",
+		"request.requestKind.kind == 'Pod'",
+		"request.requestResource.version == 'v1'",
+		"request.requestSubResource == ''",
+		"request.userInfo.username == ''",
+		"size(request.userInfo.groups) == 0",
+		"request.dryRun == true",
 	}
-	if got := kind["version"]; got != "v1" {
-		t.Errorf("kind.version = %v, want %q", got, "v1")
+
+	for _, expr := range exprs {
+		ast, issues := env.Compile(expr)
+		require.NoErrorf(t, issues.Err(), "compile %q", expr)
+
+		prg, err := env.Program(ast)
+		require.NoErrorf(t, err, "program %q", expr)
+
+		out, _, err := prg.Eval(activation)
+		require.NoErrorf(t, err, "eval %q", expr)
+		assert.Equalf(t, true, out.Value(), "expr %q should be true", expr)
 	}
 }
 
@@ -85,12 +128,8 @@ func TestStubBindingsOldObjectIsNull(t *testing.T) {
 	// oldObject must be present (declared on the env) and null, so a CREATE
 	// has the same null oldObject it would have at live admission.
 	v, ok := b["oldObject"]
-	if !ok {
-		t.Fatal("oldObject missing from bindings; must be present and null")
-	}
-	if v != nil {
-		t.Errorf("oldObject = %v, want nil (null)", v)
-	}
+	require.True(t, ok, "oldObject must be present and null")
+	assert.Nil(t, v)
 }
 
 func TestStubBindingsNamespaceObject(t *testing.T) {
@@ -106,26 +145,18 @@ func TestStubBindingsNamespaceObject(t *testing.T) {
 	t.Run("namespaced resource binds the namespace object", func(t *testing.T) {
 		b := stubBindings(namespacedPod(), nsObject)
 		got, ok := b["namespaceObject"].(map[string]any)
-		if !ok {
-			t.Fatalf("namespaceObject is %T, want the namespace object", b["namespaceObject"])
-		}
+		require.True(t, ok, "namespaceObject should be the namespace object")
 		name, _, _ := unstructured.NestedString(got, "metadata", "name")
-		if name != "production" {
-			t.Errorf("namespaceObject.metadata.name = %q, want %q", name, "production")
-		}
+		assert.Equal(t, "production", name)
 	})
 
 	t.Run("cluster-scoped resource binds null", func(t *testing.T) {
 		b := stubBindings(clusterScopedRole(), nsObject)
-		if got := b["namespaceObject"]; got != nil {
-			t.Errorf("namespaceObject = %v, want nil for cluster-scoped resource", got)
-		}
+		assert.Nil(t, b["namespaceObject"])
 	})
 
 	t.Run("namespaced resource without a namespace object binds null", func(t *testing.T) {
 		b := stubBindings(namespacedPod(), nil)
-		if got := b["namespaceObject"]; got != nil {
-			t.Errorf("namespaceObject = %v, want nil when the scan lacks it", got)
-		}
+		assert.Nil(t, b["namespaceObject"])
 	})
 }

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -1,0 +1,131 @@
+package cel
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func namespacedPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "nginx",
+			"namespace": "production",
+		},
+	}
+}
+
+func clusterScopedRole() map[string]any {
+	return map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": "view",
+		},
+	}
+}
+
+func TestStubRequest(t *testing.T) {
+	req := stubRequest(namespacedPod())
+
+	if got := req["operation"]; got != operationCreate {
+		t.Errorf("operation = %v, want %q", got, operationCreate)
+	}
+	if got := req["name"]; got != "nginx" {
+		t.Errorf("name = %v, want %q", got, "nginx")
+	}
+	if got := req["namespace"]; got != "production" {
+		t.Errorf("namespace = %v, want %q", got, "production")
+	}
+
+	// userInfo must exist but carry no identity.
+	userInfo, ok := req["userInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("userInfo is %T, want map[string]any", req["userInfo"])
+	}
+	if got := userInfo["username"]; got != "" {
+		t.Errorf("userInfo.username = %v, want empty", got)
+	}
+	if groups, ok := userInfo["groups"].([]any); !ok || len(groups) != 0 {
+		t.Errorf("userInfo.groups = %v, want empty slice", userInfo["groups"])
+	}
+
+	// kind is a GroupVersionKind; core-group resources have an empty group.
+	kind, ok := req["kind"].(map[string]any)
+	if !ok {
+		t.Fatalf("kind is %T, want map[string]any", req["kind"])
+	}
+	if got := kind["group"]; got != "" {
+		t.Errorf("kind.group = %v, want empty (core group)", got)
+	}
+	if got := kind["version"]; got != "v1" {
+		t.Errorf("kind.version = %v, want %q", got, "v1")
+	}
+	if got := kind["kind"]; got != "Pod" {
+		t.Errorf("kind.kind = %v, want %q", got, "Pod")
+	}
+}
+
+func TestStubRequestGroupedAPIVersion(t *testing.T) {
+	req := stubRequest(clusterScopedRole())
+	kind := req["kind"].(map[string]any)
+	if got := kind["group"]; got != "rbac.authorization.k8s.io" {
+		t.Errorf("kind.group = %v, want %q", got, "rbac.authorization.k8s.io")
+	}
+	if got := kind["version"]; got != "v1" {
+		t.Errorf("kind.version = %v, want %q", got, "v1")
+	}
+}
+
+func TestStubBindingsOldObjectIsNull(t *testing.T) {
+	b := stubBindings(namespacedPod(), nil)
+
+	// oldObject must be present (declared on the env) and null, so a CREATE
+	// has the same null oldObject it would have at live admission.
+	v, ok := b["oldObject"]
+	if !ok {
+		t.Fatal("oldObject missing from bindings; must be present and null")
+	}
+	if v != nil {
+		t.Errorf("oldObject = %v, want nil (null)", v)
+	}
+}
+
+func TestStubBindingsNamespaceObject(t *testing.T) {
+	nsObject := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "production",
+			"labels": map[string]any{"team": "payments"},
+		},
+	}
+
+	t.Run("namespaced resource binds the namespace object", func(t *testing.T) {
+		b := stubBindings(namespacedPod(), nsObject)
+		got, ok := b["namespaceObject"].(map[string]any)
+		if !ok {
+			t.Fatalf("namespaceObject is %T, want the namespace object", b["namespaceObject"])
+		}
+		name, _, _ := unstructured.NestedString(got, "metadata", "name")
+		if name != "production" {
+			t.Errorf("namespaceObject.metadata.name = %q, want %q", name, "production")
+		}
+	})
+
+	t.Run("cluster-scoped resource binds null", func(t *testing.T) {
+		b := stubBindings(clusterScopedRole(), nsObject)
+		if got := b["namespaceObject"]; got != nil {
+			t.Errorf("namespaceObject = %v, want nil for cluster-scoped resource", got)
+		}
+	})
+
+	t.Run("namespaced resource without a namespace object binds null", func(t *testing.T) {
+		b := stubBindings(namespacedPod(), nil)
+		if got := b["namespaceObject"]; got != nil {
+			t.Errorf("namespaceObject = %v, want nil when the scan lacks it", got)
+		}
+	})
+}


### PR DESCRIPTION
## Overview

This adds the request stub for the CEL engine, the small piece that runs before the evaluator. Since Kubescape scans files and isn't reacting to a live API call, there's no real admission request to give the policy, so I just fake one.

The main bit is stubRequest(obj). It builds the request like the apiserver would for a fresh CREATE, so operation is always CREATE and I pull name, namespace and kind off the object. userInfo is there but empty, since we can't know who's making the request when we're only scanning files. That's a known gap from issue #2001, not something I'm pretending to fix.

Then there's stubBindings, which the evaluator will call next. It returns the stubbed request, oldObject as null, and namespaceObject. I set oldObject and namespaceObject to nil on purpose instead of leaving them out, because the env declares both and a declared variable that's missing errors at eval time instead of reading as null. namespaceObject binds to the namespace object when the resource is namespaced, and null when it's cluster scoped or the scan doesn't have it.

Tests cover all of that and everything builds and passes on its own, nothing here depends on the evaluator PR.

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline CEL admission request stubbing layer for Kubernetes evaluations, including CREATE operation details, kind/resource information, `dryRun: false`, and user identity/group shape.
  * Improved namespace handling by binding the Namespace object only for namespaced resources when available; otherwise leaves `namespaceObject` unset.

* **Tests**
  * Expanded end-to-end coverage for admission request shape completeness, API version/group parsing, and CEL selection results against the stubbed environment.
  * Added assertions for `oldObject` create semantics and correct namespace binding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->