### PR TITLE
fix: support namespace/kind/name workload format (#2459)

### DIFF
--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -215,7 +215,8 @@ func Test_validateWorkloadIdentifier(t *testing.T) {
 	}{
 		{"valid workload identifier should be valid", "deployment/test", nil},
 		{"invalid workload identifier missing kind", "deployment", ErrInvalidWorkloadIdentifier},
-		{"invalid workload identifier with namespace", "ns/deployment/name", ErrInvalidWorkloadIdentifier},
+		{"valid workload identifier with namespace", "ns/deployment/name", nil},
+		{"invalid workload identifier with too many segments", "cluster/ns/deployment/name", ErrInvalidWorkloadIdentifier},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -71,9 +71,13 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}
-			kind, name, err := parseWorkloadIdentifierString(args[0])
+			namespace, kind, name, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %w", err)
+			}
+
+			if namespace != "" && scanInfo.Namespace == "" {
+				scanInfo.Namespace = namespace
 			}
 
 			setWorkloadScanInfo(scanInfo, kind, name)
@@ -119,22 +123,34 @@ func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, kind string, name string) {
 }
 
 func validateWorkloadIdentifier(workloadIdentifier string) error {
-	// workloadIdentifier is in the form of kind/name
+	// workloadIdentifier is in the form of kind/name or namespace/kind/name
 	x := strings.Split(workloadIdentifier, "/")
-	if len(x) != 2 || x[0] == "" || x[1] == "" {
-		return ErrInvalidWorkloadIdentifier
+	if len(x) == 2 {
+		if x[0] == "" || x[1] == "" {
+			return ErrInvalidWorkloadIdentifier
+		}
+		return nil
+	}
+	if len(x) == 3 {
+		if x[0] == "" || x[1] == "" || x[2] == "" {
+			return ErrInvalidWorkloadIdentifier
+		}
+		return nil
 	}
 
-	return nil
+	return ErrInvalidWorkloadIdentifier
 }
 
-func parseWorkloadIdentifierString(workloadIdentifier string) (kind, name string, err error) {
+func parseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, name string, err error) {
 	// workloadIdentifier is in the form of namespace/kind/name
 	// example: default/Deployment/nginx-deployment
 	x := strings.Split(workloadIdentifier, "/")
-	if len(x) != 2 {
-		return "", "", ErrInvalidWorkloadIdentifier
+	if len(x) == 2 {
+		return "", x[0], x[1], nil
+	}
+	if len(x) == 3 {
+		return x[0], x[1], x[2], nil
 	}
 
-	return x[0], x[1], nil
+	return "", "", "", ErrInvalidWorkloadIdentifier
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -123,32 +123,24 @@ func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, kind string, name string) {
 }
 
 func validateWorkloadIdentifier(workloadIdentifier string) error {
-	// workloadIdentifier is in the form of kind/name or namespace/kind/name
-	x := strings.Split(workloadIdentifier, "/")
-	if len(x) == 2 {
-		if x[0] == "" || x[1] == "" {
-			return ErrInvalidWorkloadIdentifier
-		}
-		return nil
-	}
-	if len(x) == 3 {
-		if x[0] == "" || x[1] == "" || x[2] == "" {
-			return ErrInvalidWorkloadIdentifier
-		}
-		return nil
-	}
-
-	return ErrInvalidWorkloadIdentifier
+	_, _, _, err := parseWorkloadIdentifierString(workloadIdentifier)
+	return err
 }
 
 func parseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, name string, err error) {
-	// workloadIdentifier is in the form of namespace/kind/name
+	// workloadIdentifier is in the form of kind/name or namespace/kind/name
 	// example: default/Deployment/nginx-deployment
 	x := strings.Split(workloadIdentifier, "/")
 	if len(x) == 2 {
+		if x[0] == "" || x[1] == "" {
+			return "", "", "", ErrInvalidWorkloadIdentifier
+		}
 		return "", x[0], x[1], nil
 	}
 	if len(x) == 3 {
+		if x[0] == "" || x[1] == "" || x[2] == "" {
+			return "", "", "", ErrInvalidWorkloadIdentifier
+		}
 		return x[0], x[1], x[2], nil
 	}
 

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -168,7 +168,7 @@ func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := parseWorkloadIdentifierString(tt.input)
+			_, _, _, err := parseWorkloadIdentifierString(tt.input)
 			assert.Error(t, err)
 		})
 	}
@@ -176,43 +176,55 @@ func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
 
 func Test_parseWorkloadIdentifierString_Valid(t *testing.T) {
 	t.Run("valid identifier", func(t *testing.T) {
-		kind, name, err := parseWorkloadIdentifierString("default/Deployment")
+		namespace, kind, name, err := parseWorkloadIdentifierString("default/Deployment/nginx-deployment")
 		assert.NoError(t, err)
-		assert.Equal(t, "default", kind)
-		assert.Equal(t, "Deployment", name)
+		assert.Equal(t, "default", namespace)
+		assert.Equal(t, "Deployment", kind)
+		assert.Equal(t, "nginx-deployment", name)
 	})
 }
 
 func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 	testCases := []struct {
-		Description string
-		Input       string
-		WantKind    string
-		WantName    string
-		WantErr     bool
+		Description   string
+		Input         string
+		WantNamespace string
+		WantKind      string
+		WantName      string
+		WantErr       bool
 	}{
 		{
-			Description: "valid kind and name",
-			Input:       "Deployment/nginx",
-			WantKind:    "Deployment",
-			WantName:    "nginx",
-			WantErr:     false,
+			Description:   "valid kind and name",
+			Input:         "Deployment/nginx",
+			WantNamespace: "",
+			WantKind:      "Deployment",
+			WantName:      "nginx",
+			WantErr:       false,
+		},
+		{
+			Description:   "valid namespace kind and name",
+			Input:         "default/Deployment/nginx",
+			WantNamespace: "default",
+			WantKind:      "Deployment",
+			WantName:      "nginx",
+			WantErr:       false,
 		},
 		{
 			Description: "too many segments",
-			Input:       "default/Deployment/nginx",
+			Input:       "cluster/default/Deployment/nginx",
 			WantErr:     true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
-			kind, name, err := parseWorkloadIdentifierString(tc.Input)
+			namespace, kind, name, err := parseWorkloadIdentifierString(tc.Input)
 			if tc.WantErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
+			assert.Equal(t, tc.WantNamespace, namespace)
 			assert.Equal(t, tc.WantKind, kind)
 			assert.Equal(t, tc.WantName, name)
 		})

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -162,7 +162,11 @@ func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
 		},
 		{
 			name:  "too many segments",
-			input: "default/Deployment/nginx",
+			input: "cluster/default/Deployment/nginx",
+		},
+		{
+			name:  "empty segment",
+			input: "default//nginx",
 		},
 	}
 


### PR DESCRIPTION
## Overview
This PR resolves a logic bug where `kubescape scan workload` would reject the documented `namespace/kind/name` input format.

**Current behavior**: The `parseWorkloadIdentifierString` and `validateWorkloadIdentifier` functions strictly allowed exactly two segments (`len(x) == 2`). If a user provided a namespace prefix, the length would be 3, triggering an immediate `ErrInvalidWorkloadIdentifier`.
**Future behavior**: The CLI now gracefully accepts both the 2-segment (`kind/name`) and 3-segment (`namespace/kind/name`) formats, extracting the namespace correctly and applying it to the `ScanInfo` object.

## Additional Information

> The parsed namespace string is set in `scanInfo.Namespace` if the explicit `--namespace` flag is not already set.

## How to Test

> 1. Build kubescape locally
> 2. Run: `kubescape scan workload default/Deployment/nginx-deployment`
> 3. Verify that the CLI successfully parses the namespace and executes the scan instead of returning an `invalid workload identifier` error.

## Related issues/PRs:

* Resolved #2459

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload scan identifiers now accept `kind/name` or `namespace/kind/name`.
  * If the identifier includes a namespace, it’s used automatically unless `--namespace` was set explicitly.
* **Bug Fixes**
  * Stricter identifier validation now rejects malformed inputs (including empty or extra path segments).
  * Parsing now reliably extracts and preserves namespace, kind, and name for workload scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->