### PR TITLE
fix(git): make remote workspaces concurrency safe

### DIFF
--- a/core/cautils/remotegitutils.go
+++ b/core/cautils/remotegitutils.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	nethttp "net/http"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -15,9 +17,18 @@ import (
 	giturl "github.com/kubescape/go-git-url"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"golang.org/x/sync/singleflight"
 )
 
-var tmpDirPaths map[string]string
+const gitVisibilityCheckTimeout = 10 * time.Second
+
+var (
+	tmpDirPaths   = make(map[string]string)
+	tmpDirRefs    = make(map[string]int)
+	tmpDirPathsMu sync.Mutex
+	cloneGroup    singleflight.Group
+	plainClone    = git.PlainClone
+)
 
 func hashRepoURL(repoURL string) string {
 	h := sha256.New()
@@ -25,36 +36,76 @@ func hashRepoURL(repoURL string) string {
 	return string(h.Sum(nil))
 }
 
-func getDirPath(repoURL string) string {
-	if tmpDirPaths == nil {
-		return ""
+func repoWorkspaceKey(gitURL giturl.IGitAPI) string {
+	cloneURL := gitURL.GetHttpCloneURL()
+	if gitURL.GetBranchName() == "" {
+		return hashRepoURL(cloneURL)
 	}
-	return tmpDirPaths[hashRepoURL(repoURL)]
+	return hashRepoURL(cloneURL + "\x00" + gitURL.GetBranchName())
 }
 
-// Create a temporary directory this function is called once
-func createTempDir(repoURL string) (string, error) {
-	tmpDirPath := getDirPath(repoURL)
-	if tmpDirPath != "" {
-		return tmpDirPath, nil
+func getDirPath(repoURL string) string {
+	return getDirPathByKey(hashRepoURL(repoURL))
+}
+
+func getDirPathByKey(key string) string {
+	tmpDirPathsMu.Lock()
+	defer tmpDirPathsMu.Unlock()
+
+	path := tmpDirPaths[key]
+	if path == "" {
+		return ""
 	}
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		delete(tmpDirPaths, key)
+		delete(tmpDirRefs, key)
+		return ""
+	}
+	return path
+}
+
+func reserveWorkspace(key string) string {
+	tmpDirPathsMu.Lock()
+	defer tmpDirPathsMu.Unlock()
+	path := tmpDirPaths[key]
+	if path != "" {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			tmpDirRefs[key]++
+			return path
+		}
+		delete(tmpDirPaths, key)
+		delete(tmpDirRefs, key)
+	}
+	tmpDirRefs[key]++
+	return ""
+}
+
+func cancelWorkspaceReservation(key string) {
+	tmpDirPathsMu.Lock()
+	defer tmpDirPathsMu.Unlock()
+	if tmpDirRefs[key] <= 1 {
+		delete(tmpDirRefs, key)
+		return
+	}
+	tmpDirRefs[key]--
+}
+
+// createTempDir creates an unregistered workspace. A path is published only
+// after the clone succeeds, so callers can never observe a partial repository.
+func createTempDir() (string, error) {
 	// create temp directory
-	tmpDir, err := os.MkdirTemp("", "")
+	tmpDir, err := os.MkdirTemp("", "kubescape-git-*")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
 	}
-	if tmpDirPaths == nil {
-		tmpDirPaths = make(map[string]string)
-	}
-	tmpDirPaths[hashRepoURL(repoURL)] = tmpDir
-
 	return tmpDir, nil
 }
 
 // To Check if the given repository is Public(No Authentication needed), send a HTTP GET request to the URL
 // If response code is 200, the repository is Public.
 func isGitRepoPublic(u string) bool {
-	resp, err := nethttp.Get(u) //nolint:gosec
+	client := &nethttp.Client{Timeout: gitVisibilityCheckTimeout}
+	resp, err := client.Get(u) //nolint:gosec
 	if err != nil {
 		return false
 	}
@@ -93,60 +144,105 @@ func getProviderError(gitURL giturl.IGitAPI) error {
 // cloneRepo clones a repository to a local temporary directory and returns the directory
 func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 	cloneURL := gitURL.GetHttpCloneURL()
-
-	// Check if directory exists
-	if p := getDirPath(cloneURL); p != "" {
-		// directory exists, meaning this repo was cloned
-		return p, nil
+	key := repoWorkspaceKey(gitURL)
+	if path := reserveWorkspace(key); path != "" {
+		return path, nil
 	}
-	// Get the URL to clone
 
-	// Create temp directory
-	tmpDir, err := createTempDir(cloneURL)
+	value, err, _ := cloneGroup.Do(key, func() (interface{}, error) {
+		if path := getDirPathByKey(key); path != "" {
+			return path, nil
+		}
+
+		tmpDir, err := createTempDir()
+		if err != nil {
+			return "", err
+		}
+		keepWorkspace := false
+		defer func() {
+			if !keepWorkspace {
+				_ = os.RemoveAll(tmpDir)
+			}
+		}()
+
+		isGitTokenPresent := isGitTokenPresent(gitURL)
+
+		// Declare the authentication variable required for cloneOptions
+		var auth transport.AuthMethod
+
+		if isGitTokenPresent {
+			auth = &http.BasicAuth{
+				Username: "x-token-auth",
+				Password: gitURL.GetToken(),
+			}
+		} else {
+			// If the repository is public, no authentication is needed
+			if isGitRepoPublic(cloneURL) {
+				auth = nil
+			} else {
+				return "", getProviderError(gitURL)
+			}
+		}
+
+		// For Azure repo cloning
+		transport.UnsupportedCapabilities = []capability.Capability{
+			capability.ThinPack,
+		}
+
+		// Clone option
+		cloneOpts := git.CloneOptions{URL: cloneURL, Auth: auth}
+		if gitURL.GetBranchName() != "" {
+			cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(gitURL.GetBranchName())
+			cloneOpts.SingleBranch = true
+		}
+
+		// Actual clone
+		if _, err = plainClone(tmpDir, false, &cloneOpts); err != nil {
+			return "", fmt.Errorf("failed to clone %s: %w", gitURL.GetRepoName(), err)
+		}
+
+		tmpDirPathsMu.Lock()
+		tmpDirPaths[key] = tmpDir
+		tmpDirPathsMu.Unlock()
+		keepWorkspace = true
+		return tmpDir, nil
+	})
 	if err != nil {
+		cancelWorkspaceReservation(key)
 		return "", err
 	}
 
-	isGitTokenPresent := isGitTokenPresent(gitURL)
+	return value.(string), nil
+}
 
-	// Declare the authentication variable required for cloneOptions
-	var auth transport.AuthMethod
-
-	if isGitTokenPresent {
-		auth = &http.BasicAuth{
-			Username: "x-token-auth",
-			Password: gitURL.GetToken(),
-		}
-	} else {
-		// If the repository is public, no authentication is needed
-		if isGitRepoPublic(cloneURL) {
-			auth = nil
-		} else {
-			return "", getProviderError(gitURL)
-		}
-	}
-
-	// For Azure repo cloning
-	transport.UnsupportedCapabilities = []capability.Capability{
-		capability.ThinPack,
-	}
-
-	// Clone option
-	cloneOpts := git.CloneOptions{URL: cloneURL, Auth: auth}
-	if gitURL.GetBranchName() != "" {
-		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(gitURL.GetBranchName())
-		cloneOpts.SingleBranch = true
-	}
-
-	// Actual clone
-	_, err = git.PlainClone(tmpDir, false, &cloneOpts)
+// ReleaseClonedRepo releases one scan's ownership of a cloned repository. The
+// workspace is deleted only after the last scan using it has finished.
+func ReleaseClonedRepo(path string) error {
+	gitURL, err := giturl.NewGitAPI(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to clone %s. %w", gitURL.GetRepoName(), err)
+		return err
 	}
-	// tmpDir = filepath.Join(tmpDir, gitURL.GetRepoName())
-	tmpDirPaths[hashRepoURL(cloneURL)] = tmpDir
+	key := repoWorkspaceKey(gitURL)
 
-	return tmpDir, nil
+	tmpDirPathsMu.Lock()
+	workspace := tmpDirPaths[key]
+	if workspace == "" {
+		tmpDirPathsMu.Unlock()
+		return nil
+	}
+	if tmpDirRefs[key] > 1 {
+		tmpDirRefs[key]--
+		tmpDirPathsMu.Unlock()
+		return nil
+	}
+	delete(tmpDirPaths, key)
+	delete(tmpDirRefs, key)
+	tmpDirPathsMu.Unlock()
+
+	if err := os.RemoveAll(workspace); err != nil {
+		return fmt.Errorf("failed to remove cloned repository %s: %w", workspace, err)
+	}
+	return nil
 }
 
 // CloneGitRepo clone git repository
@@ -180,5 +276,5 @@ func GetClonedPath(path string) string {
 		return ""
 	}
 
-	return getDirPath(gitURL.GetHttpCloneURL())
+	return getDirPathByKey(repoWorkspaceKey(gitURL))
 }

--- a/core/cautils/remotegitutils.go
+++ b/core/cautils/remotegitutils.go
@@ -23,11 +23,12 @@ import (
 const gitVisibilityCheckTimeout = 10 * time.Second
 
 var (
-	tmpDirPaths   = make(map[string]string)
-	tmpDirRefs    = make(map[string]int)
-	tmpDirPathsMu sync.Mutex
-	cloneGroup    singleflight.Group
-	plainClone    = git.PlainClone
+	tmpDirPaths      = make(map[string]string)
+	tmpDirRefs       = make(map[string]int)
+	tmpDirPathsMu    sync.Mutex
+	cloneGroup       singleflight.Group
+	plainClone       = git.PlainClone
+	gitTransportOnce sync.Once
 )
 
 func hashRepoURL(repoURL string) string {
@@ -105,7 +106,7 @@ func createTempDir() (string, error) {
 // If response code is 200, the repository is Public.
 func isGitRepoPublic(u string) bool {
 	client := &nethttp.Client{Timeout: gitVisibilityCheckTimeout}
-	resp, err := client.Get(u) //nolint:gosec
+	resp, err := client.Get(u)
 	if err != nil {
 		return false
 	}
@@ -143,6 +144,15 @@ func getProviderError(gitURL giturl.IGitAPI) error {
 
 // cloneRepo clones a repository to a local temporary directory and returns the directory
 func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
+	// This is a process-wide go-git setting. Configure it once before any
+	// clone starts so different repositories can be cloned concurrently
+	// without racing on transport.UnsupportedCapabilities.
+	gitTransportOnce.Do(func() {
+		transport.UnsupportedCapabilities = []capability.Capability{
+			capability.ThinPack,
+		}
+	})
+
 	cloneURL := gitURL.GetHttpCloneURL()
 	key := repoWorkspaceKey(gitURL)
 	if path := reserveWorkspace(key); path != "" {
@@ -182,11 +192,6 @@ func cloneRepo(gitURL giturl.IGitAPI) (string, error) {
 			} else {
 				return "", getProviderError(gitURL)
 			}
-		}
-
-		// For Azure repo cloning
-		transport.UnsupportedCapabilities = []capability.Capability{
-			capability.ThinPack,
 		}
 
 		// Clone option

--- a/core/cautils/remotegitutils_lifecycle_test.go
+++ b/core/cautils/remotegitutils_lifecycle_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -122,6 +123,40 @@ func TestCloneRepoDeduplicatesConcurrentClonesAndReferenceCountsUsers(t *testing
 	require.NoError(t, ReleaseClonedRepo("https://github.com/example/project"))
 	assert.NoDirExists(t, workspace)
 	assert.Empty(t, GetClonedPath("https://github.com/example/project"))
+}
+
+func TestCloneRepoClonesDifferentRepositoriesConcurrently(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	const repositories = 4
+	cloneStarted := make(chan struct{}, repositories)
+	releaseClones := make(chan struct{})
+	useFakeClone(t, func(_ string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
+		cloneStarted <- struct{}{}
+		<-releaseClones
+		return &git.Repository{}, nil
+	})
+
+	errs := make(chan error, repositories)
+	urls := make([]string, repositories)
+	for i := range repositories {
+		urls[i] = fmt.Sprintf("https://github.com/example/project-%d", i)
+		gitURL := authenticatedGitURL(t, urls[i])
+		go func() {
+			_, err := cloneRepo(gitURL)
+			errs <- err
+		}()
+	}
+
+	for range repositories {
+		<-cloneStarted
+	}
+	close(releaseClones)
+	for range repositories {
+		require.NoError(t, <-errs)
+	}
+	for _, url := range urls {
+		require.NoError(t, ReleaseClonedRepo(url))
+	}
 }
 
 func TestCloneRepoDoesNotPublishOrLeakFailedWorkspace(t *testing.T) {

--- a/core/cautils/remotegitutils_lifecycle_test.go
+++ b/core/cautils/remotegitutils_lifecycle_test.go
@@ -1,0 +1,217 @@
+package cautils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	giturl "github.com/kubescape/go-git-url"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+)
+
+func resetRepoWorkspaceState(t *testing.T) {
+	t.Helper()
+	tmpDirPathsMu.Lock()
+	paths := make([]string, 0, len(tmpDirPaths))
+	for _, path := range tmpDirPaths {
+		paths = append(paths, path)
+	}
+	tmpDirPaths = make(map[string]string)
+	tmpDirRefs = make(map[string]int)
+	tmpDirPathsMu.Unlock()
+	cloneGroup = singleflight.Group{}
+	for _, path := range paths {
+		require.NoError(t, os.RemoveAll(path))
+	}
+}
+
+func useFakeClone(t *testing.T, clone func(string, bool, *git.CloneOptions) (*git.Repository, error)) {
+	t.Helper()
+	original := plainClone
+	plainClone = clone
+	t.Cleanup(func() {
+		plainClone = original
+		resetRepoWorkspaceState(t)
+	})
+}
+
+func authenticatedGitURL(t *testing.T, rawURL string) giturl.IGitAPI {
+	t.Helper()
+	parsed, err := giturl.NewGitAPI(rawURL)
+	require.NoError(t, err)
+	parsed.SetToken("test-token")
+	return parsed
+}
+
+func initializeCloneWorkspace(path string, options *git.CloneOptions) (*git.Repository, error) {
+	repository, err := git.PlainInit(path, false)
+	if err != nil {
+		return nil, err
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(path, "manifest.yaml"), []byte("kind: ConfigMap\n"), 0o600); err != nil {
+		return nil, err
+	}
+	if _, err := worktree.Add("manifest.yaml"); err != nil {
+		return nil, err
+	}
+	signature := &object.Signature{Name: "test", Email: "test@example.com", When: time.Unix(1, 0)}
+	if _, err := worktree.Commit("initial commit", &git.CommitOptions{Author: signature, Committer: signature}); err != nil {
+		return nil, err
+	}
+	if _, err := repository.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{options.URL}}); err != nil {
+		return nil, err
+	}
+	return repository, nil
+}
+
+func TestCloneRepoDeduplicatesConcurrentClonesAndReferenceCountsUsers(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	var cloneCalls atomic.Int32
+	cloneStarted := make(chan struct{})
+	releaseClone := make(chan struct{})
+	var startOnce sync.Once
+	useFakeClone(t, func(path string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls.Add(1)
+		startOnce.Do(func() { close(cloneStarted) })
+		<-releaseClone
+		return &git.Repository{}, nil
+	})
+
+	const users = 8
+	results := make(chan string, users)
+	errors := make(chan error, users)
+	for i := 0; i < users; i++ {
+		parsed := authenticatedGitURL(t, "https://github.com/example/project")
+		go func(gitURL giturl.IGitAPI) {
+			path, err := cloneRepo(gitURL)
+			results <- path
+			errors <- err
+		}(parsed)
+	}
+	<-cloneStarted
+	close(releaseClone)
+
+	var workspace string
+	for i := 0; i < users; i++ {
+		require.NoError(t, <-errors)
+		path := <-results
+		if workspace == "" {
+			workspace = path
+		}
+		assert.Equal(t, workspace, path)
+	}
+	assert.Equal(t, int32(1), cloneCalls.Load())
+
+	for i := 0; i < users-1; i++ {
+		require.NoError(t, ReleaseClonedRepo("https://github.com/example/project"))
+		assert.DirExists(t, workspace)
+	}
+	require.NoError(t, ReleaseClonedRepo("https://github.com/example/project"))
+	assert.NoDirExists(t, workspace)
+	assert.Empty(t, GetClonedPath("https://github.com/example/project"))
+}
+
+func TestCloneRepoDoesNotPublishOrLeakFailedWorkspace(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	var attemptedPath string
+	useFakeClone(t, func(path string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
+		attemptedPath = path
+		return nil, errors.New("clone interrupted")
+	})
+
+	_, err := cloneRepo(authenticatedGitURL(t, "https://github.com/example/broken"))
+	require.ErrorContains(t, err, "clone interrupted")
+	assert.NotEmpty(t, attemptedPath)
+	assert.NoDirExists(t, attemptedPath)
+	assert.Empty(t, GetClonedPath("https://github.com/example/broken"))
+}
+
+func TestCloneRepoKeepsBranchesInSeparateWorkspaces(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	var cloneCalls atomic.Int32
+	useFakeClone(t, func(path string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls.Add(1)
+		return &git.Repository{}, nil
+	})
+
+	mainURL := "https://github.com/example/project/tree/main"
+	featureURL := "https://github.com/example/project/tree/feature"
+	mainPath, err := cloneRepo(authenticatedGitURL(t, mainURL))
+	require.NoError(t, err)
+	featurePath, err := cloneRepo(authenticatedGitURL(t, featureURL))
+	require.NoError(t, err)
+
+	assert.NotEqual(t, mainPath, featurePath)
+	assert.Equal(t, int32(2), cloneCalls.Load())
+	assert.Equal(t, mainPath, GetClonedPath(mainURL))
+	assert.Equal(t, featurePath, GetClonedPath(featureURL))
+
+	require.NoError(t, ReleaseClonedRepo(mainURL))
+	assert.NoDirExists(t, mainPath)
+	assert.DirExists(t, featurePath)
+	require.NoError(t, ReleaseClonedRepo(featureURL))
+	assert.NoDirExists(t, featurePath)
+}
+
+func TestGetClonedPathEvictsDeletedWorkspace(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	workspace := t.TempDir()
+	url := "https://github.com/example/stale.git"
+	key := hashRepoURL(url)
+	tmpDirPathsMu.Lock()
+	tmpDirPaths[key] = workspace
+	tmpDirRefs[key] = 1
+	tmpDirPathsMu.Unlock()
+	require.NoError(t, os.RemoveAll(workspace))
+
+	assert.Empty(t, getDirPath(url))
+	tmpDirPathsMu.Lock()
+	defer tmpDirPathsMu.Unlock()
+	assert.NotContains(t, tmpDirPaths, key)
+	assert.NotContains(t, tmpDirRefs, key)
+}
+
+func TestScanningContextClonesAndCleansEveryRemoteInput(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+	var cloneCalls atomic.Int32
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls.Add(1)
+		return initializeCloneWorkspace(path, options)
+	})
+
+	inputs := []string{
+		"https://github.com/example/first",
+		"https://github.com/example/second",
+	}
+	scanInfo := &ScanInfo{InputPatterns: inputs}
+	require.Equal(t, ContextGitRemote, scanInfo.GetScanningContext())
+	assert.Equal(t, int32(2), cloneCalls.Load())
+
+	workspaces := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		workspace := GetClonedPath(input)
+		require.NotEmpty(t, workspace)
+		assert.DirExists(t, workspace)
+		workspaces = append(workspaces, workspace)
+	}
+
+	scanInfo.Cleanup()
+	for i, input := range inputs {
+		assert.Empty(t, GetClonedPath(input))
+		assert.NoDirExists(t, workspaces[i])
+	}
+}

--- a/core/cautils/remotegitutils_test.go
+++ b/core/cautils/remotegitutils_test.go
@@ -3,24 +3,35 @@ package cautils
 import (
 	"errors"
 	"fmt"
-	"os"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
 	giturl "github.com/kubescape/go-git-url"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsGitRepoPublic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/public" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
 	tests := []struct {
 		url  string
 		want bool
 	}{
 		{
-			url:  "https://github.com/kubescape/kubescape/",
+			url:  server.URL + "/public",
 			want: true,
 		},
 		{
-			url:  "http://invalidurl",
+			url:  server.URL + "/private",
 			want: false,
 		},
 		{
@@ -68,30 +79,17 @@ func TestGetProviderError(t *testing.T) {
 }
 
 func TestCloneRepo(t *testing.T) {
-	tests := []struct {
-		url string
-		err error
-	}{
-		{
-			url: "https://github.com/kubescape/kubescape/",
-			err: nil,
-		},
-	}
+	resetRepoWorkspaceState(t)
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		return initializeCloneWorkspace(path, options)
+	})
+	gitURL := authenticatedGitURL(t, "https://github.com/kubescape/kubescape/")
 
-	for _, tt := range tests {
-		t.Run(tt.url, func(t *testing.T) {
-			// Create a temporary directory
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %v", err)
-			}
+	tempDir, err := cloneRepo(gitURL)
 
-			gitURL, _ := giturl.NewGitAPI(tt.url)
-			tempDir, err := cloneRepo(gitURL)
-			assert.NotEqual(t, tmpDir, tempDir)
-			assert.Equal(t, tt.err, err)
-		})
-	}
+	require.NoError(t, err)
+	assert.DirExists(t, tempDir)
+	require.NoError(t, ReleaseClonedRepo("https://github.com/kubescape/kubescape/"))
 }
 func TestGetClonedPath(t *testing.T) {
 	testCases := []struct {
@@ -110,8 +108,10 @@ func TestGetClonedPath(t *testing.T) {
 			expected: "",
 		},
 	}
+	clonedPath := t.TempDir()
 	tmpDirPaths = make(map[string]string)
-	tmpDirPaths[hashRepoURL("https://github.com/kubescape/kubescape.git")] = "/path/to/cloned/repo" // replace with the actual path
+	tmpDirPaths[hashRepoURL("https://github.com/kubescape/kubescape.git")] = clonedPath
+	testCases[0].expected = clonedPath
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -141,8 +141,10 @@ func TestGetDirPath(t *testing.T) {
 	}
 
 	// Initialize tmpDirPaths
+	clonedPath := t.TempDir()
 	tmpDirPaths = make(map[string]string)
-	tmpDirPaths[hashRepoURL("https://github.com/user/repo.git")] = "/path/to/cloned/repo" // replace with the actual path
+	tmpDirPaths[hashRepoURL("https://github.com/user/repo.git")] = clonedPath
+	testCases[0].expected = clonedPath
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -395,12 +395,19 @@ func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 
 	// git url
 	if _, err := giturl.NewGitURL(input); err == nil {
+		originalInput := input
 		if repo, err := CloneGitRepo(&input); err == nil {
 			if _, err := NewLocalGitRepository(repo); err == nil {
-				scanInfo.cleanups = append(scanInfo.cleanups, func() {
-					_ = os.RemoveAll(repo)
+				scanInfo.AddCleanup(func() {
+					if err := ReleaseClonedRepo(originalInput); err != nil {
+						logger.L().Warning("failed to clean up cloned repository", helpers.String("url", originalInput), helpers.Error(err))
+					}
 				})
+				scanInfo.cloneAdditionalRemoteInputs(originalInput)
 				return ContextGitRemote
+			}
+			if err := ReleaseClonedRepo(originalInput); err != nil {
+				logger.L().Warning("failed to clean up invalid cloned repository", helpers.String("url", originalInput), helpers.Error(err))
 			}
 		}
 		// If giturl.NewGitURL succeeded but cloning failed, the input is a git URL
@@ -435,6 +442,31 @@ func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 
 	//  dir/glob
 	return ContextDir
+}
+
+// cloneAdditionalRemoteInputs prepares every remote input before file loading.
+// Previously only the first URL was cloned, so later URL inputs were interpreted
+// as local filesystem paths and silently skipped.
+func (scanInfo *ScanInfo) cloneAdditionalRemoteInputs(firstInput string) {
+	for _, candidate := range scanInfo.InputPatterns {
+		if candidate == firstInput {
+			continue
+		}
+		if _, err := giturl.NewGitURL(candidate); err != nil {
+			continue
+		}
+
+		originalInput := candidate
+		if _, err := CloneGitRepo(&candidate); err != nil {
+			logger.L().Error("failed to clone additional git input", helpers.String("url", originalInput), helpers.Error(err))
+			continue
+		}
+		scanInfo.AddCleanup(func() {
+			if err := ReleaseClonedRepo(originalInput); err != nil {
+				logger.L().Warning("failed to clean up cloned repository", helpers.String("url", originalInput), helpers.Error(err))
+			}
+		})
+	}
 }
 
 func (scanInfo *ScanInfo) setContextMetadata(ctx context.Context, contextMetadata *reporthandlingv2.ContextMetadata) {


### PR DESCRIPTION


## Overview
### Make remote repository workspaces safe across concurrent scans

Remote Git clones were stored in a package-level map without synchronization. The path was published before cloning completed, failed clones left temporary directories behind, and scan cleanup deleted the directory without removing the cached entry. Concurrent scans could race, reuse a partial clone, or receive a path that another scan had already deleted.

This PR gives cloned repositories a clear lifecycle. Concurrent requests for the same repository share one completed clone, each scan holds a reference while it uses the workspace, and the final cleanup removes both the directory and its cache entry.

## What changed

- Protect the workspace registry with a mutex.
- Deduplicate concurrent clones of the same repository and branch.
- Include the requested branch in the cache key so different branches never share a checkout.
- Publish a workspace only after cloning succeeds.
- Remove temporary directories after failed clones.
- Detect and evict cached paths that no longer exist.
- Reference count shared workspaces so one scan cannot delete another scan's clone.
- Clone every remote URL in a multi-input scan instead of preparing only the first one.
- Release clones through `ScanInfo.Cleanup` and clean up clones that fail local repository validation.
- Add a timeout to the unauthenticated repository visibility check.
- Replace network-dependent unit tests with deterministic local fixtures.

## Why this matters

Remote scans are common in CI and in the HTTP service, where multiple scans can overlap. Returning a partial, wrong-branch, or deleted checkout can make resources disappear from a security scan or make the scan fail intermittently. The new lifecycle makes the result independent of request timing.

## How to test

```bash
go test ./core/cautils
go test -race ./core/cautils -run 'Test(CloneRepoDeduplicates|CloneRepoDoesNot|CloneRepoKeeps|GetClonedPathEvicts|ScanningContextClones)' -count=1
```

The tests cover concurrent clone deduplication, reference-counted cleanup, failed-clone cleanup, stale cache eviction, branch isolation, and multiple remote inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent remote Git cloning with in-flight deduplication and safe workspace reuse via reference counting.
  * Workspaces and cached cloned paths are now separated by repository and branch.
  * Cloned directories are only recorded after successful clone; failures no longer leave stale temp directories behind.
  * Cleanup and cache eviction now correctly remove cached workspaces when the last reference is released.
  * Scan processing now clones additional remote Git URL inputs and cleans them up correctly; public repo detection uses a fixed timeout.
* **Tests**
  * Added lifecycle tests for concurrency, failure handling, branch separation, cache eviction, and scan-context behavior.
  * Updated existing unit tests to be more deterministic using runtime temp directories and an HTTP test server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->