### PR TITLE
rbac file todo to check api version is resolved

### DIFF
--- a/core/cautils/rbac.go
+++ b/core/cautils/rbac.go
@@ -84,7 +84,7 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 		if err != nil {
 			return nil, err
 		}
-		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1" // TODO - is the correct apiVersion?
+		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1"
 		crIMeta := workloadinterface.NewWorkloadObj(crmap)
 		crIMeta.SetKind("ClusterRole")
 		allresources[crIMeta.GetID()] = crIMeta
@@ -94,7 +94,7 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 		if err != nil {
 			return nil, err
 		}
-		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1" // TODO - is the correct apiVersion?
+		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1"
 		crIMeta := workloadinterface.NewWorkloadObj(crmap)
 		crIMeta.SetKind("Role")
 		allresources[crIMeta.GetID()] = crIMeta
@@ -104,7 +104,7 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 		if err != nil {
 			return nil, err
 		}
-		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1" // TODO - is the correct apiVersion?
+		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1"
 		crIMeta := workloadinterface.NewWorkloadObj(crmap)
 		crIMeta.SetKind("ClusterRoleBinding")
 		allresources[crIMeta.GetID()] = crIMeta
@@ -114,7 +114,7 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 		if err != nil {
 			return nil, err
 		}
-		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1" // TODO - is the correct apiVersion?
+		crmap["apiVersion"] = "rbac.authorization.k8s.io/v1"
 		crIMeta := workloadinterface.NewWorkloadObj(crmap)
 		crIMeta.SetKind("RoleBinding")
 		allresources[crIMeta.GetID()] = crIMeta

--- a/core/cautils/rbac_test.go
+++ b/core/cautils/rbac_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/rbac-utils/rbacscanner"
+	"github.com/kubescape/rbac-utils/rbacutils"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,6 +111,114 @@ func TestConvertToMap(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedName, got["metadata"].(map[string]any)["name"])
 			assert.Contains(t, got, "rules")
+		})
+	}
+}
+
+func TestRBACObjectsToResources(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *rbacutils.RbacObjects
+	}{
+		{
+			name: "all RBAC resource types",
+			obj: &rbacutils.RbacObjects{
+				ClusterRoles: &rbacv1.ClusterRoleList{
+					Items: []rbacv1.ClusterRole{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-cluster-role",
+							},
+						},
+					},
+				},
+				Roles: &rbacv1.RoleList{
+					Items: []rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-role",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+				ClusterRoleBindings: &rbacv1.ClusterRoleBindingList{
+					Items: []rbacv1.ClusterRoleBinding{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-cluster-role-binding",
+							},
+						},
+					},
+				},
+				RoleBindings: &rbacv1.RoleBindingList{
+					Items: []rbacv1.RoleBinding{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-role-binding",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+				SA2WLIDmap:   make(map[string][]string),
+				SAID2WLIDmap: make(map[string][]string),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rbacObjects := NewRBACObjects(&rbacscanner.RbacScannerFromK8sAPI{})
+			resources, err := rbacObjects.rbacObjectsToResources(tt.obj)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resources)
+
+			// Verify ClusterRole has correct apiVersion and kind
+			clusterRoleFound := false
+			for _, resource := range resources {
+				if resource.GetKind() == "ClusterRole" {
+					clusterRoleFound = true
+					// Access the underlying map to check apiVersion
+					obj := resource.GetObject()
+					assert.Equal(t, "rbac.authorization.k8s.io/v1", obj["apiVersion"])
+				}
+			}
+			assert.True(t, clusterRoleFound, "ClusterRole should be present in resources")
+
+			// Verify Role has correct apiVersion and kind
+			roleFound := false
+			for _, resource := range resources {
+				if resource.GetKind() == "Role" {
+					roleFound = true
+					obj := resource.GetObject()
+					assert.Equal(t, "rbac.authorization.k8s.io/v1", obj["apiVersion"])
+				}
+			}
+			assert.True(t, roleFound, "Role should be present in resources")
+
+			// Verify ClusterRoleBinding has correct apiVersion and kind
+			clusterRoleBindingFound := false
+			for _, resource := range resources {
+				if resource.GetKind() == "ClusterRoleBinding" {
+					clusterRoleBindingFound = true
+					obj := resource.GetObject()
+					assert.Equal(t, "rbac.authorization.k8s.io/v1", obj["apiVersion"])
+				}
+			}
+			assert.True(t, clusterRoleBindingFound, "ClusterRoleBinding should be present in resources")
+
+			// Verify RoleBinding has correct apiVersion and kind
+			roleBindingFound := false
+			for _, resource := range resources {
+				if resource.GetKind() == "RoleBinding" {
+					roleBindingFound = true
+					obj := resource.GetObject()
+					assert.Equal(t, "rbac.authorization.k8s.io/v1", obj["apiVersion"])
+				}
+			}
+			assert.True(t, roleBindingFound, "RoleBinding should be present in resources")
 		})
 	}
 }


### PR DESCRIPTION
## Discription 
In rbac file there is a todo command which is to check that version is correct 
Current Kubernetes Dependencies:

k8s.io/api v0.35.2 (corresponds to Kubernetes 1.35.x)
k8s.io/apimachinery v0.35.2
k8s.io/client-go v0.35.2
RBAC API Version History:

rbac.authorization.k8s.io/v1 was introduced in Kubernetes 1.8 (2017)
rbac.authorization.k8s.io/v1beta1 was deprecated in Kubernetes 1.17
rbac.authorization.k8s.io/v1beta1 was removed in Kubernetes 1.22
Conclusion: Since kubescape uses Kubernetes 1.35.x client libraries (far newer than 1.17+), rbac.authorization.k8s.io/v1 is definitively the correct and only supported API version for RBAC resources.
And also I have added test function in rbac_test file TestRBACObjectsToResources 

1. Creates mock RBAC objects (ClusterRole, Role, ClusterRoleBinding, RoleBinding)
2.Calls rbacObjectsToResources
3.Asserts that each resource has apiVersion set to rbac.authorization.k8s.io/v1
4.Asserts that the kind field is set correctly for each resource type

#2520 
<img width="709" height="137" alt="image" src="https://github.com/user-attachments/assets/927378d8-0ea4-43d9-ae41-99bb7013d813" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured RBAC resources consistently report the correct Kubernetes API version.

* **Tests**
  * Added coverage for ClusterRoles, Roles, ClusterRoleBindings, and RoleBindings to verify their resource kinds and API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->