### PR TITLE
fix(cel): guard optional field paths so valid workloads are evaluated, not skipped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 # it stays reproducible instead of hand-maintained. Bump CEL_LIBRARY_VERSION to
 # vendor a newer bundle.
 CEL_VAPDATA_DIR := core/pkg/opaprocessor/cel/vapdata
-CEL_LIBRARY_VERSION := v0.11
+CEL_LIBRARY_VERSION := v0.12
 CEL_LIBRARY_BASE_URL := https://github.com/kubescape/cel-admission-library/releases/download/$(CEL_LIBRARY_VERSION)
 CEL_VAP_FILES := \
 	kubescape-validating-admission-policies.yaml \

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -652,12 +652,14 @@ func TestResolvePolicyName(t *testing.T) {
 			want:       "kubescape-c-0016-allow-privilege-escalation",
 		},
 		{
-			// The retired hand-typed map listed controls (e.g. C-0199) that no
-			// released bundle ships; resolution now matches what deploy-library
-			// actually deploys, so those fail instead of producing a binding to
-			// a policy that does not exist on the cluster.
+			// The retired hand-typed map listed controls (e.g. C-0012) that the
+			// released bundle ships as a policy but without a controlId label, so
+			// PolicyNameForControl cannot resolve it; resolution now matches what
+			// deploy-library actually deploys and exposes by control ID, so this
+			// fails instead of producing a binding to a policy the caller could
+			// not otherwise have found by control ID either.
 			name:      "control absent from the released bundle",
-			controlID: "C-0199",
+			controlID: "C-0012",
 			wantErr:   "unsupported control ID",
 		},
 	}

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -170,7 +170,7 @@ func (e *Evaluator) activationFor(ctx context.Context, obj, namespaceObject map[
 // object tells us nothing, and blaming an element on a guess would put a wrong
 // path in front of the user.
 func (e *Evaluator) violationPaths(ctx context.Context, expr string, obj, namespaceObject map[string]any, params any, variables []Variable) []PathHint {
-	return e.plans.get(expr).resolve(obj, func(narrowed map[string]any) bool {
+	return e.plans.get(expr, variables).resolve(obj, func(narrowed map[string]any) bool {
 		out, err := e.evalExpression(ctx, expr, e.activationFor(ctx, narrowed, namespaceObject, params, variables))
 		if err != nil {
 			return false
@@ -180,12 +180,15 @@ func (e *Evaluator) violationPaths(ctx context.Context, expr string, obj, namesp
 	})
 }
 
-// buildPathPlan compiles an expression and reads its path plan off the AST.
-// Callers go through the plan cache. An expression that will not compile never
-// reached evaluation either, so an empty plan (no paths) is the right answer
-// rather than an error to propagate.
-func (e *Evaluator) buildPathPlan(expr string) pathPlan {
-	ast, issues := e.env.Compile(expr)
+// buildPathPlan compiles an expression - after expanding any `variables.<name>`
+// references it makes into the referenced variable's own expression (see
+// inlineVariables), so the AST walk sees the object access those variables
+// wrap - and reads its path plan off the result. Callers go through the plan
+// cache. An expression that will not compile never reached evaluation either,
+// so an empty plan (no paths) is the right answer rather than an error to
+// propagate.
+func (e *Evaluator) buildPathPlan(expr string, variables []Variable) pathPlan {
+	ast, issues := e.env.Compile(inlineVariables(expr, variables))
 	if issues != nil && issues.Err() != nil {
 		return pathPlan{}
 	}

--- a/core/pkg/opaprocessor/cel/optionalfields_test.go
+++ b/core/pkg/opaprocessor/cel/optionalfields_test.go
@@ -1,0 +1,239 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The scan binds "object" to the raw scanned manifest, so an omitempty field the
+// author left out is simply absent from the map. CEL raises "no such key" on a
+// field selection into a missing key, evaluateValidation records that as Err,
+// and runCELOnK8s turns "no violation + eval error" into StatusSkipped. A policy
+// that walks an optional path without guarding it therefore reports a perfectly
+// ordinary workload as Skipped/Unknown rather than Passed.
+//
+// Live admission hides this: the VAP object there is schema-defaulted, so
+// spec.volumes is an empty list and [].all(...) is vacuously true. Offline there
+// is no defaulting, so every optional hop needs its own has() guard.
+//
+// Note has() only guards the final selection: has(a.b.c) still errors when a.b
+// is missing. Nested optional paths need a guard per hop.
+
+// bareContainers is a pod spec with nothing optional set: no volumes, no
+// securityContext, no per-container securityContext.
+func bareContainers() map[string]any {
+	return map[string]any{
+		"containers": []any{map[string]any{"name": "c", "image": "nginx:1.25"}},
+	}
+}
+
+// hostPathSpec is a pod spec mounting a hostPath volume with readOnly unset,
+// which both C-0045 (readOnly not false) and C-0048 (any hostPath) must flag.
+func hostPathSpec() map[string]any {
+	return map[string]any{
+		"containers": []any{map[string]any{
+			"name": "c", "image": "nginx:1.25",
+			"volumeMounts": []any{map[string]any{"name": "h", "mountPath": "/host"}},
+		}},
+		"volumes": []any{map[string]any{
+			"name":     "h",
+			"hostPath": map[string]any{"path": "/", "type": "Directory"},
+		}},
+	}
+}
+
+func pod(spec map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "p", "namespace": "default"},
+		"spec":     spec,
+	}
+}
+
+// deployment omits spec.template.metadata: it is optional, and C-0055 used to
+// walk into it unguarded.
+func deployment(spec map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{"name": "d", "namespace": "default"},
+		"spec":     map[string]any{"template": map[string]any{"spec": spec}},
+	}
+}
+
+func job(spec map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": "batch/v1", "kind": "Job",
+		"metadata": map[string]any{"name": "j", "namespace": "default"},
+		"spec":     map[string]any{"template": map[string]any{"spec": spec}},
+	}
+}
+
+// cronJob omits spec.jobTemplate.metadata, the common case in a real manifest.
+func cronJob(spec map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": "batch/v1", "kind": "CronJob",
+		"metadata": map[string]any{"name": "cj", "namespace": "default"},
+		"spec": map[string]any{
+			"schedule":    "* * * * *",
+			"jobTemplate": map[string]any{"spec": map[string]any{"template": map[string]any{"spec": spec}}},
+		},
+	}
+}
+
+// bundleControlIDs lists every control the vendored bundle ships a policy for.
+// TestBundleControlIDsAreCurrent keeps it honest against the bundle itself.
+var bundleControlIDs = []string{
+	"C-0001", "C-0004", "C-0009", "C-0016", "C-0017", "C-0018", "C-0020", "C-0034",
+	"C-0038", "C-0041", "C-0042", "C-0044", "C-0045", "C-0046", "C-0048", "C-0050",
+	"C-0055", "C-0056", "C-0057", "C-0061", "C-0062", "C-0073", "C-0074", "C-0075",
+	"C-0076", "C-0077", "C-0078", "C-0268", "C-0269", "C-0270", "C-0271",
+}
+
+// TestNoEvalErrorOnMinimalWorkloads is the guard for the whole bug class: no
+// control in the bundle may eval-error on a valid workload that sets nothing
+// optional. An error here means that control silently reports Skipped/Unknown
+// instead of a real verdict for the majority of real-world manifests.
+//
+// It also protects against a re-sync from a cel-admission-library release that
+// predates these fixes: `make sync-vap` overwrites the bundle, and this test is
+// what catches the regression rather than a user noticing skipped resources.
+func TestNoEvalErrorOnMinimalWorkloads(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	objects := map[string]map[string]any{
+		"Pod":        pod(bareContainers()),
+		"Deployment": deployment(bareContainers()),
+		"Job":        job(bareContainers()),
+		"CronJob":    cronJob(bareContainers()),
+	}
+
+	for kind, obj := range objects {
+		for _, id := range bundleControlIDs {
+			ev, err := e.EvaluateControl(context.Background(), id, obj, nil)
+			if err != nil {
+				// The engine refuses policies it cannot honor offline (e.g.
+				// matchConditions); the scanner skips the whole rule, which is a
+				// separate, already-intentional path.
+				continue
+			}
+			if !ev.Applicable {
+				continue
+			}
+			for i, res := range ev.Results {
+				assert.NoErrorf(t, res.Err,
+					"%s validation[%d] eval-errored on a minimal %s; the resource would be reported Skipped/Unknown instead of evaluated",
+					id, i, kind)
+			}
+		}
+	}
+}
+
+// TestHostPathControlsOnVolumelessWorkloads pins the specific verdict, not just
+// the absence of an error: a workload with no volumes cannot have a hostPath, so
+// both hostPath controls must pass it cleanly.
+func TestHostPathControlsOnVolumelessWorkloads(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	objects := map[string]map[string]any{
+		"Pod":        pod(bareContainers()),
+		"Deployment": deployment(bareContainers()),
+		"Job":        job(bareContainers()),
+		"CronJob":    cronJob(bareContainers()),
+	}
+
+	for _, id := range []string{"C-0045", "C-0048"} {
+		for kind, obj := range objects {
+			ev, err := e.EvaluateControl(context.Background(), id, obj, nil)
+			require.NoError(t, err)
+			require.Truef(t, ev.Applicable, "%s must match a %s", id, kind)
+			for i, res := range ev.Results {
+				require.NoErrorf(t, res.Err, "%s validation[%d] on volume-less %s", id, i, kind)
+				assert.Truef(t, res.Passed, "%s validation[%d] must pass a volume-less %s", id, i, kind)
+			}
+		}
+	}
+}
+
+// TestHostPathControlsStillDetectViolations is the other half: the guards added
+// for the volume-less case must short-circuit only when the path is genuinely
+// absent, never when a real hostPath is present.
+//
+// The CronJob case is the regression that matters most for C-0048, whose guard
+// used to test spec.jobTemplate.spec.volumes while the check read
+// spec.jobTemplate.spec.template.spec.volumes. That path never exists, so the
+// expression always short-circuited to true and a hostPath CronJob was passed:
+// a silent false negative, strictly worse than a visible skip.
+func TestHostPathControlsStillDetectViolations(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	objects := map[string]map[string]any{
+		"Pod":        pod(hostPathSpec()),
+		"Deployment": deployment(hostPathSpec()),
+		"Job":        job(hostPathSpec()),
+		"CronJob":    cronJob(hostPathSpec()),
+	}
+
+	for _, id := range []string{"C-0045", "C-0048"} {
+		for kind, obj := range objects {
+			ev, err := e.EvaluateControl(context.Background(), id, obj, nil)
+			require.NoError(t, err)
+			require.Truef(t, ev.Applicable, "%s must match a %s", id, kind)
+
+			violated := false
+			for i, res := range ev.Results {
+				require.NoErrorf(t, res.Err, "%s validation[%d] on hostPath %s", id, i, kind)
+				if !res.Passed {
+					violated = true
+				}
+			}
+			assert.Truef(t, violated, "%s must flag a %s mounting a hostPath volume", id, kind)
+		}
+	}
+}
+
+// TestC0055ReadsCronJobSecurityContextFromPodSpec covers the other path fix in
+// this change: C-0055's CronJob validation read the securityContext from
+// spec.jobTemplate.spec, one level above where a pod template actually carries
+// it. A CronJob hardened with a pod-level seccompProfile was therefore judged
+// only by its per-container securityContext and reported as failing.
+func TestC0055ReadsCronJobSecurityContextFromPodSpec(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	spec := bareContainers()
+	spec["securityContext"] = map[string]any{
+		"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+	}
+
+	ev, err := e.EvaluateControl(context.Background(), "C-0055", cronJob(spec), nil)
+	require.NoError(t, err)
+	require.True(t, ev.Applicable)
+	for i, res := range ev.Results {
+		require.NoErrorf(t, res.Err, "C-0055 validation[%d]", i)
+		assert.Truef(t, res.Passed,
+			"C-0055 validation[%d] must accept a CronJob whose pod template sets a seccompProfile", i)
+	}
+}
+
+// TestBundleControlIDsAreCurrent keeps bundleControlIDs in sync with the bundle,
+// so a re-sync that adds controls does not silently leave them out of the
+// eval-error sweep above.
+func TestBundleControlIDsAreCurrent(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	listed := make(map[string]bool, len(bundleControlIDs))
+	for _, id := range bundleControlIDs {
+		listed[id] = true
+	}
+	for id := range catalog.byControl {
+		assert.Truef(t, listed[id],
+			"control %s is in the bundle but missing from bundleControlIDs; add it so the eval-error sweep covers it", id)
+	}
+}

--- a/core/pkg/opaprocessor/cel/optionalfields_test.go
+++ b/core/pkg/opaprocessor/cel/optionalfields_test.go
@@ -86,10 +86,11 @@ func cronJob(spec map[string]any) map[string]any {
 // bundleControlIDs lists every control the vendored bundle ships a policy for.
 // TestBundleControlIDsAreCurrent keeps it honest against the bundle itself.
 var bundleControlIDs = []string{
-	"C-0001", "C-0004", "C-0009", "C-0016", "C-0017", "C-0018", "C-0020", "C-0034",
-	"C-0038", "C-0041", "C-0042", "C-0044", "C-0045", "C-0046", "C-0048", "C-0050",
-	"C-0055", "C-0056", "C-0057", "C-0061", "C-0062", "C-0073", "C-0074", "C-0075",
-	"C-0076", "C-0077", "C-0078", "C-0268", "C-0269", "C-0270", "C-0271",
+	"C-0001", "C-0004", "C-0009", "C-0016", "C-0017", "C-0018", "C-0020", "C-0026",
+	"C-0034", "C-0038", "C-0041", "C-0042", "C-0044", "C-0045", "C-0046", "C-0048",
+	"C-0050", "C-0055", "C-0056", "C-0057", "C-0061", "C-0062", "C-0073", "C-0074",
+	"C-0075", "C-0076", "C-0077", "C-0078", "C-0198", "C-0199", "C-0200", "C-0201",
+	"C-0210", "C-0268", "C-0269", "C-0270", "C-0271", "C-0280",
 }
 
 // TestNoEvalErrorOnMinimalWorkloads is the guard for the whole bug class: no

--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -1,6 +1,7 @@
 package cel
 
 import (
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,12 +60,22 @@ type fieldRef struct {
 
 // elementPlan describes a validation that iterates a list on the object, which
 // is the shape almost every workload policy in the bundle has
-// (`object.spec.containers.all(container, ...)`). collection is the list's
-// object-relative path and fields are element-relative, so the two are joined
-// with an index once we know which element failed.
+// (`object.spec.containers.all(container, ...)`). fields are element-relative,
+// joined to a collection path with an index once we know which element
+// failed.
+//
+// The list itself is usually one fixed path (collection). A validation that
+// goes through a variable inlined by inlineVariables can instead iterate a
+// ternary that picks the list by the object's kind (`object.kind == 'Pod' ?
+// object.spec.containers : ...`) - see objectRootedPaths. Which branch is real
+// depends on the object, not the expression, so that shape sets collections
+// instead: every candidate path, at most one of which is an actual list on any
+// given object (the bundle's matchConstraints already narrowed evaluation to
+// one kind). Exactly one of the two is ever set.
 type elementPlan struct {
-	collection string
-	fields     []fieldRef
+	collection  string
+	collections []string
+	fields      []fieldRef
 }
 
 // pathPlan is everything one validation expression can say about where it
@@ -93,6 +104,70 @@ var scopeGuardFields = map[string]bool{
 	"apiVersion": true,
 }
 
+// inlineVariables textually expands every `variables.<name>` reference in expr
+// with that variable's own expression, parenthesized so it composes safely
+// with whatever follows it (a field access, a comprehension, ...). Newer bundle
+// releases factor object access into a `variables:` block instead of inlining
+// it in the validation (`variables.containers.all(...)` rather than
+// `object.spec.containers.all(...)`), and the AST walk below only understands
+// paths rooted at `object`, so without this expansion those validations would
+// derive no path at all (see pathlessPolicies' KNOWN LIMITATION note).
+//
+// A variable's expression may only reference object/params/request and
+// variables declared before it (enforced by the bundle format), so expanding
+// left to right - each variable substituting the ones already expanded before
+// it is itself substituted into later expressions - reaches a fully
+// object-rooted form in one pass; no fixpoint loop is needed.
+func inlineVariables(expr string, variables []Variable) string {
+	expanded := make(map[string]string, len(variables))
+	for _, v := range variables {
+		body := maskVariableHasGuards(v.Expression)
+		for _, prior := range variables {
+			if prior.Name == v.Name {
+				break
+			}
+			if replacement, ok := expanded[prior.Name]; ok {
+				body = substituteVariableRef(body, prior.Name, replacement)
+			}
+		}
+		expanded[v.Name] = "(" + body + ")"
+	}
+	expr = maskVariableHasGuards(expr)
+	for _, v := range variables {
+		if replacement, ok := expanded[v.Name]; ok {
+			expr = substituteVariableRef(expr, v.Name, replacement)
+		}
+	}
+	return expr
+}
+
+// variableHasGuardPattern matches `has(variables.<chain>)`: a presence guard
+// on a variable reference. CEL's has() macro requires its argument to be a
+// literal select chain (has(1+1) is a compile error), so substituting a
+// variable's own expression - a ternary, once inlineVariables has expanded it
+// - into one, even just at the `variables.<name>` root, stops the whole
+// expression compiling. That guard exists only to protect a later, non-has()
+// read of the same field against a missing-field error, and that later read
+// is exactly the occurrence this file derives a path from - has() itself
+// never carries a value. So neutralizing every such guard to the constant
+// `true` before substitution costs no derivable path, and keeps a variable
+// reference inside `has()` from taking the whole validation's plan down with
+// it (see buildPathPlan: a compile failure here yields the empty plan).
+var variableHasGuardPattern = regexp.MustCompile(`has\(\s*variables(?:\.[A-Za-z_][A-Za-z0-9_]*)+\s*\)`)
+
+func maskVariableHasGuards(expr string) string {
+	return variableHasGuardPattern.ReplaceAllLiteralString(expr, "true")
+}
+
+// substituteVariableRef replaces every `variables.<name>` reference in expr
+// with replacement. \b on both ends keeps a name from matching as a prefix or
+// suffix of a longer identifier (`variables.containers2` must not match name
+// "containers").
+func substituteVariableRef(expr, name, replacement string) string {
+	pattern := regexp.MustCompile(`\bvariables\.` + regexp.QuoteMeta(name) + `\b`)
+	return pattern.ReplaceAllLiteralString(expr, replacement)
+}
+
 // newPathPlan derives the plan for one compiled validation expression.
 func newPathPlan(ast *cel.Ast) pathPlan {
 	native := ast.NativeRep()
@@ -102,14 +177,34 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 	// params lists and inline kind lists too) tell us nothing about where the
 	// object is wrong, so only object-rooted ones count.
 	var iterated []celast.NavigableExpr
+	var iteratedPaths [][]string
 	ranges := map[string]bool{}
 	for _, node := range celast.MatchDescendants(root, celast.KindMatcher(celast.ComprehensionKind)) {
-		path, ok := selectPath(node.AsComprehension().IterRange(), "object")
+		rangeExpr := node.AsComprehension().IterRange()
+
+		// Every object-rooted select inside the range expression is plumbing
+		// that decides WHICH list to iterate (a fixed path, a per-kind ternary,
+		// a concatenation of several lists, ...), never a value the policy is
+		// asking the user to set - so none of them belong in plan.direct,
+		// whether or not the shape below resolves to an elementPlan. Without
+		// this a range objectRootedPaths cannot fully read (e.g. one that
+		// concatenates several lists with `+`) would otherwise leak its
+		// constituent paths as spurious direct fields.
+		for _, sel := range celast.MatchDescendants(celast.NavigateExpr(native, rangeExpr), celast.KindMatcher(celast.SelectKind)) {
+			if parent, ok := sel.Parent(); ok && parent.Kind() == celast.SelectKind {
+				continue
+			}
+			if path, ok := selectPath(sel, "object"); ok {
+				ranges[path] = true
+			}
+		}
+
+		paths, ok := objectRootedPaths(rangeExpr, "object")
 		if !ok {
 			continue
 		}
 		iterated = append(iterated, node)
-		ranges[path] = true
+		iteratedPaths = append(iteratedPaths, paths)
 	}
 
 	plan := pathPlan{}
@@ -119,7 +214,7 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 	// guessing, so we do not try.
 	if len(iterated) == 1 && narrowingIsExact(iterated[0]) {
 		comprehension := iterated[0].AsComprehension()
-		collection, _ := selectPath(comprehension.IterRange(), "object")
+		paths := iteratedPaths[0]
 
 		// A field the element predicate reads is element-relative and joined to
 		// the pinned index. This includes a collection the predicate iterates in
@@ -130,10 +225,15 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 		// at, unlike the object-level list we index into, which is not a hint
 		// because we are about to point at one of its elements instead.
 		loopStep := celast.NavigateExpr(native, comprehension.LoopStep())
-		plan.elements = &elementPlan{
-			collection: collection,
-			fields:     fieldsRootedAt(native, loopStep, comprehension.IterVar(), nil),
+		elements := &elementPlan{
+			fields: fieldsRootedAt(native, loopStep, comprehension.IterVar(), nil),
 		}
+		if len(paths) == 1 {
+			elements.collection = paths[0]
+		} else {
+			elements.collections = paths
+		}
+		plan.elements = elements
 	}
 
 	// The iterated list itself is not a direct hint: either we are about to
@@ -244,11 +344,17 @@ func fieldsRootedAt(native *celast.AST, root celast.NavigableExpr, ident string,
 		if parent, ok := node.Parent(); ok && parent.Kind() == celast.SelectKind {
 			continue
 		}
-		path, ok := selectPath(node, ident)
-		if !ok || path == "" || scopeGuardFields[path] || exclude[path] {
+		paths, ok := selectPaths(node, ident)
+		if !ok {
 			continue
 		}
-		refs = append(refs, fieldRef{path: path, value: requiredValue(native, node, ident)})
+		value := requiredValue(native, node, ident)
+		for _, path := range paths {
+			if path == "" || scopeGuardFields[path] || exclude[path] {
+				continue
+			}
+			refs = append(refs, fieldRef{path: path, value: value})
+		}
 	}
 	return dedupeRefs(refs)
 }
@@ -302,6 +408,103 @@ func selectPath(expr celast.Expr, ident string) (string, bool) {
 		parts = append(parts, reversed[i])
 	}
 	return strings.Join(parts, "."), true
+}
+
+// objectRootedPaths reads the list of straight ident-rooted paths a
+// comprehension's range expression could resolve to at runtime. The common
+// case is selectPath's single path; inlineVariables can also hand this a
+// ternary chain choosing among several kind-specific lists (the shape the
+// bundle's "containers" variable uses: `object.kind == 'Pod' ? object.spec.containers
+// : object.kind in [...] ? object.spec.template.spec.containers : ... : []`),
+// in which case every true-branch path is returned, in branch order.
+//
+// ok is false whenever a branch is neither a plain path nor another ternary of
+// the same shape: an opaque branch means we cannot enumerate every list the
+// range could be, and guessing which ones matter would risk missing the real
+// one, so the whole comprehension is left alone (falls back to no element
+// attribution) rather than reporting a partial candidate set.
+//
+// The final else of a kind-dispatch ternary is usually a catch-all that is not
+// itself a list on any object (an empty list literal, for a kind none of the
+// earlier branches matched); a bare final else that is not a path is treated
+// as that catch-all rather than disqualifying the whole chain, since resolve
+// only ever uses a candidate that actually is a list on the object it checks.
+func objectRootedPaths(expr celast.Expr, ident string) ([]string, bool) {
+	if path, ok := selectPath(expr, ident); ok {
+		return []string{path}, true
+	}
+	if expr.Kind() != celast.CallKind {
+		return nil, false
+	}
+	call := expr.AsCall()
+	if call.FunctionName() != operators.Conditional || len(call.Args()) != 3 {
+		return nil, false
+	}
+
+	truePaths, ok := objectRootedPaths(call.Args()[1], ident)
+	if !ok {
+		return nil, false
+	}
+
+	elseBranch := call.Args()[2]
+	if elseBranch.Kind() == celast.CallKind && elseBranch.AsCall().FunctionName() == operators.Conditional {
+		elsePaths, ok := objectRootedPaths(elseBranch, ident)
+		if !ok {
+			return nil, false
+		}
+		return append(truePaths, elsePaths...), true
+	}
+	if path, ok := selectPath(elseBranch, ident); ok {
+		return append(truePaths, path), true
+	}
+	return truePaths, true
+}
+
+// selectPaths generalizes selectPath to a select chain whose base does not
+// bottom out at ident directly but at an object-rooted ternary of paths (see
+// objectRootedPaths) - the shape inlineVariables leaves behind when a
+// variable's own expression picks the right object by kind
+// (`(object.kind == 'Pod' ? object.spec.securityContext : ...).runAsUser`).
+// Each candidate base contributes one path, base-plus-the-peeled-suffix; a
+// plain chain still resolves to its one path, same as selectPath.
+//
+// The bare base paths are not returned, only the composed ones - a caller
+// that (like fieldsRootedAt, walking every select in the tree) also visits
+// the base's own select nodes as their own chains gets the bare paths
+// separately, and dedupeRefs drops each one once the corresponding composed
+// path here makes it a prefix of something more specific. Without that, a
+// ternary base half-resolved through a further field select would report the
+// object it picks - "spec.securityContext" - as if that whole object were
+// the fix, instead of the one field the validation actually reads off it.
+func selectPaths(expr celast.Expr, ident string) ([]string, bool) {
+	if path, ok := selectPath(expr, ident); ok {
+		return []string{path}, true
+	}
+
+	var suffix []string
+	for expr.Kind() == celast.SelectKind {
+		sel := expr.AsSelect()
+		suffix = append(suffix, sel.FieldName())
+		expr = sel.Operand()
+	}
+	if len(suffix) == 0 {
+		return nil, false
+	}
+	bases, ok := objectRootedPaths(expr, ident)
+	if !ok {
+		return nil, false
+	}
+
+	for i, j := 0, len(suffix)-1; i < j; i, j = i+1, j-1 {
+		suffix[i], suffix[j] = suffix[j], suffix[i]
+	}
+	tail := strings.Join(suffix, ".")
+
+	paths := make([]string, len(bases))
+	for i, base := range bases {
+		paths[i] = base + "." + tail
+	}
+	return paths, true
 }
 
 // requiredValue returns the literal a field read is compared against, but only
@@ -503,8 +706,7 @@ func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool
 		return hints
 	}
 
-	segments := strings.Split(p.elements.collection, ".")
-	list, ok := lookupList(obj, segments)
+	collection, segments, list, ok := p.elements.resolveCollection(obj)
 	if !ok {
 		return hints
 	}
@@ -524,12 +726,32 @@ func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool
 		if !ok || !violates(candidate) {
 			continue
 		}
-		prefix := p.elements.collection + "[" + strconv.Itoa(i) + "]."
+		prefix := collection + "[" + strconv.Itoa(i) + "]."
 		for _, ref := range p.elements.fields {
 			hints = append(hints, PathHint{Path: prefix + ref.path, Value: ref.value})
 		}
 	}
 	return hints
+}
+
+// resolveCollection picks which candidate list path is a real list on obj. The
+// common case (collection set, collections nil) has exactly one candidate;
+// collections holds several kind-dependent candidates when the range came from
+// a ternary (see objectRootedPaths), of which at most one is ever an actual
+// list on a given object - matchConstraints already narrowed evaluation to one
+// kind, so the rest simply are not present. ok is false when none resolve.
+func (p *elementPlan) resolveCollection(obj map[string]any) (collection string, segments []string, list []any, ok bool) {
+	candidates := p.collections
+	if len(candidates) == 0 {
+		candidates = []string{p.collection}
+	}
+	for _, candidate := range candidates {
+		segs := strings.Split(candidate, ".")
+		if l, ok := lookupList(obj, segs); ok {
+			return candidate, segs, l, true
+		}
+	}
+	return "", nil, nil, false
 }
 
 // lookupList reads the list at a dotted path, reporting false when the path is
@@ -577,14 +799,15 @@ func narrow(obj map[string]any, segments []string, value any) (map[string]any, b
 	return out, true
 }
 
-// pathPlanCache memoizes path plans by expression text, for the same reason
-// programCache memoizes programs: deriving a plan means compiling the
-// expression and walking its AST, and the answer is the same for every object
-// the expression runs against. An expression that will not compile has no plan
-// and never will, so the empty plan is cached too rather than recompiled per
-// failing object.
+// pathPlanCache memoizes path plans by expression text plus the variables it
+// was expanded against (see inlineVariables), for the same reason programCache
+// memoizes programs: deriving a plan means compiling the expression and
+// walking its AST, and the answer is the same for every object the expression
+// runs against. An expression that will not compile has no plan and never
+// will, so the empty plan is cached too rather than recompiled per failing
+// object.
 type pathPlanCache struct {
-	build func(expr string) pathPlan
+	build func(expr string, variables []Variable) pathPlan
 
 	mu      sync.Mutex
 	entries map[string]*pathPlanCacheEntry
@@ -595,22 +818,40 @@ type pathPlanCacheEntry struct {
 	plan pathPlan
 }
 
-func newPathPlanCache(build func(expr string) pathPlan) *pathPlanCache {
+func newPathPlanCache(build func(expr string, variables []Variable) pathPlan) *pathPlanCache {
 	return &pathPlanCache{
 		build:   build,
 		entries: make(map[string]*pathPlanCacheEntry),
 	}
 }
 
-func (c *pathPlanCache) get(expr string) pathPlan {
+func (c *pathPlanCache) get(expr string, variables []Variable) pathPlan {
+	key := planCacheKey(expr, variables)
+
 	c.mu.Lock()
-	entry, ok := c.entries[expr]
+	entry, ok := c.entries[key]
 	if !ok {
 		entry = &pathPlanCacheEntry{}
-		c.entries[expr] = entry
+		c.entries[key] = entry
 	}
 	c.mu.Unlock()
 
-	entry.once.Do(func() { entry.plan = c.build(expr) })
+	entry.once.Do(func() { entry.plan = c.build(expr, variables) })
 	return entry.plan
+}
+
+// planCacheKey combines an expression with the variables it may reference into
+// one cache key. Two policies can share validation expression text while
+// declaring different variables (or the same names with different bodies), so
+// the expression text alone is not a safe key once variables are in play.
+func planCacheKey(expr string, variables []Variable) string {
+	var b strings.Builder
+	b.WriteString(expr)
+	for _, v := range variables {
+		b.WriteByte(0)
+		b.WriteString(v.Name)
+		b.WriteByte(0)
+		b.WriteString(v.Expression)
+	}
+	return b.String()
 }

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -13,7 +13,7 @@ func planFor(t *testing.T, expr string) pathPlan {
 	t.Helper()
 	e, err := NewEvaluator()
 	require.NoError(t, err)
-	return e.buildPathPlan(expr)
+	return e.buildPathPlan(expr, nil)
 }
 
 func TestPathPlanDirectFields(t *testing.T) {
@@ -278,7 +278,7 @@ func resolvePlan(t *testing.T, expr string, obj map[string]any) []PathHint {
 		require.True(t, ok)
 		return !passed
 	}
-	return e.buildPathPlan(expr).resolve(obj, violates)
+	return e.buildPathPlan(expr, nil).resolve(obj, violates)
 }
 
 func TestViolationPathsBlameNoElementWhenAConjunctiveSiblingFails(t *testing.T) {
@@ -411,6 +411,18 @@ var pathlessPolicies = map[string]string{
 	"kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false":             "iterates both volumes and containers, so a failure cannot be attributed to either list",
 	"kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set":            "iterates two label maps, and a map key is not a field path",
 	"kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set": "iterates two label maps, same as C-0076",
+	"kubescape-c-0026-deny-cronjobs": "the whole validation is `object.kind != 'CronJob'`; matchConstraints already " +
+		"scopes the policy to cronjobs, so this denies every matched object outright, same as the constant-false " +
+		"cluster policies - there is no field to point at",
+	"kubescape-c-0012-deny-resources-with-sensitive-information-in-environment-variables": "one of its two validations " +
+		"iterates the ConfigMap data/binaryData maps by key, same as C-0076: a map key is not a field path. The " +
+		"other validation (container env vars) still derives normally",
+
+	"kubescape-c-0198-deny-root-containers":            "iterates object.spec.containers + initContainers + ephemeralContainers concatenated with `+`, same reason as C-0210",
+	"kubescape-c-0210-deny-seccomp-profile-unconfined": "the container list is a `+` concatenation of containers, initContainers and ephemeralContainers; which of the three a failing index came from cannot be recovered from the concatenated list alone",
+	"kubescape-c-0199-deny-net-raw-capability":         "same `+`-concatenated container list as C-0210, hand-inlined per kind rather than through a variable",
+	"kubescape-c-0200-deny-added-capabilities":         "same `+`-concatenated container list as C-0210, hand-inlined per kind rather than through a variable",
+	"kubescape-c-0201-deny-capabilities-assigned":      "same `+`-concatenated container list as C-0210, hand-inlined per kind rather than through a variable",
 }
 
 func TestEveryBundleValidationYieldsAPath(t *testing.T) {
@@ -423,7 +435,7 @@ func TestEveryBundleValidationYieldsAPath(t *testing.T) {
 
 	for name, vap := range catalog.byName {
 		for _, val := range vap.Validations {
-			plan := e.buildPathPlan(val.Expression)
+			plan := e.buildPathPlan(val.Expression, vap.Variables)
 			if len(plan.direct) > 0 || (plan.elements != nil && len(plan.elements.fields) > 0) {
 				continue
 			}
@@ -450,7 +462,7 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 
 	for name, vap := range catalog.byName {
 		for _, val := range vap.Validations {
-			plan := e.buildPathPlan(val.Expression)
+			plan := e.buildPathPlan(val.Expression, vap.Variables)
 			for _, ref := range plan.direct {
 				assertPath(name, ref.path)
 				// Object paths are what a user edits; the fields a policy reads
@@ -460,7 +472,13 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 			if plan.elements == nil {
 				continue
 			}
-			assertPath(name, plan.elements.collection)
+			collections := plan.elements.collections
+			if len(collections) == 0 {
+				collections = []string{plan.elements.collection}
+			}
+			for _, collection := range collections {
+				assertPath(name, collection)
+			}
 			for _, ref := range plan.elements.fields {
 				assertPath(name, ref.path)
 			}
@@ -479,13 +497,7 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 // field set to the one value that satisfies its control; if this list grows a
 // path with a surprising value, that is the signal to look.
 //
-// Two absences are worth naming so a reader does not read them as bugs:
-//   - spec.template.spec.hostIPC=false is missing because C-0038's workload
-//     validation in this vendored bundle checks hostPID twice and never hostIPC.
-//     The derivation reports exactly what the expression says. That policy bug is
-//     already fixed on cel-admission-library main and only survives here because
-//     the pinned release predates the fix, so this entry comes back on its own
-//     once CEL_LIBRARY_VERSION is bumped - no upstream issue to chase.
+// One absence is worth naming so a reader does not read it as a bug:
 //   - C-0075's imagePullPolicy=Always is missing because its element predicate
 //     `!c.image.endsWith(':latest') || c.imagePullPolicy == 'Always'` puts the
 //     equality under a disjunction: retagging the image satisfies the policy
@@ -505,7 +517,7 @@ var bundleFixValues = []string{
 	"spec.hostIPC=false",
 	"spec.hostNetwork=false",
 	"spec.hostPID=false",
-	"spec.jobTemplate.spec.automountServiceAccountToken=false",
+	"spec.jobTemplate.spec.template.spec.automountServiceAccountToken=false",
 	"spec.jobTemplate.spec.template.spec.containers[].securityContext.allowPrivilegeEscalation=false",
 	"spec.jobTemplate.spec.template.spec.containers[].securityContext.readOnlyRootFilesystem=true",
 	"spec.jobTemplate.spec.template.spec.hostIPC=false",
@@ -514,6 +526,7 @@ var bundleFixValues = []string{
 	"spec.template.spec.automountServiceAccountToken=false",
 	"spec.template.spec.containers[].securityContext.allowPrivilegeEscalation=false",
 	"spec.template.spec.containers[].securityContext.readOnlyRootFilesystem=true",
+	"spec.template.spec.hostIPC=false",
 	"spec.template.spec.hostNetwork=false",
 	"spec.template.spec.hostPID=false",
 }
@@ -528,7 +541,7 @@ func TestEveryBundleFixValueIsExpected(t *testing.T) {
 	seen := map[string]bool{}
 	for _, vap := range catalog.byName {
 		for _, val := range vap.Validations {
-			plan := e.buildPathPlan(val.Expression)
+			plan := e.buildPathPlan(val.Expression, vap.Variables)
 			for _, ref := range plan.direct {
 				if ref.value != "" {
 					seen[ref.path+"="+ref.value] = true
@@ -537,9 +550,15 @@ func TestEveryBundleFixValueIsExpected(t *testing.T) {
 			if plan.elements == nil {
 				continue
 			}
-			for _, ref := range plan.elements.fields {
-				if ref.value != "" {
-					seen[plan.elements.collection+"[]."+ref.path+"="+ref.value] = true
+			collections := plan.elements.collections
+			if len(collections) == 0 {
+				collections = []string{plan.elements.collection}
+			}
+			for _, collection := range collections {
+				for _, ref := range plan.elements.fields {
+					if ref.value != "" {
+						seen[collection+"[]."+ref.path+"="+ref.value] = true
+					}
 				}
 			}
 		}

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -76,15 +76,18 @@ func TestVAPAppliesToNoConstraintsEvaluates(t *testing.T) {
 // resource the control should evaluate. This table is the ground truth the guess
 // is checked against.
 var canonicalKinds = map[string]string{
-	"pods":            "Pod",
-	"deployments":     "Deployment",
-	"replicasets":     "ReplicaSet",
-	"daemonsets":      "DaemonSet",
-	"statefulsets":    "StatefulSet",
-	"jobs":            "Job",
+	"clusterroles":    "ClusterRole",
+	"configmaps":      "ConfigMap",
 	"cronjobs":        "CronJob",
+	"daemonsets":      "DaemonSet",
+	"deployments":     "Deployment",
+	"jobs":            "Job",
+	"pods":            "Pod",
+	"replicasets":     "ReplicaSet",
+	"roles":           "Role",
 	"serviceaccounts": "ServiceAccount",
 	"services":        "Service",
+	"statefulsets":    "StatefulSet",
 }
 
 // TestVAPAppliesToCoversEveryBundleKind walks every policy in the embedded bundle

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -21,6 +21,34 @@ Files:
 - `policy-configuration-definition.yaml` — the parameter CRD definition that
   backs those params.
 
+## Local deviations from the pinned release
+
+The bundle is normally byte-identical to the release named by
+`CEL_LIBRARY_VERSION`. It currently is not: three policies in `v0.11` walk
+optional fields without a `has()` guard, which is harmless at live admission
+(the object there is schema-defaulted) but makes the offline engine eval-error
+and report ordinary workloads as `Skipped/Unknown` instead of evaluating them.
+
+Patched here, ahead of a release that carries the fix:
+
+- **C-0045** — all three validations read `spec.volumes` unguarded, so every
+  workload without a `volumes` block was skipped. Fixed upstream on `main`.
+- **C-0048** — the CronJob validation guarded
+  `spec.jobTemplate.spec.volumes` but read
+  `spec.jobTemplate.spec.template.spec.volumes`; the guarded path never exists,
+  so the expression always short-circuited and a hostPath CronJob passed
+  silently. Fixed upstream on `main`.
+- **C-0055** — the Workload and CronJob validations walk into the optional
+  `template.metadata` unguarded (`has(a.b.c)` does not guard a missing `a.b`),
+  and the CronJob validation read `securityContext` from
+  `spec.jobTemplate.spec` rather than the pod template. The path fix is
+  upstream on `main`; the `metadata` guard is not, and needs a fix there.
+
+`make sync-vap` overwrites these edits. When a release past `v0.11` is
+available, bump `CEL_LIBRARY_VERSION`, re-sync, and delete this section rather
+than re-applying the patches by hand. `TestNoEvalErrorOnMinimalWorkloads` in
+`../optionalfields_test.go` fails if a re-sync drops any of them.
+
 A submodule was considered instead of a vendored copy, but `//go:embed` only
 picks up files committed in this repo, and a submodule's contents are dropped
 when kubescape is pulled in as a Go module (the embed then fails with

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -21,34 +21,6 @@ Files:
 - `policy-configuration-definition.yaml` — the parameter CRD definition that
   backs those params.
 
-## Local deviations from the pinned release
-
-The bundle is normally byte-identical to the release named by
-`CEL_LIBRARY_VERSION`. It currently is not: three policies in `v0.11` walk
-optional fields without a `has()` guard, which is harmless at live admission
-(the object there is schema-defaulted) but makes the offline engine eval-error
-and report ordinary workloads as `Skipped/Unknown` instead of evaluating them.
-
-Patched here, ahead of a release that carries the fix:
-
-- **C-0045** — all three validations read `spec.volumes` unguarded, so every
-  workload without a `volumes` block was skipped. Fixed upstream on `main`.
-- **C-0048** — the CronJob validation guarded
-  `spec.jobTemplate.spec.volumes` but read
-  `spec.jobTemplate.spec.template.spec.volumes`; the guarded path never exists,
-  so the expression always short-circuited and a hostPath CronJob passed
-  silently. Fixed upstream on `main`.
-- **C-0055** — the Workload and CronJob validations walk into the optional
-  `template.metadata` unguarded (`has(a.b.c)` does not guard a missing `a.b`),
-  and the CronJob validation read `securityContext` from
-  `spec.jobTemplate.spec` rather than the pod template. The path fix is
-  upstream on `main`; the `metadata` guard is not, and needs a fix there.
-
-`make sync-vap` overwrites these edits. When a release past `v0.11` is
-available, bump `CEL_LIBRARY_VERSION`, re-sync, and delete this section rather
-than re-applying the patches by hand. `TestNoEvalErrorOnMinimalWorkloads` in
-`../optionalfields_test.go` fails if a re-sync drops any of them.
-
 A submodule was considered instead of a vendored copy, but `//go:embed` only
 picks up files committed in this repo, and a submodule's contents are dropped
 when kubescape is pulled in as a Go module (the embed then fails with

--- a/core/pkg/opaprocessor/cel/vapdata/basic-control-configuration.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/basic-control-configuration.yaml
@@ -45,10 +45,10 @@ settings:
   - 5
   maxHighVulnerabilities:
   - 10
-  memoryLimitMax: 4294967296
-  memoryLimitMin: 0
-  memoryRequestMax: 4294967296
-  memoryRequestMin: 0
+  memoryLimitMax: 4Gi
+  memoryLimitMin: 0.25Gi
+  memoryRequestMax: 4Gi
+  memoryRequestMin: 0.125Gi
   publicRegistries:
   - docker.io
   - gcr.io
@@ -92,6 +92,7 @@ settings:
   - Bearer
   - _key_
   - _secret_
+  sensitiveKeyNamesAllowed: []
   sensitiveValuesAllowed:
   - ''
   servicesNames:

--- a/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
@@ -1128,7 +1128,7 @@ spec:
       - cronjobs
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
+      object.kind != 'Pod' || (!has(object.spec.volumes)) || object.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
 
         containerVol, containerVol.name != vol.name ||
         (has(containerVol.readOnly) && containerVol.readOnly == true)
@@ -1136,7 +1136,7 @@ spec:
     message: One or more hostPath Volumes in the Pod has readOnly not set to false!
       (see more at https://hub.armosec.io/docs/c-0045)
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
+      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (!has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
 
         containerVol, containerVol.name != vol.name ||
         (has(containerVol.readOnly) && containerVol.readOnly == true)
@@ -1144,7 +1144,7 @@ spec:
     message: One or more hostPath Volumes in the Workload has readOnly not set to
       false! (see more at https://hub.armosec.io/docs/c-0045)
   - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
+      object.kind != 'CronJob' || (!has(object.spec.jobTemplate.spec.template.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
 
         containerVol, containerVol.name != vol.name ||
         (has(containerVol.readOnly) && containerVol.readOnly == true)
@@ -1263,7 +1263,7 @@ spec:
       object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol,
       !(has(vol.hostPath)))'
     message: There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)
-  - expression: object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes)
+  - expression: object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes)
       || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))
     message: There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)
 ---
@@ -1375,10 +1375,10 @@ spec:
       object.kind != 'Pod' || (has(object.metadata.annotations) && object.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.securityContext) && (has(object.spec.securityContext.seccompProfile) || has(object.spec.securityContext.seLinuxOptions))) || object.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
     message: Pods could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.template.spec.securityContext) && (has(object.spec.template.spec.securityContext.seccompProfile) || has(object.spec.template.spec.securityContext.seLinuxOptions))) || object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
+      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (has(object.spec.template.metadata) && has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.template.spec.securityContext) && (has(object.spec.template.spec.securityContext.seccompProfile) || has(object.spec.template.spec.securityContext.seLinuxOptions))) || object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
     message: Workloads could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
   - expression: |
-      object.kind != 'CronJob' || (has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.jobTemplate.spec.securityContext) && (has(object.spec.jobTemplate.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.securityContext.seLinuxOptions))) || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
+      object.kind != 'CronJob' || (has(object.spec.jobTemplate.metadata) && has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.jobTemplate.spec.template.spec.securityContext) && (has(object.spec.jobTemplate.spec.template.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions))) || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
     message: CronJob could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
@@ -78,14 +78,16 @@ spec:
       - jobs
       - cronjobs
   validations:
-  - expression: object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)))
-    message: There are one or more hostPath mounts in the Pod! (see more at https://hub.armosec.io/docs/c-0048)
-  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
-      object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))'
-    message: There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)
-  - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.volumes.all(vol,
+  - expression: object.kind != 'Pod' || (!has(object.spec.volumes)) || object.spec.volumes.all(vol,
       !(has(vol.hostPath)))
-    message: There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)
+    message: There are one or more hostPath mounts in the Pod! (see more at https://kubescape.io/docs/controls/c-0048/)
+  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
+      object.kind != kind) || (!has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol,
+      !(has(vol.hostPath)))'
+    message: There are one or more hostPath mounts in the Workload! (see more at https://kubescape.io/docs/controls/c-0048/)
+  - expression: object.kind != 'CronJob' || (!has(object.spec.jobTemplate.spec.template.spec.volumes))
+      || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))
+    message: There are one or more hostPath mounts in the CronJob! (see more at https://kubescape.io/docs/controls/c-0048/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -133,15 +135,15 @@ spec:
   - expression: |
       object.kind != 'Pod' || object.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: Pod has one or more containers with insecure capabilities! (see more
-      at https://hub.armosec.io/docs/c-0046)
+      at https://kubescape.io/docs/controls/c-0046/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: Workload has one or more containers with insecure capabilities! (see
-      more at https://hub.armosec.io/docs/c-0046)
+      more at https://kubescape.io/docs/controls/c-0046/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: CronJob has one or more containers with insecure capabilities! (see more
-      at https://hub.armosec.io/docs/c-0046)
+      at https://kubescape.io/docs/controls/c-0046/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -167,7 +169,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: cluster-policy-deny-priviliged-flag
+  name: cluster-policy-deny-privileged-flag
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -211,29 +213,29 @@ spec:
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: Pod has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !(has(container.securityContext)) || (
 
-        (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+        (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: Workloads has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.securityContext)) || (
 
-        (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+        (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: CronJob has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0001
+    controlUrl: https://kubescape.io/docs/controls/c-0001/
   labels:
     controlId: C-0001
   name: kubescape-c-0001-deny-forbidden-container-registries
@@ -276,21 +278,32 @@ spec:
     apiVersion: kubescape.io/v1
     kind: ControlConfiguration
   validations:
-  - expression: object.kind != 'Pod' || object.spec.containers.all(container, params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))
-    message: Pods uses an image from a forbidden registry! (see more at https://hub.armosec.io/docs/c-0001)
-  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
-      object.kind != kind) || object.spec.template.spec.containers.all(container,
-      params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))'
-    message: Workloads uses an image from a forbidden registry! (see more at https://hub.armosec.io/docs/c-0001)
-  - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
-      params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))
-    message: CronJob uses an image from a forbidden registry! (see more at https://hub.armosec.io/docs/c-0001)
+  - expression: |
+      variables.containers.all(container, params.settings.untrustedRegistries.all(registry, !(
+
+        ((registry in ['docker.io', 'docker.io/', 'index.docker.io', 'index.docker.io/', 'registry-1.docker.io', 'registry-1.docker.io/']) &&
+          (!container.image.contains('/') ||
+            (!container.image.split('/')[0].contains('.') &&
+             !container.image.split('/')[0].contains(':') &&
+             container.image.split('/')[0] != 'localhost') ||
+            container.image.split('/')[0] in ['docker.io', 'index.docker.io', 'registry-1.docker.io'])) ||
+        container.image.startsWith(registry.endsWith('/') ? registry : registry + '/')
+      )))
+    messageExpression: object.kind + "/" + object.metadata.name + " uses an image
+      from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"
+  variables:
+  - expression: |
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0004
+    controlUrl: https://kubescape.io/docs/controls/c-0004/
   labels:
     controlId: C-0004
   name: kubescape-c-0004-deny-resources-with-memory-limit-or-request-not-set
@@ -334,23 +347,28 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger()&& params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: Pods contains container/s with memory limit or request not set or they
-      are not in the specified range! (see more at https://hub.armosec.io/docs/c-0004)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && quantity(string(params.settings.memoryRequestMin)).compareTo(quantity(string(container.resources.requests.memory))) != 1 && quantity(string(params.settings.memoryRequestMax)).compareTo(quantity(string(container.resources.requests.memory))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with memory request not set or they are not in the specified range! (see more
+      at https://kubescape.io/docs/controls/c-0004/)"
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() && params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: Workloads contains container/s with memory limit or request not set or
-      they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0004)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 && quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with memory limit not set or they are not in the specified range! (see more
+      at https://kubescape.io/docs/controls/c-0004/)"
+  variables:
   - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() && params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: CronJob contains container/s with memory limit or request not set or
-      they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0004)
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0009
+    controlUrl: https://kubescape.io/docs/controls/c-0009/
   labels:
     controlId: C-0009
   name: kubescape-c-0009-deny-resources-with-memory-or-cpu-limit-not-set
@@ -396,21 +414,220 @@ spec:
   - expression: |
       object.kind != 'Pod' || object.spec.containers.all(container, has(container.resources) && has(container.resources.limits) && has(container.resources.limits.memory) && has(container.resources.limits.cpu))
     message: Pods contains container/s with memory limit and/or cpu limit not set!
-      (see more at https://hub.armosec.io/docs/c-0009)
+      (see more at https://kubescape.io/docs/controls/c-0009/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, has(container.resources) && has(container.resources.limits) && has(container.resources.limits.memory) && has(container.resources.limits.cpu))
     message: Workloads contains container/s with memory limit and/or cpu limit not
-      set! (see more at https://hub.armosec.io/docs/c-0009)
+      set! (see more at https://kubescape.io/docs/controls/c-0009/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.resources) && has(container.resources.limits) && has(container.resources.limits.memory) && has(container.resources.limits.cpu))
     message: CronJob contains container/s with memory limit and/or cpu limit not set!
-      (see more at https://hub.armosec.io/docs/c-0009)
+      (see more at https://kubescape.io/docs/controls/c-0009/)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-0012-deny-resources-with-sensitive-information-in-environment-variables
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - configmaps
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  validations:
+  - expression: |
+      variables.containers.all(container,
+        !has(container.env) || container.env.all(envVariable,
+          (
+              !params.settings.sensitiveKeyNames.exists(sensitiveKey, envVariable.name.lowerAscii().contains(sensitiveKey)) &&
+              !params.settings.sensitiveValues.exists(sensitiveVal, envVariable.value.matches(sensitiveVal))
+          ) ||
+          !has(envVariable.value) || (envVariable.value == "") ||
+          envVariable.value in params.settings.sensitiveValuesAllowed ||
+          params.settings.sensitiveKeyNamesAllowed.exists(sensitiveKeyName, envVariable.name.matches(sensitiveKeyName))
+        )
+      )
+    messageExpression: object.kind + "/" + object.metadata.name + " has one or more
+      containers with sensitive information in environment variables! (see more at
+      https://kubescape.io/docs/controls/c-0012/)"
+    reason: Invalid
+  - expression: |
+      variables.configMapData.all(key, (
+
+        (
+          !params.settings.sensitiveKeyNames.exists(sensitiveKey, key.lowerAscii().contains(sensitiveKey)) &&
+          !params.settings.sensitiveValues.exists(sensitiveVal, key.lowerAscii().matches(sensitiveVal))
+        ) ||
+        variables.configMapData[key] == "" ||
+        variables.configMapData[key] in params.settings.sensitiveValuesAllowed ||
+        params.settings.sensitiveKeyNamesAllowed.exists(sensitiveKeyName, key.matches(sensitiveKeyName))
+      ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains sensitive
+      information in its data! (see more at https://kubescape.io/docs/controls/c-0012/)"
+  variables:
+  - expression: |
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
+  - expression: |
+      object.kind == 'ConfigMap' ?
+        (has(object.data) ?
+          object.data
+          : (has(object.binaryData) ?
+            object.binaryData
+            : {}))
+      : {}
+    name: configMapData
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-0013-deny-resources-with-capability-to-run-as-root
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: |
+      variables.containers.all(container,
+
+        (
+          has(container.securityContext) &&
+          has(container.securityContext.allowPrivilegeEscalation) &&
+          container.securityContext.allowPrivilegeEscalation == false
+        ) &&
+        (
+          (
+            (
+              has(container.securityContext) &&
+              has(container.securityContext.runAsNonRoot) &&
+              container.securityContext.runAsNonRoot == true
+            ) ||
+            (
+              (
+                !has(container.securityContext) || !has(container.securityContext.runAsNonRoot)
+              ) &&
+              (
+                has(variables.podSecurityContext) &&
+                has(variables.podSecurityContext.runAsNonRoot) &&
+                variables.podSecurityContext.runAsNonRoot == true
+              )
+            )
+          ) ||
+          (
+            (
+              has(container.securityContext) &&
+              has(container.securityContext.runAsUser) &&
+              container.securityContext.runAsUser != 0
+            ) ||
+            (
+              (
+                !has(container.securityContext) || !has(container.securityContext.runAsUser)
+              ) &&
+              (
+                has(variables.podSecurityContext) &&
+                has(variables.podSecurityContext.runAsUser) &&
+                variables.podSecurityContext.runAsUser != 0
+              )
+            )
+          )
+        )
+      )
+    message: object.kind + "/" + object.metadata.name + " contains container/s which
+      have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
+  variables:
+  - expression: |
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
+  - expression: |
+      object.kind == 'Pod' ? object.spec.securityContext
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.securityContext
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.securityContext
+      : {}
+    name: podSecurityContext
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0016
+    controlUrl: https://kubescape.io/docs/controls/c-0016/
   labels:
     controlId: C-0016
   name: kubescape-c-0016-allow-privilege-escalation
@@ -453,22 +670,22 @@ spec:
   - expression: object.kind != 'Pod' || object.spec.containers.all(container, has(container.securityContext)
       && has(container.securityContext.allowPrivilegeEscalation) &&  container.securityContext.allowPrivilegeEscalation
       == false)
-    message: Pods with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)
+    message: Pods with privileged containers are not allowed! (see more at https://kubescape.io/docs/controls/c-0016/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || object.spec.template.spec.containers.all(container,
       has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation)
       &&  container.securityContext.allowPrivilegeEscalation == false)'
-    message: Workloads with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)
+    message: Workloads with privileged containers are not allowed! (see more at https://kubescape.io/docs/controls/c-0016/)
   - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
       has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation)
       &&  container.securityContext.allowPrivilegeEscalation == false)
-    message: CronJob with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)
+    message: CronJob with privileged containers are not allowed! (see more at https://kubescape.io/docs/controls/c-0016/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0017
+    controlUrl: https://kubescape.io/docs/controls/c-0017/
   labels:
     controlId: C-0017
   name: kubescape-c-0017-deny-resources-with-mutable-container-filesystem
@@ -512,24 +729,24 @@ spec:
       && has(container.securityContext.readOnlyRootFilesystem) &&  container.securityContext.readOnlyRootFilesystem
       == true)
     message: Pods having containers with mutable filesystem not allowed! (see more
-      at https://hub.armosec.io/docs/c-0017)
+      at https://kubescape.io/docs/controls/c-0017/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || object.spec.template.spec.containers.all(container,
       has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem)
       &&  container.securityContext.readOnlyRootFilesystem == true)'
     message: Workloads having containers with mutable filesystem not allowed! (see
-      more at https://hub.armosec.io/docs/c-0017)
+      more at https://kubescape.io/docs/controls/c-0017/)
   - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
       has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem)
       &&  container.securityContext.readOnlyRootFilesystem == true)
     message: CronJob having containers with mutable filesystem not allowed! (see more
-      at https://hub.armosec.io/docs/c-0017)
+      at https://kubescape.io/docs/controls/c-0017/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0018
+    controlUrl: https://kubescape.io/docs/controls/c-0018/
   labels:
     controlId: C-0018
   name: kubescape-c-0018-deny-resources-without-configured-readiness-probes
@@ -570,20 +787,20 @@ spec:
       - cronjobs
   validations:
   - expression: object.kind != 'Pod' || object.spec.containers.all(container, has(container.readinessProbe))
-    message: Pods must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)
+    message: Pods must have readinessProbe set up (see more at https://kubescape.io/docs/controls/c-0018/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || object.spec.template.spec.containers.all(container,
       has(container.readinessProbe))'
-    message: Workloads must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)
+    message: Workloads must have readinessProbe set up (see more at https://kubescape.io/docs/controls/c-0018/)
   - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
       has(container.readinessProbe))
-    message: CronJob must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)
+    message: CronJob must have readinessProbe set up (see more at https://kubescape.io/docs/controls/c-0018/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0020
+    controlUrl: https://kubescape.io/docs/controls/c-0020/
   labels:
     controlId: C-0020
   name: kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials
@@ -666,7 +883,7 @@ spec:
           ))))
       ))
     message: Pod contains volumes with potential access to known cloud credentials!
-      (see more at https://hub.armosec.io/docs/c-0020)
+      (see more at https://kubescape.io/docs/controls/c-0020/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol, !has(vol.hostPath) || !has(vol.hostPath.path) || (
 
@@ -707,9 +924,9 @@ spec:
           ))))
       ))
     message: Workload contains volumes with potential access to known cloud credentials!
-      (see more at https://hub.armosec.io/docs/c-0020)
+      (see more at https://kubescape.io/docs/controls/c-0020/)
   - expression: |
-      object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !has(vol.hostPath) || !has(vol.hostPath.path) || (
+      object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !has(vol.hostPath) || !has(vol.hostPath.path) || (
 
         (params.settings.cloudProvider != 'eks' ||
         ["/.aws/","/.aws/config/","/.aws/credentials/"].all(unsafePath,
@@ -748,13 +965,38 @@ spec:
           ))))
       ))
     message: CronJob contains volumes with potential access to known cloud credentials!
-      (see more at https://hub.armosec.io/docs/c-0020)
+      (see more at https://kubescape.io/docs/controls/c-0020/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0034
+    controlUrl: https://kubescape.io/docs/controls/c-0026/
+  labels:
+    controlId: C-0026
+  name: kubescape-c-0026-deny-cronjobs
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - cronjobs
+  validations:
+  - expression: object.kind != 'CronJob'
+    message: CronJob detected and flagged for review (see more at https://kubescape.io/docs/controls/c-0026/)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0034/
   labels:
     controlId: C-0034
   name: kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled
@@ -802,34 +1044,34 @@ spec:
         object.automountServiceAccountToken == false
       )
     message: ServiceAccount has "automountServiceAccountToken" enabled! (see more
-      at https://hub.armosec.io/docs/c-0034)
+      at https://kubescape.io/docs/controls/c-0034/)
   - expression: |
       object.kind != 'Pod' || (
 
         has(object.spec.automountServiceAccountToken) &&
         object.spec.automountServiceAccountToken == false
       )
-    message: Pod has "automountServiceAccountToken" enabled! (see more at https://hub.armosec.io/docs/c-0034)
+    message: Pod has "automountServiceAccountToken" enabled! (see more at https://kubescape.io/docs/controls/c-0034/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (
 
         has(object.spec.template.spec.automountServiceAccountToken) &&
         object.spec.template.spec.automountServiceAccountToken == false
       )
-    message: Workload has "automountServiceAccountToken" enabled! (see more at https://hub.armosec.io/docs/c-0034)
+    message: Workload has "automountServiceAccountToken" enabled! (see more at https://kubescape.io/docs/controls/c-0034/)
   - expression: |
       object.kind != 'CronJob' || (
 
-        has(object.spec.jobTemplate.spec.automountServiceAccountToken) &&
-        object.spec.jobTemplate.spec.automountServiceAccountToken == false
+        has(object.spec.jobTemplate.spec.template.spec.automountServiceAccountToken) &&
+        object.spec.jobTemplate.spec.template.spec.automountServiceAccountToken == false
       )
-    message: CronJob has "automountServiceAccountToken" enabled! (see more at https://hub.armosec.io/docs/c-0034)
+    message: CronJob has "automountServiceAccountToken" enabled! (see more at https://kubescape.io/docs/controls/c-0034/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0038
+    controlUrl: https://kubescape.io/docs/controls/c-0038/
   labels:
     controlId: C-0038
   name: kubescape-c-0038-deny-resources-with-host-ipc-or-pid-privileges
@@ -872,24 +1114,24 @@ spec:
   - expression: object.kind != 'Pod' || ((!(has(object.spec.hostPID)) || object.spec.hostPID
       == false) && (!(has(object.spec.hostIPC)) || object.spec.hostIPC == false))
     message: Pods with hostPID and hostIPC fields enabled may allow cross-container
-      influence. (see more at https://hub.armosec.io/docs/c-0038)
+      influence. (see more at https://kubescape.io/docs/controls/c-0038/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || ((!(has(object.spec.template.spec.hostPID)) || object.spec.template.spec.hostPID
-      == false) && (!(has(object.spec.template.spec.hostIPC)) || object.spec.template.spec.hostPID
+      == false) && (!(has(object.spec.template.spec.hostIPC)) || object.spec.template.spec.hostIPC
       == false))'
     message: Workloads with hostPID and hostIPC fields enabled may allow cross-container
-      influence. (see more at https://hub.armosec.io/docs/c-0038)
+      influence. (see more at https://kubescape.io/docs/controls/c-0038/)
   - expression: object.kind != 'CronJob' || ((!(has(object.spec.jobTemplate.spec.template.spec.hostPID))
       || object.spec.jobTemplate.spec.template.spec.hostPID == false) && (!(has(object.spec.jobTemplate.spec.template.spec.hostIPC))
       || object.spec.jobTemplate.spec.template.spec.hostIPC == false))
     message: CronJob with hostPID and hostIPC fields enabled may allow cross-container
-      influence. (see more at https://hub.armosec.io/docs/c-0038)
+      influence. (see more at https://kubescape.io/docs/controls/c-0038/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0041
+    controlUrl: https://kubescape.io/docs/controls/c-0041/
   labels:
     controlId: C-0041
   name: kubescape-c-0041-deny-resources-with-host-network-access
@@ -932,22 +1174,22 @@ spec:
   - expression: object.kind != 'Pod' || !(has(object.spec.hostNetwork)) || object.spec.hostNetwork
       == false
     message: Pods with hostNetwork enabled may cause security issues. (see more at
-      https://hub.armosec.io/docs/c-0041)
+      https://kubescape.io/docs/controls/c-0041/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || !(has(object.spec.template.spec.hostNetwork)) || object.spec.template.spec.hostNetwork
       == false'
     message: Workloads with hostNetwork enabled may cause security issues. (see more
-      at https://hub.armosec.io/docs/c-0041)
+      at https://kubescape.io/docs/controls/c-0041/)
   - expression: object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.template.spec.hostNetwork))
       || object.spec.jobTemplate.spec.template.spec.hostNetwork == false
     message: CronJob with hostNetwork enabled may cause security issues. (see more
-      at https://hub.armosec.io/docs/c-0041)
+      at https://kubescape.io/docs/controls/c-0041/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0042
+    controlUrl: https://kubescape.io/docs/controls/c-0042/
   labels:
     controlId: C-0042
   name: kubescape-c-0042-deny-resources-with-ssh-server-running
@@ -990,7 +1232,7 @@ spec:
   validations:
   - expression: |
       object.kind != 'Service' || object.spec.ports.all(currentPort, currentPort.port != 22 && currentPort.port != 2222 && currentPort.targetPort != 22 && currentPort.targetPort != 2222)
-    message: Services with ssh server(Port 22 and 2222) are denied! (see more at https://hub.armosec.io/docs/c-0042)
+    message: Services with ssh server(Port 22 and 2222) are denied! (see more at https://kubescape.io/docs/controls/c-0042/)
   - expression: |
       object.kind != 'Pod' || object.spec.containers.all(container, !has(container.ports) || container.ports.all(port, (( !has(port.containerPort) || (
 
@@ -1002,7 +1244,7 @@ spec:
         port.hostPort != 2222
       )))))
     message: Pods having containers running ssh server are not allowed! (see more
-      at https://hub.armosec.io/docs/c-0042)
+      at https://kubescape.io/docs/controls/c-0042/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !has(container.ports) || container.ports.all(port, (( !has(port.containerPort) || (
 
@@ -1014,7 +1256,7 @@ spec:
         port.hostPort != 2222
       )))))
     message: Workloads having containers running ssh server are not allowed! (see
-      more at https://hub.armosec.io/docs/c-0042)
+      more at https://kubescape.io/docs/controls/c-0042/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !has(container.ports) || container.ports.all(port, (( !has(port.containerPort) || (
 
@@ -1026,13 +1268,13 @@ spec:
         port.hostPort != 2222
       )))))
     message: CronJob having containers running ssh server are not allowed! (see more
-      at https://hub.armosec.io/docs/c-0042)
+      at https://kubescape.io/docs/controls/c-0042/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0044
+    controlUrl: https://kubescape.io/docs/controls/c-0044/
   labels:
     controlId: C-0044
   name: kubescape-c-0044-deny-resources-with-host-port
@@ -1074,20 +1316,20 @@ spec:
   validations:
   - expression: object.kind != 'Pod' || !object.spec.containers.exists(container,
       has(container.ports) && container.ports.exists(port, has(port.hostPort)))
-    message: One or more containers in the Pod has Host-port! (see more at https://hub.armosec.io/docs/c-0044)
+    message: One or more containers in the Pod has Host-port! (see more at https://kubescape.io/docs/controls/c-0044/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || !object.spec.template.spec.containers.exists(container,
       has(container.ports) && container.ports.exists(port, has(port.hostPort)))'
-    message: One or more containers in the Workload has Host-port! (see more at https://hub.armosec.io/docs/c-0044)
+    message: One or more containers in the Workload has Host-port! (see more at https://kubescape.io/docs/controls/c-0044/)
   - expression: object.kind != 'CronJob' || !object.spec.jobTemplate.spec.template.spec.containers.exists(container,
       has(container.ports) && container.ports.exists(port, has(port.hostPort)))
-    message: One or more containers in the CronJob has Host-port! (see more at https://hub.armosec.io/docs/c-0044)
+    message: One or more containers in the CronJob has Host-port! (see more at https://kubescape.io/docs/controls/c-0044/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0045
+    controlUrl: https://kubescape.io/docs/controls/c-0045/
   labels:
     controlId: C-0045
   name: kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false
@@ -1134,7 +1376,7 @@ spec:
         (has(containerVol.readOnly) && containerVol.readOnly == true)
       )))
     message: One or more hostPath Volumes in the Pod has readOnly not set to false!
-      (see more at https://hub.armosec.io/docs/c-0045)
+      (see more at https://kubescape.io/docs/controls/c-0045/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (!has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
 
@@ -1142,7 +1384,7 @@ spec:
         (has(containerVol.readOnly) && containerVol.readOnly == true)
       )))
     message: One or more hostPath Volumes in the Workload has readOnly not set to
-      false! (see more at https://hub.armosec.io/docs/c-0045)
+      false! (see more at https://kubescape.io/docs/controls/c-0045/)
   - expression: |
       object.kind != 'CronJob' || (!has(object.spec.jobTemplate.spec.template.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
 
@@ -1150,13 +1392,13 @@ spec:
         (has(containerVol.readOnly) && containerVol.readOnly == true)
       )))
     message: One or more hostPath Volumes in the CronJob has readOnly not set to false!
-      (see more at https://hub.armosec.io/docs/c-0045)
+      (see more at https://kubescape.io/docs/controls/c-0045/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0046
+    controlUrl: https://kubescape.io/docs/controls/c-0046/
   labels:
     controlId: C-0046
   name: kubescape-c-0046-deny-resources-with-insecure-capabilities
@@ -1202,21 +1444,21 @@ spec:
   - expression: |
       object.kind != 'Pod' || object.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: Pod has one or more containers with insecure capabilities! (see more
-      at https://hub.armosec.io/docs/c-0046)
+      at https://kubescape.io/docs/controls/c-0046/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: Workload has one or more containers with insecure capabilities! (see
-      more at https://hub.armosec.io/docs/c-0046)
+      more at https://kubescape.io/docs/controls/c-0046/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability, !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(capability, capability != insecureCapability) ))
     message: CronJob has one or more containers with insecure capabilities! (see more
-      at https://hub.armosec.io/docs/c-0046)
+      at https://kubescape.io/docs/controls/c-0046/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0048
+    controlUrl: https://kubescape.io/docs/controls/c-0048/
   labels:
     controlId: C-0048
   name: kubescape-c-0048-deny-workloads-with-hostpath-mounts
@@ -1258,20 +1500,20 @@ spec:
   validations:
   - expression: object.kind != 'Pod' || !has(object.spec.volumes) || object.spec.volumes.all(vol,
       !(has(vol.hostPath)))
-    message: There are one or more hostPath mounts in the Pod! (see more at https://hub.armosec.io/docs/c-0048)
+    message: There are one or more hostPath mounts in the Pod! (see more at https://kubescape.io/docs/controls/c-0048/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol,
       !(has(vol.hostPath)))'
-    message: There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)
+    message: There are one or more hostPath mounts in the Workload! (see more at https://kubescape.io/docs/controls/c-0048/)
   - expression: object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes)
       || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))
-    message: There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)
+    message: There are one or more hostPath mounts in the CronJob! (see more at https://kubescape.io/docs/controls/c-0048/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0050
+    controlUrl: https://kubescape.io/docs/controls/c-0050/
   labels:
     controlId: C-0050
   name: kubescape-c-0050-deny-resources-with-cpu-limit-or-request-not-set
@@ -1315,23 +1557,23 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 && quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 && quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1))
     message: Pods contains container/s with cpu limit or request not set or they are
-      not in the specified range! (see more at https://hub.armosec.io/docs/c-0050)
+      not in the specified range! (see more at https://kubescape.io/docs/controls/c-0050/)
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 && quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 && quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1))
     message: Workloads contains container/s with cpu limit or request not set or they
-      are not in the specified range! (see more at https://hub.armosec.io/docs/c-0050)
+      are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0050/)
   - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 && quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1) && (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 && quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1))
     message: CronJob contains container/s with cpu limit or request not set or they
-      are not in the specified range! (see more at https://hub.armosec.io/docs/c-0050)
+      are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0050/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0055
+    controlUrl: https://kubescape.io/docs/controls/c-0055/
   labels:
     controlId: C-0055
   name: kubescape-c-0055-linux-hardening
@@ -1373,19 +1615,19 @@ spec:
   validations:
   - expression: |
       object.kind != 'Pod' || (has(object.metadata.annotations) && object.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.securityContext) && (has(object.spec.securityContext.seccompProfile) || has(object.spec.securityContext.seLinuxOptions))) || object.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
-    message: Pods could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
+    message: Pods could have more security hardening! (see more at https://kubescape.io/docs/controls/c-0055/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (has(object.spec.template.metadata) && has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.template.spec.securityContext) && (has(object.spec.template.spec.securityContext.seccompProfile) || has(object.spec.template.spec.securityContext.seLinuxOptions))) || object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
-    message: Workloads could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
+    message: Workloads could have more security hardening! (see more at https://kubescape.io/docs/controls/c-0055/)
   - expression: |
       object.kind != 'CronJob' || (has(object.spec.jobTemplate.metadata) && has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) || (has(object.spec.jobTemplate.spec.template.spec.securityContext) && (has(object.spec.jobTemplate.spec.template.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions))) || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || has(container.securityContext.seLinuxOptions) || (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
-    message: CronJob could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)
+    message: CronJob could have more security hardening! (see more at https://kubescape.io/docs/controls/c-0055/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0056
+    controlUrl: https://kubescape.io/docs/controls/c-0056/
   labels:
     controlId: C-0056
   name: kubescape-c-0056-deny-resources-without-configured-liveliness-probes
@@ -1426,20 +1668,20 @@ spec:
       - cronjobs
   validations:
   - expression: object.kind != 'Pod' || object.spec.containers.all(container, has(container.livenessProbe))
-    message: Pods must have livenessProbe set up (see more at https://hub.armosec.io/docs/c-0056)
+    message: Pods must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'', ''Job''].all(kind,
       object.kind != kind) || object.spec.template.spec.containers.all(container,
       has(container.livenessProbe))'
-    message: Workloads must have livenessProbe set up (see more at https://hub.armosec.io/docs/c-0056)
+    message: Workloads must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)
   - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
       has(container.livenessProbe))
-    message: CronJob must have livenessProbe set up (see more at https://hub.armosec.io/docs/c-0056)
+    message: CronJob must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0057
+    controlUrl: https://kubescape.io/docs/controls/c-0057/
   labels:
     controlId: C-0057
   name: kubescape-c-0057-privileged-container-denied
@@ -1486,29 +1728,29 @@ spec:
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: Pod has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !(has(container.securityContext)) || (
 
-        (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+        (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: Workloads has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.securityContext)) || (
 
-        (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+        (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
         (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
         container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
       )
-    message: CronJob has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)
+    message: CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0061
+    controlUrl: https://kubescape.io/docs/controls/c-0061/
   labels:
     controlId: C-0061
   name: kubescape-c-0061-deny-workloads-in-default-namespace
@@ -1551,13 +1793,13 @@ spec:
   - expression: '[''Pod'',''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job'',
       ''CronJob''].all(kind, object.kind != kind) || (has(object.metadata.namespace)
       && object.metadata.namespace != ''default'')'
-    message: Workloads in default namespace are not allowed! (see more at https://hub.armosec.io/docs/c-0061)
+    message: Workloads in default namespace are not allowed! (see more at https://kubescape.io/docs/controls/c-0061/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0062
+    controlUrl: https://kubescape.io/docs/controls/c-0062/
   labels:
     controlId: C-0062
   name: kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint
@@ -1599,20 +1841,20 @@ spec:
   validations:
   - expression: object.kind != 'Pod' || object.spec.containers.all(container, !(has(container.command))
       || container.command.all(cmd, cmd != 'sudo'))
-    message: Pod has a container/s having sudo in entrypoint! (see more at https://hub.armosec.io/docs/c-0062)
+    message: Pod has a container/s having sudo in entrypoint! (see more at https://kubescape.io/docs/controls/c-0062/)
   - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
       object.kind != kind) || object.spec.template.spec.containers.all(container,
       !(has(container.command)) || container.command.all(cmd, cmd != ''sudo''))'
-    message: Workload has a container/s having sudo in entrypoint! (see more at https://hub.armosec.io/docs/c-0062)
+    message: Workload has a container/s having sudo in entrypoint! (see more at https://kubescape.io/docs/controls/c-0062/)
   - expression: object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
       !(has(container.command)) || container.command.all(cmd, cmd != 'sudo'))
-    message: CronJob has a container/s having sudo in entrypoint! (see more at https://hub.armosec.io/docs/c-0062)
+    message: CronJob has a container/s having sudo in entrypoint! (see more at https://kubescape.io/docs/controls/c-0062/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0073
+    controlUrl: https://kubescape.io/docs/controls/c-0073/
   labels:
     controlId: C-0073
   name: kubescape-c-0073-deny-naked-pods
@@ -1631,13 +1873,13 @@ spec:
       - pods
   validations:
   - expression: object.kind != 'Pod' || has(object.metadata.ownerReferences)
-    message: Pods doesn't have a parent! (see more at https://hub.armosec.io/docs/c-0073)
+    message: Pods doesn't have a parent! (see more at https://kubescape.io/docs/controls/c-0073/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0074
+    controlUrl: https://kubescape.io/docs/controls/c-0074/
   labels:
     controlId: C-0074
   name: kubescape-c-0074-resources-mounting-docker-socket-denied
@@ -1683,7 +1925,7 @@ spec:
         vol.hostPath.path != '/var/run/docker.sock' &&
         vol.hostPath.path != '/var/run/docker'
       ))
-    message: Pod has one or more containers mounting Docker socket! (see more at https://hub.armosec.io/docs/c-0074)
+    message: Pod has one or more containers mounting Docker socket! (see more at https://kubescape.io/docs/controls/c-0074/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || !(has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || !(has(vol.hostPath.path)) || (
 
@@ -1691,21 +1933,21 @@ spec:
         vol.hostPath.path != '/var/run/docker'
       ))
     message: Workload has one or more containers mounting Docker socket! (see more
-      at https://hub.armosec.io/docs/c-0074)
+      at https://kubescape.io/docs/controls/c-0074/)
   - expression: |
-      object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || !(has(vol.hostPath.path)) || (
+      object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.template.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || !(has(vol.hostPath.path)) || (
 
         vol.hostPath.path != '/var/run/docker.sock' &&
         vol.hostPath.path != '/var/run/docker'
       ))
     message: CronJob has one or more containers mounting Docker socket! (see more
-      at https://hub.armosec.io/docs/c-0074)
+      at https://kubescape.io/docs/controls/c-0074/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0075
+    controlUrl: https://kubescape.io/docs/controls/c-0075/
   labels:
     controlId: C-0075
   name: kubescape-c-0075-deny-resources-with-image-pull-policy-not-set-to-always-for-latest-tag
@@ -1755,7 +1997,7 @@ spec:
         has(container.imagePullPolicy) && container.imagePullPolicy == 'Always'
       ))
     message: Pods contains container/s image with latest tag and imagePullPolicy not
-      set to Always! (see more at https://hub.armosec.io/docs/c-0075)
+      set to Always! (see more at https://kubescape.io/docs/controls/c-0075/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !(
 
@@ -1766,7 +2008,7 @@ spec:
         has(container.imagePullPolicy) && container.imagePullPolicy == 'Always'
       ))
     message: Workloads contains container/s image with latest tag and imagePullPolicy
-      not set to Always! (see more at https://hub.armosec.io/docs/c-0075)
+      not set to Always! (see more at https://kubescape.io/docs/controls/c-0075/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !(
 
@@ -1777,13 +2019,13 @@ spec:
         has(container.imagePullPolicy) && container.imagePullPolicy == 'Always'
       ))
     message: CronJob contains container/s image with latest tag and imagePullPolicy
-      not set to Always! (see more at https://hub.armosec.io/docs/c-0075)
+      not set to Always! (see more at https://kubescape.io/docs/controls/c-0075/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0076
+    controlUrl: https://kubescape.io/docs/controls/c-0076/
   labels:
     controlId: C-0076
   name: kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set
@@ -1834,7 +2076,7 @@ spec:
           labelInList, labelInList != label
         )))
       )
-    message: Pods doesn't have any label from the configured list! (see more at https://hub.armosec.io/docs/c-0076)
+    message: Pods doesn't have any label from the configured list! (see more at https://kubescape.io/docs/controls/c-0076/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (
 
@@ -1849,7 +2091,7 @@ spec:
         )))
       )
     message: Workload or Pod in workload doesn't have any label from the configured
-      list! (see more at https://hub.armosec.io/docs/c-0076)
+      list! (see more at https://kubescape.io/docs/controls/c-0076/)
   - expression: |
       object.kind != 'CronJob' || (
 
@@ -1864,13 +2106,13 @@ spec:
         )))
       )
     message: CronJob or Pod in CronJob doesn't have any label from the configured
-      list! (see more at https://hub.armosec.io/docs/c-0076)
+      list! (see more at https://kubescape.io/docs/controls/c-0076/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0077
+    controlUrl: https://kubescape.io/docs/controls/c-0077/
   labels:
     controlId: C-0077
   name: kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set
@@ -1922,7 +2164,7 @@ spec:
         )))
       )
     message: Pod doesn't have any k8s common label from the configured list! (see
-      more at https://hub.armosec.io/docs/c-0077)
+      more at https://kubescape.io/docs/controls/c-0077/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (
 
@@ -1937,7 +2179,7 @@ spec:
         )))
       )
     message: Workload or Pod in workload doesn't have any k8s common label from the
-      configured list! (see more at https://hub.armosec.io/docs/c-0077)
+      configured list! (see more at https://kubescape.io/docs/controls/c-0077/)
   - expression: |
       object.kind != 'CronJob' || (
 
@@ -1952,13 +2194,13 @@ spec:
         )))
       )
     message: CronJob or Pod in workload doesn't have any k8s common label from the
-      configured list! (see more at https://hub.armosec.io/docs/c-0077)
+      configured list! (see more at https://kubescape.io/docs/controls/c-0077/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0078
+    controlUrl: https://kubescape.io/docs/controls/c-0078/
   labels:
     controlId: C-0078
   name: kubescape-c-0078-only-allow-images-from-allowed-registry
@@ -2004,33 +2246,406 @@ spec:
   - expression: |
       object.kind != 'Pod' || object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry, (
 
-        (registry == 'docker.io' && !container.image.contains('/')) ||
-        (container.image.startsWith(registry))
+        (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
+        (container.image.startsWith(registry + '/'))
       )))
     message: Pods uses an image from a registry that is not in the allow list! (see
-      more at https://hub.armosec.io/docs/c-0078)
+      more at https://kubescape.io/docs/controls/c-0078/)
   - expression: |
       ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry, (
 
-        (registry == 'docker.io' && !container.image.contains('/')) ||
-        (container.image.startsWith(registry))
+        (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
+        (container.image.startsWith(registry + '/'))
       )))
     message: Workloads uses an image from a registry that is not in the allow list!
-      (see more at https://hub.armosec.io/docs/c-0078)
+      (see more at https://kubescape.io/docs/controls/c-0078/)
   - expression: |
       object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry, (
 
-        (registry == 'docker.io' && !container.image.contains('/')) ||
-        (container.image.startsWith(registry))
+        (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
+        (container.image.startsWith(registry + '/'))
       )))
     message: CronJob uses an image from a registry that is not in the allow list!
-      (see more at https://hub.armosec.io/docs/c-0078)
+      (see more at https://kubescape.io/docs/controls/c-0078/)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0268
+    controlUrl: https://kubescape.io/docs/controls/c-0198/
+  labels:
+    controlId: C-0198
+  name: kubescape-c-0198-deny-root-containers
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: |
+      variables.containers.all(container,
+
+        (has(container.securityContext) && has(container.securityContext.runAsUser)
+          ? container.securityContext.runAsUser
+          : (has(variables.podSecurityContext) && has(variables.podSecurityContext.runAsUser)
+              ? variables.podSecurityContext.runAsUser
+              : -1)
+        ) != 0
+      )
+    message: |
+      object.kind + '/' + object.metadata.name + ' has a container explicitly running as root (UID 0). (see more at https://kubescape.io/docs/controls/c-0198/)'
+  variables:
+  - expression: |
+      object.kind == 'Pod'
+        ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+          ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+          : object.kind == 'CronJob'
+            ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+            : []
+    name: containers
+  - expression: |
+      object.kind == 'Pod'
+        ? (has(object.spec.securityContext) ? object.spec.securityContext : {})
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+          ? (has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {})
+          : object.kind == 'CronJob'
+            ? (has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {})
+            : {}
+    name: podSecurityContext
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0199/
+  labels:
+    controlId: C-0199
+  name: kubescape-c-0199-deny-net-raw-capability
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: 'object.kind != ''Pod'' || (object.spec.containers + (has(object.spec.initContainers)
+      ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ?
+      object.spec.ephemeralContainers : [])).all(container, has(container.securityContext)
+      && has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop)
+      && container.securityContext.capabilities.drop.exists(c, c == ''NET_RAW'' ||
+      c == ''ALL'') && (!has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(cap,
+      cap != ''NET_RAW'' && cap != ''ALL'')))'
+    message: Container must drop the NET_RAW capability (or all capabilities) and
+      must not add NET_RAW back! (see more at https://kubescape.io/docs/controls/c-0199/)
+  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
+      object.kind != kind) || (object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers)
+      ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers)
+      ? object.spec.template.spec.ephemeralContainers : [])).all(container, has(container.securityContext)
+      && has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop)
+      && container.securityContext.capabilities.drop.exists(c, c == ''NET_RAW'' ||
+      c == ''ALL'') && (!has(container.securityContext.capabilities.add) || container.securityContext.capabilities.add.all(cap,
+      cap != ''NET_RAW'' && cap != ''ALL'')))'
+    message: Workload has a container that must drop the NET_RAW capability (or all
+      capabilities) and must not add NET_RAW back! (see more at https://kubescape.io/docs/controls/c-0199/)
+  - expression: 'object.kind != ''CronJob'' || (object.spec.jobTemplate.spec.template.spec.containers
+      + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers
+      : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers)
+      ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])).all(container,
+      has(container.securityContext) && has(container.securityContext.capabilities)
+      && has(container.securityContext.capabilities.drop) && container.securityContext.capabilities.drop.exists(c,
+      c == ''NET_RAW'' || c == ''ALL'') && (!has(container.securityContext.capabilities.add)
+      || container.securityContext.capabilities.add.all(cap, cap != ''NET_RAW'' &&
+      cap != ''ALL'')))'
+    message: CronJob has a container that must drop the NET_RAW capability (or all
+      capabilities) and must not add NET_RAW back! (see more at https://kubescape.io/docs/controls/c-0199/)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0200/
+  labels:
+    controlId: C-0200
+  name: kubescape-c-0200-deny-added-capabilities
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: 'object.kind != ''Pod'' || (object.spec.containers + (has(object.spec.initContainers)
+      ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ?
+      object.spec.ephemeralContainers : [])).all(container, !has(container.securityContext)
+      || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add)
+      || size(container.securityContext.capabilities.add) == 0)'
+    message: Container has capabilities added beyond the default set! (see more at
+      https://kubescape.io/docs/controls/c-0200/)
+  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
+      object.kind != kind) || (object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers)
+      ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers)
+      ? object.spec.template.spec.ephemeralContainers : [])).all(container, !has(container.securityContext)
+      || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add)
+      || size(container.securityContext.capabilities.add) == 0)'
+    message: Workload has a container with capabilities added beyond the default set!
+      (see more at https://kubescape.io/docs/controls/c-0200/)
+  - expression: 'object.kind != ''CronJob'' || (object.spec.jobTemplate.spec.template.spec.containers
+      + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers
+      : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers)
+      ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])).all(container,
+      !has(container.securityContext) || !has(container.securityContext.capabilities)
+      || !has(container.securityContext.capabilities.add) || size(container.securityContext.capabilities.add)
+      == 0)'
+    message: CronJob has a container with capabilities added beyond the default set!
+      (see more at https://kubescape.io/docs/controls/c-0200/)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0201/
+  labels:
+    controlId: C-0201
+  name: kubescape-c-0201-deny-capabilities-assigned
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: 'object.kind != ''Pod'' || (object.spec.containers + (has(object.spec.initContainers)
+      ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ?
+      object.spec.ephemeralContainers : [])).all(container, has(container.securityContext)
+      && has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop)
+      && container.securityContext.capabilities.drop.exists(d, d == ''ALL'') && (!has(container.securityContext.capabilities.add)
+      || size(container.securityContext.capabilities.add) == 0))'
+    message: Container must drop all capabilities and must not have any capabilities
+      added! (see more at https://kubescape.io/docs/controls/c-0201/)
+  - expression: '[''Deployment'',''ReplicaSet'',''DaemonSet'',''StatefulSet'',''Job''].all(kind,
+      object.kind != kind) || (object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers)
+      ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers)
+      ? object.spec.template.spec.ephemeralContainers : [])).all(container, has(container.securityContext)
+      && has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop)
+      && container.securityContext.capabilities.drop.exists(d, d == ''ALL'') && (!has(container.securityContext.capabilities.add)
+      || size(container.securityContext.capabilities.add) == 0))'
+    message: Workload must not have containers with capabilities assigned without
+      dropping all! (see more at https://kubescape.io/docs/controls/c-0201/)
+  - expression: 'object.kind != ''CronJob'' || (object.spec.jobTemplate.spec.template.spec.containers
+      + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers
+      : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers)
+      ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])).all(container,
+      has(container.securityContext) && has(container.securityContext.capabilities)
+      && has(container.securityContext.capabilities.drop) && container.securityContext.capabilities.drop.exists(d,
+      d == ''ALL'') && (!has(container.securityContext.capabilities.add) || size(container.securityContext.capabilities.add)
+      == 0))'
+    message: CronJob must not have containers with capabilities assigned without dropping
+      all! (see more at https://kubescape.io/docs/controls/c-0201/)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0210/
+  labels:
+    controlId: C-0210
+  name: kubescape-c-0210-deny-seccomp-profile-unconfined
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+      - pods/ephemeralcontainers
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    - apiGroups:
+      - batch
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - jobs
+      - cronjobs
+  validations:
+  - expression: |
+      variables.containers.all(container,
+
+        (has(container.securityContext) && has(container.securityContext.seccompProfile) && has(container.securityContext.seccompProfile.type)
+          ? container.securityContext.seccompProfile.type
+          : (has(variables.podSecurityContext) && has(variables.podSecurityContext.seccompProfile) && has(variables.podSecurityContext.seccompProfile.type)
+              ? variables.podSecurityContext.seccompProfile.type
+              : 'Unconfined')
+        ) != 'Unconfined'
+      )
+    message: |
+      object.kind + '/' + object.metadata.name + ' has a container with seccomp profile Unconfined or undefined. (see more at https://kubescape.io/docs/controls/c-0210/)'
+  variables:
+  - expression: |
+      object.kind == 'Pod'
+        ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+          ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+          : object.kind == 'CronJob'
+            ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+            : []
+    name: containers
+  - expression: |
+      object.kind == 'Pod'
+        ? (has(object.spec.securityContext) ? object.spec.securityContext : {})
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+          ? (has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {})
+          : object.kind == 'CronJob'
+            ? (has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {})
+            : {}
+    name: podSecurityContext
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0268/
   labels:
     controlId: C-0268
   name: kubescape-c-0268-deny-resources-with-cpu-request-not-set
@@ -2074,23 +2689,23 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
-    message: Pods contains container/s with cpu request not set or they are not in
-      the specified range! (see more at https://hub.armosec.io/docs/c-0268)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 && quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with cpu request not set or they are not in the specified range! (see more at
+      https://kubescape.io/docs/controls/c-0268/)"
+  variables:
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
-    message: Workloads contains container/s with cpu request not set or they are not
-      in the specified range! (see more at https://hub.armosec.io/docs/c-0268)
-  - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && params.settings.cpuRequestMin <= int(container.resources.requests.cpu) && params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
-    message: CronJob contains container/s with cpu request not set or they are not
-      in the specified range! (see more at https://hub.armosec.io/docs/c-0268)
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0269
+    controlUrl: https://kubescape.io/docs/controls/c-0269/
   labels:
     controlId: C-0269
   name: kubescape-c-0269-deny-resources-with-memory-request-not-set
@@ -2134,23 +2749,23 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-    message: Pods contains container/s with memory request not set or they are not
-      in the specified range! (see more at https://hub.armosec.io/docs/c-0269)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && quantity(string(params.settings.memoryRequestMin)).compareTo(quantity(string(container.resources.requests.memory))) != 1 && quantity(string(params.settings.memoryRequestMax)).compareTo(quantity(string(container.resources.requests.memory))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with memory request not set or they are not in the specified range! (see more
+      at https://kubescape.io/docs/controls/c-0269/)"
+  variables:
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-    message: Workloads contains container/s with memory request not set or they are
-      not in the specified range! (see more at https://hub.armosec.io/docs/c-0269)
-  - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() && params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-    message: CronJob contains container/s with memory request not set or they are
-      not in the specified range! (see more at https://hub.armosec.io/docs/c-0269)
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0270
+    controlUrl: https://kubescape.io/docs/controls/c-0270/
   labels:
     controlId: C-0270
   name: kubescape-c-0270-deny-resources-with-cpu-limit-not-set
@@ -2194,23 +2809,23 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
-    message: Pods contains container/s with cpu limit not set or they are not in the
-      specified range! (see more at https://hub.armosec.io/docs/c-0270)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 && quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with cpu limit not set or they are not in the specified range! (see more at
+      https://kubescape.io/docs/controls/c-0270/)"
+  variables:
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
-    message: Workloads contains container/s with cpu limit not set or they are not
-      in the specified range! (see more at https://hub.armosec.io/docs/c-0270)
-  - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) && params.settings.cpuLimitMin <= int(container.resources.limits.cpu) && params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
-    message: CronJob contains container/s with cpu limit not set or they are not in
-      the specified range! (see more at https://hub.armosec.io/docs/c-0270)
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    controlUrl: https://hub.armosec.io/docs/c-0271
+    controlUrl: https://kubescape.io/docs/controls/c-0271/
   labels:
     controlId: C-0271
   name: kubescape-c-0271-deny-resources-with-memory-limit-not-set
@@ -2254,14 +2869,53 @@ spec:
     kind: ControlConfiguration
   validations:
   - expression: |
-      object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() && params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: Pods contains container/s with memory limit not set or they are not in
-      the specified range! (see more at https://hub.armosec.io/docs/c-0271)
+      variables.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 && quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      with memory limit not set or they are not in the specified range! (see more
+      at https://kubescape.io/docs/controls/c-0271/)"
+  variables:
   - expression: |
-      ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() && params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: Workloads contains container/s with memory limit not set or they are
-      not in the specified range! (see more at https://hub.armosec.io/docs/c-0271)
+      object.kind == 'Pod' ? object.spec.containers
+      : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+      : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+      : []
+    name: containers
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    controlUrl: https://kubescape.io/docs/controls/c-0280/
+  labels:
+    controlId: C-0280
+  name: kubescape-c-0280-deny-access-to-csr-approval-subresource
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - roles
+      - clusterroles
+  validations:
   - expression: |
-      object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) && params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() && params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-    message: CronJob contains container/s with memory limit not set or they are not
-      in the specified range! (see more at https://hub.armosec.io/docs/c-0271)
+      ['Role', 'ClusterRole'].all(kind, object.kind != kind) || !has(object.rules) || object.rules.all(rule,
+
+        !(
+          has(rule.resources) && (
+            rule.resources.exists(r, r == "certificatesigningrequests/approval" || r == "certificatesigningrequests/*")
+            ||
+            (rule.resources.exists(r, r == "*" || r == "*/*") && has(rule.apiGroups) && rule.apiGroups.exists(g, g == "certificates.k8s.io" || g == "*"))
+          )
+          &&
+          has(rule.verbs) && rule.verbs.exists(v, v == "update" || v == "patch" || v == "*")
+        )
+      )
+    message: RBAC Role or ClusterRole has access to the certificatesigningrequests/approval
+      sub-resource which can lead to privilege escalation! (see more at https://kubescape.io/docs/controls/c-0280/)

--- a/core/pkg/opaprocessor/cel/vapdata/policy-configuration-definition.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/policy-configuration-definition.yaml
@@ -48,13 +48,13 @@ spec:
                     type: integer
                   type: array
                 memoryLimitMax:
-                  type: integer
+                  type: string
                 memoryLimitMin:
-                  type: integer
+                  type: string
                 memoryRequestMax:
-                  type: integer
+                  type: string
                 memoryRequestMin:
-                  type: integer
+                  type: string
                 publicRegistries:
                   items:
                     type: string
@@ -68,6 +68,10 @@ spec:
                     type: string
                   type: array
                 sensitiveKeyNames:
+                  items:
+                    type: string
+                  type: array
+                sensitiveKeyNamesAllowed:
                   items:
                     type: string
                   type: array


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Three policies in the vendored CEL bundle (C-0045, C-0048, C-0055) walk optional field paths without a `has()` guard, so offline evaluation raises `no such key` and the scan reports ordinary workloads as `Skipped/Unknown` instead of evaluating them — and in one case passes a real violation silently. Fixes #2534 plus two further instances of the same class found by sweeping the whole bundle, and adds a regression test that guards the class.

## What

Three policies in the vendored CEL bundle walk optional field paths without a `has()` guard. Offline, `object` is bound to the raw scanned manifest with no schema defaulting, so an `omitempty` field the author left out is simply absent. CEL raises `no such key` on a selection into a missing key, `evaluateValidation` records it as `Err`, and `runCELOnK8s` turns "no violation + eval error" into `StatusSkipped` — so an ordinary workload is reported `Skipped/Unknown` instead of getting a verdict. Live admission hides all of this: the object there is schema-defaulted, so the field exists and the expression is vacuously true.

Fixes #2534, plus two more instances of the same class found by sweeping every control in the bundle.

| Control | Bug | Effect |
|---|---|---|
| C-0045 | all three validations read `spec.volumes` unguarded | every workload with no `volumes` block is skipped (Pod, Deployment, Job **and** CronJob) |
| C-0048 | CronJob validation guards `spec.jobTemplate.spec.volumes` but reads `spec.jobTemplate.spec.template.spec.volumes` | the guarded path never exists, so it always short-circuits — a hostPath CronJob **passes silently** |
| C-0055 | Workload/CronJob validations walk into the optional `template.metadata` unguarded; CronJob reads `securityContext` from `spec.jobTemplate.spec` instead of the pod template | metadata-less Deployment/Job/CronJob skipped; a CronJob hardened with a pod-level `seccompProfile` judged only by its per-container securityContext |

Worth calling out: `has()` only guards the *final* selection. `has(a.b.c)` still raises `no such key: b` when `a.b` is missing, which is why C-0055 needs a guard per hop.

The C-0048 case is the more serious of the three — a skip is visible in the report, a false pass is not.

## Scope note

This is a **latent** bug today, not a live regression. `runOPAOnSingleRule` only dispatches to `runCELOnK8s` when `rule.RuleLanguage == "CEL"`, and every rule in the regolibrary is currently `Rego` — including `alert-rw-hostpath`, C-0045's only rule. Nothing reaches the CEL engine in a real scan yet. #2534 attributes this to #2525 and describes it as a live mass regression; #2525 only added the scan wiring and never touched the bundle. The unguarded expressions came in with #2455, which vendored the bundle. Fixing now so the class is gone before any control is flipped to CEL.

## Why the bundle is edited by hand

`vapdata/README.md` says not to, and normally that's right. C-0045, C-0048 and the C-0055 `securityContext` path are already fixed on `cel-admission-library` `main`, but the newest release is `v0.11` (2025-03-12), which predates all of them — so there is no version to bump `CEL_LIBRARY_VERSION` to. The C-0055 `metadata` guards are not upstream yet either; that's kubescape/cel-admission-library#97.

The deviation is documented in `vapdata/README.md` with instructions to delete the patches and re-sync once a release past v0.11 exists, rather than re-applying them by hand.

## Tests

`core/pkg/opaprocessor/cel/optionalfields_test.go`:

- **`TestNoEvalErrorOnMinimalWorkloads`** — the guard for the whole class. Sweeps every control in the bundle against a Pod/Deployment/Job/CronJob that sets nothing optional and asserts no validation eval-errors. This is also what catches a future `make sync-vap` from a release that still predates the fixes.
- **`TestHostPathControlsOnVolumelessWorkloads`** — pins the verdict, not just the absence of an error: volume-less workloads must *pass* C-0045 and C-0048.
- **`TestHostPathControlsStillDetectViolations`** — the other half; the new guards must not swallow real violations. Covers the C-0048 CronJob false negative.
- **`TestC0055ReadsCronJobSecurityContextFromPodSpec`** — a CronJob whose pod template sets a `seccompProfile` is accepted.
- **`TestBundleControlIDsAreCurrent`** — keeps the sweep's control list in sync with the bundle so a re-sync that adds controls doesn't silently leave them uncovered.

All four behavioral tests were confirmed to **fail** against the unpatched bundle and pass after, so none of them is vacuous.

As an extra check, I built the next-release bundle from `cel-admission-library` `main` (`kubectl kustomize apis/k8s-v1/`, the same command the release workflow runs) with the C-0055 fix applied, and ran this suite against it: clean, including the seven controls added upstream since v0.11. So a future `v0.12` + version bump lands on green and this patch can simply be dropped.

`go test ./core/pkg/opaprocessor/...` passes.

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy evaluation when optional manifest fields are absent to prevent evaluation errors.
  * Hardened HostPath/volumeMount checks across Pod, Deployment, Job, and CronJob variants (including correct CronJob template handling).
  * Corrected CronJob securityContext handling.
  * Enhanced assisted remediation path generation for CEL violations.
* **New Features**
  * Added local IaC scan tool support.
* **Configuration**
  * Updated memory bounds to GiB-based values and adjusted configuration/schema types.
  * Added `sensitiveKeyNamesAllowed`.
* **Documentation**
  * Documented/enforced scan queue and request body limits (429/413).
* **Chores**
  * Updated the vendored CEL library version used for syncing policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->