### PR TITLE
feat: give CEL findings the remediation paths their Rego equivalents carry

### DIFF
--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -43,6 +43,11 @@ type ValidationResult struct {
 	Passed     bool
 	Message    string
 	Err        error
+	// Paths are the places in the object this validation looked at, derived
+	// from the expression (see paths.go). Only set for a violation, since a
+	// passing or unknown verdict has nothing to remediate. Empty is normal: an
+	// expression we cannot read a path out of reports none rather than guess.
+	Paths []PathHint
 }
 
 // Evaluator runs a VAP's variables and validations against scanned objects. The
@@ -54,6 +59,10 @@ type Evaluator struct {
 	// expression is compiled once per Evaluator rather than once per scanned
 	// object (see cache.go).
 	programs *programCache
+	// plans caches the path plan derived from each expression, so the AST walk
+	// behind a violation's remediation paths happens once per expression rather
+	// than once per failing object (see paths.go).
+	plans *pathPlanCache
 	// costLimit overrides the per-evaluation CEL cost budget. Zero means "do not
 	// override", which leaves the budget the base env already bakes in
 	// (apiserver's PerCallLimit). When cost limits are wired up the real value
@@ -84,6 +93,7 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 	// The cache closes over e so compiles pick up option-set state (costLimit);
 	// options are applied above, before anything can trigger a compile.
 	e.programs = newProgramCache(e.compileProgram)
+	e.plans = newPathPlanCache(e.buildPathPlan)
 	return e, nil
 }
 
@@ -121,19 +131,65 @@ func (e *Evaluator) EvaluateOnObject(
 	variables []Variable,
 	validations []Validation,
 ) ([]ValidationResult, error) {
-	// stubBindings owns request, oldObject and namespaceObject. We add the
-	// remaining env-declared variables so every declared variable is bound (an
-	// unbound declared variable errors at eval time, see env.go).
+	activation := e.activationFor(ctx, obj, namespaceObject, params, variables)
+
+	results := make([]ValidationResult, 0, len(validations))
+	for _, val := range validations {
+		res := e.evaluateValidation(ctx, val, activation)
+		if res.Err == nil && !res.Passed {
+			res.Paths = e.violationPaths(ctx, val.Expression, obj, namespaceObject, params, variables)
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// activationFor builds the variable bindings one evaluation runs against.
+//
+// stubBindings owns request, oldObject and namespaceObject. We add the
+// remaining env-declared variables so every declared variable is bound (an
+// unbound declared variable errors at eval time, see env.go).
+//
+// Path derivation builds a second activation for the same object with one list
+// narrowed, which is why this is separate: the lazy variables memoize against
+// the object they were built for, so a modified object needs its own bindings
+// rather than a reused map.
+func (e *Evaluator) activationFor(ctx context.Context, obj, namespaceObject map[string]any, params any, variables []Variable) map[string]any {
 	activation := stubBindings(obj, namespaceObject)
 	activation["object"] = obj
 	activation["params"] = params
 	activation["variables"] = e.lazyVariables(ctx, variables, activation)
+	return activation
+}
 
-	results := make([]ValidationResult, 0, len(validations))
-	for _, val := range validations {
-		results = append(results, e.evaluateValidation(ctx, val, activation))
+// violationPaths derives the remediation paths for a validation that just
+// failed on an object (see paths.go for how, and why it needs to re-evaluate).
+//
+// The re-check treats anything other than a clean violation as "not this
+// element": an expression that errors or returns a non-bool on the narrowed
+// object tells us nothing, and blaming an element on a guess would put a wrong
+// path in front of the user.
+func (e *Evaluator) violationPaths(ctx context.Context, expr string, obj, namespaceObject map[string]any, params any, variables []Variable) []PathHint {
+	return e.plans.get(expr).resolve(obj, func(narrowed map[string]any) bool {
+		out, err := e.evalExpression(ctx, expr, e.activationFor(ctx, narrowed, namespaceObject, params, variables))
+		if err != nil {
+			return false
+		}
+		passed, ok := out.Value().(bool)
+		return ok && !passed
+	})
+}
+
+// buildPathPlan compiles an expression and reads its path plan off the AST.
+// Callers go through the plan cache. An expression that will not compile never
+// reached evaluation either, so an empty plan (no paths) is the right answer
+// rather than an error to propagate.
+func (e *Evaluator) buildPathPlan(expr string) pathPlan {
+	ast, issues := e.env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return pathPlan{}
 	}
-	return results, nil
+	return newPathPlan(ast)
 }
 
 // variablesTypeName is the CEL type name of the lazy variables map. It only

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -375,10 +375,15 @@ func negated(node celast.NavigableExpr) bool {
 //     just tests presence (`!has(x)`) or the resource kind is not a fix a user
 //     would make, so `!has(hostNetwork) || hostNetwork == false` stays a
 //     requirement while `namespace == 'kube-system' || hostNetwork == false`
-//     does not. For an element predicate (ident is the loop variable) any
-//     disjunction is treated as disqualifying: element fix values in the bundle
-//     are all conjunctive, and reasoning about element-level alternatives is
-//     not worth the risk of writing a wrong value.
+//     does not.
+//   - crossing out of an element predicate (ident is the loop variable) into the
+//     object level does not end the walk: the comprehension is itself a term of
+//     the outer expression, so an outer disjunction can still make an element
+//     value an alternative. `namespace == 'x' || containers.all(c, c.name == 'v')`
+//     must not write name='v' as a fix, exactly as the direct-field case must
+//     not. Inside the element predicate a disjunction is disqualifying outright
+//     (the exists accumulator is a `||`, and element-level alternatives are not
+//     worth reasoning about); once at the object level the sibling check applies.
 //   - anything else (a bare function wrapping the boolean, a ternary) is not
 //     something we reason about, so the value is dropped.
 func valueIsRequirement(native *celast.AST, node celast.NavigableExpr, ident string) bool {
@@ -389,7 +394,9 @@ func valueIsRequirement(native *celast.AST, node celast.NavigableExpr, ident str
 		}
 		switch parent.Kind() {
 		case celast.ComprehensionKind:
-			return true
+			// Leaving the element predicate; judge the rest of the walk as an
+			// object-level term, so an outer disjunction is still accounted for.
+			ident = "object"
 		case celast.CallKind:
 			switch parent.AsCall().FunctionName() {
 			case operators.LogicalAnd:

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -21,10 +21,9 @@ import (
 // specific list element: "spec.containers[0].securityContext.readOnlyRootFilesystem".
 //
 // Value is the literal the expression requires at that path, and is only set
-// when the requirement is an unambiguous equality. It is empty whenever the
-// expression asks for something we cannot turn into a single value (a prefix
-// check, a range comparison, a plain presence test), because a caller may write
-// a non-empty Value straight into the user's YAML.
+// when the requirement is unambiguous: an equality the policy demands, not one
+// of several alternatives. It is empty whenever the expression asks for
+// something we cannot turn into a single value a caller could safely write.
 type PathHint struct {
 	Path  string
 	Value string
@@ -45,9 +44,14 @@ type PathHint struct {
 //
 // Stage 2 only ever runs for an object that already failed, so the extra
 // evaluations cost nothing on a clean scan.
+//
+// The rule running through both stages is that a wrong path is worse than no
+// path, because `kubescape fix` writes a hint's value straight into a user's
+// YAML. Every place the analysis cannot be sure it drops the value, or the
+// path, rather than guess.
 
-// fieldRef is one field an expression reads, with the literal it is required to
-// equal when the expression makes that unambiguous.
+// fieldRef is one field an expression reads, with the literal the policy
+// requires it to equal, when the expression makes that requirement unambiguous.
 type fieldRef struct {
 	path  string
 	value string
@@ -69,9 +73,12 @@ type pathPlan struct {
 	// direct are fields read straight off the object.
 	direct []fieldRef
 	// elements is set only when the expression iterates exactly one list on the
-	// object. With none there is nothing to index; with more than one we cannot
-	// tell which list a failure came from, and blaming the wrong one is worse
-	// than staying quiet, so both cases fall back to direct paths only.
+	// object AND narrowing that list to one element and re-checking is an exact
+	// test of that element (see narrowingIsExact). With no such list there is
+	// nothing to index; with more than one we cannot tell which list a failure
+	// came from; with a list whose quantifier makes the elements alternatives
+	// rather than requirements, blaming one would be a guess. All three fall
+	// back to direct paths only.
 	elements *elementPlan
 }
 
@@ -79,7 +86,8 @@ type pathPlan struct {
 // the policy covers this kind at all - every policy in the bundle opens with
 // `object.kind != 'Pod' || ...`. They are never what a user has to fix, and
 // appliesTo has already made that decision before we get here, so they never
-// become a hint.
+// become a hint (and a disjunct that only tests them is not a real alternative
+// to a fix, see siblingHasObjectAlternative).
 var scopeGuardFields = map[string]bool{
 	"kind":       true,
 	"apiVersion": true,
@@ -105,34 +113,125 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 	}
 
 	plan := pathPlan{}
-	if len(iterated) == 1 {
+	// Exactly one object-rooted list, and only when re-checking a single element
+	// against the whole validation is a faithful test of that element. Anything
+	// else and we cannot attribute a failure to a specific element without
+	// guessing, so we do not try.
+	if len(iterated) == 1 && narrowingIsExact(iterated[0]) {
 		comprehension := iterated[0].AsComprehension()
 		collection, _ := selectPath(comprehension.IterRange(), "object")
+
+		// A comprehension nested inside this one iterates a list on the element,
+		// not on the element's own fields; excluding its range keeps that inner
+		// collection from being reported as the element's fix path (the same
+		// reason the object-level ranges are excluded from direct fields below).
+		loopStep := celast.NavigateExpr(native, comprehension.LoopStep())
+		nestedRanges := map[string]bool{}
+		for _, node := range celast.MatchDescendants(loopStep, celast.KindMatcher(celast.ComprehensionKind)) {
+			if path, ok := selectPath(node.AsComprehension().IterRange(), comprehension.IterVar()); ok {
+				nestedRanges[path] = true
+			}
+		}
+
 		plan.elements = &elementPlan{
 			collection: collection,
-			fields:     fieldsRootedAt(celast.NavigateExpr(native, comprehension.LoopStep()), comprehension.IterVar()),
+			fields:     fieldsRootedAt(native, loopStep, comprehension.IterVar(), nestedRanges),
 		}
 	}
 
-	for _, ref := range fieldsRootedAt(root, "object") {
-		// The iterated list itself is not a hint: either we are about to point
-		// at one of its elements, or we could not tell which list failed and
-		// naming them all would just be noise.
-		if scopeGuardFields[ref.path] || ranges[ref.path] {
-			continue
-		}
-		plan.direct = append(plan.direct, ref)
-	}
+	// The iterated list itself is not a direct hint: either we are about to
+	// point at one of its elements, or we could not tell which list failed and
+	// naming them all would just be noise.
+	plan.direct = fieldsRootedAt(native, root, "object", ranges)
 	return plan
 }
 
-// fieldsRootedAt collects the fields an expression reads off a given variable.
+// narrowingIsExact reports whether resolve may attribute a failure to a single
+// element of an object-rooted comprehension.
+//
+// resolve narrows the list to one element and re-runs the WHOLE validation. For
+// that to be a faithful test of the one element, the element's contribution has
+// to be conjunctive with the verdict:
+//
+//   - `all(e, p)`  fails because some element fails p. Re-run on a singleton is
+//     p(e): fails exactly for the offenders. Exact.
+//   - `!exists(e, p)` (equivalently `all(e, !p)`) fails because some element
+//     satisfies p. Re-run is !p(e): fails exactly for those. Also exact.
+//   - bare `exists(e, p)` fails because NO element satisfies p. Re-run is p(e),
+//     which fails for every element, so it would blame them all. Not exact.
+//   - `!all(e, p)` is the mirror image and equally not exact.
+//
+// So an `all` under an even number of negations, or an `exists` under an odd
+// number, is exact; the other two combinations are not. A ternary between the
+// comprehension and the root is not something we reason about, so it is treated
+// as not exact.
+func narrowingIsExact(comprehension celast.NavigableExpr) bool {
+	all, ok := quantifierIsAll(comprehension.AsComprehension())
+	if !ok {
+		return false
+	}
+
+	negations := 0
+	for node := comprehension; ; {
+		parent, ok := node.Parent()
+		if !ok {
+			break
+		}
+		if parent.Kind() == celast.CallKind {
+			switch parent.AsCall().FunctionName() {
+			case operators.LogicalNot:
+				negations++
+			case operators.Conditional:
+				return false
+			}
+		}
+		node = parent
+	}
+
+	even := negations%2 == 0
+	if all {
+		return even
+	}
+	return !even
+}
+
+// quantifierIsAll classifies a comprehension as the all macro (true) or the
+// exists macro (false), reporting false in the second return for anything else
+// (exists_one, map, filter), which we do not attribute elements from. The two
+// macros are told apart by how the standard library expands them: all seeds the
+// accumulator true and folds with &&, exists seeds false and folds with ||.
+func quantifierIsAll(c celast.ComprehensionExpr) (isAll bool, ok bool) {
+	init := c.AccuInit()
+	if init.Kind() != celast.LiteralKind {
+		return false, false
+	}
+	seed, isBool := init.AsLiteral().Value().(bool)
+	if !isBool {
+		return false, false
+	}
+	step := c.LoopStep()
+	if step.Kind() != celast.CallKind {
+		return false, false
+	}
+	switch {
+	case seed && step.AsCall().FunctionName() == operators.LogicalAnd:
+		return true, true
+	case !seed && step.AsCall().FunctionName() == operators.LogicalOr:
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// fieldsRootedAt collects the fields an expression reads off a given variable,
+// with the value each field is required to hold where that is unambiguous.
 //
 // Only the longest chain of each read counts: `has(c.securityContext) &&
 // c.securityContext.readOnlyRootFilesystem == true` reads two nested paths but
 // describes one requirement, and pointing a user at the parent as well as the
-// leaf is noise. So chains that another chain extends are dropped.
-func fieldsRootedAt(root celast.NavigableExpr, ident string) []fieldRef {
+// leaf is noise. So chains that another chain extends are dropped. Scope guards
+// and the excluded paths (an iterated collection) never become fields.
+func fieldsRootedAt(native *celast.AST, root celast.NavigableExpr, ident string, exclude map[string]bool) []fieldRef {
 	var refs []fieldRef
 	for _, node := range celast.MatchDescendants(root, celast.KindMatcher(celast.SelectKind)) {
 		// A select whose parent is a select is the operand of a longer chain;
@@ -141,10 +240,10 @@ func fieldsRootedAt(root celast.NavigableExpr, ident string) []fieldRef {
 			continue
 		}
 		path, ok := selectPath(node, ident)
-		if !ok || path == "" {
+		if !ok || path == "" || scopeGuardFields[path] || exclude[path] {
 			continue
 		}
-		refs = append(refs, fieldRef{path: path, value: requiredValue(node)})
+		refs = append(refs, fieldRef{path: path, value: requiredValue(native, node, ident)})
 	}
 	return dedupeRefs(refs)
 }
@@ -200,17 +299,21 @@ func selectPath(expr celast.Expr, ident string) (string, bool) {
 	return strings.Join(parts, "."), true
 }
 
-// requiredValue returns the literal a field read is compared against, when the
-// comparison is an equality the field has to satisfy for the policy to pass -
+// requiredValue returns the literal a field read is compared against, but only
+// when the policy genuinely REQUIRES the field to hold that value -
 // `container.securityContext.readOnlyRootFilesystem == true` means the fix is
 // to set that path to true.
 //
-// Everything else yields no value, on purpose. `!=` says what the field must
-// not be, which is not a value to write. And an equality reached through a
-// negation or a ternary may be inverted by the time it reaches the result, so
-// the literal there is not necessarily what the policy wants. A caller may
-// write a value into a user's file, so anything short of certain is empty.
-func requiredValue(node celast.NavigableExpr) string {
+// Everything short of a required value yields none, on purpose, because the
+// value is written into a user's file:
+//   - `!=` says what the field must not be, which is not a value to write.
+//   - an equality reached through a negation or a ternary may be inverted by
+//     the time it reaches the verdict (see negated).
+//   - an equality that is one branch of a disjunction is an ALTERNATIVE, not a
+//     requirement: `namespace == 'kube-system' || hostNetwork == false` is
+//     satisfied by either, so writing both would move a workload into
+//     kube-system to satisfy a host-network policy (see valueIsRequirement).
+func requiredValue(native *celast.AST, node celast.NavigableExpr, ident string) string {
 	parent, ok := node.Parent()
 	if !ok || parent.Kind() != celast.CallKind {
 		return ""
@@ -229,7 +332,7 @@ func requiredValue(node celast.NavigableExpr) string {
 	if literal == nil || literal.Kind() != celast.LiteralKind {
 		return ""
 	}
-	if negated(parent) {
+	if negated(parent) || !valueIsRequirement(native, parent, ident) {
 		return ""
 	}
 	value, ok := literalString(literal.AsLiteral())
@@ -257,6 +360,81 @@ func negated(node celast.NavigableExpr) bool {
 	}
 }
 
+// valueIsRequirement reports whether an equality is a value the policy requires
+// rather than one of several alternatives. Walking from the equality up to the
+// root (or the enclosing comprehension, which bounds an element predicate):
+//
+//   - a conjunction (&&) passes a requirement through unchanged.
+//   - a disjunction (||) makes its branches alternatives. It is only safe when
+//     no OTHER branch offers a competing object field to write: a branch that
+//     just tests presence (`!has(x)`) or the resource kind is not a fix a user
+//     would make, so `!has(hostNetwork) || hostNetwork == false` stays a
+//     requirement while `namespace == 'kube-system' || hostNetwork == false`
+//     does not. For an element predicate (ident is the loop variable) any
+//     disjunction is treated as disqualifying: element fix values in the bundle
+//     are all conjunctive, and reasoning about element-level alternatives is
+//     not worth the risk of writing a wrong value.
+//   - anything else (a bare function wrapping the boolean, a ternary) is not
+//     something we reason about, so the value is dropped.
+func valueIsRequirement(native *celast.AST, node celast.NavigableExpr, ident string) bool {
+	for {
+		parent, ok := node.Parent()
+		if !ok {
+			return true
+		}
+		switch parent.Kind() {
+		case celast.ComprehensionKind:
+			return true
+		case celast.CallKind:
+			switch parent.AsCall().FunctionName() {
+			case operators.LogicalAnd:
+			case operators.LogicalOr:
+				if ident != "object" {
+					return false
+				}
+				for _, arg := range parent.AsCall().Args() {
+					if arg.ID() == node.ID() {
+						continue
+					}
+					if siblingHasObjectAlternative(native, arg) {
+						return false
+					}
+				}
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+		node = parent
+	}
+}
+
+// siblingHasObjectAlternative reports whether a disjunction branch reads a real
+// object field as a condition - one that would itself be offered as a competing
+// fix. A presence test (`has(...)`, a test-only select) and a scope-guard read
+// (object.kind) do not count: neither is a value a user would write to satisfy
+// the policy, so a disjunct built only from those leaves the sibling equality a
+// genuine requirement.
+func siblingHasObjectAlternative(native *celast.AST, branch celast.Expr) bool {
+	for _, node := range celast.MatchDescendants(celast.NavigateExpr(native, branch), celast.KindMatcher(celast.SelectKind)) {
+		// Only the outermost select of a chain carries the path; an inner link
+		// (including every link of a presence test's chain) has a select parent.
+		if parent, ok := node.Parent(); ok && parent.Kind() == celast.SelectKind {
+			continue
+		}
+		if node.AsSelect().IsTestOnly() {
+			continue // presence test: not a value to write
+		}
+		path, ok := selectPath(node, "object")
+		if !ok || scopeGuardFields[path] {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // literalString renders a CEL literal as the string form a YAML fix would
 // write. Types with no unambiguous rendering yield false and no hint value.
 func literalString(val ref.Val) (string, bool) {
@@ -279,11 +457,11 @@ func literalString(val ref.Val) (string, bool) {
 // resolve turns a plan into hints for one object that failed the validation.
 //
 // violates re-runs the same validation against a modified object and reports
-// whether it still fails. That is how a list index gets pinned: the policy says
-// every container must satisfy something, so replacing the list with a single
-// container and re-checking says whether that container is one of the offenders.
-// Elements that pass on their own are not blamed, and if the failure came from
-// somewhere else entirely no element is blamed at all.
+// whether it still fails. That is how a list index gets pinned: for a list
+// whose narrowing is exact (see narrowingIsExact), replacing the list with a
+// single element and re-checking says whether that element is one of the
+// offenders. Elements that pass on their own are not blamed, and if the failure
+// came from somewhere else entirely no element is blamed at all.
 func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool) []PathHint {
 	hints := make([]PathHint, 0, len(p.direct))
 	for _, ref := range p.direct {
@@ -300,7 +478,8 @@ func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool
 	}
 
 	for i, element := range list {
-		if !violates(narrow(obj, segments, []any{element})) {
+		candidate, ok := narrow(obj, segments, []any{element})
+		if !ok || !violates(candidate) {
 			continue
 		}
 		prefix := p.elements.collection + "[" + strconv.Itoa(i) + "]."
@@ -329,24 +508,31 @@ func lookupList(obj map[string]any, segments []string) ([]any, bool) {
 	return list, ok
 }
 
-// narrow returns a copy of obj with the value at a dotted path replaced. Only
-// the maps along that path are copied and everything else is shared, so
-// narrowing a pod's container list once per container stays cheap.
-func narrow(obj map[string]any, segments []string, value any) map[string]any {
+// narrow returns a copy of obj with the value at a dotted path replaced,
+// reporting false when the path does not run through maps all the way down.
+// Only the maps along that path are copied and everything else is shared, so
+// narrowing a pod's container list once per container stays cheap. The bool
+// keeps a path that does not resolve from silently returning an unchanged copy,
+// which resolve would then read as every element violating.
+func narrow(obj map[string]any, segments []string, value any) (map[string]any, bool) {
 	out := make(map[string]any, len(obj))
 	for key, val := range obj {
 		out[key] = val
 	}
 	if len(segments) == 1 {
 		out[segments[0]] = value
-		return out
+		return out, true
 	}
 	child, ok := obj[segments[0]].(map[string]any)
 	if !ok {
-		return out
+		return nil, false
 	}
-	out[segments[0]] = narrow(child, segments[1:], value)
-	return out
+	narrowed, ok := narrow(child, segments[1:], value)
+	if !ok {
+		return nil, false
+	}
+	out[segments[0]] = narrowed
+	return out, true
 }
 
 // pathPlanCache memoizes path plans by expression text, for the same reason

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -1,0 +1,388 @@
+package cel
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// PathHint is one place in the scanned object that a failed validation looked
+// at. It is deliberately a neutral type: package cel does not depend on the
+// report model, so the scanner maps hints onto the report's remediation fields
+// at its own boundary.
+//
+// Path is dotted and object-relative, indexed where the failure was pinned to a
+// specific list element: "spec.containers[0].securityContext.readOnlyRootFilesystem".
+//
+// Value is the literal the expression requires at that path, and is only set
+// when the requirement is an unambiguous equality. It is empty whenever the
+// expression asks for something we cannot turn into a single value (a prefix
+// check, a range comparison, a plain presence test), because a caller may write
+// a non-empty Value straight into the user's YAML.
+type PathHint struct {
+	Path  string
+	Value string
+}
+
+// A ValidatingAdmissionPolicy carries no path information: a validation is an
+// expression, a message and a reason, and nothing else. Rego rules hand back
+// failedPaths/fixPaths because their author wrote them out by hand; for CEL the
+// paths have to be recovered from the expression itself.
+//
+// That happens in two stages, split because the first is expensive and object
+// independent while the second is cheap and object specific:
+//
+//  1. pathPlan reads the compiled expression once and records which fields it
+//     reads (see newPathPlan). Cached per expression.
+//  2. resolve turns that plan into concrete hints for one failing object,
+//     pinning list indices by re-checking the expression element by element.
+//
+// Stage 2 only ever runs for an object that already failed, so the extra
+// evaluations cost nothing on a clean scan.
+
+// fieldRef is one field an expression reads, with the literal it is required to
+// equal when the expression makes that unambiguous.
+type fieldRef struct {
+	path  string
+	value string
+}
+
+// elementPlan describes a validation that iterates a list on the object, which
+// is the shape almost every workload policy in the bundle has
+// (`object.spec.containers.all(container, ...)`). collection is the list's
+// object-relative path and fields are element-relative, so the two are joined
+// with an index once we know which element failed.
+type elementPlan struct {
+	collection string
+	fields     []fieldRef
+}
+
+// pathPlan is everything one validation expression can say about where it
+// failed, independent of any particular object.
+type pathPlan struct {
+	// direct are fields read straight off the object.
+	direct []fieldRef
+	// elements is set only when the expression iterates exactly one list on the
+	// object. With none there is nothing to index; with more than one we cannot
+	// tell which list a failure came from, and blaming the wrong one is worse
+	// than staying quiet, so both cases fall back to direct paths only.
+	elements *elementPlan
+}
+
+// scopeGuardFields are object fields a validation reads only to decide whether
+// the policy covers this kind at all - every policy in the bundle opens with
+// `object.kind != 'Pod' || ...`. They are never what a user has to fix, and
+// appliesTo has already made that decision before we get here, so they never
+// become a hint.
+var scopeGuardFields = map[string]bool{
+	"kind":       true,
+	"apiVersion": true,
+}
+
+// newPathPlan derives the plan for one compiled validation expression.
+func newPathPlan(ast *cel.Ast) pathPlan {
+	native := ast.NativeRep()
+	root := celast.NavigateAST(native)
+
+	// Comprehensions over something other than the object (the bundle iterates
+	// params lists and inline kind lists too) tell us nothing about where the
+	// object is wrong, so only object-rooted ones count.
+	var iterated []celast.NavigableExpr
+	ranges := map[string]bool{}
+	for _, node := range celast.MatchDescendants(root, celast.KindMatcher(celast.ComprehensionKind)) {
+		path, ok := selectPath(node.AsComprehension().IterRange(), "object")
+		if !ok {
+			continue
+		}
+		iterated = append(iterated, node)
+		ranges[path] = true
+	}
+
+	plan := pathPlan{}
+	if len(iterated) == 1 {
+		comprehension := iterated[0].AsComprehension()
+		collection, _ := selectPath(comprehension.IterRange(), "object")
+		plan.elements = &elementPlan{
+			collection: collection,
+			fields:     fieldsRootedAt(celast.NavigateExpr(native, comprehension.LoopStep()), comprehension.IterVar()),
+		}
+	}
+
+	for _, ref := range fieldsRootedAt(root, "object") {
+		// The iterated list itself is not a hint: either we are about to point
+		// at one of its elements, or we could not tell which list failed and
+		// naming them all would just be noise.
+		if scopeGuardFields[ref.path] || ranges[ref.path] {
+			continue
+		}
+		plan.direct = append(plan.direct, ref)
+	}
+	return plan
+}
+
+// fieldsRootedAt collects the fields an expression reads off a given variable.
+//
+// Only the longest chain of each read counts: `has(c.securityContext) &&
+// c.securityContext.readOnlyRootFilesystem == true` reads two nested paths but
+// describes one requirement, and pointing a user at the parent as well as the
+// leaf is noise. So chains that another chain extends are dropped.
+func fieldsRootedAt(root celast.NavigableExpr, ident string) []fieldRef {
+	var refs []fieldRef
+	for _, node := range celast.MatchDescendants(root, celast.KindMatcher(celast.SelectKind)) {
+		// A select whose parent is a select is the operand of a longer chain;
+		// the outermost one carries the full path.
+		if parent, ok := node.Parent(); ok && parent.Kind() == celast.SelectKind {
+			continue
+		}
+		path, ok := selectPath(node, ident)
+		if !ok || path == "" {
+			continue
+		}
+		refs = append(refs, fieldRef{path: path, value: requiredValue(node)})
+	}
+	return dedupeRefs(refs)
+}
+
+// dedupeRefs drops duplicates and any path another path extends, then orders
+// what is left so the same object always produces the same hints.
+func dedupeRefs(refs []fieldRef) []fieldRef {
+	kept := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		// Prefer a ref that carries a value: the same field can be read once as
+		// a presence test and once as an equality, and the equality is the one
+		// that can be fixed.
+		if existing, seen := kept[ref.path]; !seen || existing == "" {
+			kept[ref.path] = ref.value
+		}
+	}
+
+	out := make([]fieldRef, 0, len(kept))
+	for path, value := range kept {
+		extended := false
+		for other := range kept {
+			if other != path && strings.HasPrefix(other, path+".") {
+				extended = true
+				break
+			}
+		}
+		if !extended {
+			out = append(out, fieldRef{path: path, value: value})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out
+}
+
+// selectPath renders a chain of field selections rooted at ident as a dotted
+// path, reporting false for a chain rooted at anything else. `has(x.y)` is a
+// select too (a presence test), so it yields the same path a plain read would.
+func selectPath(expr celast.Expr, ident string) (string, bool) {
+	var reversed []string
+	for expr.Kind() == celast.SelectKind {
+		sel := expr.AsSelect()
+		reversed = append(reversed, sel.FieldName())
+		expr = sel.Operand()
+	}
+	if expr.Kind() != celast.IdentKind || expr.AsIdent() != ident {
+		return "", false
+	}
+
+	parts := make([]string, 0, len(reversed))
+	for i := len(reversed) - 1; i >= 0; i-- {
+		parts = append(parts, reversed[i])
+	}
+	return strings.Join(parts, "."), true
+}
+
+// requiredValue returns the literal a field read is compared against, when the
+// comparison is an equality the field has to satisfy for the policy to pass -
+// `container.securityContext.readOnlyRootFilesystem == true` means the fix is
+// to set that path to true.
+//
+// Everything else yields no value, on purpose. `!=` says what the field must
+// not be, which is not a value to write. And an equality reached through a
+// negation or a ternary may be inverted by the time it reaches the result, so
+// the literal there is not necessarily what the policy wants. A caller may
+// write a value into a user's file, so anything short of certain is empty.
+func requiredValue(node celast.NavigableExpr) string {
+	parent, ok := node.Parent()
+	if !ok || parent.Kind() != celast.CallKind {
+		return ""
+	}
+	call := parent.AsCall()
+	if call.FunctionName() != operators.Equals || len(call.Args()) != 2 {
+		return ""
+	}
+
+	var literal celast.Expr
+	for _, arg := range call.Args() {
+		if arg.ID() != node.ID() {
+			literal = arg
+		}
+	}
+	if literal == nil || literal.Kind() != celast.LiteralKind {
+		return ""
+	}
+	if negated(parent) {
+		return ""
+	}
+	value, ok := literalString(literal.AsLiteral())
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+// negated reports whether a node sits under a logical not or a ternary, either
+// of which can flip what its result means for the policy's verdict.
+func negated(node celast.NavigableExpr) bool {
+	for {
+		parent, ok := node.Parent()
+		if !ok {
+			return false
+		}
+		if parent.Kind() == celast.CallKind {
+			switch parent.AsCall().FunctionName() {
+			case operators.LogicalNot, operators.Conditional:
+				return true
+			}
+		}
+		node = parent
+	}
+}
+
+// literalString renders a CEL literal as the string form a YAML fix would
+// write. Types with no unambiguous rendering yield false and no hint value.
+func literalString(val ref.Val) (string, bool) {
+	switch v := val.Value().(type) {
+	case bool:
+		return strconv.FormatBool(v), true
+	case string:
+		return v, true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case uint64:
+		return strconv.FormatUint(v, 10), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+// resolve turns a plan into hints for one object that failed the validation.
+//
+// violates re-runs the same validation against a modified object and reports
+// whether it still fails. That is how a list index gets pinned: the policy says
+// every container must satisfy something, so replacing the list with a single
+// container and re-checking says whether that container is one of the offenders.
+// Elements that pass on their own are not blamed, and if the failure came from
+// somewhere else entirely no element is blamed at all.
+func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool) []PathHint {
+	hints := make([]PathHint, 0, len(p.direct))
+	for _, ref := range p.direct {
+		hints = append(hints, PathHint{Path: ref.path, Value: ref.value})
+	}
+	if p.elements == nil || len(p.elements.fields) == 0 {
+		return hints
+	}
+
+	segments := strings.Split(p.elements.collection, ".")
+	list, ok := lookupList(obj, segments)
+	if !ok {
+		return hints
+	}
+
+	for i, element := range list {
+		if !violates(narrow(obj, segments, []any{element})) {
+			continue
+		}
+		prefix := p.elements.collection + "[" + strconv.Itoa(i) + "]."
+		for _, ref := range p.elements.fields {
+			hints = append(hints, PathHint{Path: prefix + ref.path, Value: ref.value})
+		}
+	}
+	return hints
+}
+
+// lookupList reads the list at a dotted path, reporting false when the path is
+// absent or does not hold a list.
+func lookupList(obj map[string]any, segments []string) ([]any, bool) {
+	var current any = obj
+	for _, segment := range segments {
+		parent, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = parent[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	list, ok := current.([]any)
+	return list, ok
+}
+
+// narrow returns a copy of obj with the value at a dotted path replaced. Only
+// the maps along that path are copied and everything else is shared, so
+// narrowing a pod's container list once per container stays cheap.
+func narrow(obj map[string]any, segments []string, value any) map[string]any {
+	out := make(map[string]any, len(obj))
+	for key, val := range obj {
+		out[key] = val
+	}
+	if len(segments) == 1 {
+		out[segments[0]] = value
+		return out
+	}
+	child, ok := obj[segments[0]].(map[string]any)
+	if !ok {
+		return out
+	}
+	out[segments[0]] = narrow(child, segments[1:], value)
+	return out
+}
+
+// pathPlanCache memoizes path plans by expression text, for the same reason
+// programCache memoizes programs: deriving a plan means compiling the
+// expression and walking its AST, and the answer is the same for every object
+// the expression runs against. An expression that will not compile has no plan
+// and never will, so the empty plan is cached too rather than recompiled per
+// failing object.
+type pathPlanCache struct {
+	build func(expr string) pathPlan
+
+	mu      sync.Mutex
+	entries map[string]*pathPlanCacheEntry
+}
+
+type pathPlanCacheEntry struct {
+	once sync.Once
+	plan pathPlan
+}
+
+func newPathPlanCache(build func(expr string) pathPlan) *pathPlanCache {
+	return &pathPlanCache{
+		build:   build,
+		entries: make(map[string]*pathPlanCacheEntry),
+	}
+}
+
+func (c *pathPlanCache) get(expr string) pathPlan {
+	c.mu.Lock()
+	entry, ok := c.entries[expr]
+	if !ok {
+		entry = &pathPlanCacheEntry{}
+		c.entries[expr] = entry
+	}
+	c.mu.Unlock()
+
+	entry.once.Do(func() { entry.plan = c.build(expr) })
+	return entry.plan
+}

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -121,21 +121,18 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 		comprehension := iterated[0].AsComprehension()
 		collection, _ := selectPath(comprehension.IterRange(), "object")
 
-		// A comprehension nested inside this one iterates a list on the element,
-		// not on the element's own fields; excluding its range keeps that inner
-		// collection from being reported as the element's fix path (the same
-		// reason the object-level ranges are excluded from direct fields below).
+		// A field the element predicate reads is element-relative and joined to
+		// the pinned index. This includes a collection the predicate iterates in
+		// turn (a container's ports, a container's command): we cannot pin the
+		// inner index without a second level of re-checking, so that inner
+		// collection stays a review path pointing at the offending element's
+		// list - which still tells the user the container and the field to look
+		// at, unlike the object-level list we index into, which is not a hint
+		// because we are about to point at one of its elements instead.
 		loopStep := celast.NavigateExpr(native, comprehension.LoopStep())
-		nestedRanges := map[string]bool{}
-		for _, node := range celast.MatchDescendants(loopStep, celast.KindMatcher(celast.ComprehensionKind)) {
-			if path, ok := selectPath(node.AsComprehension().IterRange(), comprehension.IterVar()); ok {
-				nestedRanges[path] = true
-			}
-		}
-
 		plan.elements = &elementPlan{
 			collection: collection,
-			fields:     fieldsRootedAt(native, loopStep, comprehension.IterVar(), nestedRanges),
+			fields:     fieldsRootedAt(native, loopStep, comprehension.IterVar(), nil),
 		}
 	}
 
@@ -165,6 +162,14 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 // number, is exact; the other two combinations are not. A ternary between the
 // comprehension and the root is not something we reason about, so it is treated
 // as not exact.
+//
+// This is necessary but not sufficient: re-running the WHOLE validation is only
+// a test of the element when the comprehension is also the sole reason the
+// validation failed. A conjunctive sibling that reads the object
+// (`hostNetwork == false && containers.all(...)`) fails on every singleton too,
+// which would blame every element. resolve guards that separately, by checking
+// the validation passes once the list is emptied before it attributes any
+// element (see resolve).
 func narrowingIsExact(comprehension celast.NavigableExpr) bool {
 	all, ok := quantifierIsAll(comprehension.AsComprehension())
 	if !ok {
@@ -474,6 +479,16 @@ func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool
 	segments := strings.Split(p.elements.collection, ".")
 	list, ok := lookupList(obj, segments)
 	if !ok {
+		return hints
+	}
+
+	// narrowingIsExact establishes the element is conjunctive with the verdict,
+	// but re-running the whole validation is only a test of an element when the
+	// comprehension is also the reason it failed. Emptying the list makes the
+	// comprehension satisfied (all over nothing is vacuously true, and so is the
+	// !exists we also attribute); if the validation still fails then, the cause
+	// is a sibling reading the object, not any element, so none is blamed.
+	if emptied, ok := narrow(obj, segments, []any{}); ok && violates(emptied) {
 		return hints
 	}
 

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -474,6 +474,26 @@ func literalString(val ref.Val) (string, bool) {
 // single element and re-checking says whether that element is one of the
 // offenders. Elements that pass on their own are not blamed, and if the failure
 // came from somewhere else entirely no element is blamed at all.
+//
+// KNOWN IMPRECISION, deliberate: which ELEMENT failed is pinned, which of
+// several CONJUNCTIVE FIELDS failed is not. A validation requiring both
+// `hostPID == false` and `hostIPC == false` reports both paths even when only
+// one of them is actually set, where the Rego equivalent has a separate rule per
+// field and names only the failing one.
+//
+// This is a precision gap, not a soundness one, and the distinction is what
+// makes it acceptable to ship: every value emitted here is the value the policy
+// REQUIRES at that path (see requiredValue), so applying a redundant one can
+// never make the object less compliant - worst case it writes a field that
+// already held that value. That is categorically different from the
+// alternatives-under-a-disjunction case, where applying the fix could satisfy
+// the wrong branch or produce invalid YAML, and which is therefore refused
+// outright rather than merely imprecise.
+//
+// Pinning the field too would mean evaluating each conjunct separately against
+// the object, which needs the plan to track which conjunct each field came from
+// and whether absence satisfies it (`!has(x) || x == v` vs `has(x) && x == v`
+// differ). Worth doing, but as its own change.
 func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool) []PathHint {
 	hints := make([]PathHint, 0, len(p.direct))
 	for _, ref := range p.direct {

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -449,14 +449,17 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 //   - spec.template.spec.hostIPC=false is missing because of the upstream C-0038
 //     workload bug, which checks hostPID twice and never hostIPC. The derivation
 //     reports exactly what the expression says.
-//   - C-0075's imagePullPolicy=Always is missing by this analysis's own choice,
-//     not the bundle's. Its element predicate
+//   - C-0075's imagePullPolicy=Always is missing because its element predicate
 //     `!c.image.endsWith(':latest') || c.imagePullPolicy == 'Always'` puts the
-//     equality under a disjunction, and element-level values under a disjunction
-//     are dropped rather than reasoned about (see valueIsRequirement). So a
-//     C-0075 finding carries image and imagePullPolicy as review paths where the
-//     Rego rule offers a writable fix - a deliberate parity gap on the side of
-//     not writing a value we are unsure of.
+//     equality under a disjunction: retagging the image satisfies the policy
+//     just as well as setting the pull policy, so neither is a value to write
+//     (see valueIsRequirement). This is NOT a parity gap. The Rego rule
+//     (regolibrary image-pull-policy-is-not-set-to-always) reaches the same
+//     conclusion by hand: all three of its deny blocks emit image and
+//     imagePullPolicy as reviewPaths with an empty fixPaths. So a CEL finding
+//     and its Rego equivalent flag the same two fields for review, neither
+//     offering a value, which is the behaviour a human rule author chose for
+//     this shape too.
 var bundleFixValues = []string{
 	"automountServiceAccountToken=false",
 	"spec.automountServiceAccountToken=false",

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,50 @@ func TestPathPlanIgnoresElementsWhenTwoObjectListsAreIterated(t *testing.T) {
 	assert.Empty(t, plan.direct)
 }
 
+func TestPathPlanNoElementsForBareExists(t *testing.T) {
+	// exists fails when NO element satisfies the predicate, so narrowing to one
+	// element and re-checking would flag every element as the offender. There is
+	// no sound way to attribute the failure, so no element is attributed.
+	plan := planFor(t, "object.kind != 'Pod' || object.spec.containers.exists(c, c.name == 'sidecar')")
+	assert.Nil(t, plan.elements, "a bare exists cannot pin a failing element")
+	assert.Empty(t, plan.direct)
+}
+
+func TestPathPlanAttributesElementsForNegatedExists(t *testing.T) {
+	// !exists(e, p) is all(e, !p): re-checking a single element is exact again,
+	// so the element that satisfies p (the one causing the violation) can be
+	// named. But the equality lives under the exists accumulator's disjunction,
+	// so its literal is not a value to write.
+	plan := planFor(t, "object.kind != 'Pod' || !object.spec.containers.exists(c, c.name == 'bad')")
+	require.NotNil(t, plan.elements)
+	assert.Equal(t, "spec.containers", plan.elements.collection)
+	require.Len(t, plan.elements.fields, 1)
+	assert.Equal(t, "name", plan.elements.fields[0].path)
+	assert.Empty(t, plan.elements.fields[0].value, "an exists alternative is not a fix value")
+}
+
+func TestPathPlanDropsValueForDisjunctiveAlternatives(t *testing.T) {
+	// The heart of the disjunction blocker: two independent object fields, either
+	// of which satisfies the policy. Writing both as fixes would move the
+	// workload into kube-system to satisfy a host-network policy, so neither
+	// carries a value.
+	plan := planFor(t, "object.metadata.namespace == 'kube-system' || object.spec.hostNetwork == false")
+	require.Len(t, plan.direct, 2)
+	for _, ref := range plan.direct {
+		assert.Emptyf(t, ref.value, "%s is one of two alternatives, not a required value", ref.path)
+	}
+}
+
+func TestPathPlanKeepsValueGuardedByPresenceTest(t *testing.T) {
+	// The safe disjunction the bundle actually uses: the only other branch is a
+	// presence test (and a scope guard) on the same field, neither of which is a
+	// competing fix, so the equality stays a genuine requirement.
+	plan := planFor(t, "object.kind != 'Pod' || !has(object.spec.hostNetwork) || object.spec.hostNetwork == false")
+	require.Len(t, plan.direct, 1)
+	assert.Equal(t, "spec.hostNetwork", plan.direct[0].path)
+	assert.Equal(t, "false", plan.direct[0].value, "!has(x) || x == v is a requirement, not an alternative")
+}
+
 func TestPathPlanDropsValueUnderNegation(t *testing.T) {
 	// The literal in `x == true` says what makes the expression true, not what
 	// makes the policy pass, once a negation sits between the two.
@@ -225,6 +270,15 @@ var pathlessPolicies = map[string]string{
 	"kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false":             "iterates both volumes and containers, so a failure cannot be attributed to either list",
 	"kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set":            "iterates two label maps, and a map key is not a field path",
 	"kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set": "iterates two label maps, same as C-0076",
+
+	// The offending value in these three is two lists deep (a port inside a
+	// container, a command word inside a container): pinning the outer element
+	// is exact, but the inner collection is excluded rather than reported whole,
+	// so nothing above the element level is left to point at. Two-level pinning
+	// is a later PR.
+	"kubescape-c-0042-deny-resources-with-ssh-server-running":                   "the container variant iterates ports inside containers; the outer container carries no field of its own",
+	"kubescape-c-0044-deny-resources-with-host-port":                            "iterates hostPort inside a container's ports, two lists deep",
+	"kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint": "iterates command words inside a container's command list, two lists deep",
 }
 
 func TestEveryBundleValidationYieldsAPath(t *testing.T) {
@@ -280,4 +334,76 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 			}
 		}
 	}
+}
+
+// bundleFixValues is every (path, value) pair the current bundle produces a fix
+// value for, as "path=value" (element paths written "collection[].field=value").
+// It is golden data on purpose. TestEveryBundleValidationYieldsAPath guards
+// against LOSING a path; this guards against GAINING a wrong value, which is the
+// direction the whole PR's risk argument points: a value is written into a
+// user's YAML, so a make sync-vap that turns `== true` into `== false`, or
+// introduces a fix for a field that is really one of several alternatives, has
+// to fail a test rather than ship silently. Every entry here is a security
+// field set to the one value that satisfies its control; if this list grows a
+// path with a surprising value, that is the signal to look.
+//
+// (The absence of spec.template.spec.hostIPC=false is not a gap in the test: it
+// is the upstream C-0038 workload bug, which checks hostPID twice and never
+// hostIPC. The derivation reports exactly what the expression says.)
+var bundleFixValues = []string{
+	"automountServiceAccountToken=false",
+	"spec.automountServiceAccountToken=false",
+	"spec.containers[].securityContext.allowPrivilegeEscalation=false",
+	"spec.containers[].securityContext.readOnlyRootFilesystem=true",
+	"spec.hostIPC=false",
+	"spec.hostNetwork=false",
+	"spec.hostPID=false",
+	"spec.jobTemplate.spec.automountServiceAccountToken=false",
+	"spec.jobTemplate.spec.template.spec.containers[].securityContext.allowPrivilegeEscalation=false",
+	"spec.jobTemplate.spec.template.spec.containers[].securityContext.readOnlyRootFilesystem=true",
+	"spec.jobTemplate.spec.template.spec.hostIPC=false",
+	"spec.jobTemplate.spec.template.spec.hostNetwork=false",
+	"spec.jobTemplate.spec.template.spec.hostPID=false",
+	"spec.template.spec.automountServiceAccountToken=false",
+	"spec.template.spec.containers[].securityContext.allowPrivilegeEscalation=false",
+	"spec.template.spec.containers[].securityContext.readOnlyRootFilesystem=true",
+	"spec.template.spec.hostNetwork=false",
+	"spec.template.spec.hostPID=false",
+}
+
+func TestEveryBundleFixValueIsExpected(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	seen := map[string]bool{}
+	for _, vap := range catalog.byName {
+		for _, val := range vap.Validations {
+			plan := e.buildPathPlan(val.Expression)
+			for _, ref := range plan.direct {
+				if ref.value != "" {
+					seen[ref.path+"="+ref.value] = true
+				}
+			}
+			if plan.elements == nil {
+				continue
+			}
+			for _, ref := range plan.elements.fields {
+				if ref.value != "" {
+					seen[plan.elements.collection+"[]."+ref.path+"="+ref.value] = true
+				}
+			}
+		}
+	}
+
+	got := make([]string, 0, len(seen))
+	for pair := range seen {
+		got = append(got, pair)
+	}
+	sort.Strings(got)
+
+	assert.Equal(t, bundleFixValues, got,
+		"the set of fix values the bundle produces changed; if a make sync-vap added or altered a value, confirm it is a genuine requirement (not one of several alternatives) before updating bundleFixValues")
 }

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -163,6 +163,31 @@ func TestPathPlanDropsValueForDisjunctiveAlternatives(t *testing.T) {
 	}
 }
 
+func TestPathPlanDropsElementValueUnderOuterDisjunction(t *testing.T) {
+	// The element equality is conjunctive WITHIN the predicate, but the whole
+	// comprehension is one branch of an outer disjunction whose other branch is
+	// an independent object field. Setting the element value is then an
+	// alternative to satisfying that other branch, not a requirement - and for a
+	// field like name, writing it onto every failing element would make the API
+	// reject duplicate names. The path is still reported, the value is not.
+	plan := planFor(t, "object.metadata.namespace == 'kube-system' || object.spec.containers.all(c, c.name == 'sidecar')")
+	require.NotNil(t, plan.elements)
+	require.Len(t, plan.elements.fields, 1)
+	assert.Equal(t, "name", plan.elements.fields[0].path)
+	assert.Empty(t, plan.elements.fields[0].value, "an element value under an outer disjunction is an alternative, not a fix")
+}
+
+func TestPathPlanKeepsElementValueUnderScopeGuardDisjunction(t *testing.T) {
+	// The shape the bundle actually uses: the comprehension sits under a kind
+	// guard disjunction, whose only other branch reads object.kind. That is not
+	// a competing fix, so the element value survives.
+	plan := planFor(t, "object.kind != 'Pod' || object.spec.containers.all(c, has(c.securityContext) && c.securityContext.readOnlyRootFilesystem == true)")
+	require.NotNil(t, plan.elements)
+	require.Len(t, plan.elements.fields, 1)
+	assert.Equal(t, "securityContext.readOnlyRootFilesystem", plan.elements.fields[0].path)
+	assert.Equal(t, "true", plan.elements.fields[0].value, "a kind guard is not a competing alternative to the element requirement")
+}
+
 func TestPathPlanKeepsValueGuardedByPresenceTest(t *testing.T) {
 	// The safe disjunction the bundle actually uses: the only other branch is a
 	// presence test (and a scope guard) on the same field, neither of which is a
@@ -335,6 +360,15 @@ func TestPassingResultsCarryNoPaths(t *testing.T) {
 // regression in derivation or an upstream rewrite into a shape we cannot read,
 // and TestEveryBundleValidationYieldsAPath turns that into a `make sync-vap`
 // failure instead of findings that quietly lose their remediation paths.
+//
+// KNOWN LIMITATION for a future sync: the plan is derived from the validation
+// expression's AST only, not from any `variables:` block it references. The
+// embedded bundle inlines its object access today, but upstream controls are
+// moving to the variables pattern; a validation whose object access lives in a
+// variable (validation is just `variables.foo`) derives no path and will fail
+// this test at sync time. That failure is the signal to either teach the
+// derivation to inline variable definitions or exempt the policy here - not a
+// silent loss of paths.
 var pathlessPolicies = map[string]string{
 	"cluster-policy-deny-attach":      "denies outright (the expression is the constant false), so there is no field to point at",
 	"cluster-policy-deny-exec":        "denies outright, same as attach",

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -323,8 +323,15 @@ func TestViolationPathsStillPinElementsWhenTheSiblingPasses(t *testing.T) {
 		},
 	}
 
-	assert.Contains(t, resolvePlan(t, expr, obj),
-		PathHint{Path: "spec.containers[1].securityContext.readOnlyRootFilesystem", Value: "true"})
+	// Pinned exactly rather than by containment, so the direct hint is visible
+	// too: spec.hostNetwork is reported even though it is already compliant here,
+	// which is the conjunctive-field imprecision documented on resolve and in
+	// TestConjunctiveFieldsAreAllReportedNotJustTheFailingOne. Only container[1]
+	// is blamed; the compliant container[0] is not.
+	assert.Equal(t, []PathHint{
+		{Path: "spec.hostNetwork", Value: "false"},
+		{Path: "spec.containers[1].securityContext.readOnlyRootFilesystem", Value: "true"},
+	}, resolvePlan(t, expr, obj))
 }
 
 func TestViolationPathsBlameNoElementWhenTheFailureIsElsewhere(t *testing.T) {

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -1,0 +1,283 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func planFor(t *testing.T, expr string) pathPlan {
+	t.Helper()
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	return e.buildPathPlan(expr)
+}
+
+func TestPathPlanDirectFields(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want []fieldRef
+	}{
+		{
+			name: "equality against a literal carries the value to set",
+			expr: "object.kind != 'Pod' || !has(object.spec.hostNetwork) || object.spec.hostNetwork == false",
+			want: []fieldRef{{path: "spec.hostNetwork", value: "false"}},
+		},
+		{
+			name: "presence test alone carries no value",
+			expr: "object.kind != 'Pod' || has(object.metadata.ownerReferences)",
+			want: []fieldRef{{path: "metadata.ownerReferences"}},
+		},
+		{
+			name: "inequality states what the field must not be, which is not a value",
+			expr: "object.kind != 'Pod' || object.metadata.namespace != 'default'",
+			want: []fieldRef{{path: "metadata.namespace"}},
+		},
+		{
+			name: "the presence test of a field read for equality is not a separate path",
+			expr: "has(object.spec.automountServiceAccountToken) && object.spec.automountServiceAccountToken == false",
+			want: []fieldRef{{path: "spec.automountServiceAccountToken", value: "false"}},
+		},
+		{
+			name: "several fields each keep their own value",
+			expr: "(!has(object.spec.hostPID) || object.spec.hostPID == false) && (!has(object.spec.hostIPC) || object.spec.hostIPC == false)",
+			want: []fieldRef{
+				{path: "spec.hostIPC", value: "false"},
+				{path: "spec.hostPID", value: "false"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planFor(t, tc.expr)
+			assert.Equal(t, tc.want, plan.direct)
+			assert.Nil(t, plan.elements)
+		})
+	}
+}
+
+func TestPathPlanSkipsScopeGuards(t *testing.T) {
+	// Every policy in the bundle opens by testing object.kind, and one shape
+	// tests it inside a comprehension over an inline list of kinds. Neither is
+	// something a user fixes, and neither list is a list on the object.
+	plan := planFor(t, "['Deployment','Job'].all(kind, object.kind != kind) || object.spec.template.spec.hostNetwork == false")
+	assert.Equal(t, []fieldRef{{path: "spec.template.spec.hostNetwork", value: "false"}}, plan.direct)
+	assert.Nil(t, plan.elements, "a comprehension over an inline list is not a list on the object")
+}
+
+func TestPathPlanElementFields(t *testing.T) {
+	cases := []struct {
+		name       string
+		expr       string
+		collection string
+		want       []fieldRef
+	}{
+		{
+			name:       "container field with the value it must hold",
+			expr:       "object.spec.containers.all(c, has(c.securityContext) && has(c.securityContext.readOnlyRootFilesystem) && c.securityContext.readOnlyRootFilesystem == true)",
+			collection: "spec.containers",
+			want:       []fieldRef{{path: "securityContext.readOnlyRootFilesystem", value: "true"}},
+		},
+		{
+			name:       "nested presence tests collapse onto the fields actually required",
+			expr:       "object.spec.containers.all(c, has(c.resources) && has(c.resources.limits) && has(c.resources.limits.memory) && has(c.resources.limits.cpu))",
+			collection: "spec.containers",
+			want: []fieldRef{
+				{path: "resources.limits.cpu"},
+				{path: "resources.limits.memory"},
+			},
+		},
+		{
+			name:       "a comprehension over params does not shadow the one over the object",
+			expr:       "object.spec.containers.all(c, params.settings.registries.all(r, !c.image.startsWith(r)))",
+			collection: "spec.containers",
+			want:       []fieldRef{{path: "image"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planFor(t, tc.expr)
+			require.NotNil(t, plan.elements)
+			assert.Equal(t, tc.collection, plan.elements.collection)
+			assert.Equal(t, tc.want, plan.elements.fields)
+			assert.Empty(t, plan.direct, "the iterated list is not a path of its own")
+		})
+	}
+}
+
+func TestPathPlanIgnoresElementsWhenTwoObjectListsAreIterated(t *testing.T) {
+	// With two lists in play a failure cannot be attributed to either one, and
+	// blaming the wrong list would put a wrong path in front of the user. Both
+	// lists drop out rather than being reported as suspects.
+	plan := planFor(t, "object.spec.volumes.all(v, !has(v.hostPath)) && object.spec.containers.all(c, has(c.readinessProbe))")
+	assert.Nil(t, plan.elements)
+	assert.Empty(t, plan.direct)
+}
+
+func TestPathPlanDropsValueUnderNegation(t *testing.T) {
+	// The literal in `x == true` says what makes the expression true, not what
+	// makes the policy pass, once a negation sits between the two.
+	plan := planFor(t, "object.kind != 'Pod' || !(object.spec.hostNetwork == true)")
+	require.Len(t, plan.direct, 1)
+	assert.Equal(t, "spec.hostNetwork", plan.direct[0].path)
+	assert.Empty(t, plan.direct[0].value, "a negated equality is not a value to write")
+}
+
+func TestPathPlanDropsValueForNonLiteralComparison(t *testing.T) {
+	plan := planFor(t, "object.spec.replicas == params.settings.minReplicas")
+	require.Len(t, plan.direct, 1)
+	assert.Empty(t, plan.direct[0].value)
+}
+
+func TestPathPlanOfUncompilableExpressionIsEmpty(t *testing.T) {
+	plan := planFor(t, "object.spec.((((")
+	assert.Empty(t, plan.direct)
+	assert.Nil(t, plan.elements)
+}
+
+// mixedFilesystemPod violates C-0017 through its first and third containers
+// only: the second one sets readOnlyRootFilesystem and is compliant.
+func mixedFilesystemPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "mixed", "namespace": "prod"},
+		"spec": map[string]any{"containers": []any{
+			map[string]any{"name": "no-context", "image": "nginx"},
+			map[string]any{"name": "compliant", "image": "nginx", "securityContext": map[string]any{"readOnlyRootFilesystem": true}},
+			map[string]any{"name": "writable", "image": "nginx", "securityContext": map[string]any{"readOnlyRootFilesystem": false}},
+		}},
+	}
+}
+
+func failingPaths(t *testing.T, controlID string, obj map[string]any) []PathHint {
+	t.Helper()
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	eval, err := e.EvaluateControl(context.Background(), controlID, obj, nil)
+	require.NoError(t, err)
+	require.True(t, eval.Applicable)
+
+	var hints []PathHint
+	for _, res := range eval.Results {
+		require.NoError(t, res.Err)
+		if !res.Passed {
+			hints = append(hints, res.Paths...)
+		}
+	}
+	return hints
+}
+
+func TestViolationPathsPinTheFailingElements(t *testing.T) {
+	// The middle container satisfies the policy on its own, so it must not be
+	// named: a scan that points a user at a compliant container is worse than
+	// one that points at the list.
+	assert.Equal(t, []PathHint{
+		{Path: "spec.containers[0].securityContext.readOnlyRootFilesystem", Value: "true"},
+		{Path: "spec.containers[2].securityContext.readOnlyRootFilesystem", Value: "true"},
+	}, failingPaths(t, "C-0017", mixedFilesystemPod()))
+}
+
+func TestViolationPathsBlameNoElementWhenTheFailureIsElsewhere(t *testing.T) {
+	// C-0034 fails on the pod's own automountServiceAccountToken. Its
+	// containers have nothing to do with the verdict and none is named.
+	pod := mixedFilesystemPod()
+	pod["spec"].(map[string]any)["automountServiceAccountToken"] = true
+
+	assert.Equal(t, []PathHint{
+		{Path: "spec.automountServiceAccountToken", Value: "false"},
+	}, failingPaths(t, "C-0034", pod))
+}
+
+func TestPassingResultsCarryNoPaths(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	pod := mixedFilesystemPod()
+	pod["spec"].(map[string]any)["containers"] = []any{
+		map[string]any{"name": "compliant", "securityContext": map[string]any{"readOnlyRootFilesystem": true}},
+	}
+
+	eval, err := e.EvaluateControl(context.Background(), "C-0017", pod, nil)
+	require.NoError(t, err)
+	for _, res := range eval.Results {
+		require.True(t, res.Passed)
+		assert.Empty(t, res.Paths, "a passing validation has nothing to remediate")
+	}
+}
+
+// pathlessPolicies are the bundle policies no path can be derived from, with
+// the reason each one is exempt. Anything else that stops yielding a path is a
+// regression in derivation or an upstream rewrite into a shape we cannot read,
+// and TestEveryBundleValidationYieldsAPath turns that into a `make sync-vap`
+// failure instead of findings that quietly lose their remediation paths.
+var pathlessPolicies = map[string]string{
+	"cluster-policy-deny-attach":      "denies outright (the expression is the constant false), so there is no field to point at",
+	"cluster-policy-deny-exec":        "denies outright, same as attach",
+	"cluster-policy-deny-portforward": "denies outright, same as attach",
+
+	"kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false":             "iterates both volumes and containers, so a failure cannot be attributed to either list",
+	"kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set":            "iterates two label maps, and a map key is not a field path",
+	"kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set": "iterates two label maps, same as C-0076",
+}
+
+func TestEveryBundleValidationYieldsAPath(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+	require.NotEmpty(t, catalog.byName, "bundle parsed to no policies")
+
+	for name, vap := range catalog.byName {
+		for _, val := range vap.Validations {
+			plan := e.buildPathPlan(val.Expression)
+			if len(plan.direct) > 0 || (plan.elements != nil && len(plan.elements.fields) > 0) {
+				continue
+			}
+			_, exempt := pathlessPolicies[name]
+			assert.Truef(t, exempt,
+				"no path could be derived from a validation of policy %q, so its failures would report where nothing went wrong; expression:\n%s\n"+
+					"either restore the derivation or add the policy to pathlessPolicies with the reason it cannot carry paths", name, val.Expression)
+		}
+	}
+}
+
+func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	assertPath := func(policy, path string) {
+		t.Helper()
+		require.NotEmpty(t, path, "policy %q derived an empty path", policy)
+		assert.NotContains(t, path, "..", "policy %q derived a path with an empty segment: %q", policy, path)
+	}
+
+	for name, vap := range catalog.byName {
+		for _, val := range vap.Validations {
+			plan := e.buildPathPlan(val.Expression)
+			for _, ref := range plan.direct {
+				assertPath(name, ref.path)
+				// Object paths are what a user edits; the fields a policy reads
+				// only to decide whether it covers this kind are not.
+				assert.False(t, scopeGuardFields[ref.path], "policy %q derived the scope guard %q as a remediation path", name, ref.path)
+			}
+			if plan.elements == nil {
+				continue
+			}
+			assertPath(name, plan.elements.collection)
+			for _, ref := range plan.elements.fields {
+				assertPath(name, ref.path)
+			}
+		}
+	}
+}

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -98,6 +98,15 @@ func TestPathPlanElementFields(t *testing.T) {
 			collection: "spec.containers",
 			want:       []fieldRef{{path: "image"}},
 		},
+		{
+			// A collection the element iterates in turn cannot be pinned to an
+			// inner index, but it is still reported: it names the offending
+			// element's field to look at, unlike the object-level list we index.
+			name:       "a collection iterated inside the element stays a review path",
+			expr:       "object.spec.containers.all(c, !has(c.ports) || c.ports.all(p, !has(p.hostPort)))",
+			collection: "spec.containers",
+			want:       []fieldRef{{path: "ports"}},
+		},
 	}
 
 	for _, tc := range cases {
@@ -229,6 +238,70 @@ func TestViolationPathsPinTheFailingElements(t *testing.T) {
 	}, failingPaths(t, "C-0017", mixedFilesystemPod()))
 }
 
+// resolvePlan drives a plan's resolve against obj, re-evaluating expr for the
+// per-element re-check the way the evaluator does at scan time.
+func resolvePlan(t *testing.T, expr string, obj map[string]any) []PathHint {
+	t.Helper()
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	violates := func(candidate map[string]any) bool {
+		activation := e.activationFor(context.Background(), candidate, nil, nil, nil)
+		out, err := e.evalExpression(context.Background(), expr, activation)
+		require.NoError(t, err)
+		passed, ok := out.Value().(bool)
+		require.True(t, ok)
+		return !passed
+	}
+	return e.buildPathPlan(expr).resolve(obj, violates)
+}
+
+func TestViolationPathsBlameNoElementWhenAConjunctiveSiblingFails(t *testing.T) {
+	// The comprehension is exact on its own, but a conjunctive sibling reads the
+	// object and fails independently, so re-checking any single container still
+	// fails. Emptying the list must reveal the sibling as the real cause and stop
+	// every container from being blamed for a fix (readOnlyRootFilesystem) that
+	// is not why the object failed.
+	expr := "object.spec.hostNetwork == false && object.spec.containers.all(c, has(c.securityContext) && c.securityContext.readOnlyRootFilesystem == true)"
+	obj := map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "p"},
+		"spec": map[string]any{
+			"hostNetwork": true, // the real failure, independent of any container
+			"containers": []any{
+				map[string]any{"name": "a", "securityContext": map[string]any{"readOnlyRootFilesystem": true}},
+				map[string]any{"name": "b", "securityContext": map[string]any{"readOnlyRootFilesystem": true}},
+			},
+		},
+	}
+
+	hints := resolvePlan(t, expr, obj)
+	for _, h := range hints {
+		assert.NotContainsf(t, h.Path, "containers[", "a compliant container was blamed for a failure caused by hostNetwork: %s", h.Path)
+	}
+	assert.Contains(t, hints, PathHint{Path: "spec.hostNetwork", Value: "false"}, "the real cause is still reported")
+}
+
+func TestViolationPathsStillPinElementsWhenTheSiblingPasses(t *testing.T) {
+	// Same shape, but the sibling (hostNetwork) is compliant, so the container is
+	// the genuine cause and the empty-list guard must not suppress it.
+	expr := "object.spec.hostNetwork == false && object.spec.containers.all(c, has(c.securityContext) && c.securityContext.readOnlyRootFilesystem == true)"
+	obj := map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "p"},
+		"spec": map[string]any{
+			"hostNetwork": false,
+			"containers": []any{
+				map[string]any{"name": "a", "securityContext": map[string]any{"readOnlyRootFilesystem": true}},
+				map[string]any{"name": "b"}, // the offender
+			},
+		},
+	}
+
+	assert.Contains(t, resolvePlan(t, expr, obj),
+		PathHint{Path: "spec.containers[1].securityContext.readOnlyRootFilesystem", Value: "true"})
+}
+
 func TestViolationPathsBlameNoElementWhenTheFailureIsElsewhere(t *testing.T) {
 	// C-0034 fails on the pod's own automountServiceAccountToken. Its
 	// containers have nothing to do with the verdict and none is named.
@@ -270,15 +343,6 @@ var pathlessPolicies = map[string]string{
 	"kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false":             "iterates both volumes and containers, so a failure cannot be attributed to either list",
 	"kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set":            "iterates two label maps, and a map key is not a field path",
 	"kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set": "iterates two label maps, same as C-0076",
-
-	// The offending value in these three is two lists deep (a port inside a
-	// container, a command word inside a container): pinning the outer element
-	// is exact, but the inner collection is excluded rather than reported whole,
-	// so nothing above the element level is left to point at. Two-level pinning
-	// is a later PR.
-	"kubescape-c-0042-deny-resources-with-ssh-server-running":                   "the container variant iterates ports inside containers; the outer container carries no field of its own",
-	"kubescape-c-0044-deny-resources-with-host-port":                            "iterates hostPort inside a container's ports, two lists deep",
-	"kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint": "iterates command words inside a container's command list, two lists deep",
 }
 
 func TestEveryBundleValidationYieldsAPath(t *testing.T) {
@@ -347,9 +411,18 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 // field set to the one value that satisfies its control; if this list grows a
 // path with a surprising value, that is the signal to look.
 //
-// (The absence of spec.template.spec.hostIPC=false is not a gap in the test: it
-// is the upstream C-0038 workload bug, which checks hostPID twice and never
-// hostIPC. The derivation reports exactly what the expression says.)
+// Two absences are worth naming so a reader does not read them as bugs:
+//   - spec.template.spec.hostIPC=false is missing because of the upstream C-0038
+//     workload bug, which checks hostPID twice and never hostIPC. The derivation
+//     reports exactly what the expression says.
+//   - C-0075's imagePullPolicy=Always is missing by this analysis's own choice,
+//     not the bundle's. Its element predicate
+//     `!c.image.endsWith(':latest') || c.imagePullPolicy == 'Always'` puts the
+//     equality under a disjunction, and element-level values under a disjunction
+//     are dropped rather than reasoned about (see valueIsRequirement). So a
+//     C-0075 finding carries image and imagePullPolicy as review paths where the
+//     Rego rule offers a writable fix - a deliberate parity gap on the side of
+//     not writing a value we are unsure of.
 var bundleFixValues = []string{
 	"automountServiceAccountToken=false",
 	"spec.automountServiceAccountToken=false",

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -338,6 +338,33 @@ func TestViolationPathsBlameNoElementWhenTheFailureIsElsewhere(t *testing.T) {
 	}, failingPaths(t, "C-0034", pod))
 }
 
+func TestConjunctiveFieldsAreAllReportedNotJustTheFailingOne(t *testing.T) {
+	// Documents the known imprecision in resolve: the failing ELEMENT is pinned,
+	// the failing FIELD among several conjunctive requirements is not. C-0038
+	// requires both hostPID and hostIPC to be false; a Pod that sets only
+	// hostPID still gets both paths, where Rego's host-pid-ipc-privileges has a
+	// separate deny block per field and names only the one that failed.
+	//
+	// This is safe rather than merely tolerated: the value reported for hostIPC
+	// is the value the policy requires there, so applying it cannot make the Pod
+	// less compliant. If field-level pinning is added later this test should
+	// change to expect only spec.hostPID.
+	pod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "hostpid", "namespace": "default"},
+		"spec": map[string]any{
+			"hostPID":    true, // the only violation; hostIPC is absent, so compliant
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	}
+
+	assert.Equal(t, []PathHint{
+		{Path: "spec.hostIPC", Value: "false"},
+		{Path: "spec.hostPID", Value: "false"},
+	}, failingPaths(t, "C-0038", pod))
+}
+
 func TestPassingResultsCarryNoPaths(t *testing.T) {
 	e, err := NewEvaluator()
 	require.NoError(t, err)
@@ -446,9 +473,12 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 // path with a surprising value, that is the signal to look.
 //
 // Two absences are worth naming so a reader does not read them as bugs:
-//   - spec.template.spec.hostIPC=false is missing because of the upstream C-0038
-//     workload bug, which checks hostPID twice and never hostIPC. The derivation
-//     reports exactly what the expression says.
+//   - spec.template.spec.hostIPC=false is missing because C-0038's workload
+//     validation in this vendored bundle checks hostPID twice and never hostIPC.
+//     The derivation reports exactly what the expression says. That policy bug is
+//     already fixed on cel-admission-library main and only survives here because
+//     the pinned release predates the fix, so this entry comes back on its own
+//     once CEL_LIBRARY_VERSION is bumped - no upstream issue to chase.
 //   - C-0075's imagePullPolicy=Always is missing because its element predicate
 //     `!c.image.endsWith(':latest') || c.imagePullPolicy == 'Always'` puts the
 //     equality under a disjunction: retagging the image satisfies the policy

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -699,21 +699,29 @@ func celRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, messag
 //
 // Paths repeat across a policy's validations (the bundle guards each kind with
 // its own validation, and several can name the same field), so they are
-// deduplicated to keep one finding from listing the same path twice.
+// deduplicated by path to keep one finding from listing the same path twice.
+// The dedup is keyed on the path alone, not the whole hint: if the same path
+// arrives once with a value and once without, it must land in exactly one of
+// FixPaths or ReviewPaths, so the valued hint wins and the bare one is dropped.
 func celRemediation(hints []cel.PathHint) reporthandling.AssistedRemediation {
-	var remediation reporthandling.AssistedRemediation
-	seen := make(map[cel.PathHint]struct{}, len(hints))
+	byPath := make(map[string]string, len(hints))
+	order := make([]string, 0, len(hints))
 	for _, hint := range hints {
-		if _, dup := seen[hint]; dup {
-			continue
+		if existing, seen := byPath[hint.Path]; !seen {
+			byPath[hint.Path] = hint.Value
+			order = append(order, hint.Path)
+		} else if existing == "" {
+			byPath[hint.Path] = hint.Value // a valued hint supersedes a bare one
 		}
-		seen[hint] = struct{}{}
+	}
 
-		if hint.Value != "" {
-			remediation.FixPaths = append(remediation.FixPaths, armotypes.FixPath{Path: hint.Path, Value: hint.Value})
+	var remediation reporthandling.AssistedRemediation
+	for _, path := range order {
+		if value := byPath[path]; value != "" {
+			remediation.FixPaths = append(remediation.FixPaths, armotypes.FixPath{Path: path, Value: value})
 			continue
 		}
-		remediation.ReviewPaths = append(remediation.ReviewPaths, hint.Path)
+		remediation.ReviewPaths = append(remediation.ReviewPaths, path)
 	}
 	return remediation
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -593,6 +593,7 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 
 		violated := false
 		var messages []string
+		var hints []cel.PathHint
 		var objErrs []error
 		for _, res := range eval.Results {
 			if res.Err != nil {
@@ -602,12 +603,13 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 			if !res.Passed {
 				violated = true
 				messages = append(messages, res.Message)
+				hints = append(hints, res.Paths...)
 			}
 		}
 
 		switch {
 		case violated:
-			responses = append(responses, celRuleResponse(rule, obj, messages))
+			responses = append(responses, celRuleResponse(rule, obj, messages, hints))
 			// A confirmed violation wins over a sibling validation that errored,
 			// matching admission (a deny stands). Surface the dropped errors so a
 			// broken validation in an otherwise-failing policy is not invisible.
@@ -672,16 +674,48 @@ func (opap *OPAProcessor) getCELEvaluator() (*cel.Evaluator, error) {
 // handling (processRule) treats CEL and Rego violations identically: a
 // RuleResponse with no Exception is a failure (opa-utils RuleResponse.Failed),
 // and GetFailedResources reads the object back out of AlertObject.K8SApiObjects.
-func celRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, messages []string) reporthandling.RuleResponse {
+func celRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, messages []string, hints []cel.PathHint) reporthandling.RuleResponse {
 	return reporthandling.RuleResponse{
-		AlertMessage: strings.Join(messages, "; "),
-		RuleStatus:   reporthandling.StatusFailed,
-		PackageName:  rule.Name,
-		Rulename:     rule.Name,
+		AlertMessage:        strings.Join(messages, "; "),
+		AssistedRemediation: celRemediation(hints),
+		RuleStatus:          reporthandling.StatusFailed,
+		PackageName:         rule.Name,
+		Rulename:            rule.Name,
 		AlertObject: reporthandling.AlertObject{
 			K8SApiObjects: []map[string]any{obj},
 		},
 	}
+}
+
+// celRemediation maps the evaluator's neutral path hints onto the report
+// model's remediation fields, so appendPaths gives a CEL failure the same
+// ResourceAssociatedRule.Paths a Rego failure carries.
+//
+// A hint with a value says what the policy requires at that path, which is a
+// fix `kubescape fix` can write into the YAML. A hint without one only says
+// where the policy looked, so it becomes a review path: naming the field is
+// useful, but inventing the value to put there would let `kubescape fix` write
+// something the policy never asked for.
+//
+// Paths repeat across a policy's validations (the bundle guards each kind with
+// its own validation, and several can name the same field), so they are
+// deduplicated to keep one finding from listing the same path twice.
+func celRemediation(hints []cel.PathHint) reporthandling.AssistedRemediation {
+	var remediation reporthandling.AssistedRemediation
+	seen := make(map[cel.PathHint]struct{}, len(hints))
+	for _, hint := range hints {
+		if _, dup := seen[hint]; dup {
+			continue
+		}
+		seen[hint] = struct{}{}
+
+		if hint.Value != "" {
+			remediation.FixPaths = append(remediation.FixPaths, armotypes.FixPath{Path: hint.Path, Value: hint.Value})
+			continue
+		}
+		remediation.ReviewPaths = append(remediation.ReviewPaths, hint.Path)
+	}
+	return remediation
 }
 
 // celResourceID labels an object in an eval-error message; it falls back to a

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor/cel"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
@@ -683,6 +684,22 @@ func TestRunOPAOnSingleRuleDispatch(t *testing.T) {
 	})
 }
 
+func TestCELRemediation(t *testing.T) {
+	remediation := celRemediation([]cel.PathHint{
+		{Path: "spec.hostNetwork", Value: "false"},
+		{Path: "spec.containers[0].image"},
+		// The bundle guards each kind with its own validation, so the same
+		// path can arrive from more than one of them.
+		{Path: "spec.hostNetwork", Value: "false"},
+		{Path: "spec.containers[0].image"},
+	})
+
+	assert.Equal(t, []armotypes.FixPath{{Path: "spec.hostNetwork", Value: "false"}}, remediation.FixPaths,
+		"a hint with a value is a fix kubescape fix can write")
+	assert.Equal(t, []string{"spec.containers[0].image"}, remediation.ReviewPaths,
+		"a hint without a value names the field but not what to put there")
+}
+
 func TestRunCELOnK8s(t *testing.T) {
 	opap := &OPAProcessor{}
 	rule := &reporthandling.PolicyRule{
@@ -739,6 +756,24 @@ func TestRunCELOnK8s(t *testing.T) {
 		failed := responses[0].GetFailedResources()
 		require.Len(t, failed, 1)
 		assert.Equal(t, "mutable", failed[0]["metadata"].(map[string]any)["name"])
+	})
+
+	t.Run("failure carries the remediation paths appendPaths needs", func(t *testing.T) {
+		// The gap this closes: without paths on the response, appendPaths has
+		// nothing to contribute and the finding reaches the printers and
+		// `kubescape fix` with an empty Paths list.
+		responses, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod}, nil, "C-0017")
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+
+		assert.Equal(t, []armotypes.FixPath{
+			{Path: "spec.containers[0].securityContext.readOnlyRootFilesystem", Value: "true"},
+		}, responses[0].FixPaths)
+
+		paths := appendPaths(nil, responses[0].AssistedRemediation, "resource-id")
+		require.Len(t, paths, 1)
+		assert.Equal(t, "spec.containers[0].securityContext.readOnlyRootFilesystem", paths[0].FixPath.Path)
+		assert.Equal(t, "resource-id", paths[0].ResourceID)
 	})
 
 	t.Run("compliant object produces no response and no skip", func(t *testing.T) {

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -700,6 +700,27 @@ func TestCELRemediation(t *testing.T) {
 		"a hint without a value names the field but not what to put there")
 }
 
+func TestCELRemediationSamePathValuedAndBare(t *testing.T) {
+	// The same path can be read as a bare presence test by one validation and as
+	// an equality by another. It must land in exactly one bucket: the valued
+	// hint wins, so it is a FixPath and never also a ReviewPath. Order of arrival
+	// must not matter.
+	valuedFirst := celRemediation([]cel.PathHint{
+		{Path: "spec.hostNetwork", Value: "false"},
+		{Path: "spec.hostNetwork"},
+	})
+	bareFirst := celRemediation([]cel.PathHint{
+		{Path: "spec.hostNetwork"},
+		{Path: "spec.hostNetwork", Value: "false"},
+	})
+
+	want := reporthandling.AssistedRemediation{FixPaths: []armotypes.FixPath{{Path: "spec.hostNetwork", Value: "false"}}}
+	assert.Equal(t, want, valuedFirst)
+	assert.Equal(t, want, bareFirst)
+	assert.Empty(t, valuedFirst.ReviewPaths, "a path that has a fix value must not also be listed for review")
+	assert.Empty(t, bareFirst.ReviewPaths)
+}
+
 func TestRunCELOnK8s(t *testing.T) {
 	opap := &OPAProcessor{}
 	rule := &reporthandling.PolicyRule{


### PR DESCRIPTION
## Overview

Follow up to #2525. In that review matthyx pointed out CEL failures come out with no AssistedRemediation paths, so a CEL finding shows up without the remediation paths its Rego equivalent carries. I said I'd do it separately so #2525 stayed about dispatch and scoping. This is that PR.

`celRuleResponse` left AssistedRemediation zero, so `appendPaths` had nothing to add and the finding landed with empty `ResourceAssociatedRule.Paths`. Blank path columns, no SARIF region, and `kubescape fix` couldn't touch a CEL finding at all. A VAP validation has no path info in it, so paths have to be pulled out of the expression.

New file `cel/paths.go`, two stages. First, per expression and cached: walk the AST for the longest field chains rooted at `object`, and for the one loop whose range is rooted at `object`, the chains rooted at its loop variable. `object.kind` never becomes a path, `appliesTo` already answered that. Second, per failing object: `.all()` over a one element list is just the predicate on that element, so to find which container is at fault I copy the object with the list narrowed to one element and run the validation again. Still fails means real offender, passes means it doesn't get named. Only runs for objects that already failed.

I did try the simpler version first (plain field chains only, loops later) but 88 of the bundle's 103 validations loop over a list, and the Rego rules give indexed paths like `spec.containers[0].securityContext.readOnlyRootFilesystem`, so it would have shipped almost nothing.

Since `kubescape fix` writes FixPaths into someone's yaml, a wrong path is worse than no path, so it stays quiet in two places: two object lists in one expression means no paths (can't tell which list failed), and a value only comes from `<chain> == <literal>`, since `!=` isn't a value to write and an equality under a `!` or ternary might be flipped. Those give a path with no value, which becomes a ReviewPath instead of a FixPath. 91 of 103 validations end up with a path, the rest are the three constant-`false` policies and the three multi list controls.

C-0017 on a pod with bad / good / bad containers gives paths for 0 and 2 and skips the compliant one, matching the Rego rule and the format fixhandler's own tests use.

AlertScore I left at zero on purpose. Nothing reads it (grepped kubescape and opa-utils v0.0.301, just the type, the field and a mock), and the only honest value would be Rego's hand picked per rule score, which a VAP has no equivalent for. BaseScore is a different number for a different job, so filling it felt like inventing data. Happy to be argued out of this one.

Side note, this doubles as a linter for the bundle. It found two policies that read a field they don't mean to. I'll open an issue on cel-admission-library rather than patch the vendored copy, since `make sync-vap` would overwrite it.

Tests cover the plan shapes, both bail outs, index pinning, nothing named when the failure is elsewhere, and passing results carrying none. Plus a bundle driven `TestEveryBundleValidationYieldsAPath` with a documented exempt list, same self updating idea as the scoping test from #2525, so a `make sync-vap` that rewrites an expression into an unreadable shape fails instead of quietly dropping paths. On the kubescape side, a test that `appendPaths` now produces a non-empty `ResourceAssociatedRule.Paths`, the seam that was dead before.

`go build ./core/...`, `go vet ./core/...` and both suites pass.

Part of #2001

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added user-facing remediation “paths” for CEL validation failures, including exact field locations and safer list element attribution.
  - Assisted remediation now includes deduplicated `FixPaths` (with fix values when derivation is unambiguous) and `ReviewPaths`.

- **Bug Fixes**
  - Passing CEL validations no longer produce remediation paths.
  - Remediation blame is better aligned to the actual failing element, avoiding incorrect element-level fixes when the cause is elsewhere.

- **Tests**
  - Added comprehensive CEL and bundle-wide regression tests covering path/value derivation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->