### PR TITLE
docs: fix stale KS_CACHE TODO in customerloader.go, point at existing --cache-dir/KS_CACHE_DIR support

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -183,8 +183,9 @@ KS_DEFAULT_CONFIGMAP_NAMESPACE   // configmap namespace, if not set default is '
 
 KS_ACCOUNT_ID
 
-TODO - support:
-KS_CACHE // path to cached files
+The cache directory (where this config file is stored, see ConfigFileFullPath) is
+configurable via the --cache-dir flag or the KS_CACHE_DIR environment variable; see
+initCacheDir in cmd/rootutils.go. It defaults to getter.DefaultLocalStore ($HOME/.kubescape).
 */
 var _ ITenantConfig = &ClusterConfig{}
 


### PR DESCRIPTION
## Overview

Fixes #2504.

The issue asks for the cache path to be configurable via an environment variable, pointing at `core/cautils/customerloader.go`, which has a stale comment:

```go
TODO - support:
KS_CACHE // path to cached files
```

This is already implemented, just under a different name and in a different file. `cmd/rootutils.go`'s `initCacheDir` already supports overriding the cache directory via the `--cache-dir` flag or the `KS_CACHE_DIR` environment variable (added in May), setting `getter.DefaultLocalStore`. The config file this comment documents (`ConfigFileFullPath`) is stored via `getter.GetDefaultPath`, which is `filepath.Join(DefaultLocalStore, name)` — the same variable `--cache-dir`/`KS_CACHE_DIR` already control. So the underlying feature exists; the TODO just never got removed, which is presumably what led to this being filed as still-missing.

## Change

Replaced the stale TODO with an accurate pointer to the existing `--cache-dir` / `KS_CACHE_DIR` mechanism and where it's implemented, so this doesn't mislead future readers (or issue filers) again.

No functional/behavior change.

## Testing

- `go build ./core/cautils/...` and `go vet ./core/cautils/...` clean.
- `go test ./core/cautils/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to configure the cached configuration directory.
  * Documented the available command-line and environment variable options, along with the default location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->