### PR TITLE
[ LFX 2026] feat(exceptions): honor objectSelector.matchExpressions via PostureExceptionPolicy.ObjectSelector

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"regexp"
 	"sort"
 	"time"
 
@@ -151,6 +150,13 @@ func convertCRDObjectToPosturePolicies(
 	if err != nil {
 		return nil, err
 	}
+	// objectSelector (matchLabels + matchExpressions) is carried as a policy-level
+	// LabelSelector and evaluated by the exception processor with labels.Selector
+	// semantics, ANDed against the resource designators above.
+	objectSelector, err := decodeObjectSelector(obj)
+	if err != nil {
+		return nil, err
+	}
 
 	policies := make([]armotypes.PostureExceptionPolicy, 0, len(postureItems))
 	for _, raw := range postureItems {
@@ -169,7 +175,7 @@ func convertCRDObjectToPosturePolicies(
 		// frameworkName scopes the exception to a single framework; an empty value
 		// (field omitted) applies the exception framework-wide.
 		frameworkName, _ := item["frameworkName"].(string)
-		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, frameworkName, action, expiresAt, reason, resources)
+		policy, err := convertSecurityExceptionToPosturePolicy(name, controlID, frameworkName, action, expiresAt, reason, resources, objectSelector)
 		if err != nil {
 			continue
 		}
@@ -203,18 +209,9 @@ func buildResourceDesignators(
 	// exception back to the whole namespace.
 	namespace := obj.GetNamespace()
 
-	// objectSelector constrains the exception to workloads carrying matching labels.
-	// matchLabels are flattened into every resource designator so the existing label
-	// comparator (opa-utils compareLabels) enforces them, AND-combined with the other
-	// match fields per the design doc. Note: matchLabels are matched against the
-	// resource's own top-level metadata.labels (workload.GetLabels()), not the
-	// pod-template/selector labels. matchExpressions cannot be represented as
-	// key->value attributes, so they are best-effort for v1beta1: a warning is emitted
-	// and the rest of the exception still applies (partial application, never fail-closed).
-	objectSelectorLabels, err := objectSelectorMatchLabels(obj, kind)
-	if err != nil {
-		return nil, err
-	}
+	// objectSelector is handled separately as a policy-level LabelSelector (see
+	// decodeObjectSelector); this function only builds the resource/namespace-scoped
+	// designators, which the exception processor ANDs with that selector.
 
 	namespaceSelectorFound := false
 	var namespaceNames []string
@@ -304,21 +301,17 @@ func buildResourceDesignators(
 		}
 	}
 
-	// AND objectSelector.matchLabels into every designator produced above.
-	if len(objectSelectorLabels) > 0 {
-		for _, designator := range designators {
-			maps.Copy(designator, objectSelectorLabels)
-		}
-	}
-
 	return designators, nil
 }
 
-// objectSelectorMatchLabels decodes spec.match.objectSelector and returns its
-// matchLabels as regex-escaped designator attributes (the label comparator treats
-// values as regexes). matchExpressions are not representable as key->value attributes
-// and are logged as best-effort rather than failing the exception.
-func objectSelectorMatchLabels(obj *unstructured.Unstructured, kind string) (map[string]string, error) {
+// decodeObjectSelector decodes spec.match.objectSelector into an armotypes.LabelSelector
+// carrying the full selector (matchLabels + matchExpressions). It returns nil when the
+// selector is absent OR present-but-empty: an empty selector must impose no label
+// constraint (the exception is scoped by its other match fields), it must not silently
+// widen to match every workload. The exception processor (opa-utils) evaluates a non-nil
+// selector with labels.Selector semantics and ANDs it with the resource designators, so
+// both matchLabels and matchExpressions are honored.
+func decodeObjectSelector(obj *unstructured.Unstructured) (*armotypes.LabelSelector, error) {
 	selectorRaw, found, err := unstructured.NestedFieldCopy(obj.Object, "spec", "match", "objectSelector")
 	if err != nil {
 		return nil, fmt.Errorf("read objectSelector: %w", err)
@@ -334,23 +327,27 @@ func objectSelectorMatchLabels(obj *unstructured.Unstructured, kind string) (map
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(selectorMap, &labelSelector); err != nil {
 		return nil, fmt.Errorf("decode objectSelector: %w", err)
 	}
+	if len(labelSelector.MatchLabels) == 0 && len(labelSelector.MatchExpressions) == 0 {
+		return nil, nil // empty selector: no label constraint
+	}
+	return toArmoLabelSelector(labelSelector), nil
+}
 
-	if len(labelSelector.MatchExpressions) > 0 {
-		logger.L().Warning("SecurityException spec.match.objectSelector.matchExpressions is best-effort for v1beta1 and is not applied; matchLabels (if any) still apply",
-			helpers.String("name", obj.GetName()),
-			helpers.String("namespace", obj.GetNamespace()),
-			helpers.String("kind", kind),
-		)
+// toArmoLabelSelector converts a metav1.LabelSelector to the armotypes.LabelSelector
+// shape consumed by PostureExceptionPolicy.ObjectSelector.
+func toArmoLabelSelector(sel metav1.LabelSelector) *armotypes.LabelSelector {
+	out := &armotypes.LabelSelector{MatchLabels: sel.MatchLabels}
+	if len(sel.MatchExpressions) > 0 {
+		out.MatchExpressions = make([]armotypes.LabelSelectorRequirement, len(sel.MatchExpressions))
+		for i, r := range sel.MatchExpressions {
+			out.MatchExpressions[i] = armotypes.LabelSelectorRequirement{
+				Key:      r.Key,
+				Operator: r.Operator,
+				Values:   r.Values,
+			}
+		}
 	}
-
-	if len(labelSelector.MatchLabels) == 0 {
-		return nil, nil
-	}
-	escaped := make(map[string]string, len(labelSelector.MatchLabels))
-	for k, v := range labelSelector.MatchLabels {
-		escaped[k] = regexp.QuoteMeta(v)
-	}
-	return escaped, nil
+	return out
 }
 
 // resolveNamespaceSelector returns namespace names matching a label selector.
@@ -389,6 +386,7 @@ func convertSecurityExceptionToPosturePolicy(
 	expiresAt string,
 	reason string,
 	resources []map[string]string,
+	objectSelector *armotypes.LabelSelector,
 ) (armotypes.PostureExceptionPolicy, error) {
 	var actions []armotypes.PostureExceptionPolicyActions
 	switch action {
@@ -426,9 +424,10 @@ func convertSecurityExceptionToPosturePolicy(
 	}
 
 	policy := armotypes.PostureExceptionPolicy{
-		PolicyType: string(armotypes.PostureExceptionPolicyType),
-		Actions:    actions,
-		Resources:  designators,
+		PolicyType:     string(armotypes.PostureExceptionPolicyType),
+		Actions:        actions,
+		Resources:      designators,
+		ObjectSelector: objectSelector,
 		PosturePolicies: []armotypes.PosturePolicy{
 			{
 				ControlID:     controlID,

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -156,7 +156,7 @@ func TestCRDExceptionsGetter_PartialApplicationOnConversionError(t *testing.T) {
 	assert.Equal(t, "C-0001", exceptions[0].PosturePolicies[0].ControlID)
 }
 
-func TestBuildResourceDesignators_ObjectSelectorWithNamespaceSelector(t *testing.T) {
+func TestConvertCRDObjectToPosturePolicies_ObjectSelectorWithNamespaceSelector(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(
@@ -179,14 +179,24 @@ func TestBuildResourceDesignators_ObjectSelectorWithNamespaceSelector(t *testing
 		},
 	}}
 
-	// objectSelector.matchLabels must merge into the namespace x resource cross product,
-	// AND-combined with both the resolved namespaces and the resource scope.
-	got, err := buildResourceDesignators(obj, "ClusterSecurityException", k8sClient)
+	// namespaceSelector x resources builds the designator cross product; objectSelector
+	// is carried separately as a policy-level LabelSelector (not flattened into the
+	// designators) and ANDed against it by the exception processor.
+	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException", k8sClient)
 	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	designators := make([]map[string]string, 0, len(policies[0].Resources))
+	for _, d := range policies[0].Resources {
+		designators = append(designators, d.Attributes)
+	}
 	assert.ElementsMatch(t, []map[string]string{
-		{identifiers.AttributeNamespace: "staging", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web", "app": "nginx"},
-		{identifiers.AttributeNamespace: "staging-2", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web", "app": "nginx"},
-	}, got)
+		{identifiers.AttributeNamespace: "staging", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web"},
+		{identifiers.AttributeNamespace: "staging-2", identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web"},
+	}, designators)
+	require.NotNil(t, policies[0].ObjectSelector)
+	assert.Equal(t, map[string]string{"app": "nginx"}, policies[0].ObjectSelector.MatchLabels)
+	assert.Empty(t, policies[0].ObjectSelector.MatchExpressions)
 }
 
 func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
@@ -245,7 +255,6 @@ func TestBuildResourceDesignators_NamespacedScopeIsNotWidened(t *testing.T) {
 	tests := []struct {
 		name      string
 		resources []map[string]any
-		selector  map[string]any
 		want      []map[string]string
 	}{
 		{
@@ -263,27 +272,11 @@ func TestBuildResourceDesignators_NamespacedScopeIsNotWidened(t *testing.T) {
 			name: "no narrowing falls back to the whole namespace",
 			want: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
 		},
-		{
-			name:      "objectSelector AND resources is a strict intersection",
-			resources: []map[string]any{{"kind": "Deployment", "name": "web"}},
-			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
-			want: []map[string]string{
-				{
-					identifiers.AttributeNamespace: "team-a",
-					identifiers.AttributeKind:      "Deployment",
-					identifiers.AttributeName:      "web",
-					"app":                          "nginx",
-				},
-			},
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			match := map[string]any{}
-			if tc.selector != nil {
-				match["objectSelector"] = tc.selector
-			}
 			if len(tc.resources) > 0 {
 				resources := make([]any, 0, len(tc.resources))
 				for _, res := range tc.resources {
@@ -308,48 +301,42 @@ func TestBuildResourceDesignators_NamespacedScopeIsNotWidened(t *testing.T) {
 	}
 }
 
-func TestBuildResourceDesignators_ObjectSelector(t *testing.T) {
+func TestConvertCRDObjectToPosturePolicies_ObjectSelector(t *testing.T) {
 	tests := []struct {
-		name      string
-		kind      string
-		namespace string
-		selector  map[string]any
-		resources []map[string]any
-		want      []map[string]string
+		name            string
+		kind            string
+		namespace       string
+		selector        map[string]any
+		resources       []map[string]any
+		wantDesignators []map[string]string
+		wantSelector    *armotypes.LabelSelector
 	}{
 		{
-			name:      "matchLabels on namespaced SecurityException ANDs labels into the namespace scope",
-			kind:      "SecurityException",
-			namespace: "team-a",
-			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
-			want: []map[string]string{
-				{identifiers.AttributeNamespace: "team-a", "app": "nginx"},
-			},
+			name:            "matchLabels are carried on ObjectSelector, not flattened into the namespace scope",
+			kind:            "SecurityException",
+			namespace:       "team-a",
+			selector:        map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			wantDesignators: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantSelector:    &armotypes.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
 		},
 		{
-			name:      "matchLabels AND resources merge into the resource designator",
-			kind:      "ClusterSecurityException",
-			selector:  map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
-			resources: []map[string]any{{"kind": "Deployment", "name": "web"}},
-			want: []map[string]string{
-				{
-					identifiers.AttributeKind: "Deployment",
-					identifiers.AttributeName: "web",
-					"app":                     "nginx",
-				},
-			},
+			name:            "matchLabels alongside a resource keep the designator label-free",
+			kind:            "ClusterSecurityException",
+			selector:        map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			resources:       []map[string]any{{"kind": "Deployment", "name": "web"}},
+			wantDesignators: []map[string]string{{identifiers.AttributeKind: "Deployment", identifiers.AttributeName: "web"}},
+			wantSelector:    &armotypes.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
 		},
 		{
-			name:      "label values are regex-escaped",
-			kind:      "SecurityException",
-			namespace: "team-a",
-			selector:  map[string]any{"matchLabels": map[string]any{"version": "1.25"}},
-			want: []map[string]string{
-				{identifiers.AttributeNamespace: "team-a", "version": `1\.25`},
-			},
+			name:            "label values are not regex-escaped (labels.Selector uses exact match)",
+			kind:            "SecurityException",
+			namespace:       "team-a",
+			selector:        map[string]any{"matchLabels": map[string]any{"version": "1.25"}},
+			wantDesignators: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantSelector:    &armotypes.LabelSelector{MatchLabels: map[string]string{"version": "1.25"}},
 		},
 		{
-			name:      "matchExpressions are best-effort and do not fail or constrain the exception",
+			name:      "matchExpressions are honored and carried on ObjectSelector",
 			kind:      "SecurityException",
 			namespace: "team-a",
 			selector: map[string]any{
@@ -357,10 +344,15 @@ func TestBuildResourceDesignators_ObjectSelector(t *testing.T) {
 					map[string]any{"key": "env", "operator": "In", "values": []any{"prod"}},
 				},
 			},
-			want: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantDesignators: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantSelector: &armotypes.LabelSelector{
+				MatchExpressions: []armotypes.LabelSelectorRequirement{
+					{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+				},
+			},
 		},
 		{
-			name:      "matchLabels apply alongside ignored matchExpressions",
+			name:      "matchLabels and matchExpressions are both carried on ObjectSelector",
 			kind:      "SecurityException",
 			namespace: "team-a",
 			selector: map[string]any{
@@ -369,42 +361,61 @@ func TestBuildResourceDesignators_ObjectSelector(t *testing.T) {
 					map[string]any{"key": "env", "operator": "In", "values": []any{"prod"}},
 				},
 			},
-			want: []map[string]string{
-				{identifiers.AttributeNamespace: "team-a", "app": "nginx"},
+			wantDesignators: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantSelector: &armotypes.LabelSelector{
+				MatchLabels: map[string]string{"app": "nginx"},
+				MatchExpressions: []armotypes.LabelSelectorRequirement{
+					{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+				},
 			},
 		},
 		{
-			name:     "matchLabels merge into the default cluster-wide scope",
-			kind:     "ClusterSecurityException",
-			selector: map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
-			want: []map[string]string{
-				{identifiers.AttributeKind: "*", "app": "nginx"},
-			},
+			name:            "objectSelector on the default cluster-wide scope keeps a bare kind designator",
+			kind:            "ClusterSecurityException",
+			selector:        map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+			wantDesignators: []map[string]string{{identifiers.AttributeKind: "*"}},
+			wantSelector:    &armotypes.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+		},
+		{
+			name:            "empty objectSelector imposes no label constraint (nil ObjectSelector)",
+			kind:            "SecurityException",
+			namespace:       "team-a",
+			selector:        map[string]any{},
+			wantDesignators: []map[string]string{{identifiers.AttributeNamespace: "team-a"}},
+			wantSelector:    nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			obj := &unstructured.Unstructured{Object: map[string]any{
-				"apiVersion": "kubescape.io/v1beta1",
-				"kind":       tc.kind,
-				"metadata":   map[string]any{"name": "exception-a", "namespace": tc.namespace},
-				"spec": map[string]any{
-					"match":   map[string]any{"objectSelector": tc.selector},
-					"posture": []any{map[string]any{"controlID": "C-0001", "action": "ignore"}},
-				},
-			}}
+			match := map[string]any{"objectSelector": tc.selector}
 			if len(tc.resources) > 0 {
 				resources := make([]any, 0, len(tc.resources))
 				for _, res := range tc.resources {
 					resources = append(resources, res)
 				}
-				obj.Object["spec"].(map[string]any)["match"].(map[string]any)["resources"] = resources
+				match["resources"] = resources
 			}
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       tc.kind,
+				"metadata":   map[string]any{"name": "exception-a", "namespace": tc.namespace},
+				"spec": map[string]any{
+					"match":   match,
+					"posture": []any{map[string]any{"controlID": "C-0001", "action": "ignore"}},
+				},
+			}}
 
-			got, err := buildResourceDesignators(obj, tc.kind, nil)
+			policies, err := convertCRDObjectToPosturePolicies(obj, tc.kind, nil)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tc.want, got)
+			require.Len(t, policies, 1)
+
+			designators := make([]map[string]string, 0, len(policies[0].Resources))
+			for _, d := range policies[0].Resources {
+				designators = append(designators, d.Attributes)
+			}
+			assert.ElementsMatch(t, tc.wantDesignators, designators)
+			assert.Equal(t, tc.wantSelector, policies[0].ObjectSelector)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/anchore/stereoscope v0.1.22
 	github.com/anchore/syft v1.42.3
 	github.com/anubhav06/copa-grype v1.0.3-alpha.1
-	github.com/armosec/armoapi-go v0.0.720
+	github.com/armosec/armoapi-go v0.0.730
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/briandowns/spinner v1.23.2
@@ -34,7 +34,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.300
+	github.com/kubescape/opa-utils v0.0.301
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.720 h1:mtxUw2wWPRSQWcUf89Eoc9J81SBIC0YaK66XqAXuhCQ=
-github.com/armosec/armoapi-go v0.0.720/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.730 h1:nz0pNP7gstPzSaHPi2o+5SzTu1tr711Uq+YBOg8jOWM=
+github.com/armosec/armoapi-go v0.0.730/go.mod h1:1l+70fBK09F7zI2jArrPUWVHaLkijg+sQutFTmE6HRs=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=
@@ -1200,8 +1200,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.300 h1:dFO06j10NJUUMlAy4032yy8SVlvaOyOk3jYWQwlyaFg=
-github.com/kubescape/opa-utils v0.0.300/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.301 h1:SK+/O2ORWD07q75zEYoc0hhtXpWA5/OPvSEudAZTpQg=
+github.com/kubescape/opa-utils v0.0.301/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -7,7 +7,7 @@ replace github.com/kubescape/kubescape/v3 => ../
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
 
 require (
-	github.com/armosec/armoapi-go v0.0.720
+	github.com/armosec/armoapi-go v0.0.730
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/go-openapi/runtime v0.29.3
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.300
+	github.com/kubescape/opa-utils v0.0.301
 	github.com/kubescape/storage v0.0.258
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -315,8 +315,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.720 h1:mtxUw2wWPRSQWcUf89Eoc9J81SBIC0YaK66XqAXuhCQ=
-github.com/armosec/armoapi-go v0.0.720/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.730 h1:nz0pNP7gstPzSaHPi2o+5SzTu1tr711Uq+YBOg8jOWM=
+github.com/armosec/armoapi-go v0.0.730/go.mod h1:1l+70fBK09F7zI2jArrPUWVHaLkijg+sQutFTmE6HRs=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=
@@ -1204,8 +1204,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/opa-utils v0.0.300 h1:dFO06j10NJUUMlAy4032yy8SVlvaOyOk3jYWQwlyaFg=
-github.com/kubescape/opa-utils v0.0.300/go.mod h1:v+ZV4gEaP2Tpwv1ev1kJM7+habuNUUeC1BO2XvnrUfY=
+github.com/kubescape/opa-utils v0.0.301 h1:SK+/O2ORWD07q75zEYoc0hhtXpWA5/OPvSEudAZTpQg=
+github.com/kubescape/opa-utils v0.0.301/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview

`CRDExceptionsGetter` (`core/cautils/getter/crdexceptionsgetter.go`) reads
`SecurityException` / `ClusterSecurityException` CRDs in-cluster and converts each into
`armotypes.PostureExceptionPolicy` objects that the existing exception engine consumes.
It is wired in via `getExceptionsGetter()` in `core/core/initutils.go`, which wraps it
with the cloud/file getter through `NewMergedExceptionsGetter(primary, NewCRDExceptionsGetter(k8sClient))`
(cloud wins on overlap).

The CRD exposes a native Kubernetes `spec.match.objectSelector` with **`matchLabels` and
`matchExpressions`**. Until now the getter honored only `matchLabels`, and did so by
flattening them into every resource designator as **`regexp.QuoteMeta`-escaped, per-key
regex attributes** (matched by opa-utils `compareLabels`). `matchExpressions` were
**logged and skipped** as a best-effort no-op for `v1beta1`:

```go
logger.L().Warning("SecurityException spec.match.objectSelector.matchExpressions is
    best-effort for v1beta1 and is not applied; matchLabels (if any) still apply", ...)
```

The set-based operators (`In` / `NotIn` / `Exists` / `DoesNotExist`) simply could not be
expressed on the regex-designator path (RE2 has no negative lookahead; the comparator
requires the key to be present). Two upstream PRs added the missing rail:
[armosec/armoapi-go#665](https://github.com/armosec/armoapi-go/pull/665) added the typed
`PostureExceptionPolicy.ObjectSelector *LabelSelector` field, and
[kubescape/opa-utils#176](https://github.com/kubescape/opa-utils/pull/176) made the
engine evaluate that field with `labels.Selector.Matches(...)` semantics, ANDed against
the designators.

This PR is the final consumer step: the getter now routes the **entire** `objectSelector`
(matchLabels **+** matchExpressions) into `policy.ObjectSelector` and drops the
regex-flatten path and the best-effort skip. One selector, one semantic. **Closes
[kubescape/kubescape#2363](https://github.com/kubescape/kubescape/issues/2363).**

## What changed

- **Dependency bump:** `armosec/armoapi-go v0.0.720 → v0.0.730` (the field) and
  `kubescape/opa-utils v0.0.300 → v0.0.301` (the evaluator). `go mod tidy` touched only
  those two module lines; a full `go build ./...` confirms the range introduced no
  unrelated breakage.
- **New `decodeObjectSelector(obj)`** replaces `objectSelectorMatchLabels`. It decodes
  `spec.match.objectSelector` into an `*armotypes.LabelSelector` carrying both
  `matchLabels` and `matchExpressions` (via `toArmoLabelSelector`), or `nil` when the
  selector is absent **or** present-but-empty.
- **`convertCRDObjectToPosturePolicies`** decodes the selector once per CRD and threads it
  into `convertSecurityExceptionToPosturePolicy`, which sets `policy.ObjectSelector`.
- **`buildResourceDesignators`** no longer sees `objectSelector`: it builds only the
  resource/namespace-scoped designators. The best-effort `matchExpressions` warning and
  the `regexp` import are removed.

## Semantics / contract

- **matchExpressions are now honored** end-to-end (the point of the change), evaluated by
  opa-utils with real `labels.Selector` set semantics.
- **matchLabels are no longer regex-escaped.** They travel as-is on `ObjectSelector` and
  are matched by exact-equality `labels.Selector`. This is behavior-preserving for the
  previous path (which anchored `QuoteMeta`-escaped literals — an exact match by another
  name), while fixing the set operators the regex path could not express.
- **Empty-selector guard (the 1 correctness trap):** a zero/absent `objectSelector` must
  impose **no** label constraint on that axis — it must not silently widen to "matches
  every workload." `decodeObjectSelector` returns `nil` for both absent and empty (`{}`)
  selectors; opa-utils treats `nil` as "skip the label axis" (`parseObjectSelector`
  returns `(nil, true)`). Pinned by the `empty objectSelector imposes no label
  constraint` test case.
- **Fallback designator preserved.** opa-utils evaluates `ObjectSelector` *inside* the
  per-designator match and early-returns when a designator has no attributes, so an
  exception still needs ≥1 non-empty designator for the selector to be reached. The getter
  keeps its existing fallback (`{namespace}` for a namespaced `SecurityException`,
  `{kind: "*"}` for a `ClusterSecurityException`), so an `objectSelector`-only exception
  still has a scope to AND against. Unchanged by this PR.
- **Malformed selector** stays safe: a bad `objectSelector` value (e.g. a string instead
  of an object) still fails conversion of that one CRD and is skipped with a warning
  (partial application, never fail-closed) — the other CRDs still apply.

## Dependencies

| Module | From | To | Brings in |
| --- | --- | --- | --- |
| `github.com/armosec/armoapi-go` | `v0.0.720` | `v0.0.730` | `PostureExceptionPolicy.ObjectSelector` field ([#665](https://github.com/armosec/armoapi-go/pull/665)) |
| `github.com/kubescape/opa-utils` | `v0.0.300` | `v0.0.301` | `labels.Selector` evaluation of `ObjectSelector` ([#176](https://github.com/kubescape/opa-utils/pull/176)) |

## How to Test

```bash
go build ./...                                   # ok
go vet ./core/cautils/getter/...                 # clean
go test -race ./core/cautils/getter/...          # ok
# exception-application path (consumes the field downstream):
go test ./core/pkg/opaprocessor/... ./core/pkg/resultshandling/... ./core/pkg/securityexception/...   # ok
```

Unit tests in `core/cautils/getter/crdexceptionsgetter_test.go`:

| Test | What it pins down |
| --- | --- |
| `TestConvertCRDObjectToPosturePolicies_ObjectSelector` | matchLabels carried on `ObjectSelector` (not flattened into designators); values **not** regex-escaped; `matchExpressions` honored; matchLabels+matchExpressions together; bare `{namespace}`/`{kind:"*"}` fallback kept label-free; **empty `{}` selector → nil `ObjectSelector`** |
| `TestConvertCRDObjectToPosturePolicies_ObjectSelectorWithNamespaceSelector` | namespaceSelector × resources cross product stays label-free; `objectSelector` is carried separately on `ObjectSelector` for the engine to AND |
| `TestCRDExceptionsGetter_PartialApplicationOnConversionError` | a malformed `objectSelector` fails only its own CRD; the rest still apply |
| `TestBuildResourceDesignators_NamespacedScopeIsNotWidened`, `TestBuildResourceDesignators_NamespaceSelector`, `TestConvertCRDObjectToPosturePolicies_DefaultScope`, `TestConvertCRDObjectToPosturePolicies_FrameworkName`, `TestMergedExceptionsGetter_Deduplication` | existing designator/scope/merge behavior unchanged |

## Related issues / PRs

Epic: [kubescape/kubescape#1982](https://github.com/kubescape/kubescape/issues/1982) — SecurityException CRD implementation.

The `objectSelector.matchExpressions` chain (this PR is the last step):

1. [armosec/armoapi-go#665](https://github.com/armosec/armoapi-go/pull/665) — add typed `PostureExceptionPolicy.ObjectSelector` field *(merged, `v0.0.730`)*.
2. [kubescape/opa-utils#176](https://github.com/kubescape/opa-utils/pull/176) — evaluate `ObjectSelector` via `labels.Selector` *(merged, `v0.0.301`)*.
3. **This PR** — populate the field from the full `objectSelector`, retire the regex-flatten + best-effort skip. **Closes [#2363](https://github.com/kubescape/kubescape/issues/2363).**

Prior/adjacent SecurityException work:

- [kubescape/kubescape#2366](https://github.com/kubescape/kubescape/pull/2366) — earlier bug fixes; honored `objectSelector.matchLabels` via regex designators and shipped `matchExpressions` as the best-effort no-op this PR removes.
- [kubescape/helm-charts#859](https://github.com/kubescape/helm-charts/pull/859) — CEL validation for the `SecurityException`/`ClusterSecurityException` CRDs (`v1beta1`) *(merged)*.
- [kubescape/kubescape#2403](https://github.com/kubescape/kubescape/pull/2403) — removed the orphan, uninstallable `deploy/crd` SecurityException CRD *(merged)*.
- Design reference: [`docs/security-exception-design.md`](https://github.com/kubescape/kubevuln/blob/main/docs/security-exception-design.md) (`kubescape/kubevuln`; CRDs ship as `kubescape.io/v1beta1`).

Still open in the epic after this PR: operator `SecurityExceptionWatchHandler` (rescan on change/expiry), Headlamp plugin, full-stack e2e.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have added tests covering the new axis (matchLabels not-escaped, matchExpressions honored, empty→nil guard) and updated the designator/merge tests
- [x] New and existing unit tests pass locally with my changes (`go build ./...`, `go vet`, `go test -race` all green)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRD `objectSelector` handling to preserve full label semantics, including both `matchLabels` and `matchExpressions`.
  * Correctly separates selector criteria from resource designators to avoid unintended matching behavior.
  * Ensures empty or absent selectors result in a `nil` selector and keeps `matchLabels` values unescaped as-is.

* **Tests**
  * Updated and expanded coverage to validate new `objectSelector` conversion behavior across namespaced and cluster-wide scopes.

* **Chores**
  * Updated Go module dependencies to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->