### PR TITLE
feat(operator): add quarantine action to remediate CLI subcommand

### DIFF
--- a/cmd/operator/remediate.go
+++ b/cmd/operator/remediate.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -13,9 +14,22 @@ import (
 )
 
 const (
-	annotateSubCommand string = "annotate"
-	revertSubCommand   string = "revert"
+	annotateSubCommand   string = "annotate"
+	quarantineSubCommand string = "quarantine"
+	revertSubCommand     string = "revert"
 )
+
+// remediateActions is the set of actions the CLI accepts, in help/error order.
+var remediateActions = []string{annotateSubCommand, quarantineSubCommand, revertSubCommand}
+
+func isSupportedRemediateAction(action string) bool {
+	for _, a := range remediateActions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
 
 var operatorRemediateExamples = fmt.Sprintf(`
   # Preview (dry-run) annotating a workload as remediated — no changes are made
@@ -24,7 +38,13 @@ var operatorRemediateExamples = fmt.Sprintf(`
   # Apply the annotation (the only flag that performs a real cluster write)
   %[1]s operator remediate annotate --kind Deployment --target-namespace payments --name api --reason "C-0016" --confirm
 
-  # Revert a previously applied annotation
+  # Preview (dry-run) quarantining a workload — creates a deny-all NetworkPolicy isolating its pods
+  %[1]s operator remediate quarantine --kind Deployment --target-namespace payments --name api --reason "C-0016"
+
+  # Apply the quarantine
+  %[1]s operator remediate quarantine --kind Deployment --target-namespace payments --name api --reason "C-0016" --confirm
+
+  # Revert a previously applied action (removes the annotation and/or NetworkPolicy on the target)
   %[1]s operator remediate revert --kind Deployment --target-namespace payments --name api --confirm
 
 `, cautils.ExecName())
@@ -38,16 +58,16 @@ func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorIn
 
 	remediateCmd := &cobra.Command{
 		Use:     "remediate <action>",
-		Short:   "Act on scan findings via the Kubescape Operator (Phase 1: annotate, revert — dry-run by default)",
+		Short:   "Act on scan findings via the Kubescape Operator (annotate, quarantine, revert — dry-run by default)",
 		Long:    ``,
 		Example: operatorRemediateExamples,
 		Args: func(cmd *cobra.Command, args []string) error {
 			operatorInfo.Subcommands = append(operatorInfo.Subcommands, cautils.RemediateCommand)
 			if len(args) != 1 {
-				return fmt.Errorf("for the operator remediate sub-command, you must pass exactly one action (%s or %s). Refer to the examples above", annotateSubCommand, revertSubCommand)
+				return fmt.Errorf("for the operator remediate sub-command, you must pass exactly one action (%s). Refer to the examples above", strings.Join(remediateActions, ", "))
 			}
-			if args[0] != annotateSubCommand && args[0] != revertSubCommand {
-				return fmt.Errorf("for the operator remediate sub-command, only %s and %s are supported. Refer to the examples above", annotateSubCommand, revertSubCommand)
+			if !isSupportedRemediateAction(args[0]) {
+				return fmt.Errorf("for the operator remediate sub-command, only %s are supported. Refer to the examples above", strings.Join(remediateActions, ", "))
 			}
 			return nil
 		},
@@ -65,9 +85,9 @@ func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorIn
 				return err
 			}
 
-			// annotate writes an audit trail; nudge (don't block) for a justification.
-			if remediationInfo.Action == annotateSubCommand && remediationInfo.Reason == "" {
-				logger.L().Warning("no --reason provided; annotate records an audit trail, consider adding --reason to justify the action")
+			// annotate and quarantine write an audit trail; nudge (don't block) for a justification.
+			if (remediationInfo.Action == annotateSubCommand || remediationInfo.Action == quarantineSubCommand) && remediationInfo.Reason == "" {
+				logger.L().Warning(fmt.Sprintf("no --reason provided; %s records an audit trail, consider adding --reason to justify the action", remediationInfo.Action))
 			}
 
 			operatorAdapter, err := core.NewOperatorAdapter(operatorInfo.OperatorScanInfo, operatorInfo.Namespace)

--- a/cmd/operator/remediate_test.go
+++ b/cmd/operator/remediate_test.go
@@ -20,10 +20,11 @@ func TestGetOperatorRemediateCmd(t *testing.T) {
 
 	// supported actions pass arg validation
 	assert.Nil(t, cmd.Args(&cobra.Command{}, []string{annotateSubCommand}))
+	assert.Nil(t, cmd.Args(&cobra.Command{}, []string{quarantineSubCommand}))
 	assert.Nil(t, cmd.Args(&cobra.Command{}, []string{revertSubCommand}))
 
 	// unknown action is rejected
-	err = cmd.Args(&cobra.Command{}, []string{"quarantine"})
+	err = cmd.Args(&cobra.Command{}, []string{"explode"})
 	assert.Error(t, err)
 
 	// exactly one action is required: extra positional args are rejected

--- a/core/cautils/operatorscaninfo.go
+++ b/core/cautils/operatorscaninfo.go
@@ -124,13 +124,13 @@ var remediationTargetKinds = map[string]bool{
 // OperatorAdapter transport (POST apis.Commands to v1/triggerAction) — a
 // remediation is a new verb on that pipeline, not a new endpoint.
 //
-// Phase 1 supports the lowest-blast-radius actions only: `annotate` and its
-// `revert`, on an explicit target. Findings-driven targeting (--control /
-// --min-severity) and the quarantine/cordon actions arrive in later phases.
+// Supported actions: `annotate` + `revert` (Phase 1) and `quarantine` (Phase 2),
+// all on an explicit target. Findings-driven targeting (--control /
+// --min-severity) and the `cordon` action arrive in later phases.
 type RemediationInfo struct {
-	// Action is the operation to perform: "annotate" or "revert".
+	// Action is the operation to perform: "annotate", "quarantine" or "revert".
 	Action string
-	// Target (explicit, Phase 1).
+	// Target (explicit).
 	Kind      string
 	Namespace string
 	Name      string
@@ -152,12 +152,12 @@ func (r *RemediationInfo) IsDryRun() bool {
 
 func (r *RemediationInfo) ValidatePayload(*apis.Commands) error {
 	switch apis.OperatorActionType(r.Action) {
-	case apis.OperatorActionAnnotate, apis.OperatorActionRevert:
-		// supported in Phase 1
-	case apis.OperatorActionQuarantine, apis.OperatorActionCordon:
-		return fmt.Errorf("remediation action %q is not supported yet (planned for a later phase); supported: annotate, revert", r.Action)
+	case apis.OperatorActionAnnotate, apis.OperatorActionQuarantine, apis.OperatorActionRevert:
+		// supported: annotate + revert (Phase 1), quarantine (Phase 2)
+	case apis.OperatorActionCordon:
+		return fmt.Errorf("remediation action %q is not supported yet (planned for a later phase); supported: annotate, quarantine, revert", r.Action)
 	default:
-		return fmt.Errorf("unknown remediation action %q (supported: annotate, revert)", r.Action)
+		return fmt.Errorf("unknown remediation action %q (supported: annotate, quarantine, revert)", r.Action)
 	}
 
 	if r.Kind == "" || r.Name == "" {

--- a/core/cautils/remediationinfo_test.go
+++ b/core/cautils/remediationinfo_test.go
@@ -25,9 +25,10 @@ func TestRemediationInfo_ValidatePayload(t *testing.T) {
 		wantErr bool
 	}{
 		{"valid annotate", RemediationInfo{Action: "annotate", Kind: "Deployment", Namespace: "payments", Name: "api"}, false},
+		{"valid quarantine", RemediationInfo{Action: "quarantine", Kind: "Deployment", Namespace: "payments", Name: "api"}, false},
 		{"valid revert", RemediationInfo{Action: "revert", Kind: "Pod", Namespace: "default", Name: "p"}, false},
 		{"unknown action", RemediationInfo{Action: "explode", Kind: "Deployment", Namespace: "ns", Name: "a"}, true},
-		{"later-phase action", RemediationInfo{Action: "quarantine", Kind: "Deployment", Namespace: "ns", Name: "a"}, true},
+		{"later-phase action", RemediationInfo{Action: "cordon", Kind: "Deployment", Namespace: "ns", Name: "a"}, true},
 		{"missing name", RemediationInfo{Action: "annotate", Kind: "Deployment", Namespace: "ns"}, true},
 		{"unsupported kind", RemediationInfo{Action: "annotate", Kind: "Service", Namespace: "ns", Name: "a"}, true},
 		{"missing namespace", RemediationInfo{Action: "annotate", Kind: "Deployment", Name: "a"}, true},
@@ -75,6 +76,37 @@ func TestRemediationInfo_GetRequestPayload(t *testing.T) {
 
 	// the wire verb is exactly "operatorAction" (the constant the operator switches on)
 	assert.Equal(t, "operatorAction", string(cmd.CommandName))
+
+	// --confirm produces an explicit dryRun=false the operator treats as apply
+	r.Confirm = true
+	args, err = apis.OperatorActionArgsFromMap(r.GetRequestPayload().Commands[0].Args)
+	require.NoError(t, err)
+	assert.False(t, args.IsDryRun())
+}
+
+func TestRemediationInfo_GetRequestPayload_Quarantine(t *testing.T) {
+	r := &RemediationInfo{
+		Action:     "quarantine",
+		Kind:       "Deployment",
+		Namespace:  "payments",
+		Name:       "api",
+		Reason:     "C-0016",
+		FindingRef: "workloadconfigurationscansummaries/payments/api",
+	}
+
+	args, err := apis.OperatorActionArgsFromMap(r.GetRequestPayload().Commands[0].Args)
+	require.NoError(t, err)
+	assert.Equal(t, apis.OperatorActionQuarantine, args.Action)
+	require.NotNil(t, args.Target)
+	assert.Equal(t, "Deployment", args.Target.Kind)
+	assert.Equal(t, "payments", args.Target.Namespace)
+	assert.Equal(t, "api", args.Target.Name)
+	assert.Equal(t, "C-0016", args.Reason)
+	// dry-run by default; only --confirm applies
+	assert.True(t, args.IsDryRun())
+	// the Phase-1 CLI never sends findings-driven selectors/ttl (operator rejects those)
+	assert.Nil(t, args.Selector)
+	assert.Empty(t, args.TTL)
 
 	// --confirm produces an explicit dryRun=false the operator treats as apply
 	r.Confirm = true


### PR DESCRIPTION
# operator: add `quarantine` action to the `remediate` CLI subcommand

**Related issue:** [kubescape/kubescape#1770 — Kubescape CLI control over cluster operations](https://github.com/kubescape/kubescape/issues/1770)
**Design:** [kubescape/designs-and-proposals#5 — Kubescape CLI Control over Cluster Operations](https://github.com/kubescape/designs-and-proposals/pull/5) (merged)
**Contract:** [armosec/armoapi-go#655 — `operatorAction` command contract](https://github.com/armosec/armoapi-go/pull/655) (merged, `v0.0.720`)
**Builds on:**
- [kubescape/kubescape#2448 — `operator remediate` CLI subcommand (annotate + dry-run)](https://github.com/kubescape/kubescape/pull/2448) (merged)
- [kubescape/operator#388 — `quarantine` action (deny-all NetworkPolicy)](https://github.com/kubescape/operator/pull/388) (merged)
- [kubescape/operator#383 — Phase 1 remediation (annotate + framework)](https://github.com/kubescape/operator/pull/383) (merged)
- [kubescape/helm-charts#855 — opt-in `capabilities.remediation` + gated RBAC](https://github.com/kubescape/helm-charts/pull/855) (merged)

## Overview

The operator can already execute the `quarantine` action end-to-end — [operator#388](https://github.com/kubescape/operator/pull/388)
merged the `QuarantineRemediator` (deny-all `NetworkPolicy` isolating a workload's
pods, dry-run by default, idempotent revert) into the extensible `Remediator`
framework from [operator#383](https://github.com/kubescape/operator/pull/383). But
there was **no way to trigger it from the CLI**: [kubescape#2448](https://github.com/kubescape/kubescape/pull/2448)
shipped `operator remediate` with only `annotate` and `revert`, explicitly
deferring `quarantine`/`cordon` to a later phase.

This PR closes that gap by exposing `quarantine` on the existing `remediate`
subcommand. It is a **thin CLI-surface change** — a remediation is a verb on the
existing `apis.Command` pipeline, so this adds no transport code and no new
dependency (`apis.OperatorActionQuarantine` already ships in the `armoapi-go
v0.0.720` contract the CLI is pinned to).

```bash
# Preview (dry-run) — creates nothing; the operator returns the plan
kubescape operator remediate quarantine --kind Deployment --target-namespace payments --name api --reason "C-0016"

# Apply — the deny-all NetworkPolicy is created (only --confirm performs a real write)
kubescape operator remediate quarantine --kind Deployment --target-namespace payments --name api --reason "C-0016" --confirm

# Revert — removes the annotation and/or NetworkPolicy on the target
kubescape operator remediate revert --kind Deployment --target-namespace payments --name api --confirm
```

## What changed

- **`core/cautils/operatorscaninfo.go`** — `RemediationInfo.ValidatePayload` now
  accepts `quarantine` alongside `annotate`/`revert`; only `cordon` remains
  fenced as a later phase. The payload builder (`GetRequestPayload`) already emits
  the action generically, so it needed no change — a quarantine serializes to
  `apis.Command{CommandName: TypeOperatorAction, Args: {action: "quarantine", …}}`.
- **`cmd/operator/remediate.go`** — added the `quarantine` positional action
  (validated via a small `remediateActions` set used for both arg-validation and
  error text), a worked example, an updated command summary, and extended the
  `--reason` audit nudge to cover `quarantine` (it records `reason`/`findingRef`
  on the `NetworkPolicy`, same as `annotate` does on the workload).
- **Tests** — `remediate_test.go` and `remediationinfo_test.go`: `quarantine`
  added to the accepted-actions and validation tables, a new
  `GetRequestPayload_Quarantine` round-trip test asserting the wire verb is
  `apis.OperatorActionQuarantine`, and the "later-phase" negative case repointed
  to `cordon`.

## Safe-by-default (unchanged)

Dry-run remains the default; `--confirm` is the **only** switch that performs a
real cluster write (`IsDryRun() == !Confirm`). The quarantine itself is
non-destructive per the design's [resolved open question #3](https://github.com/kubescape/designs-and-proposals/pull/5):
it isolates pods with a `NetworkPolicy` without mutating or recreating them, so
container state is preserved for forensic investigation.

Two safety facts worth noting:

- **RBAC is the hard gate.** With `capabilities.remediation: disable` (the
  default install), the operator cannot create `NetworkPolicy` objects, so a
  mistakenly-triggered quarantine fails closed with `Forbidden`, recorded on the
  `OperatorCommand` status — the CLI change grants no new powers by itself
  ([helm-charts#855](https://github.com/kubescape/helm-charts/pull/855)).
- **`revert` already covers quarantine.** The operator's `revertTarget` iterates
  `annotate`+`quarantine` idempotently, so the existing `revert` command removes
  the `NetworkPolicy` with no CLI change; the example text now says so.

## Not in scope (later phases, per the design)

- **Findings-driven targeting** (`--control` / `--min-severity`). The operator
  still rejects the findings selector (`"selector targeting is not supported yet
  (phase 2)"`), so this PR keeps explicit `--kind/--target-namespace/--name`
  targeting only; the selector needs a coordinated operator + CLI change.
- **`cordon`** — still stubbed in the operator; left fenced in the CLI so it
  errors clearly rather than sending a command the operator can't execute.

## Testing

- `go build ./cmd/operator/... ./core/cautils/...`, `go vet`, and
  `go test ./cmd/operator/... ./core/cautils/` all pass.
- Drove the built binary end-to-end: `--help` lists `quarantine`; unknown
  actions, extra positional args, missing `--target-namespace`, and unsupported
  kinds are all rejected with clear errors; a valid `quarantine` without
  `--reason` emits the audit nudge, passes client-side validation, and proceeds
  to the operator-connect stage. The wire payload round-trips to
  `apis.OperatorActionQuarantine`, which the merged operator executes.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **quarantine** remediation action across the operator CLI and remediation payload handling.
  * Updated remediation documentation/action matrix (Phase 1: **annotate**, **revert**; Phase 2: **quarantine**).

* **Bug Fixes**
  * Broadened missing-**reason** warnings to apply to both **annotate** and **quarantine**.
  * Improved CLI argument validation (supported actions listed; clearer errors for wrong counts/unsupported actions).

* **Tests**
  * Expanded CLI and payload validation coverage for supported actions.
  * Added tests for **quarantine** request generation and dry-run vs confirm behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->