### PR TITLE
fix(imagescan): preserve matches on metadata lookup errors

### DIFF
--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -195,6 +195,7 @@ func filterMatchesBasedOnSeverity(severityExceptions []string, remainingMatches 
 	for m := range remainingMatches.Enumerate() {
 		metadata, err := vp.VulnerabilityMetadata(m.Vulnerability.Reference)
 		if err != nil {
+			filteredMatches.Add(m)
 			continue
 		}
 

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -541,9 +541,9 @@ func TestFilterMatchesBasedOnSeverity(t *testing.T) {
 		assert.ElementsMatch(t, []string{"CVE-high", "CVE-medium", "CVE-error"}, matchIDs(filtered))
 	})
 
-	t.Run("excluded severities are removed and metadata errors are skipped", func(t *testing.T) {
+	t.Run("metadata lookup errors preserve matches", func(t *testing.T) {
 		filtered := filterMatchesBasedOnSeverity([]string{"HIGH"}, remainingMatches, provider)
-		assert.ElementsMatch(t, []string{"CVE-medium"}, matchIDs(filtered))
+		assert.ElementsMatch(t, []string{"CVE-medium", "CVE-error"}, matchIDs(filtered))
 	})
 }
 


### PR DESCRIPTION
# Summary

Ensure that `filterMatchesBasedOnSeverity` does not silently discard vulnerability matches when metadata lookup fails.

At present, if `VulnerabilityMetadata()` returns an error, the corresponding match is skipped during severity filtering. This leads to a situation where a valid, already-detected vulnerability may disappear from the final results—not because it meets any exclusion criteria, but due to an internal metadata retrieval issue.

This change ensures that such matches are retained when metadata lookup fails, while continuing to apply the existing severity-based filtering logic when metadata is successfully available.

## Why

The purpose of `filterMatchesBasedOnSeverity` is to exclude vulnerabilities whose severity falls within a defined set of exceptions.

Currently, metadata lookup failures are handled as follows:

```go
metadata, err := vp.VulnerabilityMetadata(m.Vulnerability.Reference)
if err != nil {
    continue
}
```

This approach causes valid vulnerability matches to be omitted from the filtered results solely due to a metadata retrieval failure. Since this failure is unrelated to the severity-based exclusion logic, it should not result in the suppression of the vulnerability.

## Changes

* Retain vulnerability matches when `VulnerabilityMetadata()` returns an error, instead of skipping them.
* Update the associated unit test to confirm that metadata lookup failures no longer lead to dropped matches.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vulnerability findings are now retained when their metadata cannot be retrieved, ensuring potential issues are not inadvertently omitted from scan results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->