### PR TITLE
docs(cli): improve report protection help and examples

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -13,11 +13,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var decryptCmdExamples = `
+  # The key is used as raw bytes and must be exactly 32 characters long.
+  # Note: openssl rand -base64 32 (44 chars) and openssl rand -hex 32 (64 chars)
+  # are NOT valid — they exceed 32 bytes once passed through as raw text.
+  export KUBESCAPE_MASTER_KEY="01234567890123456789012345678901"
+
+  # Decrypt an encrypted report
+  kubescape decrypt encrypted-report.json
+
+  # Save the decrypted report to a file
+  kubescape decrypt encrypted-report.json > decrypted-report.json
+`
+
 func GetDecryptCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "decrypt <report.json>",
-		Short: "Decrypt encrypted Kubescape reports",
-		Args:  cobra.ExactArgs(1),
+		Short: "Decrypt report metadata encrypted with kubescape scan --encrypt",
+		Long: `Decrypt report metadata using the KUBESCAPE_MASTER_KEY
+environment variable.
+
+The decrypted report is written to standard output and can be redirected
+to a file.`,
+		Example: decryptCmdExamples,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			data, err := os.ReadFile(args[0])

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -34,6 +34,18 @@ var scanCmdExamples = fmt.Sprintf(`
   # Display all resources
   %[1]s scan --verbose
 
+  # Generate an anonymized report
+  %[1]s scan --hide --format json -o report.json
+
+  # The key is used as raw bytes and must be exactly 32 characters long.
+  # Note: openssl rand -base64 32 (44 chars) and openssl rand -hex 32 (64 chars)
+  # are NOT valid — they exceed 32 bytes once passed through as raw text.
+  export KUBESCAPE_MASTER_KEY="01234567890123456789012345678901"
+  %[1]s scan --encrypt --format json -o encrypted-report.json
+
+  # Decrypt an encrypted report
+  %[1]s decrypt encrypted-report.json > decrypted-report.json
+
   # Scan different clusters from the kubectl context
   %[1]s scan --kube-context <kubernetes context>
 `, cautils.ExecName())
@@ -158,8 +170,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
-	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Hide sensitive identifiers using irreversible pseudonymization")
-	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Use reversible encryption for repository metadata instead of pseudonymization")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Replace sensitive report metadata with deterministic pseudonyms")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Encrypt sensitive report metadata using the KUBESCAPE_MASTER_KEY environment variable")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -41,16 +41,6 @@ func applyWithTransformer(
 // The DEK is wrapped using the supplied master key (KEK)
 // and stored in EncryptionMetadata for future decryption
 // workflows.
-//
-// Repository context and resource metadata (for example,
-// resource names and namespaces) are reversibly encrypted.
-// Resource IDs are derived from the restored metadata during
-// decryption to preserve report referential integrity.
-//
-// Other anonymized fields, such as annotations, source paths,
-// labels, and additional session data, continue to use
-// mapping-based anonymization and remain irreversibly
-// pseudonymized.
 func ApplyEncrypted(
 	resultsHandler *resultshandling.ResultsHandler,
 	dek []byte,


### PR DESCRIPTION
PART OF #1200

## Overview

Improve the CLI help for the report protection workflow by:

- adding scan `--hide` and `scan --encrypt` examples
- documenting the kubescape decrypt workflow
- improving the `--hide` and `--encrypt` flag descriptions
- adding detailed help and examples to the `decrypt` command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded `decrypt` command help with clear setup guidance for `KUBESCAPE_MASTER_KEY`, output behavior (stdout), and copy-pastable examples (including saving to a file).
  * Extended `scan` command help examples to cover anonymized reports (`--hide`) and encrypted reports (`--encrypt`), followed by decryption.
  * Updated `--hide` and `--encrypt` flag descriptions to more accurately reflect deterministic pseudonymization and encryption using `KUBESCAPE_MASTER_KEY`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->