### PR TITLE
fix(printer): don't append .txt to /dev/null in PrettyPrinter.SetWriter

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -200,7 +200,8 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
 		if outputFile == "" {
 			outputFile = prettyOutputFile
 		}
-		if filepath.Ext(outputFile) != printer.PrettyOutputExt {
+		// os.DevNull is used to silence the UI printer, appending an extension would turn it into a regular file
+		if outputFile != os.DevNull && filepath.Ext(outputFile) != printer.PrettyOutputExt {
 			outputFile = outputFile + printer.PrettyOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -125,4 +126,44 @@ func TestPrintScanCoverage_AllSectionsRendered(t *testing.T) {
 	assert.Contains(t, out, "clusterroles")
 	assert.Contains(t, out, "C-0001")
 	assert.Contains(t, out, "/v1/pods")
+}
+
+func TestSetWriter_Pretty(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		expected   string
+	}{
+		{
+			name:       "Output file name doesn't contain any extension",
+			outputFile: "customFilename",
+			expected:   "customFilename.txt",
+		},
+		{
+			name:       "Output file name contains .txt",
+			outputFile: "customFilename.txt",
+			expected:   "customFilename.txt",
+		},
+		{
+			name:       "Output file name is empty",
+			outputFile: "",
+			expected:   "/dev/stdout",
+		},
+		{
+			name:       "Output file is os.DevNull",
+			outputFile: os.DevNull,
+			expected:   os.DevNull,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pp := NewPrettyPrinter(false, "v2", false, cautils.ViewTypes("control"), cautils.ScanTypes("cluster"), []string{}, "")
+
+			pp.SetWriter(ctx, tt.outputFile)
+			assert.Equal(t, tt.expected, pp.writer.Name())
+		})
+	}
 }


### PR DESCRIPTION
## Overview

Every default `kubescape scan` invocation logs a spurious warning before completing:

[warning] failed to open file for writing, reason: open /dev/null.txt: operation not permitted

**Current behavior:** when `--format` is set without `--output`, `GetUIPrinter` silences the UI printer by pointing it at `os.DevNull`. `PrettyPrinter.SetWriter` then sees that `/dev/null` has no `.txt` extension and appends one, turning the path into `/dev/null.txt`. Creating a regular file there fails — `EACCES` on non-root Linux, `operation not permitted` on macOS devfs even as root — so the warning is emitted.

The warning is only the visible half of the problem. When the create fails, `printer.GetWriter` falls back to `os.Stdout`, so the pretty printer is not silenced at all: it writes to stdout, which is exactly what redirecting to `/dev/null` was meant to prevent. On `kubescape scan --format json`, the human-readable table can interleave with the JSON on stdout. Conversely, when the process *can* write to `/dev`, a stray `/dev/null.txt` regular file is created instead.

**Future behavior:** `PrettyPrinter.SetWriter` leaves `os.DevNull` untouched rather than appending an extension. `/dev/null` opens cleanly on both Linux and macOS, so the UI printer is genuinely silenced, no warning is logged, no file is created in `/dev`, and stdout carries only the requested format.

## Additional Information

The fix is a single condition in `PrettyPrinter.SetWriter` — the extension append is skipped for `os.DevNull`, and the rest of the path handling (trimming, the `report` default) is unchanged.

This follows existing intent in the codebase rather than introducing a new special case: `printer.LogOutputFile` already treats `os.DevNull` specially alongside stdout/stderr, so the literal path is expected to survive as far as the writer.

The `io.Discard` alternati considered and not taken:`PrettyPrinter.writer` is a concrete `*os.File`, so it would require changing the field type and rippling the for eliding a handful ofwrites the kernel already discards.

Only `GetUIPrinter` passes `os.DevNull` to a printer, and it only ever constructs
a `PrettyPrinter`, so no oon is affected.

## How to Test

Reproduce on `master` (as on macOS):

```bash
kubescape scan --format json
```
Before this change, the run emits failed to open file for writing, reason: open
/dev/null.txt: ... and thetdout alongside the JSON.After it, the warning is gone and stdout contains only JSON.

Unit tests:

go test ./core/pkg/resultshandling/printer/...

TestSetWriter_Pretty was added following the table style of the neighbouring TestSetWriter_Junit / Test os.DevNull case and pinsthe existing extension-append, .txt passthrough, and empty-output behaviours so they don't regress.

## Related issues/PRs:

- Resolved #2500

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes