### PR TITLE
feat: run CEL controls as part of the scan

### DIFF
--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -2,8 +2,19 @@ package cel
 
 import "context"
 
+// ControlEvaluation is the outcome of evaluating one control against one object.
+type ControlEvaluation struct {
+	// Applicable is false when the object's kind falls outside the policy's
+	// matchConstraints. Results is then nil: at admission the object would not
+	// be matched, so the scan must not treat it as evaluated (let alone passed).
+	Applicable bool
+	// Results holds one entry per validation, in order, when Applicable.
+	Results []ValidationResult
+}
+
 // EvaluateControl loads the ValidatingAdmissionPolicy for a control from the
-// embedded bundle, resolves its params, and evaluates it against one object.
+// embedded bundle, checks the object is in the policy's scope, resolves params,
+// and evaluates the validations against the object.
 //
 // It is the single entry point the scanner (package opaprocessor) dispatches
 // through: loadVAP and resolveParams are unexported, so the scan path cannot
@@ -16,15 +27,24 @@ import "context"
 //
 // A control the offline engine cannot honor with scan/admission parity (e.g.
 // one gated on matchConditions) is refused by loadVAP and surfaces here as an
-// error. The scanner maps that to a skipped status, never a silent pass.
-func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, namespaceObject map[string]any) ([]ValidationResult, error) {
+// error. The scanner maps that to a skipped status, never a silent pass. An
+// object outside the policy's matchConstraints returns Applicable=false rather
+// than an error, since it is a normal not-matched case, not a failure.
+func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, namespaceObject map[string]any) (ControlEvaluation, error) {
 	vap, err := loadVAP(controlID)
 	if err != nil {
-		return nil, err
+		return ControlEvaluation{}, err
+	}
+	if !vap.appliesTo(obj) {
+		return ControlEvaluation{Applicable: false}, nil
 	}
 	params, err := resolveParams(vap)
 	if err != nil {
-		return nil, err
+		return ControlEvaluation{}, err
 	}
-	return e.EvaluateOnObject(ctx, obj, namespaceObject, params, vap.Variables, vap.Validations)
+	results, err := e.EvaluateOnObject(ctx, obj, namespaceObject, params, vap.Variables, vap.Validations)
+	if err != nil {
+		return ControlEvaluation{}, err
+	}
+	return ControlEvaluation{Applicable: true, Results: results}, nil
 }

--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -1,0 +1,30 @@
+package cel
+
+import "context"
+
+// EvaluateControl loads the ValidatingAdmissionPolicy for a control from the
+// embedded bundle, resolves its params, and evaluates it against one object.
+//
+// It is the single entry point the scanner (package opaprocessor) dispatches
+// through: loadVAP and resolveParams are unexported, so the scan path cannot
+// assemble a control evaluation itself. controlID is threaded down from the
+// scanner (processControl), never read off the rule.
+//
+// namespaceObject is the object's Namespace (nil for cluster-scoped resources
+// or when the scan did not capture it). params come from the embedded bundle
+// via resolveParams, matching what a live binding's ParamRef would supply.
+//
+// A control the offline engine cannot honor with scan/admission parity (e.g.
+// one gated on matchConditions) is refused by loadVAP and surfaces here as an
+// error. The scanner maps that to a skipped status, never a silent pass.
+func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, namespaceObject map[string]any) ([]ValidationResult, error) {
+	vap, err := loadVAP(controlID)
+	if err != nil {
+		return nil, err
+	}
+	params, err := resolveParams(vap)
+	if err != nil {
+		return nil, err
+	}
+	return e.EvaluateOnObject(ctx, obj, namespaceObject, params, vap.Variables, vap.Validations)
+}

--- a/core/pkg/opaprocessor/cel/dispatch_test.go
+++ b/core/pkg/opaprocessor/cel/dispatch_test.go
@@ -49,12 +49,13 @@ func TestEvaluateControlLoadsAndEvaluatesFromBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("violating object fails the policy", func(t *testing.T) {
-		results, err := e.EvaluateControl(context.Background(), "C-0017", mutableFilesystemPod(), nil)
+		eval, err := e.EvaluateControl(context.Background(), "C-0017", mutableFilesystemPod(), nil)
 		require.NoError(t, err)
-		require.NotEmpty(t, results)
+		require.True(t, eval.Applicable)
+		require.NotEmpty(t, eval.Results)
 
 		violated := false
-		for _, res := range results {
+		for _, res := range eval.Results {
 			require.NoError(t, res.Err)
 			if !res.Passed {
 				violated = true
@@ -65,14 +66,30 @@ func TestEvaluateControlLoadsAndEvaluatesFromBundle(t *testing.T) {
 	})
 
 	t.Run("compliant object passes every validation", func(t *testing.T) {
-		results, err := e.EvaluateControl(context.Background(), "C-0017", readOnlyFilesystemPod(), nil)
+		eval, err := e.EvaluateControl(context.Background(), "C-0017", readOnlyFilesystemPod(), nil)
 		require.NoError(t, err)
-		require.NotEmpty(t, results)
+		require.True(t, eval.Applicable)
+		require.NotEmpty(t, eval.Results)
 
-		for _, res := range results {
+		for _, res := range eval.Results {
 			require.NoError(t, res.Err)
 			assert.True(t, res.Passed)
 		}
+	})
+
+	t.Run("object outside matchConstraints is not applicable", func(t *testing.T) {
+		// C-0017 constrains pods and workload kinds, not ConfigMaps. At admission
+		// a ConfigMap is never matched, so the scan must not evaluate it.
+		configMap := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm", "namespace": "default"},
+			"data":       map[string]any{"k": "v"},
+		}
+		eval, err := e.EvaluateControl(context.Background(), "C-0017", configMap, nil)
+		require.NoError(t, err)
+		assert.False(t, eval.Applicable, "a ConfigMap is outside C-0017's matchConstraints")
+		assert.Empty(t, eval.Results)
 	})
 }
 

--- a/core/pkg/opaprocessor/cel/dispatch_test.go
+++ b/core/pkg/opaprocessor/cel/dispatch_test.go
@@ -1,0 +1,89 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mutableFilesystemPod violates C-0017: a Pod whose container does not set
+// readOnlyRootFilesystem: true.
+func mutableFilesystemPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "mutable", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"name": "c", "image": "nginx"},
+			},
+		},
+	}
+}
+
+// readOnlyFilesystemPod satisfies C-0017.
+func readOnlyFilesystemPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "readonly", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name":            "c",
+					"image":           "nginx",
+					"securityContext": map[string]any{"readOnlyRootFilesystem": true},
+				},
+			},
+		},
+	}
+}
+
+// TestEvaluateControlLoadsAndEvaluatesFromBundle proves the facade wires the
+// loader to the evaluator: given only a control ID and an object, it loads the
+// control's policy from the embedded bundle and returns the right verdict.
+func TestEvaluateControlLoadsAndEvaluatesFromBundle(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	t.Run("violating object fails the policy", func(t *testing.T) {
+		results, err := e.EvaluateControl(context.Background(), "C-0017", mutableFilesystemPod(), nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		violated := false
+		for _, res := range results {
+			require.NoError(t, res.Err)
+			if !res.Passed {
+				violated = true
+				assert.NotEmpty(t, res.Message)
+			}
+		}
+		assert.True(t, violated, "a pod with a mutable root filesystem must violate C-0017")
+	})
+
+	t.Run("compliant object passes every validation", func(t *testing.T) {
+		results, err := e.EvaluateControl(context.Background(), "C-0017", readOnlyFilesystemPod(), nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		for _, res := range results {
+			require.NoError(t, res.Err)
+			assert.True(t, res.Passed)
+		}
+	})
+}
+
+// TestEvaluateControlUnknownControl proves a control absent from the bundle
+// surfaces the loader error rather than a verdict, so the scanner can map it to
+// a skipped status instead of a silent pass.
+func TestEvaluateControlUnknownControl(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	_, err = e.EvaluateControl(context.Background(), "C-9999", mutableFilesystemPod(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "C-9999")
+}

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -60,6 +60,13 @@ type VAP struct {
 
 	// paramKind mirrors spec.paramKind; nil when the policy declares no params.
 	paramKind *admissionregistrationv1.ParamKind
+
+	// matchConstraints mirrors spec.matchConstraints: the GVKs the policy
+	// applies to. Offline we use it to scope evaluation (see appliesTo), because
+	// the validations self-guard by object.kind and evaluate to true for a
+	// non-matching kind, which the scan would otherwise record as a pass live
+	// admission never made (the object would not be matched at all).
+	matchConstraints *admissionregistrationv1.MatchResources
 }
 
 // requireSupported reports whether the offline engine can honor this policy with
@@ -225,17 +232,18 @@ func indexUnique(index map[string]*VAP, duplicates map[string]struct{}, key stri
 // violation message the same way the apiserver does. matchConditions is carried
 // so loadVAP can refuse a gated policy (see requireSupported).
 //
-// spec.matchConstraints and spec.failurePolicy are intentionally dropped:
-// offline resource selection is the caller's job (and the bundle's validations
-// already self-guard by object.kind), and eval errors are always mapped to an
-// errored/skipped status regardless of failurePolicy, which is the parity-safe
-// direction.
+// spec.matchConstraints is kept so the scan can scope evaluation to the kinds
+// the policy actually applies to (see appliesTo); without it a non-matching
+// object slips through the validations' self-guards as a pass. spec.failurePolicy
+// is still dropped: eval errors are always mapped to an errored/skipped status
+// regardless of failurePolicy, which is the parity-safe direction.
 func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 	vap := &VAP{
-		ControlID:       policy.Labels[controlIDLabel],
-		PolicyName:      policy.Name,
-		matchConditions: policy.Spec.MatchConditions,
-		paramKind:       policy.Spec.ParamKind,
+		ControlID:        policy.Labels[controlIDLabel],
+		PolicyName:       policy.Name,
+		matchConditions:  policy.Spec.MatchConditions,
+		paramKind:        policy.Spec.ParamKind,
+		matchConstraints: policy.Spec.MatchConstraints,
 	}
 	for _, v := range policy.Spec.Variables {
 		vap.Variables = append(vap.Variables, Variable{Name: v.Name, Expression: v.Expression})

--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -1,0 +1,92 @@
+package cel
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// appliesTo reports whether an object of the given kind falls within the
+// policy's spec.matchConstraints. At live admission a non-matching object is
+// never handed to the policy, so the offline scan must not evaluate it either:
+// the validations self-guard by object.kind and evaluate to true for a
+// non-matching kind, which the scanner would otherwise record as a pass the
+// cluster never made (issue #2001).
+//
+// Matching is by resource rule (apiGroups/apiVersions/resources, honoring "*"
+// and excludeResourceRules). The label selectors and operations on
+// matchConstraints are not applied offline: the vendored bundle uses neither,
+// and ignoring them can only widen scope, which surfaces as an evaluated result
+// rather than a silently dropped one.
+func (v *VAP) appliesTo(obj map[string]any) bool {
+	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
+		return true // no scoping info: evaluate (a malformed-policy edge)
+	}
+	gvr, ok := objectGVR(obj)
+	if !ok {
+		return true // kind undeterminable; let evaluation proceed (it will error and skip)
+	}
+
+	included := false
+	for i := range v.matchConstraints.ResourceRules {
+		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], gvr) {
+			included = true
+			break
+		}
+	}
+	if !included {
+		return false
+	}
+	for i := range v.matchConstraints.ExcludeResourceRules {
+		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], gvr) {
+			return false
+		}
+	}
+	return true
+}
+
+// objectGVR guesses an object's GroupVersionResource from its apiVersion and
+// kind. Offline there is no discovery or RESTMapper, so we use apimachinery's
+// standard kind->resource guess (lower-case and pluralize), which is correct
+// for every kind the bundle's policies constrain.
+func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
+	apiVersion, _ := obj["apiVersion"].(string)
+	kind, _ := obj["kind"].(string)
+	if apiVersion == "" || kind == "" {
+		return schema.GroupVersionResource{}, false
+	}
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return schema.GroupVersionResource{}, false
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
+	return gvr, true
+}
+
+func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource) bool {
+	return matchesValue(rule.APIGroups, gvr.Group) &&
+		matchesValue(rule.APIVersions, gvr.Version) &&
+		matchesResource(rule.Resources, gvr.Resource)
+}
+
+// matchesValue reports whether want is listed, treating "*" as "any".
+func matchesValue(allowed []string, want string) bool {
+	for _, a := range allowed {
+		if a == "*" || a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesResource is matchesValue for resources, also accepting the "*/*"
+// subresource wildcard. A "resource/subresource" entry never matches a bare
+// resource, which is correct: the scan does not evaluate subresources.
+func matchesResource(allowed []string, want string) bool {
+	for _, a := range allowed {
+		if a == "*" || a == "*/*" || a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -102,36 +102,44 @@ func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
 			continue
 		}
 		for _, rr := range vap.matchConstraints.ResourceRules {
-			group := firstOr(rr.APIGroups, "")
-			if group == "*" {
-				group = ""
-			}
-			version := firstOr(rr.APIVersions, "v1")
-			if version == "*" {
-				version = "v1"
-			}
-			apiVersion := version
-			if group != "" {
-				apiVersion = group + "/" + version
-			}
-			for _, res := range rr.Resources {
-				if res == "*" || strings.Contains(res, "/") {
-					continue // wildcard or subresource: not a scanned top-level kind
+			// A resource rule is a cross-product: every apiGroup x apiVersion x
+			// resource it lists is in scope. Check all of them, so a rule that
+			// ever lists more than one group or version is fully covered rather
+			// than asserted on one arbitrary combination.
+			for _, group := range defaultIfEmpty(rr.APIGroups, "") {
+				if group == "*" {
+					group = ""
 				}
-				kind, ok := canonicalKinds[res]
-				require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
-				assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
-					"policy %q constrains %q but appliesTo rejects a %s %s; UnsafeGuessKindToResource likely mis-guessed the plural", name, res, apiVersion, kind)
+				for _, version := range defaultIfEmpty(rr.APIVersions, "v1") {
+					if version == "*" {
+						version = "v1"
+					}
+					apiVersion := version
+					if group != "" {
+						apiVersion = group + "/" + version
+					}
+					for _, res := range rr.Resources {
+						if res == "*" || strings.Contains(res, "/") {
+							continue // wildcard or subresource: not a scanned top-level kind
+						}
+						kind, ok := canonicalKinds[res]
+						require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
+						assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
+							"policy %q constrains %q but appliesTo rejects a %s %s; UnsafeGuessKindToResource likely mis-guessed the plural", name, res, apiVersion, kind)
+					}
+				}
 			}
 		}
 	}
 }
 
-func firstOr(xs []string, fallback string) string {
+// defaultIfEmpty keeps the loop above total: a rule that omits apiGroups or
+// apiVersions still yields one combination to assert on.
+func defaultIfEmpty(xs []string, fallback string) []string {
 	if len(xs) > 0 {
-		return xs[0]
+		return xs
 	}
-	return fallback
+	return []string{fallback}
 }
 
 func TestVAPAppliesToExcludeRules(t *testing.T) {

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -1,0 +1,78 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+func rule(groups, versions, resources []string) admissionregistrationv1.NamedRuleWithOperations {
+	return admissionregistrationv1.NamedRuleWithOperations{
+		RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+			Rule: admissionregistrationv1.Rule{
+				APIGroups:   groups,
+				APIVersions: versions,
+				Resources:   resources,
+			},
+		},
+	}
+}
+
+func vapWithConstraints(rules ...admissionregistrationv1.NamedRuleWithOperations) *VAP {
+	return &VAP{matchConstraints: &admissionregistrationv1.MatchResources{ResourceRules: rules}}
+}
+
+func obj(apiVersion, kind string) map[string]any {
+	return map[string]any{"apiVersion": apiVersion, "kind": kind, "metadata": map[string]any{"name": "x"}}
+}
+
+func TestVAPAppliesTo(t *testing.T) {
+	// A C-0017-shaped constraint: core pods + apps workloads + batch jobs.
+	pods := rule([]string{""}, []string{"v1"}, []string{"pods"})
+	workloads := rule([]string{"apps"}, []string{"v1"}, []string{"deployments", "replicasets", "daemonsets", "statefulsets"})
+	jobs := rule([]string{"batch"}, []string{"v1"}, []string{"jobs", "cronjobs"})
+	v := vapWithConstraints(pods, workloads, jobs)
+
+	cases := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		want       bool
+	}{
+		{"pod matches core/pods", "v1", "Pod", true},
+		{"deployment matches apps/deployments", "apps/v1", "Deployment", true},
+		{"cronjob matches batch/cronjobs", "batch/v1", "CronJob", true},
+		{"configmap is out of scope", "v1", "ConfigMap", false},
+		{"deployment in wrong group is out of scope", "v1", "Deployment", false},
+		{"pod in wrong version is out of scope", "v2", "Pod", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, v.appliesTo(obj(tc.apiVersion, tc.kind)))
+		})
+	}
+}
+
+func TestVAPAppliesToWildcards(t *testing.T) {
+	any := vapWithConstraints(rule([]string{"*"}, []string{"*"}, []string{"*"}))
+	assert.True(t, any.appliesTo(obj("v1", "Pod")))
+	assert.True(t, any.appliesTo(obj("apps/v1", "Deployment")))
+	assert.True(t, any.appliesTo(obj("networking.k8s.io/v1", "NetworkPolicy")))
+}
+
+func TestVAPAppliesToNoConstraintsEvaluates(t *testing.T) {
+	// Missing matchConstraints is a malformed-policy edge; fall back to
+	// evaluating rather than silently skipping everything.
+	v := &VAP{}
+	assert.True(t, v.appliesTo(obj("v1", "Pod")))
+}
+
+func TestVAPAppliesToExcludeRules(t *testing.T) {
+	v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+		ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{rule([]string{""}, []string{"v1"}, []string{"pods", "configmaps"})},
+		ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{rule([]string{""}, []string{"v1"}, []string{"configmaps"})},
+	}}
+	assert.True(t, v.appliesTo(obj("v1", "Pod")))
+	assert.False(t, v.appliesTo(obj("v1", "ConfigMap")), "excluded resource must not apply")
+}

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -1,9 +1,11 @@
 package cel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
@@ -66,6 +68,70 @@ func TestVAPAppliesToNoConstraintsEvaluates(t *testing.T) {
 	// evaluating rather than silently skipping everything.
 	v := &VAP{}
 	assert.True(t, v.appliesTo(obj("v1", "Pod")))
+}
+
+// canonicalKinds maps a matchConstraints resource to the Kind the scanner feeds
+// for it. The one silent-failure mode of appliesTo is UnsafeGuessKindToResource
+// mis-guessing a plural (irregular kind or a CRD), which would quietly drop a
+// resource the control should evaluate. This table is the ground truth the guess
+// is checked against.
+var canonicalKinds = map[string]string{
+	"pods":            "Pod",
+	"deployments":     "Deployment",
+	"replicasets":     "ReplicaSet",
+	"daemonsets":      "DaemonSet",
+	"statefulsets":    "StatefulSet",
+	"jobs":            "Job",
+	"cronjobs":        "CronJob",
+	"serviceaccounts": "ServiceAccount",
+	"services":        "Service",
+}
+
+// TestVAPAppliesToCoversEveryBundleKind walks every policy in the embedded bundle
+// and asserts appliesTo accepts an object of the Kind each constrained resource
+// stands for. It is driven by the bundle, so a `make sync-vap` that introduces a
+// policy for a new kind fails here (unknown resource -> add it to canonicalKinds)
+// rather than silently dropping that kind at scan time once the guess is wrong.
+func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+	require.NotEmpty(t, catalog.byName, "bundle parsed to no policies")
+
+	for name, vap := range catalog.byName {
+		if vap.matchConstraints == nil {
+			continue
+		}
+		for _, rr := range vap.matchConstraints.ResourceRules {
+			group := firstOr(rr.APIGroups, "")
+			if group == "*" {
+				group = ""
+			}
+			version := firstOr(rr.APIVersions, "v1")
+			if version == "*" {
+				version = "v1"
+			}
+			apiVersion := version
+			if group != "" {
+				apiVersion = group + "/" + version
+			}
+			for _, res := range rr.Resources {
+				if res == "*" || strings.Contains(res, "/") {
+					continue // wildcard or subresource: not a scanned top-level kind
+				}
+				kind, ok := canonicalKinds[res]
+				require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
+				assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
+					"policy %q constrains %q but appliesTo rejects a %s %s; UnsafeGuessKindToResource likely mis-guessed the plural", name, res, apiVersion, kind)
+			}
+		}
+	}
+}
+
+func firstOr(xs []string, fallback string) string {
+	if len(xs) > 0 {
+		return xs[0]
+	}
+	return fallback
 }
 
 func TestVAPAppliesToExcludeRules(t *testing.T) {

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -580,7 +580,14 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		}
 
 		if !eval.Applicable {
-			outcome.excluded[celResourceID(obj)] = struct{}{}
+			// Exclusions are silent in the results (the resource is out of scope,
+			// as at admission), but log one so a wrong GVR guess that quietly drops
+			// a resource the control should have seen stays diagnosable.
+			resID := celResourceID(obj)
+			logger.L().Debug("CEL control does not apply to resource, excluding it",
+				helpers.String("rule", rule.Name),
+				helpers.String("resource", resID))
+			outcome.excluded[resID] = struct{}{}
 			continue
 		}
 

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -292,12 +292,16 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 			opap.AllResources[inputResource.GetID()] = inputResource
 		}
 
-		ruleResponses, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData, controlID)
+		ruleResponses, celOut, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData, controlID)
 		if err != nil {
-			evalErrs = append(evalErrs, fmt.Errorf("rego eval failed for namespace %q: %w", i, err))
+			evalErrs = append(evalErrs, fmt.Errorf("eval failed for namespace %q: %w", i, err))
 			opap.markResourcesSkipped(resources, rule, ruleRegoDependenciesData, inputResources, err)
 			continue
 		}
+
+		// Seed the CEL rule's unknown-verdict resources as skipped so the
+		// pass-inference below preserves them. celOut is empty for the Rego path.
+		opap.seedCELSkips(resources, rule, ruleRegoDependenciesData, celOut.skipped)
 
 		// Build the set of failed IDs so we can correctly mark the remainder as passed.
 		// Resources are only written to the result map after a successful OPA evaluation,
@@ -328,6 +332,9 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 			id := inputResource.GetID()
 			if _, failed := failedIDs[id]; failed {
 				continue
+			}
+			if _, excluded := celOut.excluded[id]; excluded {
+				continue // outside the CEL policy's scope: not evaluated, so not a pass
 			}
 			if existing, ok := resources[id]; ok && (existing.Status == apis.StatusFailed || existing.Status == apis.StatusSkipped) {
 				continue
@@ -499,15 +506,35 @@ func appendPaths(paths []armotypes.PosturePaths, assistedRemediation reporthandl
 	return paths
 }
 
-func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData, controlID string) ([]reporthandling.RuleResponse, error) {
+func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData, controlID string) ([]reporthandling.RuleResponse, celOutcome, error) {
 	switch rule.RuleLanguage {
 	case reporthandling.RegoLanguage, reporthandling.RegoLanguage2:
-		return opap.runRegoOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
+		responses, err := opap.runRegoOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
+		return responses, celOutcome{}, err
 	case reporthandling.CELLanguage:
 		return opap.runCELOnK8s(ctx, rule, k8sObjects, getRuleData, controlID)
 	default:
-		return nil, fmt.Errorf("rule: '%s', language '%v' not supported", rule.Name, rule.RuleLanguage)
+		return nil, celOutcome{}, fmt.Errorf("rule: '%s', language '%v' not supported", rule.Name, rule.RuleLanguage)
 	}
+}
+
+// celOutcome carries the per-resource results of a CEL rule that are not
+// violations: resources whose verdict is unknown (skipped) and resources the
+// policy does not cover (excluded). processRule applies these so neither kind is
+// misreported as passed. The Rego path returns a zero celOutcome.
+type celOutcome struct {
+	// skipped holds resources with an unknown verdict (a validation errored on
+	// them): they must land as StatusSkipped, not passed.
+	skipped []skippedCELResource
+	// excluded holds the IDs of resources outside the policy's matchConstraints:
+	// admission would never match them, so they must not appear in the rule's
+	// results at all.
+	excluded map[string]struct{}
+}
+
+type skippedCELResource struct {
+	obj map[string]any
+	err error
 }
 
 // runCELOnK8s evaluates a CEL-based PolicyRule against k8s objects by loading
@@ -518,38 +545,49 @@ func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reportha
 // getRuleData is part of the shared dispatch signature but unused here: CEL
 // expressions come from the loaded VAP, not from the rule's Rego text.
 //
-// Only violations produce a RuleResponse, matching the Rego path (processRule
-// infers the passing resources as the input minus the failed ones). An eval
-// error is neither a pass nor a violation; as with a Rego eval error we return
-// it so the whole rule is marked skipped, rather than let an unknown verdict
-// masquerade as a pass. A definite violation still reports as a failure, but if
-// any resource's verdict is unknown the rule-level skip supersedes the batch,
-// which is the parity-safe direction.
-func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, _ func(*reporthandling.PolicyRule) string, controlID string) ([]reporthandling.RuleResponse, error) {
+// Verdicts map to the Rego path's shape (processRule infers the passing
+// resources as the input minus everything else), but per resource rather than
+// per batch, so one odd object cannot bury the rest:
+//   - a violation produces a RuleResponse (a failure);
+//   - an object outside the policy's matchConstraints is excluded, matching
+//     admission where it is never matched;
+//   - an object with no violation but an eval error has an unknown verdict and
+//     is skipped, never inferred as a pass;
+//   - anything else passes (no entry; processRule infers it).
+//
+// A control-wide failure (the evaluator or policy will not load) is the only
+// rule-level error: every object hits it identically, so the whole rule is
+// skipped, the same path a Rego eval error takes.
+func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, _ func(*reporthandling.PolicyRule) string, controlID string) ([]reporthandling.RuleResponse, celOutcome, error) {
 	evaluator, err := opap.getCELEvaluator()
 	if err != nil {
-		return nil, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+		return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 	}
 
 	var responses []reporthandling.RuleResponse
-	var evalErrs []error
+	outcome := celOutcome{excluded: make(map[string]struct{})}
 	for _, obj := range k8sObjects {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, celOutcome{}, err
 		}
 
 		// namespaceObject is not resolved yet: policies referencing it eval-error
 		// and their resources are skipped (parity-safe), never passed. Wiring the
 		// real namespace object is a follow-up.
-		results, err := evaluator.EvaluateControl(ctx, controlID, obj, nil)
+		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, nil)
 		if err != nil {
-			return nil, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+		}
+
+		if !eval.Applicable {
+			outcome.excluded[celResourceID(obj)] = struct{}{}
+			continue
 		}
 
 		violated := false
 		var messages []string
 		var objErrs []error
-		for _, res := range results {
+		for _, res := range eval.Results {
 			if res.Err != nil {
 				objErrs = append(objErrs, res.Err)
 				continue
@@ -563,15 +601,54 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		switch {
 		case violated:
 			responses = append(responses, celRuleResponse(rule, obj, messages))
+			// A confirmed violation wins over a sibling validation that errored,
+			// matching admission (a deny stands). Surface the dropped errors so a
+			// broken validation in an otherwise-failing policy is not invisible.
+			if len(objErrs) > 0 {
+				logger.L().Debug("CEL validation error on an already-violating resource",
+					helpers.String("rule", rule.Name),
+					helpers.String("resource", celResourceID(obj)),
+					helpers.Error(errors.Join(objErrs...)))
+			}
 		case len(objErrs) > 0:
-			evalErrs = append(evalErrs, fmt.Errorf("resource %s: %w", celResourceID(obj), errors.Join(objErrs...)))
+			outcome.skipped = append(outcome.skipped, skippedCELResource{obj: obj, err: errors.Join(objErrs...)})
 		}
 	}
 
-	if len(evalErrs) > 0 {
-		return nil, errors.Join(evalErrs...)
+	return responses, outcome, nil
+}
+
+// seedCELSkips records the CEL rule's unknown-verdict resources as StatusSkipped
+// (with their eval error in InfoMap) before pass-inference, so they are not
+// later mistaken for passes. It mirrors markResourcesSkipped but per resource,
+// each with its own error, and never downgrades a confirmed failure.
+func (opap *OPAProcessor) seedCELSkips(out map[string]*resourcesresults.ResourceAssociatedRule, rule *reporthandling.PolicyRule, deps resources.RegoDependenciesData, skipped []skippedCELResource) {
+	for _, s := range skipped {
+		meta := objectsenvelopes.NewObject(s.obj)
+		if meta == nil {
+			continue
+		}
+		if opap.skipNamespace(meta.GetNamespace()) {
+			continue
+		}
+		id := meta.GetID()
+		if existing, ok := out[id]; ok && existing.Status == apis.StatusFailed {
+			continue
+		}
+		out[id] = &resourcesresults.ResourceAssociatedRule{
+			Name:                  rule.Name,
+			ControlConfigurations: deps.PostureControlInputs,
+			Status:                apis.StatusSkipped,
+			SubStatus:             apis.SubStatusUnknown,
+		}
+		if opap.InfoMap != nil {
+			opap.InfoMap[id] = apis.StatusInfo{
+				InnerInfo:   s.err.Error(),
+				InnerStatus: apis.StatusSkipped,
+				SubStatus:   apis.SubStatusUnknown,
+			}
+		}
 	}
-	return responses, nil
 }
 
 // getCELEvaluator lazily builds the CEL evaluator shared across the whole scan
@@ -666,18 +743,22 @@ func (opap *OPAProcessor) regoEval(ctx context.Context, inputObj []map[string]an
 	return results, nil
 }
 
-// enumerateData resolves a rule's ResourceEnumerator. A CEL rule carries no
-// enumerator (it scopes via the VAP's matchConstraints), so the empty-enumerator
-// short-circuit returns its objects untouched and the enumerator path below is
-// only ever the Rego path. controlID is threaded through for signature
-// uniformity; it is unused on the Rego enumerator path.
+// enumerateData resolves a rule's ResourceEnumerator. A CEL rule must not carry
+// one (it scopes via the VAP's matchConstraints); the guard below enforces that
+// rather than trusting it, because routing a CEL rule through the enumerator
+// would run its validations as the enumerator and silently drop every compliant
+// resource. So the enumerator path here is provably the Rego path, and controlID
+// is unused on it.
 func (opap *OPAProcessor) enumerateData(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, controlID string) ([]map[string]any, error) {
 	if ruleEnumeratorData(rule) == "" {
 		return k8sObjects, nil
 	}
+	if rule.RuleLanguage == reporthandling.CELLanguage {
+		return nil, fmt.Errorf("rule: '%s', CEL rules must not declare a ResourceEnumerator; they scope via the policy's matchConstraints", rule.Name)
+	}
 
 	ruleRegoDependenciesData := opap.makeRegoDeps(rule.ControlConfigInputs, nil)
-	ruleResponse, err := opap.runOPAOnSingleRule(ctx, rule, k8sObjects, ruleEnumeratorData, ruleRegoDependenciesData, controlID)
+	ruleResponse, _, err := opap.runOPAOnSingleRule(ctx, rule, k8sObjects, ruleEnumeratorData, ruleRegoDependenciesData, controlID)
 	if err != nil {
 		return nil, err
 	}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor/cel"
 	"github.com/kubescape/kubescape/v3/core/pkg/score"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -59,6 +60,13 @@ type OPAProcessor struct {
 	// TimedOutControls maps controlID to the reason its evaluation was
 	// aborted after exceeding ControlTimeout.
 	TimedOutControls map[string]string
+	// celEvaluator is the CEL engine shared across the whole scan, built once
+	// via celEvaluatorOnce. One evaluator (and its compiled-program cache) is
+	// reused for every control and object because building the CEL env is far
+	// more expensive than evaluating with it.
+	celEvaluator     *cel.Evaluator
+	celEvaluatorOnce sync.Once
+	celEvaluatorErr  error
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -206,7 +214,7 @@ func (opap *OPAProcessor) processControl(ctx context.Context, control *reporthan
 			ruleErrs = append(ruleErrs, err)
 			break
 		}
-		resourceAssociatedRule, err := opap.processRule(ctx, &control.Rules[i], control.FixedInput)
+		resourceAssociatedRule, err := opap.processRule(ctx, &control.Rules[i], control.FixedInput, control.ControlID)
 		if err != nil {
 			ruleErrs = append(ruleErrs, fmt.Errorf("rule %q: %w", control.Rules[i].Name, err))
 		}
@@ -239,7 +247,7 @@ func (opap *OPAProcessor) processControl(ctx context.Context, control *reporthan
 //
 // NOTE: processRule no longer mutates the state of the current OPAProcessor instance,
 // and returns a map instead, to be merged by the caller.
-func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.PolicyRule, fixedControlInputs map[string][]string) (map[string]*resourcesresults.ResourceAssociatedRule, error) {
+func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.PolicyRule, fixedControlInputs map[string][]string, controlID string) (map[string]*resourcesresults.ResourceAssociatedRule, error) {
 	resources := make(map[string]*resourcesresults.ResourceAssociatedRule)
 
 	ruleRegoDependenciesData := opap.makeRegoDeps(rule.ControlConfigInputs, fixedControlInputs)
@@ -268,7 +276,7 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 		inputRawResources := workloadinterface.ListMetaToMap(inputResources)
 
 		// the failed resources are a subgroup of the enumeratedData, so we store the enumeratedData like it was the input data
-		enumeratedData, err := opap.enumerateData(ctx, rule, inputRawResources)
+		enumeratedData, err := opap.enumerateData(ctx, rule, inputRawResources, controlID)
 		if err != nil {
 			evalErrs = append(evalErrs, fmt.Errorf("enumerator failed for namespace %q: %w", i, err))
 			opap.markResourcesSkipped(resources, rule, ruleRegoDependenciesData, inputResources, err)
@@ -284,7 +292,7 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 			opap.AllResources[inputResource.GetID()] = inputResource
 		}
 
-		ruleResponses, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData)
+		ruleResponses, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData, controlID)
 		if err != nil {
 			evalErrs = append(evalErrs, fmt.Errorf("rego eval failed for namespace %q: %w", i, err))
 			opap.markResourcesSkipped(resources, rule, ruleRegoDependenciesData, inputResources, err)
@@ -491,21 +499,114 @@ func appendPaths(paths []armotypes.PosturePaths, assistedRemediation reporthandl
 	return paths
 }
 
-func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData) ([]reporthandling.RuleResponse, error) {
+func (opap *OPAProcessor) runOPAOnSingleRule(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData, controlID string) ([]reporthandling.RuleResponse, error) {
 	switch rule.RuleLanguage {
 	case reporthandling.RegoLanguage, reporthandling.RegoLanguage2:
 		return opap.runRegoOnK8s(ctx, rule, k8sObjects, getRuleData, ruleRegoDependenciesData)
 	case reporthandling.CELLanguage:
-		return opap.runCELOnK8s(ctx, rule, k8sObjects, getRuleData)
+		return opap.runCELOnK8s(ctx, rule, k8sObjects, getRuleData, controlID)
 	default:
 		return nil, fmt.Errorf("rule: '%s', language '%v' not supported", rule.Name, rule.RuleLanguage)
 	}
 }
 
-// runCELOnK8s evaluates a CEL-based PolicyRule against k8s objects.
-// Stub: the CEL evaluator is added in follow-up PRs (kubescape/kubescape#2001).
-func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string) ([]reporthandling.RuleResponse, error) {
-	return nil, fmt.Errorf("rule: '%s', CEL evaluation not yet implemented", rule.Name)
+// runCELOnK8s evaluates a CEL-based PolicyRule against k8s objects by loading
+// the control's ValidatingAdmissionPolicy from the embedded bundle and running
+// its validations. controlID is threaded down from processControl (not read off
+// the rule) and selects which policy to load.
+//
+// getRuleData is part of the shared dispatch signature but unused here: CEL
+// expressions come from the loaded VAP, not from the rule's Rego text.
+//
+// Only violations produce a RuleResponse, matching the Rego path (processRule
+// infers the passing resources as the input minus the failed ones). An eval
+// error is neither a pass nor a violation; as with a Rego eval error we return
+// it so the whole rule is marked skipped, rather than let an unknown verdict
+// masquerade as a pass. A definite violation still reports as a failure, but if
+// any resource's verdict is unknown the rule-level skip supersedes the batch,
+// which is the parity-safe direction.
+func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, _ func(*reporthandling.PolicyRule) string, controlID string) ([]reporthandling.RuleResponse, error) {
+	evaluator, err := opap.getCELEvaluator()
+	if err != nil {
+		return nil, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+	}
+
+	var responses []reporthandling.RuleResponse
+	var evalErrs []error
+	for _, obj := range k8sObjects {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// namespaceObject is not resolved yet: policies referencing it eval-error
+		// and their resources are skipped (parity-safe), never passed. Wiring the
+		// real namespace object is a follow-up.
+		results, err := evaluator.EvaluateControl(ctx, controlID, obj, nil)
+		if err != nil {
+			return nil, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+		}
+
+		violated := false
+		var messages []string
+		var objErrs []error
+		for _, res := range results {
+			if res.Err != nil {
+				objErrs = append(objErrs, res.Err)
+				continue
+			}
+			if !res.Passed {
+				violated = true
+				messages = append(messages, res.Message)
+			}
+		}
+
+		switch {
+		case violated:
+			responses = append(responses, celRuleResponse(rule, obj, messages))
+		case len(objErrs) > 0:
+			evalErrs = append(evalErrs, fmt.Errorf("resource %s: %w", celResourceID(obj), errors.Join(objErrs...)))
+		}
+	}
+
+	if len(evalErrs) > 0 {
+		return nil, errors.Join(evalErrs...)
+	}
+	return responses, nil
+}
+
+// getCELEvaluator lazily builds the CEL evaluator shared across the whole scan
+// (see the celEvaluator field).
+func (opap *OPAProcessor) getCELEvaluator() (*cel.Evaluator, error) {
+	opap.celEvaluatorOnce.Do(func() {
+		opap.celEvaluator, opap.celEvaluatorErr = cel.NewEvaluator()
+	})
+	return opap.celEvaluator, opap.celEvaluatorErr
+}
+
+// celRuleResponse builds the RuleResponse for one object that violated a CEL
+// policy, shaped like the Rego path's failure responses so downstream result
+// handling (processRule) treats CEL and Rego violations identically: a
+// RuleResponse with no Exception is a failure (opa-utils RuleResponse.Failed),
+// and GetFailedResources reads the object back out of AlertObject.K8SApiObjects.
+func celRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, messages []string) reporthandling.RuleResponse {
+	return reporthandling.RuleResponse{
+		AlertMessage: strings.Join(messages, "; "),
+		RuleStatus:   reporthandling.StatusFailed,
+		PackageName:  rule.Name,
+		Rulename:     rule.Name,
+		AlertObject: reporthandling.AlertObject{
+			K8SApiObjects: []map[string]any{obj},
+		},
+	}
+}
+
+// celResourceID labels an object in an eval-error message; it falls back to a
+// placeholder when the object is not a recognizable envelope.
+func celResourceID(obj map[string]any) string {
+	if meta := objectsenvelopes.NewObject(obj); meta != nil {
+		return meta.GetID()
+	}
+	return "<unknown>"
 }
 
 // runRegoOnK8s compiles an OPA PolicyRule and evaluates its against k8s
@@ -565,13 +666,18 @@ func (opap *OPAProcessor) regoEval(ctx context.Context, inputObj []map[string]an
 	return results, nil
 }
 
-func (opap *OPAProcessor) enumerateData(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any) ([]map[string]any, error) {
+// enumerateData resolves a rule's ResourceEnumerator. A CEL rule carries no
+// enumerator (it scopes via the VAP's matchConstraints), so the empty-enumerator
+// short-circuit returns its objects untouched and the enumerator path below is
+// only ever the Rego path. controlID is threaded through for signature
+// uniformity; it is unused on the Rego enumerator path.
+func (opap *OPAProcessor) enumerateData(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, controlID string) ([]map[string]any, error) {
 	if ruleEnumeratorData(rule) == "" {
 		return k8sObjects, nil
 	}
 
 	ruleRegoDependenciesData := opap.makeRegoDeps(rule.ControlConfigInputs, nil)
-	ruleResponse, err := opap.runOPAOnSingleRule(ctx, rule, k8sObjects, ruleEnumeratorData, ruleRegoDependenciesData)
+	ruleResponse, err := opap.runOPAOnSingleRule(ctx, rule, k8sObjects, ruleEnumeratorData, ruleRegoDependenciesData, controlID)
 	if err != nil {
 		return nil, err
 	}

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -90,7 +90,7 @@ deny[msga] {
 	}
 	rule.Name = "cluster-role-path-accumulation"
 
-	got, err := opap.processRule(context.Background(), rule, nil)
+	got, err := opap.processRule(context.Background(), rule, nil, "")
 	assert.NoError(t, err)
 
 	crResult, ok := got[clusterRole.GetID()]

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -438,7 +439,7 @@ func TestProcessRule(t *testing.T) {
 		// since all resources JSON is a large file, we need to unzip it and set the variable before running the benchmark
 		unzipAllResourcesTestDataAndSetVar("testdata/allResourcesMock.json.zip", "testdata/allResourcesMock.json")
 		opap := NewOPAProcessorMock(tc.opaSessionObjMock, tc.resourcesMock)
-		resources, err := opap.processRule(context.Background(), &tc.rule, nil)
+		resources, err := opap.processRule(context.Background(), &tc.rule, nil, "")
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedResult, resources, t.Name)
 	}
@@ -647,15 +648,26 @@ func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
 	opap := &OPAProcessor{}
 	getRuleData := func(r *reporthandling.PolicyRule) string { return r.Rule }
 
-	t.Run("CEL language routes to runCELOnK8s stub", func(t *testing.T) {
+	t.Run("CEL language routes to runCELOnK8s and loads by control ID", func(t *testing.T) {
 		rule := &reporthandling.PolicyRule{
 			PortalBase:   armotypes.PortalBase{Name: "cel-test-rule"},
 			RuleLanguage: reporthandling.CELLanguage,
 		}
-		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "CEL evaluation not yet implemented")
+		// A control absent from the embedded bundle must surface the loader's
+		// lookup error, which proves dispatch went through the CEL path and the
+		// exported facade rather than the Rego path. An object is required
+		// because runCELOnK8s only loads the policy once it has a resource to
+		// evaluate.
+		obj := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata":   map[string]any{"name": "p", "namespace": "default"},
+			"spec":       map[string]any{},
+		}
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, []map[string]any{obj}, getRuleData, resources.RegoDependenciesData{}, "C-9999")
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cel-test-rule")
+		assert.Contains(t, err.Error(), "C-9999")
 	})
 
 	t.Run("unknown language returns not-supported error", func(t *testing.T) {
@@ -663,9 +675,79 @@ func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
 			PortalBase:   armotypes.PortalBase{Name: "mystery-rule"},
 			RuleLanguage: reporthandling.RuleLanguages("Mystery"),
 		}
-		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{})
+		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{}, "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not supported")
 		assert.Contains(t, err.Error(), "mystery-rule")
+	})
+}
+
+func TestRunCELOnK8s(t *testing.T) {
+	opap := &OPAProcessor{}
+	rule := &reporthandling.PolicyRule{
+		PortalBase:   armotypes.PortalBase{Name: "cel-c-0017"},
+		RuleLanguage: reporthandling.CELLanguage,
+	}
+
+	// C-0017 flags containers without a read-only root filesystem.
+	violatingPod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "mutable", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	}
+	compliantPod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "readonly", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{
+				"name":            "c",
+				"image":           "nginx",
+				"securityContext": map[string]any{"readOnlyRootFilesystem": true},
+			}},
+		},
+	}
+
+	t.Run("violation produces a failure response carrying the object", func(t *testing.T) {
+		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-0017")
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+
+		assert.Equal(t, rule.Name, responses[0].Rulename)
+		assert.NotEmpty(t, responses[0].AlertMessage)
+		failed := responses[0].GetFailedResources()
+		require.Len(t, failed, 1)
+		assert.Equal(t, "mutable", failed[0]["metadata"].(map[string]any)["name"])
+	})
+
+	t.Run("compliant object produces no response", func(t *testing.T) {
+		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{compliantPod}, nil, "C-0017")
+		require.NoError(t, err)
+		assert.Empty(t, responses)
+	})
+
+	t.Run("only the violating object is reported in a mixed batch", func(t *testing.T) {
+		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{compliantPod, violatingPod}, nil, "C-0017")
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+		failed := responses[0].GetFailedResources()
+		require.Len(t, failed, 1)
+		assert.Equal(t, "mutable", failed[0]["metadata"].(map[string]any)["name"])
+	})
+
+	t.Run("unknown control skips the rule via an error", func(t *testing.T) {
+		_, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-9999")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cel-c-0017")
+		assert.Contains(t, err.Error(), "C-9999")
+	})
+
+	t.Run("empty batch is a clean no-op", func(t *testing.T) {
+		responses, err := opap.runCELOnK8s(context.Background(), rule, nil, nil, "C-0017")
+		require.NoError(t, err)
+		assert.Empty(t, responses)
 	})
 }

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -664,7 +665,7 @@ func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
 			"metadata":   map[string]any{"name": "p", "namespace": "default"},
 			"spec":       map[string]any{},
 		}
-		_, err := opap.runOPAOnSingleRule(context.Background(), rule, []map[string]any{obj}, getRuleData, resources.RegoDependenciesData{}, "C-9999")
+		_, _, err := opap.runOPAOnSingleRule(context.Background(), rule, []map[string]any{obj}, getRuleData, resources.RegoDependenciesData{}, "C-9999")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cel-test-rule")
 		assert.Contains(t, err.Error(), "C-9999")
@@ -675,7 +676,7 @@ func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
 			PortalBase:   armotypes.PortalBase{Name: "mystery-rule"},
 			RuleLanguage: reporthandling.RuleLanguages("Mystery"),
 		}
-		_, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{}, "")
+		_, _, err := opap.runOPAOnSingleRule(context.Background(), rule, nil, getRuleData, resources.RegoDependenciesData{}, "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not supported")
 		assert.Contains(t, err.Error(), "mystery-rule")
@@ -711,10 +712,27 @@ func TestRunCELOnK8s(t *testing.T) {
 		},
 	}
 
+	// brokenPod has no spec, so object.spec.containers errors at eval time: its
+	// verdict is unknown.
+	brokenPod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "broken", "namespace": "default"},
+	}
+	// configMap is outside C-0017's matchConstraints.
+	configMap := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "cm", "namespace": "default"},
+		"data":       map[string]any{"k": "v"},
+	}
+
 	t.Run("violation produces a failure response carrying the object", func(t *testing.T) {
-		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-0017")
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-0017")
 		require.NoError(t, err)
 		require.Len(t, responses, 1)
+		assert.Empty(t, outcome.skipped)
+		assert.Empty(t, outcome.excluded)
 
 		assert.Equal(t, rule.Name, responses[0].Rulename)
 		assert.NotEmpty(t, responses[0].AlertMessage)
@@ -723,31 +741,53 @@ func TestRunCELOnK8s(t *testing.T) {
 		assert.Equal(t, "mutable", failed[0]["metadata"].(map[string]any)["name"])
 	})
 
-	t.Run("compliant object produces no response", func(t *testing.T) {
-		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{compliantPod}, nil, "C-0017")
+	t.Run("compliant object produces no response and no skip", func(t *testing.T) {
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{compliantPod}, nil, "C-0017")
 		require.NoError(t, err)
 		assert.Empty(t, responses)
+		assert.Empty(t, outcome.skipped)
+		assert.Empty(t, outcome.excluded)
 	})
 
-	t.Run("only the violating object is reported in a mixed batch", func(t *testing.T) {
-		responses, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{compliantPod, violatingPod}, nil, "C-0017")
+	// Blocker 1: a single object whose expression errors must NOT bury a
+	// confirmed violation on another object in the same batch.
+	t.Run("a broken object does not erase a sibling violation", func(t *testing.T) {
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod, brokenPod}, nil, "C-0017")
+		require.NoError(t, err, "an eval error on one object must not fail the whole rule")
+		require.Len(t, responses, 1, "the confirmed violation must survive")
+		assert.Equal(t, "mutable", responses[0].GetFailedResources()[0]["metadata"].(map[string]any)["name"])
+
+		require.Len(t, outcome.skipped, 1, "the broken object must be reported as an unknown-verdict skip")
+		skippedMeta := objectsenvelopes.NewObject(outcome.skipped[0].obj)
+		require.NotNil(t, skippedMeta)
+		assert.Equal(t, "broken", skippedMeta.GetName())
+	})
+
+	// Blocker 2: an out-of-scope object must be excluded, not left to be
+	// inferred as passed.
+	t.Run("out-of-scope object is excluded, not passed", func(t *testing.T) {
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{configMap}, nil, "C-0017")
 		require.NoError(t, err)
-		require.Len(t, responses, 1)
-		failed := responses[0].GetFailedResources()
-		require.Len(t, failed, 1)
-		assert.Equal(t, "mutable", failed[0]["metadata"].(map[string]any)["name"])
+		assert.Empty(t, responses)
+		assert.Empty(t, outcome.skipped)
+
+		id := objectsenvelopes.NewObject(configMap).GetID()
+		_, excluded := outcome.excluded[id]
+		assert.True(t, excluded, "a ConfigMap must be excluded from C-0017")
 	})
 
-	t.Run("unknown control skips the rule via an error", func(t *testing.T) {
-		_, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-9999")
+	t.Run("unknown control skips the whole rule via an error", func(t *testing.T) {
+		_, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-9999")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cel-c-0017")
 		assert.Contains(t, err.Error(), "C-9999")
 	})
 
 	t.Run("empty batch is a clean no-op", func(t *testing.T) {
-		responses, err := opap.runCELOnK8s(context.Background(), rule, nil, nil, "C-0017")
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, nil, nil, "C-0017")
 		require.NoError(t, err)
 		assert.Empty(t, responses)
+		assert.Empty(t, outcome.skipped)
+		assert.Empty(t, outcome.excluded)
 	})
 }

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/anchore/stereoscope v0.1.22 // indirect
 	github.com/anchore/syft v1.42.3 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/anubhav06/copa-grype v1.0.3-alpha.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aquasecurity/go-pep440-version v0.0.1 // indirect
@@ -301,6 +302,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/cel-go v0.28.1 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -297,6 +297,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/anubhav06/copa-grype v1.0.3-alpha.1 h1:hXuFSOVekcPFENdUdvMyGx+SvIh0vIgzY+j1pnkoJaw=
 github.com/anubhav06/copa-grype v1.0.3-alpha.1/go.mod h1:JhE+hPD6XOcS2dfgw8MwOQVCUlIQUHN+XiwBItxFIfM=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -893,6 +895,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/certificate-transparency-go v1.3.2 h1:9ahSNZF2o7SYMaKaXhAumVEzXB2QaayzII9C8rv7v+A=
 github.com/google/certificate-transparency-go v1.3.2/go.mod h1:H5FpMUaGa5Ab2+KCYsxg6sELw3Flkl7pGZzWdBoYLXs=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=


### PR DESCRIPTION
## Overview

This is the PR where the CEL engine actually starts doing something in a real scan. Up until now everything was there but nothing routed to it, the CEL branch in the dispatch just returned a "not implemented" error.

So two things happen here.

First, I thread the control id down to the CEL path. The scanner already had it in processControl, it just wasn't passed further down. I pass it through processRule, enumerateData and runOPAOnSingleRule so runCELOnK8s finally knows which control it's running. These are all internal methods so it's a contained change, and the Rego path just ignores the extra arg.

Second, I filled in runCELOnK8s. The problem was that loadVAP and resolveParams live in the cel package and aren't exported, so the scanner couldn't reach them. To keep that stuff private I added one small exported entry point on the evaluator, EvaluateControl, that does loadVAP + resolveParams + EvaluateOnObject behind the scenes. The scanner just calls that with a control id and an object.

The evaluator is built once per scan and reused, so the compiled program cache from the earlier PR carries across every control and object instead of rebuilding each time.

For turning verdicts into results I kept it the same as Rego. A resource only produces a RuleResponse when it fails, and processRule figures out the passing ones by subtracting the failed from the input. So I do the same, if any validation comes back false I build a failure response with the object in it, otherwise nothing.

Eval errors were the tricky part. An eval error isn't a pass and isn't a clean fail, we genuinely don't know the verdict. So instead of guessing I return an error for the rule, which sends it down the same markResourcesSkipped path a Rego eval error takes. That way a resource we couldn't evaluate shows up as skipped, never as a silent pass. That felt like the safest call for keeping scan and admission in agreement.

One thing I left out on purpose: namespaceObject is passed as nil for now. If a policy references it, it eval errors and that resource just gets skipped, which is safe. Wiring the real namespace object from the scanned resources is a bit more work so I want to do it as its own follow up instead of stuffing it in here.

Tests: I added tests for EvaluateControl against a real control from the bundle (C-0017), a violating pod fails and a clean pod passes, plus an unknown control returns an error. And tests for runCELOnK8s itself, checking the failure response carries the object, a compliant object gives nothing, a mixed batch only reports the bad one, and an unknown control skips the rule. I also fixed the old dispatch test that was still asserting the "not implemented" message.

Part of #2001.

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added control-aware CEL policy evaluation that selects the correct policy and applies its parameters by control ID.
  - CEL evaluation now scopes objects using policy match constraints to decide whether each object applies.
- **Bug Fixes**
  - Improved verdict handling: violating objects generate responses; non-applicable objects are excluded; per-object evaluation problems are reported as skipped/unknown without failing the whole rule.
  - Unknown control IDs now return clearer, control-specific errors.
- **Tests**
  - Expanded unit and rule-level tests for scoping, mixed/empty batches, exclusions, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->