### PR TITLE
Fix control-inputs fallback to return real local getter instead of unloaded store

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -72,6 +72,13 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				return err
 			}
 
+			if strings.Contains(scanInfo.ControlsVersion, "/") {
+				return fmt.Errorf(
+					"invalid --controls-version %q: must be a regolibrary release tag and cannot contain '/'",
+					scanInfo.ControlsVersion,
+				)
+			}
+
 			if scanInfo.EncryptionEnabled {
 
 				if _, err := reportcrypto.GetMasterKeyFromEnv("encryption"); err != nil {
@@ -149,7 +156,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.SecurityViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")
-	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release used to download controls (e.g. 'v2.0.301'). If not used will download the latest release")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HostSensorYamlPath, "host-scan-yaml", "", "Override default host scanner DaemonSet. Use this flag cautiously")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v2", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomClusterName, "cluster-name", "", "Set the custom name of the cluster. Not same as the kube-context flag")

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -47,6 +47,16 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Short:   "Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations",
 		Long:    `Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.`,
 		Example: scanCmdExamples,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// runs for the bare scan command and all subcommands (framework, control, workload, image)
+			if strings.Contains(scanInfo.ControlsVersion, "/") {
+				return fmt.Errorf(
+					"invalid --controls-version %q: must be a regolibrary release tag and cannot contain '/'",
+					scanInfo.ControlsVersion,
+				)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scanInfo.FailThresholdSeverity != "" {
 				if err := shared.ValidateSeverity(
@@ -70,13 +80,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				shared.ScanFormats,
 			); err != nil {
 				return err
-			}
-
-			if strings.Contains(scanInfo.ControlsVersion, "/") {
-				return fmt.Errorf(
-					"invalid --controls-version %q: must be a regolibrary release tag and cannot contain '/'",
-					scanInfo.ControlsVersion,
-				)
 			}
 
 			if scanInfo.EncryptionEnabled {
@@ -156,7 +159,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.SecurityViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")
-	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release. Has no effect when --account is set (cloud backend is used instead)")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HostSensorYamlPath, "host-scan-yaml", "", "Override default host scanner DaemonSet. Use this flag cautiously")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v2", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomClusterName, "cluster-name", "", "Set the custom name of the cluster. Not same as the kube-context flag")

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -149,6 +149,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.SecurityViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release used to download controls (e.g. 'v2.0.301'). If not used will download the latest release")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HostSensorYamlPath, "host-scan-yaml", "", "Override default host scanner DaemonSet. Use this flag cautiously")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v2", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomClusterName, "cluster-name", "", "Set the custom name of the cluster. Not same as the kube-context flag")

--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -22,7 +22,8 @@ var (
 
 // Use gitregostore to get policies from github release
 type DownloadReleasedPolicy struct {
-	gs *gitregostore.GitRegoStore
+	gs      *gitregostore.GitRegoStore
+	version string
 }
 
 func NewDownloadReleasedPolicy() *DownloadReleasedPolicy {
@@ -39,8 +40,33 @@ func NewDownloadReleasedPolicyWithVersion(version string) *DownloadReleasedPolic
 		return NewDownloadReleasedPolicy()
 	}
 	return &DownloadReleasedPolicy{
-		gs: gitregostore.NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "download/"+version, "", -1),
+		gs:      gitregostore.NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "download/"+version, "", -1),
+		version: version,
 	}
+}
+
+// IsVersionPinned reports whether this getter targets a specific, user-selected
+// regolibrary release tag rather than the latest release.
+func (drp *DownloadReleasedPolicy) IsVersionPinned() bool {
+	return drp.version != ""
+}
+
+// SetRegoObjectsWithFallback downloads the policy objects and reports whether
+// the caller should fall back to the bundled cache on failure.
+//
+// When a version is pinned, a download failure is a hard error (fallback=false,
+// err!=nil): the user explicitly asked for a specific release, so silently
+// serving a different, cached policy set would be misleading. When no version
+// is pinned, a download failure is not an error but requests a fallback
+// (fallback=true, err=nil), preserving the existing latest-release behavior.
+func (drp *DownloadReleasedPolicy) SetRegoObjectsWithFallback() (fallback bool, err error) {
+	if err := drp.SetRegoObjects(); err != nil {
+		if drp.version != "" {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func (drp *DownloadReleasedPolicy) GetControl(ID string) (*reporthandling.Control, error) {
@@ -136,7 +162,13 @@ func (drp *DownloadReleasedPolicy) SetRegoObjects() error {
 	if len(fwNames) != 0 && err == nil {
 		return nil
 	}
-	return drp.gs.SetRegoObjects()
+	if err := drp.gs.SetRegoObjects(); err != nil {
+		if drp.version != "" {
+			return fmt.Errorf("failed to download controls for pinned version %q: %w", drp.version, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (drp *DownloadReleasedPolicy) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {

--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -146,6 +146,11 @@ func (drp *DownloadReleasedPolicy) GetControlsInputs(clusterName string) (map[st
 	if err != nil {
 		return nil, err
 	}
+	if defaultConfigInputs.Settings.PostureControlInputs == nil {
+		// the rego store failed to load, so no control inputs are available;
+		// report it as an error instead of silently returning empty inputs
+		return nil, fmt.Errorf("no control configuration inputs available")
+	}
 	return defaultConfigInputs.Settings.PostureControlInputs, err
 }
 

--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -31,6 +31,18 @@ func NewDownloadReleasedPolicy() *DownloadReleasedPolicy {
 	}
 }
 
+// NewDownloadReleasedPolicyWithVersion returns a DownloadReleasedPolicy pinned
+// to a specific regolibrary release tag (e.g. "v2.0.301"). An empty version
+// falls back to the latest release, matching NewDownloadReleasedPolicy.
+func NewDownloadReleasedPolicyWithVersion(version string) *DownloadReleasedPolicy {
+	if version == "" {
+		return NewDownloadReleasedPolicy()
+	}
+	return &DownloadReleasedPolicy{
+		gs: gitregostore.NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "download/"+version, "", -1),
+	}
+}
+
 func (drp *DownloadReleasedPolicy) GetControl(ID string) (*reporthandling.Control, error) {
 	var control *reporthandling.Control
 	var err error

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -181,3 +181,35 @@ func TestNewDownloadReleasedPolicyWithVersion(t *testing.T) {
 		require.Contains(t, p.gs.URL, "download/v2.0.301")
 	})
 }
+
+func TestSetRegoObjectsWithFallback(t *testing.T) {
+	t.Parallel()
+
+	// unroutable URL (port 0) so the download fails deterministically offline
+	const unreachableURL = "http://127.0.0.1:0/download"
+
+	t.Run("empty version keeps cache fallback on download failure", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("")
+		require.False(t, p.IsVersionPinned())
+		p.gs.URL = unreachableURL
+
+		fallback, err := p.SetRegoObjectsWithFallback()
+		require.NoError(t, err)
+		require.True(t, fallback)
+	})
+
+	t.Run("pinned version returns a hard error on download failure", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("v0.0.0-does-not-exist")
+		require.True(t, p.IsVersionPinned())
+		p.gs.URL = unreachableURL
+
+		fallback, err := p.SetRegoObjectsWithFallback()
+		require.Error(t, err)
+		require.False(t, fallback)
+		require.Contains(t, err.Error(), "v0.0.0-does-not-exist")
+	})
+}

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -162,3 +162,22 @@ func hydrateReleasedPolicyFromMock(t testing.TB, p *DownloadReleasedPolicy) {
 func testRegoFile(framework string) string {
 	return filepath.Join(testutils.CurrentDir(), "testdata", fmt.Sprintf("%s.json", framework))
 }
+
+func TestNewDownloadReleasedPolicyWithVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty version falls back to the latest release", func(t *testing.T) {
+		t.Parallel()
+
+		pinned := NewDownloadReleasedPolicyWithVersion("")
+		latest := NewDownloadReleasedPolicy()
+		require.Equal(t, latest.gs.URL, pinned.gs.URL)
+	})
+
+	t.Run("pinned version targets the release tag", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("v2.0.301")
+		require.Contains(t, p.gs.URL, "download/v2.0.301")
+	})
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -108,6 +108,7 @@ type ScanInfo struct {
 	UseFrom               []string           // Load framework from local file (instead of download). Use when running offline
 	UseDefault            bool               // Load framework from cached file (instead of download). Use when running offline
 	UseArtifactsFrom      string             // Load artifacts from local path. Use when running offline
+	ControlsVersion       string             // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
 	VerboseMode           bool               // Display all the input resources and not only failed resources
 	Hide                  bool               // Hide sensitive identifiers (names, namespaces, images) in results
 	EncryptionEnabled     bool

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -100,7 +100,10 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	controlsInputsGetter := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
+	controlsInputsGetter, err := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
+	if err != nil {
+		return err
+	}
 	controlInputs, err := controlsInputsGetter.GetControlsInputs(tenant.GetContextName())
 	if err != nil {
 		return err
@@ -122,7 +125,10 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
-	exceptionsGetter := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	exceptionsGetter, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	if err != nil {
+		return err
+	}
 
 	exceptions, err := exceptionsGetter.GetExceptions(tenant.GetContextName())
 	if err != nil {
@@ -145,7 +151,10 @@ func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo
 	var err error
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	attackTracksGetter := getAttackTracksGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	attackTracksGetter, err := getAttackTracksGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	if err != nil {
+		return err
+	}
 
 	attackTracks, err := attackTracksGetter.GetAttackTracks()
 	if err != nil {
@@ -169,7 +178,10 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
+	g, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
+	if err != nil {
+		return err
+	}
 
 	if downloadInfo.Identifier == "" {
 		// if framework name not specified - download all frameworks
@@ -220,7 +232,10 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) err
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
+	g, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
+	if err != nil {
+		return err
+	}
 
 	if downloadInfo.Identifier == "" {
 		// TODO - support

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -100,7 +100,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	controlsInputsGetter, err := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
+	controlsInputsGetter, _, err := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	if err != nil {
 		return err
 	}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -81,7 +81,7 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	}
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached exceptions
-		logger.L().Ctx(ctx).Error("failed to get exceptions for the pinned controls version from github release", helpers.Error(err))
+		logger.L().Ctx(ctx).Fatal("failed to get exceptions for the pinned controls version from github release", helpers.Error(err))
 		primary = downloadReleasedPolicy
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
@@ -309,7 +309,7 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 	}
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, surface it instead of silently degrading
-		logger.L().Ctx(ctx).Error("failed to get config inputs for the pinned controls version from github release", helpers.Error(err))
+		logger.L().Ctx(ctx).Fatal("failed to get config inputs for the pinned controls version from github release", helpers.Error(err))
 	} else if fallback { // if failed to pull config inputs, this may affect the scanning results
 		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, this may affect the scanning results")
 	}
@@ -319,7 +319,7 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 func getDownloadReleasedPolicy(ctx context.Context, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IPolicyGetter {
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached policies
-		logger.L().Ctx(ctx).Error("failed to get policies for the pinned controls version from github release", helpers.Error(err))
+		logger.L().Ctx(ctx).Fatal("failed to get policies for the pinned controls version from github release", helpers.Error(err))
 		return downloadReleasedPolicy
 	} else if fallback { // if failed to pull policy, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get policies from github release, loading policies from cache")
@@ -366,7 +366,7 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached attack tracks
-		logger.L().Ctx(ctx).Error("failed to get attack tracks for the pinned controls version from github release", helpers.Error(err))
+		logger.L().Ctx(ctx).Fatal("failed to get attack tracks for the pinned controls version from github release", helpers.Error(err))
 		return downloadReleasedPolicy
 	} else if fallback { // if failed to pull attack tracks, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get attack tracks from github release, loading attack tracks from cache")

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -67,6 +67,9 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
 	}
 	if accountID != "" {
+		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
+			logger.L().Ctx(ctx).Warning("--controls-version is ignored for exceptions when an account ID is set; exceptions are downloaded from the Kubescape Cloud backend")
+		}
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIConnector()
 		k8sClient := getExceptionsK8sClient(ctx)
@@ -76,8 +79,14 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
-	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
-		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading attack tracks from cache", helpers.Error(err))
+	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
+		// pinned version: hard error, do not silently serve cached exceptions
+		logger.L().Ctx(ctx).Error("failed to get exceptions for the pinned controls version from github release", helpers.Error(err))
+		primary = downloadReleasedPolicy
+		k8sClient := getExceptionsK8sClient(ctx)
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+	} else if fallback { // if failed to pull exceptions, fallback to cache
+		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading exceptions from cache")
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
@@ -248,6 +257,9 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
 	}
 	if accountID != "" && getter.GetKSCloudAPIConnector().GetCloudAPIURL() != "" && frameworkScope {
+		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
+			logger.L().Ctx(ctx).Warning("--controls-version is ignored when an account ID is set; policies are downloaded from the Kubescape Cloud backend")
+		}
 		g := getter.GetKSCloudAPIConnector() // download policy from Kubescape Cloud backend
 		return g
 	} else if accountID != "" && getter.GetKSCloudAPIConnector().GetCloudAPIURL() == "" && frameworkScope {
@@ -274,6 +286,9 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)})
 	}
 	if accountID != "" {
+		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
+			logger.L().Ctx(ctx).Warning("--controls-version is ignored for control config when an account ID is set; control config is downloaded from the Kubescape Cloud backend")
+		}
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
 		return g
 	}
@@ -292,19 +307,25 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
-	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull config inputs, fallback to BE
-		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, this may affect the scanning results", helpers.Error(err))
+	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
+		// pinned version: hard error, surface it instead of silently degrading
+		logger.L().Ctx(ctx).Error("failed to get config inputs for the pinned controls version from github release", helpers.Error(err))
+	} else if fallback { // if failed to pull config inputs, this may affect the scanning results
+		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, this may affect the scanning results")
 	}
 	return downloadReleasedPolicy
 }
 
 func getDownloadReleasedPolicy(ctx context.Context, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IPolicyGetter {
-	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull policy, fallback to cache
-		logger.L().Ctx(ctx).Warning("failed to get policies from github release, loading policies from cache", helpers.Error(err))
-		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
-	} else {
+	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
+		// pinned version: hard error, do not silently serve cached policies
+		logger.L().Ctx(ctx).Error("failed to get policies for the pinned controls version from github release", helpers.Error(err))
 		return downloadReleasedPolicy
+	} else if fallback { // if failed to pull policy, fallback to cache
+		logger.L().Ctx(ctx).Warning("failed to get policies from github release, loading policies from cache")
+		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
 	}
+	return downloadReleasedPolicy
 }
 
 func getDefaultFrameworksPaths() []string {
@@ -333,6 +354,9 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
 	}
 	if accountID != "" {
+		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
+			logger.L().Ctx(ctx).Warning("--controls-version is ignored for attack tracks when an account ID is set; attack tracks are downloaded from the Kubescape Cloud backend")
+		}
 		g := getter.GetKSCloudAPIConnector() // download attack tracks from Kubescape Cloud backend
 		return g
 	}
@@ -340,8 +364,12 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
 
-	if err := downloadReleasedPolicy.SetRegoObjects(); err != nil { // if failed to pull attack tracks, fallback to cache
-		logger.L().Ctx(ctx).Warning("failed to get attack tracks from github release, loading attack tracks from cache", helpers.Error(err))
+	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
+		// pinned version: hard error, do not silently serve cached attack tracks
+		logger.L().Ctx(ctx).Error("failed to get attack tracks for the pinned controls version from github release", helpers.Error(err))
+		return downloadReleasedPolicy
+	} else if fallback { // if failed to pull attack tracks, fallback to cache
+		logger.L().Ctx(ctx).Warning("failed to get attack tracks from github release, loading attack tracks from cache")
 		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
 	}
 	return downloadReleasedPolicy

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -275,19 +275,22 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 //  2. Kubescape Cloud API (if accountID configured)
 //  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
 //  4. Defaults from regolibrary GitHub releases
-func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) (getter.IControlsInputsGetter, error) {
+// getConfigInputsGetter returns the control inputs getter and a bool reporting
+// whether the inputs are served from the local cache fallback (GitHub download
+// failed) rather than fetched fresh, so the caller can record a PolicyDegradation.
+func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) (getter.IControlsInputsGetter, bool, error) {
 	if len(ControlsInputs) > 0 {
-		return getter.NewLoadPolicy([]string{ControlsInputs}), nil
+		return getter.NewLoadPolicy([]string{ControlsInputs}), false, nil
 	}
 	if airGapped {
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)}), nil
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)}), false, nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored for control config when an account ID is set; control config is downloaded from the Kubescape Cloud backend")
 		}
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
-		return g, nil
+		return g, false, nil
 	}
 
 	// Try to read control inputs from the ControlInput CRD in-cluster (live cluster scans only)
@@ -295,7 +298,7 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
 			if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
-				return crdInputs, nil
+				return crdInputs, false, nil
 			}
 			logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 		}
@@ -306,11 +309,12 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 	}
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, surface it instead of silently degrading
-		return nil, err
-	} else if fallback { // if failed to pull config inputs, this may affect the scanning results
-		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, this may affect the scanning results")
+		return nil, false, err
+	} else if fallback { // if failed to pull config inputs, fallback to cache
+		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, loading config inputs from cache")
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)}), true, nil
 	}
-	return downloadReleasedPolicy, nil
+	return downloadReleasedPolicy, false, nil
 }
 
 func getDownloadReleasedPolicy(ctx context.Context, downloadReleasedPolicy *getter.DownloadReleasedPolicy) (getter.IPolicyGetter, error) {

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -52,19 +52,19 @@ func getExceptionsK8sClient(ctx context.Context) client.Client {
 	return k8sClient
 }
 
-func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IExceptionsGetter {
+func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IExceptionsGetter, error) {
 	var primary getter.IExceptionsGetter
 
 	if useExceptions != "" {
 		// load exceptions from file
 		primary = getter.NewLoadPolicy([]string{useExceptions})
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
 	if airGapped {
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
@@ -73,7 +73,7 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIConnector()
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
@@ -81,19 +81,16 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 	}
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached exceptions
-		logger.L().Ctx(ctx).Fatal("failed to get exceptions for the pinned controls version from github release", helpers.Error(err))
-		primary = downloadReleasedPolicy
-		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+		return nil, err
 	} else if fallback { // if failed to pull exceptions, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading exceptions from cache")
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
 	primary = downloadReleasedPolicy
 	k8sClient := getExceptionsK8sClient(ctx)
-	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient))
+	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 
 }
 
@@ -249,19 +246,19 @@ func isScanTypeForSubmission(scanType cautils.ScanTypes) bool {
 }
 
 // setPolicyGetter set the policy getter - local file/github release/Kubescape Cloud API
-func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, accountID string, frameworkScope bool, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IPolicyGetter {
+func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, accountID string, frameworkScope bool, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IPolicyGetter, error) {
 	if len(loadPoliciesFromFile) > 0 {
-		return getter.NewLoadPolicy(loadPoliciesFromFile)
+		return getter.NewLoadPolicy(loadPoliciesFromFile), nil
 	}
 	if airGapped {
-		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
+		return getter.NewLoadPolicy(getDefaultFrameworksPaths()), nil
 	}
 	if accountID != "" && getter.GetKSCloudAPIConnector().GetCloudAPIURL() != "" && frameworkScope {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored when an account ID is set; policies are downloaded from the Kubescape Cloud backend")
 		}
 		g := getter.GetKSCloudAPIConnector() // download policy from Kubescape Cloud backend
-		return g
+		return g, nil
 	} else if accountID != "" && getter.GetKSCloudAPIConnector().GetCloudAPIURL() == "" && frameworkScope {
 		logger.L().Ctx(ctx).Warning("Kubescape Cloud API URL is not set, loading policies from cache")
 	}
@@ -278,19 +275,19 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 //  2. Kubescape Cloud API (if accountID configured)
 //  3. ControlInput CRD in-cluster (if connected to cluster and CRD exists)
 //  4. Defaults from regolibrary GitHub releases
-func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) getter.IControlsInputsGetter {
+func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) (getter.IControlsInputsGetter, error) {
 	if len(ControlsInputs) > 0 {
-		return getter.NewLoadPolicy([]string{ControlsInputs})
+		return getter.NewLoadPolicy([]string{ControlsInputs}), nil
 	}
 	if airGapped {
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)})
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)}), nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored for control config when an account ID is set; control config is downloaded from the Kubescape Cloud backend")
 		}
 		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
-		return g
+		return g, nil
 	}
 
 	// Try to read control inputs from the ControlInput CRD in-cluster (live cluster scans only)
@@ -298,7 +295,7 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
 			if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
-				return crdInputs
+				return crdInputs, nil
 			}
 			logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 		}
@@ -309,23 +306,22 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 	}
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, surface it instead of silently degrading
-		logger.L().Ctx(ctx).Fatal("failed to get config inputs for the pinned controls version from github release", helpers.Error(err))
+		return nil, err
 	} else if fallback { // if failed to pull config inputs, this may affect the scanning results
 		logger.L().Ctx(ctx).Warning("failed to get config inputs from github release, this may affect the scanning results")
 	}
-	return downloadReleasedPolicy
+	return downloadReleasedPolicy, nil
 }
 
-func getDownloadReleasedPolicy(ctx context.Context, downloadReleasedPolicy *getter.DownloadReleasedPolicy) getter.IPolicyGetter {
+func getDownloadReleasedPolicy(ctx context.Context, downloadReleasedPolicy *getter.DownloadReleasedPolicy) (getter.IPolicyGetter, error) {
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached policies
-		logger.L().Ctx(ctx).Fatal("failed to get policies for the pinned controls version from github release", helpers.Error(err))
-		return downloadReleasedPolicy
+		return nil, err
 	} else if fallback { // if failed to pull policy, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get policies from github release, loading policies from cache")
-		return getter.NewLoadPolicy(getDefaultFrameworksPaths())
+		return getter.NewLoadPolicy(getDefaultFrameworksPaths()), nil
 	}
-	return downloadReleasedPolicy
+	return downloadReleasedPolicy, nil
 }
 
 func getDefaultFrameworksPaths() []string {
@@ -346,19 +342,19 @@ func listFrameworksNames(policyGetter getter.IPolicyGetter) []string {
 	return getter.NativeFrameworks
 }
 
-func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) getter.IAttackTracksGetter {
+func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IAttackTracksGetter, error) {
 	if len(attackTracks) > 0 {
-		return getter.NewLoadPolicy([]string{attackTracks})
+		return getter.NewLoadPolicy([]string{attackTracks}), nil
 	}
 	if airGapped {
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)}), nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored for attack tracks when an account ID is set; attack tracks are downloaded from the Kubescape Cloud backend")
 		}
 		g := getter.GetKSCloudAPIConnector() // download attack tracks from Kubescape Cloud backend
-		return g
+		return g, nil
 	}
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
@@ -366,13 +362,12 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 
 	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
 		// pinned version: hard error, do not silently serve cached attack tracks
-		logger.L().Ctx(ctx).Fatal("failed to get attack tracks for the pinned controls version from github release", helpers.Error(err))
-		return downloadReleasedPolicy
+		return nil, err
 	} else if fallback { // if failed to pull attack tracks, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get attack tracks from github release, loading attack tracks from cache")
-		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)})
+		return getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalAttackTracksFilename)}), nil
 	}
-	return downloadReleasedPolicy
+	return downloadReleasedPolicy, nil
 }
 
 // GetUIPrinter returns a printer that will be used to print to the program’s UI (terminal)

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -146,7 +146,7 @@ func TestGettersAirGappedUseCache(t *testing.T) {
 			policyGetter, err := getPolicyGetter(ctx, nil, accountID, true, nil, true)
 			assert.NoError(t, err)
 			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(policyGetter).String())
-			configInputsGetter, err := getConfigInputsGetter(ctx, "", accountID, nil, false, true)
+			configInputsGetter, _, err := getConfigInputsGetter(ctx, "", accountID, nil, false, true)
 			assert.NoError(t, err)
 			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(configInputsGetter).String())
 			attackTracksGetter, err := getAttackTracksGetter(ctx, "", accountID, nil, true)
@@ -609,7 +609,7 @@ func TestPinnedVersionGettersReturnHardError(t *testing.T) {
 	})
 
 	t.Run("getConfigInputsGetter", func(t *testing.T) {
-		g, err := getConfigInputsGetter(ctx, "", "", newPinned(), false, false)
+		g, _, err := getConfigInputsGetter(ctx, "", "", newPinned(), false, false)
 		require.Error(t, err)
 		require.Nil(t, g)
 	})

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -132,7 +132,8 @@ func TestGetExceptionsGetter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy, false)
+			got, err := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy, false)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, reflect.TypeOf(got).String())
 		})
 	}
@@ -142,14 +143,18 @@ func TestGettersAirGappedUseCache(t *testing.T) {
 	ctx := context.Background()
 	for _, accountID := range []string{"", "123456789012"} {
 		t.Run("accountID="+accountID, func(t *testing.T) {
-			assert.Equal(t, "*getter.LoadPolicy",
-				reflect.TypeOf(getPolicyGetter(ctx, nil, accountID, true, nil, true)).String())
-			assert.Equal(t, "*getter.LoadPolicy",
-				reflect.TypeOf(getConfigInputsGetter(ctx, "", accountID, nil, false, true)).String())
-			assert.Equal(t, "*getter.LoadPolicy",
-				reflect.TypeOf(getAttackTracksGetter(ctx, "", accountID, nil, true)).String())
-			assert.Equal(t, "*getter.MergedExceptionsGetter",
-				reflect.TypeOf(getExceptionsGetter(ctx, "", accountID, nil, true)).String())
+			policyGetter, err := getPolicyGetter(ctx, nil, accountID, true, nil, true)
+			assert.NoError(t, err)
+			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(policyGetter).String())
+			configInputsGetter, err := getConfigInputsGetter(ctx, "", accountID, nil, false, true)
+			assert.NoError(t, err)
+			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(configInputsGetter).String())
+			attackTracksGetter, err := getAttackTracksGetter(ctx, "", accountID, nil, true)
+			assert.NoError(t, err)
+			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(attackTracksGetter).String())
+			exceptionsGetter, err := getExceptionsGetter(ctx, "", accountID, nil, true)
+			assert.NoError(t, err)
+			assert.Equal(t, "*getter.MergedExceptionsGetter", reflect.TypeOf(exceptionsGetter).String())
 		})
 	}
 }
@@ -579,7 +584,45 @@ func TestGetDownloadReleasedPolicy(t *testing.T) {
 
 	require.NoError(t, downloadReleasedPolicy.SetRegoObjects())
 
-	result := getDownloadReleasedPolicy(ctx, downloadReleasedPolicy)
+	result, err := getDownloadReleasedPolicy(ctx, downloadReleasedPolicy)
 
+	require.NoError(t, err)
 	assert.NotNil(t, result)
+}
+
+// With a pinned --controls-version whose release does not exist, the download
+// fails and each getter must propagate a hard error (returning nil, err) rather
+// than logging Fatal and falling through with an empty getter. Fatal is a no-op
+// under --logger none, so only real error propagation halts the scan.
+func TestPinnedVersionGettersReturnHardError(t *testing.T) {
+	ctx := context.Background()
+	const pinnedVersion = "v0.0.0-does-not-exist"
+
+	newPinned := func() *getter.DownloadReleasedPolicy {
+		return getter.NewDownloadReleasedPolicyWithVersion(pinnedVersion)
+	}
+
+	t.Run("getPolicyGetter", func(t *testing.T) {
+		g, err := getPolicyGetter(ctx, nil, "", true, newPinned(), false)
+		require.Error(t, err)
+		require.Nil(t, g)
+	})
+
+	t.Run("getConfigInputsGetter", func(t *testing.T) {
+		g, err := getConfigInputsGetter(ctx, "", "", newPinned(), false, false)
+		require.Error(t, err)
+		require.Nil(t, g)
+	})
+
+	t.Run("getExceptionsGetter", func(t *testing.T) {
+		g, err := getExceptionsGetter(ctx, "", "", newPinned(), false)
+		require.Error(t, err)
+		require.Nil(t, g)
+	})
+
+	t.Run("getAttackTracksGetter", func(t *testing.T) {
+		g, err := getAttackTracksGetter(ctx, "", "", newPinned(), false)
+		require.Error(t, err)
+		require.Nil(t, g)
+	})
 }

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -95,7 +95,10 @@ func naturalSortControls(entries []metav1.ControlListEntry) []metav1.ControlList
 
 func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
-	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
+	policyGetter, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
+	if err != nil {
+		return nil, err
+	}
 
 	return listFrameworksNames(policyGetter), nil
 }
@@ -103,7 +106,10 @@ func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]metav1.ControlListEntry, error) {
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
 
-	policyGetter := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
+	policyGetter, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
+	if err != nil {
+		return nil, err
+	}
 	pipes, err := policyGetter.ListControls()
 	if err != nil {
 		return nil, err
@@ -153,7 +159,10 @@ func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi())
 
 	var exceptionsNames []string
-	ksCloudAPI := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	ksCloudAPI, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	if err != nil {
+		return exceptionsNames, err
+	}
 	exceptions, err := ksCloudAPI.GetExceptions("")
 	if err != nil {
 		return exceptionsNames, err

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -197,6 +197,13 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	}
 	interfaces.report.SetTenantConfig(interfaces.tenantConfig)
 
+	// remove host scanner components
+	defer func() {
+		if err := interfaces.hostSensorHandler.TearDown(); err != nil {
+			logger.L().Ctx(ks.Context()).StopError("Failed to tear down host scanner", helpers.Error(err))
+		}
+	}()
+
 	// Only create DownloadReleasedPolicy if not in air-gapped mode
 	airGapped := isAirGappedMode(scanInfo)
 	var downloadReleasedPolicy *getter.DownloadReleasedPolicy
@@ -234,13 +241,6 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	if scanInfo.ScanAll {
 		scanInfo.SetPolicyIdentifiers(listFrameworksNames(scanInfo.PolicyGetter), apisv1.KindFramework)
 	}
-
-	// remove host scanner components
-	defer func() {
-		if err := interfaces.hostSensorHandler.TearDown(); err != nil {
-			logger.L().Ctx(ks.Context()).StopError("Failed to tear down host scanner", helpers.Error(err))
-		}
-	}()
 
 	logger.L().StopSuccess("Initialized scanner")
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -221,7 +221,8 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 		spanInit.End()
 		return nil, err
 	}
-	scanInfo.ControlsInputsGetter, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
+	var controlInputsFromCache bool
+	scanInfo.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
@@ -253,6 +254,9 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	if err != nil {
 		spanInit.End()
 		return resultsHandling, err
+	}
+	if controlInputsFromCache {
+		scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: "failed to fetch from GitHub, loaded from local cache"})
 	}
 	spanPolicies.End()
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -209,10 +209,26 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	}
 
 	// set policy getter only after setting the customerGUID
-	scanInfo.PolicyGetter = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
-	scanInfo.ControlsInputsGetter = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
-	scanInfo.ExceptionsGetter = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
-	scanInfo.AttackTracksGetter = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	scanInfo.PolicyGetter, err = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
+	if err != nil {
+		spanInit.End()
+		return nil, err
+	}
+	scanInfo.ControlsInputsGetter, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
+	if err != nil {
+		spanInit.End()
+		return nil, err
+	}
+	scanInfo.ExceptionsGetter, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	if err != nil {
+		spanInit.End()
+		return nil, err
+	}
+	scanInfo.AttackTracksGetter, err = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	if err != nil {
+		spanInit.End()
+		return nil, err
+	}
 
 	// TODO - list supported frameworks/controls
 	if scanInfo.ScanAll {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -205,7 +205,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 		// don't initialize the downloader to prevent network access
 		downloadReleasedPolicy = nil
 	} else {
-		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy() // download config inputs from github release
+		downloadReleasedPolicy = getter.NewDownloadReleasedPolicyWithVersion(scanInfo.ControlsVersion) // download config inputs from github release
 	}
 
 	// set policy getter only after setting the customerGUID


### PR DESCRIPTION
## Overview

This is the fix for #2513.

The issue was that when GitHub is unreachable, `getConfigInputsGetter` returned the failed `downloadReleasedPolicy` whose store never loaded -- unlike exceptions and attack-tracks which both correctly fall back to `NewLoadPolicy([local file])`. The store's accessor `GetDefaultConfigInputs()` returns `(CustomerConfig{}, nil)` even when nothing loaded, so `getControlInputs()` returned `(nil, nil)` and `getPolicies()` took the success branch, logged "Loaded account configurations", and never recorded a `PolicyDegradation`. The entire degradation safety net added in `554dd66a` was bypassed.

Config-driven controls (`insecureCapabilities`, `untrustedRegistries`, `sensitiveKeyNames`, `max_critical_vulnerabilities`) then evaluated against empty lists -- genuinely misconfigured workloads scored PASS with `coverageScore: 100` and `degraded: false`.

The fix makes `getConfigInputsGetter` mirror the exceptions and attack-tracks fallback pattern -- return `getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalControlInputsFilename)})` on fallback, and record a `PolicyDegradation` so the degradation is visible in `ScanCoverage`. Added a nil check in `GetControlsInputs` as defense in depth so the unloaded-store state surfaces as an error if reached.

Now the two cases are actually distinct:

- GitHub reachable → control inputs downloaded and applied normally
- GitHub unreachable → bundled cache used, `PolicyDegradation` recorded, `coverageScore` reflects the gap

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes****

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--controls-version` option to pin scans to a specific Regolibrary release tag (validated to disallow `/`).
  * Added `ScanInfo.ControlsVersion` so the pinned release is reused during downloads.
* **Bug Fixes**
  * Pinned download failures now halt execution with a clear error; unpinned failures fall back to cached/local data (including improved error handling in listing and initialization).
  * Missing posture control inputs in downloaded configurations now returns an error.
  * When control inputs come from local cache due to GitHub fetch failure, scan results now reflect the degradation.
* **Tests**
  * Expanded coverage for pinning vs fallback and hard-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->