### PR TITLE
feat(patch): add support for OCI and Local exports

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -107,6 +107,9 @@ func validateImagePatchInfo(patchInfo *metav1.PatchInfo) error {
 	}
 
 	if patchInfo.Push {
+		if patchInfo.OutputMode != "" && patchInfo.OutputMode != "docker" && patchInfo.OutputMode != "image" {
+			return fmt.Errorf("--push and --output-mode %q are mutually exclusive; --push always pushes to the registry (output-mode=image)", patchInfo.OutputMode)
+		}
 		patchInfo.OutputMode = "image"
 	}
 

--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -81,7 +81,9 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.BuildkitAddress, "address", "a", "unix:///run/buildkit/buildkitd.sock", "Address of buildkitd service, defaults to local buildkitd.sock")
 	patchCmd.PersistentFlags().DurationVar(&patchInfo.Timeout, "timeout", 5*time.Minute, "Timeout for the operation, defaults to '5m'")
 	patchCmd.PersistentFlags().BoolVar(&patchInfo.IgnoreError, "ignore-errors", false, "Ignore errors and continue patching other images. Default to false")
-	patchCmd.PersistentFlags().BoolVar(&patchInfo.Push, "push", false, "Push the patched image to the source registry. Default to false (the patched image is only loaded into the local image store)")
+	patchCmd.PersistentFlags().BoolVar(&patchInfo.Push, "push", false, "Push the patched image to the source registry. Default to false (the patched image is only loaded into the local image store). If set, this overrides output-mode to 'image'.")
+	patchCmd.PersistentFlags().StringVar(&patchInfo.OutputMode, "output-mode", "docker", "Output mode for the patched image (docker, image, oci, local)")
+	patchCmd.PersistentFlags().StringVar(&patchInfo.OutputPath, "output-path", "", "Destination path for oci or local output mode")
 
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.Username, "username", "u", "", "Username for registry login")
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "Password for registry login")
@@ -102,6 +104,19 @@ func validateImagePatchInfo(patchInfo *metav1.PatchInfo) error {
 
 	if patchInfo.Image == "" {
 		return errors.New("image tag is required")
+	}
+
+	if patchInfo.Push {
+		patchInfo.OutputMode = "image"
+	}
+
+	supportedModes := []string{"docker", "image", "oci", "local"}
+	if !slices.Contains(supportedModes, patchInfo.OutputMode) {
+		return fmt.Errorf("invalid output mode %q, supported modes: docker, image, oci, local", patchInfo.OutputMode)
+	}
+
+	if (patchInfo.OutputMode == "oci" || patchInfo.OutputMode == "local") && patchInfo.OutputPath == "" {
+		return fmt.Errorf("output-path is required when output-mode is %s", patchInfo.OutputMode)
 	}
 
 	// Convert image to canonical format (required by copacetic for patching images)

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -152,4 +152,3 @@ func Test_validateImagePatchInfo_OutputModeValidation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "image", patchInfoPush.OutputMode)
 }
-

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -122,3 +122,34 @@ func Test_validateImagePatchInfo_DigestOnlyReturnsError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "unexpected error while parsing image tag", err.Error())
 }
+
+func Test_validateImagePatchInfo_OutputModeValidation(t *testing.T) {
+	// Invalid output mode
+	patchInfoInvalid := &metav1.PatchInfo{
+		Image:      "nginx",
+		OutputMode: "invalid-mode",
+	}
+	err := validateImagePatchInfo(patchInfoInvalid)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output mode")
+
+	// Missing output-path for oci
+	patchInfoOciNoPath := &metav1.PatchInfo{
+		Image:      "nginx",
+		OutputMode: "oci",
+	}
+	err = validateImagePatchInfo(patchInfoOciNoPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "output-path is required when output-mode is oci")
+
+	// Push overrides to image
+	patchInfoPush := &metav1.PatchInfo{
+		Image:      "nginx",
+		OutputMode: "docker", // should be overridden
+		Push:       true,
+	}
+	err = validateImagePatchInfo(patchInfoPush)
+	assert.NoError(t, err)
+	assert.Equal(t, "image", patchInfoPush.OutputMode)
+}
+

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -142,7 +142,7 @@ func Test_validateImagePatchInfo_OutputModeValidation(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "output-path is required when output-mode is oci")
 
-	// Push overrides to image
+	// Push overrides to image when output-mode is default (docker)
 	patchInfoPush := &metav1.PatchInfo{
 		Image:      "nginx",
 		OutputMode: "docker", // should be overridden
@@ -151,4 +151,14 @@ func Test_validateImagePatchInfo_OutputModeValidation(t *testing.T) {
 	err = validateImagePatchInfo(patchInfoPush)
 	assert.NoError(t, err)
 	assert.Equal(t, "image", patchInfoPush.OutputMode)
+
+	// Push with explicit non-image output-mode should error
+	patchInfoPushConflict := &metav1.PatchInfo{
+		Image:      "nginx",
+		OutputMode: "oci",
+		Push:       true,
+	}
+	err = validateImagePatchInfo(patchInfoPushConflict)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -69,27 +69,30 @@ func Test_validateImagePatchInfo_Image(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-// TestPatchCmd_PushFlag verifies the --push flag exists, defaults to false, and
-// is wired into PatchInfo.Push when passed. Guards against accidental regression
-// of the default-no-push behavior added for issue #2185.
-func TestPatchCmd_PushFlag(t *testing.T) {
+// TestPatchCmd_OutputModeFlags verifies the --output-mode and --output-path flags exist, default correctly, and
+// are wired into PatchInfo. Guards against accidental regression of the output mode behavior.
+func TestPatchCmd_OutputModeFlags(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetPatchCmd(mockKubescape)
 
-	pushFlag := cmd.PersistentFlags().Lookup("push")
-	assert.NotNil(t, pushFlag, "--push flag must be registered")
-	assert.Equal(t, "false", pushFlag.DefValue, "--push must default to false (do not push by default)")
+	outputModeFlag := cmd.PersistentFlags().Lookup("output-mode")
+	assert.NotNil(t, outputModeFlag, "--output-mode flag must be registered")
+	assert.Equal(t, "docker", outputModeFlag.DefValue, "--output-mode must default to docker")
 
-	// Default value: parsing without --push leaves it false.
+	outputPathFlag := cmd.PersistentFlags().Lookup("output-path")
+	assert.NotNil(t, outputPathFlag, "--output-path flag must be registered")
+	assert.Equal(t, "", outputPathFlag.DefValue, "--output-path must default to empty")
+
+	// Default value: parsing without flags leaves output-mode as docker
 	require.NoError(t, cmd.PersistentFlags().Parse([]string{"--image", "nginx:1.23"}))
-	assert.False(t, pushFlag.Changed)
+	assert.False(t, outputModeFlag.Changed)
 
-	// Explicit --push sets the flag to true.
+	// Explicit --output-mode sets the flag
 	cmd2 := GetPatchCmd(mockKubescape)
-	require.NoError(t, cmd2.PersistentFlags().Parse([]string{"--image", "nginx:1.23", "--push"}))
-	pushFlag2 := cmd2.PersistentFlags().Lookup("push")
-	assert.True(t, pushFlag2.Changed)
-	assert.Equal(t, "true", pushFlag2.Value.String())
+	require.NoError(t, cmd2.PersistentFlags().Parse([]string{"--image", "nginx:1.23", "--output-mode", "image"}))
+	outputModeFlag2 := cmd2.PersistentFlags().Lookup("output-mode")
+	assert.True(t, outputModeFlag2.Changed)
+	assert.Equal(t, "image", outputModeFlag2.Value.String())
 }
 
 func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -63,7 +63,8 @@ func Test_validateImagePatchInfo_EmptyImage(t *testing.T) {
 
 func Test_validateImagePatchInfo_Image(t *testing.T) {
 	patchInfo := &metav1.PatchInfo{
-		Image: "testing",
+		Image:      "testing",
+		OutputMode: "docker",
 	}
 	err := validateImagePatchInfo(patchInfo)
 	assert.Nil(t, err)
@@ -97,7 +98,8 @@ func TestPatchCmd_OutputModeFlags(t *testing.T) {
 
 func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {
 	patchInfo := &metav1.PatchInfo{
-		Image: "nginx",
+		Image:      "nginx",
+		OutputMode: "docker",
 	}
 
 	err := validateImagePatchInfo(patchInfo)
@@ -111,7 +113,8 @@ func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {
 
 func Test_validateImagePatchInfo_DigestOnlyReturnsError(t *testing.T) {
 	patchInfo := &metav1.PatchInfo{
-		Image: "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Image:      "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		OutputMode: "docker",
 	}
 
 	err := validateImagePatchInfo(patchInfo)

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -108,17 +108,19 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 		disableCopaLogger()
 	}
 
-	if err = copaPatch(ks.Context(), patchInfo.Timeout, patchInfo.BuildkitAddress, patchInfo.Image, fileName, patchedImageName, "", patchInfo.IgnoreError, patchInfo.Push, patchInfo.BuildKitOpts); err != nil {
+	if err = copaPatch(ks.Context(), patchInfo.Timeout, patchInfo.BuildkitAddress, patchInfo.Image, fileName, patchedImageName, "", patchInfo.IgnoreError, patchInfo.OutputMode, patchInfo.OutputPath, patchInfo.BuildKitOpts); err != nil {
 		return false, err
 	}
 
 	// Restore the output streams
 	os.Stdout, os.Stderr = sout, serr
 
-	if patchInfo.Push {
+	if patchInfo.OutputMode == "image" {
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Pushed: %s", patchedImageName))
-	} else {
+	} else if patchInfo.OutputMode == "docker" {
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Loaded locally: %s", patchedImageName))
+	} else if patchInfo.OutputMode == "oci" || patchInfo.OutputMode == "local" {
+		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Exported to: %s", patchInfo.OutputPath))
 	}
 
 	// ===================== Re-scan the image =====================
@@ -172,13 +174,13 @@ func disableCopaLogger() {
 
 // copaPatch is a slightly modified copy of the Patch function from the original "project-copacetic/copacetic" repo
 // https://github.com/project-copacetic/copacetic/blob/main/pkg/patch/patch.go
-func copaPatch(ctx context.Context, timeout time.Duration, buildkitAddr, image, reportFile, patchedImageName, workingFolder string, ignoreError, push bool, bkOpts buildkit.Opts) error {
+func copaPatch(ctx context.Context, timeout time.Duration, buildkitAddr, image, reportFile, patchedImageName, workingFolder string, ignoreError bool, outputMode, outputPath string, bkOpts buildkit.Opts) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	ch := make(chan error, 1)
 	go func() {
-		ch <- patchWithContext(timeoutCtx, buildkitAddr, image, reportFile, patchedImageName, workingFolder, ignoreError, push, bkOpts)
+		ch <- patchWithContext(timeoutCtx, buildkitAddr, image, reportFile, patchedImageName, workingFolder, ignoreError, outputMode, outputPath, bkOpts)
 	}()
 
 	select {
@@ -194,7 +196,7 @@ func copaPatch(ctx context.Context, timeout time.Duration, buildkitAddr, image, 
 	}
 }
 
-func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patchedImageName, workingFolder string, ignoreError, push bool, bkOpts buildkit.Opts) error {
+func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patchedImageName, workingFolder string, ignoreError bool, outputMode, outputPath string, bkOpts buildkit.Opts) error {
 	// Ensure working folder exists for call to InstallUpdates
 	if workingFolder == "" {
 		var err error
@@ -232,7 +234,7 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 	cfg := authprovider.DockerAuthProviderConfig{AuthConfigProvider: authprovider.LoadAuthConfig(dockerConfig)}
 	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(cfg)}
 
-	exportEntry, pipeR, err := buildPatchExport(push, patchedImageName)
+	exportEntry, pipeR, err := buildPatchExport(outputMode, outputPath, patchedImageName)
 	if err != nil {
 		return err
 	}
@@ -289,7 +291,7 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 		}
 
 		// Export the patched image state to Docker
-		// TODO: Add support for other output modes as buildctl does.
+		// Add support for other output modes as buildctl does.
 		log.Infof("Patching %d vulnerabilities", len(updates.Updates))
 		patchedImageState, errPkgs, err := manager.InstallUpdates(ctx, updates, ignoreError)
 		log.Infof("Error is: %v", err)
@@ -381,8 +383,9 @@ var lookPath = exec.LookPath
 //
 // In the no-push branch the caller is expected to read the returned pipeR
 // concurrently (via dockerLoad). If push is true the pipeR is nil.
-func buildPatchExport(push bool, patchedImageName string) (client.ExportEntry, *io.PipeReader, error) {
-	if push {
+func buildPatchExport(outputMode, outputPath, patchedImageName string) (client.ExportEntry, *io.PipeReader, error) {
+	switch outputMode {
+	case "image":
 		return client.ExportEntry{
 			Type: client.ExporterImage,
 			Attrs: map[string]string{
@@ -390,20 +393,44 @@ func buildPatchExport(push bool, patchedImageName string) (client.ExportEntry, *
 				"push": "true",
 			},
 		}, nil, nil
+	case "oci":
+		if outputPath == "" {
+			return client.ExportEntry{}, nil, fmt.Errorf("output-path must be provided for oci export")
+		}
+		return client.ExportEntry{
+			Type: client.ExporterOCI,
+			Attrs: map[string]string{
+				"name": patchedImageName,
+			},
+			Output: func(_ map[string]string) (io.WriteCloser, error) {
+				return os.Create(outputPath)
+			},
+		}, nil, nil
+	case "local":
+		if outputPath == "" {
+			return client.ExportEntry{}, nil, fmt.Errorf("output-path must be provided for local export")
+		}
+		return client.ExportEntry{
+			Type:      client.ExporterLocal,
+			OutputDir: outputPath,
+		}, nil, nil
+	case "docker":
+		fallthrough
+	default:
+		if _, err := lookPath("docker"); err != nil {
+			return client.ExportEntry{}, nil, fmt.Errorf(
+				"docker CLI not found on PATH: required to load the patched image locally; "+
+					"pass --push to push to a registry instead: %w", err)
+		}
+		pipeR, pipeW := io.Pipe()
+		return client.ExportEntry{
+			Type:  client.ExporterDocker,
+			Attrs: map[string]string{"name": patchedImageName},
+			Output: func(_ map[string]string) (io.WriteCloser, error) {
+				return pipeW, nil
+			},
+		}, pipeR, nil
 	}
-	if _, err := lookPath("docker"); err != nil {
-		return client.ExportEntry{}, nil, fmt.Errorf(
-			"docker CLI not found on PATH: required to load the patched image locally; "+
-				"pass --push to push to a registry instead: %w", err)
-	}
-	pipeR, pipeW := io.Pipe()
-	return client.ExportEntry{
-		Type:  client.ExporterDocker,
-		Attrs: map[string]string{"name": patchedImageName},
-		Output: func(_ map[string]string) (io.WriteCloser, error) {
-			return pipeW, nil
-		},
-	}, pipeR, nil
 }
 
 // dockerLoad streams an OCI tarball from r into `docker load`. Used for the

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -126,13 +126,18 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 
 	// ===================== Re-scan the image =====================
 
-	logger.L().Start(fmt.Sprintf("Re-scanning image: %s", patchedImageName))
-
-	scanResultsPatched, err := svc.Scan(ks.Context(), patchedImageName, creds, nil, nil)
-	if err != nil {
-		return false, err
+	var scanResultsPatched *cautils.ImageScanData
+	if patchInfo.OutputMode == "image" || patchInfo.OutputMode == "docker" {
+		logger.L().Start(fmt.Sprintf("Re-scanning image: %s", patchedImageName))
+		scanResultsPatched, err = svc.Scan(ks.Context(), patchedImageName, creds, nil, nil)
+		if err != nil {
+			return false, err
+		}
+		logger.L().StopSuccess(fmt.Sprintf("Successfully re-scanned image: %s", patchedImageName))
+	} else {
+		logger.L().Warning("Re-scan not applicable for OCI/Local exports")
+		scanResultsPatched = &cautils.ImageScanData{}
 	}
-	logger.L().StopSuccess(fmt.Sprintf("Successfully re-scanned image: %s", patchedImageName))
 
 	// ===================== Clean up =====================
 	// Remove the scan results file, which was used to patch the image

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -124,26 +125,29 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Exported to: %s", patchInfo.OutputPath))
 	}
 
-	// ===================== Re-scan the image =====================
-
-	var scanResultsPatched *cautils.ImageScanData
-	if patchInfo.OutputMode == "image" || patchInfo.OutputMode == "docker" {
-		logger.L().Start(fmt.Sprintf("Re-scanning image: %s", patchedImageName))
-		scanResultsPatched, err = svc.Scan(ks.Context(), patchedImageName, creds, nil, nil)
-		if err != nil {
-			return false, err
-		}
-		logger.L().StopSuccess(fmt.Sprintf("Successfully re-scanned image: %s", patchedImageName))
-	} else {
-		logger.L().Warning("Re-scan not applicable for OCI/Local exports")
-		scanResultsPatched = &cautils.ImageScanData{}
-	}
-
 	// ===================== Clean up =====================
 	// Remove the scan results file, which was used to patch the image
 	if err := os.Remove(fileName); err != nil {
 		logger.L().Warning(fmt.Sprintf("failed to remove residual file: %v", fileName), helpers.Error(err))
 	}
+
+	// ===================== Early return for OCI/Local exports =====================
+	// Re-scan and vulnerability report are not applicable for these output modes.
+	// Skipping them avoids a nil-pointer panic in JSON/SARIF printers and prevents
+	// a misleading empty vulnerability report with default formatting.
+	if patchInfo.OutputMode == "oci" || patchInfo.OutputMode == "local" {
+		logger.L().Warning("Re-scan not applicable for OCI/Local exports; skipping vulnerability report")
+		return false, nil
+	}
+
+	// ===================== Re-scan the image =====================
+
+	logger.L().Start(fmt.Sprintf("Re-scanning image: %s", patchedImageName))
+	scanResultsPatched, err := svc.Scan(ks.Context(), patchedImageName, creds, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	logger.L().StopSuccess(fmt.Sprintf("Successfully re-scanned image: %s", patchedImageName))
 
 	// ===================== Results Handling =====================
 
@@ -296,8 +300,6 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 			}
 		}
 
-		// Export the patched image state to Docker
-		// Add support for other output modes as buildctl does.
 		log.Infof("Patching %d vulnerabilities", len(updates.Updates))
 		patchedImageState, errPkgs, err := manager.InstallUpdates(ctx, updates, ignoreError)
 		log.Infof("Error is: %v", err)
@@ -374,21 +376,18 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 // test host's PATH.
 var lookPath = exec.LookPath
 
-// buildPatchExport selects the buildkit export entry for the patched image.
+// buildPatchExport selects the buildkit export entry for the patched image
+// based on the requested outputMode:
 //
-// When push is true, the patched image is pushed directly to the source
-// registry via ExporterImage with the buildkit "push" attribute. When push
-// is false (the default), the image is streamed through `docker load` via
-// ExporterDocker so it lands in the user's docker image store — this is the
-// only path that holds the "loaded into the local image store" contract
-// regardless of whether dockerd is configured to share a containerd store
-// with buildkit; ExporterImage would otherwise land in buildkit's worker
-// namespace and be invisible to dockerd on the standalone `sudo buildkitd`
-// flow. See:
-// https://github.com/moby/buildkit?tab=readme-ov-file#containerd-image-store
-//
-// In the no-push branch the caller is expected to read the returned pipeR
-// concurrently (via dockerLoad). If push is true the pipeR is nil.
+//   - "image": pushes the patched image directly to the source registry via
+//     ExporterImage with the buildkit "push" attribute. pipeR is nil.
+//   - "oci": writes the patched image as an OCI tarball to outputPath via
+//     ExporterOCI. pipeR is nil.
+//   - "local": extracts the patched image filesystem to the directory at
+//     outputPath via ExporterLocal. pipeR is nil.
+//   - "docker" (default): streams the image through `docker load` via
+//     ExporterDocker so it lands in the user's docker image store. The caller
+//     is expected to read the returned pipeR concurrently (via dockerLoad).
 func buildPatchExport(outputMode, outputPath, patchedImageName string) (client.ExportEntry, *io.PipeReader, error) {
 	switch outputMode {
 	case "image":
@@ -409,6 +408,11 @@ func buildPatchExport(outputMode, outputPath, patchedImageName string) (client.E
 				"name": patchedImageName,
 			},
 			Output: func(_ map[string]string) (io.WriteCloser, error) {
+				if dir := filepath.Dir(outputPath); dir != "." {
+					if err := os.MkdirAll(dir, 0o755); err != nil {
+						return nil, fmt.Errorf("failed to create parent directory for output-path %q: %w", outputPath, err)
+					}
+				}
 				return os.Create(outputPath)
 			},
 		}, nil, nil

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -115,11 +115,12 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	// Restore the output streams
 	os.Stdout, os.Stderr = sout, serr
 
-	if patchInfo.OutputMode == "image" {
+	switch patchInfo.OutputMode {
+	case "image":
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Pushed: %s", patchedImageName))
-	} else if patchInfo.OutputMode == "docker" {
+	case "docker":
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Loaded locally: %s", patchedImageName))
-	} else if patchInfo.OutputMode == "oci" || patchInfo.OutputMode == "local" {
+	case "oci", "local":
 		logger.L().StopSuccess(fmt.Sprintf("Patched image successfully. Exported to: %s", patchInfo.OutputPath))
 	}
 

--- a/core/core/patch_test.go
+++ b/core/core/patch_test.go
@@ -71,7 +71,7 @@ func TestBuildPatchedImageName(t *testing.T) {
 // ExporterImage with the buildkit "push" attribute set. Without that attr
 // nothing reaches the source registry.
 func TestBuildPatchExport_PushTrue(t *testing.T) {
-	entry, pipeR, err := buildPatchExport(true, "docker.io/library/nginx:1.23-patched")
+	entry, pipeR, err := buildPatchExport("image", "", "docker.io/library/nginx:1.23-patched")
 
 	require.NoError(t, err)
 	assert.Nil(t, pipeR, "pipe reader must be unused in push mode")
@@ -96,7 +96,7 @@ func TestBuildPatchExport_PushFalse(t *testing.T) {
 	}
 	t.Cleanup(func() { lookPath = origLookPath })
 
-	entry, pipeR, err := buildPatchExport(false, "docker.io/library/nginx:1.23-patched")
+	entry, pipeR, err := buildPatchExport("docker", "", "docker.io/library/nginx:1.23-patched")
 
 	require.NoError(t, err)
 	require.NotNil(t, pipeR, "no-push path must hand back a pipe reader for docker load")
@@ -124,7 +124,7 @@ func TestBuildPatchExport_PushFalseDockerMissing(t *testing.T) {
 	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
 	t.Cleanup(func() { lookPath = origLookPath })
 
-	_, _, err := buildPatchExport(false, "nginx:1.23-patched")
+	_, _, err := buildPatchExport("docker", "", "nginx:1.23-patched")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "docker CLI",

--- a/core/meta/datastructures/v1/patch.go
+++ b/core/meta/datastructures/v1/patch.go
@@ -13,6 +13,8 @@ type PatchInfo struct {
 	Timeout         time.Duration // timeout for patching an image
 	IgnoreError     bool          // ignore errors and continue patching
 	Push            bool          // push the patched image to the registry (default: false)
+	OutputMode      string        // output mode for patched image (docker, image, oci, local)
+	OutputPath      string        // destination path for oci or local export
 	BuildKitOpts    buildkit.Opts //build kit options
 
 	// Image registry credentials


### PR DESCRIPTION
## Overview
Currently, the `kubescape patch` command only supports pushing the patched image directly to a remote registry (using the legacy `--push` flag). 

This PR exposes BuildKit's native Exporter capabilities through the CLI to allow outputting patched images locally. It introduces two new flags to the `patch` command: `--output-mode` and `--output-path`.
- `--output-mode oci`: Exports the patched image as a raw OCI tarball to `--output-path`.
- `--output-mode local`: Extracts the patched image's filesystem directly to a local directory at `--output-path`.
- `--output-mode image` (or retaining the `--push` flag): Keeps the original behavior of pushing the image to a remote registry.

## Additional Information
> This significantly improves the patch workflow for CI/CD pipelines and air-gapped environments where direct registry access isn't available or where users want to archive the OCI tarball as a build artifact.

## How to Test
> 1. Build the binary locally: `go build -o kubescape .`
> 2. Run an OCI export test: `./kubescape patch --image docker.io/library/nginx:1.23 --output-mode oci --output-path /tmp/nginx-patched.tar`
> 3. Verify the `/tmp/nginx-patched.tar` file is successfully created on your filesystem.

## Related issues/PRs:
* Resolved #2470 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable patched-image output controls via `--output-mode` and `--output-path` for docker streaming, `image`, OCI, and local exports.
  * Patch now reports success messaging based on the selected output mode.

* **Bug Fixes**
  * Improved validation for compatible output settings, including requiring `--output-path` for OCI and local modes.
  * When pushing, output behavior is aligned to `image` mode to ensure consistent results.

* **Tests**
  * Updated and added CLI and exporter-related tests to cover the new output-mode/path handling and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->