### PR TITLE
Expand encryption and decryption coverage for resource metadata

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -97,7 +97,20 @@ func GetDecryptCommand() *cobra.Command {
 					)
 				}
 
+				idMapping := make(map[string]string)
+
 				for i := range resources {
+
+					var oldID string
+
+					if rawID, ok := resources[i]["resourceID"]; ok {
+						if err := json.Unmarshal(rawID, &oldID); err != nil {
+							return fmt.Errorf(
+								"failed to parse resourceID: %w",
+								err,
+							)
+						}
+					}
 
 					objectRaw, ok := resources[i]["object"]
 					if ok {
@@ -117,6 +130,22 @@ func GetDecryptCommand() *cobra.Command {
 						); err != nil {
 							return err
 						}
+
+						newID := resource.GetID()
+
+						if oldID != "" {
+							idMapping[oldID] = newID
+						}
+
+						updatedID, err := json.Marshal(newID)
+						if err != nil {
+							return fmt.Errorf(
+								"failed to marshal resourceID: %w",
+								err,
+							)
+						}
+
+						resources[i]["resourceID"] = updatedID
 
 						updatedObject, err := json.Marshal(
 							resource.GetWorkload(),
@@ -179,6 +208,65 @@ func GetDecryptCommand() *cobra.Command {
 				}
 
 				report["resources"] = updatedResources
+				resultsRaw, ok := report["results"]
+				if ok {
+					var results []map[string]json.RawMessage
+
+					if err := json.Unmarshal(
+						resultsRaw,
+						&results,
+					); err != nil {
+						return fmt.Errorf(
+							"failed to parse results: %w",
+							err,
+						)
+					}
+
+					for i := range results {
+						var resourceID string
+
+						resourceIDRaw, ok := results[i]["resourceID"]
+						if !ok {
+							continue
+						}
+
+						if err := json.Unmarshal(
+							resourceIDRaw,
+							&resourceID,
+						); err != nil {
+							return fmt.Errorf(
+								"failed to parse result resourceID: %w",
+								err,
+							)
+						}
+
+						newID := resourceID
+						if mappedID, ok := idMapping[resourceID]; ok {
+							newID = mappedID
+						}
+						updatedID, err := json.Marshal(newID)
+						if err != nil {
+							return fmt.Errorf(
+								"failed to marshal result resourceID: %w",
+								err,
+							)
+						}
+
+						results[i]["resourceID"] = updatedID
+					}
+
+					updatedResults, err := json.Marshal(
+						results,
+					)
+					if err != nil {
+						return fmt.Errorf(
+							"failed to marshal results: %w",
+							err,
+						)
+					}
+
+					report["results"] = updatedResults
+				}
 			}
 			encoder := json.NewEncoder(os.Stdout)
 			encoder.SetIndent("", "  ")

--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/spf13/cobra"
 )
@@ -123,16 +124,13 @@ func GetDecryptCommand() *cobra.Command {
 								err,
 							)
 						}
-
 						if err := reportcrypto.DecryptResourceMetadata(
 							resource,
 							dek,
 						); err != nil {
 							return err
 						}
-
 						newID := resource.GetID()
-
 						if oldID != "" {
 							idMapping[oldID] = newID
 						}
@@ -210,8 +208,7 @@ func GetDecryptCommand() *cobra.Command {
 				report["resources"] = updatedResources
 				resultsRaw, ok := report["results"]
 				if ok {
-					var results []map[string]json.RawMessage
-
+					var results []resourcesresults.Result
 					if err := json.Unmarshal(
 						resultsRaw,
 						&results,
@@ -222,39 +219,7 @@ func GetDecryptCommand() *cobra.Command {
 						)
 					}
 
-					for i := range results {
-						var resourceID string
-
-						resourceIDRaw, ok := results[i]["resourceID"]
-						if !ok {
-							continue
-						}
-
-						if err := json.Unmarshal(
-							resourceIDRaw,
-							&resourceID,
-						); err != nil {
-							return fmt.Errorf(
-								"failed to parse result resourceID: %w",
-								err,
-							)
-						}
-
-						newID := resourceID
-						if mappedID, ok := idMapping[resourceID]; ok {
-							newID = mappedID
-						}
-						updatedID, err := json.Marshal(newID)
-						if err != nil {
-							return fmt.Errorf(
-								"failed to marshal result resourceID: %w",
-								err,
-							)
-						}
-
-						results[i]["resourceID"] = updatedID
-					}
-
+					remapResults(results, idMapping)
 					updatedResults, err := json.Marshal(
 						results,
 					)
@@ -274,4 +239,60 @@ func GetDecryptCommand() *cobra.Command {
 			return encoder.Encode(report)
 		},
 	}
+}
+
+// remapResults restores all resource ID references that were rewritten
+// during encryption so they remain consistent with the decrypted resources.
+func remapResults(results []resourcesresults.Result, idMapping map[string]string) {
+	for i := range results {
+		results[i].ResourceID = remapResourceID(
+			results[i].ResourceID,
+			idMapping,
+		)
+
+		if results[i].PrioritizedResource != nil {
+			results[i].PrioritizedResource.ResourceID =
+				remapResourceID(
+					results[i].PrioritizedResource.ResourceID,
+					idMapping,
+				)
+		}
+
+		for controlIndex := range results[i].AssociatedControls {
+			for ruleIndex := range results[i].AssociatedControls[controlIndex].ResourceAssociatedRules {
+
+				rule := &results[i].AssociatedControls[controlIndex].ResourceAssociatedRules[ruleIndex]
+
+				for pathIndex := range rule.Paths {
+					rule.Paths[pathIndex].ResourceID =
+						remapResourceID(
+							rule.Paths[pathIndex].ResourceID,
+							idMapping,
+						)
+				}
+
+				for relatedIndex := range rule.RelatedResourcesIDs {
+					rule.RelatedResourcesIDs[relatedIndex] =
+						remapResourceID(
+							rule.RelatedResourcesIDs[relatedIndex],
+							idMapping,
+						)
+				}
+			}
+		}
+	}
+}
+
+// remapResourceID restores a resource ID if it was rewritten during
+// encryption. Unknown IDs are returned unchanged.
+func remapResourceID(
+	id string,
+	idMapping map[string]string,
+) string {
+
+	if mappedID, ok := idMapping[id]; ok {
+		return mappedID
+	}
+
+	return id
 }

--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	"github.com/kubescape/opa-utils/reporthandling"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -97,6 +98,39 @@ func GetDecryptCommand() *cobra.Command {
 				}
 
 				for i := range resources {
+
+					objectRaw, ok := resources[i]["object"]
+					if ok {
+						resource, err := workloadinterface.NewWorkload(
+							objectRaw,
+						)
+						if err != nil {
+							return fmt.Errorf(
+								"failed to parse resource object: %w",
+								err,
+							)
+						}
+
+						if err := reportcrypto.DecryptResourceMetadata(
+							resource,
+							dek,
+						); err != nil {
+							return err
+						}
+
+						updatedObject, err := json.Marshal(
+							resource.GetWorkload(),
+						)
+						if err != nil {
+							return fmt.Errorf(
+								"failed to marshal resource object: %w",
+								err,
+							)
+						}
+
+						resources[i]["object"] = updatedObject
+					}
+
 					sourceRaw, ok := resources[i]["source"]
 					if !ok {
 						continue

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -50,6 +50,20 @@ func TestDecryptCommand(t *testing.T) {
 				)
 			require.NoError(t, err)
 
+			encryptedName, err :=
+				reportcrypto.EncryptString(
+					"nginx-deployment",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedNamespace, err :=
+				reportcrypto.EncryptString(
+					"production",
+					dek,
+				)
+			require.NoError(t, err)
+
 			wrappedDEK, err :=
 				reportcrypto.WrapDEK(
 					dek,
@@ -68,6 +82,14 @@ func TestDecryptCommand(t *testing.T) {
 					{
 						"resourceID":  "resource-1",
 						"customField": "must-survive",
+						"object": map[string]any{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]any{
+								"name":      encryptedName,
+								"namespace": encryptedNamespace,
+							},
+						},
 						"source": map[string]any{
 							"path":         encryptedPath,
 							"relativePath": encryptedRelativePath,
@@ -217,6 +239,32 @@ func TestDecryptCommand(t *testing.T) {
 				t,
 				"must-survive",
 				resource["customField"],
+			)
+
+			object, ok := resource["object"].(map[string]any)
+			require.True(
+				t,
+				ok,
+				"object should be an object",
+			)
+
+			metadataObj, ok := object["metadata"].(map[string]any)
+			require.True(
+				t,
+				ok,
+				"metadata should be an object",
+			)
+
+			assert.Equal(
+				t,
+				"nginx-deployment",
+				metadataObj["name"],
+			)
+
+			assert.Equal(
+				t,
+				"production",
+				metadataObj["namespace"],
 			)
 
 			source, ok := resource["source"].(map[string]any)

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -96,6 +96,11 @@ func TestDecryptCommand(t *testing.T) {
 						},
 					},
 				},
+				"results": []map[string]any{
+					{
+						"resourceID": "resource-1",
+					},
+				},
 				"metadata": map[string]any{
 					"targetMetadata": map[string]any{
 						"gitRepoContextMetadata": map[string]any{
@@ -122,10 +127,7 @@ func TestDecryptCommand(t *testing.T) {
 			_, err = tmp.Write(data)
 			require.NoError(t, err)
 
-			require.NoError(
-				t,
-				tmp.Close(),
-			)
+			require.NoError(t, tmp.Close())
 
 			t.Setenv(
 				"KUBESCAPE_MASTER_KEY",
@@ -156,10 +158,7 @@ func TestDecryptCommand(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.NoError(
-				t,
-				w.Close(),
-			)
+			require.NoError(t, w.Close())
 
 			var buf bytes.Buffer
 
@@ -174,117 +173,61 @@ func TestDecryptCommand(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			assert.Contains(
-				t,
-				output,
-				"resourceLabels",
-			)
+			assert.Contains(t, output, "resourceLabels")
 
-			assert.Contains(
-				t,
-				output,
-				"scanCoverage",
-			)
+			assert.Contains(t, output, "scanCoverage")
 
 			metadata, ok :=
 				output["metadata"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"metadata should be an object",
-			)
+			require.True(t, ok, "metadata should be an object")
 
 			targetMetadata, ok :=
 				metadata["targetMetadata"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"targetMetadata should be an object",
-			)
+			require.True(t, ok, "targetMetadata should be an object")
 
 			repoMetadata, ok :=
 				targetMetadata["gitRepoContextMetadata"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"gitRepoContextMetadata should be an object",
-			)
+			require.True(t, ok, "gitRepoContextMetadata should be an object")
 
-			assert.Equal(
-				t,
-				"kubescape",
-				repoMetadata["repo"],
-			)
+			assert.Equal(t, "kubescape", repoMetadata["repo"])
 
 			resources, ok := output["resources"].([]any)
-			require.True(
-				t,
-				ok,
-				"resources should be an array",
-			)
+			require.True(t, ok, "resources should be an array")
 
-			require.Len(
-				t,
-				resources,
-				1,
-			)
+			require.Len(t, resources, 1)
 
 			resource, ok := resources[0].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"resource should be an object",
-			)
-			assert.Equal(
-				t,
-				"must-survive",
-				resource["customField"],
-			)
+			require.True(t, ok, "resource should be an object")
 
+			resourceID, ok := resource["resourceID"].(string)
+			require.True(t, ok, "resourceID should be a string")
+
+			assert.Equal(t, "apps/v1/production/Deployment/nginx-deployment", resourceID)
+
+			assert.Equal(t, "must-survive", resource["customField"])
+			results, ok := output["results"].([]any)
+			require.True(t, ok, "results should be an array")
+
+			require.Len(t, results, 1)
+
+			result, ok := results[0].(map[string]any)
+			require.True(t, ok, "result should be an object")
+
+			assert.Equal(t, resourceID, result["resourceID"])
 			object, ok := resource["object"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"object should be an object",
-			)
+			require.True(t, ok, "object should be an object")
 
 			metadataObj, ok := object["metadata"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"metadata should be an object",
-			)
+			require.True(t, ok, "metadata should be an object")
 
-			assert.Equal(
-				t,
-				"nginx-deployment",
-				metadataObj["name"],
-			)
-
-			assert.Equal(
-				t,
-				"production",
-				metadataObj["namespace"],
-			)
+			assert.Equal(t, "nginx-deployment", metadataObj["name"])
+			assert.Equal(t, "production", metadataObj["namespace"])
 
 			source, ok := resource["source"].(map[string]any)
-			require.True(
-				t,
-				ok,
-				"source should be an object",
-			)
+			require.True(t, ok, "source should be an object")
 
-			assert.Equal(
-				t,
-				"/workspace/manifests/nginx/deployment.yaml",
-				source["path"],
-			)
-
-			assert.Equal(
-				t,
-				"manifests/nginx/deployment.yaml",
-				source["relativePath"],
-			)
+			assert.Equal(t, "/workspace/manifests/nginx/deployment.yaml", source["path"])
+			assert.Equal(t, "manifests/nginx/deployment.yaml", source["relativePath"])
 		})
 	}
 }

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -99,6 +99,25 @@ func TestDecryptCommand(t *testing.T) {
 				"results": []map[string]any{
 					{
 						"resourceID": "resource-1",
+						"prioritizedResource": map[string]any{
+							"resourceID": "resource-1",
+						},
+						"controls": []map[string]any{
+							{
+								"rules": []map[string]any{
+									{
+										"paths": []map[string]any{
+											{
+												"resourceID": "resource-1",
+											},
+										},
+										"relatedResourcesIDs": []string{
+											"resource-1",
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 				"metadata": map[string]any{
@@ -212,8 +231,24 @@ func TestDecryptCommand(t *testing.T) {
 
 			result, ok := results[0].(map[string]any)
 			require.True(t, ok, "result should be an object")
-
 			assert.Equal(t, resourceID, result["resourceID"])
+
+			prioritized, ok := result["prioritizedResource"].(map[string]any)
+			require.True(t, ok, "prioritizedResource should be an object")
+			assert.Equal(t, resourceID, prioritized["resourceID"])
+
+			controls, ok := result["controls"].([]any)
+			require.True(t, ok, "controls should be an array")
+			require.Len(t, controls, 1)
+
+			control, ok := controls[0].(map[string]any)
+			require.True(t, ok, "control should be an object")
+
+			rules, ok := control["rules"].([]any)
+			require.True(t, ok, "rules should be an array")
+
+			require.Len(t, rules, 1)
+
 			object, ok := resource["object"].(map[string]any)
 			require.True(t, ok, "object should be an object")
 
@@ -228,6 +263,23 @@ func TestDecryptCommand(t *testing.T) {
 
 			assert.Equal(t, "/workspace/manifests/nginx/deployment.yaml", source["path"])
 			assert.Equal(t, "manifests/nginx/deployment.yaml", source["relativePath"])
+
+			rule, ok := rules[0].(map[string]any)
+			require.True(t, ok, "rule should be an object")
+
+			paths, ok := rule["paths"].([]any)
+			require.True(t, ok, "paths should be an array")
+			require.Len(t, paths, 1)
+
+			path, ok := paths[0].(map[string]any)
+			require.True(t, ok, "path should be an object")
+			assert.Equal(t, resourceID, path["resourceID"])
+
+			related, ok := rule["relatedResourcesIDs"].([]any)
+			require.True(t, ok, "relatedResourcesIDs should be an array")
+
+			require.Len(t, related, 1)
+			assert.Equal(t, resourceID, related[0])
 		})
 	}
 }

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -36,17 +36,21 @@ func applyWithTransformer(
 }
 
 // ApplyEncrypted anonymizes a scan session while encrypting
-// RepoContextMetadata using the supplied DEK.
+// sensitive report metadata using the supplied DEK.
 //
 // The DEK is wrapped using the supplied master key (KEK)
 // and stored in EncryptionMetadata for future decryption
 // workflows.
 //
-// Resource identifiers, namespaces, annotations, source paths,
-// and other session data continue to use mapping-based
-// anonymization and remain irreversibly pseudonymized.
+// Repository context and resource metadata (for example,
+// resource names and namespaces) are reversibly encrypted.
+// Resource IDs are derived from the restored metadata during
+// decryption to preserve report referential integrity.
 //
-// Only repo context metadata is reversibly encrypted.
+// Other anonymized fields, such as annotations, source paths,
+// labels, and additional session data, continue to use
+// mapping-based anonymization and remain irreversibly
+// pseudonymized.
 func ApplyEncrypted(
 	resultsHandler *resultshandling.ResultsHandler,
 	dek []byte,

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -171,10 +171,13 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 // resolveMappedID preserves referential integrity when IDs are rewritten during
 // anonymization, ensuring cross-references remain valid.
 func resolveMappedID(mapping *Mapping, idMapping map[string]string, originalID, prefix string) string {
+
+	// Exact match (most common case)
 	if mappedID, ok := idMapping[originalID]; ok {
 		return mappedID
 	}
 
+	// Fallback for IDs that are not backed by a resource object.
 	return mapping.GetOrCreate(prefix, originalID)
 }
 

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -25,14 +25,10 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 
 	newAllResources := make(map[string]workloadinterface.IMetadata, len(session.AllResources))
 	for oldID, resource := range session.AllResources {
-		if name := resource.GetName(); name != "" {
-			resource.SetName(mapping.GetOrCreate("res", name))
-		}
 
-		if namespace := resource.GetNamespace(); namespace != "" {
-			resource.SetNamespace(mapping.GetOrCreate("ns", namespace))
+		if err := transformResourceMetadata(resource, repoTransformer); err != nil {
+			return err
 		}
-
 		// sourcePath leaks manifest filenames/line references in hidden output
 		// (for example test-anonymize.yaml:1), so anonymize it alongside other
 		// resource-local metadata.
@@ -319,10 +315,39 @@ func transformValue(transformer Transformer, prefix string, value string) (strin
 		return value, nil
 	}
 
-	return transformer.Transform(
-		prefix,
-		value,
-	)
+	return transformer.Transform(prefix, value)
+}
+
+func transformResourceMetadata(
+	resource workloadinterface.IMetadata,
+	transformer Transformer,
+) error {
+
+	if resource == nil {
+		return nil
+	}
+
+	var err error
+
+	if name := resource.GetName(); name != "" {
+		name, err = transformValue(transformer, "res", name)
+		if err != nil {
+			return err
+		}
+
+		resource.SetName(name)
+	}
+
+	if namespace := resource.GetNamespace(); namespace != "" {
+		namespace, err = transformValue(transformer, "ns", namespace)
+		if err != nil {
+			return err
+		}
+
+		resource.SetNamespace(namespace)
+	}
+
+	return nil
 }
 
 func transformRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, transformer Transformer) error {
@@ -334,64 +359,37 @@ func transformRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, tr
 
 	var err error
 
-	repoCopy.Repo, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.Repo,
-	)
+	repoCopy.Repo, err = transformValue(transformer, "git", repoCopy.Repo)
 	if err != nil {
 		return err
 	}
 
-	repoCopy.Owner, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.Owner,
-	)
+	repoCopy.Owner, err = transformValue(transformer, "git", repoCopy.Owner)
 	if err != nil {
 		return err
 	}
 
-	repoCopy.Branch, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.Branch,
-	)
+	repoCopy.Branch, err = transformValue(transformer, "git", repoCopy.Branch)
 	if err != nil {
 		return err
 	}
 
-	repoCopy.DefaultBranch, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.DefaultBranch,
-	)
+	repoCopy.DefaultBranch, err = transformValue(transformer, "git", repoCopy.DefaultBranch)
 	if err != nil {
 		return err
 	}
 
-	repoCopy.RemoteURL, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.RemoteURL,
-	)
+	repoCopy.RemoteURL, err = transformValue(transformer, "git", repoCopy.RemoteURL)
 	if err != nil {
 		return err
 	}
 
-	repoCopy.LocalRootPath, err = transformValue(
-		transformer,
-		"git",
-		repoCopy.LocalRootPath,
-	)
+	repoCopy.LocalRootPath, err = transformValue(transformer, "git", repoCopy.LocalRootPath)
 	if err != nil {
 		return err
 	}
 
-	if err := transformLastCommit(
-		&repoCopy.LastCommit,
-		transformer,
-	); err != nil {
+	if err := transformLastCommit(&repoCopy.LastCommit, transformer); err != nil {
 		return err
 	}
 
@@ -409,38 +407,22 @@ func transformLastCommit(commit *reporthandling.LastCommit, transformer Transfor
 
 	var err error
 
-	commitCopy.Hash, err = transformValue(
-		transformer,
-		"git",
-		commitCopy.Hash,
-	)
+	commitCopy.Hash, err = transformValue(transformer, "git", commitCopy.Hash)
 	if err != nil {
 		return err
 	}
 
-	commitCopy.CommitterName, err = transformValue(
-		transformer,
-		"git",
-		commitCopy.CommitterName,
-	)
+	commitCopy.CommitterName, err = transformValue(transformer, "git", commitCopy.CommitterName)
 	if err != nil {
 		return err
 	}
 
-	commitCopy.CommitterEmail, err = transformValue(
-		transformer,
-		"git",
-		commitCopy.CommitterEmail,
-	)
+	commitCopy.CommitterEmail, err = transformValue(transformer, "git", commitCopy.CommitterEmail)
 	if err != nil {
 		return err
 	}
 
-	commitCopy.Message, err = transformValue(
-		transformer,
-		"git",
-		commitCopy.Message,
-	)
+	commitCopy.Message, err = transformValue(transformer, "git", commitCopy.Message)
 	if err != nil {
 		return err
 	}
@@ -469,66 +451,38 @@ func transformResourceSource(
 
 	var err error
 
-	sourceCopy.Path, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.Path,
-	)
+	sourceCopy.Path, err = transformValue(transformer, "src", sourceCopy.Path)
 	if err != nil {
 		return err
 	}
 
-	sourceCopy.RelativePath, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.RelativePath,
-	)
+	sourceCopy.RelativePath, err = transformValue(transformer, "src", sourceCopy.RelativePath)
 	if err != nil {
 		return err
 	}
 
-	sourceCopy.HelmPath, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.HelmPath,
-	)
+	sourceCopy.HelmPath, err = transformValue(transformer, "src", sourceCopy.HelmPath)
 	if err != nil {
 		return err
 	}
 
-	sourceCopy.HelmChartName, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.HelmChartName,
-	)
+	sourceCopy.HelmChartName, err = transformValue(transformer, "src", sourceCopy.HelmChartName)
 	if err != nil {
 		return err
 	}
 
-	sourceCopy.HelmTemplateFile, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.HelmTemplateFile,
-	)
+	sourceCopy.HelmTemplateFile, err = transformValue(transformer, "src", sourceCopy.HelmTemplateFile)
 	if err != nil {
 		return err
 	}
 
-	sourceCopy.KustomizeDirectoryName, err = transformValue(
-		transformer,
-		"src",
-		sourceCopy.KustomizeDirectoryName,
-	)
+	sourceCopy.KustomizeDirectoryName, err = transformValue(transformer, "src", sourceCopy.KustomizeDirectoryName)
 	if err != nil {
 		return err
 	}
 
 	for i := range sourceCopy.HelmValuesPaths {
-		sourceCopy.HelmValuesPaths[i], err = transformValue(
-			transformer,
-			"src",
-			sourceCopy.HelmValuesPaths[i],
-		)
+		sourceCopy.HelmValuesPaths[i], err = transformValue(transformer, "src", sourceCopy.HelmValuesPaths[i])
 		if err != nil {
 			return err
 		}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -999,3 +999,95 @@ func TestAnonymizeSession_ResourceSourceEncryption(
 
 	assert.Equal(t, "abc123", decryptedHash)
 }
+
+func TestTransformResourceMetadata_EncryptionTransformer(
+	t *testing.T,
+) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "payment-api",
+			"namespace": "production",
+		},
+	})
+
+	err = transformResourceMetadata(
+		resource,
+		transformer,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(
+		t,
+		resource.GetName(),
+		"ENC[AES256_GCM,",
+	)
+
+	assert.Contains(
+		t,
+		resource.GetNamespace(),
+		"ENC[AES256_GCM,",
+	)
+
+	decryptedName, err := reportcrypto.DecryptString(
+		resource.GetName(),
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"payment-api",
+		decryptedName,
+	)
+
+	decryptedNamespace, err := reportcrypto.DecryptString(
+		resource.GetNamespace(),
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"production",
+		decryptedNamespace,
+	)
+}
+
+func TestTransformResourceMetadata_Error(
+	t *testing.T,
+) {
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "payment-api",
+			"namespace": "production",
+		},
+	})
+
+	err := transformResourceMetadata(
+		resource,
+		&failingTransformer{},
+	)
+
+	require.Error(t, err)
+
+	assert.Equal(
+		t,
+		"payment-api",
+		resource.GetName(),
+	)
+
+	assert.Equal(
+		t,
+		"production",
+		resource.GetNamespace(),
+	)
+}

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -2,6 +2,7 @@ package reportcrypto
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -83,7 +84,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.Repo != "" {
 		repoMetadata.Repo, err =
-			DecryptString(repoMetadata.Repo, dek)
+			decryptIfEncrypted(repoMetadata.Repo, dek)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to decrypt repo: %w",
@@ -94,7 +95,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.Owner != "" {
 		repoMetadata.Owner, err =
-			DecryptString(repoMetadata.Owner, dek)
+			decryptIfEncrypted(repoMetadata.Owner, dek)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to decrypt owner: %w",
@@ -105,7 +106,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.Branch != "" {
 		repoMetadata.Branch, err =
-			DecryptString(repoMetadata.Branch, dek)
+			decryptIfEncrypted(repoMetadata.Branch, dek)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to decrypt branch: %w",
@@ -116,7 +117,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.DefaultBranch != "" {
 		repoMetadata.DefaultBranch, err =
-			DecryptString(
+			decryptIfEncrypted(
 				repoMetadata.DefaultBranch,
 				dek,
 			)
@@ -130,7 +131,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.RemoteURL != "" {
 		repoMetadata.RemoteURL, err =
-			DecryptString(
+			decryptIfEncrypted(
 				repoMetadata.RemoteURL,
 				dek,
 			)
@@ -144,7 +145,7 @@ func DecryptRepoContextMetadata(
 
 	if repoMetadata.LocalRootPath != "" {
 		repoMetadata.LocalRootPath, err =
-			DecryptString(
+			decryptIfEncrypted(
 				repoMetadata.LocalRootPath,
 				dek,
 			)
@@ -181,7 +182,7 @@ func decryptLastCommit(
 	var err error
 
 	if commit.Hash != "" {
-		commit.Hash, err = DecryptString(
+		commit.Hash, err = decryptIfEncrypted(
 			commit.Hash,
 			dek,
 		)
@@ -194,7 +195,7 @@ func decryptLastCommit(
 	}
 
 	if commit.CommitterName != "" {
-		commit.CommitterName, err = DecryptString(
+		commit.CommitterName, err = decryptIfEncrypted(
 			commit.CommitterName,
 			dek,
 		)
@@ -207,7 +208,7 @@ func decryptLastCommit(
 	}
 
 	if commit.CommitterEmail != "" {
-		commit.CommitterEmail, err = DecryptString(
+		commit.CommitterEmail, err = decryptIfEncrypted(
 			commit.CommitterEmail,
 			dek,
 		)
@@ -220,7 +221,7 @@ func decryptLastCommit(
 	}
 
 	if commit.Message != "" {
-		commit.Message, err = DecryptString(
+		commit.Message, err = decryptIfEncrypted(
 			commit.Message,
 			dek,
 		)
@@ -264,7 +265,7 @@ func DecryptResourceSource(
 	var err error
 
 	if source.Path != "" {
-		source.Path, err = DecryptString(
+		source.Path, err = decryptIfEncrypted(
 			source.Path,
 			dek,
 		)
@@ -277,7 +278,7 @@ func DecryptResourceSource(
 	}
 
 	if source.RelativePath != "" {
-		source.RelativePath, err = DecryptString(
+		source.RelativePath, err = decryptIfEncrypted(
 			source.RelativePath,
 			dek,
 		)
@@ -290,7 +291,7 @@ func DecryptResourceSource(
 	}
 
 	if source.HelmPath != "" {
-		source.HelmPath, err = DecryptString(
+		source.HelmPath, err = decryptIfEncrypted(
 			source.HelmPath,
 			dek,
 		)
@@ -303,7 +304,7 @@ func DecryptResourceSource(
 	}
 
 	if source.HelmChartName != "" {
-		source.HelmChartName, err = DecryptString(
+		source.HelmChartName, err = decryptIfEncrypted(
 			source.HelmChartName,
 			dek,
 		)
@@ -316,7 +317,7 @@ func DecryptResourceSource(
 	}
 
 	if source.HelmTemplateFile != "" {
-		source.HelmTemplateFile, err = DecryptString(
+		source.HelmTemplateFile, err = decryptIfEncrypted(
 			source.HelmTemplateFile,
 			dek,
 		)
@@ -329,7 +330,7 @@ func DecryptResourceSource(
 	}
 
 	if source.KustomizeDirectoryName != "" {
-		source.KustomizeDirectoryName, err = DecryptString(
+		source.KustomizeDirectoryName, err = decryptIfEncrypted(
 			source.KustomizeDirectoryName,
 			dek,
 		)
@@ -346,7 +347,7 @@ func DecryptResourceSource(
 			continue
 		}
 
-		source.HelmValuesPaths[i], err = DecryptString(
+		source.HelmValuesPaths[i], err = decryptIfEncrypted(
 			source.HelmValuesPaths[i],
 			dek,
 		)
@@ -389,7 +390,7 @@ func DecryptResourceMetadata(
 	var err error
 
 	if name := resource.GetName(); name != "" {
-		name, err = DecryptString(
+		name, err = decryptIfEncrypted(
 			name,
 			dek,
 		)
@@ -404,7 +405,7 @@ func DecryptResourceMetadata(
 	}
 
 	if namespace := resource.GetNamespace(); namespace != "" {
-		namespace, err = DecryptString(
+		namespace, err = decryptIfEncrypted(
 			namespace,
 			dek,
 		)
@@ -419,4 +420,18 @@ func DecryptResourceMetadata(
 	}
 
 	return nil
+}
+
+func decryptIfEncrypted(value string, dek []byte) (string, error) {
+	if value == "" {
+		return value, nil
+	}
+
+	value = strings.TrimSpace(value)
+
+	if !strings.HasPrefix(value, "ENC[") {
+		return value, nil
+	}
+
+	return DecryptString(value, dek)
 }

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -3,6 +3,7 @@ package reportcrypto
 import (
 	"fmt"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
@@ -363,6 +364,58 @@ func DecryptResourceSource(
 		dek,
 	); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// DecryptResourceMetadata decrypts resource identifiers previously
+// encrypted by transformResourceMetadata.
+//
+// This operation mutates the supplied resource metadata in place.
+//
+// Current coverage:
+//
+//   - Name
+//   - Namespace
+func DecryptResourceMetadata(
+	resource workloadinterface.IMetadata,
+	dek []byte,
+) error {
+	if resource == nil {
+		return nil
+	}
+
+	var err error
+
+	if name := resource.GetName(); name != "" {
+		name, err = DecryptString(
+			name,
+			dek,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt resource name: %w",
+				err,
+			)
+		}
+
+		resource.SetName(name)
+	}
+
+	if namespace := resource.GetNamespace(); namespace != "" {
+		namespace, err = DecryptString(
+			namespace,
+			dek,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt resource namespace: %w",
+				err,
+			)
+		}
+
+		resource.SetNamespace(namespace)
 	}
 
 	return nil

--- a/core/pkg/reportcrypto/decrypt_test.go
+++ b/core/pkg/reportcrypto/decrypt_test.go
@@ -3,6 +3,7 @@ package reportcrypto
 import (
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	reporthandling "github.com/kubescape/opa-utils/reporthandling"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
@@ -469,6 +470,66 @@ func TestDecryptResourceSource_Nil(
 	t *testing.T,
 ) {
 	err := DecryptResourceSource(
+		nil,
+		make([]byte, 32),
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDecryptResourceMetadata_RoundTrip(
+	t *testing.T,
+) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedName, err := EncryptString(
+		"payments-api",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedNamespace, err := EncryptString(
+		"production",
+		dek,
+	)
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      encryptedName,
+				"namespace": encryptedNamespace,
+			},
+		},
+	)
+
+	err = DecryptResourceMetadata(
+		resource,
+		dek,
+	)
+
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"payments-api",
+		resource.GetName(),
+	)
+
+	assert.Equal(
+		t,
+		"production",
+		resource.GetNamespace(),
+	)
+}
+
+func TestDecryptResourceMetadata_Nil(
+	t *testing.T,
+) {
+	err := DecryptResourceMetadata(
 		nil,
 		make([]byte, 32),
 	)


### PR DESCRIPTION
Part of: #1200

### Overview

Extend the encryption/decryption workflow to cover Kubernetes resource metadata already supported by the anonymization pipeline.

* Adds a shared `transformResourceMetadata` helper used by both anonymization and encryption.
* Extends encryption/decryption support to Kubernetes resource `name` and `namespace`.
* Updates the `decrypt` command to restore encrypted resource metadata, rebuild `resourceID` values from the restored metadata, and update `results[].resourceID` references to preserve report referential integrity.
* Improves backwards compatibility by skipping decryption for plaintext values, allowing mixed or older reports to be decrypted successfully.
* Preserves the existing report structure while decrypting only the encrypted fields.
* Adds unit and integration tests covering round-trip encryption/decryption, `resourceID` reconstruction, updated result references, and error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decrypts additional per-resource report details, including encrypted resource metadata such as name and namespace.
  * Remaps all report result references to match decrypted resource identifiers.
  * Enhances session anonymization to consistently transform resource metadata and related fields.
* **Bug Fixes**
  * Prevents decryption attempts on non-encrypted (plaintext) values to avoid altering unencrypted data.
* **Tests**
  * Adds unit tests for decrypting resource metadata (round-trip and nil/error handling scenarios).
* **Documentation**
  * Clarifies what parts of scan session data are reversibly encrypted vs pseudonymized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->