### PR TITLE
docs: add ICS/OT workload scanning guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@ We welcome contributions to improve our documentation! Please see the [Contribut
 | [troubleshooting.md](troubleshooting.md) | ✅ Current | Common issues and solutions |
 | [providers.md](providers.md) | ✅ Current | Backend service providers |
 | [environment-dependencies-policy.md](environment-dependencies-policy.md) | ✅ Current | Dependency policies |
+| [ics-ot-workloads.md](ics-ot-workloads.md) | ✅ Current | Scanning ICS/OT workloads on Kubernetes |
 
 ---
 

--- a/docs/ics-ot-workloads.md
+++ b/docs/ics-ot-workloads.md
@@ -1,0 +1,203 @@
+# Scanning ICS/OT Workloads
+
+This guide explains how to use Kubescape to scan Industrial Control System (ICS) and Operational Technology (OT) workloads running on Kubernetes. It targets OT security engineers running containerized SCADA components, PLC protocol bridges, and OPC-UA servers where standard Kubernetes hardening controls frequently conflict with Layer-1 protocol requirements.
+
+## Prerequisites
+
+- The `kubescape` CLI installed
+- The example manifests under `examples/ics-ot/` in this repository
+- (Optional) A kubeconfig pointing at a target cluster. The walkthrough uses `--keep-local`, so no cluster is required
+- (Optional) `jq` for slicing the JSON output
+
+## How It Works
+
+Kubescape evaluates Kubernetes manifests against controls from the NSA, MITRE, and CIS frameworks. In OT namespaces, the same controls that flag misconfigurations in cloud-native workloads also flag legitimate OT deviations such as `hostNetwork: true` for Modbus bridges or `privileged: true` for vendor SCADA containers. This guide walks through scanning two example OT workloads, then shows how to scope an exception for a documented deviation without muting other findings.
+
+## Common ICS/OT Protocols and Ports
+
+| Protocol | Default port | Transport | Typical use |
+|----------|--------------|-----------|-------------|
+| Modbus TCP | 502 | TCP | PLC read/write, HMI polling |
+| DNP3 | 20000 | TCP | SCADA to RTU communication |
+| OPC-UA | 4840 | TCP | Vendor-neutral SCADA data exchange |
+| S7Comm | 102 | TCP | Siemens S7 PLC programming and data |
+| EtherNet/IP | 44818 | TCP/UDP | Rockwell/Allen-Bradley PLCs |
+| BACnet | 47808 | UDP | Building automation |
+| IEC 60870-5-104 | 2404 | TCP | Power system telecontrol |
+
+Several of these protocols (Modbus, S7Comm, BACnet) lack authentication at the protocol layer and rely on network segmentation for isolation, which is why Kubescape findings on `hostNetwork`, `hostPort`, and `NET_ADMIN` capability additions matter disproportionately in OT namespaces.
+
+## Kubescape Controls Relevant to ICS/OT
+
+The controls below are the ones most commonly triggered by legitimate OT workloads. Control names are quoted from the vendored ValidatingAdmissionPolicy bundle at `core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml`.
+
+| Control ID | Control name | OT relevance |
+|------------|--------------|--------------|
+| C-0016 | Allow privilege escalation | Vendor containers with setuid helpers to bind privileged ports |
+| C-0038 | Deny resources with host IPC or PID privileges | COM/DCOM bridges that mirror host process state |
+| C-0041 | Deny resources with host network access | Modbus/DNP3 bridges that require direct fieldbus reachability |
+| C-0044 | Deny resources with host port | Legacy HMIs that connect to a well-known TCP/502 |
+| C-0046 | Deny resources with insecure capabilities | Multicast discovery, raw-socket protocol bridges |
+| C-0048 | Deny workloads with hostpath mounts | USB-to-RS-485 adapters, PLC tag databases |
+| C-0057 | Privileged container denied | Vendor SCADA containers requiring `/dev/mem` access |
+| C-0074 | Resources mounting docker socket denied | Edge nodes that bootstrap sibling OT containers |
+
+## Scanning an ICS/OT Workload
+
+The example manifest at `examples/ics-ot/modbus-deployment.yaml` defines a Modbus TCP controller in the `ot-modbus` namespace. It deliberately violates C-0041 (`hostNetwork: true`), C-0044 (`hostPort: 502`), C-0048 (`hostPath` mount for `/dev/ttyUSB0`), and C-0057 (`privileged: true`).
+
+Scan it directly from the manifest file with `--keep-local` so no cluster connection is required:
+
+```bash
+kubescape scan --keep-local examples/ics-ot/modbus-deployment.yaml --format json --output /tmp/modbus-scan.json
+```
+
+The pretty-printer output groups failed controls by resource. For the Modbus example, the table includes rows for `HostNetwork access` (C-0041), `HostPath mount` (C-0048), `Privileged container` (C-0057), and several additional controls that fire on the same manifest (non-root user, default service account, host port, and others). The exact set depends on the framework bundle currently in use; pass `--format json` for an authoritative list.
+
+To scan both example manifests together:
+
+```bash
+kubescape scan --keep-local examples/ics-ot/ --format json --output /tmp/ot-scan.json
+```
+
+The OPC-UA manifest at `examples/ics-ot/opcua-deployment.yaml` triggers C-0057 (`privileged: true`), C-0016 (`allowPrivilegeEscalation: true`), C-0038 (`hostPID: true`), and C-0046 (`CAP_NET_ADMIN` added), plus the same set of secondary findings.
+
+### Filtering the JSON output
+
+The JSON output nests control results under `results[].controls[]`, with the per-control status at `status.status`. To extract a flat list of failed controls:
+
+```bash
+jq -r '.results[].controls[] | select(.status.status=="failed") | "\(.controlID) \(.name)"' \
+  /tmp/ot-scan.json | sort -u
+```
+
+### Severity thresholds in CI
+
+For OT pipelines, a common pattern is to fail the build only on `critical` or `high` severity findings and surface lower-severity findings as informational. Use `--severity-threshold` for this:
+
+```bash
+kubescape scan --keep-local examples/ics-ot/ \
+  --severity-threshold high --format junit --output /tmp/ot-scan-junit.xml
+```
+
+## Applying Exceptions for Legitimate OT Use Cases
+
+When a finding represents a documented and risk-accepted OT deviation, suppress it with a scoped exception rather than a global disable. The exception file at `examples/exceptions/ics-ot-exceptions.json` targets C-0041 (`hostNetwork`) for resources labeled `sector: ics-ot`:
+
+```json
+[
+    {
+        "name": "exclude-ot-sector-host-network",
+        "policyType": "postureExceptionPolicy",
+        "actions": ["alertOnly"],
+        "resources": [
+            {
+                "designatorType": "Attributes",
+                "attributes": { "sector": "ics-ot" }
+            }
+        ],
+        "posturePolicies": [
+            { "controlID": "C-0041" }
+        ]
+    }
+]
+```
+
+Re-scan with the exception applied:
+
+```bash
+kubescape scan --keep-local examples/ics-ot/ \
+  --exceptions examples/exceptions/ics-ot-exceptions.json \
+  --format json --output /tmp/ot-scan-exc.json
+```
+
+The C-0041 finding against `modbus-controller` moves out of the failed set (it appears as `passed` with `subStatus: w/exceptions` in the JSON). The other findings (C-0044, C-0048, C-0057 on the Modbus controller; C-0016, C-0038, C-0046, C-0057 on the OPC-UA server) remain in `failed` state because they are not covered by the exception. Scope exceptions narrowly so that genuinely new misconfigurations still surface.
+
+## Network Policies for OT Namespaces
+
+Suppressing a Kubescape finding does not remove the underlying risk, it only acknowledges it. For every OT exception, document a compensating control. The most common compensating control in OT namespaces is a NetworkPolicy that restricts which pods may open a session to the protocol port.
+
+The following pattern works for Modbus controllers: default-deny all ingress to the `ot-modbus` namespace, then allow TCP/502 only from the HMI namespace.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: ot-modbus
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-modbus-from-hmi
+  namespace: ot-modbus
+spec:
+  podSelector:
+    matchLabels:
+      app: modbus-controller
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              sector: ics-ot-hmi
+      ports:
+        - protocol: TCP
+          port: 502
+```
+
+Kubescape does not enforce NetworkPolicies, it only inspects them. Maintaining a one-exception-one-policy mapping makes it possible to answer an auditor's question (what stops an attacker in the HMI namespace from reaching the SIS) with a pointer to a single named resource.
+
+A second, often-overlooked pattern is to default-deny egress from OT namespaces as well. Vendor containers frequently phone home to vendor update endpoints; an explicit egress allowlist keeps that traffic on a known path and prevents a compromised OT container from becoming a beacon host.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: ot-modbus
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+```
+
+In a plant-network deployment, combine this with upstream firewall rules at the OT/IT boundary so that the egress allowlist is enforced at both the Kubernetes layer and the L3 boundary layer.
+
+## Framework Mappings
+
+NIST SP 800-82 Rev. 3 and IEC 62443-4-2 both acknowledge that OT systems have legitimate deviations from IT hardening baselines, as long as those deviations are documented, scoped, and compensated for with network segmentation. The Kubescape controls listed above map most naturally to the network integrity and least-functionality families of those frameworks (PR.AC-5 and PR.PT-3 in 800-82 r3; SR 5.1, SR 5.2, and SR 7.6 in 24443-4-2). Treat these as "maps to" relationships rather than one-to-one equivalences. Always confirm the identifiers against the current source publication before including them in a compliance report; Kubescape findings are an input to the protective-requirement analysis, not a substitute for it.
+
+## Troubleshooting
+
+### Scan returns zero findings on an OT pod
+
+Confirm the pod's namespace and labels match what Kubescape evaluates. If the namespace is in a `kube-system`-style exception file passed via `--exceptions`, all findings for that namespace are suppressed. Run the scan without `--exceptions` to confirm the findings exist in the raw output, then layer the exception file back in.
+
+### C-0041 is suppressed for workloads outside the OT namespace
+
+The exception file uses attribute-based selectors. If the `sector: ics-ot` label has been applied to non-OT workloads, those workloads will also be matched. Audit labels with `kubectl get pods -A -l sector=ics-ot -o wide` and remove misapplied labels before re-scanning.
+
+### Exception file is silently ignored
+
+Kubescape requires both a `resources` entry and a `posturePolicies` entry in each exception object. A file containing only `posturePolicies` will not match any resources and will produce no `excluded` rows. Validate the JSON syntax (`python3 -m json.tool examples/exceptions/ics-ot-exceptions.json`) and confirm that the `designatorType` is `Attributes` and that the attribute keys match either a Kubernetes resource label or a built-in field (`name`, `kind`, `namespace`, `cluster`).
+
+### `kubescape scan` fails with "failed to download policies"
+
+The first scan in an environment requires outbound HTTPS to download the regolibrary frameworks. Air-gapped environments must pre-populate the local cache or use the `--use-from` flag to point at a pre-downloaded bundle. See `docs/getting-started.md` for the offline workflow.
+
+### The JSON output shows `status: passed` for an obviously violated control
+
+Some controls require a cluster-side admission webhook to fully evaluate. The `--keep-local` scan evaluates the manifest against the static rule set, which may not catch every condition. For authoritative results, scan against a live cluster with a kubeconfig that has read access to the target namespaces.
+
+## Further Reading
+
+- [NIST SP 800-82 Rev. 3, Guide to Operational Technology (OT) Security](https://csrc.nist.gov/pubs/sp/800/82/r3/final)
+- [IEC 62443-4-2, Security for industrial automation and control systems](https://www.iec.ch/dyn/www/f?p=103:7:0::::FSP_ORG_ID:1257)
+- [MITRE ATT&CK for ICS](https://attack.mitre.org/matrices/ics/)
+- [Kubescape documentation hub](https://kubescape.io/docs/)
+- [Kubescape controls reference](https://kubescape.io/docs/controls/)
+- [Kubescape exceptions guide](../examples/exceptions/README.md)
+- [Azure Pipelines integration](azure-pipelines.md)

--- a/docs/ics-ot-workloads.md
+++ b/docs/ics-ot-workloads.md
@@ -6,7 +6,7 @@ This guide explains how to use Kubescape to scan Industrial Control System (ICS)
 
 - The `kubescape` CLI installed
 - The example manifests under `examples/ics-ot/` in this repository
-- (Optional) A kubeconfig pointing at a target cluster. The walkthrough uses `--keep-local`, so no cluster is required
+- (Optional) A kubeconfig pointing at a target cluster. No cluster is required for the walkthrough because the scan target is a manifest file. `--keep-local` additionally prevents results from being sent to the configured backend
 - (Optional) `jq` for slicing the JSON output
 
 ## How It Works
@@ -168,7 +168,7 @@ In a plant-network deployment, combine this with upstream firewall rules at the 
 
 ## Framework Mappings
 
-NIST SP 800-82 Rev. 3 and IEC 62443-4-2 both acknowledge that OT systems have legitimate deviations from IT hardening baselines, as long as those deviations are documented, scoped, and compensated for with network segmentation. The Kubescape controls listed above map most naturally to the network integrity and least-functionality families of those frameworks (PR.AC-5 and PR.PT-3 in 800-82 r3; SR 5.1, SR 5.2, and SR 7.6 in 24443-4-2). Treat these as "maps to" relationships rather than one-to-one equivalences. Always confirm the identifiers against the current source publication before including them in a compliance report; Kubescape findings are an input to the protective-requirement analysis, not a substitute for it.
+NIST SP 800-82 Rev. 3 and IEC 62443-4-2 both acknowledge that OT systems have legitimate deviations from IT hardening baselines, as long as those deviations are documented, scoped, and compensated for with network segmentation. The Kubescape controls listed above map most naturally to the network integrity and least-functionality families of those frameworks (PR.AC-5 and PR.PT-3 in 800-82 r3; SR 5.1, SR 5.2, and SR 7.6 in 62443-4-2). Treat these as "maps to" relationships rather than one-to-one equivalences. Always confirm the identifiers against the current source publication before including them in a compliance report; Kubescape findings are an input to the protective-requirement analysis, not a substitute for it.
 
 ## Troubleshooting
 

--- a/examples/exceptions/README.md
+++ b/examples/exceptions/README.md
@@ -303,6 +303,35 @@ You can combine multiple exceptions in a single file:
 ]
 ```
 
+### Exclude ICS/OT Namespaces from a Specific Control
+
+Industrial Control System / Operational Technology (ICS/OT) workloads frequently require deviations from standard Kubernetes hardening, for example `hostNetwork: true` for Modbus/DNP3 protocol bridges that need direct reachability to PLC subnets. See [`docs/ics-ot-workloads.md`](../../docs/ics-ot-workloads.md) for the full guidance on scanning OT workloads with Kubescape.
+
+The example below scopes the exception narrowly: it suppresses only C-0041 (`hostNetwork`) for resources carrying the label `sector: ics-ot`, leaving every other control in the failed state so genuinely new misconfigurations still surface. Pair every exception with a compensating control (typically a NetworkPolicy that default-denies ingress to the OT namespace) and document the risk acceptance in your change-management system.
+
+```json
+[
+    {
+        "name": "exclude-ot-sector-host-network",
+        "policyType": "postureExceptionPolicy",
+        "actions": ["alertOnly"],
+        "resources": [
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "sector": "ics-ot"
+                }
+            }
+        ],
+        "posturePolicies": [
+            {
+                "controlID": "C-0041"
+            }
+        ]
+    }
+]
+```
+
 ---
 
 ## Related Documentation

--- a/examples/exceptions/ics-ot-exceptions.json
+++ b/examples/exceptions/ics-ot-exceptions.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "exclude-ot-sector-host-network",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+            "alertOnly"
+        ],
+        "resources": [
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "sector": "ics-ot"
+                }
+            }
+        ],
+        "posturePolicies": [
+            {
+                "controlID": "C-0041"
+            }
+        ]
+    }
+]

--- a/examples/ics-ot/modbus-deployment.yaml
+++ b/examples/ics-ot/modbus-deployment.yaml
@@ -1,0 +1,75 @@
+# Example ICS/OT workload: Modbus TCP PLC bridge.
+#
+# This manifest deliberately violates several Kubescape controls to
+# demonstrate deviations common in ICS/OT deployments. Do NOT run
+# unmodified in production without a formal risk acceptance.
+# See docs/ics-ot-workloads.md for the full guidance.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ot-modbus
+  labels:
+    sector: ics-ot
+    environment: ot
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: modbus-controller
+  namespace: ot-modbus
+  labels:
+    app: modbus-controller
+    sector: ics-ot
+    protocol: modbus-tcp
+  annotations:
+    # C-0041: bridge needs direct PLC subnet reachability without NAT.
+    kubescape.io/control-C-0041: "hostNetwork required for direct PLC subnet access"
+    # C-0048: USB-to-RS-485 adapter exposed as a character device.
+    kubescape.io/control-C-0048: "hostPath /dev/ttyUSB0 for RS-485 serial bridge"
+    # C-0057: vendor libmodbus requires /dev/mem for timing-critical polling.
+    kubescape.io/control-C-0057: "privileged mode required by vendor libmodbus"
+    # C-0044: Modbus TCP clients connect to well-known TCP/502.
+    kubescape.io/control-C-0044: "hostPort 502 for legacy HMI clients"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: modbus-controller
+  template:
+    metadata:
+      labels:
+        app: modbus-controller
+        sector: ics-ot
+        protocol: modbus-tcp
+    spec:
+      hostNetwork: true                # C-0041
+      dnsPolicy: ClusterFirstWithHostNet
+      automountServiceAccountToken: false
+      containers:
+        - name: modbus-bridge
+          image: openplc/openplc-v3:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: modbus-tcp
+              containerPort: 502
+              hostPort: 502            # C-0044
+              protocol: TCP
+          securityContext:
+            privileged: true           # C-0057
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: serial-device
+              mountPath: /dev/ttyUSB0
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+      volumes:
+        - name: serial-device
+          hostPath:                    # C-0048
+            path: /dev/ttyUSB0
+            type: CharDevice

--- a/examples/ics-ot/opcua-deployment.yaml
+++ b/examples/ics-ot/opcua-deployment.yaml
@@ -1,0 +1,88 @@
+# Example ICS/OT workload: OPC-UA server with a legacy COM bridge.
+#
+# Like the Modbus example, this manifest deliberately violates
+# Kubescape controls to mirror real OT deployment patterns. Do NOT
+# run unmodified in production without a formal risk acceptance.
+# See docs/ics-ot-workloads.md for the full guidance.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ot-opcua
+  labels:
+    sector: ics-ot
+    environment: ot
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opcua-server
+  namespace: ot-opcua
+  labels:
+    app: opcua-server
+    sector: ics-ot
+    protocol: opc-ua
+  annotations:
+    # C-0057: vendor COM bridge mounts /dev/mem; privileged profile required.
+    kubescape.io/control-C-0057: "privileged mode required by vendor COM bridge"
+    # C-0016: setuid helper binds TCP/4840 below 1024. Track for replacement.
+    kubescape.io/control-C-0016: "setuid helper requires privilege escalation"
+    # C-0038: COM bridge inspects host process state to mirror SCADA process table.
+    kubescape.io/control-C-0038: "hostPID required for COM process-table bridge"
+    # C-0046: multicast OPC-UA discovery sockets need NET_ADMIN.
+    kubescape.io/control-C-0046: "CAP_NET_ADMIN for multicast discovery sockets"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opcua-server
+  template:
+    metadata:
+      labels:
+        app: opcua-server
+        sector: ics-ot
+        protocol: opc-ua
+    spec:
+      hostPID: true                    # C-0038
+      automountServiceAccountToken: false
+      containers:
+        - name: opcua-server
+          image: openplc/openplc-v3:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: opc-ua-tcp
+              containerPort: 4840
+              protocol: TCP
+          securityContext:
+            privileged: true           # C-0057
+            allowPrivilegeEscalation: true  # C-0016
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              add:
+                - NET_ADMIN            # C-0046
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opcua-server
+  namespace: ot-opcua
+  labels:
+    app: opcua-server
+    sector: ics-ot
+    protocol: opc-ua
+spec:
+  type: ClusterIP
+  selector:
+    app: opcua-server
+  ports:
+    - name: opc-ua-tcp
+      port: 4840
+      targetPort: 4840
+      protocol: TCP


### PR DESCRIPTION
## Overview

Adds a guide for scanning Industrial Control System (ICS) and Operational Technology (OT) workloads on Kubernetes with Kubescape. Targets OT security engineers running containerized SCADA components, PLC protocol bridges, and OPC-UA servers where standard hardening controls (hostNetwork, privileged, hostPath) frequently conflict with Layer-1 protocol requirements.

The guide includes two example manifests that deliberately violate the controls most commonly triggered by OT workloads (C-0016, C-0038, C-0041, C-0044, C-0046, C-0048, C-0057, C-0074), a scoped exception that suppresses C-0041 for resources labeled `sector: ics-ot` without muting other findings, and a NetworkPolicy pattern as the compensating control.

## How to Test

No cluster required. Build kubescape from this branch and scan the example manifests with `--keep-local`:

```bash
make build

./kubescape scan --keep-local examples/ics-ot/modbus-deployment.yaml --format json --output /tmp/modbus-scan.json
./kubescape scan --keep-local examples/ics-ot/opcua-deployment.yaml --format json --output /tmp/opcua-scan.json
./kubescape scan --keep-local examples/ics-ot/ \
  --exceptions examples/exceptions/ics-ot-exceptions.json \
  --format json --output /tmp/ot-scan-exc.json
```

The Modbus manifest triggers C-0041, C-0044, C-0048, and C-0057 plus several additional controls (non-root user, immutable filesystem, network policy, and others) depending on the framework bundle in use. The OPC-UA manifest triggers C-0016, C-0038, C-0046, and C-0057 plus the same secondary findings. The exception file suppresses C-0041 for resources labeled `sector: ics-ot` (the finding moves to `passed` with `subStatus: w/exceptions`) while leaving every other control in `failed` state.

## Additional Information

The markdown and YAML additions are excluded from CI by the `paths-ignore` glob in `.github/workflows/00-pr-scanner.yaml`. The new `examples/exceptions/ics-ot-exceptions.json` triggers the PR scanner (build, smoke tests, golangci-lint) because `.json` is not in the ignore list and the `examples/*` glob does not match files in subdirectories. The JSON syntax has been validated locally; no Go code is touched.

## Related issues/PRs

- Proposal discussion: #2472

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [N/A] If it is a core feature, I have added thorough tests.
- [N/A] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ICS/OT Kubernetes scanning guide with walkthrough scan commands, severity threshold workflows, and control-failure filtering.
  * Included Modbus TCP and OPC-UA example manifests demonstrating common OT deviations, plus a ready-to-use OT exception JSON to suppress a specific control.

* **Documentation**
  * Updated the documentation index to list the new ICS/OT guide.
  * Expanded the Exceptions README with an “exclude ICS/OT namespaces from a specific control” example, including rescanning and compensating NetworkPolicy guidance.
  * Added troubleshooting notes (scoping, targeting, and offline policy behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->