### PR TITLE
Embed and load VAP YAML from the vendored bundle

### DIFF
--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -50,17 +50,45 @@ type VAP struct {
 	Variables   []Variable
 	Validations []Validation
 
+	// matchConditions gates whether a policy runs at all: at admission a policy
+	// whose matchConditions evaluate to false is skipped and none of its
+	// validations run. The offline engine does not evaluate them yet, so we keep
+	// them here only so loadVAP can refuse such a policy (see requireSupported)
+	// rather than run its validations unconditionally and emit violations live
+	// admission would never raise.
+	matchConditions []admissionregistrationv1.MatchCondition
+
 	// paramKind mirrors spec.paramKind; nil when the policy declares no params.
 	paramKind *admissionregistrationv1.ParamKind
+}
+
+// requireSupported reports whether the offline engine can honor this policy with
+// scan/admission parity. matchConditions is an admission-time gate we do not
+// evaluate yet; running a gated policy's validations unconditionally would emit
+// violations live admission never would, so we refuse the control instead. The
+// error maps to the same errored/skipped status a Rego eval error takes, never a
+// silent pass or a false violation. Removing this guard is the seam for when the
+// evaluator learns to evaluate matchConditions.
+func (v *VAP) requireSupported() error {
+	if len(v.matchConditions) > 0 {
+		return fmt.Errorf("control %q uses spec.matchConditions, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
+	}
+	return nil
 }
 
 // vapIndex is built once from the embedded bundle and reused. Parsing every
 // document on each lookup would be wasteful, and the bundle never changes at
 // runtime, so a lazily-built controlID -> VAP map is enough.
+//
+// vapIndexErr is reserved for whole-bundle failures (the embed cannot be read or
+// decoded) — the engine genuinely cannot function then. A per-control problem
+// like a duplicate never lands here: it poisons only its own control (see
+// vapDuplicates) so one bad policy cannot take the whole engine offline.
 var (
-	vapIndexOnce sync.Once
-	vapIndex     map[string]*VAP
-	vapIndexErr  error
+	vapIndexOnce  sync.Once
+	vapIndex      map[string]*VAP
+	vapDuplicates map[string]struct{}
+	vapIndexErr   error
 )
 
 // loadVAP returns the policy for a control ID (threaded in from processControl,
@@ -72,9 +100,15 @@ func loadVAP(controlID string) (*VAP, error) {
 	if vapIndexErr != nil {
 		return nil, vapIndexErr
 	}
+	if _, dup := vapDuplicates[controlID]; dup {
+		return nil, fmt.Errorf("control %q is defined by more than one policy in the VAP bundle; refusing it rather than pick one", controlID)
+	}
 	vap, ok := vapIndex[controlID]
 	if !ok {
 		return nil, fmt.Errorf("no %s for control %q in embedded bundle", vapKind, controlID)
+	}
+	if err := vap.requireSupported(); err != nil {
+		return nil, err
 	}
 	return vap, nil
 }
@@ -87,7 +121,7 @@ func buildVAPIndex() {
 		vapIndexErr = fmt.Errorf("read embedded VAP bundle: %w", err)
 		return
 	}
-	vapIndex, vapIndexErr = parseVAPBundle(data)
+	vapIndex, vapDuplicates, vapIndexErr = parseVAPBundle(data)
 }
 
 // parseVAPBundle turns a multi-document bundle into the controlID -> VAP map.
@@ -100,10 +134,14 @@ func buildVAPIndex() {
 // Policies with no controlId label (cluster-scoped helper policies) are skipped
 // too: they are not addressable by control and the scan never asks for them.
 //
-// A duplicate control ID is still an error: that is two policies fighting over a
-// control we do consume, and picking one silently would hide a real bundle bug.
-func parseVAPBundle(data []byte) (map[string]*VAP, error) {
+// A duplicate control ID poisons only that control: two policies fighting over one
+// control is a real bundle bug, so neither silently wins — the control is dropped
+// from the index and returned in the duplicates set, and loadVAP refuses it. The
+// rest of the bundle still indexes, so one bad control cannot take the whole
+// engine offline. Only an unreadable/undecodable bundle is a whole-bundle error.
+func parseVAPBundle(data []byte) (map[string]*VAP, map[string]struct{}, error) {
 	index := make(map[string]*VAP)
+	duplicates := make(map[string]struct{})
 	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
 	for {
 		var policy admissionregistrationv1.ValidatingAdmissionPolicy
@@ -111,7 +149,7 @@ func parseVAPBundle(data []byte) (map[string]*VAP, error) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, fmt.Errorf("decode VAP bundle: %w", err)
+			return nil, nil, fmt.Errorf("decode VAP bundle: %w", err)
 		}
 
 		if policy.Kind != vapKind || policy.APIVersion != vapAPIVersion {
@@ -122,23 +160,37 @@ func parseVAPBundle(data []byte) (map[string]*VAP, error) {
 		if controlID == "" {
 			continue
 		}
-		if _, dup := index[controlID]; dup {
-			return nil, fmt.Errorf("duplicate control %q in VAP bundle", controlID)
+		if _, poisoned := duplicates[controlID]; poisoned {
+			// Already seen twice; stay poisoned for any further occurrences.
+			continue
+		}
+		if _, seen := index[controlID]; seen {
+			duplicates[controlID] = struct{}{}
+			delete(index, controlID)
+			continue
 		}
 		index[controlID] = newVAP(&policy)
 	}
 
-	return index, nil
+	return index, duplicates, nil
 }
 
 // newVAP flattens a parsed policy into the evaluator's structs. The message and
 // messageExpression travel with each validation so the evaluator can resolve the
-// violation message the same way the apiserver does.
+// violation message the same way the apiserver does. matchConditions is carried
+// so loadVAP can refuse a gated policy (see requireSupported).
+//
+// spec.matchConstraints and spec.failurePolicy are intentionally dropped:
+// offline resource selection is the caller's job (and the bundle's validations
+// already self-guard by object.kind), and eval errors are always mapped to an
+// errored/skipped status regardless of failurePolicy, which is the parity-safe
+// direction.
 func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 	vap := &VAP{
-		ControlID:  policy.Labels[controlIDLabel],
-		PolicyName: policy.Name,
-		paramKind:  policy.Spec.ParamKind,
+		ControlID:       policy.Labels[controlIDLabel],
+		PolicyName:      policy.Name,
+		matchConditions: policy.Spec.MatchConditions,
+		paramKind:       policy.Spec.ParamKind,
 	}
 	for _, v := range policy.Spec.Variables {
 		vap.Variables = append(vap.Variables, Variable{Name: v.Name, Expression: v.Expression})

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -1,0 +1,199 @@
+package cel
+
+import (
+	"bytes"
+	"embed"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+// vapdataFS bakes the vendored cel-admission-library bundle (see vapdata/README.md)
+// into the binary. Embedding keeps the VAP YAML as the source of truth (per issue
+// #2001) and pinned to the vendored release, with no runtime file-path lookups or
+// network fetch at scan time.
+//
+//go:embed vapdata
+var vapdataFS embed.FS
+
+const (
+	// vapdataDir is the embedded directory and, for the sanity tests, the on-disk
+	// directory name (they run from the package dir).
+	vapdataDir = "vapdata"
+	// vapBundleFile holds the ValidatingAdmissionPolicy documents, one per `---`.
+	vapBundleFile = "kubescape-validating-admission-policies.yaml"
+	// controlConfigFile holds the ControlConfiguration a policy's paramKind
+	// resolves against (issue #2001: params come from this file in the bundle).
+	controlConfigFile = "basic-control-configuration.yaml"
+
+	// controlIDLabel is the metadata label the bundle tags each control's policy
+	// with (e.g. C-0017). Cluster-scoped helper policies carry no such label.
+	controlIDLabel = "controlId"
+
+	vapKind       = "ValidatingAdmissionPolicy"
+	vapAPIVersion = "admissionregistration.k8s.io/v1"
+)
+
+// VAP is one ValidatingAdmissionPolicy from the bundle, reduced to what the
+// evaluator consumes: the variables and validations already flattened into the
+// evaluator's structs, plus the paramKind so resolveParams knows whether to bind
+// params. The full YAML is parsed as a real ValidatingAdmissionPolicy first, so
+// we keep the structure rather than a flattened string.
+type VAP struct {
+	ControlID   string
+	PolicyName  string
+	Variables   []Variable
+	Validations []Validation
+
+	// paramKind mirrors spec.paramKind; nil when the policy declares no params.
+	paramKind *admissionregistrationv1.ParamKind
+}
+
+// vapIndex is built once from the embedded bundle and reused. Parsing every
+// document on each lookup would be wasteful, and the bundle never changes at
+// runtime, so a lazily-built controlID -> VAP map is enough.
+var (
+	vapIndexOnce sync.Once
+	vapIndex     map[string]*VAP
+	vapIndexErr  error
+)
+
+// loadVAP returns the policy for a control ID (threaded in from processControl,
+// never read off a rule). It fails when the control is absent from the embedded
+// bundle rather than silently returning nothing, so a scan cannot quietly skip a
+// control it thinks it covers.
+func loadVAP(controlID string) (*VAP, error) {
+	vapIndexOnce.Do(buildVAPIndex)
+	if vapIndexErr != nil {
+		return nil, vapIndexErr
+	}
+	vap, ok := vapIndex[controlID]
+	if !ok {
+		return nil, fmt.Errorf("no %s for control %q in embedded bundle", vapKind, controlID)
+	}
+	return vap, nil
+}
+
+// buildVAPIndex reads the embedded bundle and hands the bytes to parseVAPBundle.
+// Splitting the two keeps the parsing logic testable with in-memory bundles.
+func buildVAPIndex() {
+	data, err := vapdataFS.ReadFile(vapdataDir + "/" + vapBundleFile)
+	if err != nil {
+		vapIndexErr = fmt.Errorf("read embedded VAP bundle: %w", err)
+		return
+	}
+	vapIndex, vapIndexErr = parseVAPBundle(data)
+}
+
+// parseVAPBundle turns a multi-document bundle into the controlID -> VAP map.
+//
+// It consumes only v1 ValidatingAdmissionPolicy documents and skips everything
+// else. The bundle is a mixed stream synced from cel-admission-library, which
+// also ships ValidatingAdmissionPolicyBinding (and blank) documents; failing the
+// whole index over one document we do not consume would take the entire engine
+// down on a routine `make sync-vap`, so a foreign kind is skipped, not fatal.
+// Policies with no controlId label (cluster-scoped helper policies) are skipped
+// too: they are not addressable by control and the scan never asks for them.
+//
+// A duplicate control ID is still an error: that is two policies fighting over a
+// control we do consume, and picking one silently would hide a real bundle bug.
+func parseVAPBundle(data []byte) (map[string]*VAP, error) {
+	index := make(map[string]*VAP)
+	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+	for {
+		var policy admissionregistrationv1.ValidatingAdmissionPolicy
+		if err := decoder.Decode(&policy); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decode VAP bundle: %w", err)
+		}
+
+		if policy.Kind != vapKind || policy.APIVersion != vapAPIVersion {
+			continue
+		}
+
+		controlID := policy.Labels[controlIDLabel]
+		if controlID == "" {
+			continue
+		}
+		if _, dup := index[controlID]; dup {
+			return nil, fmt.Errorf("duplicate control %q in VAP bundle", controlID)
+		}
+		index[controlID] = newVAP(&policy)
+	}
+
+	return index, nil
+}
+
+// newVAP flattens a parsed policy into the evaluator's structs. The message and
+// messageExpression travel with each validation so the evaluator can resolve the
+// violation message the same way the apiserver does.
+func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
+	vap := &VAP{
+		ControlID:  policy.Labels[controlIDLabel],
+		PolicyName: policy.Name,
+		paramKind:  policy.Spec.ParamKind,
+	}
+	for _, v := range policy.Spec.Variables {
+		vap.Variables = append(vap.Variables, Variable{Name: v.Name, Expression: v.Expression})
+	}
+	for _, v := range policy.Spec.Validations {
+		vap.Validations = append(vap.Validations, Validation{
+			Expression:        v.Expression,
+			Message:           v.Message,
+			MessageExpression: v.MessageExpression,
+		})
+	}
+	return vap
+}
+
+// resolveParams returns the value bound to the evaluator's "params" variable. A
+// policy with no paramKind gets nil (matching a live binding with no ParamRef).
+// Otherwise the whole ControlConfiguration is returned so expressions can reach
+// params.settings.<field>, exactly what a live ParamRef would supply.
+//
+// The returned map is shared across calls (see controlConfig) and is treated as
+// read-only: the evaluator only binds it into a CEL activation, which never
+// mutates it.
+func resolveParams(vap *VAP) (any, error) {
+	if vap.paramKind == nil {
+		return nil, nil
+	}
+	params, err := controlConfig()
+	if err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+// controlConfig parses the embedded ControlConfiguration once and caches it. It
+// is one shared file with identical content for every params-bearing control, so
+// re-reading and re-parsing it per evaluation would be wasted work.
+var (
+	controlConfigOnce sync.Once
+	controlConfigVal  map[string]any
+	controlConfigErr  error
+)
+
+func controlConfig() (map[string]any, error) {
+	controlConfigOnce.Do(func() {
+		data, err := vapdataFS.ReadFile(vapdataDir + "/" + controlConfigFile)
+		if err != nil {
+			controlConfigErr = fmt.Errorf("read embedded control configuration: %w", err)
+			return
+		}
+		// sigs.k8s.io/yaml decodes via JSON, so numbers, lists and maps come out
+		// as the JSON-shaped types CEL expects (the same shape the apiserver hands
+		// a paramKind object).
+		if err := yaml.Unmarshal(data, &controlConfigVal); err != nil {
+			controlConfigErr = fmt.Errorf("parse embedded control configuration: %w", err)
+		}
+	})
+	return controlConfigVal, controlConfigErr
+}

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -100,7 +100,7 @@ metadata:
 spec:
   policyName: kubescape-c-1000
 `
-	index, err := parseVAPBundle([]byte(bundle))
+	index, _, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
 	assert.Len(t, index, 1)
 	assert.Contains(t, index, "C-1000")
@@ -111,18 +111,55 @@ spec:
 // an empty key.
 func TestParseVAPBundleSkipsNoControlID(t *testing.T) {
 	bundle := vapDoc("cluster-policy-helper", "") + "---\n" + vapDoc("kubescape-c-1000", "C-1000")
-	index, err := parseVAPBundle([]byte(bundle))
+	index, _, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
 	assert.Len(t, index, 1)
 	assert.Contains(t, index, "C-1000")
 	assert.NotContains(t, index, "")
 }
 
-// TestParseVAPBundleDuplicateControl proves two policies claiming the same control
-// is a hard error, not a silent last-one-wins.
+// TestParseVAPBundleDuplicateControl proves a duplicated control poisons only
+// itself: neither copy silently wins (it is dropped from the index and returned
+// in the duplicates set), while the rest of the bundle still indexes. One bad
+// control must not take the whole engine offline.
 func TestParseVAPBundleDuplicateControl(t *testing.T) {
-	bundle := vapDoc("kubescape-c-1000-a", "C-1000") + "---\n" + vapDoc("kubescape-c-1000-b", "C-1000")
-	_, err := parseVAPBundle([]byte(bundle))
+	bundle := vapDoc("kubescape-c-1000-a", "C-1000") +
+		"---\n" + vapDoc("kubescape-c-1000-b", "C-1000") +
+		"---\n" + vapDoc("kubescape-c-2000", "C-2000")
+	index, duplicates, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+
+	assert.NotContains(t, index, "C-1000", "a duplicated control must not silently win")
+	assert.Contains(t, duplicates, "C-1000")
+	assert.Contains(t, index, "C-2000", "an unrelated control must still index")
+}
+
+// TestLoadVAPRefusesMatchConditions proves a policy with a matchConditions gate is
+// captured but refused, rather than having its validations run unconditionally.
+// Today's bundle ships none, but a future sync could, and running one offline
+// would emit violations live admission (which honors the gate) never would.
+func TestLoadVAPRefusesMatchConditions(t *testing.T) {
+	bundle := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-1001
+  labels:
+    controlId: C-1001
+spec:
+  matchConditions:
+  - name: only-kube-system
+    expression: "object.metadata.namespace == 'kube-system'"
+  validations:
+  - expression: "false"
+`
+	index, _, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+
+	vap := index["C-1001"]
+	require.NotNil(t, vap)
+	require.NotEmpty(t, vap.matchConditions, "matchConditions must be captured, not dropped")
+
+	err = vap.requireSupported()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "C-1000")
+	assert.Contains(t, err.Error(), "matchConditions")
 }

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -1,0 +1,128 @@
+package cel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadVAPParamlessControl loads a known paramless control and checks the
+// structured pieces the evaluator needs come back intact.
+func TestLoadVAPParamlessControl(t *testing.T) {
+	vap, err := loadVAP("C-0017")
+	require.NoError(t, err)
+
+	assert.Equal(t, "C-0017", vap.ControlID)
+	assert.Contains(t, vap.PolicyName, "c-0017")
+	assert.Nil(t, vap.paramKind, "C-0017 declares no paramKind")
+
+	// The C-0017 bundle policy has three validations (Pod, workload, CronJob).
+	require.Len(t, vap.Validations, 3)
+	assert.Contains(t, vap.Validations[0].Expression, "readOnlyRootFilesystem")
+	assert.NotEmpty(t, vap.Validations[0].Message)
+
+	// A paramless policy resolves to nil params, matching a live binding with no
+	// ParamRef.
+	params, err := resolveParams(vap)
+	require.NoError(t, err)
+	assert.Nil(t, params)
+}
+
+// TestLoadVAPWithParams loads a control that declares a paramKind and checks
+// resolveParams pulls the real values out of basic-control-configuration.yaml.
+func TestLoadVAPWithParams(t *testing.T) {
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+
+	require.NotNil(t, vap.paramKind, "C-0046 declares a paramKind")
+	assert.Equal(t, "ControlConfiguration", vap.paramKind.Kind)
+
+	// The validations reference params.settings.insecureCapabilities, so the
+	// resolved params must expose that under settings.
+	require.NotEmpty(t, vap.Validations)
+	assert.Contains(t, vap.Validations[0].Expression, "params.settings.insecureCapabilities")
+
+	params, err := resolveParams(vap)
+	require.NoError(t, err)
+
+	settings, ok := params.(map[string]any)["settings"].(map[string]any)
+	require.True(t, ok, "resolved params must carry a settings map")
+
+	caps, ok := settings["insecureCapabilities"].([]any)
+	require.True(t, ok, "settings.insecureCapabilities must be a list")
+	require.NotEmpty(t, caps)
+
+	var haveSysAdmin bool
+	for _, c := range caps {
+		if c == "SYS_ADMIN" {
+			haveSysAdmin = true
+		}
+	}
+	assert.True(t, haveSysAdmin, "expected SYS_ADMIN among the vendored insecureCapabilities")
+}
+
+// TestLoadVAPUnknownControl asserts an unknown control fails loudly rather than
+// returning an empty policy a scan would treat as "nothing to check".
+func TestLoadVAPUnknownControl(t *testing.T) {
+	_, err := loadVAP("C-9999")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "C-9999"))
+}
+
+// vapDoc renders a minimal VAP document for the in-memory bundle tests.
+func vapDoc(name, controlID string) string {
+	labels := ""
+	if controlID != "" {
+		labels = "\n  labels:\n    controlId: " + controlID
+	}
+	return `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: ` + name + labels + `
+spec:
+  validations:
+  - expression: "true"
+`
+}
+
+// TestParseVAPBundleSkipsForeignKinds proves a non-VAP document (the bindings the
+// upstream bundle commonly ships) is skipped, not fatal: the VAP alongside it
+// still indexes. This is the guard against a routine `make sync-vap` taking the
+// whole engine down.
+func TestParseVAPBundleSkipsForeignKinds(t *testing.T) {
+	bundle := vapDoc("kubescape-c-1000", "C-1000") + `---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kubescape-c-1000-binding
+spec:
+  policyName: kubescape-c-1000
+`
+	index, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+	assert.Len(t, index, 1)
+	assert.Contains(t, index, "C-1000")
+}
+
+// TestParseVAPBundleSkipsNoControlID proves policies without a controlId label
+// (cluster-scoped helpers) are dropped from the index rather than indexed under
+// an empty key.
+func TestParseVAPBundleSkipsNoControlID(t *testing.T) {
+	bundle := vapDoc("cluster-policy-helper", "") + "---\n" + vapDoc("kubescape-c-1000", "C-1000")
+	index, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+	assert.Len(t, index, 1)
+	assert.Contains(t, index, "C-1000")
+	assert.NotContains(t, index, "")
+}
+
+// TestParseVAPBundleDuplicateControl proves two policies claiming the same control
+// is a hard error, not a silent last-one-wins.
+func TestParseVAPBundleDuplicateControl(t *testing.T) {
+	bundle := vapDoc("kubescape-c-1000-a", "C-1000") + "---\n" + vapDoc("kubescape-c-1000-b", "C-1000")
+	_, err := parseVAPBundle([]byte(bundle))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "C-1000")
+}

--- a/core/pkg/opaprocessor/cel/vapdata_test.go
+++ b/core/pkg/opaprocessor/cel/vapdata_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The loader (a later PR) will //go:embed this directory. These tests guard the
-// prerequisite: the vendored bundle is actually in the tree and looks like the
-// cel-admission-library release, so `make sync-vap` populated it and did not,
-// say, leave an empty directory or an HTML error page.
-
-const vapdataDir = "vapdata"
+// These tests guard the prerequisite the loader (loader.go) //go:embeds: the
+// vendored bundle is actually in the tree and looks like the cel-admission-library
+// release, so `make sync-vap` populated it and did not, say, leave an empty
+// directory or an HTML error page. (vapdataDir is declared in loader.go.)
 
 // TestVapdataBundlePresent checks the three files the engine relies on exist and
 // are non-empty.


### PR DESCRIPTION
## Overview

This builds the loader on top of the vendored bundle from the previous PR. It //go:embeds the vapdata/ directory so the VAP YAML is baked into the binary, then adds loadVAP(controlID) which parses the bundle once into a control-ID → policy index and returns the variables, validations, and messages for a control. Params are handled by resolveParams: a policy with a paramKind gets the ControlConfiguration from basic-control-configuration.yaml (parsed once and cached), and a policy without one gets nil, matching what a live binding would supply. The bundle is a mixed stream, so anything that isn't a ValidatingAdmissionPolicy (bindings, blanks) is skipped rather than failing the whole index, while a duplicate control ID stays a hard error since that's a real bundle bug. An unknown control fails loudly instead of returning nothing a scan would treat as "all clear". Tests cover a paramless control, a params-bearing control, the unknown-control error, and the skip/duplicate paths with small in-memory bundles.
Part of #2001 

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Load validating admission policy data from bundled resources at runtime and prepare it for in-memory evaluation.
  * Support parameterized policies using cached control configuration.
* **Bug Fixes**
  * Ignore policies missing a required control identifier.
  * Detect and exclude duplicate control IDs from being used (and report duplicates during parsing).
  * Refuse policies that declare match conditions.
* **Tests**
  * Expanded coverage for parameter handling, bundle parsing/skip behavior, duplicates, and match-condition rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->