### PR TITLE
fix(scan): surface manifest loading failures

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -51,9 +51,9 @@ type Chart struct {
 // --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
 // fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
 func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
-	helmDirectories, err := listHelmChartDirs(basePath)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to discover Helm charts under %q: %w", basePath, err)
+	helmDirectories, discoveryErrs := listHelmChartDirs(basePath)
+	for _, err := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
 	}
 
 	// Parse user-supplied value overrides once; reuse for every chart we render.
@@ -105,25 +105,27 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 
 // listHelmChartDirs scans a given path (recursively) and returns the directories holding a helm chart.
 // Subcharts are picked up by the same walk, since each carries its own Chart.yaml.
-func listHelmChartDirs(basePath string) ([]string, error) {
+func listHelmChartDirs(basePath string) ([]string, []error) {
 	directories, errs := listDirs(basePath)
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
-	}
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
-		if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+		chartFile := filepath.Join(dir, "Chart.yaml")
+		if _, err := os.Stat(chartFile); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect Helm chart metadata %q: %w", chartFile, err))
 			continue
 		}
 		ok, err := IsHelmDirectory(dir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to inspect %q as a Helm chart: %w", dir, err)
+			errs = append(errs, fmt.Errorf("failed to inspect %q as a Helm chart: %w", dir, err))
+			continue
 		}
 		if ok {
 			helmDirectories = append(helmDirectories, dir)
 		}
 	}
-	return helmDirectories, nil
+	return helmDirectories, errs
 }
 
 // excludeHelmTemplateFiles drops the files living under the templates/ directory of a helm chart.
@@ -234,7 +236,11 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 
 	files, errs := listFiles(input)
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("failed to discover manifest files for %q: %w", input, errors.Join(errs...))
+		discoveryErr := fmt.Errorf("failed to discover all manifest files for %q: %w", input, errors.Join(errs...))
+		if len(files) == 0 {
+			return nil, discoveryErr
+		}
+		logger.L().Ctx(ctx).Warning("Continuing with manifest files found before a discovery error", helpers.Error(discoveryErr))
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no YAML or JSON manifest files found for input %q", input)
@@ -246,7 +252,16 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 
 	workloads, errs := loadFiles(rootPath, files)
 	if len(errs) > 0 {
-		return workloads, fmt.Errorf("failed to load one or more manifests from %q: %w", input, errors.Join(errs...))
+		loadErr := fmt.Errorf("failed to load one or more manifests from %q: %w", input, errors.Join(errs...))
+		// Directory and glob scans have historically been best effort. Keep the
+		// valid resources from mixed inputs, but make the skipped files visible.
+		// An explicitly requested file, or an input with no usable resources,
+		// remains a hard failure because returning success would scan nothing or
+		// conceal corruption in the exact file the user requested.
+		if isFile(input) || len(workloads) == 0 {
+			return workloads, loadErr
+		}
+		logger.L().Ctx(ctx).Warning("Skipping invalid manifest files", helpers.Error(loadErr))
 	}
 
 	return workloads, nil
@@ -346,10 +361,9 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 	}
 
 	f, err := glob(root, shouldMatch, onlyDirectories)
+	paths = append(paths, f...)
 	if err != nil {
 		errs = append(errs, err)
-	} else {
-		paths = append(paths, f...)
 	}
 
 	return paths, errs
@@ -513,7 +527,7 @@ func glob(root, pattern string, onlyDirectories bool) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return matches, err
 	}
 	return matches, nil
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -50,7 +51,10 @@ type Chart struct {
 // --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
 // fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
 func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
-	helmDirectories := listHelmChartDirs(basePath)
+	helmDirectories, err := listHelmChartDirs(basePath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to discover Helm charts under %q: %w", basePath, err)
+	}
 
 	// Parse user-supplied value overrides once; reuse for every chart we render.
 	var userValues map[string]any
@@ -71,26 +75,28 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 	renderedCharts := make([]string, 0, len(helmDirectories))
 	for _, helmDir := range helmDirectories {
 		chart, err := NewHelmChart(helmDir)
-		if err == nil {
-			values := chart.GetDefaultValues()
-			if userValues != nil {
-				values = mergeMaps(values, userValues)
-			}
-			wls, errs := chart.GetWorkloadsWithOptions(values, releaseOpts)
-			if len(errs) > 0 {
-				logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering of Helm chart template '%s', failed: %v", chart.GetName(), errs))
-				continue
-			}
-			renderedCharts = append(renderedCharts, helmDir)
-			chartName := chart.GetName()
-			prov := chart.Provenance()
-			for k, v := range wls {
-				sourceToWorkloads[k] = v
-				sourceToChart[k] = Chart{
-					Name:       chartName,
-					Path:       helmDir,
-					Provenance: prov[k],
-				}
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("Failed to load Helm chart", helpers.String("path", helmDir), helpers.Error(err))
+			continue
+		}
+		values := chart.GetDefaultValues()
+		if userValues != nil {
+			values = mergeMaps(values, userValues)
+		}
+		wls, errs := chart.GetWorkloadsWithOptions(values, releaseOpts)
+		if len(errs) > 0 {
+			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering of Helm chart template '%s', failed: %v", chart.GetName(), errs))
+			continue
+		}
+		renderedCharts = append(renderedCharts, helmDir)
+		chartName := chart.GetName()
+		prov := chart.Provenance()
+		for k, v := range wls {
+			sourceToWorkloads[k] = v
+			sourceToChart[k] = Chart{
+				Name:       chartName,
+				Path:       helmDir,
+				Provenance: prov[k],
 			}
 		}
 	}
@@ -99,15 +105,25 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 
 // listHelmChartDirs scans a given path (recursively) and returns the directories holding a helm chart.
 // Subcharts are picked up by the same walk, since each carries its own Chart.yaml.
-func listHelmChartDirs(basePath string) []string {
-	directories, _ := listDirs(basePath)
+func listHelmChartDirs(basePath string) ([]string, error) {
+	directories, errs := listDirs(basePath)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
-		if ok, _ := IsHelmDirectory(dir); ok {
+		if _, err := os.Stat(filepath.Join(dir, "Chart.yaml")); err != nil {
+			continue
+		}
+		ok, err := IsHelmDirectory(dir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect %q as a Helm chart: %w", dir, err)
+		}
+		if ok {
 			helmDirectories = append(helmDirectories, dir)
 		}
 	}
-	return helmDirectories
+	return helmDirectories, nil
 }
 
 // excludeHelmTemplateFiles drops the files living under the templates/ directory of a helm chart.
@@ -174,11 +190,11 @@ func mergeMaps(base, override map[string]any) map[string]any {
 
 // If the contents at given path is a Kustomize Directory, LoadResourcesFromKustomizeDirectory will
 // generate yaml files using "Kustomize" & renders a map of workloads from those yaml files
-func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, string) {
+func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, string, error) {
 	isKustomizeDirectory := isKustomizeDirectory(basePath)
 	isKustomizeFile := IsKustomizeFile(basePath)
 	if ok := isKustomizeDirectory || isKustomizeFile; !ok {
-		return nil, ""
+		return nil, "", nil
 	}
 
 	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
@@ -198,29 +214,30 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 	kustomizeDirectoryName := getKustomizeDirectoryName(newBasePath)
 
 	if len(errs) > 0 {
-		logger.L().Ctx(ctx).Warning(fmt.Sprintf("Rendering yaml from Kustomize failed: %v", errs))
+		err := fmt.Errorf("failed to render Kustomize resources from %q: %w", newBasePath, errors.Join(errs...))
+		logger.L().Ctx(ctx).Error("Rendering yaml from Kustomize failed", helpers.Error(err))
+		return nil, kustomizeDirectoryName, err
 	}
 
 	maps.Copy(sourceToWorkloads, wls)
-	return sourceToWorkloads, kustomizeDirectoryName
+	return sourceToWorkloads, kustomizeDirectoryName, nil
 }
 
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts
 // are the chart directories LoadResourcesFromHelmCharts already rendered; their templates are left
 // to that render and skipped here. Pass nil to scan everything (e.g. when no charts were rendered).
-func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, renderedCharts []string) map[string][]workloadinterface.IMetadata {
+func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, renderedCharts []string) (map[string][]workloadinterface.IMetadata, error) {
 	// skip the plain-YAML glob for a kustomize directory; the kustomize render handles it
 	if isKustomizeDirectory(input) {
-		return nil
+		return nil, nil
 	}
 
 	files, errs := listFiles(input)
 	if len(errs) > 0 {
-		logger.L().Ctx(ctx).Warning(fmt.Sprintf("%v", errs))
+		return nil, fmt.Errorf("failed to discover manifest files for %q: %w", input, errors.Join(errs...))
 	}
 	if len(files) == 0 {
-		logger.L().Ctx(ctx).Error("no files found to scan", helpers.String("input", input))
-		return nil
+		return nil, fmt.Errorf("no YAML or JSON manifest files found for input %q", input)
 	}
 
 	// skip the plain-YAML glob for the templates of charts the helm render already covered; a chart
@@ -229,10 +246,10 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 
 	workloads, errs := loadFiles(rootPath, files)
 	if len(errs) > 0 {
-		logger.L().Ctx(ctx).Warning(fmt.Sprintf("%v", errs))
+		return workloads, fmt.Errorf("failed to load one or more manifests from %q: %w", input, errors.Join(errs...))
 	}
 
-	return workloads
+	return workloads, nil
 }
 
 func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterface.IMetadata, []error) {
@@ -250,7 +267,13 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 
 		w, e := ReadFile(f, getFileFormat(filePaths[i]))
 		if e != nil {
-			logger.L().Debug("failed to read file", helpers.String("file", filePaths[i]), helpers.Error(e))
+			// Raw Helm templates are a best-effort fallback when chart rendering
+			// fails. Go-template actions are not valid YAML, so keep scanning any
+			// static templates without treating templated siblings as corrupt
+			// standalone manifests.
+			if !bytes.Contains(f, []byte("{{")) {
+				errs = append(errs, fmt.Errorf("failed to parse %q: %w", filePaths[i], e))
+			}
 		}
 		if len(w) != 0 {
 			path := filePaths[i]
@@ -332,18 +355,19 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 	return paths, errs
 }
 
-func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, _ error) {
+func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err error) {
 	yamlObjs = []workloadinterface.IMetadata{}
 	defer func() {
 		if r := recover(); r != nil {
-			logger.L().Warning(fmt.Sprintf("panic during YAML parsing: %v", r))
+			err = fmt.Errorf("panic during YAML parsing: %v", r)
 		}
 	}()
 
+	var parseErrs []error
 	for i, doc := range splitYAMLDocuments(yamlFile) {
 		var t any
-		if err := yaml.Unmarshal(doc, &t); err != nil {
-			logger.L().Warning(fmt.Sprintf("skipping malformed YAML document %d: %v", i+1, err))
+		if unmarshalErr := yaml.Unmarshal(doc, &t); unmarshalErr != nil {
+			parseErrs = append(parseErrs, fmt.Errorf("document %d: %w", i+1, unmarshalErr))
 			continue
 		}
 		j := convertYamlToJson(t)
@@ -363,7 +387,7 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, _ er
 		}
 	}
 
-	return
+	return yamlObjs, errors.Join(parseErrs...)
 }
 
 func splitYAMLDocuments(data []byte) [][]byte {

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +54,7 @@ func TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath(t *testing.T) {
 	dir := t.TempDir()
 	broken := writeManifestFixture(t, dir, "broken.json", `{"apiVersion":`)
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+	workloads, err := LoadResourcesFromFiles(context.Background(), broken, dir, nil)
 
 	require.Error(t, err)
 	assert.Empty(t, workloads)
@@ -66,7 +67,7 @@ func TestLoadResourcesFromFilesReturnsYAMLDocumentNumber(t *testing.T) {
 	manifest := validPodManifest + "---\nmetadata: [unterminated\n"
 	path := writeManifestFixture(t, dir, "mixed.yaml", manifest)
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+	workloads, err := LoadResourcesFromFiles(context.Background(), path, dir, nil)
 
 	require.Error(t, err)
 	require.Contains(t, workloads, path)
@@ -75,17 +76,74 @@ func TestLoadResourcesFromFilesReturnsYAMLDocumentNumber(t *testing.T) {
 	assert.Contains(t, err.Error(), path)
 }
 
-func TestLoadResourcesFromFilesDoesNotHidePartialDirectoryFailure(t *testing.T) {
+func TestLoadResourcesFromFilesKeepsValidResourcesFromMixedDirectory(t *testing.T) {
 	dir := t.TempDir()
 	valid := writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
 	broken := writeManifestFixture(t, dir, "broken.yaml", "apiVersion: v1\nmetadata: [unterminated\n")
 
 	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.Contains(t, workloads, valid)
 	assert.Len(t, workloads[valid], 1)
-	assert.Contains(t, err.Error(), broken)
+	assert.NotContains(t, workloads, broken)
+}
+
+func TestLoadResourcesFromFilesKeepsFilesFoundBeforeDirectoryReadError(t *testing.T) {
+	dir := t.TempDir()
+	valid := writeManifestFixture(t, dir, "a-valid.yaml", validPodManifest)
+	unreadable := filepath.Join(dir, "z-unreadable")
+	require.NoError(t, os.Mkdir(unreadable, 0o700))
+	writeManifestFixture(t, unreadable, "hidden.yaml", validPodManifest)
+	require.NoError(t, os.Chmod(unreadable, 0))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+	if _, err := os.ReadDir(unreadable); err == nil {
+		t.Skip("filesystem permissions are not enforced for the test user")
+	}
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, valid)
+	assert.Len(t, workloads[valid], 1)
+}
+
+func TestListHelmChartDirsReportsMetadataIOErrorsAndKeepsValidCharts(t *testing.T) {
+	dir := t.TempDir()
+	validChart := filepath.Join(dir, "a-valid")
+	require.NoError(t, os.Mkdir(validChart, 0o700))
+	writeManifestFixture(t, validChart, "Chart.yaml", "apiVersion: v2\nname: valid\nversion: 0.1.0\n")
+
+	brokenChart := filepath.Join(dir, "z-broken")
+	require.NoError(t, os.Mkdir(brokenChart, 0o700))
+	chartFile := filepath.Join(brokenChart, "Chart.yaml")
+	require.NoError(t, os.Symlink("Chart.yaml", chartFile))
+
+	charts, errs := listHelmChartDirs(dir)
+
+	assert.Contains(t, charts, validChart)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errors.Join(errs...).Error(), chartFile)
+}
+
+func TestHelmRenderedYAMLParseFailureMarksChartUnrendered(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "Chart.yaml", "apiVersion: v2\nname: broken\nversion: 0.1.0\n")
+	templates := filepath.Join(dir, "templates")
+	require.NoError(t, os.Mkdir(templates, 0o700))
+	writeManifestFixture(t, templates, "broken.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: [unterminated\n")
+
+	chart, err := NewHelmChart(dir)
+	require.NoError(t, err)
+	workloads, renderErrs := chart.GetWorkloadsWithOptions(chart.GetDefaultValues(), HelmValueOptions{}.ReleaseOptions())
+
+	assert.Empty(t, workloads)
+	require.NotEmpty(t, renderErrs)
+	assert.Contains(t, errors.Join(renderErrs...).Error(), "failed to parse rendered Helm template")
+
+	_, _, renderedCharts, err := LoadResourcesFromHelmCharts(context.Background(), dir, HelmValueOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, renderedCharts, "a chart with invalid rendered YAML must remain available to the plain-file fallback")
 }
 
 func TestLoadResourcesFromKustomizeDirectoryPropagatesBuildFailure(t *testing.T) {

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -1,0 +1,117 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validPodManifest = `apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: nginx:latest
+`
+
+func writeManifestFixture(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestLoadResourcesFromFilesReturnsErrorForMissingInput(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), missing, missing, nil)
+
+	require.Error(t, err)
+	assert.Nil(t, workloads)
+	assert.Contains(t, err.Error(), "no YAML or JSON manifest files")
+	assert.Contains(t, err.Error(), missing)
+}
+
+func TestLoadResourcesFromFilesReturnsErrorForEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.Error(t, err)
+	assert.Nil(t, workloads)
+	assert.Contains(t, err.Error(), "no YAML or JSON manifest files")
+}
+
+func TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath(t *testing.T) {
+	dir := t.TempDir()
+	broken := writeManifestFixture(t, dir, "broken.json", `{"apiVersion":`)
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.Error(t, err)
+	assert.Empty(t, workloads)
+	assert.Contains(t, err.Error(), broken)
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestLoadResourcesFromFilesReturnsYAMLDocumentNumber(t *testing.T) {
+	dir := t.TempDir()
+	manifest := validPodManifest + "---\nmetadata: [unterminated\n"
+	path := writeManifestFixture(t, dir, "mixed.yaml", manifest)
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.Error(t, err)
+	require.Contains(t, workloads, path)
+	assert.Len(t, workloads[path], 1, "valid documents should remain available for diagnostics")
+	assert.Contains(t, err.Error(), "document 2")
+	assert.Contains(t, err.Error(), path)
+}
+
+func TestLoadResourcesFromFilesDoesNotHidePartialDirectoryFailure(t *testing.T) {
+	dir := t.TempDir()
+	valid := writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+	broken := writeManifestFixture(t, dir, "broken.yaml", "apiVersion: v1\nmetadata: [unterminated\n")
+
+	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.Error(t, err)
+	require.Contains(t, workloads, valid)
+	assert.Len(t, workloads[valid], 1)
+	assert.Contains(t, err.Error(), broken)
+}
+
+func TestLoadResourcesFromKustomizeDirectoryPropagatesBuildFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - missing-deployment.yaml
+`)
+
+	workloads, name, err := LoadResourcesFromKustomizeDirectory(context.Background(), dir)
+
+	require.Error(t, err)
+	assert.Nil(t, workloads)
+	assert.Equal(t, dir, name)
+	assert.Contains(t, err.Error(), "failed to render Kustomize resources")
+	assert.Contains(t, err.Error(), "missing-deployment.yaml")
+}
+
+func TestLoadResourcesFromKustomizeDirectoryNoopsForPlainDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "pod.yaml", validPodManifest)
+
+	workloads, name, err := LoadResourcesFromKustomizeDirectory(context.Background(), dir)
+
+	require.NoError(t, err)
+	assert.Nil(t, workloads)
+	assert.Empty(t, name)
+}

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -33,8 +33,7 @@ func TestListFiles(t *testing.T) {
 
 func TestLoadResourcesFromFiles(t *testing.T) {
 	workloads, err := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid.yaml")
+	require.NoError(t, err)
 	assert.Equal(t, 12, len(workloads))
 
 	for i, w := range workloads {
@@ -511,6 +510,7 @@ metadata:
 ---
 {not: valid: yaml: [`,
 			wantCount: 1, // the malformed doc is skipped, the good one is kept
+			wantErr:   true,
 		},
 		{
 			name:      "non-Kubernetes object (no kind) returns no results",

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -32,7 +32,9 @@ func TestListFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromFiles(t *testing.T) {
-	workloads := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
+	workloads, err := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid.yaml")
 	assert.Equal(t, 12, len(workloads))
 
 	for i, w := range workloads {
@@ -48,7 +50,8 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 func TestLoadResourcesFromFiles_SupportsMixedCaseExtensions(t *testing.T) {
 	o, _ := os.Getwd()
 	testDir := filepath.Join(o, "testdata", "mixed_extensions")
-	workloads := LoadResourcesFromFiles(context.Background(), testDir, "", nil)
+	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, "", nil)
+	require.NoError(t, err)
 	assert.Equal(t, 2, len(workloads))
 
 	expectedFiles := []string{
@@ -76,7 +79,8 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplates(t *testing.T) {
 		filepath.Join(testDir, "mychart"),
 		filepath.Join(testDir, "mychart", "charts", "mysubchart"),
 	}
-	workloads := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	require.NoError(t, err)
 
 	expectedFiles := []string{
 		filepath.Join(testDir, "plain-pod.yaml"),
@@ -94,7 +98,8 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplates(t *testing.T) {
 func TestLoadResourcesFromFiles_SkipsHelmTemplatesOfScannedChart(t *testing.T) {
 	testDir := filepath.Join(helmChartLayoutPath(), "mychart")
 	renderedCharts := []string{testDir, filepath.Join(testDir, "charts", "mysubchart")}
-	workloads := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	require.NoError(t, err)
 
 	expectedFile := filepath.Join(testDir, "crds", "widget.yaml")
 	_, ok := workloads[expectedFile]
@@ -108,7 +113,8 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplatesOfScannedChart(t *testing.T) {
 func TestLoadResourcesFromFiles_ScansTemplatesOfUnrenderedChart(t *testing.T) {
 	testDir := filepath.Join(helmChartLayoutPath(), "mychart")
 	// no charts rendered successfully, so nothing may be excluded
-	workloads := LoadResourcesFromFiles(context.Background(), testDir, testDir, nil)
+	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, nil)
+	require.NoError(t, err)
 
 	staticTemplate := filepath.Join(testDir, "templates", "serviceaccount.yaml")
 	_, ok := workloads[staticTemplate]
@@ -221,8 +227,9 @@ func TestLoadResourcesFromHelmCharts(t *testing.T) {
 
 func TestLoadFiles(t *testing.T) {
 	files, _ := listFiles(onlineBoutiquePath())
-	_, err := loadFiles("", files)
-	assert.Equal(t, 0, len(err))
+	_, errs := loadFiles("", files)
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "invalid.yaml")
 }
 
 func TestListDirs(t *testing.T) {

--- a/core/cautils/helmchart.go
+++ b/core/cautils/helmchart.go
@@ -181,6 +181,7 @@ func (hc *HelmChart) GetWorkloadsWithOptions(values map[string]any, releaseOpts 
 		wls, e := ReadFile([]byte(renderedYaml), YAML_FILE_FORMAT)
 		if e != nil {
 			logger.L().Debug("failed to read rendered yaml file", helpers.String("file", path), helpers.Error(e))
+			errs = append(errs, fmt.Errorf("failed to parse rendered Helm template %q: %w", path, e))
 		}
 		if len(wls) == 0 {
 			continue

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/kubescape/go-logger"
-	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -101,7 +100,7 @@ func (kd *KustomizeDirectory) GetWorkloads(kustomizeDirectoryPath string) (map[s
 	wls, e := ReadFile(yml, YAML_FILE_FORMAT)
 
 	if e != nil {
-		logger.L().Debug("failed to read rendered yaml file", helpers.String("file", kustomizeDirectoryPath), helpers.Error(e))
+		errs = append(errs, e)
 	}
 
 	if len(wls) != 0 {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -222,7 +222,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	}
 
 	// load resource from local file system
-	sourceToWorkloads := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, renderedCharts)
+	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, renderedCharts)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// update workloads and workloadIDToSource
 	var warnIssued bool
@@ -318,7 +321,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 
 	//patch, get value from env
 	// Load resources from Kustomize directory
-	kustomizeSourceToWorkloads, kustomizeDirectoryName := cautils.LoadResourcesFromKustomizeDirectory(ctx, path) //?
+	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// update workloads and workloadIDToSource with workloads from Kustomize Directory
 	for source, ws := range kustomizeSourceToWorkloads {
@@ -357,6 +363,9 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 
 	// backstop: drop cross-provider identity collisions the path-level kustomize skip can't see (e.g. helm + raw YAML)
 	workloads, workloadIDToSource = dedupWorkloads(workloads, workloadIDToSource)
+	if len(workloads) == 0 {
+		return nil, nil, fmt.Errorf("no scannable Kubernetes resources found for input %q", path)
+	}
 
 	return workloadIDToSource, workloads, nil
 }

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -111,4 +112,33 @@ func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) 
 	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, workloadIDToSource[deploymentIDs[0]].FileType)
 	assert.Equal(t, "production", deployment.GetNamespace())
 	assert.Equal(t, "prod-test-app", deployment.GetName())
+}
+
+func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("replicas: 3\n"), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.Error(t, err)
+	assert.Nil(t, sources)
+	assert.Nil(t, workloads)
+	assert.Contains(t, err.Error(), "no scannable Kubernetes resources")
+}
+
+func TestGetResourcesFromPathPropagatesKustomizeFailure(t *testing.T) {
+	dir := t.TempDir()
+	kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - missing.yaml
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(kustomization), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.Error(t, err)
+	assert.Nil(t, sources)
+	assert.Nil(t, workloads)
+	assert.Contains(t, err.Error(), "failed to render Kustomize resources")
 }


### PR DESCRIPTION
## Summary

### Surface manifest loading failures without breaking mixed directory scans

Kubescape previously hid several important manifest loading failures. Missing inputs, unreadable files, malformed explicitly requested manifests, and failed Kustomize renders could all produce an empty or incomplete result without a useful error.

Directory and glob scans are intentionally best effort, though. Real repositories can contain helper YAML files or malformed files alongside valid Kubernetes resources. This PR keeps that established behavior while making skipped files visible through detailed warnings.

## What changed

- Return errors when manifest discovery fails or no YAML or JSON files are found.
- Fail when an explicitly requested YAML or JSON file cannot be parsed.
- Fail when an input produces no valid Kubernetes resources.
- Continue mixed directory and glob scans when valid resources remain, with a warning that identifies every skipped file.
- Include the source path and YAML document number in parsing diagnostics.
- Preserve valid documents when another document in the same YAML stream is malformed.
- Propagate Kustomize build and rendered YAML parsing failures.
- Propagate Helm chart discovery errors.
- Keep raw Helm template fallback behavior for files containing Go template expressions.

## Why this matters

Users now receive actionable failures when Kubescape cannot scan the requested target, while existing repository scans do not fail just because one file is intentionally invalid or is not a Kubernetes manifest. Mixed scans still report which files were skipped, so incomplete input is visible without discarding valid resources.

## How to test

```bash
go test ./core/cautils ./core/pkg/resourcehandler
KUBESCAPE_SKIP_UPDATE_CHECK=true go run . scan --keep-local control C-0048 'examples/online-boutique/*.yaml'
```

The tests cover missing and empty inputs, malformed explicit files, malformed YAML documents, mixed valid and invalid directories, Kustomize failures, and directories without Kubernetes resources. The CLI smoke command verifies that the online-boutique glob still scans its 12 valid resources and reports the intentionally invalid file as a warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource scanning to propagate manifest/Kustomize/YAML parsing errors with clearer file and “document” diagnostics, while keeping successfully parsed workloads from other inputs.
  * Kustomize build/render failures now return errors reliably, and callers stop rather than continuing with empty/partial results.
  * Directories without scannable Kubernetes resources now return an explicit error.
  * Helm: rendered-template parse issues are captured; problematic charts are skipped with warnings, while discovery problems are logged without halting overall discovery.
* **Tests**
  * Added/updated regression coverage for error propagation and partial-load behavior across YAML, Helm, and Kustomize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->