### PR TITLE
feat(reportcrypto): add decryption support for encrypted resource metadata

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -257,7 +257,6 @@ func GetDecryptCommand() *cobra.Command {
 
 // remapResults restores all resource ID references that were rewritten
 // during encryption so they remain consistent with the decrypted resources.
-
 func remapResults(results []resourcesresults.Result, idMapping map[string]string) {
 	for i := range results {
 		results[i].ResourceID = remapResourceID(
@@ -300,8 +299,10 @@ func remapResults(results []resourcesresults.Result, idMapping map[string]string
 
 // remapResourceID restores a resource ID if it was rewritten during
 // encryption. Unknown IDs are returned unchanged.
-
-func remapResourceID(id string, idMapping map[string]string) string {
+func remapResourceID(
+	id string,
+	idMapping map[string]string,
+) string {
 
 	if mappedID, ok := idMapping[id]; ok {
 		return mappedID

--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -128,9 +128,22 @@ func GetDecryptCommand() *cobra.Command {
 							return err
 						}
 
+						if err := reportcrypto.DecryptResourceLabels(resource, dek); err != nil {
+							return err
+						}
+
+						if err := reportcrypto.DecryptResourceAnnotations(resource, dek); err != nil {
+							return err
+						}
+
+						if err := reportcrypto.DecryptResourceObjectSourcePath(resource, dek); err != nil {
+							return err
+						}
+
 						if err := reportcrypto.DecryptContainerMetadata(resource, dek); err != nil {
 							return err
 						}
+
 						newID := resource.GetID()
 						if oldID != "" {
 							idMapping[oldID] = newID
@@ -244,6 +257,7 @@ func GetDecryptCommand() *cobra.Command {
 
 // remapResults restores all resource ID references that were rewritten
 // during encryption so they remain consistent with the decrypted resources.
+
 func remapResults(results []resourcesresults.Result, idMapping map[string]string) {
 	for i := range results {
 		results[i].ResourceID = remapResourceID(
@@ -286,10 +300,8 @@ func remapResults(results []resourcesresults.Result, idMapping map[string]string
 
 // remapResourceID restores a resource ID if it was rewritten during
 // encryption. Unknown IDs are returned unchanged.
-func remapResourceID(
-	id string,
-	idMapping map[string]string,
-) string {
+
+func remapResourceID(id string, idMapping map[string]string) string {
 
 	if mappedID, ok := idMapping[id]; ok {
 		return mappedID

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -126,6 +126,26 @@ func TestDecryptCommand(t *testing.T) {
 				)
 			require.NoError(t, err)
 
+			encryptedLabel, err :=
+				reportcrypto.EncryptString(
+					"backend",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedAnnotation, err :=
+				reportcrypto.EncryptString(
+					"payments-service",
+					dek,
+				)
+			require.NoError(t, err)
+
+			encryptedSourcePath, err :=
+				reportcrypto.EncryptString(
+					"/workspace/manifests/nginx/deployment.yaml",
+					dek,
+				)
+			require.NoError(t, err)
 			wrappedDEK, err :=
 				reportcrypto.WrapDEK(
 					dek,
@@ -147,9 +167,16 @@ func TestDecryptCommand(t *testing.T) {
 						"object": map[string]any{
 							"apiVersion": "apps/v1",
 							"kind":       "Deployment",
+							"sourcePath": encryptedSourcePath + ":27",
 							"metadata": map[string]any{
 								"name":      encryptedName,
 								"namespace": encryptedNamespace,
+								"labels": map[string]any{
+									"app": encryptedLabel,
+								},
+								"annotations": map[string]any{
+									"owner": encryptedAnnotation,
+								},
 							},
 							"spec": map[string]any{
 								"serviceAccountName": encryptedServiceAccount,
@@ -158,6 +185,7 @@ func TestDecryptCommand(t *testing.T) {
 										"name": encryptedImagePullSecret,
 									},
 								},
+
 								"containers": []any{
 									map[string]any{
 										"name":  encryptedContainerName,
@@ -367,6 +395,16 @@ func TestDecryptCommand(t *testing.T) {
 
 			assert.Equal(t, "nginx-deployment", metadataObj["name"])
 			assert.Equal(t, "production", metadataObj["namespace"])
+
+			labels := metadataObj["labels"].(map[string]any)
+
+			assert.Equal(t, "backend", labels["app"])
+
+			annotations := metadataObj["annotations"].(map[string]any)
+
+			assert.Equal(t, "payments-service", annotations["owner"])
+
+			assert.Equal(t, "/workspace/manifests/nginx/deployment.yaml:27", object["sourcePath"])
 
 			spec, ok := object["spec"].(map[string]any)
 			require.True(t, ok)

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -51,7 +51,6 @@ func applyWithTransformer(
 // labels, and additional session data, continue to use
 // mapping-based anonymization and remain irreversibly
 // pseudonymized.
-
 func ApplyEncrypted(
 	resultsHandler *resultshandling.ResultsHandler,
 	dek []byte,

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -24,7 +24,7 @@ func applyWithTransformer(
 
 	mapping := NewMapping()
 
-	if err := anonymizeSession(
+	if err := transformSession(
 		resultsHandler.ScanData,
 		mapping,
 		transformer,
@@ -51,6 +51,7 @@ func applyWithTransformer(
 // labels, and additional session data, continue to use
 // mapping-based anonymization and remain irreversibly
 // pseudonymized.
+
 func ApplyEncrypted(
 	resultsHandler *resultshandling.ResultsHandler,
 	dek []byte,

--- a/core/pkg/anonymizer/encryptiontransformer.go
+++ b/core/pkg/anonymizer/encryptiontransformer.go
@@ -1,6 +1,8 @@
 package anonymizer
 
-import "github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+import (
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+)
 
 // EncryptionTransformer implements Transformer using AES-256-GCM encryption.
 //
@@ -21,9 +23,12 @@ func NewEncryptionTransformer(
 
 // Transform encrypts the provided value using the configured DEK and
 // returns a SOPS-inspired ENC[AES256_GCM,...] ciphertext representation.
+
 func (t *EncryptionTransformer) Transform(
+
 	prefix string,
 	value string,
+
 ) (string, error) {
 	return reportcrypto.EncryptString(
 		value,

--- a/core/pkg/anonymizer/encryptiontransformer.go
+++ b/core/pkg/anonymizer/encryptiontransformer.go
@@ -1,8 +1,6 @@
 package anonymizer
 
-import (
-	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
-)
+import "github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 
 // EncryptionTransformer implements Transformer using AES-256-GCM encryption.
 //
@@ -23,12 +21,9 @@ func NewEncryptionTransformer(
 
 // Transform encrypts the provided value using the configured DEK and
 // returns a SOPS-inspired ENC[AES256_GCM,...] ciphertext representation.
-
 func (t *EncryptionTransformer) Transform(
-
 	prefix string,
 	value string,
-
 ) (string, error) {
 	return reportcrypto.EncryptString(
 		value,

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -17,7 +17,6 @@ import (
 // transformSession applies the supplied Transformer to sensitive resource
 // identifiers and metadata while preserving referential integrity across
 // the full OPA session.
-
 func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transformer Transformer) error {
 	if session == nil {
 		return nil
@@ -35,14 +34,12 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 		// sourcePath may expose manifest filenames and line references
 		// (for example test-anonymize.yaml:1), so transform it alongside
 		// other resource-local metadata.
-
 		if err := transformResourceObjectSourcePath(resource, transformer); err != nil {
 			return err
 		}
 
 		// Annotations may contain infrastructure identifiers, secret paths, or
 		// other sensitive metadata at both top-level and nested workload templates.
-
 		if err := transformResourceAnnotations(resource, transformer); err != nil {
 			return err
 		}
@@ -195,7 +192,6 @@ func resolveMappedID(mapping *Mapping, idMapping map[string]string, originalID, 
 // transformResourceLabels applies the supplied Transformer to labels
 // explicitly configured for copying into reports while preserving the
 // existing label selection behavior.
-
 func transformResourceLabels(resource workloadinterface.IMetadata, labelsToCopy []string, transformer Transformer) error {
 
 	bw, ok := resource.(workloadinterface.IWorkload)
@@ -233,7 +229,6 @@ func transformResourceLabels(resource workloadinterface.IMetadata, labelsToCopy 
 // transformResourceAnnotations applies the supplied Transformer to
 // annotation values throughout a resource object, including nested
 // workload templates such as Deployment pod specs.
-
 func transformResourceAnnotations(resource workloadinterface.IMetadata, transformer Transformer) error {
 
 	if resource == nil {
@@ -257,7 +252,6 @@ func transformResourceAnnotations(resource workloadinterface.IMetadata, transfor
 // transformResourceObjectSourcePath applies the supplied Transformer to
 // object.sourcePath while preserving trailing line-number context (for
 // example src-xxxx:12).
-
 func transformResourceObjectSourcePath(resource workloadinterface.IMetadata, transformer Transformer) error {
 
 	if resource == nil {
@@ -296,7 +290,6 @@ func transformResourceObjectSourcePath(resource workloadinterface.IMetadata, tra
 // transformSourcePath applies the supplied Transformer to the path portion
 // of a sourcePath while preserving any trailing line number (for example
 // src-xxxx:12).
-
 func transformSourcePath(sourcePath string, transformer Transformer) (string, error) {
 
 	lastColon := strings.LastIndex(sourcePath, ":")
@@ -322,7 +315,6 @@ func transformSourcePath(sourcePath string, transformer Transformer) (string, er
 // transformAnnotationNodes recursively traverses unstructured resource
 // objects, applying the supplied Transformer to annotation values
 // wherever metadata.annotations appears regardless of workload nesting.
-
 func transformAnnotationNodes(node any, transformer Transformer) error {
 
 	switch v := node.(type) {
@@ -351,7 +343,6 @@ func transformAnnotationNodes(node any, transformer Transformer) error {
 // transformAnnotationMap applies the supplied Transformer to annotation
 // values while preserving annotation keys, which remain meaningful
 // Kubernetes identifiers.
-
 func transformAnnotationMap(obj map[string]any, transformer Transformer) error {
 
 	rawMetadata, ok := obj["metadata"]
@@ -399,7 +390,10 @@ func transformValue(transformer Transformer, prefix string, value string) (strin
 	return transformer.Transform(prefix, value)
 }
 
-func transformResourceMetadata(resource workloadinterface.IMetadata, transformer Transformer) error {
+func transformResourceMetadata(
+	resource workloadinterface.IMetadata,
+	transformer Transformer,
+) error {
 
 	if resource == nil {
 		return nil
@@ -510,7 +504,10 @@ func transformLastCommit(commit *reporthandling.LastCommit, transformer Transfor
 	return nil
 }
 
-func transformResourceSource(source *reporthandling.Source, transformer Transformer) error {
+func transformResourceSource(
+	source *reporthandling.Source,
+	transformer Transformer,
+) error {
 	if source == nil {
 		return nil
 	}

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -14,9 +14,11 @@ import (
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
-// anonymizeSession rewrites sensitive resource identifiers and metadata while
-// preserving internal referential integrity across the full OPA session.
-func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, transformer Transformer) error {
+// transformSession applies the supplied Transformer to sensitive resource
+// identifiers and metadata while preserving referential integrity across
+// the full OPA session.
+
+func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transformer Transformer) error {
 	if session == nil {
 		return nil
 	}
@@ -29,14 +31,21 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 		if err := transformResourceMetadata(resource, transformer); err != nil {
 			return err
 		}
-		// sourcePath leaks manifest filenames/line references in hidden output
-		// (for example test-anonymize.yaml:1), so anonymize it alongside other
-		// resource-local metadata.
-		anonymizeResourceObjectSourcePath(resource, mapping)
+
+		// sourcePath may expose manifest filenames and line references
+		// (for example test-anonymize.yaml:1), so transform it alongside
+		// other resource-local metadata.
+
+		if err := transformResourceObjectSourcePath(resource, transformer); err != nil {
+			return err
+		}
 
 		// Annotations may contain infrastructure identifiers, secret paths, or
 		// other sensitive metadata at both top-level and nested workload templates.
-		anonymizeResourceAnnotations(resource, mapping)
+
+		if err := transformResourceAnnotations(resource, transformer); err != nil {
+			return err
+		}
 
 		// Container-related metadata is transformed separately to preserve the
 		// existing typed/unstructured traversal behavior while supporting
@@ -46,7 +55,9 @@ func anonymizeSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 		}
 
 		if len(session.LabelsToCopy) > 0 {
-			anonymizeResourceLabels(resource, session.LabelsToCopy, mapping)
+			if err := transformResourceLabels(resource, session.LabelsToCopy, transformer); err != nil {
+				return err
+			}
 		}
 
 		newID := resource.GetID()
@@ -181,126 +192,186 @@ func resolveMappedID(mapping *Mapping, idMapping map[string]string, originalID, 
 	return mapping.GetOrCreate(prefix, originalID)
 }
 
-// anonymizeResourceLabels anonymizes only labels explicitly configured for
-// copying into reports, preserving existing --hide behavior.
-func anonymizeResourceLabels(resource workloadinterface.IMetadata, labelsToCopy []string, mapping *Mapping) {
+// transformResourceLabels applies the supplied Transformer to labels
+// explicitly configured for copying into reports while preserving the
+// existing label selection behavior.
+
+func transformResourceLabels(resource workloadinterface.IMetadata, labelsToCopy []string, transformer Transformer) error {
+
 	bw, ok := resource.(workloadinterface.IWorkload)
 	if !ok {
-		return
+		return nil
 	}
 
 	labels := bw.GetLabels()
 	if len(labels) == 0 {
-		return
+		return nil
 	}
 
 	for _, key := range labelsToCopy {
 		if val, exists := labels[key]; exists && val != "" {
-			bw.SetLabel(key, mapping.GetOrCreate("lbl", val))
+
+			transformedValue, err := transformValue(
+				transformer,
+				"lbl",
+				val,
+			)
+			if err != nil {
+				return err
+			}
+
+			bw.SetLabel(
+				key,
+				transformedValue,
+			)
 		}
 	}
+
+	return nil
 }
 
-// anonymizeResourceAnnotations walks the full resource object and anonymizes
-// annotation values anywhere metadata.annotations appears, including nested
+// transformResourceAnnotations applies the supplied Transformer to
+// annotation values throughout a resource object, including nested
 // workload templates such as Deployment pod specs.
-func anonymizeResourceAnnotations(resource workloadinterface.IMetadata, mapping *Mapping) {
+
+func transformResourceAnnotations(resource workloadinterface.IMetadata, transformer Transformer) error {
+
 	if resource == nil {
-		return
+		return nil
 	}
 
 	obj := resource.GetObject()
 	if obj == nil {
-		return
+		return nil
 	}
 
-	anonymizeAnnotationNodes(obj, mapping)
+	if err := transformAnnotationNodes(obj, transformer); err != nil {
+		return err
+	}
+
 	resource.SetObject(obj)
+
+	return nil
 }
 
-// anonymizeResourceObjectSourcePath anonymizes object.sourcePath while
-// preserving line number context (e.g. src-xxxx:12).
-func anonymizeResourceObjectSourcePath(resource workloadinterface.IMetadata, mapping *Mapping) {
+// transformResourceObjectSourcePath applies the supplied Transformer to
+// object.sourcePath while preserving trailing line-number context (for
+// example src-xxxx:12).
+
+func transformResourceObjectSourcePath(resource workloadinterface.IMetadata, transformer Transformer) error {
+
 	if resource == nil {
-		return
+		return nil
 	}
 
 	obj := resource.GetObject()
 	if obj == nil {
-		return
+		return nil
 	}
 
 	rawSourcePath, ok := obj["sourcePath"]
 	if !ok {
-		return
+		return nil
 	}
 
 	sourcePath, ok := rawSourcePath.(string)
 	if !ok || sourcePath == "" {
-		return
+		return nil
 	}
 
-	obj["sourcePath"] = anonymizeSourcePath(sourcePath, mapping)
+	transformedSourcePath, err := transformSourcePath(
+		sourcePath,
+		transformer,
+	)
+	if err != nil {
+		return err
+	}
+
+	obj["sourcePath"] = transformedSourcePath
 	resource.SetObject(obj)
+
+	return nil
 }
 
-// anonymizeSourcePath preserves trailing line numbers while anonymizing the
-// underlying file path.
-func anonymizeSourcePath(sourcePath string, mapping *Mapping) string {
+// transformSourcePath applies the supplied Transformer to the path portion
+// of a sourcePath while preserving any trailing line number (for example
+// src-xxxx:12).
+
+func transformSourcePath(sourcePath string, transformer Transformer) (string, error) {
+
 	lastColon := strings.LastIndex(sourcePath, ":")
 	if lastColon == -1 {
-		return mapping.GetOrCreate("src", sourcePath)
+		return transformValue(transformer, "src", sourcePath)
 	}
 
 	pathPart := sourcePath[:lastColon]
 	linePart := sourcePath[lastColon:]
 
 	if pathPart == "" {
-		return mapping.GetOrCreate("src", sourcePath)
+		return transformValue(transformer, "src", sourcePath)
 	}
 
-	return mapping.GetOrCreate("src", pathPart) + linePart
+	transformedPath, err := transformValue(transformer, "src", pathPart)
+	if err != nil {
+		return "", err
+	}
+
+	return transformedPath + linePart, nil
 }
 
-// anonymizeAnnotationNodes recursively traverses unstructured resource objects
-// to locate metadata blocks regardless of workload nesting depth.
-func anonymizeAnnotationNodes(node any, mapping *Mapping) {
+// transformAnnotationNodes recursively traverses unstructured resource
+// objects, applying the supplied Transformer to annotation values
+// wherever metadata.annotations appears regardless of workload nesting.
+
+func transformAnnotationNodes(node any, transformer Transformer) error {
+
 	switch v := node.(type) {
 	case map[string]any:
-		anonymizeAnnotationMap(v, mapping)
+		if err := transformAnnotationMap(v, transformer); err != nil {
+			return err
+		}
 
 		for _, child := range v {
-			anonymizeAnnotationNodes(child, mapping)
+			if err := transformAnnotationNodes(child, transformer); err != nil {
+				return err
+			}
 		}
 
 	case []any:
 		for _, item := range v {
-			anonymizeAnnotationNodes(item, mapping)
+			if err := transformAnnotationNodes(item, transformer); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
-// anonymizeAnnotationMap anonymizes string annotation values while preserving
-// annotation keys, which remain meaningful Kubernetes identifiers.
-func anonymizeAnnotationMap(obj map[string]any, mapping *Mapping) {
+// transformAnnotationMap applies the supplied Transformer to annotation
+// values while preserving annotation keys, which remain meaningful
+// Kubernetes identifiers.
+
+func transformAnnotationMap(obj map[string]any, transformer Transformer) error {
+
 	rawMetadata, ok := obj["metadata"]
 	if !ok || rawMetadata == nil {
-		return
+		return nil
 	}
 
 	metadata, ok := rawMetadata.(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	rawAnnotations, ok := metadata["annotations"]
 	if !ok || rawAnnotations == nil {
-		return
+		return nil
 	}
 
 	annotations, ok := rawAnnotations.(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 
 	for key, val := range annotations {
@@ -309,8 +380,15 @@ func anonymizeAnnotationMap(obj map[string]any, mapping *Mapping) {
 			continue
 		}
 
-		annotations[key] = mapping.GetOrCreate("ann", str)
+		transformedValue, err := transformValue(transformer, "ann", str)
+		if err != nil {
+			return err
+		}
+
+		annotations[key] = transformedValue
 	}
+
+	return nil
 }
 
 func transformValue(transformer Transformer, prefix string, value string) (string, error) {
@@ -321,10 +399,7 @@ func transformValue(transformer Transformer, prefix string, value string) (strin
 	return transformer.Transform(prefix, value)
 }
 
-func transformResourceMetadata(
-	resource workloadinterface.IMetadata,
-	transformer Transformer,
-) error {
+func transformResourceMetadata(resource workloadinterface.IMetadata, transformer Transformer) error {
 
 	if resource == nil {
 		return nil
@@ -435,10 +510,7 @@ func transformLastCommit(commit *reporthandling.LastCommit, transformer Transfor
 	return nil
 }
 
-func transformResourceSource(
-	source *reporthandling.Source,
-	transformer Transformer,
-) error {
+func transformResourceSource(source *reporthandling.Source, transformer Transformer) error {
 	if source == nil {
 		return nil
 	}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -1,9 +1,9 @@
 package anonymizer
 
 import (
-	"testing"
-
 	"errors"
+	"strings"
+	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -83,16 +83,16 @@ func TestResolveMappedID(t *testing.T) {
 	}
 }
 
-func TestAnonymizeSession_NilSession(t *testing.T) {
+func TestTransformSession_NilSession(t *testing.T) {
 	mapping := NewMapping()
 
 	require.NoError(
 		t,
-		anonymizeSession(nil, mapping, NewMappingTransformer()),
+		transformSession(nil, mapping, NewMappingTransformer()),
 	)
 }
 
-func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
+func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 	pod := workloadinterface.NewWorkloadObj(map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
@@ -114,7 +114,7 @@ func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
 
 	mapping := NewMapping()
 
-	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, mapping, NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, resource := range session.AllResources {
@@ -125,7 +125,7 @@ func TestAnonymizeSession_NamesAndNamespacesReplaced(t *testing.T) {
 	}
 }
 
-func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
+func TestTransformSession_IDConsistencyAcrossMaps(t *testing.T) {
 	pod := workloadinterface.NewWorkloadObj(map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
@@ -204,7 +204,7 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 	}
 
 	mapping := NewMapping()
-	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, mapping, NewMappingTransformer())
 	require.NoError(t, err)
 
 	var newID string
@@ -327,7 +327,7 @@ func TestAnonymizeSession_IDConsistencyAcrossMaps(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func TestAnonymizeSession_LabelHandling(t *testing.T) {
+func TestTransformSession_LabelHandling(t *testing.T) {
 	tests := []struct {
 		name         string
 		labelsToCopy []string
@@ -379,7 +379,7 @@ func TestAnonymizeSession_LabelHandling(t *testing.T) {
 			}
 
 			mapping := NewMapping()
-			err := anonymizeSession(session, mapping, NewMappingTransformer())
+			err := transformSession(session, mapping, NewMappingTransformer())
 			require.NoError(t, err)
 
 			for _, resource := range session.AllResources {
@@ -408,16 +408,16 @@ func TestAnonymizeResourceLabels_Guards(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapping := NewMapping()
 
 			assert.NotPanics(t, func() {
-				anonymizeResourceLabels(test.resource, []string{"team"}, mapping)
+				err := transformResourceLabels(test.resource, []string{"team"}, NewMappingTransformer())
+				require.NoError(t, err)
 			})
 		})
 	}
 }
 
-func TestAnonymizeSession_Annotations(t *testing.T) {
+func TestTransformSession_Annotations(t *testing.T) {
 	tests := []struct {
 		name     string
 		resource map[string]any
@@ -565,7 +565,7 @@ func TestAnonymizeSession_Annotations(t *testing.T) {
 			mapping := NewMapping()
 
 			assert.NotPanics(t, func() {
-				err := anonymizeSession(session, mapping, NewMappingTransformer())
+				err := transformSession(session, mapping, NewMappingTransformer())
 				require.NoError(t, err)
 			})
 
@@ -576,7 +576,7 @@ func TestAnonymizeSession_Annotations(t *testing.T) {
 	}
 }
 
-func TestAnonymizeSession_RepoContextMetadata(t *testing.T) {
+func TestTransformSession_RepoContextMetadata(t *testing.T) {
 	repoContext := &reporthandlingv2.RepoContextMetadata{
 		Provider:      "github",
 		Repo:          "kubescape",
@@ -634,7 +634,7 @@ func TestAnonymizeSession_RepoContextMetadata(t *testing.T) {
 	}
 
 	mapping := NewMapping()
-	err := anonymizeSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, mapping, NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, repo := range []*reporthandlingv2.RepoContextMetadata{
@@ -925,7 +925,7 @@ func TestTransformResourceSource_Error(
 	assert.Equal(t, "/workspace/private/app.yaml", source.Path)
 }
 
-func TestAnonymizeSession_ResourceSourceEncryption(
+func TestTransformSession_ResourceSourceEncryption(
 	t *testing.T,
 ) {
 	dek, err := reportcrypto.GenerateDEK()
@@ -965,7 +965,7 @@ func TestAnonymizeSession_ResourceSourceEncryption(
 		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
 	}
 
-	err = anonymizeSession(
+	err = transformSession(
 		session,
 		NewMapping(),
 		NewEncryptionTransformer(dek),
@@ -1089,5 +1089,146 @@ func TestTransformResourceMetadata_Error(
 		t,
 		"production",
 		resource.GetNamespace(),
+	)
+}
+
+func TestTransformResourceLabels_EncryptionTransformer(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				"team": "payments",
+				"env":  "production",
+			},
+		},
+	})
+
+	err = transformResourceLabels(
+		resource,
+		[]string{"team", "env"},
+		NewEncryptionTransformer(dek),
+	)
+	require.NoError(t, err)
+
+	labels := resource.GetLabels()
+
+	assert.Contains(t, labels["team"], "ENC[AES256_GCM,")
+	assert.Contains(t, labels["env"], "ENC[AES256_GCM,")
+
+	team, err := reportcrypto.DecryptString(labels["team"], dek)
+	require.NoError(t, err)
+
+	env, err := reportcrypto.DecryptString(labels["env"], dek)
+	require.NoError(t, err)
+
+	assert.Equal(t, "payments", team)
+	assert.Equal(t, "production", env)
+}
+
+func TestTransformResourceAnnotations_EncryptionTransformer(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				"vault.hashicorp.com/path": "secret/prod/payment",
+				"example.com/token":        "my-secret-token",
+			},
+		},
+	})
+
+	err = transformResourceAnnotations(
+		resource,
+		NewEncryptionTransformer(dek),
+	)
+	require.NoError(t, err)
+
+	metadata := resource.GetObject()["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+
+	value1 := annotations["vault.hashicorp.com/path"].(string)
+	value2 := annotations["example.com/token"].(string)
+
+	assert.Contains(t, value1, "ENC[AES256_GCM,")
+	assert.Contains(t, value2, "ENC[AES256_GCM,")
+
+	decrypted1, err := reportcrypto.DecryptString(value1, dek)
+	require.NoError(t, err)
+
+	decrypted2, err := reportcrypto.DecryptString(value2, dek)
+	require.NoError(t, err)
+
+	assert.Equal(t, "secret/prod/payment", decrypted1)
+	assert.Equal(t, "my-secret-token", decrypted2)
+}
+
+func TestTransformResourceObjectSourcePath_EncryptionTransformer(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"sourcePath": "/workspace/manifests/payment.yaml:42",
+	})
+
+	err = transformResourceObjectSourcePath(
+		resource,
+		NewEncryptionTransformer(dek),
+	)
+	require.NoError(t, err)
+
+	sourcePath := resource.GetObject()["sourcePath"].(string)
+
+	assert.Contains(t, sourcePath, "ENC[AES256_GCM,")
+	assert.True(t, len(sourcePath) > 3)
+	assert.Equal(t, ":42", sourcePath[len(sourcePath)-3:])
+
+	encryptedPath := sourcePath[:len(sourcePath)-3]
+
+	decrypted, err := reportcrypto.DecryptString(encryptedPath, dek)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/workspace/manifests/payment.yaml", decrypted)
+}
+
+func TestTransformSourcePath_EncryptionTransformer(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	transformed, err := transformSourcePath(
+		"/workspace/manifests/payment.yaml:42",
+		transformer,
+	)
+	require.NoError(t, err)
+
+	lastColon := strings.LastIndex(transformed, ":")
+	require.NotEqual(t, -1, lastColon)
+
+	encryptedPath := transformed[:lastColon]
+	linePart := transformed[lastColon:]
+
+	assert.Contains(t, encryptedPath, "ENC[AES256_GCM,")
+	assert.Equal(t, ":42", linePart)
+
+	decryptedPath, err := reportcrypto.DecryptString(
+		encryptedPath,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"/workspace/manifests/payment.yaml",
+		decryptedPath,
 	)
 }

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -19,8 +19,10 @@ import (
 //	     UnwrapDEK()
 //	          ↓
 //	          DEK
-
-func DEKFromMetadata(metadata *reporthandlingv2.Metadata, masterKey []byte) ([]byte, error) {
+func DEKFromMetadata(
+	metadata *reporthandlingv2.Metadata,
+	masterKey []byte,
+) ([]byte, error) {
 
 	if metadata == nil {
 		return nil, fmt.Errorf("metadata is nil")
@@ -59,8 +61,10 @@ func DEKFromMetadata(metadata *reporthandlingv2.Metadata, masterKey []byte) ([]b
 //   - LastCommit.CommitterEmail
 //
 // Additional fields can be added as encryption coverage expands.
-
-func DecryptRepoContextMetadata(metadata *reporthandlingv2.Metadata, masterKey []byte) error {
+func DecryptRepoContextMetadata(
+	metadata *reporthandlingv2.Metadata,
+	masterKey []byte,
+) error {
 
 	dek, err := DEKFromMetadata(
 		metadata,
@@ -172,8 +176,10 @@ func DecryptRepoContextMetadata(metadata *reporthandlingv2.Metadata, masterKey [
 // been encrypted by transformLastCommit.
 //
 // This operation mutates the supplied LastCommit object in place.
-
-func decryptLastCommit(commit *reporthandling.LastCommit, dek []byte) error {
+func decryptLastCommit(
+	commit *reporthandling.LastCommit,
+	dek []byte,
+) error {
 	if commit == nil {
 		return nil
 	}
@@ -253,8 +259,10 @@ func decryptLastCommit(commit *reporthandling.LastCommit, dek []byte) error {
 //   - LastCommit.CommitterName
 //   - LastCommit.CommitterEmail
 //   - LastCommit.Message
-
-func DecryptResourceSource(source *reporthandling.Source, dek []byte) error {
+func DecryptResourceSource(
+	source *reporthandling.Source,
+	dek []byte,
+) error {
 	if source == nil {
 		return nil
 	}
@@ -376,8 +384,10 @@ func DecryptResourceSource(source *reporthandling.Source, dek []byte) error {
 //
 //   - Name
 //   - Namespace
-
-func DecryptResourceMetadata(resource workloadinterface.IMetadata, dek []byte) error {
+func DecryptResourceMetadata(
+	resource workloadinterface.IMetadata,
+	dek []byte,
+) error {
 	if resource == nil {
 		return nil
 	}
@@ -435,7 +445,6 @@ func decryptIfEncrypted(value string, dek []byte) (string, error) {
 //
 // Every label value is passed through decryptIfEncrypted, which leaves
 // plaintext values unchanged while restoring encrypted values.
-
 func DecryptResourceLabels(resource workloadinterface.IMetadata, dek []byte) error {
 
 	if resource == nil {
@@ -480,7 +489,6 @@ func DecryptResourceLabels(resource workloadinterface.IMetadata, dek []byte) err
 
 // DecryptResourceAnnotations restores encrypted annotation values
 // throughout a workload object, including nested workload templates.
-
 func DecryptResourceAnnotations(resource workloadinterface.IMetadata, dek []byte) error {
 
 	if resource == nil {
@@ -507,7 +515,6 @@ func DecryptResourceAnnotations(resource workloadinterface.IMetadata, dek []byte
 // decryptAnnotationNodes recursively traverses resource objects to
 // locate metadata.annotations blocks regardless of workload nesting
 // depth.
-
 func decryptAnnotationNodes(node any, dek []byte) error {
 
 	switch v := node.(type) {
@@ -547,7 +554,6 @@ func decryptAnnotationNodes(node any, dek []byte) error {
 
 // decryptAnnotationMap restores encrypted annotation values while
 // preserving annotation keys.
-
 func decryptAnnotationMap(obj map[string]any, dek []byte) error {
 
 	rawMetadata, ok := obj["metadata"]
@@ -597,7 +603,6 @@ func decryptAnnotationMap(obj map[string]any, dek []byte) error {
 
 // DecryptResourceObjectSourcePath restores object.sourcePath while
 // preserving trailing line-number context.
-
 func DecryptResourceObjectSourcePath(resource workloadinterface.IMetadata, dek []byte) error {
 
 	if resource == nil {
@@ -635,7 +640,6 @@ func DecryptResourceObjectSourcePath(resource workloadinterface.IMetadata, dek [
 
 // decryptSourcePath restores the path portion of a sourcePath while
 // preserving any trailing line-number suffix.
-
 func decryptSourcePath(sourcePath string, dek []byte) (string, error) {
 
 	lastColon := strings.LastIndex(

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -18,11 +18,9 @@ import (
 //	          ↓
 //	     UnwrapDEK()
 //	          ↓
-//	           DEK
-func DEKFromMetadata(
-	metadata *reporthandlingv2.Metadata,
-	masterKey []byte,
-) ([]byte, error) {
+//	          DEK
+
+func DEKFromMetadata(metadata *reporthandlingv2.Metadata, masterKey []byte) ([]byte, error) {
 
 	if metadata == nil {
 		return nil, fmt.Errorf("metadata is nil")
@@ -54,12 +52,15 @@ func DEKFromMetadata(
 //   - Branch
 //   - RemoteURL
 //   - LastCommit.Message
+//   - DefaultBranch
+//   - LocalRootPath
+//   - LastCommit.Hash
+//   - LastCommit.CommitterName
+//   - LastCommit.CommitterEmail
 //
 // Additional fields can be added as encryption coverage expands.
-func DecryptRepoContextMetadata(
-	metadata *reporthandlingv2.Metadata,
-	masterKey []byte,
-) error {
+
+func DecryptRepoContextMetadata(metadata *reporthandlingv2.Metadata, masterKey []byte) error {
 
 	dek, err := DEKFromMetadata(
 		metadata,
@@ -171,10 +172,8 @@ func DecryptRepoContextMetadata(
 // been encrypted by transformLastCommit.
 //
 // This operation mutates the supplied LastCommit object in place.
-func decryptLastCommit(
-	commit *reporthandling.LastCommit,
-	dek []byte,
-) error {
+
+func decryptLastCommit(commit *reporthandling.LastCommit, dek []byte) error {
 	if commit == nil {
 		return nil
 	}
@@ -254,10 +253,8 @@ func decryptLastCommit(
 //   - LastCommit.CommitterName
 //   - LastCommit.CommitterEmail
 //   - LastCommit.Message
-func DecryptResourceSource(
-	source *reporthandling.Source,
-	dek []byte,
-) error {
+
+func DecryptResourceSource(source *reporthandling.Source, dek []byte) error {
 	if source == nil {
 		return nil
 	}
@@ -379,10 +376,8 @@ func DecryptResourceSource(
 //
 //   - Name
 //   - Namespace
-func DecryptResourceMetadata(
-	resource workloadinterface.IMetadata,
-	dek []byte,
-) error {
+
+func DecryptResourceMetadata(resource workloadinterface.IMetadata, dek []byte) error {
 	if resource == nil {
 		return nil
 	}
@@ -434,4 +429,248 @@ func decryptIfEncrypted(value string, dek []byte) (string, error) {
 	}
 
 	return DecryptString(value, dek)
+}
+
+// DecryptResourceLabels restores encrypted resource label values.
+//
+// Every label value is passed through decryptIfEncrypted, which leaves
+// plaintext values unchanged while restoring encrypted values.
+
+func DecryptResourceLabels(resource workloadinterface.IMetadata, dek []byte) error {
+
+	if resource == nil {
+		return nil
+	}
+
+	bw, ok := resource.(workloadinterface.IWorkload)
+	if !ok {
+		return nil
+	}
+
+	labels := bw.GetLabels()
+	if len(labels) == 0 {
+		return nil
+	}
+
+	for key, value := range labels {
+		if value == "" {
+			continue
+		}
+
+		decryptedValue, err := decryptIfEncrypted(
+			value,
+			dek,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt label %q: %w",
+				key,
+				err,
+			)
+		}
+
+		bw.SetLabel(
+			key,
+			decryptedValue,
+		)
+	}
+
+	return nil
+}
+
+// DecryptResourceAnnotations restores encrypted annotation values
+// throughout a workload object, including nested workload templates.
+
+func DecryptResourceAnnotations(resource workloadinterface.IMetadata, dek []byte) error {
+
+	if resource == nil {
+		return nil
+	}
+
+	obj := resource.GetObject()
+	if obj == nil {
+		return nil
+	}
+
+	if err := decryptAnnotationNodes(
+		obj,
+		dek,
+	); err != nil {
+		return err
+	}
+
+	resource.SetObject(obj)
+
+	return nil
+}
+
+// decryptAnnotationNodes recursively traverses resource objects to
+// locate metadata.annotations blocks regardless of workload nesting
+// depth.
+
+func decryptAnnotationNodes(node any, dek []byte) error {
+
+	switch v := node.(type) {
+
+	case map[string]any:
+
+		if err := decryptAnnotationMap(
+			v,
+			dek,
+		); err != nil {
+			return err
+		}
+
+		for _, child := range v {
+			if err := decryptAnnotationNodes(
+				child,
+				dek,
+			); err != nil {
+				return err
+			}
+		}
+
+	case []any:
+
+		for _, item := range v {
+			if err := decryptAnnotationNodes(
+				item,
+				dek,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// decryptAnnotationMap restores encrypted annotation values while
+// preserving annotation keys.
+
+func decryptAnnotationMap(obj map[string]any, dek []byte) error {
+
+	rawMetadata, ok := obj["metadata"]
+	if !ok || rawMetadata == nil {
+		return nil
+	}
+
+	metadata, ok := rawMetadata.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	rawAnnotations, ok := metadata["annotations"]
+	if !ok || rawAnnotations == nil {
+		return nil
+	}
+
+	annotations, ok := rawAnnotations.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	for key, value := range annotations {
+
+		str, ok := value.(string)
+		if !ok || str == "" {
+			continue
+		}
+
+		decryptedValue, err := decryptIfEncrypted(
+			str,
+			dek,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to decrypt annotation %q: %w",
+				key,
+				err,
+			)
+		}
+
+		annotations[key] = decryptedValue
+	}
+
+	return nil
+}
+
+// DecryptResourceObjectSourcePath restores object.sourcePath while
+// preserving trailing line-number context.
+
+func DecryptResourceObjectSourcePath(resource workloadinterface.IMetadata, dek []byte) error {
+
+	if resource == nil {
+		return nil
+	}
+
+	obj := resource.GetObject()
+	if obj == nil {
+		return nil
+	}
+
+	rawSourcePath, ok := obj["sourcePath"]
+	if !ok {
+		return nil
+	}
+
+	sourcePath, ok := rawSourcePath.(string)
+	if !ok || sourcePath == "" {
+		return nil
+	}
+
+	decryptedPath, err := decryptSourcePath(
+		sourcePath,
+		dek,
+	)
+	if err != nil {
+		return err
+	}
+
+	obj["sourcePath"] = decryptedPath
+	resource.SetObject(obj)
+
+	return nil
+}
+
+// decryptSourcePath restores the path portion of a sourcePath while
+// preserving any trailing line-number suffix.
+
+func decryptSourcePath(sourcePath string, dek []byte) (string, error) {
+
+	lastColon := strings.LastIndex(
+		sourcePath,
+		":",
+	)
+
+	if lastColon == -1 {
+		return decryptIfEncrypted(
+			sourcePath,
+			dek,
+		)
+	}
+
+	pathPart := sourcePath[:lastColon]
+	linePart := sourcePath[lastColon:]
+
+	if pathPart == "" {
+		return decryptIfEncrypted(
+			sourcePath,
+			dek,
+		)
+	}
+
+	decryptedPath, err := decryptIfEncrypted(
+		pathPart,
+		dek,
+	)
+	if err != nil {
+		return "",
+			fmt.Errorf(
+				"failed to decrypt source path: %w",
+				err,
+			)
+	}
+
+	return decryptedPath + linePart, nil
 }

--- a/core/pkg/reportcrypto/decrypt_test.go
+++ b/core/pkg/reportcrypto/decrypt_test.go
@@ -536,3 +536,181 @@ func TestDecryptResourceMetadata_Nil(
 
 	require.NoError(t, err)
 }
+
+func TestDecryptResourceLabels_RoundTrip(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedTeam, err := EncryptString(
+		"payments",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedEnv, err := EncryptString(
+		"production",
+		dek,
+	)
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"labels": map[string]any{
+					"team": encryptedTeam,
+					"env":  encryptedEnv,
+				},
+			},
+		},
+	)
+
+	err = DecryptResourceLabels(
+		resource,
+		dek,
+	)
+	require.NoError(t, err)
+
+	labels := resource.GetLabels()
+
+	assert.Equal(
+		t,
+		"payments",
+		labels["team"],
+	)
+
+	assert.Equal(
+		t,
+		"production",
+		labels["env"],
+	)
+}
+
+func TestDecryptResourceAnnotations_RoundTrip(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedValue1, err := EncryptString(
+		"secret/data/payment",
+		dek,
+	)
+	require.NoError(t, err)
+
+	encryptedValue2, err := EncryptString(
+		"abcd1234",
+		dek,
+	)
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					"vault.hashicorp.com/path": encryptedValue1,
+					"example.com/token":        encryptedValue2,
+				},
+			},
+		},
+	)
+
+	err = DecryptResourceAnnotations(
+		resource,
+		dek,
+	)
+	require.NoError(t, err)
+
+	metadata := resource.GetObject()["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+
+	assert.Equal(
+		t,
+		"secret/data/payment",
+		annotations["vault.hashicorp.com/path"],
+	)
+
+	assert.Equal(
+		t,
+		"abcd1234",
+		annotations["example.com/token"],
+	)
+}
+
+func TestDecryptResourceObjectSourcePath_RoundTrip(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	encryptedPath, err := EncryptString(
+		"/workspace/manifests/payment.yaml",
+		dek,
+	)
+	require.NoError(t, err)
+
+	resource := workloadinterface.NewWorkloadObj(
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"sourcePath": encryptedPath + ":42",
+		},
+	)
+
+	err = DecryptResourceObjectSourcePath(
+		resource,
+		dek,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"/workspace/manifests/payment.yaml:42",
+		resource.GetObject()["sourcePath"],
+	)
+}
+
+func TestDecryptResourceLabels_Nil(t *testing.T) {
+	err := DecryptResourceLabels(
+		nil,
+		make([]byte, 32),
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDecryptResourceAnnotations_Nil(t *testing.T) {
+	err := DecryptResourceAnnotations(
+		nil,
+		make([]byte, 32),
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDecryptResourceObjectSourcePath_Nil(t *testing.T) {
+	err := DecryptResourceObjectSourcePath(
+		nil,
+		make([]byte, 32),
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDecryptResourceLabels_Plaintext(t *testing.T) {
+	resource := workloadinterface.NewWorkloadObj(
+		map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"labels": map[string]any{
+					"team": "backend",
+				},
+			},
+		},
+	)
+
+	err := DecryptResourceLabels(resource, make([]byte, 32))
+	require.NoError(t, err)
+
+	assert.Equal(t, "backend", resource.GetLabels()["team"])
+}


### PR DESCRIPTION
PartOf : : #1200 

## Overview

This PR extends the report decryption workflow to restore all resource metadata that is now encrypted during anonymization.

## Changes

### Report decryption

Added support for :

- Resource labels
- Resource annotations (including nested workload templates)
- Resource `sourcePath`
- Resource source metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Decrypted resources now correctly restore encrypted labels and annotations.
  - Source paths are decrypted while preserving trailing line references.
  - Improved error handling prevents incomplete or silently incorrect transformations.

- **Tests**
  - Added coverage for encrypted and plaintext metadata, source paths, round-trip behavior, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->