### PR TITLE
fix(sarif): surface PrettyWrite errors instead of silently writing empty file

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -250,7 +250,10 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 
 	report.AddRun(run)
 
-	report.PrettyWrite(sp.writer)
+	// Surface write failures instead of silently leaving an empty/partial file.
+	if err := report.PrettyWrite(sp.writer); err != nil {
+		return fmt.Errorf("failed to write SARIF report: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Overview

printConfigurationScan in the SARIF printer ignored the error returned by report.PrettyWrite(sp.writer). If that write fails (broken pipe, disk full, encoding error, etc.), the SARIF file is left empty or partial, no error is logged, and the scan still exits 0 — a silent failure.

This captures the error and returns it. The caller (ActionPrint) already logs errors from printConfigurationScan as "failed to write results in sarif format", so a write failure now surfaces to the user instead of producing a silent empty file.

// Surface write failures instead of silently leaving an empty/partial file.
if err := report.PrettyWrite(sp.writer); err != nil {
    return fmt.Errorf("failed to write SARIF report: %w", err)
}

## Additional Information

Investigated for #2495 (empty SARIF output). I could not reproduce the 0-byte file on the current codebase — directory, single-file, absolute-path, and cross-working-directory scans all produced valid, non-empty SARIF. The ignored PrettyWrite error is, however, the one path that matches the reported symptom (empty file + no logged error), so this hardens it regardless of the underlying trigger. This does not by itself confirm the root cause of #2495.

## How to Test

kubescape scan framework nsa,mitre ./manifests --format sarif --output r.sarif

- r.sarif is written and non-empty; parses as valid SARIF 2.1.0.
- If the write fails, the scan now logs failed to write results in sarif format instead of silently leaving an empty file.

Existing unit tests: go test ./core/pkg/resultshandling/printer/v2/

## Related issues/PRs:

- Refs #2495

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF report generation now surfaces write failures instead of silently producing incomplete or empty output.
  * Error messages provide clearer details when report writing cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->