### PR TITLE
fix: don't crash or auto-submit when no backend is configured

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -135,7 +135,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
 	severity := scanInfo.FailThresholdSeverity
 
-	if scanInfo.Submit && scanInfo.OmitRawResources {
+	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
 		return ErrOmitRawResourcesOrSubmit
 	}
 

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -244,7 +244,7 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 		scanInfo.View = string(cautils.ResourceViewType)
 	}
 
-	if scanInfo.Submit && scanInfo.Local {
+	if scanInfo.Submit.GetBool() && scanInfo.Local {
 		return ErrKeepLocalOrSubmit
 	}
 	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
@@ -256,7 +256,7 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
 		return ErrBadThreshold
 	}
-	if scanInfo.Submit && scanInfo.OmitRawResources {
+	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
 		return ErrOmitRawResourcesOrSubmit
 	}
 	if err := validateControlTimeout(scanInfo); err != nil {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -50,6 +50,15 @@ var scanCmdExamples = fmt.Sprintf(`
   %[1]s scan --kube-context <kubernetes context>
 `, cautils.ExecName())
 
+// applyExplicitSubmitFlag marks scanInfo.SubmitExplicitlySet when the caller passed
+// --submit on the command line, so that setSubmitBehavior does not silently override
+// an explicit opt-out based on tenant/backend auto-detection.
+func applyExplicitSubmitFlag(cmd *cobra.Command, scanInfo *cautils.ScanInfo) {
+	if f := cmd.Flags().Lookup("submit"); f != nil && f.Changed {
+		scanInfo.SubmitExplicitlySet = true
+	}
+}
+
 func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	var scanInfo cautils.ScanInfo
 
@@ -67,6 +76,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					scanInfo.ControlsVersion,
 				)
 			}
+			applyExplicitSubmitFlag(cmd, &scanInfo)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -50,15 +50,6 @@ var scanCmdExamples = fmt.Sprintf(`
   %[1]s scan --kube-context <kubernetes context>
 `, cautils.ExecName())
 
-// applyExplicitSubmitFlag marks scanInfo.SubmitExplicitlySet when the caller passed
-// --submit on the command line, so that setSubmitBehavior does not silently override
-// an explicit opt-out based on tenant/backend auto-detection.
-func applyExplicitSubmitFlag(cmd *cobra.Command, scanInfo *cautils.ScanInfo) {
-	if f := cmd.Flags().Lookup("submit"); f != nil && f.Changed {
-		scanInfo.SubmitExplicitlySet = true
-	}
-}
-
 func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	var scanInfo cautils.ScanInfo
 
@@ -76,7 +67,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					scanInfo.ControlsVersion,
 				)
 			}
-			applyExplicitSubmitFlag(cmd, &scanInfo)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -185,7 +175,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.HostSensorYamlPath, "host-scan-yaml", "", "Override default host scanner DaemonSet. Use this flag cautiously")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v2", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomClusterName, "cluster-name", "", "Set the custom name of the cluster. Not same as the kube-context flag")
-	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Submit, "submit", "", false, "Submit the scan results to Kubescape SaaS where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
+	submitF := scanCmd.PersistentFlags().VarPF(&scanInfo.Submit, "submit", "", "Submit the scan results to Kubescape SaaS where you can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more. By default the results are not submitted")
+	submitF.NoOptDefVal = "true"
+	submitF.DefValue = "false"
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.OmitRawResources, "omit-raw-resources", "", false, "Omit raw resources from the output. By default the raw resources are included in the output")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.PrintAttackTree, "print-attack-tree", "", false, "Print attack tree")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -379,6 +379,35 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
+func TestApplyExplicitSubmitFlag(t *testing.T) {
+	// --submit not passed - default value, not explicitly set
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	si := &cautils.ScanInfo{}
+	applyExplicitSubmitFlag(cmd, si)
+	assert.False(t, si.SubmitExplicitlySet)
+
+	// --submit=false passed explicitly - regression test for
+	// https://github.com/kubescape/kubescape/issues/2555, so an explicit
+	// opt-out is not silently overridden by tenant/backend auto-detection.
+	// ParseFlags (not PersistentFlags().Set) is used so cobra merges the
+	// persistent flags into cmd.Flags(), matching real CLI invocation.
+	mockKubescape = &mocks.MockIKubescape{}
+	cmd = GetScanCommand(mockKubescape)
+	require.NoError(t, cmd.ParseFlags([]string{"--submit=false"}))
+	si = &cautils.ScanInfo{}
+	applyExplicitSubmitFlag(cmd, si)
+	assert.True(t, si.SubmitExplicitlySet)
+
+	// --submit=true passed explicitly
+	mockKubescape = &mocks.MockIKubescape{}
+	cmd = GetScanCommand(mockKubescape)
+	require.NoError(t, cmd.ParseFlags([]string{"--submit=true"}))
+	si = &cautils.ScanInfo{}
+	applyExplicitSubmitFlag(cmd, si)
+	assert.True(t, si.SubmitExplicitlySet)
+}
+
 func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -379,33 +379,54 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
-func TestApplyExplicitSubmitFlag(t *testing.T) {
-	// --submit not passed - default value, not explicitly set
+func TestSubmitFlag_TracksExplicitCommandLineUse(t *testing.T) {
+	// Regression test for https://github.com/kubescape/kubescape/issues/2555:
+	// --submit is bound directly as a cautils.BoolPtrFlag (like --enable-host-scan),
+	// so "not passed" (nil) is structurally distinguishable from "passed with any
+	// value" (non-nil) without any separate hand-rolled bookkeeping that could be
+	// forgotten at a call site or broken by a future PersistentPreRunE change.
+
+	// --submit not passed - flag not Changed
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)
-	si := &cautils.ScanInfo{}
-	applyExplicitSubmitFlag(cmd, si)
-	assert.False(t, si.SubmitExplicitlySet)
+	f := cmd.PersistentFlags().Lookup("submit")
+	require.NotNil(t, f, "--submit flag must be registered")
+	assert.False(t, f.Changed)
+	assert.Equal(t, "false", f.DefValue)
 
-	// --submit=false passed explicitly - regression test for
-	// https://github.com/kubescape/kubescape/issues/2555, so an explicit
-	// opt-out is not silently overridden by tenant/backend auto-detection.
-	// ParseFlags (not PersistentFlags().Set) is used so cobra merges the
-	// persistent flags into cmd.Flags(), matching real CLI invocation.
+	// --submit=false passed explicitly
 	mockKubescape = &mocks.MockIKubescape{}
 	cmd = GetScanCommand(mockKubescape)
 	require.NoError(t, cmd.ParseFlags([]string{"--submit=false"}))
-	si = &cautils.ScanInfo{}
-	applyExplicitSubmitFlag(cmd, si)
-	assert.True(t, si.SubmitExplicitlySet)
+	f = cmd.PersistentFlags().Lookup("submit")
+	assert.True(t, f.Changed)
+	assert.Equal(t, "false", f.Value.String())
 
-	// --submit=true passed explicitly
+	// --submit (bare, no value) passed explicitly - must still imply true, matching
+	// the original BoolVarP-based flag's behavior (NoOptDefVal="true")
 	mockKubescape = &mocks.MockIKubescape{}
 	cmd = GetScanCommand(mockKubescape)
-	require.NoError(t, cmd.ParseFlags([]string{"--submit=true"}))
-	si = &cautils.ScanInfo{}
-	applyExplicitSubmitFlag(cmd, si)
-	assert.True(t, si.SubmitExplicitlySet)
+	require.NoError(t, cmd.ParseFlags([]string{"--submit"}))
+	f = cmd.PersistentFlags().Lookup("submit")
+	assert.True(t, f.Changed)
+	assert.Equal(t, "true", f.Value.String())
+}
+
+func TestSubmitFlag_PropagatesToAllSubcommands(t *testing.T) {
+	// Pins the invariant matthyx flagged in review: --submit must reach every
+	// scan subcommand. Because it's a cobra-inherited persistent flag rather
+	// than something wired through a hand-rolled PersistentPreRunE, this is a
+	// structural guarantee rather than something a future subcommand change
+	// could silently break.
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+
+	for _, sub := range cmd.Commands() {
+		t.Run(sub.Name(), func(t *testing.T) {
+			f := sub.InheritedFlags().Lookup("submit")
+			require.NotNil(t, f, "subcommand %q must inherit --submit from the parent scan command", sub.Name())
+		})
+	}
 }
 
 func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -31,7 +31,7 @@ func Test_validateControlScanInfo(t *testing.T) {
 		},
 		{
 			"Submit with omit-raw-resources should be invalid",
-			&cautils.ScanInfo{Submit: true, OmitRawResources: true},
+			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), OmitRawResources: true},
 			ErrOmitRawResourcesOrSubmit,
 		},
 	}
@@ -88,12 +88,12 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 		},
 		{
 			"Submit with keep-local should be invalid",
-			&cautils.ScanInfo{Submit: true, Local: true, AccountID: validAccountID},
+			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), Local: true, AccountID: validAccountID},
 			ErrKeepLocalOrSubmit,
 		},
 		{
 			"Submit with omit-raw-resources should be invalid",
-			&cautils.ScanInfo{Submit: true, OmitRawResources: true, AccountID: validAccountID},
+			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), OmitRawResources: true, AccountID: validAccountID},
 			ErrOmitRawResourcesOrSubmit,
 		},
 		{

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -338,30 +338,60 @@ func existsConfigFile() bool {
 	return err == nil
 }
 
+// chmod is a package-level indirection so tests can simulate a chmod failure
+// (e.g. EPERM on a restrictive mount) without needing real filesystem
+// permission tricks, which don't reliably fail for the owning user.
+var chmod = os.Chmod
+
 func updateConfigFile(configObj *ConfigObj) error {
 	fullPath := ConfigFileFullPath()
 	dir := filepath.Dir(fullPath)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	// Tighten permissions on pre-existing directory in case it was
+	// Tighten permissions on a pre-existing directory in case it was
 	// created with broader permissions by an older version. This is a
 	// best-effort hardening step: MkdirAll above already applies 0700 to
 	// directories it creates, so a failure here (e.g. chmod is rejected on
 	// some mounted volumes such as an emptyDir mounted as non-root) must
 	// not prevent the config from being persisted.
-	if err := os.Chmod(dir, 0700); err != nil {
-		logger.L().Warning("failed to tighten permissions on config directory", helpers.String("dir", dir), helpers.Error(err))
+	if err := chmod(dir, 0700); err != nil {
+		mode := "unknown"
+		if fi, statErr := os.Stat(dir); statErr == nil {
+			mode = fi.Mode().Perm().String()
+		}
+		logger.L().Warning("failed to tighten permissions on config directory", helpers.String("dir", dir), helpers.String("currentMode", mode), helpers.Error(err))
 	}
-	if err := os.WriteFile(fullPath, configObj.Config(), 0600); err != nil {
+
+	// Write via a temp file in the same directory, then rename it over the
+	// target. os.CreateTemp always creates the file at mode 0600, and rename
+	// replaces the destination's inode outright - so the final file always
+	// ends up at the correct permissions on a fresh inode, regardless of
+	// whatever mode a pre-existing config.json (e.g. from an older kubescape
+	// version) had, and without needing a chmod on the target path at all.
+	tmpFile, err := os.CreateTemp(dir, ".config-*.json.tmp")
+	if err != nil {
 		return err
 	}
-	// Tighten permissions on pre-existing file in case it was created
-	// with broader permissions by an older version. Same best-effort
-	// rationale as above: WriteFile already applies 0600 to files it creates.
-	if err := os.Chmod(fullPath, 0600); err != nil {
-		logger.L().Warning("failed to tighten permissions on config file", helpers.String("path", fullPath), helpers.Error(err))
+	tmpPath := tmpFile.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(configObj.Config()); err != nil {
+		tmpFile.Close()
+		return err
 	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, fullPath); err != nil {
+		return err
+	}
+	removeTmp = false
 	return nil
 }
 

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -345,16 +345,24 @@ func updateConfigFile(configObj *ConfigObj) error {
 		return err
 	}
 	// Tighten permissions on pre-existing directory in case it was
-	// created with broader permissions by an older version.
+	// created with broader permissions by an older version. This is a
+	// best-effort hardening step: MkdirAll above already applies 0700 to
+	// directories it creates, so a failure here (e.g. chmod is rejected on
+	// some mounted volumes such as an emptyDir mounted as non-root) must
+	// not prevent the config from being persisted.
 	if err := os.Chmod(dir, 0700); err != nil {
-		return err
+		logger.L().Warning("failed to tighten permissions on config directory", helpers.String("dir", dir), helpers.Error(err))
 	}
 	if err := os.WriteFile(fullPath, configObj.Config(), 0600); err != nil {
 		return err
 	}
 	// Tighten permissions on pre-existing file in case it was created
-	// with broader permissions by an older version.
-	return os.Chmod(fullPath, 0600)
+	// with broader permissions by an older version. Same best-effort
+	// rationale as above: WriteFile already applies 0600 to files it creates.
+	if err := os.Chmod(fullPath, 0600); err != nil {
+		logger.L().Warning("failed to tighten permissions on config file", helpers.String("path", fullPath), helpers.Error(err))
+	}
+	return nil
 }
 
 func (c *ClusterConfig) GenerateAccountID() (string, error) {

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -416,3 +416,26 @@ func TestUpdateCredentials_EnvAppliedWhenNoFlag(t *testing.T) {
 		t.Errorf("expected AccessKey=env-access-key, got %s", configObj.AccessKey)
 	}
 }
+
+func TestUpdateConfigFile_SucceedsWhenDirectoryAlreadyHasCorrectPermissions(t *testing.T) {
+	// Regression test for https://github.com/kubescape/kubescape/issues/2555:
+	// on some mounted volumes (e.g. an emptyDir mounted as a non-root user)
+	// os.Chmod on an already-correctly-permissioned directory/file can fail
+	// even though the directory is perfectly usable. That must not abort
+	// persisting the config.
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	defer func() { getter.DefaultLocalStore = originalStore }()
+
+	configObj := mockConfigObj()
+
+	require.NoError(t, updateConfigFile(configObj))
+	require.NoError(t, updateConfigFile(configObj)) // second write hits the "pre-existing" chmod paths
+
+	dat, err := os.ReadFile(ConfigFileFullPath())
+	require.NoError(t, err)
+
+	readBack := &ConfigObj{}
+	require.NoError(t, json.Unmarshal(dat, readBack))
+	assert.Equal(t, configObj.AccountID, readBack.AccountID)
+}

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -417,12 +417,10 @@ func TestUpdateCredentials_EnvAppliedWhenNoFlag(t *testing.T) {
 	}
 }
 
-func TestUpdateConfigFile_SucceedsWhenDirectoryAlreadyHasCorrectPermissions(t *testing.T) {
-	// Regression test for https://github.com/kubescape/kubescape/issues/2555:
-	// on some mounted volumes (e.g. an emptyDir mounted as a non-root user)
-	// os.Chmod on an already-correctly-permissioned directory/file can fail
-	// even though the directory is perfectly usable. That must not abort
-	// persisting the config.
+func TestUpdateConfigFile_RoundTrip(t *testing.T) {
+	// Basic smoke test: writing twice (first write creates the directory/file,
+	// second write exercises the "pre-existing directory" chmod path) must
+	// round-trip the config correctly under normal conditions.
 	originalStore := getter.DefaultLocalStore
 	getter.DefaultLocalStore = t.TempDir()
 	defer func() { getter.DefaultLocalStore = originalStore }()
@@ -430,7 +428,35 @@ func TestUpdateConfigFile_SucceedsWhenDirectoryAlreadyHasCorrectPermissions(t *t
 	configObj := mockConfigObj()
 
 	require.NoError(t, updateConfigFile(configObj))
-	require.NoError(t, updateConfigFile(configObj)) // second write hits the "pre-existing" chmod paths
+	require.NoError(t, updateConfigFile(configObj))
+
+	dat, err := os.ReadFile(ConfigFileFullPath())
+	require.NoError(t, err)
+
+	readBack := &ConfigObj{}
+	require.NoError(t, json.Unmarshal(dat, readBack))
+	assert.Equal(t, configObj.AccountID, readBack.AccountID)
+}
+
+func TestUpdateConfigFile_ToleratesDirectoryChmodFailure(t *testing.T) {
+	// Regression test for https://github.com/kubescape/kubescape/issues/2555:
+	// on some mounted volumes (e.g. an emptyDir mounted as a non-root user)
+	// os.Chmod on an already-correctly-permissioned directory can fail even
+	// though the directory is perfectly usable. That must not abort
+	// persisting the config. A real filesystem can't reliably be made to
+	// reject a chmod from its owning user (which is what tests run as), so
+	// the failure is forced via the package-level `chmod` seam instead.
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	defer func() { getter.DefaultLocalStore = originalStore }()
+
+	origChmod := chmod
+	chmod = func(string, os.FileMode) error { return os.ErrPermission }
+	defer func() { chmod = origChmod }()
+
+	configObj := mockConfigObj()
+
+	require.NoError(t, updateConfigFile(configObj))
 
 	dat, err := os.ReadFile(ConfigFileFullPath())
 	require.NoError(t, err)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -127,8 +127,7 @@ type ScanInfo struct {
 	FailThresholdSeverity string                       // Severity at and above which the command should fail
 	FailCoverageThreshold float32                      // Coverage threshold below which the command fails (0 = disabled)
 	FailOnDegradedConfig  bool                         // Fail the scan if control inputs or exceptions could not be loaded and a fallback was used
-	Submit                bool                         // Submit results to Kubescape Cloud BE
-	SubmitExplicitlySet   bool                         // Submit was explicitly requested by the caller (flag/env/request field), as opposed to left at its default
+	Submit                BoolPtrFlag                  // Submit results to Kubescape Cloud BE. Get() is nil unless explicitly set by the caller (flag/env/request field)
 	ScanID                string                       // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag                  // Deploy Kubescape K8s host scanner to collect data from certain controls
 	HostSensorYamlPath    string                       // Path to hostsensor file
@@ -318,7 +317,7 @@ func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo) *reporthand
 
 	metadata.ScanMetadata.Formats = []string{scanInfo.Format}
 	metadata.ScanMetadata.FormatVersion = scanInfo.FormatVersion
-	metadata.ScanMetadata.Submit = scanInfo.Submit
+	metadata.ScanMetadata.Submit = scanInfo.Submit.GetBool()
 
 	if ns := splitNamespaceList(scanInfo.ExcludedNamespaces); len(ns) > 0 {
 		metadata.ScanMetadata.ExcludedNamespaces = ns

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -128,6 +128,7 @@ type ScanInfo struct {
 	FailCoverageThreshold float32                      // Coverage threshold below which the command fails (0 = disabled)
 	FailOnDegradedConfig  bool                         // Fail the scan if control inputs or exceptions could not be loaded and a fallback was used
 	Submit                bool                         // Submit results to Kubescape Cloud BE
+	SubmitExplicitlySet   bool                         // Submit was explicitly requested by the caller (flag/env/request field), as opposed to left at its default
 	ScanID                string                       // Report id of the current scan
 	HostSensorEnabled     BoolPtrFlag                  // Deploy Kubescape K8s host scanner to collect data from certain controls
 	HostSensorYamlPath    string                       // Path to hostsensor file

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -139,7 +139,7 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 	if !isAirGappedMode(scanInfo) {
 		_ = getter.GetKSCloudAPIConnector()
 	}
-	rbacObjects := getRBACHandler(tenantConfig, k8s, scanInfo.Submit)
+	rbacObjects := getRBACHandler(tenantConfig, k8s, scanInfo.Submit.GetBool())
 	return resourcehandler.NewK8sResourceHandler(ctx, k8s, hostSensorHandler, rbacObjects, tenantConfig.GetContextName())
 }
 
@@ -217,25 +217,24 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 	*/
 
 	// respect an explicit opt-out - never auto-submit against the caller's wishes
-	if scanInfo.SubmitExplicitlySet && !scanInfo.Submit {
-		scanInfo.Submit = false
+	if explicit := scanInfo.Submit.Get(); explicit != nil && !*explicit {
 		return
 	}
 
 	// do not submit control/workload scanning
 	if !isScanTypeForSubmission(scanInfo.ScanType) || scanInfo.Local {
-		scanInfo.Submit = false
+		scanInfo.Submit.SetBool(false)
 		return
 	}
 
 	if tenantConfig.GetCloudReportURL() == "" {
-		scanInfo.Submit = false
+		scanInfo.Submit.SetBool(false)
 		return
 	}
 
 	// a new account will be created if a report URL is set and there is no account ID
 	if tenantConfig.GetAccountID() == "" {
-		scanInfo.Submit = true
+		scanInfo.Submit.SetBool(true)
 		return
 	}
 
@@ -245,7 +244,7 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 	}
 
 	// submit if account is valid
-	scanInfo.Submit = err == nil
+	scanInfo.Submit.SetBool(err == nil)
 }
 
 func isScanTypeForSubmission(scanType cautils.ScanTypes) bool {

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -198,6 +198,10 @@ func policyIdentifierIdentities(pi []cautils.PolicyIdentifier) string {
 func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantConfig) {
 
 	/*
+		If the caller explicitly opted out of submission (--submit=false, KS_SUBMIT=false,
+		or the httphandler request body's submit:false) - Do not send report, and do not
+		let the auto-detection below override that choice.
+
 		If keep-local OR scan type which is not submittable - Do not send report
 
 		If CloudReportURL not set - Do not send report
@@ -211,6 +215,12 @@ func setSubmitBehavior(scanInfo *cautils.ScanInfo, tenantConfig cautils.ITenantC
 				Valid Account - Submit report
 
 	*/
+
+	// respect an explicit opt-out - never auto-submit against the caller's wishes
+	if scanInfo.SubmitExplicitlySet && !scanInfo.Submit {
+		scanInfo.Submit = false
+		return
+	}
 
 	// do not submit control/workload scanning
 	if !isScanTypeForSubmission(scanInfo.ScanType) || scanInfo.Local {

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -515,10 +515,9 @@ func TestSetSubmitBehavior(t *testing.T) {
 			name: "Test SetSubmitBehavior explicit opt-out is respected despite CloudReportURL and no AccountID",
 			args: args{
 				scanInfo: &cautils.ScanInfo{
-					ScanType:            cautils.ScanTypeCluster,
-					Local:               false,
-					Submit:              false,
-					SubmitExplicitlySet: true,
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+					Submit:   cautils.NewBoolPtr(new(false)),
 				},
 				tenantConfig: &TenantConfigMock{
 					clusterName:    "test",
@@ -537,10 +536,9 @@ func TestSetSubmitBehavior(t *testing.T) {
 			name: "Test SetSubmitBehavior explicit opt-in does not bypass missing CloudReportURL",
 			args: args{
 				scanInfo: &cautils.ScanInfo{
-					ScanType:            cautils.ScanTypeCluster,
-					Local:               false,
-					Submit:              true,
-					SubmitExplicitlySet: true,
+					ScanType: cautils.ScanTypeCluster,
+					Local:    false,
+					Submit:   cautils.NewBoolPtr(new(true)),
 				},
 				tenantConfig: &TenantConfigMock{
 					clusterName: "test",
@@ -561,7 +559,7 @@ func TestSetSubmitBehavior(t *testing.T) {
 
 			setSubmitBehavior(tt.args.scanInfo, tt.args.tenantConfig)
 
-			assert.Equal(t, tt.want, tt.args.scanInfo.Submit)
+			assert.Equal(t, tt.want, tt.args.scanInfo.Submit.GetBool())
 		})
 	}
 }

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -507,6 +507,51 @@ func TestSetSubmitBehavior(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			// Regression test for https://github.com/kubescape/kubescape/issues/2555:
+			// an explicit opt-out must not be silently overridden by auto-detection,
+			// even when a CloudReportURL is present and no account is set (the
+			// scenario that would otherwise force Submit=true).
+			name: "Test SetSubmitBehavior explicit opt-out is respected despite CloudReportURL and no AccountID",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType:            cautils.ScanTypeCluster,
+					Local:               false,
+					Submit:              false,
+					SubmitExplicitlySet: true,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName:    "test",
+					accountID:      "",
+					accessKey:      "",
+					cloudReportURL: "https://example.kubescape.com",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: false,
+		},
+		{
+			// An explicit opt-in must still go through the normal auto-detection -
+			// it does not bypass the "no backend configured" safety check.
+			name: "Test SetSubmitBehavior explicit opt-in does not bypass missing CloudReportURL",
+			args: args{
+				scanInfo: &cautils.ScanInfo{
+					ScanType:            cautils.ScanTypeCluster,
+					Local:               false,
+					Submit:              true,
+					SubmitExplicitlySet: true,
+				},
+				tenantConfig: &TenantConfigMock{
+					clusterName: "test",
+					accountID:   "",
+					accessKey:   "",
+				},
+				isScanTypeForSubmission: true,
+				isLocal:                 false,
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -62,7 +62,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentIn
 	// Set submit behavior AFTER loading tenant config
 	setSubmitBehavior(scanInfo, tenantConfig)
 
-	if scanInfo.Submit {
+	if scanInfo.Submit.GetBool() {
 		// submit - Create tenant & Submit report
 		if scanInfo.OmitRawResources {
 			logger.L().Ctx(ctx).Warning("omit-raw-resources flag will be ignored in submit mode")
@@ -93,7 +93,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentIn
 	// ================== setup reporter & printer objects ======================================
 
 	// reporting behavior - setup reporter
-	reportHandler := getReporter(ctx, tenantConfig, scanInfo.ScanID, scanInfo.Submit, scanInfo.FrameworkScan, *scanInfo)
+	reportHandler := getReporter(ctx, tenantConfig, scanInfo.ScanID, scanInfo.Submit.GetBool(), scanInfo.FrameworkScan, *scanInfo)
 
 	// setup printers
 	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, tenantConfig.GetContextName())

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -100,7 +100,7 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 
 	// We should submit only after printing results, so a user can see
 	// results at all times, even if submission fails
-	if rh.ReporterObj != nil && scanInfo.Submit {
+	if rh.ReporterObj != nil && scanInfo.Submit.GetBool() {
 		if err := rh.ReporterObj.Submit(ctx, rh.ScanData); err != nil {
 			return err
 		}

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -54,10 +54,7 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 
 	// submit
 	if scanRequest.Submit != nil {
-		if submit := cautils.NewBoolPtr(scanRequest.Submit); submit.Get() != nil {
-			scanInfo.Submit = *submit.Get()
-			scanInfo.SubmitExplicitlySet = true
-		}
+		scanInfo.Submit = cautils.NewBoolPtr(scanRequest.Submit)
 	}
 
 	// host scanner

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -56,6 +56,7 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 	if scanRequest.Submit != nil {
 		if submit := cautils.NewBoolPtr(scanRequest.Submit); submit.Get() != nil {
 			scanInfo.Submit = *submit.Get()
+			scanInfo.SubmitExplicitlySet = true
 		}
 	}
 

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -18,19 +18,19 @@ import (
 func TestToScanInfo_SubmitExplicitlySet(t *testing.T) {
 	// no submit field in the request - not explicitly set
 	s := ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework})
-	assert.False(t, s.SubmitExplicitlySet)
+	assert.Nil(t, s.Submit.Get())
 
 	// submit:false explicitly requested
 	falseVal := false
 	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &falseVal})
-	assert.True(t, s.SubmitExplicitlySet)
-	assert.False(t, s.Submit)
+	require.NotNil(t, s.Submit.Get())
+	assert.False(t, s.Submit.GetBool())
 
 	// submit:true explicitly requested
 	trueVal := true
 	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &trueVal})
-	assert.True(t, s.SubmitExplicitlySet)
-	assert.True(t, s.Submit)
+	require.NotNil(t, s.Submit.Get())
+	assert.True(t, s.Submit.GetBool())
 }
 
 func TestToScanInfo(t *testing.T) {
@@ -53,7 +53,7 @@ func TestToScanInfo(t *testing.T) {
 
 		assert.False(t, s.HostSensorEnabled.GetBool())
 		assert.False(t, s.Local)
-		assert.False(t, s.Submit)
+		assert.False(t, s.Submit.GetBool())
 		assert.False(t, s.ScanAll)
 		assert.True(t, s.FrameworkScan)
 		assert.Equal(t, "nsa", s.PolicyIdentifier[0].Identifier)

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -15,6 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestToScanInfo_SubmitExplicitlySet(t *testing.T) {
+	// no submit field in the request - not explicitly set
+	s := ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework})
+	assert.False(t, s.SubmitExplicitlySet)
+
+	// submit:false explicitly requested
+	falseVal := false
+	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &falseVal})
+	assert.True(t, s.SubmitExplicitlySet)
+	assert.False(t, s.Submit)
+
+	// submit:true explicitly requested
+	trueVal := true
+	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &trueVal})
+	assert.True(t, s.SubmitExplicitlySet)
+	assert.True(t, s.Submit)
+}
+
 func TestToScanInfo(t *testing.T) {
 	{
 		req := &utilsmetav1.PostScanRequest{

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -96,6 +96,7 @@ func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string
 	scanInfo := defaultScanInfo()
 	scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape from downloading the artifacts every time)
 	scanInfo.Submit = false                              // do not submit results every scan
+	scanInfo.SubmitExplicitlySet = true                  // do not submit results every scan
 	scanInfo.Local = true                                // do not submit results every scan
 	scanInfo.FrameworkScan = true
 	scanInfo.HostSensorEnabled.SetBool(false)                // disable host scanner

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -95,8 +95,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string) *cautils.ScanInfo {
 	scanInfo := defaultScanInfo()
 	scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape from downloading the artifacts every time)
-	scanInfo.Submit = false                              // do not submit results every scan
-	scanInfo.SubmitExplicitlySet = true                  // do not submit results every scan
+	scanInfo.Submit.SetBool(false)                       // deliberate opt-out, not left at the default - never flipped into submit mode by backend auto-detection
 	scanInfo.Local = true                                // do not submit results every scan
 	scanInfo.FrameworkScan = true
 	scanInfo.HostSensorEnabled.SetBool(false)                // disable host scanner

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -23,7 +23,7 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 		assert.Equal(t, scanID, scanInfo.ScanID)
 		assert.Equal(t, outputFile, scanInfo.Output)
 		assert.Equal(t, "prometheus", scanInfo.Format)
-		assert.False(t, scanInfo.Submit)
+		assert.False(t, scanInfo.Submit.GetBool())
 		assert.True(t, scanInfo.Local)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll) // Scan all available frameworks by default
@@ -39,7 +39,7 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 		assert.Equal(t, scanID, scanInfo.ScanID)
 		assert.Equal(t, outputFile, scanInfo.Output)
 		assert.Equal(t, "prometheus", scanInfo.Format)
-		assert.False(t, scanInfo.Submit)
+		assert.False(t, scanInfo.Submit.GetBool())
 		assert.True(t, scanInfo.Local)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.False(t, scanInfo.ScanAll) // Don't scan all when specific frameworks are set

--- a/httphandler/handlerequests/v1/requestparser_test.go
+++ b/httphandler/handlerequests/v1/requestparser_test.go
@@ -42,7 +42,7 @@ func TestGetScanParamsFromRequest(t *testing.T) {
 		assert.True(t, req.scanQueryParams.KeepResults)
 		assert.True(t, req.scanQueryParams.ReturnResults)
 		assert.True(t, req.scanInfo.HostSensorEnabled.GetBool())
-		assert.True(t, req.scanInfo.Submit)
+		assert.True(t, req.scanInfo.Submit.GetBool())
 		assert.Equal(t, "aaaaaaaaaa", req.scanInfo.AccountID)
 	}
 
@@ -72,7 +72,7 @@ func TestGetScanParamsFromRequest(t *testing.T) {
 		assert.False(t, req.scanQueryParams.KeepResults)
 		assert.False(t, req.scanQueryParams.ReturnResults)
 		assert.False(t, req.scanInfo.HostSensorEnabled.GetBool())
-		assert.False(t, req.scanInfo.Submit)
+		assert.False(t, req.scanInfo.Submit.GetBool())
 		assert.Equal(t, "aaaaaaaaaa", req.scanInfo.AccountID)
 	}
 }

--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -8,9 +8,31 @@ import (
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// unsetEnvForTest ensures name is absent from the process environment for the
+// duration of the test, restoring whatever value (or absence) it had before.
+// Needed because t.Setenv can only set a value, not guarantee absence, and
+// defaultScanInfo's KS_SUBMIT handling is presence-sensitive.
+func unsetEnvForTest(t *testing.T, name string) {
+	t.Helper()
+	orig, ok := os.LookupEnv(name)
+	require.NoError(t, os.Unsetenv(name))
+	t.Cleanup(func() {
+		if ok {
+			os.Setenv(name, orig)
+		} else {
+			os.Unsetenv(name)
+		}
+	})
+}
+
 func TestDefaultScanInfo(t *testing.T) {
+	// KS_SUBMIT must not leak from the ambient environment (dev machine or CI
+	// runner) into this default-value assertion.
+	unsetEnvForTest(t, "KS_SUBMIT")
+
 	s := defaultScanInfo()
 
 	assert.Equal(t, "", s.AccountID)
@@ -19,8 +41,8 @@ func TestDefaultScanInfo(t *testing.T) {
 	assert.Equal(t, "", s.AccessKey)
 	assert.False(t, s.HostSensorEnabled.GetBool())
 	assert.False(t, s.Local)
-	assert.False(t, s.Submit)
-	assert.False(t, s.SubmitExplicitlySet)
+	assert.False(t, s.Submit.GetBool())
+	assert.Nil(t, s.Submit.Get(), "Submit must not be marked explicitly set by default")
 }
 
 func TestDefaultScanInfo_SubmitExplicitlySetFromEnv(t *testing.T) {
@@ -28,11 +50,48 @@ func TestDefaultScanInfo_SubmitExplicitlySetFromEnv(t *testing.T) {
 
 	s := defaultScanInfo()
 
-	assert.False(t, s.Submit)
-	assert.True(t, s.SubmitExplicitlySet)
+	assert.False(t, s.Submit.GetBool())
+	require.NotNil(t, s.Submit.Get())
+}
+
+func TestDefaultScanInfo_KS_SUBMIT_UnparsableValueIgnored(t *testing.T) {
+	// Regression test: KS_SUBMIT="" (a common Helm rendering for an unset
+	// value) or any other unparsable value must NOT be treated as an
+	// explicit opt-out - see https://github.com/kubescape/kubescape/issues/2555.
+	for _, v := range []string{"", "yes", "enabled", "no"} {
+		t.Run("value="+v, func(t *testing.T) {
+			t.Setenv("KS_SUBMIT", v)
+			s := defaultScanInfo()
+			assert.Nil(t, s.Submit.Get(), "unparsable KS_SUBMIT=%q must not mark Submit as explicitly set", v)
+		})
+	}
+}
+
+func TestDefaultScanInfo_KS_SUBMIT_ParsedValues(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"TRUE ", true}, // tolerated: case and surrounding whitespace
+		{"false", false},
+		{"0", false},
+		{" False", false},
+	}
+	for _, tt := range tests {
+		t.Run("value="+tt.raw, func(t *testing.T) {
+			t.Setenv("KS_SUBMIT", tt.raw)
+			s := defaultScanInfo()
+			require.NotNil(t, s.Submit.Get())
+			assert.Equal(t, tt.want, s.Submit.GetBool())
+		})
+	}
 }
 
 func TestGetScanCommand(t *testing.T) {
+	unsetEnvForTest(t, "KS_SUBMIT")
+
 	req := utilsmetav1.PostScanRequest{
 		TargetType: apisv1.KindFramework,
 	}
@@ -44,10 +103,11 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, "", s.AccessKey)
 	assert.False(t, s.HostSensorEnabled.GetBool())
 	assert.False(t, s.Local)
-	assert.False(t, s.Submit)
+	assert.False(t, s.Submit.GetBool())
 }
 
 func TestGetScanCommandWithAccessKey(t *testing.T) {
+	unsetEnvForTest(t, "KS_SUBMIT")
 	config.SetAccessKey("test-123")
 
 	req := utilsmetav1.PostScanRequest{
@@ -61,7 +121,7 @@ func TestGetScanCommandWithAccessKey(t *testing.T) {
 	assert.Equal(t, "test-123", s.AccessKey)
 	assert.False(t, s.HostSensorEnabled.GetBool())
 	assert.False(t, s.Local)
-	assert.False(t, s.Submit)
+	assert.False(t, s.Submit.GetBool())
 }
 
 func TestReadResultsFile(t *testing.T) {

--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -20,6 +20,16 @@ func TestDefaultScanInfo(t *testing.T) {
 	assert.False(t, s.HostSensorEnabled.GetBool())
 	assert.False(t, s.Local)
 	assert.False(t, s.Submit)
+	assert.False(t, s.SubmitExplicitlySet)
+}
+
+func TestDefaultScanInfo_SubmitExplicitlySetFromEnv(t *testing.T) {
+	t.Setenv("KS_SUBMIT", "false")
+
+	s := defaultScanInfo()
+
+	assert.False(t, s.Submit)
+	assert.True(t, s.SubmitExplicitlySet)
 }
 
 func TestGetScanCommand(t *testing.T) {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -270,6 +270,9 @@ func defaultScanInfo() *cautils.ScanInfo {
 	scanInfo.FormatVersion = envToString("KS_FORMAT_VERSION", "v2")          // output format version
 	scanInfo.Format = envToString("KS_FORMAT", "json")                       // default output should be json
 	scanInfo.Submit = envToBool("KS_SUBMIT", false)                          // publish results to Kubescape SaaS
+	if _, ok := os.LookupEnv("KS_SUBMIT"); ok {
+		scanInfo.SubmitExplicitlySet = true
+	}
 	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                       // do not publish results to Kubescape SaaS
 	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)             // print rego rules
 	// Only set HostSensorEnabled when explicitly configured; leaving it nil allows

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -269,9 +270,16 @@ func defaultScanInfo() *cautils.ScanInfo {
 	scanInfo.HostSensorYamlPath = envToString("KS_HOST_SCAN_YAML", "")       // path to host scan YAML
 	scanInfo.FormatVersion = envToString("KS_FORMAT_VERSION", "v2")          // output format version
 	scanInfo.Format = envToString("KS_FORMAT", "json")                       // default output should be json
-	scanInfo.Submit = envToBool("KS_SUBMIT", false)                          // publish results to Kubescape SaaS
-	if _, ok := os.LookupEnv("KS_SUBMIT"); ok {
-		scanInfo.SubmitExplicitlySet = true
+	// KS_SUBMIT is presence-checked (not just envToBool'd): its mere presence
+	// marks Submit as explicitly requested, so an unparsable value (including
+	// "", which Helm commonly renders for an unset value) must not silently
+	// become a permanent, unoverridable opt-out - warn and leave it unset instead.
+	if raw, ok := os.LookupEnv("KS_SUBMIT"); ok {
+		if v, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			scanInfo.Submit.SetBool(v)
+		} else {
+			logger.L().Warning("ignoring unparsable KS_SUBMIT value", helpers.String("value", raw))
+		}
 	}
 	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                       // do not publish results to Kubescape SaaS
 	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)             // print rego rules

--- a/httphandler/main.go
+++ b/httphandler/main.go
@@ -125,7 +125,17 @@ func initializeSaaSEnv() {
 	if p := os.Getenv("KS_SERVICE_DISCOVERY_FILE_PATH"); p != "" {
 		path = p
 	}
-	if _, err := os.Stat(path); err == nil {
+	_, fileDiscoveryErr := os.Stat(path)
+	hasFileDiscovery := fileDiscoveryErr == nil
+
+	// No backend was configured (no server URL, no service-discovery file, and no
+	// account/access key) - do not reach out to the default public SaaS endpoint.
+	if !hasFileDiscovery && os.Getenv("API_URL") == "" && config.GetAccount() == "" && config.GetAccessKey() == "" {
+		logger.L().Info("no backend configured (server/account/accessKey not set) - skipping SaaS wiring")
+		return
+	}
+
+	if hasFileDiscovery {
 		logger.L().Info("using file-based service discovery", helpers.String("path", path))
 		sdGetter = servicediscoveryv3.NewServiceDiscoveryFileV3(path)
 	} else {

--- a/httphandler/main.go
+++ b/httphandler/main.go
@@ -116,23 +116,44 @@ func initializeLoggerLevel() {
 	}
 }
 
+// defaultServiceDiscoveryPath is a package-level indirection so tests can
+// override the fallback path without depending on /etc/config/services.json
+// being absent on the machine running the tests.
+var defaultServiceDiscoveryPath = "/etc/config/services.json"
+
 func initializeSaaSEnv() {
 	var sdGetter schema.IServiceDiscoveryServiceGetter
 
 	// Prefer file-based discovery: allows sidecar and private-cluster deployments
 	// to inject endpoints without network egress to api.armosec.io.
-	path := "/etc/config/services.json"
-	if p := os.Getenv("KS_SERVICE_DISCOVERY_FILE_PATH"); p != "" {
-		path = p
+	// A present-but-empty value (common for an unset Helm value) is treated
+	// the same as absent, not as an explicit override.
+	envPath, hasExplicitPath := os.LookupEnv("KS_SERVICE_DISCOVERY_FILE_PATH")
+	hasExplicitPath = hasExplicitPath && envPath != ""
+	path := defaultServiceDiscoveryPath
+	if hasExplicitPath {
+		path = envPath
 	}
 	_, fileDiscoveryErr := os.Stat(path)
 	hasFileDiscovery := fileDiscoveryErr == nil
 
-	// No backend was configured (no server URL, no service-discovery file, and no
-	// account/access key) - do not reach out to the default public SaaS endpoint.
-	if !hasFileDiscovery && os.Getenv("API_URL") == "" && config.GetAccount() == "" && config.GetAccessKey() == "" {
-		logger.L().Info("no backend configured (server/account/accessKey not set) - skipping SaaS wiring")
-		return
+	if !hasFileDiscovery {
+		// An explicit file path was configured but isn't there (typo, or a
+		// configmap that hasn't finished mounting yet) - this is a
+		// configuration problem, not "no backend configured", and falling
+		// back to the public SaaS endpoint would be a surprising thing to
+		// do silently for a deployer who opted into file-based discovery.
+		if hasExplicitPath {
+			logger.L().Warning("configured service-discovery file not found - skipping SaaS wiring", helpers.String("path", path), helpers.Error(fileDiscoveryErr))
+			return
+		}
+
+		// No backend was configured (no server URL and no account/access key) -
+		// do not reach out to the default public SaaS endpoint.
+		if os.Getenv("API_URL") == "" && config.GetAccount() == "" && config.GetAccessKey() == "" {
+			logger.L().Info("no backend configured (server/account/accessKey not set) - skipping SaaS wiring")
+			return
+		}
 	}
 
 	if hasFileDiscovery {

--- a/httphandler/main_test.go
+++ b/httphandler/main_test.go
@@ -46,8 +46,13 @@ func TestInitializeSaaSEnv_apiSuccess(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	// Ensure no file is found so the API path is exercised.
-	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", filepath.Join(t.TempDir(), "no-services.json"))
+	// Ensure no file is found, and that KS_SERVICE_DISCOVERY_FILE_PATH isn't
+	// explicitly set (which would now short-circuit before the API path),
+	// so the API path is genuinely exercised.
+	origDefaultPath := defaultServiceDiscoveryPath
+	defaultServiceDiscoveryPath = filepath.Join(t.TempDir(), "no-services.json")
+	t.Cleanup(func() { defaultServiceDiscoveryPath = origDefaultPath })
+	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", "")
 	// srv.URL is "http://127.0.0.1:PORT" — ParseHost preserves the http scheme.
 	t.Setenv("API_URL", srv.URL)
 
@@ -61,8 +66,13 @@ func TestInitializeSaaSEnv_apiSuccess(t *testing.T) {
 // TestInitializeSaaSEnv_networkFailure verifies that a transient network error
 // causes initializeSaaSEnv to log a warning and return instead of crashing.
 func TestInitializeSaaSEnv_networkFailure(t *testing.T) {
-	// Ensure no file is found so the API path is exercised.
-	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", filepath.Join(t.TempDir(), "no-services.json"))
+	// Ensure no file is found, and that KS_SERVICE_DISCOVERY_FILE_PATH isn't
+	// explicitly set (which would now short-circuit before the API path),
+	// so the API path is genuinely exercised.
+	origDefaultPath := defaultServiceDiscoveryPath
+	defaultServiceDiscoveryPath = filepath.Join(t.TempDir(), "no-services.json")
+	t.Cleanup(func() { defaultServiceDiscoveryPath = origDefaultPath })
+	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", "")
 	// Port 1 refuses connections immediately on loopback.
 	t.Setenv("API_URL", "http://127.0.0.1:1")
 
@@ -90,7 +100,12 @@ func TestInitializeSaaSEnv_noBackendConfigured(t *testing.T) {
 	getter.SetKSCloudAPIConnector(nil)
 	t.Cleanup(func() { getter.SetKSCloudAPIConnector(origConnector) })
 
-	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", filepath.Join(t.TempDir(), "no-services.json"))
+	// No explicit KS_SERVICE_DISCOVERY_FILE_PATH (an explicit-but-missing
+	// path is a different case - see TestInitializeSaaSEnv_explicitServiceDiscoveryFileMissing).
+	origDefaultPath := defaultServiceDiscoveryPath
+	defaultServiceDiscoveryPath = filepath.Join(t.TempDir(), "no-services.json")
+	t.Cleanup(func() { defaultServiceDiscoveryPath = origDefaultPath })
+	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", "")
 	t.Setenv("API_URL", "")
 
 	initializeSaaSEnv()
@@ -98,5 +113,36 @@ func TestInitializeSaaSEnv_noBackendConfigured(t *testing.T) {
 	conn := getter.GetKSCloudAPIConnector()
 	if conn.GetCloudAPIURL() != "" || conn.GetCloudReportURL() != "" {
 		t.Fatalf("expected no cloud connector URLs to be set when no backend is configured, got apiURL=%q reportURL=%q", conn.GetCloudAPIURL(), conn.GetCloudReportURL())
+	}
+}
+
+// TestInitializeSaaSEnv_explicitServiceDiscoveryFileMissing verifies that an
+// explicitly configured but missing KS_SERVICE_DISCOVERY_FILE_PATH is treated
+// as a configuration problem (skip + warn) rather than silently falling back
+// to network-based discovery, even when API_URL is also set.
+func TestInitializeSaaSEnv_explicitServiceDiscoveryFileMissing(t *testing.T) {
+	origAccount, origAccessKey := config.GetAccount(), config.GetAccessKey()
+	config.SetAccount("")
+	config.SetAccessKey("")
+	t.Cleanup(func() {
+		config.SetAccount(origAccount)
+		config.SetAccessKey(origAccessKey)
+	})
+
+	origConnector := getter.GetKSCloudAPIConnector()
+	getter.SetKSCloudAPIConnector(nil)
+	t.Cleanup(func() { getter.SetKSCloudAPIConnector(origConnector) })
+
+	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", filepath.Join(t.TempDir(), "missing-services.json"))
+	// Port 1 refuses connections immediately - if the code fell through to the
+	// network path despite the explicit file being missing, this would fail
+	// fast rather than silently succeed, making a wiring regression obvious.
+	t.Setenv("API_URL", "http://127.0.0.1:1")
+
+	initializeSaaSEnv()
+
+	conn := getter.GetKSCloudAPIConnector()
+	if conn.GetCloudAPIURL() != "" || conn.GetCloudReportURL() != "" {
+		t.Fatalf("expected no cloud connector URLs to be set when the explicit discovery file is missing, got apiURL=%q reportURL=%q", conn.GetCloudAPIURL(), conn.GetCloudReportURL())
 	}
 }

--- a/httphandler/main_test.go
+++ b/httphandler/main_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/kubescape/kubescape/v3/httphandler/config"
 )
 
 // validServicesV3JSON is a minimal well-formed service-discovery v3 payload.
@@ -68,4 +71,32 @@ func TestInitializeSaaSEnv_networkFailure(t *testing.T) {
 	t.Cleanup(func() { serviceDiscoveryTimeout = origTimeout })
 
 	initializeSaaSEnv() // must log a warning and return, not call Fatal/os.Exit
+}
+
+// TestInitializeSaaSEnv_noBackendConfigured verifies that with no service-discovery
+// file, no API_URL, and no account/accessKey, initializeSaaSEnv skips SaaS wiring
+// entirely (no network call, no cloud connector set) - see
+// https://github.com/kubescape/kubescape/issues/2555.
+func TestInitializeSaaSEnv_noBackendConfigured(t *testing.T) {
+	origAccount, origAccessKey := config.GetAccount(), config.GetAccessKey()
+	config.SetAccount("")
+	config.SetAccessKey("")
+	t.Cleanup(func() {
+		config.SetAccount(origAccount)
+		config.SetAccessKey(origAccessKey)
+	})
+
+	origConnector := getter.GetKSCloudAPIConnector()
+	getter.SetKSCloudAPIConnector(nil)
+	t.Cleanup(func() { getter.SetKSCloudAPIConnector(origConnector) })
+
+	t.Setenv("KS_SERVICE_DISCOVERY_FILE_PATH", filepath.Join(t.TempDir(), "no-services.json"))
+	t.Setenv("API_URL", "")
+
+	initializeSaaSEnv()
+
+	conn := getter.GetKSCloudAPIConnector()
+	if conn.GetCloudAPIURL() != "" || conn.GetCloudReportURL() != "" {
+		t.Fatalf("expected no cloud connector URLs to be set when no backend is configured, got apiURL=%q reportURL=%q", conn.GetCloudAPIURL(), conn.GetCloudReportURL())
+	}
 }


### PR DESCRIPTION
## Overview

Fixes a chain of issues from #2555: scanning without a backend (no `server`/`account`/`accessKey` configured) crashed with `chmod /home/nonroot/.kubescape: operation not permitted` on non-root in-cluster deployments using an emptyDir-mounted cache dir. Root-caused three separate, stacked issues:

1. **`core/cautils/customerloader.go`**: `updateConfigFile`'s permission-tightening `os.Chmod` calls on the cache directory/file were treated as fatal, even though they're only a best-effort hardening step on top of `MkdirAll`/`WriteFile`, which already set correct permissions on anything they create. On some non-root/emptyDir mounts, `chmod` on an already-correctly-permissioned path is rejected by the kernel — this now logs a warning instead of aborting the scan.

2. **`httphandler/main.go`**: `initializeSaaSEnv()` ran unconditionally at startup regardless of whether `server`/`account`/`accessKey` were configured, defaulting to live service discovery against the public `api.armosec.io` and silently registering a real `CloudReportURL` even when the deployer configured no backend at all. This now skips SaaS wiring entirely when nothing is configured.

3. **`core/core/initutils.go`**: `setSubmitBehavior` unconditionally recomputed `ScanInfo.Submit` from tenant/backend state, discarding whatever the caller (CLI `--submit`, `KS_SUBMIT` env, or the httphandler request body's `submit` field) explicitly asked for. Combined with (2), any environment where a `CloudReportURL` ended up populated would force `Submit=true` and trigger account-ID generation regardless of the caller's actual intent. `ScanInfo` now tracks whether `Submit` was explicitly set, and an explicit `false` is always respected. An explicit `true` still goes through the normal safety checks, so it can't force submission to a backend that isn't actually configured.

## Related issues/PRs

* Resolved #2555

## How to Test

```
go build ./... && go test ./...
cd httphandler && go build ./... && go test ./...
```

New regression tests cover each fix:
- `TestUpdateConfigFile_SucceedsWhenDirectoryAlreadyHasCorrectPermissions`
- `TestInitializeSaaSEnv_noBackendConfigured`
- `TestSetSubmitBehavior` (explicit opt-out / opt-in cases)
- `TestToScanInfo_SubmitExplicitlySet`, `TestDefaultScanInfo_SubmitExplicitlySetFromEnv`
- `TestApplyExplicitSubmitFlag`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit submission settings from command-line flags, environment variables, and API requests are now preserved consistently.
  * Scans no longer enable submission automatically when it was explicitly disabled.
  * Config updates now persist reliably even when permission changes are restricted, using safer atomic writes.
  * SaaS integration setup is skipped when no backend configuration is available.
* **Tests**
  * Added regression coverage for submit flag/env/api handling, config persistence under chmod failures, and backend detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->