### PR TITLE
fix(http): bound scan admission and request bodies

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -58,6 +58,11 @@ Triggers a Kubescape scan. By default, scans run asynchronously and return a sca
 
 **Response (sync with `wait=true`):** Same as [Get Results](#get-results) response.
 
+The service accepts a bounded number of pending scans. If the queue is full,
+the endpoint returns `429 Too Many Requests` with a `Retry-After` header. A
+request body larger than the configured limit returns `413 Request Entity Too
+Large` before the scan is admitted.
+
 ---
 
 ### Get Results
@@ -284,6 +289,8 @@ Configure the HTTP handler using environment variables:
 | `KS_LOGGER_NAME` | Logger name | `kubescape` |
 | `KS_LOGGER_LEVEL` | Log level | `info`, `debug`, `warning`, `error` |
 | `KS_DOWNLOAD_ARTIFACTS` | Download artifacts on each scan | `true`, `false` |
+| `KS_SCAN_QUEUE_CAPACITY` | Maximum number of scans waiting behind the active scan | `10` |
+| `KS_SCAN_REQUEST_MAX_BYTES` | Maximum size in bytes of a `POST /v1/scan` request body | `1048576` |
 
 ---
 

--- a/httphandler/handlerequests/v1/admission_test.go
+++ b/httphandler/handlerequests/v1/admission_test.go
@@ -1,0 +1,185 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func performAsyncScanRequest(t *testing.T, handler *HTTPHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/scan", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.Scan(recorder, req)
+	return recorder
+}
+
+func decodeScanResponse(t *testing.T, recorder *httptest.ResponseRecorder) utilsmetav1.Response {
+	t.Helper()
+	var response utilsmetav1.Response
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func handlerStateIsDrained(handler *HTTPHandler) bool {
+	return handler.state.len() == 0 && len(handler.scanRequestChan) == 0
+}
+
+func TestScanQueueRejectsRequestsWhenCapacityIsExhausted(t *testing.T) {
+	originalScanImpl := scanImpl
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var releaseOnce sync.Once
+	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return nil, nil
+	}
+	handler := newHTTPHandler(false, 1, defaultMaxScanRequestBodyBytes)
+	t.Cleanup(func() {
+		releaseScans()
+		require.Eventually(t, func() bool { return handlerStateIsDrained(handler) }, time.Second, 10*time.Millisecond)
+		scanImpl = originalScanImpl
+	})
+
+	body := `{"account":"test"}`
+
+	first := performAsyncScanRequest(t, handler, body)
+	require.Equal(t, http.StatusOK, first.Code)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first scan did not start")
+	}
+
+	second := performAsyncScanRequest(t, handler, body)
+	require.Equal(t, http.StatusOK, second.Code)
+	assert.Equal(t, 1, len(handler.scanRequestChan), "second scan should occupy the only queue slot")
+	assert.Equal(t, 2, handler.state.len(), "active and queued scans should be tracked")
+
+	rejected := performAsyncScanRequest(t, handler, body)
+	assert.Equal(t, http.StatusTooManyRequests, rejected.Code)
+	assert.Equal(t, "1", rejected.Header().Get("Retry-After"))
+	response := decodeScanResponse(t, rejected)
+	assert.Equal(t, utilsapisv1.ErrorScanResponseType, response.Type)
+	assert.Contains(t, fmt.Sprint(response.Response), "scan queue is full")
+	assert.Equal(t, 2, handler.state.len(), "a rejected request must not remain busy")
+
+	releaseScans()
+	require.Eventually(t, func() bool { return handlerStateIsDrained(handler) }, time.Second, 10*time.Millisecond)
+}
+
+func TestScanQueuePreservesAdmissionOrder(t *testing.T) {
+	originalScanImpl := scanImpl
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
+	completed := make(chan string, 3)
+	var callCount atomic.Int32
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		if callCount.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		completed <- scanID
+		return nil, nil
+	}
+
+	handler := newHTTPHandler(false, 2, defaultMaxScanRequestBodyBytes)
+	t.Cleanup(func() {
+		releaseScans()
+		require.Eventually(t, func() bool { return handlerStateIsDrained(handler) }, time.Second, 10*time.Millisecond)
+		scanImpl = originalScanImpl
+	})
+	body := `{"account":"test"}`
+	recorders := []*httptest.ResponseRecorder{
+		performAsyncScanRequest(t, handler, body),
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first scan did not start")
+	}
+	recorders = append(recorders,
+		performAsyncScanRequest(t, handler, body),
+		performAsyncScanRequest(t, handler, body),
+	)
+
+	want := make([]string, 0, len(recorders))
+	for _, recorder := range recorders {
+		require.Equal(t, http.StatusOK, recorder.Code)
+		want = append(want, decodeScanResponse(t, recorder).ID)
+	}
+	releaseScans()
+
+	got := make([]string, 0, len(want))
+	for range want {
+		select {
+		case id := <-completed:
+			got = append(got, id)
+		case <-time.After(2 * time.Second):
+			t.Fatal("queued scan did not complete")
+		}
+	}
+	assert.Equal(t, want, got)
+	require.Eventually(t, func() bool { return handlerStateIsDrained(handler) }, time.Second, 10*time.Millisecond)
+}
+
+func TestScanRejectsOversizedRequestBodyBeforeAdmission(t *testing.T) {
+	defer func(original scanner) { scanImpl = original }(scanImpl)
+	var calls atomic.Int32
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		calls.Add(1)
+		return nil, nil
+	}
+
+	const limit = int64(64)
+	handler := newHTTPHandler(false, 1, limit)
+	body := `{"account":"` + strings.Repeat("x", 128) + `"}`
+
+	recorder := performAsyncScanRequest(t, handler, body)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	response := decodeScanResponse(t, recorder)
+	assert.Equal(t, utilsapisv1.ErrorScanResponseType, response.Type)
+	assert.Contains(t, fmt.Sprint(response.Response), "64 byte limit")
+	assert.Zero(t, calls.Load())
+	assert.Zero(t, handler.state.len())
+	assert.Zero(t, len(handler.scanRequestChan))
+}
+
+func TestConfiguredPositiveInt(t *testing.T) {
+	const name = "TEST_KUBESCAPE_POSITIVE_INT"
+
+	t.Run("uses configured value", func(t *testing.T) {
+		t.Setenv(name, "7")
+		assert.Equal(t, 7, configuredPositiveInt(name, 3))
+	})
+
+	t.Run("rejects zero", func(t *testing.T) {
+		t.Setenv(name, "0")
+		assert.Equal(t, 3, configuredPositiveInt(name, 3))
+	})
+
+	t.Run("rejects malformed value", func(t *testing.T) {
+		t.Setenv(name, "many")
+		assert.Equal(t, 3, configuredPositiveInt(name, 3))
+	})
+}

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -89,7 +89,7 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 		readBuffer, err := io.ReadAll(r.Body)
 		if err != nil {
 			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %s", err.Error()), scanID)
-			return nil, fmt.Errorf("failed to read request body, reason: %s", err.Error())
+			return nil, fmt.Errorf("failed to read request body: %w", err)
 		}
 		if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {
 			return nil, fmt.Errorf("failed to parse request payload, reason: %s", err.Error())

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/schema"
@@ -19,6 +20,13 @@ import (
 var OutputDir = "./results/"
 var FailedOutputDir = "./failed/"
 
+const (
+	defaultScanQueueCapacity       = 10
+	defaultMaxScanRequestBodyBytes = int64(1 << 20) // 1 MiB
+	scanQueueCapacityEnv           = "KS_SCAN_QUEUE_CAPACITY"
+	scanRequestMaxBytesEnv         = "KS_SCAN_REQUEST_MAX_BYTES"
+)
+
 // A Scan Response object
 //
 // swagger:response scanResponse
@@ -28,19 +36,41 @@ type ScanResponse struct {
 }
 
 type HTTPHandler struct {
-	offline         bool
-	state           *serverState
-	scanRequestChan chan *scanRequestParams
+	offline             bool
+	state               *serverState
+	scanRequestChan     chan *scanRequestParams
+	maxRequestBodyBytes int64
 }
 
 func NewHTTPHandler(offline bool) *HTTPHandler {
+	return newHTTPHandler(offline, configuredPositiveInt(scanQueueCapacityEnv, defaultScanQueueCapacity), int64(configuredPositiveInt(scanRequestMaxBytesEnv, int(defaultMaxScanRequestBodyBytes))))
+}
+
+func newHTTPHandler(offline bool, queueCapacity int, maxRequestBodyBytes int64) *HTTPHandler {
 	handler := &HTTPHandler{
-		offline:         offline,
-		state:           newServerState(),
-		scanRequestChan: make(chan *scanRequestParams),
+		offline:             offline,
+		state:               newServerState(),
+		scanRequestChan:     make(chan *scanRequestParams, queueCapacity),
+		maxRequestBodyBytes: maxRequestBodyBytes,
 	}
 	go handler.watchForScan()
 	return handler
+}
+
+func configuredPositiveInt(name string, fallback int) int {
+	raw := envToString(name, "")
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		logger.L().Warning("invalid positive integer configuration; using default",
+			helpers.String("environmentVariable", name),
+			helpers.String("value", raw),
+			helpers.Int("default", fallback))
+		return fallback
+	}
+	return value
 }
 
 // ============================================== STATUS ========================================================
@@ -97,8 +127,16 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	r.Body = http.MaxBytesReader(w, r.Body, handler.maxRequestBodyBytes)
 	scanRequestParams, err := getScanParamsFromRequest(r, scanID)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			handler.writeErrorWithStatus(w,
+				fmt.Errorf("scan request body exceeds the %d byte limit", handler.maxRequestBodyBytes),
+				"", http.StatusRequestEntityTooLarge)
+			return
+		}
 		handler.writeError(w, err, "")
 		return
 	}
@@ -111,12 +149,17 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 
 	handler.state.setBusy(scanID)
 
-	// you must use a goroutine since the executeScan function is not always listening to the channel
-	go func() {
-		// send to scanning handler
+	select {
+	case handler.scanRequestChan <- scanRequestParams:
 		logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
-		handler.scanRequestChan <- scanRequestParams
-	}()
+	default:
+		handler.state.setNotBusy(scanID)
+		w.Header().Set("Retry-After", "1")
+		handler.writeErrorWithStatus(w,
+			fmt.Errorf("scan queue is full; retry the request later"),
+			"", http.StatusTooManyRequests)
+		return
+	}
 
 	response := &utilsmetav1.Response{
 		ID:       scanID,
@@ -322,8 +365,12 @@ func (handler *HTTPHandler) recover(ctx context.Context, w http.ResponseWriter, 
 }
 
 func (handler *HTTPHandler) writeError(w http.ResponseWriter, err error, scanID string) {
+	handler.writeErrorWithStatus(w, err, scanID, http.StatusBadRequest)
+}
+
+func (handler *HTTPHandler) writeErrorWithStatus(w http.ResponseWriter, err error, scanID string, status int) {
 	response := utilsmetav1.Response{}
-	w.WriteHeader(http.StatusBadRequest)
+	w.WriteHeader(status)
 	response.Response = err.Error()
 	response.Type = utilsapisv1.ErrorScanResponseType
 	w.Write(responseToBytes(&response))


### PR DESCRIPTION


## Summary
### Bound HTTP scan admission and request body size

Every request to `POST /v1/scan` previously created a goroutine that waited on an unbuffered channel. A burst of requests could therefore create an unbounded number of waiting goroutines and retain every parsed request in memory. The endpoint also read request bodies without a size limit.

This PR adds explicit admission control. The service now has a bounded FIFO queue, rejects excess work with a useful `429` response, and rejects oversized payloads with `413` before they enter the scan queue.

## What changed

- Replace per-request enqueue goroutines with a bounded scan queue.
- Return `429 Too Many Requests` when the queue is full.
- Add `Retry-After: 1` so clients know the request can be retried.
- Remove rejected scan IDs from busy state immediately.
- Limit request bodies with `http.MaxBytesReader`.
- Preserve wrapped body-read errors so oversized payloads can be identified reliably.
- Add `KS_SCAN_QUEUE_CAPACITY`, defaulting to `10` waiting scans.
- Add `KS_SCAN_REQUEST_MAX_BYTES`, defaulting to `1048576` bytes.
- Document the new responses and configuration.

## Why this matters

The HTTP service should stay predictable under load. A bounded queue prevents a request burst from turning into unbounded goroutine and memory growth. The body limit also stops a client from making the server allocate memory for an unexpectedly large scan payload.

## How to test

```bash
cd httphandler
go test ./handlerequests/v1
```

The tests verify queue saturation, FIFO ordering, busy-state cleanup, oversized body rejection, and invalid environment variable fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for pending scan requests and request body size.
  - Scan requests now maintain first-in, first-out processing order.
- **Bug Fixes**
  - Full scan queues now return `429 Too Many Requests` with a `Retry-After` header.
  - Oversized scan requests now return `413 Request Entity Too Large`.
  - Improved error details when request data cannot be read.
- **Documentation**
  - Updated API behavior, configuration options, and troubleshooting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->