### PR TITLE
feat : add unit tests for GetPreReqCmd and kubeconfig flag

### DIFF
--- a/cmd/prerequisites/prerequisites_test.go
+++ b/cmd/prerequisites/prerequisites_test.go
@@ -1,0 +1,30 @@
+package prerequisites
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPreReqCmd(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+
+	cmd := GetPreReqCmd(mockKubescape)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "prerequisites", cmd.Use)
+	assert.Equal(t, "Check prerequisites for installing Kubescape Operator", cmd.Short)
+	assert.NotNil(t, cmd.Run)
+}
+
+func TestGetPreReqCmdKubeconfigFlag(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+
+	cmd := GetPreReqCmd(mockKubescape)
+
+	flag := cmd.PersistentFlags().Lookup("kubeconfig")
+	assert.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+	assert.Equal(t, "Path to the kubeconfig file. If not set, in-cluster config is used or $HOME/.kube/config if outside a cluster.", flag.Usage)
+}


### PR DESCRIPTION
## Summary
- Add unit test coverage for cmd/prerequisites/prerequisites.go
## Changes
- Created cmd/prerequisites/prerequisites_test.go with tests for GetPreReqCmd
## Test Coverage
1. TestGetPreReqCmd - verifies command is returned with correct Use and Short fields and Run is set
2. TestGetPreReqCmdKubeconfigFlag - verifies --kubeconfig flag is registered with correct default value and usage text
## How to Test
Run: go test ./cmd/prerequisites/ -v

image 
<img width="553" height="128" alt="image" src="https://github.com/user-attachments/assets/f46c2ebd-d4ef-4531-9b22-71c5f0d8da16" />

#2484 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the prerequisites command is configured correctly.
  * Added validation for the persistent kubeconfig flag, including its default value and help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->