### PR TITLE
fix(printer): handle GetContainers errors when resolving container names

### DIFF
--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -102,19 +102,28 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata, paths *[]string) {
 	for i := range *paths {
 		match := specContainerRegex.FindStringSubmatch((*paths)[i])
-		if len(match) == 2 {
-			index, err := strconv.Atoi(match[1])
-			if err != nil {
-				continue
-			}
-			wl := workloadinterface.NewWorkloadObj(resource.GetObject())
-			containers, _ := wl.GetContainers()
-			if index >= len(containers) {
-				continue
-			}
-			containerName := containers[index].Name
-			(*paths)[i] = (*paths)[i] + " (" + containerName + ")"
+		if len(match) != 2 {
+			continue
 		}
+
+		index, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+
+		wl := workloadinterface.NewWorkloadObj(resource.GetObject())
+
+		containers, err := wl.GetContainers()
+		if err != nil {
+			continue
+		}
+
+		if index >= len(containers) {
+			continue
+		}
+
+		containerName := containers[index].Name
+		(*paths)[i] += " (" + containerName + ")"
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -100,30 +100,25 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 }
 
 func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata, paths *[]string) {
+	wl := workloadinterface.NewWorkloadObj(resource.GetObject())
+	containers, err := wl.GetContainers()
+	if err != nil {
+		return
+	}
+
 	for i := range *paths {
 		match := specContainerRegex.FindStringSubmatch((*paths)[i])
 		if len(match) != 2 {
 			continue
 		}
-
 		index, err := strconv.Atoi(match[1])
 		if err != nil {
 			continue
 		}
-
-		wl := workloadinterface.NewWorkloadObj(resource.GetObject())
-
-		containers, err := wl.GetContainers()
-		if err != nil {
-			continue
-		}
-
 		if index >= len(containers) {
 			continue
 		}
-
-		containerName := containers[index].Name
-		(*paths)[i] += " (" + containerName + ")"
+		(*paths)[i] += " (" + containers[index].Name + ")"
 	}
 }
 


### PR DESCRIPTION
## Summary

Handle errors returned by `GetContainers()` when resolving container names for assisted remediation paths.

## Changes

- Handle the error returned by `GetContainers()`.
- Skip appending the container name when container resolution fails.
- Preserve the existing behavior for successfully resolved workloads.

## Testing

```bash
go test ./core/pkg/resultshandling/printer/v2/... -run TestAddContainer
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves assisted remediation output for container names by handling regex mismatches and index parsing more safely.
  * Prevents misleading or incomplete container details when container lookup fails or referenced indexes are invalid.
  * When a container name is resolved, it’s appended to the existing resource path text (rather than replacing it).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->