### PR TITLE
Derive cmd/vap policy metadata from the embedded VAP bundle

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor/cel"
 	"github.com/spf13/cobra"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,9 +96,30 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// A policy that declares a paramKind needs a ParamRef on its binding
+			// to be functional, so refuse to emit a silently broken binding. The
+			// check covers both flags: --control reads the paramKind off the
+			// control's policy, --policy off the named policy (a name outside
+			// the embedded bundle is left unchecked — we know nothing about it).
 			normalizedControlID := strings.ToUpper(strings.TrimSpace(controlID))
-			if normalizedControlID != "" && parameterReference == "" && celAdmissionControlsRequiringParams[normalizedControlID] {
-				return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", normalizedControlID)
+			if parameterReference == "" {
+				if normalizedControlID != "" {
+					paramKind, err := cel.ParamKindForControl(normalizedControlID)
+					if err != nil {
+						return err
+					}
+					if paramKind != nil {
+						return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", normalizedControlID)
+					}
+				} else {
+					paramKind, found, err := cel.ParamKindForPolicy(resolvedPolicyName)
+					if err != nil {
+						return err
+					}
+					if found && paramKind != nil {
+						return fmt.Errorf("policy %s requires --parameter-reference because it uses params", resolvedPolicyName)
+					}
+				}
 			}
 			if err := isValidK8sObjectName(resolvedPolicyName); err != nil {
 				return fmt.Errorf("invalid policy name %s: %w", resolvedPolicyName, err)
@@ -149,67 +171,13 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	return createPolicyBindingCmd
 }
 
-var celAdmissionPolicyByControlID = map[string]string{
-	"C-0001": "kubescape-c-0001-deny-forbidden-container-registries",
-	"C-0004": "kubescape-c-0004-deny-resources-with-memory-limit-or-request-not-set",
-	"C-0009": "kubescape-c-0009-deny-resources-with-memory-or-cpu-limit-not-set",
-	"C-0012": "kubescape-c-0012-deny-resources-with-sensitive-information-in-environment-variables",
-	"C-0013": "kubescape-c-0013-deny-resources-with-capability-to-run-as-root",
-	"C-0016": "kubescape-c-0016-allow-privilege-escalation",
-	"C-0017": "kubescape-c-0017-deny-resources-with-mutable-container-filesystem",
-	"C-0018": "kubescape-c-0018-deny-resources-without-configured-readiness-probes",
-	"C-0020": "kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials",
-	"C-0026": "kubescape-c-0026-deny-cronjobs",
-	"C-0034": "kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled",
-	"C-0038": "kubescape-c-0038-deny-resources-with-host-ipc-or-pid-privileges",
-	"C-0041": "kubescape-c-0041-deny-resources-with-host-network-access",
-	"C-0042": "kubescape-c-0042-deny-resources-with-ssh-server-running",
-	"C-0044": "kubescape-c-0044-deny-resources-with-host-port",
-	"C-0045": "kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false",
-	"C-0046": "kubescape-c-0046-deny-resources-with-insecure-capabilities",
-	"C-0048": "kubescape-c-0048-deny-workloads-with-hostpath-mounts",
-	"C-0050": "kubescape-c-0050-deny-resources-with-cpu-limit-or-request-not-set",
-	"C-0055": "kubescape-c-0055-linux-hardening",
-	"C-0056": "kubescape-c-0056-deny-resources-without-configured-liveliness-probes",
-	"C-0057": "kubescape-c-0057-privileged-container-denied",
-	"C-0061": "kubescape-c-0061-deny-workloads-in-default-namespace",
-	"C-0062": "kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint",
-	"C-0073": "kubescape-c-0073-deny-naked-pods",
-	"C-0074": "kubescape-c-0074-resources-mounting-docker-socket-denied",
-	"C-0075": "kubescape-c-0075-deny-resources-with-image-pull-policy-not-set-to-always-for-latest-tag",
-	"C-0076": "kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set",
-	"C-0077": "kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set",
-	"C-0078": "kubescape-c-0078-only-allow-images-from-allowed-registry",
-	"C-0198": "kubescape-c-0198-deny-root-containers",
-	"C-0199": "kubescape-c-0199-deny-net-raw-capability",
-	"C-0200": "kubescape-c-0200-deny-added-capabilities",
-	"C-0201": "kubescape-c-0201-deny-capabilities-assigned",
-	"C-0210": "kubescape-c-0210-deny-seccomp-profile-unconfined",
-	"C-0268": "kubescape-c-0268-deny-resources-with-cpu-request-not-set",
-	"C-0269": "kubescape-c-0269-deny-resources-with-memory-request-not-set",
-	"C-0270": "kubescape-c-0270-deny-resources-with-cpu-limit-not-set",
-	"C-0271": "kubescape-c-0271-deny-resources-with-memory-limit-not-set",
-	"C-0280": "kubescape-c-0280-deny-access-to-csr-approval-subresource",
-}
-
-var celAdmissionControlsRequiringParams = map[string]bool{
-	"C-0001": true,
-	"C-0004": true,
-	"C-0012": true,
-	"C-0020": true,
-	"C-0046": true,
-	"C-0050": true,
-	"C-0076": true,
-	"C-0077": true,
-	"C-0078": true,
-	"C-0268": true,
-	"C-0269": true,
-	"C-0270": true,
-	"C-0271": true,
-}
-
+// resolvePolicyName resolves the --policy/--control pair to a policy name.
+// Control IDs resolve against the VAP bundle embedded in the CEL engine, so the
+// answer always matches the deployable YAML instead of a hand-maintained copy.
+// Policy names are lowercased like control IDs are uppercased: both flags then
+// accept any casing of their canonical form.
 func resolvePolicyName(policyName, controlID string) (string, error) {
-	policyName = strings.TrimSpace(policyName)
+	policyName = strings.ToLower(strings.TrimSpace(policyName))
 	controlID = strings.ToUpper(strings.TrimSpace(controlID))
 
 	if policyName == "" && controlID == "" {
@@ -222,9 +190,9 @@ func resolvePolicyName(policyName, controlID string) (string, error) {
 		return policyName, nil
 	}
 
-	resolved, ok := celAdmissionPolicyByControlID[controlID]
-	if !ok {
-		return "", fmt.Errorf("unsupported control ID %s", controlID)
+	resolved, err := cel.PolicyNameForControl(controlID)
+	if err != nil {
+		return "", fmt.Errorf("unsupported control ID %s: %w", controlID, err)
 	}
 	return resolved, nil
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -473,11 +473,32 @@ func TestCreatePolicyBindingCmdValidation(t *testing.T) {
 	})
 
 	t.Run("known parameterized control requires parameter reference", func(t *testing.T) {
+		// C-0009 declares a paramKind in the bundle but was missing from the
+		// retired hand-typed params map, so this exact invocation used to emit
+		// a broken binding silently.
 		cmd := getCreatePolicyBindingCmd()
-		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0012"})
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0009"})
 		err := cmd.Execute()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires --parameter-reference")
+	})
+
+	t.Run("parameterized policy by name requires parameter reference", func(t *testing.T) {
+		// The params check used to fire only on the --control path; --policy
+		// could silently generate a broken binding for the same policy. Also
+		// covers a cluster helper policy that no control lookup can reach.
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "cluster-policy-deny-insecure-capabilities"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --parameter-reference")
+	})
+
+	t.Run("policy name outside the bundle skips the params check", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "some-custom-policy"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
 	})
 
 	t.Run("known parameterized control accepts parameter reference", func(t *testing.T) {
@@ -586,19 +607,18 @@ func TestResolvePolicyName(t *testing.T) {
 			wantErr:   "unsupported control ID",
 		},
 		{
-			name:      "C-0199 resolves",
+			name:       "policy name is lowercased like control IDs are uppercased",
+			policyName: "KUBESCAPE-C-0016-Allow-Privilege-Escalation",
+			want:       "kubescape-c-0016-allow-privilege-escalation",
+		},
+		{
+			// The retired hand-typed map listed controls (e.g. C-0199) that no
+			// released bundle ships; resolution now matches what deploy-library
+			// actually deploys, so those fail instead of producing a binding to
+			// a policy that does not exist on the cluster.
+			name:      "control absent from the released bundle",
 			controlID: "C-0199",
-			want:      "kubescape-c-0199-deny-net-raw-capability",
-		},
-		{
-			name:      "C-0200 resolves",
-			controlID: "C-0200",
-			want:      "kubescape-c-0200-deny-added-capabilities",
-		},
-		{
-			name:      "C-0201 resolves",
-			controlID: "C-0201",
-			want:      "kubescape-c-0201-deny-capabilities-assigned",
+			wantErr:   "unsupported control ID",
 		},
 	}
 

--- a/core/pkg/opaprocessor/cel/catalog.go
+++ b/core/pkg/opaprocessor/cel/catalog.go
@@ -1,0 +1,73 @@
+package cel
+
+import (
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+// This file exposes bundle metadata to callers outside the engine, so the
+// embedded VAP YAML is the single source of truth for facts like "which policy
+// implements control C-0016" and "does it need params" — the same facts cmd/vap
+// used to keep in hand-typed maps that drifted from the library (issue #2369).
+//
+// These helpers deliberately bypass loadVAP's requireSupported gate: a policy
+// the offline engine refuses to evaluate (e.g. one gated on matchConditions) is
+// still perfectly valid to deploy and bind on a cluster, where live admission
+// evaluates the gate itself. Refusing to answer metadata questions about it
+// would wrongly block that workflow.
+
+// PolicyNameForControl returns the metadata.name of the ValidatingAdmissionPolicy
+// implementing a control (e.g. C-0016 ->
+// kubescape-c-0016-allow-privilege-escalation), read from the embedded bundle.
+// It errors when the control has no policy in the bundle.
+func PolicyNameForControl(controlID string) (string, error) {
+	vap, err := lookupVAP(controlID)
+	if err != nil {
+		return "", err
+	}
+	return vap.PolicyName, nil
+}
+
+// ParamKindForControl returns the spec.paramKind of the control's policy, nil
+// when the policy declares no params. A non-nil paramKind means a binding for
+// this policy needs a ParamRef to be functional. It errors when the control has
+// no policy in the bundle.
+func ParamKindForControl(controlID string) (*admissionregistrationv1.ParamKind, error) {
+	vap, err := lookupVAP(controlID)
+	if err != nil {
+		return nil, err
+	}
+	return copyParamKind(vap.paramKind), nil
+}
+
+// ParamKindForPolicy is the name-keyed variant of ParamKindForControl. Unlike
+// the control lookup it covers every policy in the bundle, including the
+// cluster-scoped helpers that carry no controlId. found reports whether the
+// name is in the bundle at all: a caller handed an arbitrary policy name (e.g.
+// cmd/vap --policy pointing at a policy outside the library) gets found=false
+// and should skip paramKind-based checks rather than fail.
+func ParamKindForPolicy(policyName string) (paramKind *admissionregistrationv1.ParamKind, found bool, err error) {
+	catalog, err := getVAPCatalog()
+	if err != nil {
+		return nil, false, err
+	}
+	if _, dup := catalog.dupNames[policyName]; dup {
+		return nil, false, fmt.Errorf("policy %q is defined more than once in the VAP bundle; refusing it rather than pick one", policyName)
+	}
+	vap, ok := catalog.byName[policyName]
+	if !ok {
+		return nil, false, nil
+	}
+	return copyParamKind(vap.paramKind), true, nil
+}
+
+// copyParamKind hands callers their own copy so the catalog's parsed policies
+// stay immutable.
+func copyParamKind(paramKind *admissionregistrationv1.ParamKind) *admissionregistrationv1.ParamKind {
+	if paramKind == nil {
+		return nil
+	}
+	c := *paramKind
+	return &c
+}

--- a/core/pkg/opaprocessor/cel/catalog_test.go
+++ b/core/pkg/opaprocessor/cel/catalog_test.go
@@ -1,0 +1,93 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPolicyNameForControl checks the control -> policy-name lookup against the
+// real embedded bundle, so callers (cmd/vap) resolve exactly the names the
+// deployable YAML carries.
+func TestPolicyNameForControl(t *testing.T) {
+	name, err := PolicyNameForControl("C-0016")
+	require.NoError(t, err)
+	assert.Equal(t, "kubescape-c-0016-allow-privilege-escalation", name)
+
+	_, err = PolicyNameForControl("C-9999")
+	require.Error(t, err, "a control absent from the bundle must fail loudly")
+}
+
+// TestParamKindForControl checks paramKind is read off the embedded policy.
+// C-0009 is the regression case: the retired hand-typed params map did not list
+// it, even though its policy declares a paramKind — the exact drift deriving
+// from the YAML is meant to prevent.
+func TestParamKindForControl(t *testing.T) {
+	paramKind, err := ParamKindForControl("C-0009")
+	require.NoError(t, err)
+	require.NotNil(t, paramKind, "C-0009 declares a paramKind in the bundle")
+	assert.Equal(t, "ControlConfiguration", paramKind.Kind)
+
+	paramKind, err = ParamKindForControl("C-0016")
+	require.NoError(t, err)
+	assert.Nil(t, paramKind, "C-0016 declares no paramKind")
+
+	_, err = ParamKindForControl("C-9999")
+	require.Error(t, err)
+}
+
+// TestParamKindForPolicy checks the name-keyed lookup, including the policies a
+// control lookup can never reach: cluster-scoped helpers with no controlId.
+func TestParamKindForPolicy(t *testing.T) {
+	// A cluster helper with params: no controlId label, so only reachable by name.
+	paramKind, found, err := ParamKindForPolicy("cluster-policy-deny-insecure-capabilities")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, paramKind)
+	assert.Equal(t, "ControlConfiguration", paramKind.Kind)
+
+	// A paramless control policy, by name.
+	paramKind, found, err = ParamKindForPolicy("kubescape-c-0017-deny-resources-with-mutable-container-filesystem")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Nil(t, paramKind)
+
+	// A name outside the bundle reports found=false, not an error: callers with
+	// arbitrary user-supplied policy names skip paramKind checks then.
+	_, found, err = ParamKindForPolicy("some-custom-policy")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+// TestCatalogBypassesRequireSupported proves the metadata helpers answer for a
+// matchConditions-gated policy loadVAP refuses: deploying/binding such a policy
+// is valid (live admission evaluates the gate), so metadata questions about it
+// must not be blocked. Exercised via parseVAPBundle + lookup on an in-memory
+// bundle, since the vendored bundle ships no gated policies today.
+func TestCatalogBypassesRequireSupported(t *testing.T) {
+	bundle := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-1001-gated
+  labels:
+    controlId: C-1001
+spec:
+  matchConditions:
+  - name: only-kube-system
+    expression: "object.metadata.namespace == 'kube-system'"
+  validations:
+  - expression: "false"
+`
+	catalog, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+
+	vap := catalog.byControl["C-1001"]
+	require.NotNil(t, vap)
+	require.Error(t, vap.requireSupported(), "the offline eval path refuses the gated policy")
+
+	// The name index still carries it, so name-keyed metadata stays answerable.
+	named := catalog.byName["kubescape-c-1001-gated"]
+	require.NotNil(t, named)
+	assert.Equal(t, "C-1001", named.ControlID)
+}

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -76,36 +76,78 @@ func (v *VAP) requireSupported() error {
 	return nil
 }
 
-// vapIndex is built once from the embedded bundle and reused. Parsing every
-// document on each lookup would be wasteful, and the bundle never changes at
-// runtime, so a lazily-built controlID -> VAP map is enough.
-//
-// vapIndexErr is reserved for whole-bundle failures (the embed cannot be read or
-// decoded) — the engine genuinely cannot function then. A per-control problem
-// like a duplicate never lands here: it poisons only its own control (see
-// vapDuplicates) so one bad policy cannot take the whole engine offline.
+// vapCatalog is everything indexed out of the embedded bundle. It is built once
+// and reused: parsing every document on each lookup would be wasteful, and the
+// bundle never changes at runtime.
+type vapCatalog struct {
+	// byControl maps the controlId label -> policy, for the scan path.
+	byControl map[string]*VAP
+	// dupControls poisons controls claimed by more than one policy: neither
+	// copy silently wins, and only that control is refused (the rest of the
+	// bundle keeps working).
+	dupControls map[string]struct{}
+	// byName maps metadata.name -> policy. Unlike byControl it covers every
+	// policy in the bundle, including the cluster-scoped helpers that carry no
+	// controlId, so name-keyed callers (cmd/vap --policy) can look them up.
+	byName map[string]*VAP
+	// dupNames poisons names used by more than one policy, same scheme as
+	// dupControls.
+	dupNames map[string]struct{}
+}
+
+// vapCatalogErr is reserved for whole-bundle failures (the embed cannot be read
+// or decoded) — the engine genuinely cannot function then. A per-policy problem
+// like a duplicate never lands here: it poisons only its own key (see the dup
+// sets on vapCatalog) so one bad policy cannot take the whole engine offline.
 var (
-	vapIndexOnce  sync.Once
-	vapIndex      map[string]*VAP
-	vapDuplicates map[string]struct{}
-	vapIndexErr   error
+	vapCatalogOnce sync.Once
+	vapCatalogVal  *vapCatalog
+	vapCatalogErr  error
 )
 
-// loadVAP returns the policy for a control ID (threaded in from processControl,
-// never read off a rule). It fails when the control is absent from the embedded
-// bundle rather than silently returning nothing, so a scan cannot quietly skip a
-// control it thinks it covers.
-func loadVAP(controlID string) (*VAP, error) {
-	vapIndexOnce.Do(buildVAPIndex)
-	if vapIndexErr != nil {
-		return nil, vapIndexErr
+// getVAPCatalog reads the embedded bundle once and hands the bytes to
+// parseVAPBundle. Splitting the two keeps the parsing logic testable with
+// in-memory bundles.
+func getVAPCatalog() (*vapCatalog, error) {
+	vapCatalogOnce.Do(func() {
+		data, err := vapdataFS.ReadFile(vapdataDir + "/" + vapBundleFile)
+		if err != nil {
+			vapCatalogErr = fmt.Errorf("read embedded VAP bundle: %w", err)
+			return
+		}
+		vapCatalogVal, vapCatalogErr = parseVAPBundle(data)
+	})
+	return vapCatalogVal, vapCatalogErr
+}
+
+// lookupVAP resolves a control ID to its policy without the requireSupported
+// gate. It fails when the control is absent from the embedded bundle rather
+// than silently returning nothing, so a caller cannot quietly skip a control it
+// thinks it covers. Callers that evaluate the policy offline go through loadVAP
+// instead; this seam exists for metadata lookups (see catalog.go) where a
+// gated policy is still a valid answer.
+func lookupVAP(controlID string) (*VAP, error) {
+	catalog, err := getVAPCatalog()
+	if err != nil {
+		return nil, err
 	}
-	if _, dup := vapDuplicates[controlID]; dup {
+	if _, dup := catalog.dupControls[controlID]; dup {
 		return nil, fmt.Errorf("control %q is defined by more than one policy in the VAP bundle; refusing it rather than pick one", controlID)
 	}
-	vap, ok := vapIndex[controlID]
+	vap, ok := catalog.byControl[controlID]
 	if !ok {
 		return nil, fmt.Errorf("no %s for control %q in embedded bundle", vapKind, controlID)
+	}
+	return vap, nil
+}
+
+// loadVAP returns the policy for a control ID (threaded in from processControl,
+// never read off a rule), refusing policies the offline engine cannot evaluate
+// with scan/admission parity (see requireSupported).
+func loadVAP(controlID string) (*VAP, error) {
+	vap, err := lookupVAP(controlID)
+	if err != nil {
+		return nil, err
 	}
 	if err := vap.requireSupported(); err != nil {
 		return nil, err
@@ -113,35 +155,30 @@ func loadVAP(controlID string) (*VAP, error) {
 	return vap, nil
 }
 
-// buildVAPIndex reads the embedded bundle and hands the bytes to parseVAPBundle.
-// Splitting the two keeps the parsing logic testable with in-memory bundles.
-func buildVAPIndex() {
-	data, err := vapdataFS.ReadFile(vapdataDir + "/" + vapBundleFile)
-	if err != nil {
-		vapIndexErr = fmt.Errorf("read embedded VAP bundle: %w", err)
-		return
-	}
-	vapIndex, vapDuplicates, vapIndexErr = parseVAPBundle(data)
-}
-
-// parseVAPBundle turns a multi-document bundle into the controlID -> VAP map.
+// parseVAPBundle turns a multi-document bundle into a vapCatalog.
 //
 // It consumes only v1 ValidatingAdmissionPolicy documents and skips everything
 // else. The bundle is a mixed stream synced from cel-admission-library, which
 // also ships ValidatingAdmissionPolicyBinding (and blank) documents; failing the
-// whole index over one document we do not consume would take the entire engine
+// whole catalog over one document we do not consume would take the entire engine
 // down on a routine `make sync-vap`, so a foreign kind is skipped, not fatal.
-// Policies with no controlId label (cluster-scoped helper policies) are skipped
-// too: they are not addressable by control and the scan never asks for them.
+// Policies with no controlId label (cluster-scoped helper policies) land only in
+// byName: they are not addressable by control and the scan never asks for them,
+// but name-keyed callers still need them.
 //
-// A duplicate control ID poisons only that control: two policies fighting over one
-// control is a real bundle bug, so neither silently wins — the control is dropped
-// from the index and returned in the duplicates set, and loadVAP refuses it. The
-// rest of the bundle still indexes, so one bad control cannot take the whole
-// engine offline. Only an unreadable/undecodable bundle is a whole-bundle error.
-func parseVAPBundle(data []byte) (map[string]*VAP, map[string]struct{}, error) {
-	index := make(map[string]*VAP)
-	duplicates := make(map[string]struct{})
+// A duplicate key (controlId or name) poisons only that key: two policies
+// fighting over one control or name is a real bundle bug, so neither silently
+// wins — the key is dropped from its index and recorded in the matching dup set,
+// and lookups refuse it. The rest of the bundle still indexes, so one bad policy
+// cannot take the whole engine offline. Only an unreadable/undecodable bundle is
+// a whole-bundle error.
+func parseVAPBundle(data []byte) (*vapCatalog, error) {
+	catalog := &vapCatalog{
+		byControl:   make(map[string]*VAP),
+		dupControls: make(map[string]struct{}),
+		byName:      make(map[string]*VAP),
+		dupNames:    make(map[string]struct{}),
+	}
 	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
 	for {
 		var policy admissionregistrationv1.ValidatingAdmissionPolicy
@@ -149,30 +186,38 @@ func parseVAPBundle(data []byte) (map[string]*VAP, map[string]struct{}, error) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, nil, fmt.Errorf("decode VAP bundle: %w", err)
+			return nil, fmt.Errorf("decode VAP bundle: %w", err)
 		}
 
 		if policy.Kind != vapKind || policy.APIVersion != vapAPIVersion {
 			continue
 		}
 
-		controlID := policy.Labels[controlIDLabel]
-		if controlID == "" {
-			continue
-		}
-		if _, poisoned := duplicates[controlID]; poisoned {
-			// Already seen twice; stay poisoned for any further occurrences.
-			continue
-		}
-		if _, seen := index[controlID]; seen {
-			duplicates[controlID] = struct{}{}
-			delete(index, controlID)
-			continue
-		}
-		index[controlID] = newVAP(&policy)
+		vap := newVAP(&policy)
+		indexUnique(catalog.byName, catalog.dupNames, vap.PolicyName, vap)
+		indexUnique(catalog.byControl, catalog.dupControls, vap.ControlID, vap)
 	}
 
-	return index, duplicates, nil
+	return catalog, nil
+}
+
+// indexUnique adds one policy under one key, enforcing the duplicate-poisoning
+// scheme: the first occurrence indexes, a second drops the key from the index
+// and marks it duplicated, and further occurrences stay poisoned. An empty key
+// (a helper policy with no controlId) is simply not indexed.
+func indexUnique(index map[string]*VAP, duplicates map[string]struct{}, key string, vap *VAP) {
+	if key == "" {
+		return
+	}
+	if _, poisoned := duplicates[key]; poisoned {
+		return
+	}
+	if _, seen := index[key]; seen {
+		duplicates[key] = struct{}{}
+		delete(index, key)
+		return
+	}
+	index[key] = vap
 }
 
 // newVAP flattens a parsed policy into the evaluator's structs. The message and

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -100,22 +100,23 @@ metadata:
 spec:
   policyName: kubescape-c-1000
 `
-	index, _, err := parseVAPBundle([]byte(bundle))
+	catalog, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
-	assert.Len(t, index, 1)
-	assert.Contains(t, index, "C-1000")
+	assert.Len(t, catalog.byControl, 1)
+	assert.Contains(t, catalog.byControl, "C-1000")
 }
 
 // TestParseVAPBundleSkipsNoControlID proves policies without a controlId label
-// (cluster-scoped helpers) are dropped from the index rather than indexed under
-// an empty key.
+// (cluster-scoped helpers) stay out of the control index (no empty key) while
+// remaining reachable by name, since name-keyed callers still need them.
 func TestParseVAPBundleSkipsNoControlID(t *testing.T) {
 	bundle := vapDoc("cluster-policy-helper", "") + "---\n" + vapDoc("kubescape-c-1000", "C-1000")
-	index, _, err := parseVAPBundle([]byte(bundle))
+	catalog, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
-	assert.Len(t, index, 1)
-	assert.Contains(t, index, "C-1000")
-	assert.NotContains(t, index, "")
+	assert.Len(t, catalog.byControl, 1)
+	assert.Contains(t, catalog.byControl, "C-1000")
+	assert.NotContains(t, catalog.byControl, "")
+	assert.Contains(t, catalog.byName, "cluster-policy-helper")
 }
 
 // TestParseVAPBundleDuplicateControl proves a duplicated control poisons only
@@ -126,12 +127,28 @@ func TestParseVAPBundleDuplicateControl(t *testing.T) {
 	bundle := vapDoc("kubescape-c-1000-a", "C-1000") +
 		"---\n" + vapDoc("kubescape-c-1000-b", "C-1000") +
 		"---\n" + vapDoc("kubescape-c-2000", "C-2000")
-	index, duplicates, err := parseVAPBundle([]byte(bundle))
+	catalog, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
 
-	assert.NotContains(t, index, "C-1000", "a duplicated control must not silently win")
-	assert.Contains(t, duplicates, "C-1000")
-	assert.Contains(t, index, "C-2000", "an unrelated control must still index")
+	assert.NotContains(t, catalog.byControl, "C-1000", "a duplicated control must not silently win")
+	assert.Contains(t, catalog.dupControls, "C-1000")
+	assert.Contains(t, catalog.byControl, "C-2000", "an unrelated control must still index")
+}
+
+// TestParseVAPBundleDuplicateName proves the same poisoning applies to the name
+// index: two policies sharing a metadata.name is a bundle bug (the bundle could
+// not even be kubectl-applied), so neither wins and name lookups refuse it,
+// while other names still index.
+func TestParseVAPBundleDuplicateName(t *testing.T) {
+	bundle := vapDoc("kubescape-c-1000", "C-1000") +
+		"---\n" + vapDoc("kubescape-c-1000", "C-1001") +
+		"---\n" + vapDoc("kubescape-c-2000", "C-2000")
+	catalog, err := parseVAPBundle([]byte(bundle))
+	require.NoError(t, err)
+
+	assert.NotContains(t, catalog.byName, "kubescape-c-1000", "a duplicated name must not silently win")
+	assert.Contains(t, catalog.dupNames, "kubescape-c-1000")
+	assert.Contains(t, catalog.byName, "kubescape-c-2000", "an unrelated name must still index")
 }
 
 // TestLoadVAPRefusesMatchConditions proves a policy with a matchConditions gate is
@@ -152,10 +169,10 @@ spec:
   validations:
   - expression: "false"
 `
-	index, _, err := parseVAPBundle([]byte(bundle))
+	catalog, err := parseVAPBundle([]byte(bundle))
 	require.NoError(t, err)
 
-	vap := index["C-1001"]
+	vap := catalog.byControl["C-1001"]
 	require.NotNil(t, vap)
 	require.NotEmpty(t, vap.matchConditions, "matchConditions must be captured, not dropped")
 


### PR DESCRIPTION
## Overview

Closes #2369.

cmd/vap kept two hand-typed maps (control ID → policy name, and which controls need --parameter-reference) that duplicated facts already in the cel-admission-library YAML. They had already drifted once and were patched forward in #2371. Now that the engine embeds the release bundle, both maps are derivable from it, so this PR deletes them.

- New exported helpers in the cel package read from the embedded bundle: PolicyNameForControl, ParamKindForControl, and a name-keyed ParamKindForPolicy (covers the cluster helper policies that have no controlId). They skip the offline-eval gate on purpose: a policy the scanner refuses to evaluate is still fine to deploy and bind, live admission handles it.
- The loader now indexes by policy name too, with the same duplicate-poisoning scheme as controls.
- The params check now also fires on the --policy path, not just --control, so you can't silently generate a binding that's missing its ParamRef.
- --policy is lowercased the way --control is uppercased, so both flags accept any casing.

Two real bugs this catches:

1. --control C-0009 used to emit a broken binding silently: its policy declares a paramKind but the params map didn't list it. Now it errors asking for --parameter-reference. Regression test added.
2. Nine map entries (C-0012, C-0013, C-0026, C-0198-C-0201, C-0210, C-0280) pointed at policies that exist only on library master, not in any release, so their bindings referenced policies deploy-library never installs (verified against the latest release, v0.11). These now return "unsupported control ID". They start resolving again automatically once a release ships them and the vendored bundle is bumped.

Known boundary, pre-existing: deploy-library downloads releases/latest at runtime while binding metadata comes from the pinned vendored bundle, so a skew window exists between a new upstream release and the next CEL_LIBRARY_VERSION bump. Happy to open a follow-up issue for pinning deploy-library too if that sounds right.


## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog-based policy resolution for VAP controls and policy names.
  - Policy and control identifiers are now handled consistently regardless of letter casing.
  - Supports parameter validation for both control-based and policy-name-based configurations.

- **Bug Fixes**
  - VAP creation now reports an error when a parameterized policy lacks `--parameter-reference`.
  - Unsupported or retired control IDs are rejected instead of being mapped incorrectly.
  - Policies without parameters no longer trigger unnecessary parameter-reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->