### PR TITLE
fix: preserve explicit exceptions/inputs with use-artifacts-from

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -212,12 +212,18 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 		}
 	}
 	// set config-inputs file
-	scanInfo.ControlsInputs = filepath.Join(scanInfo.UseArtifactsFrom, LocalControlInputsFilename)
+	if scanInfo.ControlsInputs == "" {
+		scanInfo.ControlsInputs = filepath.Join(scanInfo.UseArtifactsFrom, LocalControlInputsFilename)
+	}
 	// set exceptions
-	scanInfo.UseExceptions = filepath.Join(scanInfo.UseArtifactsFrom, LocalExceptionsFilename)
+	if scanInfo.UseExceptions == "" {
+		scanInfo.UseExceptions = filepath.Join(scanInfo.UseArtifactsFrom, LocalExceptionsFilename)
+	}
 
 	// set attack tracks
-	scanInfo.AttackTracks = filepath.Join(scanInfo.UseArtifactsFrom, LocalAttackTracksFilename)
+	if scanInfo.AttackTracks == "" {
+		scanInfo.AttackTracks = filepath.Join(scanInfo.UseArtifactsFrom, LocalAttackTracksFilename)
+	}
 }
 
 func (scanInfo *ScanInfo) setUseFrom() {

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -58,7 +58,8 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	if useExceptions != "" {
 		// load exceptions from file
 		primary = getter.NewLoadPolicy([]string{useExceptions})
-		return primary
+		k8sClient := getExceptionsK8sClient(ctx)
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
 	if airGapped {
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -106,7 +106,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 				accountID:              "",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
 			},
-			want: "*getter.LoadPolicy",
+			want: "*getter.MergedExceptionsGetter",
 		},
 		{
 			name: "Test GetExceptionsGetter with useExceptions and filled accountID",
@@ -116,7 +116,7 @@ func TestGetExceptionsGetter(t *testing.T) {
 				accountID:              "123456789012",
 				downloadReleasedPolicy: getter.NewDownloadReleasedPolicy(),
 			},
-			want: "*getter.LoadPolicy",
+			want: "*getter.MergedExceptionsGetter",
 		},
 		{
 			name: "Test GetExceptionsGetter with accountID",


### PR DESCRIPTION
## Overview

This is the fix for #2489 .

The issue was that `setUseArtifactsFrom` unconditionally overwrote `UseExceptions`, `ControlsInputs`, and `AttackTracks` on every scan where `UseArtifactsFrom` is set -- the HTTP microservice's default via `DefaultLocalStore`. This silently discarded exceptions submitted inline via `POST /v1/scan` and explicit `--exceptions`/`--controls-config`/`--attack-tracks` values. Compounding it, the `useExceptions != ""` branch in `getExceptionsGetter` was the only branch that didn't merge in-cluster `SecurityException` CRDs, so cached-artifacts operator scans ignored them entirely -- including the `objectSelector.matchExpressions` support just shipped in #2480.

The fix is two surgical changes. The three assignments in `setUseArtifactsFrom` now only apply as defaults when the corresponding field is empty, so explicitly-provided paths survive `Init()`. The file-based `useExceptions` branch in `getExceptionsGetter` now wraps the `LoadPolicy` in `NewMergedExceptionsGetter` with `NewCRDExceptionsGetter`, matching every other branch.

Now the two cases are actually distinct:

- Explicit exceptions path set → survives `Init()`, CRD exceptions merged on top
- No explicit path set → `UseArtifactsFrom` default applies, CRD exceptions still merged

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing artifact configuration paths when they are already set, preventing unintended overwrites.
  * Exceptions loaded from configuration files are now combined with exceptions provided through the Kubernetes configuration.
* **Tests**
  * Updated validation to cover merged exception sources in both account configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->