### PR TITLE
test(core): cover Kubescape.Download unknown-target error path

### DIFF
--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Returns a list of all available download commands when 'DownloadSupportCommands' is called.
@@ -156,183 +157,13 @@ func TestSetPathAndFilename(t *testing.T) {
 	}
 }
 
-// ========================= Unstable tests =========================
-
-// func TestDownloadConfigInputs(t *testing.T) {
-// 	ctx := context.Background()
-// 	tests := []struct {
-// 		downloadInfo *metav1.DownloadInfo
-// 	}{
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "Test-Id",
-// 				AccessKey:  "Random-value",
-// 				Identifier: "Unique-Id",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.downloadInfo.Path, func(t *testing.T) {
-// 			err := downloadConfigInputs(ctx, tt.downloadInfo)
-// 			assert.NotNil(t, err)
-// 		})
-// 	}
-// }
-
-// func TestDownloadExceptions(t *testing.T) {
-// 	ctx := context.Background()
-// 	tests := []struct {
-// 		downloadInfo *metav1.DownloadInfo
-// 	}{
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "Test-Id",
-// 				AccessKey:  "Random-value",
-// 				Identifier: "Unique-Id",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.downloadInfo.Path, func(t *testing.T) {
-// 			err := downloadExceptions(ctx, tt.downloadInfo)
-// 			assert.NotNil(t, err)
-// 		})
-// 	}
-// }
-
-// func TestDownloadAttackTracks(t *testing.T) {
-// 	ctx := context.Background()
-// 	tests := []struct {
-// 		downloadInfo *metav1.DownloadInfo
-// 		isErrNil     bool
-// 	}{
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "00000000-0000-0000-0000-000000000000",
-// 				AccessKey:  "00000000-0000-0000-0000-000000000000",
-// 				Identifier: "id",
-// 				FileName:   "",
-// 				Target:     "temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "",
-// 				AccessKey:  "",
-// 				Identifier: "",
-// 				FileName:   "",
-// 				Target:     "temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.downloadInfo.Path, func(t *testing.T) {
-// 			err := downloadAttackTracks(ctx, tt.downloadInfo)
-// 			if tt.isErrNil {
-// 				assert.Nil(t, err)
-// 			} else {
-// 				assert.NotNil(t, err)
-// 				t.Error(err)
-// 			}
-// 		})
-// 	}
-// }
-
-// func TestDownloadFramework(t *testing.T) {
-// 	ctx := context.Background()
-// 	tests := []struct {
-// 		downloadInfo *metav1.DownloadInfo
-// 		isErrNil     bool
-// 	}{
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "Test-Id",
-// 				AccessKey:  "Random-value",
-// 				Identifier: "Id",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "",
-// 				AccessKey:  "",
-// 				Identifier: "",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.downloadInfo.Path, func(t *testing.T) {
-// 			err := downloadFramework(ctx, tt.downloadInfo)
-// 			if tt.isErrNil {
-// 				assert.Nil(t, err)
-// 			} else {
-
-// 				assert.NotNil(t, err)
-// 			}
-// 		})
-// 	}
-// }
-
-// func TestDownloadControl(t *testing.T) {
-// 	ctx := context.Background()
-// 	tests := []struct {
-// 		downloadInfo *metav1.DownloadInfo
-// 		isErrNil     bool
-// 	}{
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "Test-Id",
-// 				AccessKey:  "Random-value",
-// 				Identifier: "Id",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 		{
-// 			downloadInfo: &metav1.DownloadInfo{
-// 				AccountID:  "",
-// 				AccessKey:  "",
-// 				Identifier: "",
-// 				FileName:   "",
-// 				Target:     "Temp",
-// 				Path:       filepath.Join("path", "to"),
-// 			},
-// 			isErrNil: false,
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.downloadInfo.Path, func(t *testing.T) {
-// 			err := downloadControl(ctx, tt.downloadInfo)
-// 			if tt.isErrNil {
-// 				assert.Nil(t, err)
-// 			} else {
-
-// 				assert.NotNil(t, err)
-// 			}
-// 		})
-// 	}
-// }
+// TestDownload_UnknownTargetReturnsError verifies Kubescape.Download surfaces unknown targets.
+func TestDownload_UnknownTargetReturnsError(t *testing.T) {
+	ks := NewKubescape(context.Background())
+	err := ks.Download(&metav1.DownloadInfo{
+		Target: "unknown",
+		Path:   t.TempDir(),
+	})
+	require.Error(t, err)
+	assert.EqualError(t, err, "unknown command to download")
+}


### PR DESCRIPTION
### Summary

Closes: #2469

Adds TestDownload_UnknownTargetReturnsError to core/core/download_test.go to exercise the Kubescape.Download entry point.

Helper functions were already tested in isolation; this test covers the public method end-to-end with an unknown target, verifying:

Path setup and directory creation succeed
Unknown targets surface "unknown command to download"
This is a lightweight, offline test—no account credentials or backend access needed.

### Test plan

 go test ./core/core/ -run TestDownload_UnknownTargetReturnsError

 go test ./core/core/ -run TestDownload
 
 
<img width="1125" height="204" alt="image" src="https://github.com/user-attachments/assets/6a9772dd-4db3-4f8b-8833-f9a368a902b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for download handling when an unknown target is provided, ensuring an error is returned.
  * Removed outdated commented-out test content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->