### PR TITLE
core: cautils: surface config.json parse errors in loadConfigFromData

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -321,17 +321,34 @@ func (c *ClusterConfig) updateConfigEmptyFieldsFromCredentialsSecret() error {
 	return nil
 }
 
+// loadConfigFromData populates co from a ConfigMap data map.
+// The data map may contain:
+//   - A "config.json" key whose value is a JSON-encoded ConfigObj (written by older versions).
+//   - Individual flat keys (accountID, cloudAPIURL, etc.) that match ConfigObj's JSON field names.
+//
+// Both sources are applied: config.json is read first as a base, then individual
+// keys are overlaid on top, so flat-key values always take precedence.
+// If reading config.json fails (e.g. corrupted data), that error is returned
+// immediately without attempting the flat-key overlay.
 func loadConfigFromData(co *ConfigObj, data map[string]string) error {
-	var e error
 	if jsonConf, ok := data["config.json"]; ok {
-		e = readConfig([]byte(jsonConf), co)
-	}
-	if bData, err := json.Marshal(data); err == nil {
-		e = readConfig(bData, co)
+		if err := readConfig([]byte(jsonConf), co); err != nil {
+			return err
+		}
 	}
 
-	return e
+	// Apply individual flat keys on top of whatever config.json provided.
+	// json.Marshal on a map[string]string produces {"accountID":"...", ...}
+	// which json.Unmarshal maps directly onto ConfigObj's tagged fields.
+	if bData, err := json.Marshal(data); err == nil {
+		if err := readConfig(bData, co); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
+
 
 func existsConfigFile() bool {
 	_, err := os.ReadFile(ConfigFileFullPath())

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -171,6 +171,48 @@ func TestLoadConfigFromData(t *testing.T) {
 
 }
 
+// TestLoadConfigFromData_CorruptedConfigJsonReturnsError is a regression test for
+// the bug where a parse error from the "config.json" key was silently swallowed
+// when the subsequent flat-key marshal+unmarshal succeeded.
+// After the fix, a corrupt config.json must propagate as an error.
+func TestLoadConfigFromData_CorruptedConfigJsonReturnsError(t *testing.T) {
+	co := &ConfigObj{}
+	data := map[string]string{
+		"config.json": `{this is not valid JSON`,
+		"accountID":   "fallback-account",
+	}
+	err := loadConfigFromData(co, data)
+	require.Error(t, err, "expected an error for corrupted config.json, got nil")
+	// The config object must not have been partially populated with the fallback.
+	assert.Empty(t, co.AccountID, "AccountID should remain empty when config.json parse fails")
+}
+
+// TestLoadConfigFromData_FlatKeysTakePrecedenceOverConfigJson verifies that when
+// both "config.json" and individual flat keys exist in the data map, the flat keys
+// always win (they are applied second, on top of the config.json base).
+func TestLoadConfigFromData_FlatKeysTakePrecedenceOverConfigJson(t *testing.T) {
+	base := &ConfigObj{
+		AccountID:   "base-account",
+		CloudAPIURL: "https://base-api.example.com",
+	}
+	baseJSON, err := json.Marshal(base)
+	require.NoError(t, err)
+
+	data := map[string]string{
+		"config.json": string(baseJSON),
+		"accountID":   "override-account", // flat key should win
+	}
+
+	co := &ConfigObj{}
+	require.NoError(t, loadConfigFromData(co, data))
+
+	assert.Equal(t, "override-account", co.AccountID, "flat key accountID must override config.json value")
+	// Fields only in config.json (not overridden) should still be populated.
+	assert.Equal(t, "https://base-api.example.com", co.CloudAPIURL)
+}
+
+
+
 func TestAdoptClusterName(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- Fixes `loadConfigFromData` so a corrupt `config.json` ConfigMap value returns an error instead of being overwritten by a successful flat-key unmarshal
- Documents that flat keys are applied on top of `config.json` and take precedence
- Adds regression + precedence unit tests

## Test plan
- [x] `go test ./core/cautils/ -run TestLoadConfigFromData`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading to apply values in a predictable order.
  * Individual configuration fields now override corresponding values from `config.json`.
  * Invalid `config.json` files now return an error without applying fallback settings.
  * Preserved valid configuration values that are not overridden by individual fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->