### PR TITLE
cautils: test: cover test for readYamlFile and readJsonFile

### DIFF
--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -440,3 +440,137 @@ func TestIsFileAndIsDir(t *testing.T) {
 	assert.False(t, isFile(missingPath))
 	assert.False(t, isDir(missingPath))
 }
+
+func TestReadYamlFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "valid single Kubernetes object",
+			content: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default`,
+			wantCount: 1,
+		},
+		{
+			name: "multi-document YAML with two valid objects",
+			content: `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-1
+  namespace: default`,
+			wantCount: 2,
+		},
+		{
+			name: "YAML list resource is expanded into items",
+			content: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-in-list
+      namespace: default
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: svc-in-list
+      namespace: default`,
+			wantCount: 2,
+		},
+		{
+			name:      "empty content returns no objects",
+			content:   "",
+			wantCount: 0,
+		},
+		{
+			name: "malformed YAML document is skipped",
+			content: `apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+---
+{not: valid: yaml: [`,
+			wantCount: 1, // the malformed doc is skipped, the good one is kept
+		},
+		{
+			name:      "non-Kubernetes object (no kind) returns no results",
+			content:   "foo: bar\nbaz: qux",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readYamlFile([]byte(tt.content))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, len(got))
+		})
+	}
+}
+
+func TestReadJsonFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "valid single Kubernetes object",
+			content: `{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {"name": "test-pod", "namespace": "default"}
+			}`,
+			wantCount: 1,
+		},
+		{
+			name: "JSON array of Kubernetes objects",
+			content: `[
+				{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "pod-1", "namespace": "default"}},
+				{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "svc-1", "namespace": "default"}}
+			]`,
+			wantCount: 2,
+		},
+		{
+			name:      "invalid JSON returns error",
+			content:   `{not valid json`,
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "empty JSON object (no kind) returns no workloads",
+			content:   `{}`,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readJsonFile([]byte(tt.content))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, len(got))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for `readYamlFile` and `readJsonFile` in `core/cautils`
- Covers multi-document YAML, Kubernetes List expansion, malformed/invalid input, and non-workload payloads

## Test plan
- [x] `go test ./core/cautils/ -run 'TestReadYamlFile|TestReadJsonFile'`
<img width="1052" height="531" alt="image" src="https://github.com/user-attachments/assets/66422dd3-f2ef-429a-85aa-9c6b8c778e6e" />

<img width="1052" height="531" alt="image" src="https://github.com/user-attachments/assets/f9bf50af-ac0e-42f5-a9d5-670019bd7eda" />



<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for reading Kubernetes resources from YAML and JSON files.
  * Added validation for multi-document files, lists, empty or malformed content, invalid JSON, and objects missing required metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->