### PR TITLE
feat(anonymizer): support reversible container metadata transformation

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -124,10 +124,11 @@ func GetDecryptCommand() *cobra.Command {
 								err,
 							)
 						}
-						if err := reportcrypto.DecryptResourceMetadata(
-							resource,
-							dek,
-						); err != nil {
+						if err := reportcrypto.DecryptResourceMetadata(resource, dek); err != nil {
+							return err
+						}
+
+						if err := reportcrypto.DecryptContainerMetadata(resource, dek); err != nil {
 							return err
 						}
 						newID := resource.GetID()

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -64,6 +64,69 @@ func TestDecryptCommand(t *testing.T) {
 				)
 			require.NoError(t, err)
 
+			encryptedContainerName, err :=
+				reportcrypto.EncryptString(
+					"api",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedImage, err :=
+				reportcrypto.EncryptString(
+					"nginx:latest",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedEnvValue, err :=
+				reportcrypto.EncryptString(
+					"super-secret-password",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedSecretRef, err :=
+				reportcrypto.EncryptString(
+					"payment-secret",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedConfigMapRef, err :=
+				reportcrypto.EncryptString(
+					"payment-config",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedEnvFromSecret, err :=
+				reportcrypto.EncryptString(
+					"application-secret",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedEnvFromConfigMap, err :=
+				reportcrypto.EncryptString(
+					"application-config",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedImagePullSecret, err :=
+				reportcrypto.EncryptString(
+					"registry-secret",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedServiceAccount, err :=
+				reportcrypto.EncryptString(
+					"payment-service-account",
+					dek,
+				)
+			require.NoError(t, err)
+
 			wrappedDEK, err :=
 				reportcrypto.WrapDEK(
 					dek,
@@ -88,6 +151,54 @@ func TestDecryptCommand(t *testing.T) {
 							"metadata": map[string]any{
 								"name":      encryptedName,
 								"namespace": encryptedNamespace,
+							},
+							"spec": map[string]any{
+								"serviceAccountName": encryptedServiceAccount,
+								"imagePullSecrets": []any{
+									map[string]any{
+										"name": encryptedImagePullSecret,
+									},
+								},
+								"containers": []any{
+									map[string]any{
+										"name":  encryptedContainerName,
+										"image": encryptedImage,
+										"env": []any{
+											map[string]any{
+												"name":  "DB_PASSWORD",
+												"value": encryptedEnvValue,
+											},
+											map[string]any{
+												"name": "SECRET_TOKEN",
+												"valueFrom": map[string]any{
+													"secretKeyRef": map[string]any{
+														"name": encryptedSecretRef,
+													},
+												},
+											},
+											map[string]any{
+												"name": "CONFIG_PATH",
+												"valueFrom": map[string]any{
+													"configMapKeyRef": map[string]any{
+														"name": encryptedConfigMapRef,
+													},
+												},
+											},
+										},
+										"envFrom": []any{
+											map[string]any{
+												"secretRef": map[string]any{
+													"name": encryptedEnvFromSecret,
+												},
+											},
+											map[string]any{
+												"configMapRef": map[string]any{
+													"name": encryptedEnvFromConfigMap,
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						"source": map[string]any{
@@ -257,6 +368,65 @@ func TestDecryptCommand(t *testing.T) {
 
 			assert.Equal(t, "nginx-deployment", metadataObj["name"])
 			assert.Equal(t, "production", metadataObj["namespace"])
+
+			spec, ok := object["spec"].(map[string]any)
+			require.True(t, ok)
+
+			assert.Equal(t, "payment-service-account", spec["serviceAccountName"])
+
+			pullSecrets := spec["imagePullSecrets"].([]any)
+			require.Len(t, pullSecrets, 1)
+
+			pullSecret := pullSecrets[0].(map[string]any)
+
+			assert.Equal(t, "registry-secret", pullSecret["name"])
+
+			containers := spec["containers"].([]any)
+			require.Len(t, containers, 1)
+
+			container := containers[0].(map[string]any)
+
+			assert.Equal(t, "api", container["name"])
+
+			assert.Equal(t, "nginx:latest", container["image"])
+
+			env := container["env"].([]any)
+			require.Len(t, env, 3)
+
+			db := env[0].(map[string]any)
+
+			assert.Equal(t, "super-secret-password", db["value"])
+
+			secret := env[1].(map[string]any)
+
+			valueFrom := secret["valueFrom"].(map[string]any)
+
+			secretKey := valueFrom["secretKeyRef"].(map[string]any)
+
+			assert.Equal(t, "payment-secret", secretKey["name"])
+
+			config := env[2].(map[string]any)
+
+			valueFrom = config["valueFrom"].(map[string]any)
+
+			configMap := valueFrom["configMapKeyRef"].(map[string]any)
+
+			assert.Equal(t, "payment-config", configMap["name"])
+
+			envFrom := container["envFrom"].([]any)
+			require.Len(t, envFrom, 2)
+
+			secretRef := envFrom[0].(map[string]any)
+
+			secretObj := secretRef["secretRef"].(map[string]any)
+
+			assert.Equal(t, "application-secret", secretObj["name"])
+
+			configRef := envFrom[1].(map[string]any)
+
+			configObj := configRef["configMapRef"].(map[string]any)
+
+			assert.Equal(t, "application-config", configObj["name"])
 
 			source, ok := resource["source"].(map[string]any)
 			require.True(t, ok, "source should be an object")

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -80,11 +80,10 @@ func TestDecryptCommand(t *testing.T) {
 
 			encryptedEnvValue, err :=
 				reportcrypto.EncryptString(
-					"super-secret-password",
+					"postgres://user:s3cret@db:5432/app",
 					dek,
 				)
 			require.NoError(t, err)
-
 			encryptedSecretRef, err :=
 				reportcrypto.EncryptString(
 					"payment-secret",
@@ -165,7 +164,7 @@ func TestDecryptCommand(t *testing.T) {
 										"image": encryptedImage,
 										"env": []any{
 											map[string]any{
-												"name":  "DB_PASSWORD",
+												"name":  "DATABASE_CONN",
 												"value": encryptedEnvValue,
 											},
 											map[string]any{
@@ -395,7 +394,7 @@ func TestDecryptCommand(t *testing.T) {
 
 			db := env[0].(map[string]any)
 
-			assert.Equal(t, "super-secret-password", db["value"])
+			assert.Equal(t, "postgres://user:s3cret@db:5432/app", db["value"])
 
 			secret := env[1].(map[string]any)
 

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -7,88 +7,175 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func anonymizeContainerMetadata(resource workloadinterface.IMetadata, mapping *Mapping) {
+func transformContainerMetadata(resource workloadinterface.IMetadata, transformer Transformer) error {
+
 	if resource == nil {
-		return
+		return nil
 	}
 
 	obj := resource.GetObject()
 	if obj == nil {
-		return
+		return nil
 	}
 
-	anonymizePodSpecs(obj, mapping)
+	if err := transformPodSpecs(obj, transformer); err != nil {
+		return err
+	}
+
 	resource.SetObject(obj)
+
+	return nil
 }
 
-// anonymizePodSpecs recursively traverses workload objects looking for pod-spec
-// shaped sections where container-related metadata may exist.
+// transformPodSpecs recursively traverses workload objects looking for
+// pod-spec-shaped sections where sensitive container metadata may exist.
 //
 // Kubernetes resources may reach this layer as either typed objects converted
-// into generic maps or as fully unstructured manifests depending on the scan source,
-// so traversal stays representation-agnostic and delegates shape-specific handling
-// to dedicated helpers.
-func anonymizePodSpecs(node any, mapping *Mapping) {
+// into generic maps or as fully unstructured manifests depending on the scan
+// source, so traversal stays representation-agnostic and delegates
+// shape-specific transformations to dedicated helpers.
+func transformPodSpecs(node any, transformer Transformer) error {
+
 	switch v := node.(type) {
 	case map[string]any:
-		anonymizeContainerList(v, "containers", mapping)
-		anonymizeContainerList(v, "initContainers", mapping)
-		anonymizeEphemeralContainerList(v, "ephemeralContainers", mapping)
-		anonymizeImagePullSecrets(v, mapping)
-		anonymizeServiceAccountName(v, mapping)
+		if err := transformContainerList(
+			v,
+			"containers",
+			transformer,
+		); err != nil {
+			return err
+		}
+
+		if err := transformContainerList(
+			v,
+			"initContainers",
+			transformer,
+		); err != nil {
+			return err
+		}
+
+		if err := transformEphemeralContainerList(
+			v,
+			"ephemeralContainers",
+			transformer,
+		); err != nil {
+			return err
+		}
+
+		if err := transformImagePullSecrets(
+			v,
+			transformer,
+		); err != nil {
+			return err
+		}
+
+		if err := transformServiceAccountName(
+			v,
+			transformer,
+		); err != nil {
+			return err
+		}
 
 		for _, child := range v {
-			anonymizePodSpecs(child, mapping)
+			if err := transformPodSpecs(
+				child,
+				transformer,
+			); err != nil {
+				return err
+			}
 		}
 
 	case []any:
 		for _, item := range v {
-			anonymizePodSpecs(item, mapping)
+			if err := transformPodSpecs(
+				item,
+				transformer,
+			); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
-// anonymizeContainerFields handles unstructured container objects represented
-// as map[string]interface{}.
-func anonymizeContainerFields(container map[string]any, mapping *Mapping) {
+// transformContainerFields applies the supplied Transformer to sensitive
+// fields within an unstructured container represented as a
+// map[string]any.
+//
+// This helper preserves the existing traversal behavior while allowing
+// callers to choose between deterministic pseudonymization
+// (MappingTransformer) and (EncryptionTransformer) provided with a Transformer abstraction above .
+func transformContainerFields(container map[string]any, transformer Transformer) error {
+
+	var err error
+
 	if name, ok := container["name"].(string); ok && name != "" {
-		container["name"] = mapping.GetOrCreate("ctr", name)
+		name, err = transformValue(transformer, "ctr", name)
+		if err != nil {
+			return err
+		}
+
+		container["name"] = name
 	}
 
 	if image, ok := container["image"].(string); ok && image != "" {
-		container["image"] = mapping.GetOrCreate("img", image)
+		image, err = transformValue(transformer, "img", image)
+		if err != nil {
+			return err
+		}
+
+		container["image"] = image
 	}
 
-	anonymizeUnstructuredEnv(container, mapping)
-	anonymizeUnstructuredEnvFrom(container, mapping)
+	if err := transformUnstructuredEnv(container, transformer); err != nil {
+		return err
+	}
+
+	if err := transformUnstructuredEnvFrom(container, transformer); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func anonymizeContainerList(
-	obj map[string]any,
-	key string,
-	mapping *Mapping,
-) {
+func transformContainerList(obj map[string]any, key string, transformer Transformer) error {
+
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
-		return
+		return nil
 	}
+
+	var err error
 
 	if containers, ok := rawContainers.([]corev1.Container); ok {
 		for i := range containers {
+
 			if containers[i].Name != "" {
-				containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+				containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
+				if err != nil {
+					return err
+				}
 			}
 
 			if containers[i].Image != "" {
-				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+				containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
+				if err != nil {
+					return err
+				}
 			}
 
-			anonymizeTypedEnv(containers[i].Env, mapping)
-			anonymizeTypedEnvFrom(containers[i].EnvFrom, mapping)
+			if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+				return err
+			}
+
+			if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
+				return err
+			}
 		}
 
 		obj[key] = containers
-		return
+		return nil
 	}
 
 	if containers, ok := rawContainers.([]any); ok {
@@ -98,39 +185,61 @@ func anonymizeContainerList(
 				continue
 			}
 
-			anonymizeContainerFields(container, mapping)
+			if err := transformContainerFields(container, transformer); err != nil {
+				return err
+			}
 		}
 
 		obj[key] = containers
 	}
+
+	return nil
 }
 
-func anonymizeEphemeralContainerList(
-	obj map[string]any,
-	key string,
-	mapping *Mapping,
-) {
+// transformEphemeralContainerList applies the supplied Transformer to
+// ephemeral container metadata across both typed and unstructured
+// workload representations.
+//
+// Container identifiers, image references, environment variables, and
+// referenced Kubernetes resources are transformed while preserving the
+// original workload structure.
+func transformEphemeralContainerList(obj map[string]any, key string, transformer Transformer) error {
+
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
-		return
+		return nil
 	}
+
+	var err error
 
 	if containers, ok := rawContainers.([]corev1.EphemeralContainer); ok {
 		for i := range containers {
+
 			if containers[i].Name != "" {
-				containers[i].Name = mapping.GetOrCreate("ctr", containers[i].Name)
+				containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
+				if err != nil {
+					return err
+				}
 			}
 
 			if containers[i].Image != "" {
-				containers[i].Image = mapping.GetOrCreate("img", containers[i].Image)
+				containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
+				if err != nil {
+					return err
+				}
 			}
 
-			anonymizeTypedEnv(containers[i].Env, mapping)
-			anonymizeTypedEnvFrom(containers[i].EnvFrom, mapping)
+			if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+				return err
+			}
+
+			if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
+				return err
+			}
 		}
 
 		obj[key] = containers
-		return
+		return nil
 	}
 
 	if containers, ok := rawContainers.([]any); ok {
@@ -140,22 +249,41 @@ func anonymizeEphemeralContainerList(
 				continue
 			}
 
-			anonymizeContainerFields(container, mapping)
+			if err := transformContainerFields(container, transformer); err != nil {
+				return err
+			}
 		}
 
 		obj[key] = containers
 	}
+
+	return nil
 }
 
-// anonymizeTypedEnv anonymizes literal env values and resource references
-// inside typed EnvVar definitions.
-func anonymizeTypedEnv(envVars []corev1.EnvVar, mapping *Mapping) {
+// transformTypedEnv applies the supplied Transformer to sensitive
+// environment variable values and referenced Kubernetes resources.
+//
+// Literal environment values are transformed only when they appear
+// sensitive, while Secret and ConfigMap references are always
+// transformed when present.
+func transformTypedEnv(envVars []corev1.EnvVar, transformer Transformer) error {
+	var err error
+
 	for i := range envVars {
 		envVar := &envVars[i]
 
 		if envVar.Value != "" &&
-			(isSensitiveEnvName(envVar.Name) || isSensitiveEnvValue(envVar.Value)) {
-			envVar.Value = mapping.GetOrCreate("env", envVar.Value)
+			(isSensitiveEnvName(envVar.Name) ||
+				isSensitiveEnvValue(envVar.Value)) {
+
+			envVar.Value, err = transformValue(
+				transformer,
+				"env",
+				envVar.Value,
+			)
+			if err != nil {
+				return err
+			}
 		}
 
 		if envVar.ValueFrom == nil {
@@ -164,27 +292,46 @@ func anonymizeTypedEnv(envVars []corev1.EnvVar, mapping *Mapping) {
 
 		if secretRef := envVar.ValueFrom.SecretKeyRef; secretRef != nil &&
 			secretRef.Name != "" {
-			secretRef.Name = mapping.GetOrCreate("ref", secretRef.Name)
+
+			secretRef.Name, err = transformValue(transformer, "ref", secretRef.Name)
+			if err != nil {
+				return err
+			}
 		}
 
 		if configMapRef := envVar.ValueFrom.ConfigMapKeyRef; configMapRef != nil &&
 			configMapRef.Name != "" {
-			configMapRef.Name = mapping.GetOrCreate("ref", configMapRef.Name)
+
+			configMapRef.Name, err = transformValue(transformer, "ref", configMapRef.Name)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
-// anonymizeUnstructuredEnv handles env entries in generic manifest maps.
-func anonymizeUnstructuredEnv(container map[string]any, mapping *Mapping) {
+// transformUnstructuredEnv applies the supplied Transformer to sensitive
+// environment variable values and referenced Kubernetes resources within
+// unstructured container definitions.
+// Literal environment values are transformed only when they appear
+// sensitive, while SecretKeyRef and ConfigMapKeyRef references are
+// transformed whenever present.
+
+func transformUnstructuredEnv(container map[string]any, transformer Transformer) error {
+
 	rawEnv, exists := container["env"]
 	if !exists || rawEnv == nil {
-		return
+		return nil
 	}
 
 	envVars, ok := rawEnv.([]any)
 	if !ok {
-		return
+		return nil
 	}
+
+	var err error
 
 	for _, item := range envVars {
 		envVar, ok := item.(map[string]any)
@@ -196,8 +343,15 @@ func anonymizeUnstructuredEnv(container map[string]any, mapping *Mapping) {
 
 		if value, ok := envVar["value"].(string); ok &&
 			value != "" &&
-			(isSensitiveEnvName(name) || isSensitiveEnvValue(value)) {
-			envVar["value"] = mapping.GetOrCreate("env", value)
+			(isSensitiveEnvName(name) ||
+				isSensitiveEnvValue(value)) {
+
+			value, err = transformValue(transformer, "env", value)
+			if err != nil {
+				return err
+			}
+
+			envVar["value"] = value
 		}
 
 		rawValueFrom, exists := envVar["valueFrom"]
@@ -210,37 +364,57 @@ func anonymizeUnstructuredEnv(container map[string]any, mapping *Mapping) {
 			continue
 		}
 
-		anonymizeUnstructuredReference(valueFrom, "secretKeyRef", mapping)
-		anonymizeUnstructuredReference(valueFrom, "configMapKeyRef", mapping)
+		if err := transformUnstructuredReference(valueFrom, "secretKeyRef", transformer); err != nil {
+			return err
+		}
+
+		if err := transformUnstructuredReference(valueFrom, "configMapKeyRef", transformer); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-// anonymizeTypedEnvFrom anonymizes typed envFrom resource references.
-func anonymizeTypedEnvFrom(envFrom []corev1.EnvFromSource, mapping *Mapping) {
+// transformTypedEnvFrom applies the supplied Transformer to resource
+// references contained in typed EnvFromSource definitions.
+//
+// Secret and ConfigMap references are transformed when present while
+// preserving the original workload structure.
+func transformTypedEnvFrom(envFrom []corev1.EnvFromSource, transformer Transformer) error {
+	var err error
+
 	for i := range envFrom {
 		source := &envFrom[i]
 
 		if source.SecretRef != nil && source.SecretRef.Name != "" {
-			source.SecretRef.Name = mapping.GetOrCreate(
-				"ref",
-				source.SecretRef.Name,
-			)
+			source.SecretRef.Name, err = transformValue(transformer, "ref", source.SecretRef.Name)
+			if err != nil {
+				return err
+			}
 		}
 
 		if source.ConfigMapRef != nil && source.ConfigMapRef.Name != "" {
-			source.ConfigMapRef.Name = mapping.GetOrCreate(
-				"ref",
-				source.ConfigMapRef.Name,
-			)
+			source.ConfigMapRef.Name, err = transformValue(transformer, "ref", source.ConfigMapRef.Name)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
-// anonymizeUnstructuredEnvFrom handles envFrom entries in generic manifest maps.
-func anonymizeUnstructuredEnvFrom(container map[string]any, mapping *Mapping) {
+// transformUnstructuredEnvFrom applies the supplied Transformer to
+// resource references contained in unstructured envFrom definitions.
+//
+// Secret and ConfigMap references are transformed while preserving the
+// original workload structure.
+func transformUnstructuredEnvFrom(container map[string]any, transformer Transformer) error {
+
 	rawEnvFrom, ok := container["envFrom"].([]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	for _, item := range rawEnvFrom {
@@ -249,27 +423,41 @@ func anonymizeUnstructuredEnvFrom(container map[string]any, mapping *Mapping) {
 			continue
 		}
 
-		anonymizeUnstructuredReference(envFrom, "secretRef", mapping)
-		anonymizeUnstructuredReference(envFrom, "configMapRef", mapping)
+		if err := transformUnstructuredReference(envFrom, "secretRef", transformer); err != nil {
+			return err
+		}
+
+		if err := transformUnstructuredReference(envFrom, "configMapRef", transformer); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func anonymizeUnstructuredReference(
-	obj map[string]any,
-	key string,
-	mapping *Mapping,
-) {
+// transformUnstructuredReference applies the supplied Transformer to the
+// name field of an unstructured Kubernetes object reference.
+//
+// References that do not contain a name are left unchanged.
+func transformUnstructuredReference(obj map[string]any, key string, transformer Transformer) error {
 	ref, ok := obj[key].(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	name, ok := ref["name"].(string)
 	if !ok || name == "" {
-		return
+		return nil
 	}
 
-	ref["name"] = mapping.GetOrCreate("ref", name)
+	transformedName, err := transformValue(transformer, "ref", name)
+	if err != nil {
+		return err
+	}
+
+	ref["name"] = transformedName
+
+	return nil
 }
 
 // isSensitiveEnvValue reports whether an env var value looks like a secret.
@@ -333,25 +521,37 @@ func isSensitiveEnvName(name string) bool {
 	return false
 }
 
-func anonymizeImagePullSecrets(
-	obj map[string]any,
-	mapping *Mapping,
-) {
+// transformImagePullSecrets applies the supplied Transformer to pod image
+// pull secret references across both typed and unstructured workload
+// representations.
+// Image pull secret names are transformed while preserving the original
+// workload structure.
+func transformImagePullSecrets(obj map[string]any, transformer Transformer) error {
+
 	rawRefs, ok := obj["imagePullSecrets"]
 	if !ok || rawRefs == nil {
-		return
+		return nil
 	}
+
+	var err error
 
 	// Typed Kubernetes objects (manifest decoding path)
 	if refs, ok := rawRefs.([]corev1.LocalObjectReference); ok {
 		for i := range refs {
 			if refs[i].Name != "" {
-				refs[i].Name = mapping.GetOrCreate("ref", refs[i].Name)
+				refs[i].Name, err = transformValue(
+					transformer,
+					"ref",
+					refs[i].Name,
+				)
+				if err != nil {
+					return err
+				}
 			}
 		}
 
 		obj["imagePullSecrets"] = refs
-		return
+		return nil
 	}
 
 	// Unstructured objects (runtime / normalized object path)
@@ -367,19 +567,34 @@ func anonymizeImagePullSecrets(
 				continue
 			}
 
-			ref["name"] = mapping.GetOrCreate("ref", name)
+			name, err = transformValue(
+				transformer,
+				"ref",
+				name,
+			)
+			if err != nil {
+				return err
+			}
+
+			ref["name"] = name
 		}
 
 		obj["imagePullSecrets"] = refs
 	}
+
+	return nil
 }
 
-// anonymizeServiceAccountName anonymizes pod-level service account references
-// across both typed and unstructured workload representations.
-func anonymizeServiceAccountName(
-	obj map[string]any,
-	mapping *Mapping,
-) {
+// transformServiceAccountName applies the supplied Transformer to pod-level
+// service account references across both typed and unstructured workload
+// representations.
+//
+// Service account names are transformed while preserving the workload
+// structure.
+func transformServiceAccountName(obj map[string]any, transformer Transformer) error {
+
+	var err error
+
 	for _, key := range []string{
 		"serviceAccountName",
 		"serviceAccount",
@@ -394,6 +609,13 @@ func anonymizeServiceAccountName(
 			continue
 		}
 
-		obj[key] = mapping.GetOrCreate("sa", name)
+		name, err = transformValue(transformer, "sa", name)
+		if err != nil {
+			return err
+		}
+
+		obj[key] = name
 	}
+
+	return nil
 }

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -7,6 +7,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// TransformContainerMetadata applies the supplied Transformer to
+// sensitive container-related metadata contained within a workload.
+//
+// The traversal logic is shared across all transformation modes,
+// allowing callers to perform deterministic pseudonymization,
+// reversible encryption, or decryption using different Transformer
+// implementations.
+
 func transformContainerMetadata(resource workloadinterface.IMetadata, transformer Transformer) error {
 
 	if resource == nil {
@@ -102,10 +110,13 @@ func transformPodSpecs(node any, transformer Transformer) error {
 // transformContainerFields applies the supplied Transformer to sensitive
 // fields within an unstructured container represented as a
 // map[string]any.
+
+// This helper preserves the existing traversal behavior while delegating
+// sensitive value transformation to the supplied Transformer.
 //
-// This helper preserves the existing traversal behavior while allowing
-// callers to choose between deterministic pseudonymization
-// (MappingTransformer) and (EncryptionTransformer) provided with a Transformer abstraction above .
+// Different Transformer implementations can provide pseudonymization,
+// encryption, or decryption while sharing the same traversal logic.
+
 func transformContainerFields(container map[string]any, transformer Transformer) error {
 
 	var err error
@@ -138,6 +149,13 @@ func transformContainerFields(container map[string]any, transformer Transformer)
 
 	return nil
 }
+
+// transformContainerList applies the supplied Transformer to all
+// containers contained within a typed or unstructured pod specification.
+//
+// Container names, image references, environment variables, and
+// referenced Kubernetes resources are transformed while preserving the
+// original workload structure.
 
 func transformContainerList(obj map[string]any, key string, transformer Transformer) error {
 
@@ -524,8 +542,10 @@ func isSensitiveEnvName(name string) bool {
 // transformImagePullSecrets applies the supplied Transformer to pod image
 // pull secret references across both typed and unstructured workload
 // representations.
+//
 // Image pull secret names are transformed while preserving the original
 // workload structure.
+
 func transformImagePullSecrets(obj map[string]any, transformer Transformer) error {
 
 	rawRefs, ok := obj["imagePullSecrets"]
@@ -591,6 +611,7 @@ func transformImagePullSecrets(obj map[string]any, transformer Transformer) erro
 //
 // Service account names are transformed while preserving the workload
 // structure.
+
 func transformServiceAccountName(obj map[string]any, transformer Transformer) error {
 
 	var err error

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestAnonymizeContainerMetadata(t *testing.T) {
+func TestTransformContainerMetadata(t *testing.T) {
 	tests := []struct {
 		name     string
 		object   map[string]any
@@ -714,54 +714,44 @@ func TestAnonymizeContainerMetadata(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapping := NewMapping()
+			transformer := NewMappingTransformer()
 			resource := workloadinterface.NewWorkloadObj(test.object)
 
-			anonymizeContainerMetadata(resource, mapping)
+			assert.NoError(
+				t,
+				transformContainerMetadata(resource, transformer),
+			)
 
 			spec, ok := resource.GetObject()["spec"].(map[string]any)
-			assert.True(t, ok, "expected spec to be a map[string]interface{}")
+			assert.True(t, ok, "expected spec to be a map[string]any")
 
 			test.validate(t, spec)
 		})
 	}
 }
 
-func TestAnonymizeContainerMetadata_NilResource(t *testing.T) {
-	assert.NotPanics(t, func() {
-		anonymizeContainerMetadata(nil, NewMapping())
-	})
+func TestTransformContainerMetadata_NilResource(t *testing.T) {
+	assert.NoError(t, transformContainerMetadata(nil, NewMappingTransformer()))
 }
 
-func TestAnonymizeContainerList_MissingKey(t *testing.T) {
+func TestTransformContainerList_MissingKey(t *testing.T) {
 	obj := map[string]any{}
-	mapping := NewMapping()
 
-	assert.NotPanics(t, func() {
-		anonymizeContainerList(obj, "containers", mapping)
-	})
+	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
 }
 
-func TestAnonymizeContainerList_NilValue(t *testing.T) {
-	obj := map[string]any{
-		"containers": nil,
-	}
-	mapping := NewMapping()
+func TestTransformContainerList_NilValue(t *testing.T) {
+	obj := map[string]any{"containers": nil}
 
-	assert.NotPanics(t, func() {
-		anonymizeContainerList(obj, "containers", mapping)
-	})
+	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
 }
 
-func TestAnonymizeContainerList_InvalidType(t *testing.T) {
+func TestTransformContainerList_InvalidType(t *testing.T) {
 	obj := map[string]any{
 		"containers": "invalid",
 	}
-	mapping := NewMapping()
 
-	assert.NotPanics(t, func() {
-		anonymizeContainerList(obj, "containers", mapping)
-	})
+	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
 }
 
 func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
@@ -792,8 +782,8 @@ func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
 	}
 }
 
-func TestAnonymizeUnstructuredEnv_LeaksApiKeyValue(t *testing.T) {
-	const secret = "AKIAIOSFODNN7EXAMPLE" //nolint:gosec // G101: AWS example access key ID, test fixture, not a real credential
+func TestTransformUnstructuredEnv_LeaksAPIKeyValue(t *testing.T) {
+	const secret = "AKIAIOSFODNN7EXAMPLE" //nolint:gosec
 
 	container := map[string]any{
 		"env": []any{
@@ -804,11 +794,10 @@ func TestAnonymizeUnstructuredEnv_LeaksApiKeyValue(t *testing.T) {
 		},
 	}
 
-	mapping := NewMapping()
-	anonymizeUnstructuredEnv(container, mapping)
+	assert.NoError(t, transformUnstructuredEnv(container, NewMappingTransformer()))
 
 	got := container["env"].([]any)[0].(map[string]any)["value"].(string)
 	if got == secret {
-		t.Fatalf("env var APIKEY value was not anonymized; secret leaked into output")
+		t.Fatalf("env var APIKEY value was not transformed; secret leaked into output")
 	}
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -780,7 +780,9 @@ func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
 }
 
 func TestTransformUnstructuredEnv_LeaksAPIKeyValue(t *testing.T) {
-	const secret = "AKIAIOSFODNN7EXAMPLE" //nolint:gosec
+
+	//nolint:gosec // Hardcoded test credential is intentional for transformation regression tests.
+	const secret = "AKIAIOSFODNN7EXAMPLE"
 
 	container := map[string]any{
 		"env": []any{

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -717,10 +717,7 @@ func TestTransformContainerMetadata(t *testing.T) {
 			transformer := NewMappingTransformer()
 			resource := workloadinterface.NewWorkloadObj(test.object)
 
-			assert.NoError(
-				t,
-				transformContainerMetadata(resource, transformer),
-			)
+			assert.NoError(t, transformContainerMetadata(resource, transformer))
 
 			spec, ok := resource.GetObject()["spec"].(map[string]any)
 			assert.True(t, ok, "expected spec to be a map[string]any")

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -38,9 +38,12 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 		// other sensitive metadata at both top-level and nested workload templates.
 		anonymizeResourceAnnotations(resource, mapping)
 
-		// Container-related anonymization is handled separately to preserve the
-		// existing typed/unstructured traversal behavior.
-		anonymizeContainerMetadata(resource, mapping)
+		// Container-related metadata is transformed separately to preserve the
+		// existing typed/unstructured traversal behavior while supporting
+		// multiple transformation strategies.
+		if err := transformContainerMetadata(resource, repoTransformer); err != nil {
+			return err
+		}
 
 		if len(session.LabelsToCopy) > 0 {
 			anonymizeResourceLabels(resource, session.LabelsToCopy, mapping)

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -16,7 +16,7 @@ import (
 
 // anonymizeSession rewrites sensitive resource identifiers and metadata while
 // preserving internal referential integrity across the full OPA session.
-func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTransformer Transformer) error {
+func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, transformer Transformer) error {
 	if session == nil {
 		return nil
 	}
@@ -26,7 +26,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 	newAllResources := make(map[string]workloadinterface.IMetadata, len(session.AllResources))
 	for oldID, resource := range session.AllResources {
 
-		if err := transformResourceMetadata(resource, repoTransformer); err != nil {
+		if err := transformResourceMetadata(resource, transformer); err != nil {
 			return err
 		}
 		// sourcePath leaks manifest filenames/line references in hidden output
@@ -41,7 +41,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 		// Container-related metadata is transformed separately to preserve the
 		// existing typed/unstructured traversal behavior while supporting
 		// multiple transformation strategies.
-		if err := transformContainerMetadata(resource, repoTransformer); err != nil {
+		if err := transformContainerMetadata(resource, transformer); err != nil {
 			return err
 		}
 
@@ -99,7 +99,7 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 
 		if err := transformResourceSource(
 			&source,
-			repoTransformer,
+			transformer,
 		); err != nil {
 			return err
 		}
@@ -124,17 +124,14 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, repoTran
 	session.ResourceAttackTracks = newResourceAttackTracks
 
 	if session.Metadata != nil {
-		if err := transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, repoTransformer); err != nil {
+		if err := transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, transformer); err != nil {
 			return err
 		}
 	}
 
 	if session.Report != nil {
 
-		if err := transformRepoContextMetadata(
-			session.Report.Metadata.ContextMetadata.RepoContextMetadata,
-			repoTransformer,
-		); err != nil {
+		if err := transformRepoContextMetadata(session.Report.Metadata.ContextMetadata.RepoContextMetadata, transformer); err != nil {
 			return err
 		}
 

--- a/core/pkg/reportcrypto/decryptcontainer.go
+++ b/core/pkg/reportcrypto/decryptcontainer.go
@@ -2,7 +2,6 @@ package reportcrypto
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	corev1 "k8s.io/api/core/v1"
@@ -257,10 +256,7 @@ func decryptTypedEnv(envVars []corev1.EnvVar, dek []byte) error {
 	for i := range envVars {
 		envVar := &envVars[i]
 
-		if envVar.Value != "" &&
-			(isSensitiveEnvName(envVar.Name) ||
-				isSensitiveEnvValue(envVar.Value)) {
-
+		if envVar.Value != "" {
 			envVar.Value, err = decryptIfEncrypted(envVar.Value, dek)
 			if err != nil {
 				return err
@@ -321,13 +317,7 @@ func decryptUnstructuredEnv(container map[string]any, dek []byte) error {
 			continue
 		}
 
-		name, _ := envVar["name"].(string)
-
-		if value, ok := envVar["value"].(string); ok &&
-			value != "" &&
-			(isSensitiveEnvName(name) ||
-				isSensitiveEnvValue(value)) {
-
+		if value, ok := envVar["value"].(string); ok && value != "" {
 			value, err = decryptIfEncrypted(value, dek)
 			if err != nil {
 				return err
@@ -548,76 +538,4 @@ func decryptServiceAccountName(obj map[string]any, dek []byte) error {
 	}
 
 	return nil
-}
-
-// isSensitiveEnvValue reports whether an env var value looks like a secret.
-func isSensitiveEnvValue(value string) bool {
-	value = strings.ToLower(value)
-
-	sensitivePatterns := []string{
-		"://",
-		"password=",
-		"pwd=",
-		"user id=",
-		"userid=",
-		"dsn=",
-		"sslmode=",
-	}
-
-	for _, pattern := range sensitivePatterns {
-		if strings.Contains(value, pattern) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isSensitiveEnvName reports whether an env var name looks like a credential.
-func isSensitiveEnvName(name string) bool {
-	name = strings.ToLower(name)
-
-	normalized := name
-	for _, sep := range []string{
-		"_",
-		"-",
-		".",
-		" ",
-	} {
-		normalized = strings.ReplaceAll(
-			normalized,
-			sep,
-			"",
-		)
-	}
-
-	sensitivePatterns := []string{
-		"password",
-		"passwd",
-		"pwd",
-		"secret",
-		"token",
-		"apikey",
-		"accesskey",
-		"privatekey",
-		"credential",
-		"databaseurl",
-		"dburl",
-		"redisurl",
-		"mongouri",
-		"mongodburi",
-		"dsn",
-		"connectionstring",
-	}
-
-	for _, pattern := range sensitivePatterns {
-		if strings.Contains(
-			normalized,
-			pattern,
-		) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/core/pkg/reportcrypto/decryptcontainer.go
+++ b/core/pkg/reportcrypto/decryptcontainer.go
@@ -1,0 +1,623 @@
+package reportcrypto
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DecryptContainerMetadata restores encrypted container names and image
+// references contained within a workload.
+//
+// This mirrors the traversal used during encryption while applying
+// decryption to container-specific metadata.
+
+func DecryptContainerMetadata(resource workloadinterface.IMetadata, dek []byte) error {
+
+	if resource == nil {
+		return nil
+	}
+
+	obj := resource.GetObject()
+	if obj == nil {
+		return nil
+	}
+
+	if err := decryptPodSpecs(obj, dek); err != nil {
+		return err
+	}
+
+	resource.SetObject(obj)
+
+	return nil
+}
+
+// decryptPodSpecs recursively traverses workload objects looking for
+// pod-spec-shaped sections containing container metadata.
+func decryptPodSpecs(node any, dek []byte) error {
+
+	switch v := node.(type) {
+
+	case map[string]any:
+		if err := decryptContainerList(v, "containers", dek); err != nil {
+			return err
+		}
+
+		if err := decryptContainerList(v, "initContainers", dek); err != nil {
+			return err
+		}
+
+		if err := decryptEphemeralContainerList(v, "ephemeralContainers", dek); err != nil {
+			return err
+		}
+
+		if err := decryptImagePullSecrets(v, dek); err != nil {
+			return err
+		}
+
+		if err := decryptServiceAccountName(v, dek); err != nil {
+			return err
+		}
+
+		for _, child := range v {
+			if err := decryptPodSpecs(child, dek); err != nil {
+				return err
+			}
+		}
+
+	case []any:
+		for _, item := range v {
+			if err := decryptPodSpecs(item, dek); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// decryptContainerFields restores encrypted container names and image
+// references contained in an unstructured container definition.
+
+func decryptContainerFields(container map[string]any, dek []byte) error {
+
+	var err error
+
+	if name, ok := container["name"].(string); ok && name != "" {
+		name, err = decryptIfEncrypted(name, dek)
+		if err != nil {
+			return err
+		}
+
+		container["name"] = name
+	}
+
+	if image, ok := container["image"].(string); ok && image != "" {
+		image, err = decryptIfEncrypted(image, dek)
+		if err != nil {
+			return err
+		}
+
+		container["image"] = image
+	}
+
+	if err := decryptUnstructuredEnv(container, dek); err != nil {
+		return err
+	}
+
+	if err := decryptUnstructuredEnvFrom(container, dek); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decryptContainerList restores encrypted metadata for typed and
+// unstructured containers.
+
+func decryptContainerList(obj map[string]any, key string, dek []byte) error {
+
+	rawContainers, ok := obj[key]
+	if !ok || rawContainers == nil {
+		return nil
+	}
+
+	var err error
+
+	if containers, ok := rawContainers.([]corev1.Container); ok {
+
+		for i := range containers {
+
+			if containers[i].Name != "" {
+				containers[i].Name, err =
+					decryptIfEncrypted(containers[i].Name, dek)
+				if err != nil {
+					return fmt.Errorf("failed to decrypt container name: %w", err)
+				}
+			}
+
+			if containers[i].Image != "" {
+				containers[i].Image, err =
+					decryptIfEncrypted(containers[i].Image, dek)
+				if err != nil {
+					return fmt.Errorf("failed to decrypt container image: %w", err)
+				}
+			}
+
+			if err := decryptTypedEnv(containers[i].Env, dek); err != nil {
+				return err
+			}
+
+			if err := decryptTypedEnvFrom(containers[i].EnvFrom, dek); err != nil {
+				return err
+			}
+		}
+
+		obj[key] = containers
+		return nil
+	}
+
+	if containers, ok := rawContainers.([]any); ok {
+
+		for _, item := range containers {
+
+			container, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if err := decryptContainerFields(container, dek); err != nil {
+				return err
+			}
+		}
+
+		obj[key] = containers
+	}
+
+	return nil
+}
+
+// decryptEphemeralContainerList restores encrypted metadata for typed
+// and unstructured ephemeral containers.
+
+func decryptEphemeralContainerList(obj map[string]any, key string, dek []byte) error {
+
+	rawContainers, ok := obj[key]
+	if !ok || rawContainers == nil {
+		return nil
+	}
+
+	var err error
+
+	if containers, ok := rawContainers.([]corev1.EphemeralContainer); ok {
+
+		for i := range containers {
+
+			if containers[i].Name != "" {
+				containers[i].Name, err =
+					decryptIfEncrypted(containers[i].Name, dek)
+				if err != nil {
+					return fmt.Errorf("failed to decrypt ephemeral container name: %w", err)
+				}
+			}
+
+			if containers[i].Image != "" {
+				containers[i].Image, err =
+					decryptIfEncrypted(containers[i].Image, dek)
+				if err != nil {
+					return fmt.Errorf("failed to decrypt ephemeral container image: %w", err)
+				}
+			}
+
+			if err := decryptTypedEnv(containers[i].Env, dek); err != nil {
+				return err
+			}
+
+			if err := decryptTypedEnvFrom(containers[i].EnvFrom, dek); err != nil {
+				return err
+			}
+		}
+
+		obj[key] = containers
+		return nil
+	}
+
+	if containers, ok := rawContainers.([]any); ok {
+
+		for _, item := range containers {
+
+			container, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if err := decryptContainerFields(container, dek); err != nil {
+				return err
+			}
+		}
+
+		obj[key] = containers
+	}
+
+	return nil
+}
+
+// decryptTypedEnv restores encrypted environment variable values and
+// referenced Kubernetes resources contained in typed EnvVar definitions.
+//
+// Literal environment values are decrypted only when they match the
+// sensitivity rules used during encryption, while Secret and ConfigMap
+// references are always decrypted when present.
+
+func decryptTypedEnv(envVars []corev1.EnvVar, dek []byte) error {
+
+	var err error
+
+	for i := range envVars {
+		envVar := &envVars[i]
+
+		if envVar.Value != "" &&
+			(isSensitiveEnvName(envVar.Name) ||
+				isSensitiveEnvValue(envVar.Value)) {
+
+			envVar.Value, err = decryptIfEncrypted(envVar.Value, dek)
+			if err != nil {
+				return err
+			}
+		}
+
+		if envVar.ValueFrom == nil {
+			continue
+		}
+
+		if secretRef := envVar.ValueFrom.SecretKeyRef; secretRef != nil &&
+			secretRef.Name != "" {
+
+			secretRef.Name, err = decryptIfEncrypted(secretRef.Name, dek)
+			if err != nil {
+				return err
+			}
+		}
+
+		if configMapRef := envVar.ValueFrom.ConfigMapKeyRef; configMapRef != nil &&
+			configMapRef.Name != "" {
+
+			configMapRef.Name, err = decryptIfEncrypted(configMapRef.Name, dek)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// decryptUnstructuredEnv restores encrypted environment variable values
+// and referenced Kubernetes resources contained within unstructured
+// container definitions.
+//
+// Literal environment values are decrypted only when they match the
+// sensitivity rules used during encryption, while SecretKeyRef and
+// ConfigMapKeyRef references are always decrypted when present.
+
+func decryptUnstructuredEnv(container map[string]any, dek []byte) error {
+
+	rawEnv, exists := container["env"]
+	if !exists || rawEnv == nil {
+		return nil
+	}
+
+	envVars, ok := rawEnv.([]any)
+	if !ok {
+		return nil
+	}
+
+	var err error
+
+	for _, item := range envVars {
+		envVar, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := envVar["name"].(string)
+
+		if value, ok := envVar["value"].(string); ok &&
+			value != "" &&
+			(isSensitiveEnvName(name) ||
+				isSensitiveEnvValue(value)) {
+
+			value, err = decryptIfEncrypted(value, dek)
+			if err != nil {
+				return err
+			}
+
+			envVar["value"] = value
+		}
+
+		rawValueFrom, exists := envVar["valueFrom"]
+		if !exists || rawValueFrom == nil {
+			continue
+		}
+
+		valueFrom, ok := rawValueFrom.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if err := decryptUnstructuredReference(valueFrom, "secretKeyRef", dek); err != nil {
+			return err
+		}
+
+		if err := decryptUnstructuredReference(valueFrom, "configMapKeyRef", dek); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// decryptTypedEnvFrom restores encrypted resource references contained in
+// typed EnvFromSource definitions.
+//
+// Secret and ConfigMap references are decrypted when present while
+// preserving the original workload structure.
+
+func decryptTypedEnvFrom(envFrom []corev1.EnvFromSource, dek []byte) error {
+
+	var err error
+
+	for i := range envFrom {
+		source := &envFrom[i]
+
+		if source.SecretRef != nil && source.SecretRef.Name != "" {
+			source.SecretRef.Name, err = decryptIfEncrypted(source.SecretRef.Name, dek)
+			if err != nil {
+				return err
+			}
+		}
+
+		if source.ConfigMapRef != nil && source.ConfigMapRef.Name != "" {
+			source.ConfigMapRef.Name, err = decryptIfEncrypted(source.ConfigMapRef.Name, dek)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// decryptUnstructuredEnvFrom restores encrypted resource references
+// contained in unstructured envFrom definitions.
+//
+// Secret and ConfigMap references are decrypted while preserving the
+// original workload structure.
+
+func decryptUnstructuredEnvFrom(container map[string]any, dek []byte) error {
+
+	rawEnvFrom, ok := container["envFrom"].([]any)
+if !ok {
+    return nil
+}
+
+	for _, item := range rawEnvFrom {
+		envFrom, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if err := decryptUnstructuredReference(envFrom, "secretRef", dek); err != nil {
+			return err
+		}
+
+		if err := decryptUnstructuredReference(envFrom, "configMapRef", dek); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// decryptUnstructuredReference restores the name field of an
+// unstructured Kubernetes object reference.
+//
+// References that do not contain a name are left unchanged.
+
+func decryptUnstructuredReference(obj map[string]any, key string, dek []byte) error {
+
+	ref, ok := obj[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	name, ok := ref["name"].(string)
+	if !ok || name == "" {
+		return nil
+	}
+
+	decryptedName, err := decryptIfEncrypted(name, dek)
+	if err != nil {
+		return err
+	}
+
+	ref["name"] = decryptedName
+
+	return nil
+}
+
+// decryptImagePullSecrets restores encrypted pod image pull secret
+// references across both typed and unstructured workload
+// representations.
+//
+// Image pull secret names are decrypted while preserving the original
+// workload structure.
+
+func decryptImagePullSecrets(obj map[string]any, dek []byte) error {
+
+	rawRefs, ok := obj["imagePullSecrets"]
+	if !ok || rawRefs == nil {
+		return nil
+	}
+
+	var err error
+
+	// Typed Kubernetes objects (manifest decoding path)
+	if refs, ok := rawRefs.([]corev1.LocalObjectReference); ok {
+		for i := range refs {
+			if refs[i].Name != "" {
+				refs[i].Name, err = decryptIfEncrypted(
+					refs[i].Name,
+					dek,
+				)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		obj["imagePullSecrets"] = refs
+		return nil
+	}
+
+	// Unstructured objects (runtime / normalized object path)
+	if refs, ok := rawRefs.([]any); ok {
+		for _, item := range refs {
+			ref, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, ok := ref["name"].(string)
+			if !ok || name == "" {
+				continue
+			}
+
+			name, err = decryptIfEncrypted(
+				name,
+				dek,
+			)
+			if err != nil {
+				return err
+			}
+
+			ref["name"] = name
+		}
+
+		obj["imagePullSecrets"] = refs
+	}
+
+	return nil
+}
+
+// decryptServiceAccountName restores encrypted pod-level service account
+// references across both typed and unstructured workload
+// representations.
+//
+// Service account names are decrypted while preserving the workload
+// structure.
+
+func decryptServiceAccountName(obj map[string]any, dek []byte) error {
+
+	var err error
+
+	for _, key := range []string{
+		"serviceAccountName",
+		"serviceAccount",
+	} {
+		rawName, ok := obj[key]
+		if !ok || rawName == nil {
+			continue
+		}
+
+		name, ok := rawName.(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		name, err = decryptIfEncrypted(
+			name,
+			dek,
+		)
+		if err != nil {
+			return err
+		}
+
+		obj[key] = name
+	}
+
+	return nil
+}
+
+// isSensitiveEnvValue reports whether an env var value looks like a secret.
+func isSensitiveEnvValue(value string) bool {
+	value = strings.ToLower(value)
+
+	sensitivePatterns := []string{
+		"://",
+		"password=",
+		"pwd=",
+		"user id=",
+		"userid=",
+		"dsn=",
+		"sslmode=",
+	}
+
+	for _, pattern := range sensitivePatterns {
+		if strings.Contains(value, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isSensitiveEnvName reports whether an env var name looks like a credential.
+func isSensitiveEnvName(name string) bool {
+	name = strings.ToLower(name)
+
+	normalized := name
+	for _, sep := range []string{
+		"_",
+		"-",
+		".",
+		" ",
+	} {
+		normalized = strings.ReplaceAll(
+			normalized,
+			sep,
+			"",
+		)
+	}
+
+	sensitivePatterns := []string{
+		"password",
+		"passwd",
+		"pwd",
+		"secret",
+		"token",
+		"apikey",
+		"accesskey",
+		"privatekey",
+		"credential",
+		"databaseurl",
+		"dburl",
+		"redisurl",
+		"mongouri",
+		"mongodburi",
+		"dsn",
+		"connectionstring",
+	}
+
+	for _, pattern := range sensitivePatterns {
+		if strings.Contains(
+			normalized,
+			pattern,
+		) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/core/pkg/reportcrypto/decryptcontainer.go
+++ b/core/pkg/reportcrypto/decryptcontainer.go
@@ -398,9 +398,9 @@ func decryptTypedEnvFrom(envFrom []corev1.EnvFromSource, dek []byte) error {
 func decryptUnstructuredEnvFrom(container map[string]any, dek []byte) error {
 
 	rawEnvFrom, ok := container["envFrom"].([]any)
-if !ok {
-    return nil
-}
+	if !ok {
+		return nil
+	}
 
 	for _, item := range rawEnvFrom {
 		envFrom, ok := item.(map[string]any)


### PR DESCRIPTION
Part Of: #1200

## Summary

This PR extends the encrypted report workflow to support reversible encryption and decryption of container-related metadata while continuing to share the existing transformation pipeline. The `--hide` workflow remains unchanged.

## Changes

- Add decryption support for encrypted container metadata
- Extend encryption/decryption coverage to:
  - Container names and images
  - Environment variable values
  - Secret and ConfigMap references (`env`/`envFrom`)
  - ImagePullSecrets
  - ServiceAccountName
  - Init and Ephemeral containers
- Restore decrypted resource IDs while preserving referential integrity
- Expand decrypt command tests to cover the new container metadata workflow



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added decryption support for container-related workload metadata, including containers, init/ephemeral containers, environment literals and secret/config references, envFrom references, imagePullSecrets, and service account fields.
* **Bug Fixes**
  * Reworked container metadata transformation to be transformer-based and error-returning, with safer traversal across both structured and unstructured workload shapes (including nil/missing edge cases).
* **Tests**
  * Expanded decryption coverage for additional spec fields and updated anonymization tests to validate the transformer-based behavior (including renames and new “returns no error” assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->