### PR TITLE
fix(scan): restore root PersistentPreRun for kubescape scan invocations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,14 @@ import (
 
 var rootInfo cautils.RootInfo
 
+func init() {
+	// root.go and scan/scan.go both define PersistentPreRun(E) hooks. Cobra's default
+	// behavior only runs the closest one in the command chain, silently skipping root's
+	// (logger/cache-dir/kube-context init and --server service discovery) for any
+	// `kubescape scan ...` invocation. Enable full root-to-leaf traversal so both run.
+	cobra.EnableTraverseRunHooks = true
+}
+
 var ksExamples = fmt.Sprintf(`
   # Scan a Kubernetes cluster or YAML files for image vulnerabilities and misconfigurations
   %[1]s scan

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDefaultKubescapeCommand(t *testing.T) {
@@ -21,4 +26,39 @@ func TestExecute(t *testing.T) {
 			assert.EqualErrorf(t, err, "unknown command \"^\\\\QTestExecute\\\\E$\" for \"kubescape\"", err.Error())
 		}
 	})
+}
+
+func TestScanSubcommand_RunsRootPersistentPreRun(t *testing.T) {
+	prevLoggerVal := rootInfo.Logger
+	prevLoggerName := rootInfo.LoggerName
+	prevCacheDir := rootInfo.CacheDir
+	prevStore := getter.DefaultLocalStore
+	prevLevel := logger.L().GetLevel()
+	t.Cleanup(func() {
+		rootInfo.Logger = prevLoggerVal
+		rootInfo.LoggerName = prevLoggerName
+		rootInfo.CacheDir = prevCacheDir
+		getter.DefaultLocalStore = prevStore
+		_ = logger.L().SetLevel(prevLevel)
+	})
+
+	// Force a known baseline that ONLY root's PersistentPreRun (via initLoggerLevel) can move off of.
+	require.NoError(t, logger.L().SetLevel(helpers.WarningLevel.String()))
+
+	cmd := NewDefaultKubescapeCommand(context.Background(), "", "", "")
+	cmd.SetArgs([]string{"scan", "--controls-version", "bad/value", "-l", "debug"})
+	err := cmd.Execute()
+
+	// scanCmd's PersistentPreRunE still runs and still validates --controls-version.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --controls-version")
+
+	// rootCmd's PersistentPreRun also ran: initLoggerLevel moved the logger singleton
+	// off the "warning" baseline to "debug" — the ONLY code path that can do that here.
+	// With the bug present (hook shadowed), this would still read "warning" and fail.
+	assert.Equal(t, helpers.DebugLevel.String(), logger.L().GetLevel())
+}
+
+func TestEnableTraverseRunHooksIsSetForRootAndScanHooks(t *testing.T) {
+	assert.True(t, cobra.EnableTraverseRunHooks, "root.go's PersistentPreRun and scan.go's PersistentPreRunE both need cobra to traverse all ancestor hooks, not just the closest one")
 }


### PR DESCRIPTION
## Overview

`scanCmd.PersistentPreRunE` (added in #2515, validates `--controls-version`) shadows `rootCmd.PersistentPreRun` under cobra's default "closest hook wins" semantics. Cobra only runs the *closest* `PersistentPreRun(E)` in the command chain unless told otherwise, so every `kubescape scan ...` invocation (bare `scan` + `framework`/`control`/`workload`/`image` subcommands) silently skipped **all** of root's init: logger init, cache-dir init, kube-context, and — critically — `initEnvironment()`, which performs service discovery for `--server`/`--account`.

Result: `--server`/`--account` silently stopped resolving a Cloud API URL. Scans complete "successfully" (exit 0) against local/cached policies, but nothing is ever submitted to the backend, with zero error raised.

## Fix

Set `cobra.EnableTraverseRunHooks = true` in a package-level `init()` in `cmd/root.go` — cobra's own built-in mechanism for exactly this scenario. With it enabled, cobra walks the command chain root-to-leaf and runs every `PersistentPreRun(E)` in order, so both root's init and scan's `--controls-version` validation run as originally intended.

Verified only two `PersistentPreRun`/`PersistentPostRun` hooks exist anywhere in the `cmd/` tree (root.go and scan/scan.go), so this change has no collateral effect elsewhere in the command tree.

## Testing

Added two tests to `cmd/root_test.go`:
- `TestScanSubcommand_RunsRootPersistentPreRun` — builds the real command tree, runs `scan --controls-version bad/value -l debug`, and asserts (a) scan's own validation error still fires, and (b) the logger singleton actually got moved to "debug" by root's `initLoggerLevel` — a side effect only root's hook can produce, so this fails if the shadowing regresses.
- `TestEnableTraverseRunHooksIsSetForRootAndScanHooks` — guards against the `init()` being accidentally removed later.

`go build ./...`, `go test ./cmd/...`, and `go vet ./...` all pass.

## Related issues/PRs

Fixes #2529
Regression introduced in #2515

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: oh-my-claudecode:team | cmds: /oh-my-claudecode:ralplan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command initialization so root-level settings are consistently applied when running scan commands, including when validation fails.
  * Ensured logging configuration is honored across nested command invocations.

* **Tests**
  * Added coverage verifying root command hooks run for scan commands.
  * Added tests confirming command hook traversal remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->