### PR TITLE
fix(httphandler): populate report in synchronous scan response

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -127,6 +127,16 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		// wait for scan to complete
 		response = <-scanRequestParams.resp
 
+		if response.Type == utilsapisv1.ResultsV1ScanResponseType {
+			// populate the response with the report before it is deleted below
+			if res, err := readResultsFile(scanID); err != nil {
+				response.Type = utilsapisv1.ErrorScanResponseType
+				response.Response = err.Error()
+			} else {
+				response.Response = res
+			}
+		}
+
 		if !scanRequestParams.scanQueryParams.KeepResults {
 			// delete results after returning
 			logger.L().Debug("deleting results", helpers.String("ID", scanID))

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -131,7 +131,11 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 			// populate the response with the report before it is deleted below
 			if res, err := readResultsFile(scanID); err != nil {
 				response.Type = utilsapisv1.ErrorScanResponseType
-				response.Response = err.Error()
+				if scanFailed, ok := errors.AsType[*ScanFailedError](err); ok {
+					response.Response = scanFailed.Message
+				} else {
+					response.Response = err.Error()
+				}
 			} else {
 				response.Response = res
 			}

--- a/httphandler/handlerequests/v1/requestshandler_test.go
+++ b/httphandler/handlerequests/v1/requestshandler_test.go
@@ -7,9 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
@@ -30,30 +33,114 @@ func TestScan(t *testing.T) {
 
 	// Our scanner is not setting up the k8s connection; the test is covering the rest of the wiring
 	// that the signaling from the http handler goes all the way to the scanner implementation.
+	withTempOutputDirs(t)
+
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		report := &reporthandlingv2.PostureReport{}
+		b, err := json.Marshal(report)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(OutputDir, scanID+".json"), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
 		return nil, nil
 	}
 
 	var (
 		h  = NewHTTPHandler(false)
-		rq = httptest.NewRequest("POST", "/scan?wait=true", testBody(t))
+		rq = httptest.NewRequest("POST", "/scan?wait=true&keep=true", testBody(t))
 		w  = httptest.NewRecorder()
 	)
 	h.Scan(w, rq)
 	rs := w.Result()
 	body, _ := io.ReadAll(rs.Body)
 
-	type out struct {
-		code  int
-		ctype string
-		body  string
+	var resp utilsmetav1.Response
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("failed to decode Scan response body: %v", err)
 	}
-	want := out{200, "application/json", `{"id":"","type":"v1results"}`}
-	got := out{rs.StatusCode, rs.Header.Get("Content-type"), string(body)}
 
-	if got != want {
-		t.Errorf("Scan result: %v,  want %v", got, want)
+	if rs.StatusCode != http.StatusOK {
+		t.Errorf("Scan status code = %d, want %d", rs.StatusCode, http.StatusOK)
+	}
+	if resp.Type != utilsapisv1.ResultsV1ScanResponseType {
+		t.Errorf("Scan response type = %v, want %v", resp.Type, utilsapisv1.ResultsV1ScanResponseType)
+	}
+	if resp.Response == nil {
+		t.Errorf("Scan response.Response is nil, want populated PostureReport")
+	}
+}
+
+// TestScan_SyncResponse covers the sync response branch that populates
+// response.Response from the on-disk results file (requestshandler.go:130-138).
+func TestScan_SyncResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		writeResults bool
+		wantType     utilsapisv1.ScanResponseType
+	}{
+		{
+			name:         "results file present returns populated report",
+			writeResults: true,
+			wantType:     utilsapisv1.ResultsV1ScanResponseType,
+		},
+		{
+			name:         "results file missing returns error",
+			writeResults: false,
+			wantType:     utilsapisv1.ErrorScanResponseType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTempOutputDirs(t)
+
+			defer func(o scanner) { scanImpl = o }(scanImpl)
+			scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+				if tt.writeResults {
+					b, err := json.Marshal(&reporthandlingv2.PostureReport{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(filepath.Join(OutputDir, scanID+".json"), b, 0o644); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return nil, nil
+			}
+
+			var (
+				h  = NewHTTPHandler(false)
+				rq = httptest.NewRequest("POST", "/scan?wait=true&keep=true", testBody(t))
+				w  = httptest.NewRecorder()
+			)
+			h.Scan(w, rq)
+			rs := w.Result()
+			body, _ := io.ReadAll(rs.Body)
+
+			var resp utilsmetav1.Response
+			if err := json.Unmarshal(body, &resp); err != nil {
+				t.Fatalf("failed to decode Scan response body: %v", err)
+			}
+
+			if resp.Type != tt.wantType {
+				t.Errorf("response type = %v, want %v", resp.Type, tt.wantType)
+			}
+
+			switch tt.wantType {
+			case utilsapisv1.ResultsV1ScanResponseType:
+				if resp.Response == nil {
+					t.Errorf("response.Response is nil, want populated PostureReport")
+				}
+			case utilsapisv1.ErrorScanResponseType:
+				msg, ok := resp.Response.(string)
+				if !ok || msg == "" {
+					t.Errorf("response.Response = %v, want non-empty error message", resp.Response)
+				}
+			}
+		})
 	}
 }
 

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -69,7 +69,6 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	} else {
 		logger.L().Ctx(scanReq.ctx).Success("done scanning", helpers.String("ID", scanReq.scanID))
 		if scanReq.scanQueryParams.ReturnResults {
-			//TODO(ttimonen) should we actually pass the PostureReport here somehow?
 			response.Type = utilsapisv1.ResultsV1ScanResponseType
 		}
 	}


### PR DESCRIPTION
## Overview

This is the fix for #2466 .

The issue was that `POST /v1/scan?wait=true` returned an empty payload -- `{type: resultsV1, response: null}` -- then immediately deleted the results file, making the posture report permanently unrecoverable. `executeScan` only set `response.Type` and never populated `response.Response` with the `PostureReport` (the long-standing TODO at `requestshandlerutils.go:72`). The handler then deleted the on-disk artifact assuming delivery had happened, violating the documented contract that sync mode returns the same body as `GET /results`.

The fix is in the `Scan` handler's sync branch: after receiving the completion signal, if the scan succeeded, load the report from disk via `readResultsFile(scanID)` and place it in `response.Response` -- exactly what the `GET /results` handler already does -- before the delete runs. A read failure is surfaced as an error response instead of an empty success.

Now the two cases are actually distinct:

- Scan succeeds → report read from disk → full body returned to caller → file deleted
- Read fails → error response returned → caller knows something went wrong

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan responses now return the generated report contents when results are available.
  * If the results file can’t be read, the handler returns an error response instead of incomplete output.
  * Results retention behavior remains unchanged.

* **Tests**
  * Improved scan-handler tests to validate successful result payloads (including response body contents).
  * Added coverage for the synchronous path, asserting either populated results or an error message depending on whether on-disk output is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->