### PR TITLE
fix(mcp): add double-checked mutex locking to k8sClient lazy init

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -22,11 +22,20 @@ import (
 )
 
 type KubescapeMcpserver struct {
-	s            *server.MCPServer
-	ksClient     spdxv1beta1.SpdxV1beta1Interface
-	k8sClient    *k8sinterface.KubernetesApi
-	k8sClientMu  sync.Mutex
-	policyGetter *getter.DownloadReleasedPolicy
+	s             *server.MCPServer
+	ksClient      spdxv1beta1.SpdxV1beta1Interface
+	k8sClient     *k8sinterface.KubernetesApi
+	k8sClientOnce sync.Once
+	policyGetter  *getter.DownloadReleasedPolicy
+}
+
+func (ksServer *KubescapeMcpserver) getK8sClient() *k8sinterface.KubernetesApi {
+	ksServer.k8sClientOnce.Do(func() {
+		if ksServer.k8sClient == nil {
+			ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+		}
+	})
+	return ksServer.k8sClient
 }
 
 func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubescape/go-logger"
@@ -24,6 +25,7 @@ type KubescapeMcpserver struct {
 	s            *server.MCPServer
 	ksClient     spdxv1beta1.SpdxV1beta1Interface
 	k8sClient    *k8sinterface.KubernetesApi
+	k8sClientMu  sync.Mutex
 	policyGetter *getter.DownloadReleasedPolicy
 }
 

--- a/cmd/mcpserver/rbac_scan.go
+++ b/cmd/mcpserver/rbac_scan.go
@@ -39,7 +39,11 @@ func (ksServer *KubescapeMcpserver) RunRBACScan(ctx context.Context, namespace s
 	// IsConnectedToCluster() passes but ksServer.k8sClient is still nil.
 	// Lazily build it here to recover gracefully.
 	if ksServer.k8sClient == nil {
-		ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+		ksServer.k8sClientMu.Lock()
+		if ksServer.k8sClient == nil {
+			ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+		}
+		ksServer.k8sClientMu.Unlock()
 	}
 
 	// 1. Initialize custom ScanInfo isolated to RBAC controls to guarantee speed

--- a/cmd/mcpserver/rbac_scan.go
+++ b/cmd/mcpserver/rbac_scan.go
@@ -37,14 +37,9 @@ func (ksServer *KubescapeMcpserver) RunRBACScan(ctx context.Context, namespace s
 	// Maintainer edge-case fix: If the server started while no cluster was reachable,
 	// ksServer.k8sClient will be nil. If a cluster becomes reachable later,
 	// IsConnectedToCluster() passes but ksServer.k8sClient is still nil.
-	// Lazily build it here to recover gracefully.
-	if ksServer.k8sClient == nil {
-		ksServer.k8sClientMu.Lock()
-		if ksServer.k8sClient == nil {
-			ksServer.k8sClient = k8sinterface.NewKubernetesApi()
-		}
-		ksServer.k8sClientMu.Unlock()
-	}
+	// Lazily build it here to recover gracefully. All access routed through getK8sClient
+	// to ensure perfectly synchronized sync.Once behavior.
+	client := ksServer.getK8sClient()
 
 	// 1. Initialize custom ScanInfo isolated to RBAC controls to guarantee speed
 	scanInfo := &cautils.ScanInfo{
@@ -76,13 +71,13 @@ func (ksServer *KubescapeMcpserver) RunRBACScan(ctx context.Context, namespace s
 
 	// 3. Pull required K8s resources (only pulls resources defined by C-0015 and C-0016)
 	// Reuse the cached k8sClient from the server struct to avoid per-scan re-initialization overhead.
-	k8sHandler := resourcehandler.NewK8sResourceHandler(scanCtx, ksServer.k8sClient, nil, nil, "")
+	k8sHandler := resourcehandler.NewK8sResourceHandler(scanCtx, client, nil, nil, "")
 	if err := resourcehandler.CollectResources(scanCtx, k8sHandler, scanData, scanInfo); err != nil {
 		return nil, fmt.Errorf("failed to collect RBAC resources: %w", err)
 	}
 
 	// 4. Run the core OPA Processor engine
-	deps := resources.NewRegoDependenciesData(ksServer.k8sClient.K8SConfig, "")
+	deps := resources.NewRegoDependenciesData(client.K8SConfig, "")
 	opap := opaprocessor.NewOPAProcessor(scanData, deps, "", scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, false, nil)
 
 	// Execute the evaluation logic


### PR DESCRIPTION
## Overview
This PR hardens the lazy initialization of the MCP server's Kubernetes client by wrapping it in a double-checked `sync.Mutex` lock. 

## How to Test
> 1. Run the MCP server outside of a Kubernetes cluster (without `KUBECONFIG` set).
> 2. Initiate multiple concurrent `run_rbac_security_scan` tool calls.
> 3. Connect to a valid cluster/set `KUBECONFIG` while those calls are firing.
> 4. Verify that the server gracefully recovers and initializes the client exactly once without triggering any `-race` detector panics.

## Related issues/PRs:
* Follow-up to #2492 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC scan reliability by lazily initializing the Kubernetes connection and reusing the cached client throughout the scan.
  * Added safe, concurrency-friendly initialization so temporary startup connectivity issues and concurrent access no longer lead to inconsistent RBAC scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->