### PR TITLE
fix(sarif): don't os.Exit on unencodable fix, avoid empty SARIF file

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -601,7 +601,10 @@ func ApplyFixToContent(ctx context.Context, yamlAsString, yamlExpression string)
 		return "", err
 	}
 
-	fixInfo := getFixInfo(ctx, originalRootNodes, fixedRootNodes)
+	fixInfo, err := getFixInfo(ctx, originalRootNodes, fixedRootNodes)
+	if err != nil {
+		return "", err
+	}
 
 	fixedYamlLines := getFixedYamlLines(yamlLines, fixInfo, newline)
 

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -226,6 +226,22 @@ func TestApplyFixKeepsFormatting(t *testing.T) {
 	}
 }
 
+// TestApplyFixToContent_EmptyLeadingDocument guards the regression from issue
+// #2495: a file whose first document is empty (a comment followed by "---") is
+// decoded inconsistently by go-yaml and yqlib, which used to make the fix
+// renderer call logger.Fatal and os.Exit the whole process mid-write (leaving
+// an empty SARIF file). It must now return an error gracefully instead.
+func TestApplyFixToContent_EmptyLeadingDocument(t *testing.T) {
+	yamlContent := "# a comment, followed by a document separator\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: demo\nspec:\n  template:\n    spec:\n      containers:\n        - name: app\n          image: nginx:1.27\n"
+	// The scanner counts the empty leading document, so the Deployment is di==1.
+	expression := FixPathToValidYamlExpression("spec.template.spec.containers[0].image", "nginx:1.28", 1)
+
+	got, err := ApplyFixToContent(context.Background(), yamlContent, expression)
+
+	assert.Error(t, err, "expected a graceful error rather than a process exit")
+	assert.Empty(t, got)
+}
+
 func Test_fixPathToValidYamlExpression(t *testing.T) {
 	type args struct {
 		fixPath             string

--- a/core/pkg/fixhandler/yamlhandler.go
+++ b/core/pkg/fixhandler/yamlhandler.go
@@ -87,14 +87,22 @@ func flattenWithDFSHelper(node *yaml.Node, parent *yaml.Node, dfsOrder *[]nodeIn
 	}
 }
 
-func getFixInfo(ctx context.Context, originalRootNodes, fixedRootNodes []yaml.Node) fileFixInfo {
+func getFixInfo(ctx context.Context, originalRootNodes, fixedRootNodes []yaml.Node) (fileFixInfo, error) {
 	contentToAdd := make([]contentToAdd, 0)
 	linesToRemove := make([]linesToRemove, 0)
 
 	for idx := range fixedRootNodes {
+		// The two decoders can disagree on document count (e.g. an empty leading
+		// document), so guard the paired index instead of panicking.
+		if idx >= len(originalRootNodes) {
+			break
+		}
 		originalList := flattenWithDFS(&originalRootNodes[idx])
 		fixedList := flattenWithDFS(&fixedRootNodes[idx])
-		nodeContentToAdd, nodeLinesToRemove := getFixInfoHelper(ctx, *originalList, *fixedList)
+		nodeContentToAdd, nodeLinesToRemove, err := getFixInfoHelper(ctx, *originalList, *fixedList)
+		if err != nil {
+			return fileFixInfo{}, err
+		}
 		contentToAdd = append(contentToAdd, nodeContentToAdd...)
 		linesToRemove = append(linesToRemove, nodeLinesToRemove...)
 	}
@@ -102,10 +110,10 @@ func getFixInfo(ctx context.Context, originalRootNodes, fixedRootNodes []yaml.No
 	return fileFixInfo{
 		contentsToAdd: &contentToAdd,
 		linesToRemove: &linesToRemove,
-	}
+	}, nil
 }
 
-func getFixInfoHelper(ctx context.Context, originalList, fixedList []nodeInfo) ([]contentToAdd, []linesToRemove) {
+func getFixInfoHelper(ctx context.Context, originalList, fixedList []nodeInfo) ([]contentToAdd, []linesToRemove, error) {
 
 	// While obtaining fixedYamlNode, comments and empty lines at the top are ignored.
 	// This causes a difference in Line numbers across the tree structure. In order to
@@ -132,26 +140,34 @@ func getFixInfoHelper(ctx context.Context, originalList, fixedList []nodeInfo) (
 		fixInfoMetadata.originalListTracker = originalListTracker
 		fixInfoMetadata.fixedListTracker = fixedListTracker
 
+		var err error
 		switch matchNodeResult {
 		case sameNodes:
 			originalListTracker += 1
 			fixedListTracker += 1
 
 		case removedNode:
-			originalListTracker, fixedListTracker = addLinesToRemove(ctx, fixInfoMetadata)
+			originalListTracker, fixedListTracker, err = addLinesToRemove(ctx, fixInfoMetadata)
 
 		case insertedNode:
-			originalListTracker, fixedListTracker = addLinesToInsert(ctx, fixInfoMetadata)
+			originalListTracker, fixedListTracker, err = addLinesToInsert(ctx, fixInfoMetadata)
 
 		case replacedNode:
-			originalListTracker, fixedListTracker = updateLinesToReplace(ctx, fixInfoMetadata)
+			originalListTracker, fixedListTracker, err = updateLinesToReplace(ctx, fixInfoMetadata)
+		}
+		if err != nil {
+			return nil, nil, err
 		}
 	}
 
 	// Some nodes are still not visited if they are removed at the end of the list
 	for originalListTracker < len(originalList) {
 		fixInfoMetadata.originalListTracker = originalListTracker
-		originalListTracker, _ = addLinesToRemove(ctx, fixInfoMetadata)
+		var err error
+		originalListTracker, _, err = addLinesToRemove(ctx, fixInfoMetadata)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// Some nodes are still not visited if they are inserted at the end of the list
@@ -159,15 +175,19 @@ func getFixInfoHelper(ctx context.Context, originalList, fixedList []nodeInfo) (
 		// Use negative index of last node in original list as a placeholder to determine the last line number later
 		fixInfoMetadata.originalListTracker = -(len(originalList) - 1)
 		fixInfoMetadata.fixedListTracker = fixedListTracker
-		_, fixedListTracker = addLinesToInsert(ctx, fixInfoMetadata)
+		var err error
+		_, fixedListTracker, err = addLinesToInsert(ctx, fixInfoMetadata)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
-	return contentToAdd, linesToRemove
+	return contentToAdd, linesToRemove, nil
 
 }
 
 // Adds the lines to remove and returns the updated originalListTracker
-func addLinesToRemove(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int) {
+func addLinesToRemove(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int, error) {
 	isOneLine, line := isOneLineSequenceNode(fixInfoMetadata.originalList, fixInfoMetadata.originalListTracker)
 
 	if isOneLine {
@@ -184,11 +204,11 @@ func addLinesToRemove(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (in
 		endLine:   getNodeLine(fixInfoMetadata.originalList, newOriginalListTracker-1), // newOriginalListTracker is the next node
 	})
 
-	return newOriginalListTracker, fixInfoMetadata.fixedListTracker
+	return newOriginalListTracker, fixInfoMetadata.fixedListTracker, nil
 }
 
 // Adds the lines to insert and returns the updated fixedListTracker
-func addLinesToInsert(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int) {
+func addLinesToInsert(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int, error) {
 
 	isOneLine, line := isOneLineSequenceNode(fixInfoMetadata.fixedList, fixInfoMetadata.fixedListTracker)
 
@@ -199,7 +219,10 @@ func addLinesToInsert(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (in
 	currentDFSNode := (*fixInfoMetadata.fixedList)[fixInfoMetadata.fixedListTracker]
 
 	lineToInsert := getLineToInsert(fixInfoMetadata)
-	contentToInsert := getContent(ctx, currentDFSNode.parent, fixInfoMetadata.fixedList, fixInfoMetadata.fixedListTracker)
+	contentToInsert, err := getContent(ctx, currentDFSNode.parent, fixInfoMetadata.fixedList, fixInfoMetadata.fixedListTracker)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	newFixedTracker := updateTracker(fixInfoMetadata.fixedList, fixInfoMetadata.fixedListTracker)
 
@@ -208,11 +231,11 @@ func addLinesToInsert(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (in
 		content: contentToInsert,
 	})
 
-	return fixInfoMetadata.originalListTracker, newFixedTracker
+	return fixInfoMetadata.originalListTracker, newFixedTracker, nil
 }
 
 // Adds the lines to remove and insert and updates the fixedListTracker and originalListTracker
-func updateLinesToReplace(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int) {
+func updateLinesToReplace(ctx context.Context, fixInfoMetadata *fixInfoMetadata) (int, int, error) {
 
 	isOneLine, line := isOneLineSequenceNode(fixInfoMetadata.fixedList, fixInfoMetadata.fixedListTracker)
 
@@ -228,10 +251,15 @@ func updateLinesToReplace(ctx context.Context, fixInfoMetadata *fixInfoMetadata)
 		fixInfoMetadata.fixedListTracker -= 1
 	}
 
-	addLinesToRemove(ctx, fixInfoMetadata)
-	updatedOriginalTracker, updatedFixedTracker := addLinesToInsert(ctx, fixInfoMetadata)
+	if _, _, err := addLinesToRemove(ctx, fixInfoMetadata); err != nil {
+		return 0, 0, err
+	}
+	updatedOriginalTracker, updatedFixedTracker, err := addLinesToInsert(ctx, fixInfoMetadata)
+	if err != nil {
+		return 0, 0, err
+	}
 
-	return updatedOriginalTracker, updatedFixedTracker
+	return updatedOriginalTracker, updatedFixedTracker, nil
 }
 
 func removeNewLinesAtTheEnd(yamlLines []string) []string {

--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -121,17 +121,19 @@ func enocodeIntoYaml(parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) (
 	return fmt.Sprintf(`%v`, buf.String()), nil
 }
 
-func getContent(ctx context.Context, parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) string {
+func getContent(ctx context.Context, parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) (string, error) {
 	content, err := enocodeIntoYaml(parentNode, nodeList, tracker)
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal("Cannot Encode into YAML")
+		// Best-effort remediation rendering must not kill the process; let the
+		// caller skip this fix and still write the report.
+		return "", fmt.Errorf("cannot encode fix into YAML: %w", err)
 	}
 
 	indentationSpaces := parentNode.Column - 1
 
 	content = indentContent(content, indentationSpaces)
 
-	return strings.TrimSuffix(content, "\n")
+	return strings.TrimSuffix(content, "\n"), nil
 }
 
 func indentContent(content string, indentationSpaces int) string {
@@ -337,12 +339,15 @@ func safelyCloseFile(ctx context.Context, file *os.File) {
 
 // Remove the entire line and replace it with the sequence node in fixed info. This way,
 // the original formatting is lost.
-func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMetadata, line int) (int, int) {
+func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMetadata, line int) (int, int, error) {
 	originalListTracker := getFirstNodeInLine(fixInfoMetadata.originalList, line)
 	fixedListTracker := getFirstNodeInLine(fixInfoMetadata.fixedList, line)
 
 	currentDFSNode := (*fixInfoMetadata.fixedList)[fixedListTracker]
-	contentToInsert := getContent(ctx, currentDFSNode.parent, fixInfoMetadata.fixedList, fixedListTracker)
+	contentToInsert, err := getContent(ctx, currentDFSNode.parent, fixInfoMetadata.fixedList, fixedListTracker)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	// Remove the Single line
 	*fixInfoMetadata.linesToRemove = append(*fixInfoMetadata.linesToRemove, linesToRemove{
@@ -359,7 +364,7 @@ func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMeta
 	originalListTracker = updateTracker(fixInfoMetadata.originalList, originalListTracker)
 	fixedListTracker = updateTracker(fixInfoMetadata.fixedList, fixedListTracker)
 
-	return originalListTracker, fixedListTracker
+	return originalListTracker, fixedListTracker, nil
 }
 
 // Returns the first node in the given line that is not mapping node


### PR DESCRIPTION
## Overview

Scanning with --format sarif could silently produce a 0-byte output file while --format json/--format junit worked from the same scan (#2495).

Root cause: a YAML file whose first document is empty — a comment followed by the first --- separator — is decoded inconsistently by the two YAML engines the fix renderer uses. decodeDocumentRoots (go-yaml) drops the empty leading document and folds the top comment onto the first real document, while getFixedNodes (yqlib, via select(di==N)) keeps the empty document. The two node trees no longer line up, the diff renderer reaches a node it cannot encode, and getContent responded by calling logger.L().Ctx(ctx).Fatal(...) — which os.Exits the entire process mid-write. The .sarif file was created but never written, with no error surfaced.

This PR makes the fix renderer non-fatal: getContent now returns an error that is propagated up to ApplyFixToContent. Both the SARIF printer (collectFixes) and the fix command already skip-and-log a failed ApplyFixToContent, so the report is now written normally — the single unrenderable remediation hint is dropped and logged at debug level instead of taking down the whole run. A bounds guard is also added to the document-index pairing in getFixInfo to close a related index-panic vector.

## Additional Information

- A best-effort remediation renderer should never terminate the CLI; this also protects the fix command and any other consumer from the same class of crash on unusual YAML.
- Rendering a correct remediation for the empty-leading-document case (reconciling the two decoders' document indexing) is a deeper change and is intentionally left as follow-up — this PR restores correct, non-crashing report output.

## How to Test

Create manifests/demo.yaml beginning with a comment before the first separator:

 ---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: demo
spec:
  template:
    spec:
      containers:
        - name: app
          image: nginx:1.27

kubescape scan framework nsa,mitre ./manifests --format sarif --output r.sarif

- Before: r.sarif is 0 bytes; --logger debug shows a fatal "Cannot Encode into YAML".
- After: r.sarif is a valid, non-empty SARIF 2.1.0 document; the unrenderable fix is skipped and logged at debug (cannot encode fix into YAML: ...).

Automated:

go test ./core/pkg/fixhandler/... ./core/pkg/resultshandling/printer/v2/ ./cmd/fix/...

Includes a new regression test, TestApplyFixToContent_EmptyLeadingDocument.

## Related issues/PRs:

- Resolved #2495

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML fix handling when documents are empty or malformed.
  * Errors during YAML rendering and content encoding are now returned safely instead of causing the process to terminate.
  * Prevented crashes when YAML document counts differ during fix processing.
* **Tests**
  * Added regression coverage for YAML input with an empty leading document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->