### PR TITLE
fix(httphandler): add missing panic recovery to Metrics handler

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -34,6 +34,8 @@ type MetricsQueryParams struct {
 func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	scanID := uuid.NewString()
+	defer handler.recover(r.Context(), w, scanID)
+
 	handler.state.setBusy(scanID)
 	defer handler.state.setNotBusy(scanID)
 


### PR DESCRIPTION
## Summary

`Metrics()` was the only public handler in `httphandler/handlerequests/v1`
without `defer handler.recover(...)`. `Status()`, `Scan()`, and `Results()`
all have it. This adds it, matching the existing pattern exactly.

Fixes #2464

## Root cause

The shared `handler.recover` helper was introduced in commit `8309562d`
(May 2022) and retrofitted into `Scan()`/`Results()`. `Metrics()` already
existed at that point and was not included in that refactor — confirmed via
`git log --follow` on `prometheus.go` (30 commits, no reference to panic
handling anywhere in its history). No intentional exclusion found.

## What this does / does not cover

- **Covers:** panics inside `Metrics()`'s own handler code (query decode,
  file I/O, response writing).
- **Does not cover, and does not need to:** panics inside the scan engine
  itself (`scanImpl`). Those run in a separate goroutine (`watchForScan` ->
  `executeScan`) and are already caught there by #2352. `recover()` only
  catches panics on the goroutine where they occur, so the two fixes are
  independent and non-overlapping.

## Change

```diff
 	scanID := uuid.NewString()
+	defer handler.recover(r.Context(), w, scanID)
+
 	handler.state.setBusy(scanID)
 	defer handler.state.setNotBusy(scanID)
```
One file, one added line (+ blank line for readability). No other line
touched. No behavior change on any existing success or error path.

## Testing

- `gofmt -l`, `go build ./...`, `go vet ./...` clean.
- Full existing suite in `handlerequests/v1` passes unmodified
  (`go test ./handlerequests/v1/... -count=1 -v`).
- No new regression test added. I looked for a deterministic way to trigger
  a panic inside `Metrics()`'s own goroutine — `MetricsQueryParams` has no
  slice/map fields, so `gorilla/schema` has no known panic surface on it,
  and the only viable trigger point (`scanImpl`) runs in a different
  goroutine and would validate #2352's recovery, not this one. Adding a
  seam to force one felt like more surface area than a one-line defensive
  fix warrants — open to adding it if you'd rather see one, and open to
  direction on how you'd want it seamed.

## Risk

Low. Purely additive on the panic path; every existing response contract
is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics request handling so unexpected errors or panics are recovered more reliably, using the active request context and scan identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->