### PR TITLE
[Fix] : severity-based image exceptions in JSON, SARIF, and patch output -- use filtered Matches instead of RemainingMatches

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -29,7 +29,6 @@ type ImageScanData struct {
 	Image                 string
 	Matches               match.Matches
 	Packages              []pkg.Package
-	RemainingMatches      *match.Matches
 	SBOM                  *sbom.SBOM
 	VulnerabilityProvider vulnerability.Provider
 }

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -75,7 +75,7 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	}
 
 	model, err := models.NewDocument(clio.Identification{}, scanResults.Packages, scanResults.Context,
-		*scanResults.RemainingMatches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+		scanResults.Matches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to create document: %w", err)
 	}

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -74,6 +74,10 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 		return false, err
 	}
 
+	// svc.Scan is called above with no vulnerability/severity exceptions, so scanResults.Matches
+	// is currently the full unfiltered set copa patches against. If exceptions are ever wired into
+	// this flow, keep them out of scanResults.Matches here - the patch document must still see every
+	// CVE so copa can patch it, even ones excepted from the posture report.
 	model, err := models.NewDocument(clio.Identification{}, scanResults.Packages, scanResults.Context,
 		scanResults.Matches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 	if err != nil {

--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -73,6 +73,12 @@ func buildSeverityExceptionImageScanData() cautils.ImageScanData {
 
 	return cautils.ImageScanData{
 		Image: "test-image:latest",
+		IgnoredMatches: []match.IgnoredMatch{
+			{
+				Match:              makeSeverityRegressionMatch("CVE-EXCEPTED"),
+				AppliedIgnoreRules: []match.IgnoreRule{{Vulnerability: "CVE-EXCEPTED"}},
+			},
+		},
 		Packages: []grypepkg.Package{
 			{ID: grypepkg.ID("pkg-CVE-KEPT"), Name: "pkg-CVE-KEPT", Version: "1.0.0"},
 			{ID: grypepkg.ID("pkg-CVE-EXCEPTED"), Name: "pkg-CVE-EXCEPTED", Version: "1.0.0"},

--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -1,0 +1,150 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type severityRegressionVulnerabilityProvider struct {
+	metadataByID map[string]*vulnerability.Metadata
+}
+
+func (s severityRegressionVulnerabilityProvider) PackageSearchNames(grypepkg.Package) []string {
+	return nil
+}
+
+func (s severityRegressionVulnerabilityProvider) FindVulnerabilities(...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+
+func (s severityRegressionVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference) (*vulnerability.Metadata, error) {
+	if metadata, ok := s.metadataByID[ref.ID]; ok {
+		return metadata, nil
+	}
+	return nil, errors.New("metadata not found")
+}
+
+func (s severityRegressionVulnerabilityProvider) Close() error {
+	return nil
+}
+
+func makeSeverityRegressionMatch(id string) match.Match {
+	return match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{
+				ID:        id,
+				Namespace: "nvd",
+			},
+		},
+		Package: grypepkg.Package{
+			ID:      grypepkg.ID("pkg-" + id),
+			Name:    "pkg-" + id,
+			Version: "1.0.0",
+		},
+	}
+}
+
+// buildSeverityExceptionImageScanData builds an ImageScanData whose Matches
+// simulate a severity exception having filtered "CVE-EXCEPTED" out, leaving
+// only "CVE-KEPT". This mirrors what (*Service).Scan produces when
+// severityExceptions are configured.
+func buildSeverityExceptionImageScanData() cautils.ImageScanData {
+	keptMatch := makeSeverityRegressionMatch("CVE-KEPT")
+
+	filteredMatches := match.NewMatches(keptMatch)
+
+	provider := severityRegressionVulnerabilityProvider{
+		metadataByID: map[string]*vulnerability.Metadata{
+			"CVE-KEPT":     {ID: "CVE-KEPT", Severity: "High"},
+			"CVE-EXCEPTED": {ID: "CVE-EXCEPTED", Severity: "Low"},
+		},
+	}
+
+	return cautils.ImageScanData{
+		Image: "test-image:latest",
+		Packages: []grypepkg.Package{
+			{ID: grypepkg.ID("pkg-CVE-KEPT"), Name: "pkg-CVE-KEPT", Version: "1.0.0"},
+			{ID: grypepkg.ID("pkg-CVE-EXCEPTED"), Name: "pkg-CVE-EXCEPTED", Version: "1.0.0"},
+		},
+		Matches:               filteredMatches,
+		VulnerabilityProvider: provider,
+		SBOM:                  &sbom.SBOM{},
+	}
+}
+
+// TestJsonPrinter_ImageScan_HonorsSeverityExceptions is the regression test for
+// the severity-exceptions report bug: JSON output must reflect Matches (the
+// severity-filtered set), not RemainingMatches, or excepted CVEs still show up
+// in the report despite the scan correctly excluding them everywhere else.
+func TestJsonPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
+	imageScanData := buildSeverityExceptionImageScanData()
+
+	tmp, err := os.CreateTemp("", "json-severity-exception-*.json")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	jp := NewJsonPrinter()
+	jp.writer = tmp
+
+	jp.ActionPrint(context.Background(), nil, []cautils.ImageScanData{imageScanData})
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var doc struct {
+		Matches []struct {
+			Vulnerability struct {
+				ID string `json:"id"`
+			} `json:"vulnerability"`
+		} `json:"matches"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	var ids []string
+	for _, m := range doc.Matches {
+		ids = append(ids, m.Vulnerability.ID)
+	}
+
+	assert.Contains(t, ids, "CVE-KEPT")
+	assert.NotContains(t, ids, "CVE-EXCEPTED", "severity-excepted CVE must not appear in JSON report output")
+}
+
+// TestSARIFPrinter_ImageScan_HonorsSeverityExceptions is the SARIF counterpart
+// of TestJsonPrinter_ImageScan_HonorsSeverityExceptions: see that test for the
+// bug this guards against.
+func TestSARIFPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
+	imageScanData := buildSeverityExceptionImageScanData()
+
+	tmp, err := os.CreateTemp("", "sarif-severity-exception-*.sarif")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+
+	require.NoError(t, sp.printImageScan(context.Background(), imageScanData))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	content := string(raw)
+	assert.Contains(t, content, "CVE-KEPT")
+	assert.NotContains(t, content, "CVE-EXCEPTED", "severity-excepted CVE must not appear in SARIF report output")
+}

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -87,7 +87,7 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		err = printConfigurationsScanning(opaSessionObj, imageScanData, jp)
 	} else if imageScanData != nil {
 		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
-			*imageScanData[0].RemainingMatches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 		if err2 != nil {
 			logger.L().Ctx(ctx).Error("failed to create document: %w", helpers.Error(err))
 			return

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -89,7 +89,7 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
 			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 		if err2 != nil {
-			logger.L().Ctx(ctx).Error("failed to create document: %w", helpers.Error(err))
+			logger.L().Ctx(ctx).Error("failed to create document", helpers.Error(err2))
 			return
 		}
 		err = grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: imageScanData[0].SBOM}).Present(jp.writer)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -124,7 +124,7 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 
 func (sp *SARIFPrinter) printImageScan(ctx context.Context, scanResults cautils.ImageScanData) error {
 	model, err := models.NewDocument(clio.Identification{}, scanResults.Packages, scanResults.Context,
-		*scanResults.RemainingMatches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+		scanResults.Matches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 	if err != nil {
 		return fmt.Errorf("failed to create document: %w", err)
 	}

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -234,7 +234,6 @@ func (s *Service) Scan(_ context.Context, userInput string, creds RegistryCreden
 		Image:                 userInput,
 		Matches:               filteredMatches,
 		Packages:              packages,
-		RemainingMatches:      remainingMatches,
 		SBOM:                  sbom,
 		VulnerabilityProvider: s.vp,
 	}


### PR DESCRIPTION
## Overview

This is the fix for #2518 .

The issue was that `filterMatchesBasedOnSeverity` applies severity exceptions only to `ImageScanData.Matches`, while `ImageScanData.RemainingMatches` keeps the pre-severity-filter set. The exit-code gate and pretty table correctly read `Matches`, but the JSON, SARIF, and patch presenters all built their grype document from `*RemainingMatches` -- so severity-excepted CVEs still appeared as active findings in those outputs while the same scan correctly passed/excluded them everywhere else.

The fix changes the three presenters to build `models.NewDocument` from `scanResults.Matches` (the fully-filtered set) instead of `*scanResults.RemainingMatches`. `Matches` is a value type so the deref is also dropped. No behavior change when no severity exceptions are configured since `Matches` and `RemainingMatches` are identical in that case.

Files changed:
- `core/pkg/resultshandling/printer/v2/jsonprinter.go`
- `core/pkg/resultshandling/printer/v2/sarifprinter.go`
- `core/core/patch.go`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated patching, JSON, and SARIF report generation to use the active (severity-filtered) match results, ensuring severity exceptions are properly honored.
  * Prevented valid findings from being omitted due to using an outdated match set.
* **Tests**
  * Added regression tests confirming JSON and SARIF outputs include expected findings while excluding severity-exception findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->