### PR TITLE
Add CEL evaluator

### DIFF
--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -3,6 +3,7 @@ package cel
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
@@ -40,11 +41,6 @@ type ValidationResult struct {
 	Message    string
 	Err        error
 }
-
-// defaultViolationMessage is what we report when a validation fails but neither
-// Message nor a working MessageExpression gives us anything, mirroring the
-// apiserver's generic "failed expression" fallback.
-const defaultViolationMessage = "failed validation"
 
 // Evaluator runs a VAP's variables and validations against scanned objects. The
 // CEL env is built once and reused for every object, since compiling the env is
@@ -166,22 +162,27 @@ func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, acti
 
 // resolveMessage produces the violation message for a failed validation.
 //
-// A failing messageExpression must NOT turn the violation into an error: a real
-// violation with a typo'd message is still a violation. So we fall back, never
-// promote to Err. Order: static Message, then messageExpression, then a default.
+// Order matches the apiserver (pkg/admission/plugin/policy/validating/
+// validator.go): messageExpression first, then the static Message, then a
+// "failed expression: <expr>" default. A failing messageExpression must NOT turn
+// the violation into an error: a real violation with a typo'd message is still a
+// violation, so we fall back rather than promote to Err. A non-string, empty, or
+// whitespace-only messageExpression result also falls back, as the apiserver does.
 func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activation map[string]any) string {
-	if val.Message != "" {
-		return val.Message
-	}
 	if val.MessageExpression != "" {
 		out, err := e.evalExpression(ctx, val.MessageExpression, activation)
 		if err == nil {
-			if msg, ok := out.Value().(string); ok && msg != "" {
-				return msg
+			if msg, ok := out.Value().(string); ok {
+				if msg = strings.TrimSpace(msg); msg != "" {
+					return msg
+				}
 			}
 		}
 	}
-	return defaultViolationMessage
+	if msg := strings.TrimSpace(val.Message); msg != "" {
+		return msg
+	}
+	return fmt.Sprintf("failed expression: %s", strings.TrimSpace(val.Expression))
 }
 
 // evalExpression compiles and evaluates a single CEL expression against the

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -1,0 +1,217 @@
+package cel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// Variable is one entry from a VAP's spec.variables. Each is a CEL expression
+// that may reference object/params/request and variables declared before it.
+type Variable struct {
+	Name       string
+	Expression string
+}
+
+// Validation is one entry from a VAP's spec.validations. Expression must
+// evaluate to a bool; false means the resource violates the policy.
+type Validation struct {
+	Expression string
+	// Message is the static violation message. Used as-is when set, and as the
+	// fallback when MessageExpression is absent or fails.
+	Message string
+	// MessageExpression is a CEL expression returning a string, evaluated only
+	// when a validation fails. If it errors or returns a non-string, we fall
+	// back to Message (and then a default) rather than failing the validation.
+	MessageExpression string
+}
+
+// ValidationResult is the outcome of one Validation against one object.
+//
+// Err is reserved for the case where we genuinely do not know the verdict: the
+// validation expression failed to compile or evaluate. It is NOT a pass and NOT
+// a clean false. A failed messageExpression never lands here (see resolveMessage):
+// a real violation with a broken message is still a violation.
+type ValidationResult struct {
+	Expression string
+	Passed     bool
+	Message    string
+	Err        error
+}
+
+// defaultViolationMessage is what we report when a validation fails but neither
+// Message nor a working MessageExpression gives us anything, mirroring the
+// apiserver's generic "failed expression" fallback.
+const defaultViolationMessage = "failed validation"
+
+// Evaluator runs a VAP's variables and validations against scanned objects. The
+// CEL env is built once and reused for every object, since compiling the env is
+// far more expensive than evaluating against it.
+type Evaluator struct {
+	env *cel.Env
+	// costLimit overrides the per-evaluation CEL cost budget. Zero means "do not
+	// override", which leaves the budget the base env already bakes in
+	// (apiserver's PerCallLimit). When cost limits are wired up the real value
+	// flows through here, so that becomes a value change not a signature one.
+	costLimit uint64
+}
+
+// Option configures an Evaluator.
+type Option func(*Evaluator)
+
+// WithCostLimit overrides the per-evaluation CEL cost budget. Leave it unset to
+// keep the base env's default (apiserver's PerCallLimit), which is what gives us
+// scan/admission parity.
+func WithCostLimit(limit uint64) Option {
+	return func(e *Evaluator) { e.costLimit = limit }
+}
+
+// NewEvaluator builds an Evaluator over the offline VAP CEL env (see newEnv).
+func NewEvaluator(opts ...Option) (*Evaluator, error) {
+	env, err := newEnv()
+	if err != nil {
+		return nil, err
+	}
+	e := &Evaluator{env: env}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e, nil
+}
+
+// EvaluateOnObject evaluates one VAP's variables and validations against a
+// single object.
+//
+//   - obj is the scanned resource, bound to "object".
+//   - namespaceObject is the resource's Namespace object (nil for cluster-scoped
+//     resources or when the scan does not have it); bound via the stub layer.
+//   - params is the resolved paramKind value (nil when the VAP has no paramKind),
+//     bound to "params". Once the loader is built these come from the bundle.
+//   - variables and validations come from the VAP. Once the loader is built it
+//     fills them from real YAML; for now tests fill them by hand. Same structs
+//     either way, so the signature does not change when the loader lands.
+//
+// The activation is built once and reused. Variables are evaluated first, in
+// declared order, each written back so later variables and the validations can
+// read variables.<name>. Then every validation is evaluated against it, yielding
+// one ValidationResult per validation in order.
+//
+// A variable failure is returned as a top-level error: if a variable cannot be
+// resolved, the validations that may depend on it cannot be trusted, so we do
+// not produce verdicts for this object. A validation failure, by contrast, is
+// captured per-result (see evaluateValidation), since the other validations are
+// still meaningful.
+func (e *Evaluator) EvaluateOnObject(
+	ctx context.Context,
+	obj map[string]any,
+	namespaceObject map[string]any,
+	params any,
+	variables []Variable,
+	validations []Validation,
+) ([]ValidationResult, error) {
+	// stubBindings owns request, oldObject and namespaceObject. We add the
+	// remaining env-declared variables so every declared variable is bound (an
+	// unbound declared variable errors at eval time, see env.go).
+	activation := stubBindings(obj, namespaceObject)
+	activation["object"] = obj
+	activation["params"] = params
+
+	// One inner map bound to "variables". Each evaluated variable is written into
+	// this same map, so variables.<name> resolves for both later variables and
+	// the validations. It is never rebuilt per variable.
+	vars := map[string]any{}
+	activation["variables"] = vars
+
+	for _, v := range variables {
+		out, err := e.evalExpression(ctx, v.Expression, activation)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating variable %q: %w", v.Name, err)
+		}
+		vars[v.Name] = out
+	}
+
+	results := make([]ValidationResult, 0, len(validations))
+	for _, val := range validations {
+		results = append(results, e.evaluateValidation(ctx, val, activation))
+	}
+	return results, nil
+}
+
+// evaluateValidation evaluates one validation against the prepared activation.
+// Only a compile/eval failure of the validation expression sets Err; everything
+// else resolves to a clean pass or a violation with a message.
+func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, activation map[string]any) ValidationResult {
+	res := ValidationResult{Expression: val.Expression}
+
+	out, err := e.evalExpression(ctx, val.Expression, activation)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	passed, ok := out.Value().(bool)
+	if !ok {
+		res.Err = fmt.Errorf("validation expression must return bool, got %T", out.Value())
+		return res
+	}
+
+	res.Passed = passed
+	if !passed {
+		res.Message = e.resolveMessage(ctx, val, activation)
+	}
+	return res
+}
+
+// resolveMessage produces the violation message for a failed validation.
+//
+// A failing messageExpression must NOT turn the violation into an error: a real
+// violation with a typo'd message is still a violation. So we fall back, never
+// promote to Err. Order: static Message, then messageExpression, then a default.
+func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activation map[string]any) string {
+	if val.Message != "" {
+		return val.Message
+	}
+	if val.MessageExpression != "" {
+		out, err := e.evalExpression(ctx, val.MessageExpression, activation)
+		if err == nil {
+			if msg, ok := out.Value().(string); ok && msg != "" {
+				return msg
+			}
+		}
+	}
+	return defaultViolationMessage
+}
+
+// evalExpression compiles and evaluates a single CEL expression against the
+// activation. When compile caching is added it wraps the compile step here, and
+// when cost reporting is added it surfaces the EvalDetails this currently discards.
+func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation map[string]any) (ref.Val, error) {
+	ast, issues := e.env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("compile: %w", issues.Err())
+	}
+
+	prog, err := e.program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("program: %w", err)
+	}
+
+	out, _, err := prog.ContextEval(ctx, activation)
+	if err != nil {
+		return nil, fmt.Errorf("eval: %w", err)
+	}
+	return out, nil
+}
+
+// program instantiates a runnable program from a compiled AST. The cost-limit
+// override is only applied when set; otherwise the base env's baked-in
+// PerCallLimit stands. InterruptCheckFrequency gets added here later too.
+func (e *Evaluator) program(ast *cel.Ast) (cel.Program, error) {
+	var opts []cel.ProgramOption
+	if e.costLimit > 0 {
+		opts = append(opts, cel.CostLimit(e.costLimit))
+	}
+	return e.env.Program(ast, opts...)
+}

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/cel/lazy"
 )
 
 // Variable is one entry from a VAP's spec.variables. Each is a CEL expression
@@ -89,16 +92,20 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 //     fills them from real YAML; for now tests fill them by hand. Same structs
 //     either way, so the signature does not change when the loader lands.
 //
-// The activation is built once and reused. Variables are evaluated first, in
-// declared order, each written back so later variables and the validations can
-// read variables.<name>. Then every validation is evaluated against it, yielding
-// one ValidationResult per validation in order.
+// The activation is built once and reused. Variables are bound LAZILY, matching
+// the apiserver (pkg/admission/plugin/cel/composition.go): a variable is
+// evaluated only when a validation actually references variables.<name>, the
+// result (or its error) is memoized, and a variable error surfaces only to the
+// validation(s) that touched it. This is what keeps offline == admission:
 //
-// A variable failure is returned as a top-level error: if a variable cannot be
-// resolved, the validations that may depend on it cannot be trusted, so we do
-// not produce verdicts for this object. A validation failure, by contrast, is
-// captured per-result (see evaluateValidation), since the other validations are
-// still meaningful.
+//   - a variable that errors but is never referenced does not affect the object
+//     (at admission it never runs either);
+//   - a broken variable referenced by one validation only fails that validation;
+//     the rest still get verdicts.
+//
+// Each validation then yields one ValidationResult, in order. The error return is
+// reserved for setup failures; per-validation outcomes (including eval errors)
+// live on the result (see evaluateValidation).
 func (e *Evaluator) EvaluateOnObject(
 	ctx context.Context,
 	obj map[string]any,
@@ -113,26 +120,39 @@ func (e *Evaluator) EvaluateOnObject(
 	activation := stubBindings(obj, namespaceObject)
 	activation["object"] = obj
 	activation["params"] = params
-
-	// One inner map bound to "variables". Each evaluated variable is written into
-	// this same map, so variables.<name> resolves for both later variables and
-	// the validations. It is never rebuilt per variable.
-	vars := map[string]any{}
-	activation["variables"] = vars
-
-	for _, v := range variables {
-		out, err := e.evalExpression(ctx, v.Expression, activation)
-		if err != nil {
-			return nil, fmt.Errorf("evaluating variable %q: %w", v.Name, err)
-		}
-		vars[v.Name] = out
-	}
+	activation["variables"] = e.lazyVariables(ctx, variables, activation)
 
 	results := make([]ValidationResult, 0, len(validations))
 	for _, val := range validations {
 		results = append(results, e.evaluateValidation(ctx, val, activation))
 	}
 	return results, nil
+}
+
+// variablesTypeName is the CEL type name of the lazy variables map. It only
+// labels the map value; the env declares "variables" as a dynamic type, so field
+// access resolves through the map at runtime rather than against this type.
+const variablesTypeName = "kubescape.cel.variables"
+
+// lazyVariables builds the value bound to "variables": a lazy map where each
+// variable is evaluated on first access and memoized, mirroring the apiserver's
+// composition map. The callback evaluates against the same activation the map is
+// part of, so a variable referencing variables.<earlier> triggers that earlier
+// variable's callback on demand. An eval/compile failure becomes a CEL error
+// value, which propagates only to the validation that referenced the variable.
+func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, activation map[string]any) *lazy.MapValue {
+	lazyVars := lazy.NewMapValue(types.NewObjectType(variablesTypeName))
+	for _, v := range variables {
+		v := v // capture per iteration for the callback
+		lazyVars.Append(v.Name, func(*lazy.MapValue) ref.Val {
+			out, err := e.evalExpression(ctx, v.Expression, activation)
+			if err != nil {
+				return types.NewErr("variable %q: %v", v.Name, err)
+			}
+			return out
+		})
+	}
+	return lazyVars
 }
 
 // evaluateValidation evaluates one validation against the prepared activation.
@@ -166,23 +186,40 @@ func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, acti
 // validator.go): messageExpression first, then the static Message, then a
 // "failed expression: <expr>" default. A failing messageExpression must NOT turn
 // the violation into an error: a real violation with a typo'd message is still a
-// violation, so we fall back rather than promote to Err. A non-string, empty, or
-// whitespace-only messageExpression result also falls back, as the apiserver does.
+// violation, so we fall back rather than promote to Err. A messageExpression
+// result that is non-string, empty/whitespace-only, multi-line, or longer than
+// the apiserver's limit also falls back, matching what admission would accept.
 func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activation map[string]any) string {
 	if val.MessageExpression != "" {
-		out, err := e.evalExpression(ctx, val.MessageExpression, activation)
-		if err == nil {
-			if msg, ok := out.Value().(string); ok {
-				if msg = strings.TrimSpace(msg); msg != "" {
-					return msg
-				}
-			}
+		if msg, ok := e.evalMessageExpression(ctx, val.MessageExpression, activation); ok {
+			return msg
 		}
 	}
 	if msg := strings.TrimSpace(val.Message); msg != "" {
 		return msg
 	}
 	return fmt.Sprintf("failed expression: %s", strings.TrimSpace(val.Expression))
+}
+
+// evalMessageExpression evaluates a messageExpression and reports whether its
+// result is usable. The apiserver rejects (and falls back on) a result that
+// errors, is non-string, is empty/whitespace, exceeds the size limit, or spans
+// multiple lines; we apply the same guards so the message we report offline is
+// one admission would actually use.
+func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, activation map[string]any) (string, bool) {
+	out, err := e.evalExpression(ctx, expr, activation)
+	if err != nil {
+		return "", false
+	}
+	msg, ok := out.Value().(string)
+	if !ok {
+		return "", false
+	}
+	msg = strings.TrimSpace(msg)
+	if msg == "" || len(msg) > celconfig.MaxEvaluatedMessageExpressionSizeBytes || strings.ContainsAny(msg, "\n") {
+		return "", false
+	}
+	return msg, true
 }
 
 // evalExpression compiles and evaluates a single CEL expression against the
@@ -209,6 +246,11 @@ func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation 
 // program instantiates a runnable program from a compiled AST. The cost-limit
 // override is only applied when set; otherwise the base env's baked-in
 // PerCallLimit stands. InterruptCheckFrequency gets added here later too.
+//
+// Note for when the cost limit is turned on: this applies a fresh per-expression
+// budget. The apiserver instead shares one budget across all of a policy's
+// expressions (variables + validations) per evaluation, so that accounting, not
+// just the per-call value, is what needs to be matched then.
 func (e *Evaluator) program(ast *cel.Ast) (cel.Program, error) {
 	var opts []cel.ProgramOption
 	if e.costLimit > 0 {

--- a/core/pkg/opaprocessor/cel/evaluator_test.go
+++ b/core/pkg/opaprocessor/cel/evaluator_test.go
@@ -129,9 +129,32 @@ func TestEvaluateOnObjectMessageExpression(t *testing.T) {
 	assert.Equal(t, "pod nginx uses host network", results[0].Message)
 }
 
+// TestEvaluateOnObjectMessageExpressionWinsOverStatic pins the apiserver
+// precedence: when both are set and messageExpression succeeds, it is used, not
+// the static Message.
+func TestEvaluateOnObjectMessageExpressionWinsOverStatic(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{
+			Expression:        "object.spec.hostNetwork == false",
+			Message:           "static message",
+			MessageExpression: "'dynamic ' + object.metadata.name",
+		},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	assert.Equal(t, "dynamic nginx", results[0].Message)
+}
+
 // TestEvaluateOnObjectBrokenMessageExpressionStaysViolation is the key semantic
 // guard: a failing messageExpression must NOT turn a real violation into an
-// error. It falls back to the static Message instead.
+// error. messageExpression is tried first (per apiserver precedence), errors,
+// and falls back to the static Message while the violation stands.
 func TestEvaluateOnObjectBrokenMessageExpressionStaysViolation(t *testing.T) {
 	e, err := NewEvaluator()
 	require.NoError(t, err)
@@ -171,7 +194,7 @@ func TestEvaluateOnObjectBrokenMessageExpressionNoStaticFallsToDefault(t *testin
 	require.Len(t, results, 1)
 	assert.False(t, results[0].Passed)
 	assert.NoError(t, results[0].Err)
-	assert.Equal(t, defaultViolationMessage, results[0].Message)
+	assert.Equal(t, "failed expression: object.spec.hostNetwork == false", results[0].Message)
 }
 
 // TestEvaluateOnObjectNonBoolErrors guards that a validation expression that

--- a/core/pkg/opaprocessor/cel/evaluator_test.go
+++ b/core/pkg/opaprocessor/cel/evaluator_test.go
@@ -229,21 +229,75 @@ func TestEvaluateOnObjectValidationEvalErrorSetsErr(t *testing.T) {
 	assert.False(t, results[0].Passed)
 }
 
-// TestEvaluateOnObjectVariableErrorIsTopLevel guards that a variable that fails
-// to evaluate aborts the whole object with a top-level error rather than
-// producing untrustworthy verdicts.
-func TestEvaluateOnObjectVariableErrorIsTopLevel(t *testing.T) {
+// TestEvaluateOnObjectUnreferencedBrokenVariableIsIgnored is a parity guard:
+// because variables are lazy, a variable that errors but is never referenced by
+// any validation must not affect the object, exactly as at admission where it
+// never runs.
+func TestEvaluateOnObjectUnreferencedBrokenVariableIsIgnored(t *testing.T) {
 	e, err := NewEvaluator()
 	require.NoError(t, err)
 
 	variables := []Variable{
 		{Name: "broken", Expression: "object.spec.thisKeyDoesNotExist.value"},
 	}
-	validations := []Validation{{Expression: "true"}}
+	validations := []Validation{{Expression: "object.metadata.name == 'nginx'"}}
 
 	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
-	require.Error(t, err)
-	assert.Nil(t, results)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+}
+
+// TestEvaluateOnObjectBrokenVariableFailsOnlyReferencingValidation is the other
+// parity guard: a broken variable referenced by one validation fails only that
+// validation; the others still get clean verdicts.
+func TestEvaluateOnObjectBrokenVariableFailsOnlyReferencingValidation(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	variables := []Variable{
+		{Name: "broken", Expression: "object.spec.thisKeyDoesNotExist.value"},
+	}
+	validations := []Validation{
+		{Expression: "object.metadata.name == 'nginx'"}, // does not touch the variable
+		{Expression: "variables.broken == 1"},           // touches the broken variable
+		{Expression: "object.metadata.namespace == 'production'"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	assert.True(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+
+	assert.Error(t, results[1].Err, "the validation that touched the broken variable errors")
+	assert.False(t, results[1].Passed)
+
+	assert.True(t, results[2].Passed)
+	assert.NoError(t, results[2].Err)
+}
+
+// TestEvaluateOnObjectVariableMemoizedAcrossValidations checks a referenced
+// variable resolves and is usable by multiple validations.
+func TestEvaluateOnObjectVariableMemoizedAcrossValidations(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	variables := []Variable{
+		{Name: "containers", Expression: "object.spec.containers"},
+	}
+	validations := []Validation{
+		{Expression: "size(variables.containers) == 2"},
+		{Expression: "variables.containers[0].name == 'app'"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.True(t, results[0].Passed)
+	assert.True(t, results[1].Passed)
 }
 
 func TestEvaluateOnObjectResultsAreOneToOne(t *testing.T) {

--- a/core/pkg/opaprocessor/cel/evaluator_test.go
+++ b/core/pkg/opaprocessor/cel/evaluator_test.go
@@ -1,0 +1,243 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hostNetworkPod is a Pod that sets hostNetwork, used as a deliberate violation
+// of "object.spec.hostNetwork == false".
+func hostNetworkPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "nginx",
+			"namespace": "production",
+		},
+		"spec": map[string]any{
+			"hostNetwork": true,
+			"containers": []any{
+				map[string]any{"name": "app", "image": "nginx:1.25"},
+				map[string]any{"name": "sidecar", "image": ""},
+			},
+		},
+	}
+}
+
+func TestEvaluateOnObjectFailingValidation(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{Expression: "object.spec.hostNetwork == false", Message: "host network is not allowed"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.False(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+	assert.Equal(t, "host network is not allowed", results[0].Message)
+}
+
+func TestEvaluateOnObjectPassingValidation(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	obj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "nginx", "namespace": "production"},
+		"spec":       map[string]any{"hostNetwork": false},
+	}
+
+	validations := []Validation{{Expression: "object.spec.hostNetwork == false"}}
+
+	results, err := e.EvaluateOnObject(context.Background(), obj, nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.True(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+	assert.Empty(t, results[0].Message)
+}
+
+// TestEvaluateOnObjectVariables proves variables are evaluated first and bound
+// under variables.<name> so a validation can reference them.
+func TestEvaluateOnObjectVariables(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	variables := []Variable{
+		{Name: "containers", Expression: "object.spec.containers"},
+	}
+	validations := []Validation{
+		{Expression: "variables.containers.all(c, c.image != '')", Message: "every container needs an image"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// The sidecar has an empty image, so the all() is false: a violation.
+	assert.False(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+	assert.Equal(t, "every container needs an image", results[0].Message)
+}
+
+// TestEvaluateOnObjectVariableChain proves a later variable can read an earlier
+// one through the shared variables map.
+func TestEvaluateOnObjectVariableChain(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	variables := []Variable{
+		{Name: "containers", Expression: "object.spec.containers"},
+		{Name: "count", Expression: "size(variables.containers)"},
+	}
+	validations := []Validation{
+		{Expression: "variables.count == 2"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+}
+
+func TestEvaluateOnObjectMessageExpression(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{
+			Expression:        "object.spec.hostNetwork == false",
+			MessageExpression: "'pod ' + object.metadata.name + ' uses host network'",
+		},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	assert.Equal(t, "pod nginx uses host network", results[0].Message)
+}
+
+// TestEvaluateOnObjectBrokenMessageExpressionStaysViolation is the key semantic
+// guard: a failing messageExpression must NOT turn a real violation into an
+// error. It falls back to the static Message instead.
+func TestEvaluateOnObjectBrokenMessageExpressionStaysViolation(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{
+			Expression:        "object.spec.hostNetwork == false",
+			Message:           "host network is not allowed",
+			MessageExpression: "object.spec.thisKeyDoesNotExist.value", // errors at eval
+		},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.False(t, results[0].Passed, "still a violation")
+	assert.NoError(t, results[0].Err, "broken messageExpression must not become an error")
+	assert.Equal(t, "host network is not allowed", results[0].Message)
+}
+
+// TestEvaluateOnObjectBrokenMessageExpressionNoStaticFallsToDefault checks the
+// final fallback when there is no static Message either.
+func TestEvaluateOnObjectBrokenMessageExpressionNoStaticFallsToDefault(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{
+			Expression:        "object.spec.hostNetwork == false",
+			MessageExpression: "object.spec.thisKeyDoesNotExist.value",
+		},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	assert.NoError(t, results[0].Err)
+	assert.Equal(t, defaultViolationMessage, results[0].Message)
+}
+
+// TestEvaluateOnObjectNonBoolErrors guards that a validation expression that
+// does not return bool is reported as Err, never as a silent pass.
+func TestEvaluateOnObjectNonBoolErrors(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{{Expression: "object.metadata.name"}} // returns string
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Error(t, results[0].Err)
+	assert.False(t, results[0].Passed)
+}
+
+// TestEvaluateOnObjectValidationEvalErrorSetsErr guards that an eval failure of
+// the validation expression itself becomes Err (unknown verdict), not a pass.
+func TestEvaluateOnObjectValidationEvalErrorSetsErr(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{{Expression: "object.spec.thisKeyDoesNotExist.value == 1"}}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Error(t, results[0].Err)
+	assert.False(t, results[0].Passed)
+}
+
+// TestEvaluateOnObjectVariableErrorIsTopLevel guards that a variable that fails
+// to evaluate aborts the whole object with a top-level error rather than
+// producing untrustworthy verdicts.
+func TestEvaluateOnObjectVariableErrorIsTopLevel(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	variables := []Variable{
+		{Name: "broken", Expression: "object.spec.thisKeyDoesNotExist.value"},
+	}
+	validations := []Validation{{Expression: "true"}}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, variables, validations)
+	require.Error(t, err)
+	assert.Nil(t, results)
+}
+
+func TestEvaluateOnObjectResultsAreOneToOne(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{
+		{Expression: "object.spec.hostNetwork == false"},
+		{Expression: "object.metadata.name == 'nginx'"},
+		{Expression: "object.metadata.namespace == 'production'"},
+	}
+
+	results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	assert.False(t, results[0].Passed)
+	assert.True(t, results[1].Passed)
+	assert.True(t, results[2].Passed)
+}


### PR DESCRIPTION
## Overview

This adds the evaluator, the part that actually runs a rule against a resource. The env and the request stub before this were just setup. This is where a CEL expression and an object turn into a verdict.

The core of it is EvaluateOnObject. You give it an object, params, the variables block and the validations from a VAP, and it returns which validations passed. It builds the activation once per object (reusing the stub layer for request, oldObject and namespaceObject) and evaluates the variables first, in order, into one shared map so the validations can read them through variables.<name>. Then it loops the validations.

Couple of things I was careful about. A validation has to return a bool, and if it errors or returns something else that goes into an Err field, not a silent pass. A failing variable bails the whole object out with a top level error since the validations might depend on it. But a broken messageExpression does NOT become an error, a real violation stays a violation and just falls back to the static message. 

There's also a cost limit knob on the evaluator that does nothing yet. The base env already carries the apiserver cost budget, so by default I leave it alone. The knob is just there so a later PR can set the real value without changing the function signature.

The VAP and object in the tests are hardcoded for now, which is expected. Later PRs swap in real VAP YAML and the actual scanned resources, and the signature stays the same.

#2001 


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable CEL-based evaluation of ordered variables and validations against scanned objects.
  * Added configurable expression cost limits to constrain execution.
* **Bug Fixes**
  * Improved validation result semantics for invalid/non-boolean expressions and evaluation failures so issues surface as errors.
  * Enhanced violation message handling, including message-expression precedence and safe fallbacks.
* **Tests**
  * Added end-to-end test coverage for variables (including chaining, memoization, and referenced vs. unreferenced failures) and message/error behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->