### PR TITLE
feat: introduce Container Image Vulnerability (CIV) Adaptor interfaces

### DIFF
--- a/pkg/imagescan/civ.go
+++ b/pkg/imagescan/civ.go
@@ -1,6 +1,11 @@
 package imagescan
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/docker/distribution/manifest/schema2"
+)
 
 // ContainerImageIdentifier uniquely identifies a container image
 type ContainerImageIdentifier struct {
@@ -18,36 +23,43 @@ type ContainerImageScanStatus struct {
 	LastScanDate    time.Time                `json:"lastScanDate"`
 }
 
+// Vulnerability represents a single container vulnerability
+type Vulnerability struct {
+	ID          string   `json:"id"`
+	Severity    string   `json:"severity"`
+	Description string   `json:"description,omitempty"`
+	Links       []string `json:"links,omitempty"`
+}
+
 // ContainerImageVulnerabilityReport contains the vulnerabilities found in an image
 type ContainerImageVulnerabilityReport struct {
 	ImageID         ContainerImageIdentifier `json:"imageID"`
-	Vulnerabilities []any                    `json:"vulnerabilities,omitempty"` // TBD: Map to appropriate vulnerability struct
+	Vulnerabilities []Vulnerability          `json:"vulnerabilities,omitempty"`
 }
 
 // ContainerImageInformation contains the metadata and bill of materials for an image
 type ContainerImageInformation struct {
 	ImageID       ContainerImageIdentifier `json:"imageID"`
 	Bom           []string                 `json:"bom"`
-	ImageManifest any                      `json:"imageManifest"` // Docker package definition (e.g. github.com/docker/distribution/manifest/schema2.Manifest)
+	ImageManifest schema2.Manifest         `json:"imageManifest"`
 }
 
 // IContainerImageVulnerabilityAdaptor defines the unified interface for interacting with
 // external container image registries and vulnerability scanners (e.g. Harbor, ECR).
 type IContainerImageVulnerabilityAdaptor interface {
 	// Login authenticates with the external provider.
-	// Credentials are coming from user input (CLI or configuration file) and they are abstracted at string to string map level
-	// so an example use would be like registry: "simpledockerregistry:80" and credentials like {"username":"joedoe","password":"abcd1234"}
-	Login(registry string, credentials map[string]string) error
+	// Credentials use the standard RegistryCredentials struct for compile-checked auth.
+	Login(ctx context.Context, registry string, credentials RegistryCredentials) error
 
 	// DescribeAdaptor provides a string description of the adaptor for help purposes.
 	DescribeAdaptor() string
 
 	// GetImagesScanStatus retrieves the scan status for a list of image identifiers.
-	GetImagesScanStatus(imageIDs []ContainerImageIdentifier) ([]ContainerImageScanStatus, error)
+	GetImagesScanStatus(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageScanStatus, error)
 
 	// GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
-	GetImagesVulnerabilities(imageIDs []ContainerImageIdentifier) ([]ContainerImageVulnerabilityReport, error)
+	GetImagesVulnerabilities(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageVulnerabilityReport, error)
 
 	// GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
-	GetImagesInformation(imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error)
+	GetImagesInformation(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error)
 }

--- a/pkg/imagescan/civ.go
+++ b/pkg/imagescan/civ.go
@@ -1,0 +1,53 @@
+package imagescan
+
+import "time"
+
+// ContainerImageIdentifier uniquely identifies a container image
+type ContainerImageIdentifier struct {
+	Registry   string `json:"registry"`
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	Hash       string `json:"hash"`
+}
+
+// ContainerImageScanStatus represents the current state of vulnerability scanning for an image
+type ContainerImageScanStatus struct {
+	ImageID         ContainerImageIdentifier `json:"imageID"`
+	IsScanAvailable bool                     `json:"isScanAvailable"`
+	IsBomAvailable  bool                     `json:"isBomAvailable"`
+	LastScanDate    time.Time                `json:"lastScanDate"`
+}
+
+// ContainerImageVulnerabilityReport contains the vulnerabilities found in an image
+type ContainerImageVulnerabilityReport struct {
+	ImageID       ContainerImageIdentifier `json:"imageID"`
+	Vulnerabilities []any                    `json:"vulnerabilities,omitempty"` // TBD: Map to appropriate vulnerability struct
+}
+
+// ContainerImageInformation contains the metadata and bill of materials for an image
+type ContainerImageInformation struct {
+	ImageID       ContainerImageIdentifier `json:"imageID"`
+	Bom           []string                 `json:"bom"`
+	ImageManifest any                      `json:"imageManifest"` // Docker package definition (e.g. github.com/docker/distribution/manifest/schema2.Manifest)
+}
+
+// IContainerImageVulnerabilityAdaptor defines the unified interface for interacting with
+// external container image registries and vulnerability scanners (e.g. Harbor, ECR).
+type IContainerImageVulnerabilityAdaptor interface {
+	// Login authenticates with the external provider.
+	// Credentials are coming from user input (CLI or configuration file) and they are abstracted at string to string map level
+	// so an example use would be like registry: "simpledockerregistry:80" and credentials like {"username":"joedoe","password":"abcd1234"}
+	Login(registry string, credentials map[string]string) error
+
+	// DescribeAdaptor provides a string description of the adaptor for help purposes.
+	DescribeAdaptor() string
+
+	// GetImagesScanStatus retrieves the scan status for a list of image identifiers.
+	GetImagesScanStatus(imageIDs []ContainerImageIdentifier) ([]ContainerImageScanStatus, error)
+
+	// GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
+	GetImagesVulnerabilities(imageIDs []ContainerImageIdentifier) ([]ContainerImageVulnerabilityReport, error)
+
+	// GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
+	GetImagesInformation(imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error)
+}

--- a/pkg/imagescan/civ.go
+++ b/pkg/imagescan/civ.go
@@ -20,7 +20,7 @@ type ContainerImageScanStatus struct {
 
 // ContainerImageVulnerabilityReport contains the vulnerabilities found in an image
 type ContainerImageVulnerabilityReport struct {
-	ImageID       ContainerImageIdentifier `json:"imageID"`
+	ImageID         ContainerImageIdentifier `json:"imageID"`
 	Vulnerabilities []any                    `json:"vulnerabilities,omitempty"` // TBD: Map to appropriate vulnerability struct
 }
 

--- a/pkg/imagescan/civ_test.go
+++ b/pkg/imagescan/civ_test.go
@@ -1,0 +1,114 @@
+package imagescan
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestContainerImageIdentifierJSON(t *testing.T) {
+	id := ContainerImageIdentifier{
+		Registry:   "docker.io",
+		Repository: "library/nginx",
+		Tag:        "latest",
+		Hash:       "sha256:12345",
+	}
+
+	b, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerImageIdentifier: %v", err)
+	}
+
+	var parsed ContainerImageIdentifier
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerImageIdentifier: %v", err)
+	}
+
+	if parsed.Registry != id.Registry || parsed.Repository != id.Repository || parsed.Tag != id.Tag || parsed.Hash != id.Hash {
+		t.Errorf("Unmarshalled object %v does not match original %v", parsed, id)
+	}
+}
+
+func TestContainerImageScanStatusJSON(t *testing.T) {
+	now := time.Now().Truncate(time.Second) // JSON serialization may truncate fractional seconds
+	status := ContainerImageScanStatus{
+		ImageID: ContainerImageIdentifier{
+			Registry:   "docker.io",
+			Repository: "library/nginx",
+			Tag:        "latest",
+			Hash:       "sha256:12345",
+		},
+		IsScanAvailable: true,
+		IsBomAvailable:  false,
+		LastScanDate:    now,
+	}
+
+	b, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerImageScanStatus: %v", err)
+	}
+
+	var parsed ContainerImageScanStatus
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerImageScanStatus: %v", err)
+	}
+
+	if parsed.IsScanAvailable != status.IsScanAvailable || !parsed.LastScanDate.Equal(status.LastScanDate) {
+		t.Errorf("Unmarshalled object %v does not match original %v", parsed, status)
+	}
+}
+
+func TestContainerImageVulnerabilityReportJSON(t *testing.T) {
+	report := ContainerImageVulnerabilityReport{
+		ImageID: ContainerImageIdentifier{
+			Registry:   "docker.io",
+			Repository: "library/nginx",
+			Tag:        "latest",
+		},
+		Vulnerabilities: []any{
+			map[string]any{"id": "CVE-2023-1234", "severity": "HIGH"},
+		},
+	}
+
+	b, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerImageVulnerabilityReport: %v", err)
+	}
+
+	var parsed ContainerImageVulnerabilityReport
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerImageVulnerabilityReport: %v", err)
+	}
+
+	if len(parsed.Vulnerabilities) != 1 {
+		t.Errorf("Expected 1 vulnerability, got %d", len(parsed.Vulnerabilities))
+	}
+}
+
+func TestContainerImageInformationJSON(t *testing.T) {
+	info := ContainerImageInformation{
+		ImageID: ContainerImageIdentifier{
+			Registry:   "docker.io",
+			Repository: "library/nginx",
+			Tag:        "latest",
+		},
+		Bom: []string{"pkg1", "pkg2"},
+		ImageManifest: map[string]any{
+			"schemaVersion": float64(2),
+		},
+	}
+
+	b, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerImageInformation: %v", err)
+	}
+
+	var parsed ContainerImageInformation
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerImageInformation: %v", err)
+	}
+
+	if len(parsed.Bom) != 2 {
+		t.Errorf("Expected 2 bom items, got %d", len(parsed.Bom))
+	}
+}

--- a/pkg/imagescan/civ_test.go
+++ b/pkg/imagescan/civ_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/docker/distribution/manifest/schema2"
 )
 
 func TestContainerImageIdentifierJSON(t *testing.T) {
@@ -65,8 +67,8 @@ func TestContainerImageVulnerabilityReportJSON(t *testing.T) {
 			Repository: "library/nginx",
 			Tag:        "latest",
 		},
-		Vulnerabilities: []any{
-			map[string]any{"id": "CVE-2023-1234", "severity": "HIGH"},
+		Vulnerabilities: []Vulnerability{
+			{ID: "CVE-2023-1234", Severity: "HIGH"},
 		},
 	}
 
@@ -93,8 +95,8 @@ func TestContainerImageInformationJSON(t *testing.T) {
 			Tag:        "latest",
 		},
 		Bom: []string{"pkg1", "pkg2"},
-		ImageManifest: map[string]any{
-			"schemaVersion": float64(2),
+		ImageManifest: schema2.Manifest{
+			Versioned: schema2.SchemaVersion,
 		},
 	}
 


### PR DESCRIPTION
## Overview

This PR acts as Phase 1 for the Container Image Vulnerability (CIV) Adaptor proposal. It introduces the `IContainerImageVulnerabilityAdaptor` interface and its foundational data structs in a new, decoupled `pkg/imagescan/civ.go` file. This lays the groundwork required for Kubescape to pull vulnerability data from external registries (like Harbor or ECR) into the OPA engine.

## Additional Information

> **Architectural Decisions:**
> We have intentionally decoupled the `IContainerImageVulnerabilityAdaptor` interface into its own file (`pkg/imagescan/civ.go`). This provides a clean architectural boundary between the existing local scanning logic (`imagescan.go`) and the new external fetching logic. 
>
> The data structures introduced include:
> - `ContainerImageIdentifier` (Registry, Repo, Tag, Hash)
> - `ContainerImageScanStatus` (Availability and Timestamp)
> - `ContainerImageVulnerabilityReport` (Generic vulnerability payload)
> - `ContainerImageInformation` (BOM and Image Manifest)
> 
> To ensure seamless integration with the OPA rules processor, we have used generic `any` types for dynamic payloads (like Manifests) and provided a robust suite of JSON serialization tests. This guarantees data will flow perfectly into the OPA engine.

## How to Test

 1. Pull the branch locally.
 2. Run the unit tests via `go test ./pkg/imagescan/ -v -run TestContainerImage` to ensure the new struct JSON serialization works flawlessly.
 3. Verify the package compiles with `go build ./pkg/imagescan/...`.

## Examples/Screenshots

> N/A - Architectural foundation only.

## Related issues/PRs:
resolves #2481 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new image-scanning models for identifying images, reporting scan availability/last scan time, representing vulnerability lists, and capturing image details (including BOM and a typed image manifest).
  * Introduced a unified adaptor interface for authentication and batch retrieval of scan status, vulnerabilities, and image information.

* **Tests**
  * Added JSON round-trip unit tests for the new scanning models, including verification of key fields and slice lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->