### PR TITLE
Fix local control cache

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -197,7 +197,9 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedControl != nil {
 				f.Controls = append(f.Controls, *receivedControl)
-
+				if _, ok := policyHandler.getters.PolicyGetter.(*getter.LoadPolicy); ok {
+					continue // skip caching for local files
+				}
 				cache, err := getter.PolicyCachePath(policy.Identifier)
 				if err != nil {
 					logger.L().Ctx(ctx).Warning("skipping control cache write", helpers.String("identifier", policy.Identifier), helpers.Error(err))
@@ -209,7 +211,6 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 		}
 		frameworks = append(frameworks, f)
-		// TODO: add case for control from file
 	default:
 		return frameworks, fmt.Errorf("unknown policy kind")
 	}

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -158,6 +158,7 @@ func deepCopyPolicies(src []reporthandling.Framework) ([]reporthandling.Framewor
 
 func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier) ([]reporthandling.Framework, error) {
 	frameworks := []reporthandling.Framework{}
+	_, isLocalPolicy := policyHandler.getters.PolicyGetter.(*getter.LoadPolicy)
 
 	switch getScanKind(policyIdentifier) {
 	case apisv1.KindFramework: // Download frameworks
@@ -172,7 +173,7 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedFramework != nil {
 				frameworks = append(frameworks, *receivedFramework)
-				if _, ok := policyHandler.getters.PolicyGetter.(*getter.LoadPolicy); ok {
+				if isLocalPolicy {
 					continue // skip caching for local files
 				}
 				cache, err := getter.PolicyCachePath(rule.Identifier)
@@ -197,7 +198,7 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedControl != nil {
 				f.Controls = append(f.Controls, *receivedControl)
-				if _, ok := policyHandler.getters.PolicyGetter.(*getter.LoadPolicy); ok {
+				if isLocalPolicy {
 					continue // skip caching for local files
 				}
 				cache, err := getter.PolicyCachePath(policy.Identifier)

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -267,4 +267,3 @@ func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, files)
 }
-

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -242,7 +242,7 @@ func TestGetControlInputs(t *testing.T) {
 func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 	// Create a dummy control file
 	tempFile := filepath.Join(t.TempDir(), "control1.json")
-	err := os.WriteFile(tempFile, []byte(`{"controlID": "control1", "name": "mock-control"}`), 0644)
+	err := os.WriteFile(tempFile, []byte(`{"controlID": "control1", "name": "mock-control"}`), 0600)
 	assert.NoError(t, err)
 
 	lp := getter.NewLoadPolicy([]string{tempFile})

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -3,10 +3,13 @@ package policyhandler
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
@@ -235,3 +238,33 @@ func TestGetControlInputs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cachedControlInputs, controlInputs)
 }
+
+func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
+	// Create a dummy control file
+	tempFile := filepath.Join(t.TempDir(), "control1.json")
+	err := os.WriteFile(tempFile, []byte(`{"controlID": "control1", "name": "mock-control"}`), 0644)
+	assert.NoError(t, err)
+
+	lp := getter.NewLoadPolicy([]string{tempFile})
+
+	policyHandler := NewPolicyHandler("test-cluster-bypass")
+	policyHandler.getters = &cautils.Getters{
+		PolicyGetter: lp,
+	}
+	policyIdent := []cautils.PolicyIdentifier{{Identifier: "control1", Kind: "Control"}}
+
+	// Mock the local cache directory
+	cacheDir := t.TempDir()
+	originalLocalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = cacheDir
+	defer func() { getter.DefaultLocalStore = originalLocalStore }()
+
+	_, err = policyHandler.downloadScanPolicies(context.Background(), policyIdent)
+	assert.NoError(t, err)
+
+	// Verify that the cache dir is empty (cache bypassed)
+	files, err := os.ReadDir(cacheDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}
+


### PR DESCRIPTION
## Overview
Currently, when a user scans a specific control using a local file (via the `--use-from` flag), Kubescape improperly caches that local file into the global `~/.kubescape/` directory. This PR fixes the issue by explicitly bypassing the cache write when the `PolicyGetter` is a local `LoadPolicy`. This brings the `KindControl` handling exactly in line with how `KindFramework` is already handled in the same function.

## Additional Information
> This PR removes the technical debt comment `// TODO: add case for control from file` that was left in `core/pkg/policyhandler/handlepullpolicies.go`.

## How to Test
> 1. Create a dummy local control file: `echo '{"name": "mock-control", "controlID": "C-0012"}' > mock_c0012.json`
> 2. Ensure your global cache is clean of it: `rm -f ~/.kubescape/c-0012.json`
> 3. Run the scan: `kubescape scan control C-0012 --use-from mock_c0012.json`
> 4. Verify that the cache remains untouched: `cat ~/.kubescape/c-0012.json` (should report 'No such file or directory').

## Related issues/PRs:
* Resolved #2462

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local-file detection for pulled scan policies and controls, so policies/controls sourced from local files avoid unnecessary cache writes while still downloading/appending correctly (including framework and control paths).
  * Removed the outdated note about a missing “control from file” scenario.
* **Tests**
  * Added `TestDownloadScanPolicies_LocalCacheBypass` to ensure local-file downloads do not populate the cache directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->