### PR TITLE
Cache compiled CEL programs across scanned objects

### DIFF
--- a/core/pkg/opaprocessor/cel/cache.go
+++ b/core/pkg/opaprocessor/cel/cache.go
@@ -1,0 +1,63 @@
+package cel
+
+import (
+	"sync"
+
+	"github.com/google/cel-go/cel"
+)
+
+// programCache memoizes compiled CEL programs by expression text. Compiling an
+// expression is the expensive step; running the compiled program is cheap. A
+// scan evaluates the same bundle expressions against every scanned object, so
+// without the cache a 1000-object scan would recompile each expression 1000
+// times.
+//
+// Compile failures are cached too: a broken expression stays broken no matter
+// which object it runs against, so its error is stored and served on every
+// later lookup instead of reattempting the compile per object. Eval failures
+// are the opposite — they depend on the object being evaluated (a field
+// missing on one object can be present on the next) — so they must never land
+// in the cache. That holds by construction: the cache stores programs, and
+// evaluation happens on the caller's side of the lookup.
+type programCache struct {
+	// compile builds a runnable program for one expression. Injected so tests
+	// can count invocations; the Evaluator wires in its env-backed compile.
+	compile func(expr string) (cel.Program, error)
+
+	mu      sync.Mutex
+	entries map[string]*programCacheEntry
+}
+
+// programCacheEntry is one memoized compile outcome. The entry's Once runs the
+// compile outside the cache lock, so a slow compile of one expression does not
+// block lookups of others, while concurrent lookups of the same expression
+// still compile it exactly once.
+type programCacheEntry struct {
+	once sync.Once
+	prog cel.Program
+	err  error
+}
+
+func newProgramCache(compile func(expr string) (cel.Program, error)) *programCache {
+	return &programCache{
+		compile: compile,
+		entries: make(map[string]*programCacheEntry),
+	}
+}
+
+// get returns the compiled program for an expression, compiling it on the
+// first lookup and serving the memoized program (or compile error) afterwards.
+func (c *programCache) get(expr string) (cel.Program, error) {
+	c.mu.Lock()
+	entry, ok := c.entries[expr]
+	if !ok {
+		entry = &programCacheEntry{}
+		c.entries[expr] = entry
+	}
+	c.mu.Unlock()
+
+	entry.once.Do(func() {
+		entry.prog, entry.err = c.compile(expr)
+	})
+	return entry.prog, entry.err
+}

--- a/core/pkg/opaprocessor/cel/cache_test.go
+++ b/core/pkg/opaprocessor/cel/cache_test.go
@@ -1,0 +1,108 @@
+package cel
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProgramCacheCompilesOnce proves the second lookup of an expression is
+// served from the cache: the compile function runs exactly once no matter how
+// many times the expression is fetched.
+func TestProgramCacheCompilesOnce(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+
+	compiles := 0
+	cache := newProgramCache(func(expr string) (cel.Program, error) {
+		compiles++
+		ast, issues := env.Compile(expr)
+		require.NoError(t, issues.Err())
+		return env.Program(ast)
+	})
+
+	first, err := cache.get("1 + 1 == 2")
+	require.NoError(t, err)
+	second, err := cache.get("1 + 1 == 2")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, compiles, "second lookup must not recompile")
+	assert.Same(t, first, second, "both lookups must return the memoized program")
+
+	_, err = cache.get("2 + 2 == 4")
+	require.NoError(t, err)
+	assert.Equal(t, 2, compiles, "a different expression is a different cache entry")
+}
+
+// TestProgramCacheCachesCompileFailure proves a compile failure is memoized: a
+// broken expression is broken against every object, so it must be attempted
+// once and its error served afterwards, not recompiled per scanned object.
+func TestProgramCacheCachesCompileFailure(t *testing.T) {
+	compiles := 0
+	compileErr := errors.New("compile: boom")
+	cache := newProgramCache(func(expr string) (cel.Program, error) {
+		compiles++
+		return nil, compileErr
+	})
+
+	_, err := cache.get("this does not compile")
+	require.ErrorIs(t, err, compileErr)
+	_, err = cache.get("this does not compile")
+	require.ErrorIs(t, err, compileErr, "the cached error must be served on later lookups")
+
+	assert.Equal(t, 1, compiles, "a failing expression must be compiled only once")
+}
+
+// TestEvaluatorDoesNotCacheEvalErrors proves an eval error does not poison the
+// cached program. Eval errors are data-specific — here the field is missing on
+// the first object but present on the second — so the same expression must
+// still produce a real verdict for the next object.
+func TestEvaluatorDoesNotCacheEvalErrors(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{{Expression: "object.spec.hostNetwork == false"}}
+
+	// No spec at all: the field access errors at eval time.
+	broken := map[string]any{"kind": "Pod", "metadata": map[string]any{"name": "no-spec"}}
+	results, err := e.EvaluateOnObject(context.Background(), broken, nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+
+	// Same expression, well-formed object: must get a clean verdict, proving the
+	// earlier eval error was not memoized.
+	good := map[string]any{
+		"kind":     "Pod",
+		"metadata": map[string]any{"name": "ok"},
+		"spec":     map[string]any{"hostNetwork": false},
+	}
+	results, err = e.EvaluateOnObject(context.Background(), good, nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Err)
+	assert.True(t, results[0].Passed)
+}
+
+// TestEvaluatorReusesCachedProgram proves the Evaluator routes evaluation
+// through the cache: after evaluating the same validation against two objects,
+// the cache holds exactly one entry for the expression.
+func TestEvaluatorReusesCachedProgram(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	validations := []Validation{{Expression: "object.spec.hostNetwork == false"}}
+
+	for range 2 {
+		results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil, validations)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Passed)
+	}
+
+	assert.Len(t, e.programs.entries, 1, "both evaluations must share one cache entry")
+}

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -50,6 +50,10 @@ type ValidationResult struct {
 // far more expensive than evaluating against it.
 type Evaluator struct {
 	env *cel.Env
+	// programs caches compiled programs by expression text, so each bundle
+	// expression is compiled once per Evaluator rather than once per scanned
+	// object (see cache.go).
+	programs *programCache
 	// costLimit overrides the per-evaluation CEL cost budget. Zero means "do not
 	// override", which leaves the budget the base env already bakes in
 	// (apiserver's PerCallLimit). When cost limits are wired up the real value
@@ -77,6 +81,9 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 	for _, opt := range opts {
 		opt(e)
 	}
+	// The cache closes over e so compiles pick up option-set state (costLimit);
+	// options are applied above, before anything can trigger a compile.
+	e.programs = newProgramCache(e.compileProgram)
 	return e, nil
 }
 
@@ -222,18 +229,14 @@ func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, acti
 	return msg, true
 }
 
-// evalExpression compiles and evaluates a single CEL expression against the
-// activation. When compile caching is added it wraps the compile step here, and
-// when cost reporting is added it surfaces the EvalDetails this currently discards.
+// evalExpression evaluates a single CEL expression against the activation. The
+// compiled program comes from the cache (compiled on first use, reused for
+// every later object; see cache.go). When cost reporting is added it surfaces
+// the EvalDetails this currently discards.
 func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation map[string]any) (ref.Val, error) {
-	ast, issues := e.env.Compile(expr)
-	if issues != nil && issues.Err() != nil {
-		return nil, fmt.Errorf("compile: %w", issues.Err())
-	}
-
-	prog, err := e.program(ast)
+	prog, err := e.programs.get(expr)
 	if err != nil {
-		return nil, fmt.Errorf("program: %w", err)
+		return nil, err
 	}
 
 	out, _, err := prog.ContextEval(ctx, activation)
@@ -243,18 +246,29 @@ func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation 
 	return out, nil
 }
 
-// program instantiates a runnable program from a compiled AST. The cost-limit
-// override is only applied when set; otherwise the base env's baked-in
-// PerCallLimit stands. InterruptCheckFrequency gets added here later too.
+// compileProgram compiles one expression into a runnable program. Callers go
+// through the program cache, never here directly, so each expression compiles
+// once. The cost-limit override is only applied when set; otherwise the base
+// env's baked-in PerCallLimit stands. InterruptCheckFrequency gets added here
+// later too.
 //
 // Note for when the cost limit is turned on: this applies a fresh per-expression
 // budget. The apiserver instead shares one budget across all of a policy's
 // expressions (variables + validations) per evaluation, so that accounting, not
 // just the per-call value, is what needs to be matched then.
-func (e *Evaluator) program(ast *cel.Ast) (cel.Program, error) {
+func (e *Evaluator) compileProgram(expr string) (cel.Program, error) {
+	ast, issues := e.env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("compile: %w", issues.Err())
+	}
+
 	var opts []cel.ProgramOption
 	if e.costLimit > 0 {
 		opts = append(opts, cel.CostLimit(e.costLimit))
 	}
-	return e.env.Program(ast, opts...)
+	prog, err := e.env.Program(ast, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("program: %w", err)
+	}
+	return prog, nil
 }


### PR DESCRIPTION
## Overview

This continues the offline CEL/VAP evaluation work. Compiling a CEL expression is the expensive part, running the compiled program is cheap. Until now the evaluator recompiled every expression for every object, so a scan of 1000 resources would compile the same bundle expressions 1000 times each. This PR adds a small cache keyed by expression text, each expression compiles once per evaluator and the compiled program is reused for every object after that.Part of #2001

Compile failures are cached too. Whether an expression compiles depends only on the expression text and the env, both fixed at startup, so retrying a broken expression per object can never give a different answer. Eval errors are the opposite, they depend on the object being scanned (a field missing on one object can exist on the next), so those are never cached and re-run per object.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * CEL validation expressions are now compiled once and reused, improving efficiency during repeated evaluations.
  * Compilation failures are consistently returned without repeated work.

* **Bug Fixes**
  * Runtime evaluation errors no longer affect subsequent evaluations of the same expression.

* **Tests**
  * Added coverage for compilation reuse, cached failures, and independent evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->