### PR TITLE
feat(httphandler): add SSRF-hardened scan-completion webhook callback

### DIFF
--- a/httphandler/handlerequests/v1/callback_test.go
+++ b/httphandler/handlerequests/v1/callback_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -91,13 +92,23 @@ func TestExecuteScan_CallbackOnFailure(t *testing.T) {
 	case p := <-received:
 		assert.Equal(t, "scan-failed", p.ID)
 		assert.Equal(t, callbackStatusFailed, p.Status)
-		assert.Contains(t, p.Error, "collection boom")
+		assert.Equal(t, "scan failed", p.Error)
+		assert.NotContains(t, p.Error, "collection boom")
 	case <-time.After(5 * time.Second):
 		t.Fatal("callback was not delivered within 5s")
 	}
 }
 
+func TestValidateCallbackURL_DisabledByDefault(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "")
+	t.Setenv(callbackEnabledEnv, "")
+	_, err := validateCallbackURL("http://example.com/hook")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
 func TestValidateCallbackURL_Rejections(t *testing.T) {
+	t.Setenv(callbackEnabledEnv, "true")
 	for _, tc := range []struct {
 		name, url, contains string
 	}{
@@ -115,6 +126,7 @@ func TestValidateCallbackURL_Rejections(t *testing.T) {
 
 func TestPostScanCallback_SSRFBlockedByDefault(t *testing.T) {
 	t.Setenv(callbackAllowlistEnv, "")
+	t.Setenv(callbackEnabledEnv, "true")
 	for _, tc := range []struct {
 		name, url string
 	}{
@@ -122,6 +134,9 @@ func TestPostScanCallback_SSRFBlockedByDefault(t *testing.T) {
 		{"link-local-metadata", "http://169.254.169.254/latest/meta-data"},
 		{"rfc1918-10", "http://10.0.0.5/hook"},
 		{"rfc1918-192", "http://192.168.1.10/hook"},
+		{"cgnat", "http://100.64.0.1/hook"},
+		{"this-host", "http://0.1.2.3/hook"},
+		{"broadcast", "http://255.255.255.255/hook"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := postScanCallback(context.Background(), tc.url, scanCallbackPayload{ID: "x"})
@@ -131,8 +146,23 @@ func TestPostScanCallback_SSRFBlockedByDefault(t *testing.T) {
 	}
 }
 
+func TestPostScanCallback_NoRetryOn4xx(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "127.0.0.1/32")
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := postScanCallback(context.Background(), srv.URL, scanCallbackPayload{ID: "x"})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "4xx must not be retried")
+}
+
 func TestPostScanCallback_DNSRebindToInternalIsRejected(t *testing.T) {
 	t.Setenv(callbackAllowlistEnv, "")
+	t.Setenv(callbackEnabledEnv, "true")
 	defer func(o ipResolver) { callbackResolver = o }(callbackResolver)
 	// A benign-looking host that resolves to the cloud metadata address: because
 	// screening runs on the resolved IP (and the dial is pinned to it), the

--- a/httphandler/handlerequests/v1/callback_test.go
+++ b/httphandler/handlerequests/v1/callback_test.go
@@ -1,0 +1,155 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubResolver struct {
+	ips []net.IPAddr
+	err error
+}
+
+func (s stubResolver) LookupIPAddr(context.Context, string) ([]net.IPAddr, error) {
+	return s.ips, s.err
+}
+
+// callbackReceiver starts a server that captures the first delivered payload.
+func callbackReceiver(t *testing.T) (string, <-chan scanCallbackPayload) {
+	t.Helper()
+	received := make(chan scanCallbackPayload, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p scanCallbackPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		select {
+		case received <- p:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, received
+}
+
+func TestExecuteScan_CallbackOnSuccess(t *testing.T) {
+	// httptest listens on loopback, so the allowlist must explicitly permit it.
+	t.Setenv(callbackAllowlistEnv, "127.0.0.1/32")
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		return nil, nil
+	}
+
+	url, received := callbackReceiver(t)
+	h := NewHTTPHandler(false)
+	h.executeScan(&scanRequestParams{
+		scanInfo:        &cautils.ScanInfo{},
+		scanQueryParams: &ScanQueryParams{},
+		scanID:          "scan-success",
+		ctx:             context.Background(),
+		callbackURL:     url,
+	})
+
+	select {
+	case p := <-received:
+		assert.Equal(t, "scan-success", p.ID)
+		assert.Equal(t, callbackStatusCompleted, p.Status)
+		assert.Empty(t, p.Error)
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback was not delivered within 5s")
+	}
+}
+
+func TestExecuteScan_CallbackOnFailure(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "127.0.0.1/32")
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		return nil, fmt.Errorf("collection boom")
+	}
+
+	url, received := callbackReceiver(t)
+	h := NewHTTPHandler(false)
+	h.executeScan(&scanRequestParams{
+		scanInfo:        &cautils.ScanInfo{},
+		scanQueryParams: &ScanQueryParams{},
+		scanID:          "scan-failed",
+		ctx:             context.Background(),
+		callbackURL:     url,
+	})
+
+	select {
+	case p := <-received:
+		assert.Equal(t, "scan-failed", p.ID)
+		assert.Equal(t, callbackStatusFailed, p.Status)
+		assert.Contains(t, p.Error, "collection boom")
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback was not delivered within 5s")
+	}
+}
+
+func TestValidateCallbackURL_Rejections(t *testing.T) {
+	for _, tc := range []struct {
+		name, url, contains string
+	}{
+		{"userinfo", "http://user:pass@example.com/hook", "userinfo"},
+		{"scheme", "ftp://example.com/hook", "scheme"},
+		{"no host", "http:///hook", "host"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateCallbackURL(tc.url)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.contains)
+		})
+	}
+}
+
+func TestPostScanCallback_SSRFBlockedByDefault(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "")
+	for _, tc := range []struct {
+		name, url string
+	}{
+		{"loopback", "http://127.0.0.1:1/hook"},
+		{"link-local-metadata", "http://169.254.169.254/latest/meta-data"},
+		{"rfc1918-10", "http://10.0.0.5/hook"},
+		{"rfc1918-192", "http://192.168.1.10/hook"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := postScanCallback(context.Background(), tc.url, scanCallbackPayload{ID: "x"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "disallowed")
+		})
+	}
+}
+
+func TestPostScanCallback_DNSRebindToInternalIsRejected(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "")
+	defer func(o ipResolver) { callbackResolver = o }(callbackResolver)
+	// A benign-looking host that resolves to the cloud metadata address: because
+	// screening runs on the resolved IP (and the dial is pinned to it), the
+	// rebind cannot smuggle an internal target past the literal-IP checks.
+	callbackResolver = stubResolver{ips: []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}}
+
+	err := postScanCallback(context.Background(), "http://benign.example.com/hook", scanCallbackPayload{ID: "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disallowed")
+}
+
+func TestScreenCallbackHost_PinsResolvedIP(t *testing.T) {
+	t.Setenv(callbackAllowlistEnv, "")
+	defer func(o ipResolver) { callbackResolver = o }(callbackResolver)
+	callbackResolver = stubResolver{ips: []net.IPAddr{{IP: net.ParseIP("203.0.113.7")}}}
+
+	ip, err := screenCallbackHost(context.Background(), "public.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.7", ip.String())
+}

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -24,6 +24,9 @@ type ScanQueryParams struct {
 	// Do not persist data after scanning
 	//default: false
 	SkipPersistence bool `schema:"skipPersistence" json:"skipPersistence"`
+	// URL to POST a scan-completion signal to when the scan finishes.
+	// The callback carries the scan ID only; results must be fetched via GET /v1/results.
+	CallbackURL string `schema:"callback" json:"callback"`
 }
 
 // swagger:parameters getScanResults
@@ -67,6 +70,7 @@ type scanRequestParams struct {
 	scanID          string            // generated scan ID
 	ctx             context.Context
 	resp            chan *utilsmetav1.Response // Respose chan; nil if not interested.
+	callbackURL     string                     // validated scan-completion callback URL; empty if not requested.
 }
 
 // swagger:parameters triggerScan
@@ -103,6 +107,12 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 	}
 	if p.scanQueryParams.ReturnResults {
 		p.resp = make(chan *utilsmetav1.Response, 1)
+	}
+	if p.scanQueryParams.CallbackURL != "" {
+		if _, err := validateCallbackURL(p.scanQueryParams.CallbackURL); err != nil {
+			return p, err
+		}
+		p.callbackURL = p.scanQueryParams.CallbackURL
 	}
 
 	return p, nil

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -86,7 +86,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 		payload := scanCallbackPayload{ID: scanReq.scanID, Status: callbackStatusCompleted}
 		if err != nil {
 			payload.Status = callbackStatusFailed
-			payload.Error = err.Error()
+			payload.Error = "scan failed"
 		}
 		cbCtx := context.WithoutCancel(scanReq.ctx)
 		go func() {
@@ -333,6 +333,10 @@ const (
 	// callbackAllowlistEnv, when set, is an authoritative comma-separated list of
 	// CIDRs (or bare IPs) the resolved callback host must fall within.
 	callbackAllowlistEnv = "KS_CALLBACK_ALLOWED_CIDRS"
+	// callbackEnabledEnv opts callbacks in when no allowlist is configured;
+	// without either, callbacks are disabled so the server cannot be used as an
+	// arbitrary outbound-request emitter.
+	callbackEnabledEnv = "KS_CALLBACK_ENABLED"
 
 	callbackRequestTimeout = 5 * time.Second
 	callbackWallTime       = 20 * time.Second
@@ -357,12 +361,24 @@ type ipResolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
+// callbackResolver is the resolver used for callback host screening; it is a
+// package var so tests can simulate DNS responses.
 var callbackResolver ipResolver = net.DefaultResolver
 
-// validateCallbackURL enforces the parse-time callback contract: http/https
-// only and no embedded credentials. Network-level SSRF screening happens later,
-// at dial time, in postScanCallback.
+// callbackEnabled reports whether scan-completion callbacks are turned on,
+// either explicitly via KS_CALLBACK_ENABLED or implicitly by configuring an
+// allowlist.
+func callbackEnabled() bool {
+	return envToString(callbackAllowlistEnv, "") != "" || boolutils.StringToBool(envToString(callbackEnabledEnv, ""))
+}
+
+// validateCallbackURL enforces the parse-time callback contract: callbacks must
+// be enabled, and the URL must be http/https with no embedded credentials.
+// Network-level SSRF screening happens later, at dial time, in postScanCallback.
 func validateCallbackURL(rawURL string) (*url.URL, error) {
+	if !callbackEnabled() {
+		return nil, fmt.Errorf("scan completion callbacks are disabled; set %s=true or configure %s", callbackEnabledEnv, callbackAllowlistEnv)
+	}
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid callback URL: %w", err)
@@ -379,11 +395,17 @@ func validateCallbackURL(rawURL string) (*url.URL, error) {
 	return u, nil
 }
 
+// postScanCallback delivers payload to rawURL, screening and pinning the
+// resolved IP against SSRF and retrying transport and 5xx failures within a
+// bounded wall-time deadline.
 func postScanCallback(ctx context.Context, rawURL string, payload scanCallbackPayload) error {
 	u, err := validateCallbackURL(rawURL)
 	if err != nil {
 		return err
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, callbackWallTime)
+	defer cancel()
 
 	// Resolve and screen once, then dial that exact IP, so the address vetted
 	// here is the address connected to - closing the DNS-rebinding window.
@@ -419,9 +441,6 @@ func postScanCallback(ctx context.Context, rawURL string, payload scanCallbackPa
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, callbackWallTime)
-	defer cancel()
-
 	var lastErr error
 	for attempt := 0; attempt < callbackMaxAttempts; attempt++ {
 		if attempt > 0 {
@@ -449,6 +468,9 @@ func postScanCallback(ctx context.Context, rawURL string, payload scanCallbackPa
 			return nil
 		}
 		lastErr = fmt.Errorf("callback endpoint returned status %d", resp.StatusCode)
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return lastErr
+		}
 	}
 	return lastErr
 }
@@ -494,11 +516,35 @@ func screenCallbackHost(ctx context.Context, host string) (net.IP, error) {
 	return nil, fmt.Errorf("callback host resolves to a disallowed (loopback, link-local or private) address")
 }
 
+// extraBlockedCallbackCIDRs are non-routable ranges with no net.IP predicate:
+// CGNAT, the "this host" block, and the IPv4 limited broadcast address.
+var extraBlockedCallbackCIDRs = func() []*net.IPNet {
+	nets := make([]*net.IPNet, 0, 3)
+	for _, c := range []string{"100.64.0.0/10", "0.0.0.0/8", "255.255.255.255/32"} {
+		if _, n, err := net.ParseCIDR(c); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// isBlockedCallbackIP reports whether ip falls in a loopback, link-local,
+// private, or otherwise non-routable range that must never be dialed by default.
 func isBlockedCallbackIP(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() ||
-		ip.IsUnspecified() || ip.IsMulticast()
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() ||
+		ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	for _, n := range extraBlockedCallbackCIDRs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
+// callbackAllowlist parses callbackAllowlistEnv into networks; bare IPs are
+// treated as single-host CIDRs. It returns nil when the env var is unset.
 func callbackAllowlist() ([]*net.IPNet, error) {
 	raw := envToString(callbackAllowlistEnv, "")
 	if raw == "" {
@@ -526,6 +572,7 @@ func callbackAllowlist() ([]*net.IPNet, error) {
 	return nets, nil
 }
 
+// allowlistContains reports whether ip is inside any of the given networks.
 func allowlistContains(nets []*net.IPNet, ip net.IP) bool {
 	for _, n := range nets {
 		if n.Contains(ip) {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -1,11 +1,18 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -73,6 +80,25 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	select {
 	case scanReq.resp <- response:
 	default:
+	}
+
+	if scanReq.callbackURL != "" {
+		payload := scanCallbackPayload{ID: scanReq.scanID, Status: callbackStatusCompleted}
+		if err != nil {
+			payload.Status = callbackStatusFailed
+			payload.Error = err.Error()
+		}
+		cbCtx := context.WithoutCancel(scanReq.ctx)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.L().Ctx(cbCtx).Error("scan completion callback panicked", helpers.String("ID", scanReq.scanID), helpers.Error(fmt.Errorf("%v", r)))
+				}
+			}()
+			if cbErr := postScanCallback(cbCtx, scanReq.callbackURL, payload); cbErr != nil {
+				logger.L().Ctx(cbCtx).Error("failed to deliver scan completion callback", helpers.String("ID", scanReq.scanID), helpers.Error(cbErr))
+			}
+		}()
 	}
 }
 
@@ -298,4 +324,213 @@ func writeScanErrorToFile(err error, scanID string) (e error) {
 func responseToBytes(res *utilsmetav1.Response) []byte {
 	b, _ := json.Marshal(res)
 	return b
+}
+
+const (
+	callbackStatusCompleted = "completed"
+	callbackStatusFailed    = "failed"
+
+	// callbackAllowlistEnv, when set, is an authoritative comma-separated list of
+	// CIDRs (or bare IPs) the resolved callback host must fall within.
+	callbackAllowlistEnv = "KS_CALLBACK_ALLOWED_CIDRS"
+
+	callbackRequestTimeout = 5 * time.Second
+	callbackWallTime       = 20 * time.Second
+	callbackBackoff        = 2 * time.Second
+	callbackMaxAttempts    = 3
+)
+
+// scanCallbackPayload is the completion signal POSTed to a caller-supplied
+// callback URL. It is intentionally a signal only - it carries the scan ID, not
+// the PostureReport, and receivers must GET /v1/results for the data. Delivery
+// is at-least-once and best-effort with no durability across server restarts,
+// so receivers must dedup on ID and keep a poll/reconcile fallback.
+type scanCallbackPayload struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// ipResolver is the subset of net.Resolver used for callback host screening;
+// it is a package var so tests can simulate DNS responses.
+type ipResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+var callbackResolver ipResolver = net.DefaultResolver
+
+// validateCallbackURL enforces the parse-time callback contract: http/https
+// only and no embedded credentials. Network-level SSRF screening happens later,
+// at dial time, in postScanCallback.
+func validateCallbackURL(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid callback URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("callback URL scheme must be http or https")
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("callback URL must not contain userinfo")
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("callback URL must contain a host")
+	}
+	return u, nil
+}
+
+func postScanCallback(ctx context.Context, rawURL string, payload scanCallbackPayload) error {
+	u, err := validateCallbackURL(rawURL)
+	if err != nil {
+		return err
+	}
+
+	// Resolve and screen once, then dial that exact IP, so the address vetted
+	// here is the address connected to - closing the DNS-rebinding window.
+	ip, err := screenCallbackHost(ctx, u.Hostname())
+	if err != nil {
+		return err
+	}
+
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	pinnedAddr := net.JoinHostPort(ip.String(), port)
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: callbackRequestTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: callbackRequestTimeout}).DialContext(ctx, network, pinnedAddr)
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callbackWallTime)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 0; attempt < callbackMaxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("callback delivery deadline exceeded: %w", ctx.Err())
+			case <-time.After(callbackBackoff * time.Duration(attempt)):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+		lastErr = fmt.Errorf("callback endpoint returned status %d", resp.StatusCode)
+	}
+	return lastErr
+}
+
+// screenCallbackHost resolves host and returns one IP that is permitted to be
+// dialed. When callbackAllowlistEnv is set it is authoritative (the IP must fall
+// inside it); otherwise loopback, link-local, private and other non-routable
+// ranges are denied.
+func screenCallbackHost(ctx context.Context, host string) (net.IP, error) {
+	allowlist, err := callbackAllowlist()
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []net.IP
+	if literal := net.ParseIP(host); literal != nil {
+		candidates = []net.IP{literal}
+	} else {
+		addrs, err := callbackResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve callback host: %w", err)
+		}
+		for i := range addrs {
+			candidates = append(candidates, addrs[i].IP)
+		}
+	}
+
+	for _, ip := range candidates {
+		if len(allowlist) > 0 {
+			if allowlistContains(allowlist, ip) {
+				return ip, nil
+			}
+			continue
+		}
+		if !isBlockedCallbackIP(ip) {
+			return ip, nil
+		}
+	}
+
+	if len(allowlist) > 0 {
+		return nil, fmt.Errorf("callback host is not within the configured allowlist")
+	}
+	return nil, fmt.Errorf("callback host resolves to a disallowed (loopback, link-local or private) address")
+}
+
+func isBlockedCallbackIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() ||
+		ip.IsUnspecified() || ip.IsMulticast()
+}
+
+func callbackAllowlist() ([]*net.IPNet, error) {
+	raw := envToString(callbackAllowlistEnv, "")
+	if raw == "" {
+		return nil, nil
+	}
+	var nets []*net.IPNet
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			if ip := net.ParseIP(entry); ip != nil && ip.To4() != nil {
+				entry += "/32"
+			} else {
+				entry += "/128"
+			}
+		}
+		_, n, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s entry %q: %w", callbackAllowlistEnv, entry, err)
+		}
+		nets = append(nets, n)
+	}
+	return nets, nil
+}
+
+func allowlistContains(nets []*net.IPNet, ip net.IP) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Overview

The Kubescape HTTP/operator server had two scan-completion models -- `wait=true` which holds an HTTP connection open for the entire scan duration (fights the write timeouts added in #2396 on large clusters), and fire-and-poll where every integrator reimplements the same polling loop. This PR adds an optional `?callback=<url>` query param that fires a completion signal to the caller the instant the scan finishes, without holding a connection open.

The callback is purely additive -- no existing endpoint or request body schema changes.

**Opt-in by default:** callbacks are disabled unless `KS_CALLBACK_ENABLED=true` or `KS_CALLBACK_ALLOWED_CIDRS` is set. A request with `?callback=` and no opt-in returns 400 at parse time.

## Additional Information

**Delivery contract:** the callback is at-least-once, best-effort, with no durability across server restarts. A restart between completion and delivery silently drops the notification. Receivers must keep a poll/reconcile fallback, dedup on scan ID, and treat the callback as an optimization that makes polling optional -- not a replacement for it.

**Signal only:** the callback payload contains the scan ID and completion status (`completed`/`failed`). No `PostureReport` is embedded and no internal error detail is leaked -- the receiver GETs `/v1/results?id=<scanID>` for the actual data.

**SSRF egress controls:**
- Default-deny loopback, link-local, RFC1918, CGNAT (`100.64.0.0/10`), this-host (`0.0.0.0/8`), unspecified, multicast, and IPv4 broadcast (`255.255.255.255`)
- Hostname resolved and IP pinned via a custom `Transport.DialContext` before dialing -- closes the DNS-rebinding window
- Wall-time deadline applied before DNS resolution so a stalled resolver cannot leak the goroutine indefinitely
- `KS_CALLBACK_ALLOWED_CIDRS` env var is authoritative when set (config-driven allowlist)
- Redirect following disabled
- URL userinfo rejected at parse time (400 returned to caller)
- Callback URL never logged -- only the scan ID appears in log lines

**Reliability:**
- Per-request `http.Client.Timeout` plus a `context.WithTimeout` wall-time bound so the goroutine cannot linger
- 3 retry attempts with backoff inside the wall-time deadline
- Retries only on 5xx and transport errors -- 4xx returns immediately (unrecoverable)
- Fired in a `recover()`-guarded goroutine using `context.WithoutCancel(scanReq.ctx)` -- matching the existing detached-context and recover patterns in `executeScan`

**Panic path:** if `scanImpl` panics, the existing top-level recover persists the error to disk and cleans up state but does not fire a callback. The documented poll/reconcile fallback covers that case.

Files changed:
- `requestparser.go` -- `CallbackURL` added to `ScanQueryParams` and `scanRequestParams`; `validateCallbackURL()` called at parse time, returns 400 on violation or when callbacks are disabled
- `requestshandlerutils.go` -- opt-in gate (`callbackEnabled`), callback fired after `setNotBusy` and existing resp send, `postScanCallback`, `validateCallbackURL`, `screenCallbackHost`, `isBlockedCallbackIP`, `callbackAllowlist`, `allowlistContains` helpers
- `callback_test.go` (new) -- success, failure, opt-in gate, SSRF, DNS-rebind, 4xx no-retry, and URL-validation tests

## How to Test

```bash
# enable callbacks
export KS_CALLBACK_ENABLED=true

# trigger a scan with a callback
curl -X POST "http://localhost:8080/v1/scan?callback=https://your-receiver.internal/ks-done"
# immediate BusyScanResponseType with scan ID
# callback fires on completion with {id, status}
# receiver GETs /v1/results?id=<scanID> for data

# without opt-in -- returns 400
curl -X POST "http://localhost:8080/v1/scan?callback=https://your-receiver.internal/ks-done"
# {"type":"error","response":"scan completion callbacks are disabled; set KS_CALLBACK_ENABLED=true or configure KS_CALLBACK_ALLOWED_CIDRS"}
```

Tests:
- `TestExecuteScan_CallbackOnSuccess` / `...OnFailure` -- `httptest` receiver + stub `scanImpl`, asserts completion signal arrives within 5s
- `TestValidateCallbackURL_DisabledByDefault` -- no env set, asserts 400 with "disabled" message
- `TestValidateCallbackURL_Rejections` -- userinfo, non-http scheme, missing host
- `TestPostScanCallback_SSRFBlockedByDefault` -- loopback, `169.254.169.254`, RFC1918, CGNAT, this-host, broadcast rejected
- `TestPostScanCallback_DNSRebindToInternalIsRejected` -- stub resolver returning metadata IP is rejected
- `TestPostScanCallback_NoRetryOn4xx` -- asserts exactly one request on a 400 response
- `TestScreenCallbackHost_PinsResolvedIP` -- confirms pinned IP matches resolved IP

## Related issues/PRs

* Resolved #2444 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes