### PR TITLE
Fix air-gapped mode -- thread explicit offline flag to policy getters instead of relying on nil

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -37,7 +37,7 @@ const ( // deprecated
 	ScopeCluster = "cluster"
 )
 const (
-	localControlInputsFilename string = "controls-inputs.json"
+	LocalControlInputsFilename string = "controls-inputs.json"
 	LocalExceptionsFilename    string = "exceptions.json"
 	LocalAttackTracksFilename  string = "attack-tracks.json"
 )
@@ -212,7 +212,7 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 		}
 	}
 	// set config-inputs file
-	scanInfo.ControlsInputs = filepath.Join(scanInfo.UseArtifactsFrom, localControlInputsFilename)
+	scanInfo.ControlsInputs = filepath.Join(scanInfo.UseArtifactsFrom, LocalControlInputsFilename)
 	// set exceptions
 	scanInfo.UseExceptions = filepath.Join(scanInfo.UseArtifactsFrom, LocalExceptionsFilename)
 

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -100,7 +100,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	controlsInputsGetter := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false)
+	controlsInputsGetter := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	controlInputs, err := controlsInputsGetter.GetControlsInputs(tenant.GetContextName())
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
-	exceptionsGetter := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil)
+	exceptionsGetter := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
 
 	exceptions, err := exceptionsGetter.GetExceptions(tenant.GetContextName())
 	if err != nil {
@@ -145,7 +145,7 @@ func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo
 	var err error
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	attackTracksGetter := getAttackTracksGetter(ctx, "", tenant.GetAccountID(), nil)
+	attackTracksGetter := getAttackTracksGetter(ctx, "", tenant.GetAccountID(), nil, false)
 
 	attackTracks, err := attackTracksGetter.GetAttackTracks()
 	if err != nil {
@@ -169,7 +169,7 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil)
+	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
 
 	if downloadInfo.Identifier == "" {
 		// if framework name not specified - download all frameworks
@@ -220,7 +220,7 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) err
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil)
+	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
 
 	if downloadInfo.Identifier == "" {
 		// TODO - support

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -60,15 +60,14 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		primary = getter.NewLoadPolicy([]string{useExceptions})
 		return primary
 	}
-	if accountID != "" {
-		// download exceptions from Kubescape Cloud backend
-		primary = getter.GetKSCloudAPIConnector()
+	if airGapped {
+		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
-	if airGapped {
-		// air-gapped: load exceptions from cache instead of reaching the network
-		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
+	if accountID != "" {
+		// download exceptions from Kubescape Cloud backend
+		primary = getter.GetKSCloudAPIConnector()
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
@@ -244,6 +243,9 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 	if len(loadPoliciesFromFile) > 0 {
 		return getter.NewLoadPolicy(loadPoliciesFromFile)
 	}
+	if airGapped {
+		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
+	}
 	if accountID != "" && getter.GetKSCloudAPIConnector().GetCloudAPIURL() != "" && frameworkScope {
 		g := getter.GetKSCloudAPIConnector() // download policy from Kubescape Cloud backend
 		return g
@@ -251,10 +253,6 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 		logger.L().Ctx(ctx).Warning("Kubescape Cloud API URL is not set, loading policies from cache")
 	}
 
-	if airGapped {
-		// air-gapped: load frameworks from cache instead of reaching the network
-		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
-	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
@@ -270,6 +268,9 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) getter.IControlsInputsGetter {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs})
+	}
+	if airGapped {
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)})
 	}
 	if accountID != "" {
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
@@ -287,10 +288,6 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		}
 	}
 
-	if airGapped {
-		// air-gapped: load config inputs from cache instead of reaching the network
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(TargetControlsInputs + ".json")})
-	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
@@ -331,13 +328,12 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 	if len(attackTracks) > 0 {
 		return getter.NewLoadPolicy([]string{attackTracks})
 	}
+	if airGapped {
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
+	}
 	if accountID != "" {
 		g := getter.GetKSCloudAPIConnector() // download attack tracks from Kubescape Cloud backend
 		return g
-	}
-	if airGapped {
-		// air-gapped: load attack tracks from cache instead of reaching the network
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
 	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -52,7 +52,7 @@ func getExceptionsK8sClient(ctx context.Context) client.Client {
 	return k8sClient
 }
 
-func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IExceptionsGetter {
+func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IExceptionsGetter {
 	var primary getter.IExceptionsGetter
 
 	if useExceptions != "" {
@@ -63,6 +63,12 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	if accountID != "" {
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIConnector()
+		k8sClient := getExceptionsK8sClient(ctx)
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+	}
+	if airGapped {
+		// air-gapped: load exceptions from cache instead of reaching the network
+		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
@@ -234,7 +240,7 @@ func isScanTypeForSubmission(scanType cautils.ScanTypes) bool {
 }
 
 // setPolicyGetter set the policy getter - local file/github release/Kubescape Cloud API
-func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, accountID string, frameworkScope bool, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IPolicyGetter {
+func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, accountID string, frameworkScope bool, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IPolicyGetter {
 	if len(loadPoliciesFromFile) > 0 {
 		return getter.NewLoadPolicy(loadPoliciesFromFile)
 	}
@@ -245,6 +251,10 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 		logger.L().Ctx(ctx).Warning("Kubescape Cloud API URL is not set, loading policies from cache")
 	}
 
+	if airGapped {
+		// air-gapped: load frameworks from cache instead of reaching the network
+		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
+	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
@@ -257,7 +267,7 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 //  2. Kubescape Cloud API (if accountID configured)
 //  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
 //  4. Defaults from regolibrary GitHub releases
-func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool) getter.IControlsInputsGetter {
+func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) getter.IControlsInputsGetter {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs})
 	}
@@ -277,6 +287,10 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		}
 	}
 
+	if airGapped {
+		// air-gapped: load config inputs from cache instead of reaching the network
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(TargetControlsInputs + ".json")})
+	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
@@ -313,13 +327,17 @@ func listFrameworksNames(policyGetter getter.IPolicyGetter) []string {
 	return getter.NativeFrameworks
 }
 
-func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IAttackTracksGetter {
+func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IAttackTracksGetter {
 	if len(attackTracks) > 0 {
 		return getter.NewLoadPolicy([]string{attackTracks})
 	}
 	if accountID != "" {
 		g := getter.GetKSCloudAPIConnector() // download attack tracks from Kubescape Cloud backend
 		return g
+	}
+	if airGapped {
+		// air-gapped: load attack tracks from cache instead of reaching the network
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
 	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -132,7 +132,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy)
+			got := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy, false)
 			assert.Equal(t, tt.want, reflect.TypeOf(got).String())
 		})
 	}

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -138,6 +138,22 @@ func TestGetExceptionsGetter(t *testing.T) {
 	}
 }
 
+func TestGettersAirGappedUseCache(t *testing.T) {
+	ctx := context.Background()
+	for _, accountID := range []string{"", "123456789012"} {
+		t.Run("accountID="+accountID, func(t *testing.T) {
+			assert.Equal(t, "*getter.LoadPolicy",
+				reflect.TypeOf(getPolicyGetter(ctx, nil, accountID, true, nil, true)).String())
+			assert.Equal(t, "*getter.LoadPolicy",
+				reflect.TypeOf(getConfigInputsGetter(ctx, "", accountID, nil, false, true)).String())
+			assert.Equal(t, "*getter.LoadPolicy",
+				reflect.TypeOf(getAttackTracksGetter(ctx, "", accountID, nil, true)).String())
+			assert.Equal(t, "*getter.MergedExceptionsGetter",
+				reflect.TypeOf(getExceptionsGetter(ctx, "", accountID, nil, true)).String())
+		})
+	}
+}
+
 func TestPolicyIdentifierIdentities(t *testing.T) {
 	type args struct {
 		pi []cautils.PolicyIdentifier

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -95,7 +95,7 @@ func naturalSortControls(entries []metav1.ControlListEntry) []metav1.ControlList
 
 func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
-	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil)
+	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
 
 	return listFrameworksNames(policyGetter), nil
 }
@@ -103,7 +103,7 @@ func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]metav1.ControlListEntry, error) {
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
 
-	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil)
+	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	pipes, err := policyGetter.ListControls()
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi())
 
 	var exceptionsNames []string
-	ksCloudAPI := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil)
+	ksCloudAPI := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
 	exceptions, err := ksCloudAPI.GetExceptions("")
 	if err != nil {
 		return exceptionsNames, err

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -396,8 +396,7 @@ func isPrioritizationScanType(scanType cautils.ScanTypes) bool {
 // isAirGappedMode returns true if the scan is configured to run in air-gapped mode
 // (i.e., without any network access to download policies, exceptions, or other artifacts)
 func isAirGappedMode(scanInfo *cautils.ScanInfo) bool {
-	return scanInfo.Local ||
-		len(scanInfo.UseFrom) > 0 ||
+	return len(scanInfo.UseFrom) > 0 ||
 		scanInfo.ControlsInputs != "" ||
 		scanInfo.UseExceptions != "" ||
 		scanInfo.AttackTracks != ""

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -196,8 +196,9 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	interfaces.report.SetTenantConfig(interfaces.tenantConfig)
 
 	// Only create DownloadReleasedPolicy if not in air-gapped mode
+	airGapped := isAirGappedMode(scanInfo)
 	var downloadReleasedPolicy *getter.DownloadReleasedPolicy
-	if isAirGappedMode(scanInfo) {
+	if airGapped {
 		// In air-gapped mode (--keep-local or using local files via --use-from, --controls-config, --exceptions, or attack tracks),
 		// don't initialize the downloader to prevent network access
 		downloadReleasedPolicy = nil
@@ -206,10 +207,10 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	}
 
 	// set policy getter only after setting the customerGUID
-	scanInfo.PolicyGetter = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy)
-	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster)
-	scanInfo.ExceptionsGetter = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
-	scanInfo.AttackTracksGetter = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy)
+	scanInfo.PolicyGetter = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
+	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
+	scanInfo.ExceptionsGetter = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	scanInfo.AttackTracksGetter = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
 
 	// TODO - list supported frameworks/controls
 	if scanInfo.ScanAll {

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -81,11 +81,11 @@ func TestIsAirGappedMode(t *testing.T) {
 		want     bool
 	}{
 		{
-			name: "air-gapped with Local flag",
+			name: "not air-gapped with Local flag",
 			scanInfo: &cautils.ScanInfo{
 				Local: true,
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "air-gapped with UseFrom",


### PR DESCRIPTION
## Overview

This is the fix for #2456 .

The issue was that `isAirGappedMode()` nils `downloadReleasedPolicy` in `scan.go` to prevent network access, but all four policy getters treated nil as "not initialized" and unconditionally rebuilt the downloader, immediately calling `SetRegoObjects()` which hits the GitHub release endpoint. nil alone couldn't be the signal because `download.go` and `list.go` also pass nil but genuinely want to download, so the offline intent had to be threaded explicitly.

The fix adds an `airGapped bool` parameter to the four getters. When true, each getter short-circuits to the local cache path instead of instantiating the downloader. The `airGapped` check is placed above the `accountID != ""` branch in all four getters so authenticated offline scans don't fall through to the cloud connector path. `scan.go` computes `airGapped := isAirGappedMode(scanInfo)` once and passes it through. `download.go` and `list.go` pass false since they intentionally fetch from GitHub.

Now the two cases are actually distinct:

- Offline scan → airGapped short-circuits to bundled cache → zero network calls
- Online scan → accountID/cloud branch runs as before → fetches from GitHub or KS Cloud

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for air-gapped mode when loading policies, configuration inputs, attack tracks, and exceptions.
  * When air-gapped, scan components now use local loading paths instead of cloud/GitHub/cached retrieval.
* **Bug Fixes**
  * Air-gapped detection no longer treats the “Local” flag as air-gapped; it now relies on the configured source selection.
  * Exceptions in air-gapped mode are now correctly loaded from local files and combined with in-cluster exceptions.
* **Tests**
  * Expanded unit coverage for air-gapped getter selection and updated expectations for air-gapped detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->