### PR TITLE
fix(scan): don't let --exceptions/--controls-config/--attack-tracks trigger air-gapped mode

### DIFF
--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 )
@@ -99,12 +101,14 @@ func (lp *LoadPolicy) GetFramework(frameworkName string) (*reporthandling.Framew
 	for _, filePath := range lp.filePaths {
 		buf, err := os.ReadFile(filePath)
 		if err != nil {
-			return nil, err
+			logger.L().Debug("skipping unreadable policy file", helpers.String("path", filePath), helpers.Error(err))
+			continue
 		}
 
 		var framework reporthandling.Framework
 		if err = json.Unmarshal(buf, &framework); err != nil {
-			return nil, err
+			logger.L().Debug("skipping unparsable policy file", helpers.String("path", filePath), helpers.Error(err))
+			continue
 		}
 
 		if strings.EqualFold(frameworkName, framework.Name) {
@@ -123,7 +127,8 @@ func (lp *LoadPolicy) GetFrameworks() ([]reporthandling.Framework, error) {
 	for _, f := range lp.filePaths {
 		buf, err := os.ReadFile(f)
 		if err != nil {
-			return nil, err
+			logger.L().Debug("skipping unreadable policy file", helpers.String("path", f), helpers.Error(err))
+			continue
 		}
 
 		var framework reporthandling.Framework
@@ -152,7 +157,8 @@ func (lp *LoadPolicy) ListFrameworks() ([]string, error) {
 	for _, f := range lp.filePaths {
 		buf, err := os.ReadFile(f)
 		if err != nil {
-			return nil, err
+			logger.L().Debug("skipping unreadable policy file", helpers.String("path", f), helpers.Error(err))
+			continue
 		}
 
 		var framework reporthandling.Framework

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -203,7 +203,7 @@ func TestLoadPolicy(t *testing.T) {
 			require.Equal(t, extraFramework, fws[1])
 		})
 
-		t.Run("should fail on file error", func(t *testing.T) {
+		t.Run("should skip unreadable file and return the rest", func(t *testing.T) {
 			t.Parallel()
 
 			const (
@@ -213,11 +213,14 @@ func TestLoadPolicy(t *testing.T) {
 			p := NewLoadPolicy([]string{
 				testFrameworkFile(testFramework),
 				testFrameworkFile(extraFramework),
-				testFrameworkFile(nowhere), // should raise an error
+				testFrameworkFile(nowhere), // should be skipped, not raise an error
 			})
 			fws, err := p.ListFrameworks()
-			require.Error(t, err)
-			require.Nil(t, fws)
+			require.NoError(t, err)
+			require.Len(t, fws, 2)
+
+			require.Equal(t, testFramework, fws[0])
+			require.Equal(t, extraFramework, fws[1])
 		})
 	})
 
@@ -388,6 +391,72 @@ func TestLoadPolicy(t *testing.T) {
 
 func testFrameworkFile(framework string) string {
 	return filepath.Join(testutils.CurrentDir(), "testdata", fmt.Sprintf("%s.json", framework))
+}
+
+func TestLoadPolicyMultiPathFallback(t *testing.T) {
+	t.Parallel()
+
+	writeFile := func(t *testing.T, dir, name, content string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+		return path
+	}
+
+	t.Run("GetFramework skips missing file and uses next valid one", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		missingPath := filepath.Join(tmpDir, "missing.json")
+		validPath := writeFile(t, tmpDir, "valid.json", `{"name": "MyFramework", "controls": []}`)
+
+		p := NewLoadPolicy([]string{missingPath, validPath})
+		fw, err := p.GetFramework("MyFramework")
+		require.NoError(t, err)
+		require.NotNil(t, fw)
+		require.Equal(t, "MyFramework", fw.Name)
+	})
+
+	t.Run("GetFramework skips corrupt json and uses next valid one", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		corruptPath := writeFile(t, tmpDir, "corrupt.json", `"{not valid json`)
+		validPath := writeFile(t, tmpDir, "valid.json", `{"name": "MyFramework", "controls": []}`)
+
+		p := NewLoadPolicy([]string{corruptPath, validPath})
+		fw, err := p.GetFramework("MyFramework")
+		require.NoError(t, err)
+		require.NotNil(t, fw)
+		require.Equal(t, "MyFramework", fw.Name)
+	})
+
+	t.Run("GetFrameworks skips missing file and returns frameworks from valid files", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		missingPath := filepath.Join(tmpDir, "missing.json")
+		validPath := writeFile(t, tmpDir, "valid.json", `{"name": "MyFramework", "controls": []}`)
+
+		p := NewLoadPolicy([]string{missingPath, validPath})
+		fws, err := p.GetFrameworks()
+		require.NoError(t, err)
+		require.Len(t, fws, 1)
+		require.Equal(t, "MyFramework", fws[0].Name)
+	})
+
+	t.Run("ListFrameworks skips missing file and returns names from valid files", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		missingPath := filepath.Join(tmpDir, "missing.json")
+		validPath := writeFile(t, tmpDir, "valid.json", `{"name": "MyFramework", "controls": []}`)
+
+		p := NewLoadPolicy([]string{missingPath, validPath})
+		names, err := p.ListFrameworks()
+		require.NoError(t, err)
+		require.Contains(t, names, "MyFramework")
+	})
 }
 
 func writeTempJSONControlInputs(t testing.TB) (string, map[string][]string) {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -208,8 +208,9 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	airGapped := isAirGappedMode(scanInfo)
 	var downloadReleasedPolicy *getter.DownloadReleasedPolicy
 	if airGapped {
-		// In air-gapped mode (--keep-local or using local files via --use-from, --controls-config, --exceptions, or attack tracks),
-		// don't initialize the downloader to prevent network access
+		// In air-gapped mode (--use-from is set — the user explicitly wants to load everything
+		// from local files with no network access), don't initialize the downloader to prevent
+		// network access
 		downloadReleasedPolicy = nil
 	} else {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicyWithVersion(scanInfo.ControlsVersion) // download config inputs from github release
@@ -415,11 +416,12 @@ func isPrioritizationScanType(scanType cautils.ScanTypes) bool {
 	return scanType == cautils.ScanTypeCluster || scanType == cautils.ScanTypeRepo
 }
 
-// isAirGappedMode returns true if the scan is configured to run in air-gapped mode
-// (i.e., without any network access to download policies, exceptions, or other artifacts)
+// isAirGappedMode returns true if the scan is configured to run in air-gapped mode,
+// i.e. the user explicitly wants to load everything from local files via --use-from,
+// with no network access to download the framework/policy at all. The other local-file
+// flags (--controls-config, --exceptions, --attack-tracks) each have their own
+// dedicated local-file-first branch in their respective getter functions in
+// initutils.go and don't need to disable the network downloader entirely.
 func isAirGappedMode(scanInfo *cautils.ScanInfo) bool {
-	return len(scanInfo.UseFrom) > 0 ||
-		scanInfo.ControlsInputs != "" ||
-		scanInfo.UseExceptions != "" ||
-		scanInfo.AttackTracks != ""
+	return len(scanInfo.UseFrom) > 0
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -95,25 +95,25 @@ func TestIsAirGappedMode(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "air-gapped with ControlsInputs",
+			name: "not air-gapped with ControlsInputs",
 			scanInfo: &cautils.ScanInfo{
 				ControlsInputs: "/path/to/controls",
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "air-gapped with UseExceptions",
+			name: "not air-gapped with UseExceptions",
 			scanInfo: &cautils.ScanInfo{
 				UseExceptions: "/path/to/exceptions",
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "air-gapped with AttackTracks",
+			name: "not air-gapped with AttackTracks",
 			scanInfo: &cautils.ScanInfo{
 				AttackTracks: "/path/to/attack-tracks",
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name:     "not air-gapped - all empty",


### PR DESCRIPTION
## Overview

`kubescape scan --exceptions <local-file>` fatally crashed on a cold policy cache (e.g. a fresh CI runner) because `isAirGappedMode()` treated `--exceptions` (and `--controls-config`/`--attack-tracks`) as full air-gapped signals, disabling the network policy/framework downloader entirely. Only `--use-from` actually means "load everything locally, no network" — the other three flags already have their own dedicated local-file-first branch in their respective getter functions in `initutils.go` and don't need to gate the shared framework/policy getter.

Two fixes, either of which alone resolves the reported crash:

1. **`core/core/scan.go`**: narrowed `isAirGappedMode()` to only check `len(scanInfo.UseFrom) > 0`. Refreshed the stale doc comment and an inline comment that wrongly implied `--keep-local`/`--controls-config`/`--exceptions`/`--attack-tracks` also triggered air-gapped mode.
2. **`core/cautils/getter/loadpolicy.go`**: hardened `LoadPolicy.GetFramework`/`GetFrameworks`/`ListFrameworks` to skip an unreadable or unparseable file in a multi-path list and continue to the next candidate (matching the existing tolerant behavior in `LoadPolicy.GetControl`), with a Debug log on each skip. This closes the same crash class in the download-failure-fallback and `--use-from` paths, where a missing `allcontrols.json` previously blocked lookup of `mitre.json`/`nsa.json` entirely (`getter.NativeFrameworks` puts `allcontrols` first).

## Additional Information

A side effect of fix 1: `getResourceHandler` also consumes `isAirGappedMode` to decide whether to initialize the (no-network, struct-only) cloud API connector — it will now be constructed when only `--exceptions`/`--controls-config`/`--attack-tracks` is set, since that's no longer considered air-gapped. This is intentional; those flags were never documented as "go offline" switches.

## How to Test

```
go test ./core/core/... ./core/cautils/getter/...
```

Manually: on a machine/CI runner with an empty `~/.kubescape/` cache, run `kubescape scan framework MITRE --exceptions <file>` — it should download frameworks from GitHub and succeed instead of fataling with `open .../allcontrols.json: no such file or directory`.

## Related issues/PRs:

* Fixes #2531

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

AI-skills: oh-my-claudecode:team | cmds: /clear,/oh-my-claudecode:ralplan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy discovery now skips missing, unreadable, or invalid policy files and continues loading available valid policies.
  * Scans using local controls, exceptions, or attack-track files now continue to support policy downloading.
  * Air-gapped behavior is now limited to scans explicitly configured with `--use-from`.
* **Tests**
  * Added coverage for policy fallback across multiple paths and updated scan-mode expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->