### PR TITLE
docs(cli): document report protection workflow

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,9 +41,11 @@ kubescape scan [target] [flags]
 | `--compliance-threshold <float>` | Fail if compliance score is below threshold. Applies to `scan framework`, `scan control`, and `--view resource\|control` — see [score thresholds](#score-thresholds). | `0` |
 | `--controls-config <path>` | Path to controls configuration file | - |
 | `-e, --exclude-namespaces <ns>` | Namespaces to exclude (comma-separated) | - |
+| `--encrypt` | Encrypt sensitive report metadata using the master key provided through the `KUBESCAPE_MASTER_KEY` environment variable. Encrypted reports can later be restored using `kubescape decrypt`. | `false` |
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
 | `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `sarif`, `html`, `pdf`, `prometheus` | `pretty-printer` |
+| `--hide` | Replace sensitive report metadata with anonymized values in the generated report. | `false` |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
 | `--keep-local` | Don't report results to backend | `false` |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
@@ -55,7 +57,6 @@ kubescape scan [target] [flags]
 | `--use-from <path>` | Load specific policy from path | - |
 | `-v, --verbose` | Display all resources, not just failed ones | `false` |
 | `--view <type>` | View type: `security`, `control`, `resource` | `security` |
-
 ### Examples
 
 ```bash
@@ -76,6 +77,20 @@ kubescape scan /path/to/manifests/
 # Scan Git repository
 kubescape scan https://github.com/org/repo
 
+# Anonymize sensitive report metadata
+kubescape scan --hide
+
+# Generate an anonymized JSON report
+kubescape scan --hide --format json --output report.json
+
+# Generate an encrypted JSON report
+export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+kubescape scan --encrypt --format json --output encrypted-report.json
+
+# Decrypt an encrypted report
+export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+kubescape decrypt encrypted-report.json > decrypted-report.json
+
 # Output to JSON file
 kubescape scan --format json --output results.json
 
@@ -87,7 +102,6 @@ kubescape scan --view resource --compliance-threshold 80
 # Exclude namespaces
 kubescape scan --exclude-namespaces kube-system,kube-public
 ```
-
 ### Score thresholds
 
 `--compliance-threshold` (compliance score) and the deprecated
@@ -316,6 +330,116 @@ sudo kubescape patch --image myregistry.example.com/team/app:1.2.3 --push
 
 ---
 
+## kubescape scan --hide
+
+Generate a report with anonymized sensitive report metadata.
+
+### Synopsis
+
+```bash
+kubescape scan [target] --hide [flags]
+```
+
+### Description
+
+Anonymizes sensitive report metadata by replacing values with deterministic
+pseudonyms. This helps safely share scan results without exposing sensitive
+resource information.
+
+### Examples
+
+```bash
+# Scan the current cluster and generate an anonymized report
+kubescape scan --hide --format json --output report.json
+
+# Scan local manifests and save an anonymized report
+kubescape scan /path/to/manifests \
+  --hide \
+  --format json \
+  --output report.json
+```
+
+> `--hide` anonymizes sensitive report metadata. The original values cannot be restored.
+
+---
+
+## kubescape scan --encrypt
+
+Generate a report with encrypted sensitive report metadata.
+
+### Synopsis
+
+```bash
+kubescape scan [target] --encrypt [flags]
+```
+
+### Description
+
+Encrypts sensitive report metadata using the master key supplied through the
+`KUBESCAPE_MASTER_KEY` environment variable. Encrypted reports can later be
+restored using `kubescape decrypt`.
+
+### Examples
+
+```bash
+# Export a 32-byte master key
+export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+
+# Scan the current cluster and generate an encrypted report
+kubescape scan \
+  --encrypt \
+  --format json \
+  --output encrypted-report.json
+
+# Scan local manifests and generate an encrypted report
+kubescape scan /path/to/manifests \
+  --encrypt \
+  --format json \
+  --output encrypted-report.json
+```
+
+> `--encrypt` requires the `KUBESCAPE_MASTER_KEY` environment variable. The same master key must be supplied when decrypting the report.
+
+---
+
+## kubescape decrypt
+
+Decrypt an encrypted Kubescape report.
+
+### Synopsis
+
+```bash
+kubescape decrypt <report-file>
+```
+
+### Description
+
+Decrypts an encrypted Kubescape report using the
+`KUBESCAPE_MASTER_KEY` environment variable. The decrypted report is written to
+standard output and can be redirected to a file.
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-h, --help` | Help for decrypt | - |
+
+### Examples
+
+```bash
+# Export the master key used during encryption
+export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+
+# Decrypt an encrypted report
+kubescape decrypt encrypted-report.json
+
+# Save the decrypted report to a file
+kubescape decrypt encrypted-report.json > decrypted-report.json
+```
+
+> `kubescape decrypt` restores sensitive report metadata encrypted with `kubescape scan --encrypt`. The same `KUBESCAPE_MASTER_KEY` used during encryption must be provided for successful decryption.
+
+---
 ## kubescape list
 
 List available frameworks and controls.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,11 +41,11 @@ kubescape scan [target] [flags]
 | `--compliance-threshold <float>` | Fail if compliance score is below threshold. Applies to `scan framework`, `scan control`, and `--view resource\|control` — see [score thresholds](#score-thresholds). | `0` |
 | `--controls-config <path>` | Path to controls configuration file | - |
 | `-e, --exclude-namespaces <ns>` | Namespaces to exclude (comma-separated) | - |
-| `--encrypt` | Encrypt sensitive report metadata using the master key provided through the `KUBESCAPE_MASTER_KEY` environment variable. Encrypted reports can later be restored using `kubescape decrypt`. | `false` |
+| `--encrypt` | Encrypt sensitive report metadata using the master key provided through the `KUBESCAPE_MASTER_KEY` environment variable. Requires `--format json` for reports that will later be decrypted with `kubescape decrypt`. If both `--encrypt` and `--hide` are specified, `--encrypt` takes precedence. | `false` |
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
 | `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `sarif`, `html`, `pdf`, `prometheus` | `pretty-printer` |
-| `--hide` | Replace sensitive report metadata with anonymized values in the generated report. | `false` |
+| `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
 | `--keep-local` | Don't report results to backend | `false` |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
@@ -83,12 +83,20 @@ kubescape scan --hide
 # Generate an anonymized JSON report
 kubescape scan --hide --format json --output report.json
 
+# The key is used as raw bytes and must be exactly 32 characters long.
+# Note: `openssl rand -base64 32` (44 chars) and `openssl rand -hex 32` (64 chars)
+# are NOT valid — they exceed 32 bytes once passed through as raw text.
+export KUBESCAPE_MASTER_KEY=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)
+
 # Generate an encrypted JSON report
-export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
 kubescape scan --encrypt --format json --output encrypted-report.json
 
+# The key is used as raw bytes and must be exactly 32 characters long.
+# Note: `openssl rand -base64 32` (44 chars) and `openssl rand -hex 32` (64 chars)
+# are NOT valid — they exceed 32 bytes once passed through as raw text.
+export KUBESCAPE_MASTER_KEY=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)
+
 # Decrypt an encrypted report
-export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
 kubescape decrypt encrypted-report.json > decrypted-report.json
 
 # Output to JSON file
@@ -330,7 +338,7 @@ sudo kubescape patch --image myregistry.example.com/team/app:1.2.3 --push
 
 ---
 
-## kubescape scan --hide
+## Hiding sensitive metadata
 
 Generate a report with anonymized sensitive report metadata.
 
@@ -342,9 +350,13 @@ kubescape scan [target] --hide [flags]
 
 ### Description
 
-Anonymizes sensitive report metadata by replacing values with deterministic
-pseudonyms. This helps safely share scan results without exposing sensitive
-resource information.
+Replaces sensitive report metadata with deterministic pseudonyms.
+
+This reduces incidental exposure but is not a confidentiality guarantee.
+Values drawn from small or predictable sets (such as common namespace names)
+may be recovered by comparing candidate hashes.
+
+Use `--encrypt` when sensitive metadata requires confidentiality.
 
 ### Examples
 
@@ -358,12 +370,17 @@ kubescape scan /path/to/manifests \
   --format json \
   --output report.json
 ```
-
-> `--hide` anonymizes sensitive report metadata. The original values cannot be restored.
+> `--hide` replaces sensitive values with deterministic pseudonyms derived from an
+> unsalted hash of the original value. Values drawn from a small or guessable set —
+> such as common namespace names — can be recovered by hashing candidate values and
+> matching the result, and identical values produce identical pseudonyms across
+> reports. Use `--hide` to reduce incidental exposure, not as a confidentiality
+> guarantee. To share a report whose metadata is genuinely protected, use
+> `--encrypt` and withhold the master key.
 
 ---
 
-## kubescape scan --encrypt
+## Encrypting sensitive metadata
 
 Generate a report with encrypted sensitive report metadata.
 
@@ -376,14 +393,22 @@ kubescape scan [target] --encrypt [flags]
 ### Description
 
 Encrypts sensitive report metadata using the master key supplied through the
-`KUBESCAPE_MASTER_KEY` environment variable. Encrypted reports can later be
-restored using `kubescape decrypt`.
+`KUBESCAPE_MASTER_KEY` environment variable.
+
+The master key is used as raw bytes and must be exactly 32 characters long.
+
+Use `--format json` to produce a report that can later be decrypted with
+`kubescape decrypt`.
+
+If both `--encrypt` and `--hide` are specified, `--encrypt` takes precedence.
 
 ### Examples
 
 ```bash
-# Export a 32-byte master key
-export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+# The key is used as raw bytes and must be exactly 32 characters long.
+# Note: `openssl rand -base64 32` (44 chars) and `openssl rand -hex 32` (64 chars)
+# are NOT valid — they exceed 32 bytes once passed through as raw text.
+export KUBESCAPE_MASTER_KEY=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)
 
 # Scan the current cluster and generate an encrypted report
 kubescape scan \
@@ -397,8 +422,9 @@ kubescape scan /path/to/manifests \
   --format json \
   --output encrypted-report.json
 ```
-
-> `--encrypt` requires the `KUBESCAPE_MASTER_KEY` environment variable. The same master key must be supplied when decrypting the report.
+> `--encrypt` requires the `KUBESCAPE_MASTER_KEY` environment variable.
+> The key must be exactly 32 characters long and the same key must be supplied
+> later when running `kubescape decrypt`.
 
 ---
 
@@ -414,9 +440,11 @@ kubescape decrypt <report-file>
 
 ### Description
 
-Decrypts an encrypted Kubescape report using the
-`KUBESCAPE_MASTER_KEY` environment variable. The decrypted report is written to
-standard output and can be redirected to a file.
+Decrypts report metadata that was protected with
+`kubescape scan --encrypt`.
+
+Only metadata encrypted by `kubescape scan --encrypt` is restored.
+Metadata pseudonymized with `--hide` cannot be recovered by `kubescape decrypt`.
 
 ### Flags
 
@@ -427,8 +455,10 @@ standard output and can be redirected to a file.
 ### Examples
 
 ```bash
-# Export the master key used during encryption
-export KUBESCAPE_MASTER_KEY=<32-byte-master-key>
+# The key is used as raw bytes and must be exactly 32 characters long.
+# Note: `openssl rand -base64 32` (44 chars) and `openssl rand -hex 32` (64 chars)
+# are NOT valid — they exceed 32 bytes once passed through as raw text.
+export KUBESCAPE_MASTER_KEY=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)
 
 # Decrypt an encrypted report
 kubescape decrypt encrypted-report.json
@@ -437,7 +467,9 @@ kubescape decrypt encrypted-report.json
 kubescape decrypt encrypted-report.json > decrypted-report.json
 ```
 
-> `kubescape decrypt` restores sensitive report metadata encrypted with `kubescape scan --encrypt`. The same `KUBESCAPE_MASTER_KEY` used during encryption must be provided for successful decryption.
+> `kubescape decrypt` restores metadata encrypted by
+> `kubescape scan --encrypt`. It does not reverse
+> deterministic pseudonymization produced by `--hide`.
 
 ---
 ## kubescape list
@@ -720,6 +752,7 @@ Kubescape respects the following environment variables:
 | `KS_LOGGER` | Log level |
 | `KS_LOGGER_NAME` | Logger name |
 | `KUBECONFIG` | Path to kubeconfig file |
+| `KUBESCAPE_MASTER_KEY` | 32-character master key used to encrypt and decrypt report metadata |
 | `HTTPS_PROXY` | HTTPS proxy URL |
 | `HTTP_PROXY` | HTTP proxy URL |
 | `NO_PROXY` | Hosts to exclude from proxy |


### PR DESCRIPTION
PART OF #1200 

## Summary

This PR documents the report protection workflow introduced in Kubescape.

### Changes

- Document the `--hide` scan flag
- Document the `--encrypt` scan flag
- Add CLI documentation for `kubescape decrypt`
- Add examples for anonymizing, encrypting, and decrypting reports
- Document the `KUBESCAPE_MASTER_KEY` environment variable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added reference for new `kubescape scan` options to protect sensitive report metadata via deterministic hiding (`--hide`) or metadata encryption (`--encrypt`).
  * Expanded examples to show how to run `kubescape scan` with the new flags and follow up with `kubescape decrypt` when using encryption.
  * Clarified precedence/constraints (including that only encrypted metadata can be decrypted, not hidden).
  * Updated score-threshold/coverage guidance and documented `KUBESCAPE_MASTER_KEY` environment variable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->