### PR TITLE
fix(httphandler): decouple prometheus metrics scan from request context

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -55,7 +56,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		},
 		scanInfo: scanInfo,
 		scanID:   scanID,
-		ctx:      r.Context(),
+		ctx:      context.WithoutCancel(r.Context()),
 		resp:     make(chan *utilsmetav1.Response, 1),
 	}
 

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -1,10 +1,16 @@
 package v1
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,6 +52,33 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 		assert.Equal(t, "mitre", scanInfo.PolicyIdentifier[1].Identifier)
 		assert.Equal(t, "cis-v1.10.0", scanInfo.PolicyIdentifier[2].Identifier)
 	})
+}
+
+// TestMetrics_ScanContextDecoupledFromRequest ensures the metrics scan is not
+// aborted when the scrape request context is cancelled (e.g. a Prometheus
+// scrape timeout): the scan must keep running to completion.
+func TestMetrics_ScanContextDecoupledFromRequest(t *testing.T) {
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanCtxErr := make(chan error, 1)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		cancel() // simulate the scrape connection going away mid-scan
+		scanCtxErr <- ctx.Err()
+		return nil, nil
+	}
+
+	h := NewHTTPHandler(false)
+	rq := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil).WithContext(reqCtx)
+	w := httptest.NewRecorder()
+	h.Metrics(w, rq)
+
+	select {
+	case err := <-scanCtxErr:
+		assert.NoError(t, err, "scan context must not be cancelled when the request context is")
+	case <-time.After(5 * time.Second):
+		t.Fatal("scan was not invoked")
+	}
 }
 
 func TestSplitAndTrim(t *testing.T) {

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -71,13 +71,24 @@ func TestMetrics_ScanContextDecoupledFromRequest(t *testing.T) {
 	h := NewHTTPHandler(false)
 	rq := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil).WithContext(reqCtx)
 	w := httptest.NewRecorder()
-	h.Metrics(w, rq)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		h.Metrics(w, rq)
+		close(handlerDone)
+	}()
 
 	select {
 	case err := <-scanCtxErr:
 		assert.NoError(t, err, "scan context must not be cancelled when the request context is")
 	case <-time.After(5 * time.Second):
 		t.Fatal("scan was not invoked")
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not complete")
 	}
 }
 


### PR DESCRIPTION
## Overview

The `/v1/metrics` handler was building the scan request with `ctx: r.Context()`. Prometheus closes the scrape connection when `scrape_timeout` elapses (10s default), which cancels `r.Context()` and flowed straight into the scan -- aborting it, returning HTTP 500 with no metrics body, and immediately enqueuing another doomed scan on the next scrape. On any real cluster whose full scan takes longer than 10s, the metrics endpoint effectively never succeeded.

The `Scan` handler already uses `context.WithoutCancel(r.Context())` at `requestshandler.go:105`. The two sibling handlers diverged in regression commit `4919fa60` which correctly fixed `Scan` but changed `Metrics` to the raw `r.Context()`.

**Fix:** one line in `prometheus.go` mirroring the already-correct `Scan` handler:

```go
// before
ctx: r.Context(),

// after
ctx: context.WithoutCancel(r.Context()),
```

## Additional Information

`context.WithoutCancel` keeps the request's trace span and values but is never cancelled by the request lifecycle. The scan now runs to completion regardless of scrape timeout or client disconnect. The synchronous `<-scanParams.resp` wait and all other behavior are unchanged -- if the client is still connected when the scan finishes, it gets the metrics body; if not, the result is available for the next scrape.

The permanent abort-and-retry loop is also eliminated. The scan worker is a single serial goroutine -- each timed-out scrape threw away all collection/evaluation work and immediately enqueued another doomed scan. With the fix, a slow scan runs once to completion instead of looping indefinitely.

Regression introduced by commit `4919fa60` ("fix: propagate context through httphandler storage API calls").

Affected files:
- `httphandler/handlerequests/v1/prometheus.go` -- `context.WithoutCancel` + import
- `httphandler/handlerequests/v1/prometheus_test.go` -- regression test

## How to Test

Deploy the Kubescape operator against a cluster whose full scan takes longer than 10s. Before fix: `/v1/metrics` returns 500 on every scrape. After fix: the scan runs to completion and metrics are served.

Regression test `TestMetrics_ScanContextDecoupledFromRequest`:
- Drives the real `Metrics` handler with an `httptest` request whose context is cancelled mid-scan (simulating a Prometheus scrape timeout)
- Asserts the context handed to the scan engine has `ctx.Err() == nil` after request cancellation
- Verified both directions: with fix passes, without fix fails with `context canceled`
- Mirrors existing `scanImpl` override and `httptest` patterns, needs no cluster connection, bounded by 5s timeout guard

## Related issues/PRs

* Resolved #2450

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `/v1/metrics` scraping flow so scan execution continues even if the incoming HTTP request is cancelled.

* **Tests**
  * Added a test that verifies the scan context is decoupled from HTTP request cancellation by asserting the scan-side context error remains `nil` during request cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->