### PR TITLE
[fix] : SARIF fix regions for non-ASCII manifests -- use rune length instead of byte length in calculateMove

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/presenter/models"
@@ -327,8 +328,8 @@ func calculateMove(str string, file []string, endColumn int, endLine int) (int, 
 	if endLine > len(file) {
 		return 0, 0, false
 	}
-	for num+endColumn-1 > len(file[endLine-1]) {
-		num -= len(file[endLine-1]) - endColumn + 2
+	for num+endColumn-1 > utf8.RuneCountInString(file[endLine-1]) {
+		num -= utf8.RuneCountInString(file[endLine-1]) - endColumn + 2
 		endLine++
 		endColumn = 1
 	}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -201,6 +201,21 @@ func TestCalculateMove_InvalidString(t *testing.T) {
 	assert.False(t, success)
 }
 
+// Lines containing multi-byte characters must be measured in runes, not bytes,
+// or the computed position drifts past the line's actual length.
+func TestCalculateMove_MultiByteRunes(t *testing.T) {
+	str := "10"
+	file := []string{"héllo world", "line 2", "line 3"}
+	endColumn := 5
+	endLine := 1
+
+	newLine, newColumn, success := calculateMove(str, file, endColumn, endLine)
+
+	assert.True(t, success)
+	assert.Equal(t, 2, newLine)
+	assert.Equal(t, 3, newColumn)
+}
+
 // Adds a new fix to the result with the given filepath, start and end positions, and text.
 func TestAddFix_AddsNewFixToResult(t *testing.T) {
 	result := sarif.Result{}


### PR DESCRIPTION
## Overview

This is the fix for #2536 .

`calculateMove` measured line length with `len(string)` (bytes) while `dmp.DiffToDelta` encodes segment lengths as rune counts (`utf8.RuneCountInString`). For any line containing a multi-byte UTF-8 character the byte/rune mismatch caused the loop to under/over-shoot, producing wrong `endLine`/`endColumn` values for SARIF auto-fix regions. Applying the suggested fix via GitHub code scanning or an IDE would replace the wrong span, silently corrupting the manifest. ASCII-only files hide it completely so it passes casual testing and only surfaces on internationalized or annotated manifests.

This fix replaces the two `len(file[endLine-1])` calls in `calculateMove` with `utf8.RuneCountInString(file[endLine-1])`, matching the rune-based unit used by the diff delta. No signature or control-flow change required.

Now both cases are correct:

- ASCII-only manifest: bytes == runes, behavior unchanged
- Non-ASCII manifest: rune length used throughout, correct fix regions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SARIF result positions for findings on lines containing Unicode characters.
  * Ensured column offsets remain accurate when processing multi-byte characters.

* **Tests**
  * Added coverage for Unicode text to verify correct line and column calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->