### PR TITLE
core: Add test coverage for Kubescape.Diff pretty-printer output path

### DIFF
--- a/core/core/diff_test.go
+++ b/core/core/diff_test.go
@@ -79,3 +79,27 @@ func TestDiff_ReturnsNewFailureCount(t *testing.T) {
 		assert.Equal(t, 0, count)
 	})
 }
+
+// TestDiff_PrettyFormatWritesOutput verifies the pretty-printer output path.
+func TestDiff_PrettyFormatWritesOutput(t *testing.T) {
+	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+	head := writeReport(t, `{
+		"results":[{"resourceID":"res1","controls":[
+			{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}}
+		]}],
+		"summaryDetails":{"controls":{"C-HIGH":{"scoreFactor":7.0}}}
+	}`)
+	ks := NewKubescape(context.Background())
+	out := filepath.Join(t.TempDir(), "pretty.out")
+	count, err := ks.Diff(&metav1.DiffInfo{
+		BaseFile: base,
+		HeadFile: head,
+		Format:   "pretty-printer",
+		Output:   out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "New failures")
+}


### PR DESCRIPTION
### Summary 
Closes: #2469 
Adds TestDiff_PrettyFormatWritesOutput to core/core/diff_test.go to exercise the non-JSON code path in Kubescape.Diff.

Existing tests only used Format: "json". This test uses Format: "pretty-printer" and asserts that:

Diff returns the expected new-failure count
Output is written to disk and includes the "New failures" section
### Test plan

 go test ./core/core/ -run TestDiff_PrettyFormatWritesOutput

 go test ./core/core/ -run TestDiff

### Test result
<img width="1405" height="195" alt="image" src="https://github.com/user-attachments/assets/e08971b6-63ab-48fe-bd16-19fd9839841c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for diff output in pretty format, including writing results to a file and verifying expected failure information appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->