### PR TITLE
fix(vap): deploy-library serves the embedded bundle by default

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -27,8 +27,10 @@ var vapHelperCmdExamples = fmt.Sprintf(`
 
   Examples:
 
-  # Install Kubescape CEL admission policy library
+  # Install Kubescape CEL admission policy library (the copy embedded in this binary)
   %[1]s vap deploy-library | kubectl apply -f -
+  # Install a specific cel-admission-library release instead of the embedded copy
+  %[1]s vap deploy-library --from-release v0.11 | kubectl apply -f -
   # Create a policy binding by Kubescape control ID
   %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --namespace=my-namespace | kubectl apply -f -
   # Create a policy binding by ValidatingAdmissionPolicy name
@@ -53,6 +55,7 @@ func GetVapHelperCmd() *cobra.Command {
 
 func getDeployLibraryCmd() *cobra.Command {
 	var outputFile string
+	var fromRelease string
 	var timeout time.Duration
 
 	cmd := &cobra.Command{
@@ -60,7 +63,7 @@ func getDeployLibraryCmd() *cobra.Command {
 		Short: "Install Kubescape CEL admission policy library",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			content, err := deployLibrary(timeout)
+			content, err := deployLibrary(fromRelease, timeout)
 			if err != nil {
 				return err
 			}
@@ -68,7 +71,8 @@ func getDeployLibraryCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "HTTP request timeout per download (e.g. 30s, 1m)")
+	cmd.Flags().StringVar(&fromRelease, "from-release", "", "Download the library from this cel-admission-library release tag (e.g. v0.11) instead of using the embedded copy")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "HTTP request timeout per download, only used with --from-release (e.g. 30s, 1m)")
 
 	return cmd
 }
@@ -199,41 +203,48 @@ func resolvePolicyName(policyName, controlID string) (string, error) {
 
 // Implementation of the VAP helper commands
 // deploy-library
-func deployLibrary(timeout time.Duration) (string, error) {
-	logger.L().Info("Downloading the Kubescape CEL admission policy library")
-	// Download the policy-configuration-definition.yaml from the latest release URL
-	policyConfigurationDefinitionURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/policy-configuration-definition.yaml"
-	policyConfigurationDefinition, err := downloadFileToString(policyConfigurationDefinitionURL, timeout)
-	if err != nil {
-		return "", err
+//
+// By default the library comes from the bundle embedded in this binary: the
+// same copy the scan engine evaluates and create-policy-binding resolves
+// metadata from, so what gets deployed is exactly what this build was tested
+// against. Downloading a release instead is an explicit opt-in via
+// --from-release; it can serve a library this binary knows nothing about, so
+// it is never the silent default (issue #2507).
+func deployLibrary(fromRelease string, timeout time.Duration) (string, error) {
+	if fromRelease != "" {
+		return downloadLibrary(fromRelease, timeout)
 	}
+	return cel.EmbeddedLibraryYAML()
+}
 
-	// Download the basic-control-configuration.yaml from the latest release URL
-	basicControlConfigurationURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/basic-control-configuration.yaml"
-	basicControlConfiguration, err := downloadFileToString(basicControlConfigurationURL, timeout)
-	if err != nil {
-		return "", err
-	}
+// libraryReleaseFiles are the release assets that make up the deployable
+// library, in apply order (the CRD first, then the configuration, then the
+// policies). Must stay in sync with the assets `make sync-vap` vendors.
+var libraryReleaseFiles = []string{
+	"policy-configuration-definition.yaml",
+	"basic-control-configuration.yaml",
+	"kubescape-validating-admission-policies.yaml",
+}
 
-	// Download the kubescape-validating-admission-policies.yaml from the latest release URL
-	kubescapeValidatingAdmissionPoliciesURL := "https://github.com/kubescape/cel-admission-library/releases/latest/download/kubescape-validating-admission-policies.yaml"
-	kubescapeValidatingAdmissionPolicies, err := downloadFileToString(kubescapeValidatingAdmissionPoliciesURL, timeout)
-	if err != nil {
-		return "", err
+// downloadLibrary fetches the library files from one pinned release tag and
+// concatenates them into a single multi-document YAML stream. The tag is
+// always explicit — downloading whatever "latest" points at would reintroduce
+// the skew deployLibrary's embedded default exists to prevent.
+func downloadLibrary(tag string, timeout time.Duration) (string, error) {
+	logger.L().Info(fmt.Sprintf("Downloading the Kubescape CEL admission policy library release %s", tag))
+
+	parts := make([]string, 0, len(libraryReleaseFiles))
+	for _, file := range libraryReleaseFiles {
+		url := fmt.Sprintf("https://github.com/kubescape/cel-admission-library/releases/download/%s/%s", tag, file)
+		content, err := downloadFileToString(url, timeout)
+		if err != nil {
+			return "", fmt.Errorf("download %s from release %s: %w", file, tag, err)
+		}
+		parts = append(parts, content)
 	}
 
 	logger.L().Info("Successfully downloaded admission policy library")
-
-	// Concatenate the downloaded files into a single YAML document with --- separators
-	var result strings.Builder
-	result.WriteString(policyConfigurationDefinition)
-	result.WriteString("\n---\n")
-	result.WriteString(basicControlConfiguration)
-	result.WriteString("\n---\n")
-	result.WriteString(kubescapeValidatingAdmissionPolicies)
-	result.WriteString("\n")
-
-	return result.String(), nil
+	return strings.Join(parts, "\n---\n") + "\n", nil
 }
 
 func downloadFileToString(url string, timeout time.Duration) (string, error) {

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor/cel"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -173,9 +174,37 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return rt.originalTransport.RoundTrip(req)
 }
 
-func TestDeployLibrary(t *testing.T) {
+func TestDeployLibraryServesEmbeddedBundleByDefault(t *testing.T) {
+	// Any HTTP request would land on this failing server, so a pass proves the
+	// default path never touches the network.
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &redirectTransport{
+		baseURL:           strings.TrimPrefix(server.URL, "http://"),
+		originalTransport: server.Client().Transport,
+	}
+	defer func() { http.DefaultTransport = origTransport }()
+
+	content, err := deployLibrary("", 0)
+	require.NoError(t, err)
+	assert.Zero(t, requests, "the embedded default must not touch the network")
+
+	embedded, err := cel.EmbeddedLibraryYAML()
+	require.NoError(t, err)
+	assert.Equal(t, embedded, content, "deploy-library must serve the bundle embedded in the binary")
+}
+
+func TestDeployLibraryFromRelease(t *testing.T) {
 	t.Run("all downloads succeed with concatenation", func(t *testing.T) {
+		var paths []string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path)
 			w.WriteHeader(http.StatusOK)
 			switch {
 			case strings.Contains(r.URL.Path, "policy-configuration-definition"):
@@ -198,8 +227,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		// Capture stdout
-		content, err := deployLibrary(0)
+		content, err := deployLibrary("v0.11", 0)
 		require.NoError(t, err)
 
 		parts := strings.Split(content, "\n---\n")
@@ -207,6 +235,13 @@ func TestDeployLibrary(t *testing.T) {
 		assert.Equal(t, "policy-config-content", strings.TrimSpace(parts[0]))
 		assert.Equal(t, "basic-control-content", strings.TrimSpace(parts[1]))
 		assert.Contains(t, parts[2], "kubescape-policies-content")
+
+		// The tag must be pinned in every URL: no releases/latest.
+		require.Len(t, paths, 3)
+		for _, path := range paths {
+			assert.Contains(t, path, "/releases/download/v0.11/")
+			assert.NotContains(t, path, "latest")
+		}
 	})
 
 	t.Run("first download fails", func(t *testing.T) {
@@ -226,9 +261,10 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		_, err := deployLibrary(0)
+		_, err := deployLibrary("v0.11", 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
+		assert.Contains(t, err.Error(), "policy-configuration-definition.yaml")
 	})
 
 	t.Run("second download fails", func(t *testing.T) {
@@ -248,7 +284,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		_, err := deployLibrary(0)
+		_, err := deployLibrary("v0.11", 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
 	})
@@ -270,7 +306,7 @@ func TestDeployLibrary(t *testing.T) {
 		}
 		defer func() { http.DefaultTransport = origTransport }()
 
-		_, err := deployLibrary(0)
+		_, err := deployLibrary("v0.11", 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to download file")
 	})
@@ -531,6 +567,10 @@ func TestGetDeployLibraryCmd(t *testing.T) {
 	timeoutFlag := cmd.Flags().Lookup("timeout")
 	require.NotNil(t, timeoutFlag)
 	assert.Equal(t, "0s", timeoutFlag.DefValue)
+
+	fromReleaseFlag := cmd.Flags().Lookup("from-release")
+	require.NotNil(t, fromReleaseFlag)
+	assert.Empty(t, fromReleaseFlag.DefValue, "embedded bundle must be the default")
 }
 
 func TestGetCreatePolicyBindingCmd(t *testing.T) {

--- a/core/pkg/opaprocessor/cel/bundle.go
+++ b/core/pkg/opaprocessor/cel/bundle.go
@@ -1,0 +1,39 @@
+package cel
+
+import (
+	"fmt"
+	"strings"
+)
+
+// policyConfigDefinitionFile holds the ControlConfiguration CRD the params
+// objects are instances of. The engine never reads it (it consumes the params
+// values, not their schema), but a cluster needs the CRD before the
+// configuration can be applied, so it ships in the deployable stream.
+const policyConfigDefinitionFile = "policy-configuration-definition.yaml"
+
+// deployFiles are the bundle files that make up the deployable library, in
+// apply order: the CRD first, then the configuration instance, then the
+// policies that reference it.
+var deployFiles = []string{
+	policyConfigDefinitionFile,
+	controlConfigFile,
+	vapBundleFile,
+}
+
+// EmbeddedLibraryYAML returns the vendored cel-admission-library bundle as one
+// multi-document YAML stream ready for kubectl apply. This is the same embedded
+// copy the scan engine evaluates and create-policy-binding resolves metadata
+// from, so what a user deploys is exactly what this build was tested against —
+// deploying anything else (e.g. a fresher upstream release) would let admission
+// and offline scans disagree about the same object (issue #2507).
+func EmbeddedLibraryYAML() (string, error) {
+	parts := make([]string, 0, len(deployFiles))
+	for _, name := range deployFiles {
+		data, err := vapdataFS.ReadFile(vapdataDir + "/" + name)
+		if err != nil {
+			return "", fmt.Errorf("read embedded %s: %w", name, err)
+		}
+		parts = append(parts, string(data))
+	}
+	return strings.Join(parts, "\n---\n") + "\n", nil
+}

--- a/core/pkg/opaprocessor/cel/bundle_test.go
+++ b/core/pkg/opaprocessor/cel/bundle_test.go
@@ -1,0 +1,44 @@
+package cel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbeddedLibraryYAMLServesTheVendoredBundle proves the deployable stream
+// is exactly the vendored files (read via the on-disk copies of the embedded
+// dir, like the vapdata sanity tests), so deploy-library serves the same bundle
+// the engine evaluates.
+func TestEmbeddedLibraryYAMLServesTheVendoredBundle(t *testing.T) {
+	out, err := EmbeddedLibraryYAML()
+	require.NoError(t, err)
+
+	for _, name := range deployFiles {
+		data, err := os.ReadFile(filepath.Join(vapdataDir, name))
+		require.NoError(t, err)
+		assert.Contains(t, out, string(data), "%s must be in the deployable stream verbatim", name)
+	}
+}
+
+// TestEmbeddedLibraryYAMLApplyOrder proves the documents come out in apply
+// order: the CRD before the ControlConfiguration instance that needs it, and
+// the policies last.
+func TestEmbeddedLibraryYAMLApplyOrder(t *testing.T) {
+	out, err := EmbeddedLibraryYAML()
+	require.NoError(t, err)
+
+	crd := strings.Index(out, "kind: CustomResourceDefinition")
+	config := strings.Index(out, "kind: ControlConfiguration")
+	policies := strings.Index(out, "kind: ValidatingAdmissionPolicy")
+
+	require.GreaterOrEqual(t, crd, 0, "stream must contain the params CRD")
+	require.GreaterOrEqual(t, config, 0, "stream must contain the control configuration")
+	require.GreaterOrEqual(t, policies, 0, "stream must contain the policies")
+	assert.Less(t, crd, config, "CRD must precede the configuration instance")
+	assert.Less(t, config, policies, "configuration must precede the policies")
+}


### PR DESCRIPTION
## Overview

fixes #2507

Until now `vap deploy-library` downloaded the library from the latest upstream release at runtime, but the scan engine and create-policy-binding read the bundle embedded in the binary. So the moment upstream cuts a new release, what you deploy stops matching what this build was tested against.

In this PR I changed deploy-library to just print the embedded bundle by default. It's the exact same copy the engine evaluates, and there is no network call at all. If someone really wants a different version they can pass `--from-release <tag>`, which downloads from that pinned tag. I removed the releases/latest URLs completely so there is no silent way to get an unpinned version anymore.

I also cleaned up the three copy pasted download blocks into one loop, and download errors now tell you which file and tag failed.

For tests I point all http traffic at a failing server and prove the default path makes zero requests and matches the embedded bundle byte for byte. The download tests now run through --from-release and check every URL pins the tag. There are also new tests in the cel package that check the files come out in apply order (CRD first, then the configuration, then the policies).


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `deploy-library` now supports downloading a specific, pinned policy library release with the `--from-release` option.
  - The embedded policy bundle remains the default when no release is specified.
  - Downloaded releases are assembled into a deployable multi-document YAML bundle.

- **Bug Fixes**
  - Download failures now identify the affected release asset for easier troubleshooting.
  - Deployment preserves the required resource application order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->