### PR TITLE
feat(printer): add GitLab SAST report output format

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -62,7 +62,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -76,7 +76,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -61,7 +61,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				scanInfo.Format == "" {
 
 				return fmt.Errorf(
-					"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif",
+					"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast",
 				)
 			}
 
@@ -141,7 +141,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.FailOnDegradedConfig, "fail-on-degraded-config", false, "Fail the scan (exit code 1) if control configurations or exceptions could not be loaded from their configured source and bundled defaults were used instead")
 
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif"`)
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif", "gitlab-sast"`)
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -386,7 +386,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif`)
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast`)
 }
 
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -63,7 +63,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif")
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -15,7 +15,7 @@ import (
 // ScanFormats and ImageScanFormats list the output formats supported by the scan commands.
 // They are built from the printer.*Format constants to keep a single source of truth.
 var (
-	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat}
+	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat, printer.GitLabSASTFormat}
 	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat}
 )
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -169,6 +169,8 @@ func fileExtForFormat(format string) string {
 		return printer.JunitOutputExt
 	case printer.SARIFFormat:
 		return printer.SARIFOutputExt
+	case printer.GitLabSASTFormat:
+		return printer.JsonOutputExt
 	case printer.HtmlFormat:
 		return printer.HtmlOutputExt
 	case printer.PdfFormat:

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -2,6 +2,8 @@ package resourcehandler
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -15,6 +17,26 @@ import (
 func TestNewFileResourceHandler_InitializesNewInstance(t *testing.T) {
 	fileHandler := NewFileResourceHandler()
 	assert.NotNil(t, fileHandler)
+}
+
+// A single-file scan must yield a repository-relative RelativePath: the SARIF and GitLab SAST printers build the finding's file location from it, and the GitLab printer drops findings whose path is empty, absolute, or escaping the repo root. See #2496.
+func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *testing.T) {
+	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, workloads, "the single-file scan must discover the pod")
+
+	for _, w := range workloads {
+		src, ok := workloadIDToSource[w.GetID()]
+		require.True(t, ok, "every workload must have a source")
+
+		rel := src.RelativePath
+		assert.NotEmpty(t, rel, "RelativePath must be set or the finding has no file to anchor to")
+		assert.False(t, filepath.IsAbs(rel), "RelativePath must be repository-relative, not absolute: %q", rel)
+		cleaned := filepath.ToSlash(filepath.Clean(rel))
+		assert.False(t, cleaned == ".." || strings.HasPrefix(cleaned, "../"),
+			"RelativePath must not escape the repository root: %q", rel)
+		assert.Equal(t, "pod.yaml", filepath.Base(rel))
+	}
 }
 
 // Deduplicates resources discovered by both kustomize render and the plain-YAML glob.

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -22,6 +22,7 @@ const (
 	PdfFormat         string = "pdf"
 	HtmlFormat        string = "html"
 	SARIFFormat       string = "sarif"
+	GitLabSASTFormat  string = "gitlab-sast"
 )
 
 const (

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -1,0 +1,270 @@
+package printer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+const (
+	gitLabSASTOutputFile = "report"
+
+	// gitLabSASTReportVersion is the GitLab security report schema version we emit.
+	// See https://gitlab.com/gitlab-org/security-products/security-report-schemas
+	gitLabSASTReportVersion = "15.2.4"
+	// gitLabTimeFormat is the timestamp format required by the GitLab schema (no timezone).
+	gitLabTimeFormat = "2006-01-02T15:04:05"
+
+	gitLabScannerID     = "kubescape"
+	gitLabScannerName   = "Kubescape"
+	gitLabScannerURL    = "https://kubescape.io"
+	gitLabScannerVendor = "Kubescape"
+	gitLabControlIDType = "kubescape_control_id"
+)
+
+var _ printer.IPrinter = &GitLabSASTPrinter{}
+
+// GitLabSASTPrinter emits configuration-scan results in the GitLab SAST report format,
+// so findings surface in GitLab's Security dashboard and MR approval policies rather than
+// only in the test widget (as the JUnit format does). See issue #2496.
+type GitLabSASTPrinter struct {
+	writer *os.File
+}
+
+// gitLabSASTReport mirrors the GitLab SAST report schema. Only the fields Kubescape
+// can populate are modelled; optional fields are omitted when empty.
+type gitLabSASTReport struct {
+	Version         string                `json:"version"`
+	Scan            gitLabScan            `json:"scan"`
+	Vulnerabilities []gitLabVulnerability `json:"vulnerabilities"`
+}
+
+type gitLabScan struct {
+	Analyzer  gitLabScanner `json:"analyzer"`
+	Scanner   gitLabScanner `json:"scanner"`
+	Type      string        `json:"type"`
+	StartTime string        `json:"start_time"`
+	EndTime   string        `json:"end_time"`
+	Status    string        `json:"status"`
+}
+
+type gitLabScanner struct {
+	ID      string       `json:"id"`
+	Name    string       `json:"name"`
+	URL     string       `json:"url,omitempty"`
+	Version string       `json:"version"`
+	Vendor  gitLabVendor `json:"vendor"`
+}
+
+type gitLabVendor struct {
+	Name string `json:"name"`
+}
+
+type gitLabVulnerability struct {
+	ID          string             `json:"id"`
+	Category    string             `json:"category,omitempty"`
+	Name        string             `json:"name,omitempty"`
+	Message     string             `json:"message,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Severity    string             `json:"severity,omitempty"`
+	Scanner     gitLabScannerRef   `json:"scanner"`
+	Location    gitLabLocation     `json:"location"`
+	Identifiers []gitLabIdentifier `json:"identifiers"`
+}
+
+type gitLabScannerRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type gitLabLocation struct {
+	File      string `json:"file,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+}
+
+type gitLabIdentifier struct {
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	URL   string `json:"url,omitempty"`
+}
+
+// NewGitLabSASTPrinter returns a new GitLab SAST printer instance
+func NewGitLabSASTPrinter() *GitLabSASTPrinter {
+	return &GitLabSASTPrinter{}
+}
+
+func (gp *GitLabSASTPrinter) Score(score float32) {
+}
+
+func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = gitLabSASTOutputFile
+		}
+		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JsonOutputExt {
+			outputFile = outputFile + printer.JsonOutputExt
+		}
+	}
+	gp.writer = printer.GetWriter(ctx, outputFile)
+}
+
+func (gp *GitLabSASTPrinter) PrintNextSteps() {
+}
+
+func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logger.L().Ctx(ctx).Error("failed to write results in GitLab SAST format: image scanning is not supported")
+		return
+	}
+
+	if err := gp.printConfigurationScan(ctx, opaSessionObj); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write results in GitLab SAST format", helpers.Error(err))
+		return
+	}
+	printer.LogOutputFile(gp.writer.Name())
+}
+
+func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
+	startedAt := opaSessionObj.Report.ReportGenerationTime
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+
+	report := gitLabSASTReport{
+		Version:         gitLabSASTReportVersion,
+		Vulnerabilities: []gitLabVulnerability{},
+	}
+
+	basePath := getBasePathFromMetadata(*opaSessionObj)
+
+	for resourceID, result := range opaSessionObj.ResourcesResult {
+		if !result.GetStatus(nil).IsFailed() {
+			continue
+		}
+
+		resourceSource := opaSessionObj.ResourceSource[resourceID]
+		relPath := resourceSource.RelativePath
+
+		// A finding with no file path is meaningless in GitLab's Security dashboard
+		if relPath == "" && basePath == "" {
+			continue
+		}
+
+		effectiveBase := basePath
+		if effectiveBase == "" && resourceSource.Path != "" {
+			effectiveBase = resourceSource.Path
+		}
+		rsrcAbsPath := filepath.Join(effectiveBase, relPath)
+		locationResolver, err := locationresolver.NewFixPathLocationResolver(rsrcAbsPath)
+		if err != nil {
+			logger.L().Warning("failed to create location resolver, GitLab SAST locations will default to line 1", helpers.Error(err))
+		}
+
+		for _, toPin := range result.AssociatedControls {
+			ac := toPin
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+
+			ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
+			if ctl == nil {
+				logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
+				continue
+			}
+
+			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
+			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabVulnerability(ctl, resourceID, relPath, location))
+		}
+	}
+
+	finishedAt := time.Now().UTC()
+	scanner := gitLabScanner{
+		ID:      gitLabScannerID,
+		Name:    gitLabScannerName,
+		URL:     gitLabScannerURL,
+		Version: kubescapeVersion(),
+		Vendor:  gitLabVendor{Name: gitLabScannerVendor},
+	}
+	report.Scan = gitLabScan{
+		Analyzer:  scanner,
+		Scanner:   scanner,
+		Type:      "sast",
+		StartTime: startedAt.Format(gitLabTimeFormat),
+		EndTime:   finishedAt.Format(gitLabTimeFormat),
+		Status:    "success",
+	}
+
+	encoded, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode GitLab SAST report: %w", err)
+	}
+	if _, err := gp.writer.Write(encoded); err != nil {
+		return fmt.Errorf("failed to write GitLab SAST report: %w", err)
+	}
+	return nil
+}
+
+// toGitLabVulnerability maps a failed control on a resource to a GitLab SAST vulnerability.
+func toGitLabVulnerability(ctl reportsummary.IControlSummary, resourceID, filePath string, location locationresolver.Location) gitLabVulnerability {
+	controlID := ctl.GetID()
+	// Kubescape severities (Critical/High/Medium/Low/Unknown) are all valid GitLab severities
+	severity := apis.ControlSeverityToString(ctl.GetScoreFactor())
+
+	return gitLabVulnerability{
+		ID:       gitLabVulnerabilityID(controlID, resourceID, filePath),
+		Category: "sast",
+		// The control ID is prefixed so the finding is identifiable from GitLab's title alone
+		Name:        fmt.Sprintf("%s - %s", controlID, ctl.GetName()),
+		Message:     ctl.GetName(),
+		Description: ctl.GetDescription(),
+		Severity:    severity,
+		Scanner:     gitLabScannerRef{ID: gitLabScannerID, Name: gitLabScannerName},
+		Location: gitLabLocation{
+			File:      filePath,
+			StartLine: location.Line,
+		},
+		Identifiers: []gitLabIdentifier{
+			{
+				Type:  gitLabControlIDType,
+				Name:  controlID,
+				Value: controlID,
+				URL:   cautils.GetControlLink(controlID),
+			},
+		},
+	}
+}
+
+// gitLabVulnerabilityID returns a stable, unique identifier for a finding so GitLab can
+// track it across scans for triage and dismissal.
+func gitLabVulnerabilityID(controlID, resourceID, filePath string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(controlID+"/"+resourceID+"/"+filePath)))
+}
+
+// kubescapeVersion returns the current build version, or "unknown" for local builds.
+func kubescapeVersion() string {
+	if versioncheck.BuildNumber == "" {
+		return versioncheck.UnknownBuildNumber
+	}
+	return versioncheck.BuildNumber
+}
+
+func (gp *GitLabSASTPrinter) CloseWriter() {
+	if gp.writer != nil && gp.writer != os.Stdout {
+		gp.writer.Close()
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -104,9 +104,11 @@ func NewGitLabSASTPrinter() *GitLabSASTPrinter {
 	return &GitLabSASTPrinter{}
 }
 
+// Score is a no-op: the GitLab SAST report has no field for the overall risk score
 func (gp *GitLabSASTPrinter) Score(score float32) {
 }
 
+// SetWriter opens outputFile for writing, defaulting the name and forcing a .json extension
 func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
@@ -119,9 +121,11 @@ func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
 	gp.writer = printer.GetWriter(ctx, outputFile)
 }
 
+// PrintNextSteps is a no-op: machine-readable output carries no human-facing guidance
 func (gp *GitLabSASTPrinter) PrintNextSteps() {
 }
 
+// ActionPrint writes the GitLab SAST report for a configuration scan; image scanning is not supported by this format
 func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
 		logger.L().Ctx(ctx).Error("failed to write results in GitLab SAST format: image scanning is not supported")
@@ -135,6 +139,7 @@ func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cau
 	printer.LogOutputFile(gp.writer.Name())
 }
 
+// printConfigurationScan maps each failed control on each failed resource to a GitLab SAST vulnerability and writes the report
 func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
 	startedAt := opaSessionObj.Report.ReportGenerationTime
 	if startedAt.IsZero() {
@@ -268,6 +273,7 @@ func kubescapeVersion() string {
 	return versioncheck.BuildNumber
 }
 
+// CloseWriter closes the output file, unless it is stdout, satisfying the optional printerCloser interface
 func (gp *GitLabSASTPrinter) CloseWriter() {
 	if gp.writer != nil && gp.writer != os.Stdout {
 		gp.writer.Close()

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -156,8 +156,9 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 		resourceSource := opaSessionObj.ResourceSource[resourceID]
 		relPath := resourceSource.RelativePath
 
-		// location.file is built from the relative path alone, and GitLab cannot render or triage a finding without one
-		if relPath == "" {
+		// location.file is built from the relative path alone, and GitLab can only anchor a finding to a file inside the repository
+		if !isRepositoryRelative(relPath) {
+			logger.L().Debug("resource path is not repository-relative, skipping", helpers.String("path", relPath), helpers.String("resourceID", resourceID))
 			continue
 		}
 
@@ -243,6 +244,15 @@ func toGitLabVulnerability(ctl reportsummary.IControlSummary, resourceID, filePa
 			},
 		},
 	}
+}
+
+// isRepositoryRelative reports whether path is a repository-relative file path, i.e. not empty, absolute, or escaping the repository root via ".."
+func isRepositoryRelative(path string) bool {
+	if path == "" || filepath.IsAbs(path) {
+		return false
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	return cleaned != ".." && !strings.HasPrefix(cleaned, "../")
 }
 
 // gitLabVulnerabilityID returns a stable id so GitLab can track a finding across scans for triage and dismissal

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -23,10 +23,9 @@ import (
 const (
 	gitLabSASTOutputFile = "report"
 
-	// gitLabSASTReportVersion is the GitLab security report schema version we emit.
-	// See https://gitlab.com/gitlab-org/security-products/security-report-schemas
+	// gitLabSASTReportVersion is the schema version we emit: https://gitlab.com/gitlab-org/security-products/security-report-schemas
 	gitLabSASTReportVersion = "15.2.4"
-	// gitLabTimeFormat is the timestamp format required by the GitLab schema (no timezone).
+	// gitLabTimeFormat is the timestamp format required by the GitLab schema (no timezone)
 	gitLabTimeFormat = "2006-01-02T15:04:05"
 
 	gitLabScannerID     = "kubescape"
@@ -38,15 +37,12 @@ const (
 
 var _ printer.IPrinter = &GitLabSASTPrinter{}
 
-// GitLabSASTPrinter emits configuration-scan results in the GitLab SAST report format,
-// so findings surface in GitLab's Security dashboard and MR approval policies rather than
-// only in the test widget (as the JUnit format does). See issue #2496.
+// GitLabSASTPrinter emits configuration-scan results as a GitLab SAST report, so findings reach the Security dashboard and MR approval policies rather than the test widget (#2496)
 type GitLabSASTPrinter struct {
 	writer *os.File
 }
 
-// gitLabSASTReport mirrors the GitLab SAST report schema. Only the fields Kubescape
-// can populate are modelled; optional fields are omitted when empty.
+// gitLabSASTReport mirrors the GitLab SAST report schema; only the fields Kubescape can populate are modelled
 type gitLabSASTReport struct {
 	Version         string                `json:"version"`
 	Scan            gitLabScan            `json:"scan"`
@@ -160,8 +156,8 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 		resourceSource := opaSessionObj.ResourceSource[resourceID]
 		relPath := resourceSource.RelativePath
 
-		// A finding with no file path is meaningless in GitLab's Security dashboard
-		if relPath == "" && basePath == "" {
+		// location.file is built from the relative path alone, and GitLab cannot render or triage a finding without one
+		if relPath == "" {
 			continue
 		}
 
@@ -249,13 +245,12 @@ func toGitLabVulnerability(ctl reportsummary.IControlSummary, resourceID, filePa
 	}
 }
 
-// gitLabVulnerabilityID returns a stable, unique identifier for a finding so GitLab can
-// track it across scans for triage and dismissal.
+// gitLabVulnerabilityID returns a stable id so GitLab can track a finding across scans for triage and dismissal
 func gitLabVulnerabilityID(controlID, resourceID, filePath string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(controlID+"/"+resourceID+"/"+filePath)))
 }
 
-// kubescapeVersion returns the current build version, or "unknown" for local builds.
+// kubescapeVersion returns the current build version, or "unknown" for local builds
 func kubescapeVersion() string {
 	if versioncheck.BuildNumber == "" {
 		return versioncheck.UnknownBuildNumber

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -230,52 +230,89 @@ func TestGitLabSASTPrintConfigurationScan_MissingControl(t *testing.T) {
 	assert.Empty(t, report.Vulnerabilities)
 }
 
-// TestGitLabSASTPrintConfigurationScan_SkipsResourceWithoutRelativePath covers a failed resource with no relative path but a non-empty base path: GitLab gets no file to anchor the finding to, so it must be skipped
-func TestGitLabSASTPrintConfigurationScan_SkipsResourceWithoutRelativePath(t *testing.T) {
+// TestGitLabSASTPrintConfigurationScan_SkipsUnanchorablePaths covers resource paths GitLab cannot anchor to a repository file: filepath.Rel yields "../" paths for files outside the repo root, and Helm/Kustomize sources keep an absolute path when it fails
+func TestGitLabSASTPrintConfigurationScan_SkipsUnanchorablePaths(t *testing.T) {
 	const controlID = "C-0057"
 	resourceID := "apps/v1/Deployment/default/demo"
 
-	session := cautils.NewOPASessionObjMock()
-	session.Metadata = &reporthandlingv2.Metadata{
-		ScanMetadata: reporthandlingv2.ScanMetadata{
-			ScanningTarget: reporthandlingv2.Directory,
-		},
-		ContextMetadata: reporthandlingv2.ContextMetadata{
-			DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
-				BasePath: t.TempDir(),
-			},
-		},
+	tests := []struct {
+		name    string
+		relPath string
+	}{
+		{name: "empty path", relPath: ""},
+		{name: "path escaping the repository root", relPath: "../outside/deploy.yaml"},
+		{name: "absolute path", relPath: "/etc/manifests/deploy.yaml"},
 	}
-	session.ResourcesResult[resourceID] = resourcesresults.Result{
-		ResourceID: resourceID,
-		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
-			{
-				ControlID: controlID,
-				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
-			},
-		},
-	}
-	session.ResourceSource = map[string]reporthandling.Source{
-		resourceID: {RelativePath: ""},
-	}
-	session.Report = &reporthandlingv2.PostureReport{
-		SummaryDetails: reportsummary.SummaryDetails{
-			Controls: reportsummary.ControlSummaries{
-				controlID: reportsummary.ControlSummary{
-					ControlID:   controlID,
-					Name:        "Privileged container",
-					Description: "Do not run privileged containers",
-					ScoreFactor: 8.0,
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := cautils.NewOPASessionObjMock()
+			session.Metadata = &reporthandlingv2.Metadata{
+				ScanMetadata: reporthandlingv2.ScanMetadata{
+					ScanningTarget: reporthandlingv2.Directory,
 				},
-			},
-		},
+				ContextMetadata: reporthandlingv2.ContextMetadata{
+					DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+						BasePath: t.TempDir(),
+					},
+				},
+			}
+			session.ResourcesResult[resourceID] = resourcesresults.Result{
+				ResourceID: resourceID,
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: controlID,
+						Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+					},
+				},
+			}
+			session.ResourceSource = map[string]reporthandling.Source{
+				resourceID: {RelativePath: tt.relPath},
+			}
+			session.Report = &reporthandlingv2.PostureReport{
+				SummaryDetails: reportsummary.SummaryDetails{
+					Controls: reportsummary.ControlSummaries{
+						controlID: reportsummary.ControlSummary{
+							ControlID:   controlID,
+							Name:        "Privileged container",
+							Description: "Do not run privileged containers",
+							ScoreFactor: 8.0,
+						},
+					},
+				},
+			}
+
+			// the base path is non-empty, so only the path check can skip this finding
+			require.NotEmpty(t, getBasePathFromMetadata(*session))
+
+			report := gitLabReportFor(t, session)
+			assert.Empty(t, report.Vulnerabilities, "a finding GitLab cannot anchor to a repository file must not be emitted")
+		})
+	}
+}
+
+func TestIsRepositoryRelative(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "deploy.yaml", want: true},
+		{path: "manifests/deploy.yaml", want: true},
+		{path: "./manifests/deploy.yaml", want: true},
+		{path: "manifests/../deploy.yaml", want: true},
+		{path: "", want: false},
+		{path: "..", want: false},
+		{path: "../deploy.yaml", want: false},
+		{path: "../../outside/deploy.yaml", want: false},
+		{path: "manifests/../../deploy.yaml", want: false},
+		{path: "/etc/manifests/deploy.yaml", want: false},
 	}
 
-	// the base path is non-empty, so only the relative-path check can skip this finding
-	require.NotEmpty(t, getBasePathFromMetadata(*session))
-
-	report := gitLabReportFor(t, session)
-	assert.Empty(t, report.Vulnerabilities, "a finding with no file path must not be emitted")
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRepositoryRelative(tt.path))
+		})
+	}
 }
 
 // TestGitLabSASTSeverityIsValid guards the score-factor mapping onto GitLab's severity enum: an unlisted value makes GitLab reject the whole report

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -1,0 +1,274 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitLabSessionFixture builds a session with a single failed control on a real manifest
+// written to disk, so the location resolver can resolve the failing field to a line.
+func gitLabSessionFixture(t *testing.T, controlID string, scoreFactor float32) *cautils.OPASessionObj {
+	t.Helper()
+
+	manifestDir := t.TempDir()
+	manifestPath := filepath.Join(manifestDir, "deploy.yaml")
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata: {name: demo, namespace: default}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: demo}}
+  template:
+    metadata: {labels: {app: demo}}
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.23
+        securityContext: {privileged: true}
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath("deploy.yaml:0")
+
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "privileged-container",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{
+						FixPath: armotypes.FixPath{
+							Path:  "spec.template.spec.containers[0].securityContext.privileged",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{
+			ScanningTarget: reporthandlingv2.File,
+		},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			FileContextMetadata: &reporthandlingv2.FileContextMetadata{
+				FilePath: manifestPath,
+			},
+		},
+	}
+	session.ResourcesResult[resourceID] = resourcesresults.Result{
+		ResourceID:         resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {
+			Path:         manifestDir,
+			RelativePath: "deploy.yaml",
+			FileType:     reporthandling.SourceTypeYaml,
+		},
+	}
+	session.AllResources[resourceID] = lw
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				controlID: reportsummary.ControlSummary{
+					ControlID:   controlID,
+					Name:        "Privileged container",
+					Description: "Do not run privileged containers",
+					Remediation: "Set privileged to false",
+					ScoreFactor: scoreFactor,
+				},
+			},
+		},
+	}
+	return session
+}
+
+// gitLabReportFor runs the printer against a session and returns the decoded report.
+func gitLabReportFor(t *testing.T, session *cautils.OPASessionObj) gitLabSASTReport {
+	t.Helper()
+
+	tmp, err := os.CreateTemp("", "gitlab-sast-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	})
+
+	gp := NewGitLabSASTPrinter()
+	gp.writer = tmp
+	require.NoError(t, gp.printConfigurationScan(context.Background(), session))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report gitLabSASTReport
+	require.NoError(t, json.Unmarshal(raw, &report))
+	return report
+}
+
+// TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability verifies the fields
+// GitLab needs to render a finding in the Security dashboard are all populated.
+func TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability(t *testing.T) {
+	const controlID = "C-0057"
+
+	report := gitLabReportFor(t, gitLabSessionFixture(t, controlID, 8.0))
+
+	assert.Equal(t, gitLabSASTReportVersion, report.Version)
+	assert.Equal(t, "sast", report.Scan.Type)
+	assert.Equal(t, "success", report.Scan.Status)
+	assert.Equal(t, gitLabScannerID, report.Scan.Scanner.ID)
+	assert.Equal(t, gitLabScannerName, report.Scan.Analyzer.Name)
+	assert.Equal(t, gitLabScannerVendor, report.Scan.Scanner.Vendor.Name)
+	assert.NotEmpty(t, report.Scan.Scanner.Version, "scanner version is required by the schema")
+
+	require.Len(t, report.Vulnerabilities, 1)
+	vuln := report.Vulnerabilities[0]
+
+	assert.NotEmpty(t, vuln.ID)
+	assert.Equal(t, "sast", vuln.Category)
+	// the control ID is part of the name so the finding is identifiable from GitLab's title
+	assert.Equal(t, "C-0057 - Privileged container", vuln.Name)
+	assert.Equal(t, "Privileged container", vuln.Message)
+	assert.Equal(t, "Do not run privileged containers", vuln.Description)
+	// score factor 8.0 maps to High, which is a valid GitLab severity
+	assert.Equal(t, "High", vuln.Severity)
+	assert.Equal(t, "deploy.yaml", vuln.Location.File)
+
+	require.Len(t, vuln.Identifiers, 1)
+	assert.Equal(t, gitLabControlIDType, vuln.Identifiers[0].Type)
+	assert.Equal(t, controlID, vuln.Identifiers[0].Name)
+	assert.Equal(t, controlID, vuln.Identifiers[0].Value)
+	assert.NotEmpty(t, vuln.Identifiers[0].URL)
+}
+
+// TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers is the point of reusing the
+// SARIF location resolver: findings must anchor at the offending line, not collapse to line 1.
+func TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers(t *testing.T) {
+	const privilegedLine = 13
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(t.TempDir()))
+
+	report := gitLabReportFor(t, gitLabSessionFixture(t, "C-0057", 8.0))
+
+	require.Len(t, report.Vulnerabilities, 1)
+	assert.Equal(t, privilegedLine, report.Vulnerabilities[0].Location.StartLine,
+		"the privileged field must resolve to line %d", privilegedLine)
+}
+
+// TestGitLabSASTPrintConfigurationScan_ScanTimeFormat guards the schema's timestamp
+// pattern, which rejects timezone offsets and fractional seconds.
+func TestGitLabSASTPrintConfigurationScan_ScanTimeFormat(t *testing.T) {
+	session := gitLabSessionFixture(t, "C-0057", 8.0)
+	preset := time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC)
+	session.Report.ReportGenerationTime = preset
+
+	report := gitLabReportFor(t, session)
+
+	assert.Equal(t, "2024-03-14T09:15:26", report.Scan.StartTime,
+		"start_time must use the report generation time in the schema's format")
+	_, err := time.Parse(gitLabTimeFormat, report.Scan.EndTime)
+	assert.NoError(t, err, "end_time must match the schema's timestamp format")
+}
+
+// TestGitLabSASTPrintConfigurationScan_MissingControl covers a control that failed on a
+// resource but is absent from the summary: it must be skipped rather than panic.
+func TestGitLabSASTPrintConfigurationScan_MissingControl(t *testing.T) {
+	resourceID := "apps/v1/Deployment/default/my-deployment"
+
+	result := resourcesresults.Result{
+		ResourceID: resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-MISSING",
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+			},
+		},
+	}
+	require.True(t, result.GetStatus(nil).IsFailed())
+
+	session := cautils.NewOPASessionObjMock()
+	session.ResourcesResult[resourceID] = result
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {RelativePath: "deploy.yaml"},
+	}
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{},
+		},
+	}
+
+	report := gitLabReportFor(t, session)
+	assert.Empty(t, report.Vulnerabilities)
+}
+
+// TestGitLabSASTSeverityIsValid guards the mapping from Kubescape score factors onto
+// GitLab's severity enum: an unlisted value makes GitLab reject the whole report.
+func TestGitLabSASTSeverityIsValid(t *testing.T) {
+	gitLabSeverities := []string{"Info", "Unknown", "Low", "Medium", "High", "Critical"}
+
+	tests := []struct {
+		scoreFactor float32
+		want        string
+	}{
+		{scoreFactor: 9.5, want: "Critical"},
+		{scoreFactor: 8.0, want: "High"},
+		{scoreFactor: 5.0, want: "Medium"},
+		{scoreFactor: 2.0, want: "Low"},
+		{scoreFactor: 0, want: "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			report := gitLabReportFor(t, gitLabSessionFixture(t, "C-0057", tt.scoreFactor))
+			require.Len(t, report.Vulnerabilities, 1)
+
+			assert.Equal(t, tt.want, report.Vulnerabilities[0].Severity)
+			assert.Contains(t, gitLabSeverities, report.Vulnerabilities[0].Severity)
+		})
+	}
+}
+
+func TestGitLabVulnerabilityID(t *testing.T) {
+	first := gitLabVulnerabilityID("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml")
+
+	assert.Equal(t, first, gitLabVulnerabilityID("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml"),
+		"the same finding must keep a stable id so GitLab can track it across scans")
+	assert.NotEqual(t, first, gitLabVulnerabilityID("C-0058", "apps/v1/Deployment/default/demo", "deploy.yaml"),
+		"a different control must produce a different id")
+	assert.NotEqual(t, first, gitLabVulnerabilityID("C-0057", "apps/v1/Deployment/default/other", "deploy.yaml"),
+		"a different resource must produce a different id")
+}

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -20,8 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// gitLabSessionFixture builds a session with a single failed control on a real manifest
-// written to disk, so the location resolver can resolve the failing field to a line.
+// gitLabSessionFixture builds a session with one failed control on a real manifest, so the location resolver has a file to read
 func gitLabSessionFixture(t *testing.T, controlID string, scoreFactor float32) *cautils.OPASessionObj {
 	t.Helper()
 
@@ -114,7 +113,7 @@ spec:
 	return session
 }
 
-// gitLabReportFor runs the printer against a session and returns the decoded report.
+// gitLabReportFor runs the printer against a session and returns the decoded report
 func gitLabReportFor(t *testing.T, session *cautils.OPASessionObj) gitLabSASTReport {
 	t.Helper()
 
@@ -137,8 +136,7 @@ func gitLabReportFor(t *testing.T, session *cautils.OPASessionObj) gitLabSASTRep
 	return report
 }
 
-// TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability verifies the fields
-// GitLab needs to render a finding in the Security dashboard are all populated.
+// TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability verifies the fields GitLab needs to render a finding are all populated
 func TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability(t *testing.T) {
 	const controlID = "C-0057"
 
@@ -172,8 +170,7 @@ func TestGitLabSASTPrintConfigurationScan_MapsControlToVulnerability(t *testing.
 	assert.NotEmpty(t, vuln.Identifiers[0].URL)
 }
 
-// TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers is the point of reusing the
-// SARIF location resolver: findings must anchor at the offending line, not collapse to line 1.
+// TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers is the point of reusing the SARIF resolver: findings must anchor at the offending line, not collapse to line 1
 func TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers(t *testing.T) {
 	const privilegedLine = 13
 
@@ -189,8 +186,7 @@ func TestGitLabSASTPrintConfigurationScan_ResolvesLineNumbers(t *testing.T) {
 		"the privileged field must resolve to line %d", privilegedLine)
 }
 
-// TestGitLabSASTPrintConfigurationScan_ScanTimeFormat guards the schema's timestamp
-// pattern, which rejects timezone offsets and fractional seconds.
+// TestGitLabSASTPrintConfigurationScan_ScanTimeFormat guards the schema's timestamp pattern, which rejects timezone offsets and fractional seconds
 func TestGitLabSASTPrintConfigurationScan_ScanTimeFormat(t *testing.T) {
 	session := gitLabSessionFixture(t, "C-0057", 8.0)
 	preset := time.Date(2024, 3, 14, 9, 15, 26, 0, time.UTC)
@@ -204,8 +200,7 @@ func TestGitLabSASTPrintConfigurationScan_ScanTimeFormat(t *testing.T) {
 	assert.NoError(t, err, "end_time must match the schema's timestamp format")
 }
 
-// TestGitLabSASTPrintConfigurationScan_MissingControl covers a control that failed on a
-// resource but is absent from the summary: it must be skipped rather than panic.
+// TestGitLabSASTPrintConfigurationScan_MissingControl covers a failed control absent from the summary: skip it rather than panic
 func TestGitLabSASTPrintConfigurationScan_MissingControl(t *testing.T) {
 	resourceID := "apps/v1/Deployment/default/my-deployment"
 
@@ -235,8 +230,55 @@ func TestGitLabSASTPrintConfigurationScan_MissingControl(t *testing.T) {
 	assert.Empty(t, report.Vulnerabilities)
 }
 
-// TestGitLabSASTSeverityIsValid guards the mapping from Kubescape score factors onto
-// GitLab's severity enum: an unlisted value makes GitLab reject the whole report.
+// TestGitLabSASTPrintConfigurationScan_SkipsResourceWithoutRelativePath covers a failed resource with no relative path but a non-empty base path: GitLab gets no file to anchor the finding to, so it must be skipped
+func TestGitLabSASTPrintConfigurationScan_SkipsResourceWithoutRelativePath(t *testing.T) {
+	const controlID = "C-0057"
+	resourceID := "apps/v1/Deployment/default/demo"
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{
+			ScanningTarget: reporthandlingv2.Directory,
+		},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+				BasePath: t.TempDir(),
+			},
+		},
+	}
+	session.ResourcesResult[resourceID] = resourcesresults.Result{
+		ResourceID: resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: controlID,
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+			},
+		},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {RelativePath: ""},
+	}
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				controlID: reportsummary.ControlSummary{
+					ControlID:   controlID,
+					Name:        "Privileged container",
+					Description: "Do not run privileged containers",
+					ScoreFactor: 8.0,
+				},
+			},
+		},
+	}
+
+	// the base path is non-empty, so only the relative-path check can skip this finding
+	require.NotEmpty(t, getBasePathFromMetadata(*session))
+
+	report := gitLabReportFor(t, session)
+	assert.Empty(t, report.Vulnerabilities, "a finding with no file path must not be emitted")
+}
+
+// TestGitLabSASTSeverityIsValid guards the score-factor mapping onto GitLab's severity enum: an unlisted value makes GitLab reject the whole report
 func TestGitLabSASTSeverityIsValid(t *testing.T) {
 	gitLabSeverities := []string{"Info", "Unknown", "Low", "Medium", "High", "Critical"}
 

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -258,9 +258,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 	return nil
 }
 
-// resolveFixLocation resolves the file location of a failed control on a resource,
-// falling back to line 1 when the manifest path cannot be resolved. Shared by the
-// SARIF and GitLab SAST printers.
+// resolveFixLocation resolves a failed control's location in the manifest, falling back to line 1. Shared by the SARIF and GitLab SAST printers
 func resolveFixLocation(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) locationresolver.Location {
 	defaultLocation := locationresolver.Location{Line: 1, Column: 1}
 	if locationResolver == nil {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -231,7 +231,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 						logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
 						continue
 					}
-					location := sp.resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
+					location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
 					sp.addRule(run, ctl)
 					r := sp.addResult(run, ctl, relPath, location)
 					collectFixes(ctx, r, ac, opaSessionObj, resourceID, relPath, rsrcAbsPath)
@@ -258,7 +258,10 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 	return nil
 }
 
-func (sp *SARIFPrinter) resolveFixLocation(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) locationresolver.Location {
+// resolveFixLocation resolves the file location of a failed control on a resource,
+// falling back to line 1 when the manifest path cannot be resolved. Shared by the
+// SARIF and GitLab SAST printers.
+func resolveFixLocation(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) locationresolver.Location {
 	defaultLocation := locationresolver.Location{Line: 1, Column: 1}
 	if locationResolver == nil {
 		return defaultLocation

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -132,6 +132,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewHtmlPrinter()
 	case printer.SARIFFormat:
 		return printerv2.NewSARIFPrinter()
+	case printer.GitLabSASTFormat:
+		return printerv2.NewGitLabSASTPrinter()
 	default:
 		if printFormat != printer.PrettyFormat {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Invalid format \"%s\", default format \"pretty-printer\" is applied", printFormat))
@@ -153,8 +155,8 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		}
 	}
 
-	if printFormat == printer.SARIFFormat {
-		// supported types for SARIF
+	if printFormat == printer.SARIFFormat || printFormat == printer.GitLabSASTFormat {
+		// SARIF and GitLab SAST resolve file locations, so they only apply to local files
 		switch scanContext {
 		case cautils.ContextDir, cautils.ContextFile, cautils.ContextGitLocal, cautils.ContextGitRemote:
 			return false, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -195,6 +195,36 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr:   nil,
 		},
 		{
+			name:        "gitlab-sast format for cluster context should return error",
+			scanContext: cautils.ContextCluster,
+			format:      printer.GitLabSASTFormat,
+			expectErr:   errors.New("format \"gitlab-sast\" is only supported when scanning local files"),
+		},
+		{
+			name:        "gitlab-sast format for local dir context should not return error",
+			scanContext: cautils.ContextDir,
+			format:      printer.GitLabSASTFormat,
+			expectErr:   nil,
+		},
+		{
+			name:        "gitlab-sast format for local file context should not return error",
+			scanContext: cautils.ContextFile,
+			format:      printer.GitLabSASTFormat,
+			expectErr:   nil,
+		},
+		{
+			name:        "gitlab-sast format for local git context should not return error",
+			scanContext: cautils.ContextGitLocal,
+			format:      printer.GitLabSASTFormat,
+			expectErr:   nil,
+		},
+		{
+			name:      "gitlab-sast format for image scan should return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.GitLabSASTFormat,
+			expectErr: errors.New("format \"gitlab-sast\" is not supported for image scanning"),
+		},
+		{
 			name:      "pdf format for image scan should return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PdfFormat,
@@ -271,6 +301,12 @@ func TestNewPrinter(t *testing.T) {
 		{
 			name:     "Sarif printer",
 			format:   "sarif",
+			viewType: "resource",
+			version:  defaultVersion,
+		},
+		{
+			name:     "GitLab SAST printer",
+			format:   "gitlab-sast",
 			viewType: "resource",
 			version:  defaultVersion,
 		},


### PR DESCRIPTION
## Overview

Kubescape emits SARIF for GitHub Code Scanning, but GitLab does not consume SARIF. Today the only GitLab-friendly option is `--format junit`, which lands findings in the merge request **test** widget rather than the Security dashboard — so they can't be triaged, dismissed as false positives, or gated on by MR approval policies.

**Current behavior:** GitLab users get posture findings in the test widget (via `junit`), or nothing at all in the Security dashboard.

**New behavior:** a native `gitlab-sast` format that emits GitLab's [`security-report-schema`](https://gitlab.com/gitlab-org/security-products/security-report-schemas) SAST JSON (schema `v15.2.4`), so findings appear in the Security dashboard and Vulnerability Report:

```
kubescape scan framework nsa . --format gitlab-sast --output gl-sast-report
```

Field mapping is the one proposed in #2496:

| GitLab field | Kubescape source |
|---|---|
| `vulnerabilities[].id` | stable SHA-256 of control ID + resource ID + file path |
| `vulnerabilities[].name` | control ID + control name (e.g. `C-0017 - Immutable container filesystem`) |
| `vulnerabilities[].description` | control description |
| `vulnerabilities[].severity` | control score factor → `Critical`/`High`/`Medium`/`Low`/`Unknown` |
| `vulnerabilities[].location.file` | `resources[].source.relativePath` |
| `vulnerabilities[].location.start_line` | resolved from the manifest (see below) |
| `vulnerabilities[].identifiers[]` | control ID + `hub.armosec.io` control URL |
| `scan.scanner` / `scan.analyzer` | static Kubescape metadata + build version |

Like `sarif`, the format is gated to local file/dir/git scanning contexts and is rejected for cluster and image scans.

## Additional Information

- **Line numbers — better than the issue assumed.** #2496 expected every finding to anchor at line 1 since the JSON report carries no line data. That's no longer true: the SARIF printer already resolves real lines via `FixPathLocationResolver`. To reuse that, `resolveFixLocation` is lifted from a `SARIFPrinter` method to a package-level function shared by both printers — **this is the only reason `sarifprinter.go` appears in the diff**, and SARIF behavior is unchanged. Findings for whole-resource controls (e.g. `Ingress and Egress blocked`) still anchor at line 1, which is expected.
- **Severity** maps to `Critical`/`High`/`Medium`/`Low`/`Unknown`. #2496 mentioned `Info`; Kubescape's own vocabulary yields `Unknown` for score 0, and both are valid GitLab enum values, so the mapping stays faithful to Kubescape rather than inventing a value. Easy to change if preferred.
- **`cve` is intentionally omitted** — deprecated in schema 15.x, and configuration findings aren't CVEs. The control ID is carried in `identifiers[]` instead.
- **Vulnerability `id` is stable across scans**, so GitLab can track a finding for triage/dismissal rather than resurfacing it as new.

## How to Test

1. Create a deliberately insecure manifest:

   ```yaml
   # deploy.yaml
   apiVersion: apps/v1
   kind: Deployment
   metadata: {name: exporter, namespace: default}
   spec:
     replicas: 1
     selector: {matchLabels: {app: exporter}}
     template:
       metadata: {labels: {app: exporter}}
       spec:
         containers:
           - name: exporter
             image: nginx:latest
             securityContext:
               privileged: true
               allowPrivilegeEscalation: true
               runAsUser: 0
   ```

2. Scan it with the new format:

   ```
   kubescape scan framework nsa deploy.yaml --format gitlab-sast --output gl-sast-report --keep-local
   ```

3. Validate the output against the published GitLab schema:

   ```
   curl -sSO https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/master/dist/sast-report-format.json
   python3 -c "import json,jsonschema; jsonschema.Draft7Validator(json.load(open('sast-report-format.json'))).validate(json.load(open('gl-sast-report.json'))); print('valid')"
   ```

   The report validates cleanly, and `start_line` points at the offending field (line 20 for `privileged: true`, line 22 for `runAsUser: 0`) rather than collapsing to line 1.

4. Confirm the guardrails:

   ```
   kubescape scan image nginx:latest --format gitlab-sast   # rejected: not supported for image scanning
   kubescape scan framework nsa deploy.yaml --format xml    # error lists gitlab-sast among supported formats
   ```

5. In CI, publish it as a GitLab SAST report:

   ```yaml
   kubescape:
     script:
       - kubescape scan framework nsa . --format gitlab-sast --output gl-sast-report
     artifacts:
       reports:
         sast: gl-sast-report.json
   ```

## Related issues/PRs:

* Resolved #2496

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **GitLab SAST** (`gitlab-sast`) as a supported scan output format.
  * Added a new GitLab SAST JSON printer with scan metadata, vulnerability mapping, stable IDs, and correct `.json` output handling.
* **Bug Fixes**
  * Updated CLI validation and help/error messages so `gitlab-sast` appears in supported `--format` options when `--format` is empty/invalid.
* **Tests**
  * Added coverage for GitLab SAST report generation, severity/ID stability, time formatting, and location/path edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->