### PR TITLE
test: add data-driven tests for ClusterConfig and ConfigObj loading

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -399,8 +399,12 @@ func readConfig(dat []byte, configObj *ConfigObj) error {
 	return nil
 }
 
+// servicesConfigPath is the path to the services discovery config file mounted
+// in-cluster. It is a var (not a const) so tests can point it at a temp file.
+var servicesConfigPath = "/etc/config/services.json"
+
 func loadUrlsFromFile(obj *ConfigObj) error {
-	dat, err := os.ReadFile("/etc/config/services.json")
+	dat, err := os.ReadFile(servicesConfigPath)
 	if err != nil {
 		return nil // no config file
 	}

--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -182,4 +183,119 @@ func TestClusterConfigLoadsKubernetesSourcesDataDriven(t *testing.T) {
 			assert.Equal(t, test.wantConfig, *config.configObj)
 		})
 	}
+}
+
+func Test_GetDefaultNS(t *testing.T) {
+	c := &ClusterConfig{configMapNamespace: "my-namespace"}
+	assert.Equal(t, "my-namespace", c.GetDefaultNS())
+}
+
+func Test_loadConfigFromFile(t *testing.T) {
+	t.Run("no file present returns nil without touching configObj", func(t *testing.T) {
+		useTemporaryConfigStore(t)
+
+		configObj := &ConfigObj{}
+		assert.NoError(t, loadConfigFromFile(configObj))
+		assert.Equal(t, &ConfigObj{}, configObj)
+	})
+
+	t.Run("existing file is loaded into configObj", func(t *testing.T) {
+		useTemporaryConfigStore(t)
+
+		want := &ConfigObj{AccountID: "file-account", AccessKey: "file-key", CloudAPIURL: "https://api.example.com"}
+		fullPath := ConfigFileFullPath()
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o700))
+		require.NoError(t, os.WriteFile(fullPath, want.Config(), 0o600))
+
+		configObj := &ConfigObj{}
+		require.NoError(t, loadConfigFromFile(configObj))
+		assert.Equal(t, want.AccountID, configObj.AccountID)
+		assert.Equal(t, want.AccessKey, configObj.AccessKey)
+		assert.Equal(t, want.CloudAPIURL, configObj.CloudAPIURL)
+	})
+
+	t.Run("malformed file returns an error", func(t *testing.T) {
+		useTemporaryConfigStore(t)
+
+		fullPath := ConfigFileFullPath()
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o700))
+		require.NoError(t, os.WriteFile(fullPath, []byte("not-json"), 0o600))
+
+		assert.Error(t, loadConfigFromFile(&ConfigObj{}))
+	})
+}
+
+func Test_loadUrlsFromFile_NoServicesFile(t *testing.T) {
+	// /etc/config/services.json is not expected to exist in the test environment,
+	// so loadUrlsFromFile should hit the "no config file" branch and return nil
+	// without modifying the passed-in ConfigObj.
+	configObj := &ConfigObj{}
+	assert.NoError(t, loadUrlsFromFile(configObj))
+	assert.Equal(t, &ConfigObj{}, configObj)
+}
+
+func Test_NewClusterConfig(t *testing.T) {
+	useTemporaryConfigStore(t)
+	getter.SetKSCloudAPIConnector(nil)
+	t.Cleanup(func() { getter.SetKSCloudAPIConnector(nil) })
+	t.Setenv(accountIdEnvVar, "")
+	t.Setenv(accessKeyEnvVar, "")
+	t.Setenv(cloudApiUrlEnvVar, "")
+	t.Setenv(cloudReportUrlEnvVar, "")
+	t.Setenv(defaultConfigMapNamespaceEnvVar, "security")
+
+	objects := []runtime.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cloud", Namespace: "security", Labels: map[string]string{"kubescape.io/infra": "config"}}, Data: map[string]string{
+			"clusterData": `{"cloudAPIURL":"https://api.example.com","cloudReportURL":"https://report.example.com"}`,
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "credentials", Namespace: "security", Labels: map[string]string{"kubescape.io/infra": "credentials"}}, Data: map[string][]byte{
+			"account": []byte("tenant-id"), "accessKey": []byte("access-key"),
+		}},
+	}
+
+	k8s := k8sinterface.NewKubernetesApiMock()
+	k8s.KubernetesClient = fake.NewClientset(objects...)
+
+	config := NewClusterConfig(k8s, "", "", "my:cluster", "")
+
+	assert.Equal(t, "security", config.GetDefaultNS())
+	assert.Equal(t, "tenant-id", config.GetAccountID())
+	assert.Equal(t, "access-key", config.GetAccessKey())
+	assert.Equal(t, "https://api.example.com", config.GetCloudAPIURL())
+	assert.Equal(t, "https://report.example.com", config.GetCloudReportURL())
+	assert.Equal(t, "my-cluster", config.GetContextName())
+}
+
+func Test_GetTenantConfig(t *testing.T) {
+	useTemporaryConfigStore(t)
+	getter.SetKSCloudAPIConnector(nil)
+	t.Cleanup(func() { getter.SetKSCloudAPIConnector(nil) })
+
+	t.Run("not connected to cluster returns LocalConfig", func(t *testing.T) {
+		k8sinterface.SetConnectedToCluster(false)
+		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
+
+		config := GetTenantConfig("account", "key", "cluster", "", nil)
+		_, ok := config.(*LocalConfig)
+		assert.True(t, ok, "expected *LocalConfig when not connected to a cluster")
+	})
+
+	t.Run("connected to cluster with k8s client returns ClusterConfig", func(t *testing.T) {
+		k8sinterface.SetConnectedToCluster(true)
+		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
+
+		k8s := k8sinterface.NewKubernetesApiMock()
+		config := GetTenantConfig("account", "key", "cluster", "", k8s)
+		_, ok := config.(*ClusterConfig)
+		assert.True(t, ok, "expected *ClusterConfig when connected to a cluster with a k8s client")
+	})
+
+	t.Run("connected to cluster without k8s client falls back to LocalConfig", func(t *testing.T) {
+		k8sinterface.SetConnectedToCluster(true)
+		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
+
+		config := GetTenantConfig("account", "key", "cluster", "", nil)
+		_, ok := config.(*LocalConfig)
+		assert.True(t, ok, "expected *LocalConfig when k8s client is nil")
+	})
 }

--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -194,9 +194,10 @@ func Test_loadConfigFromFile(t *testing.T) {
 	t.Run("no file present returns nil without touching configObj", func(t *testing.T) {
 		useTemporaryConfigStore(t)
 
-		configObj := &ConfigObj{}
-		assert.NoError(t, loadConfigFromFile(configObj))
-		assert.Equal(t, &ConfigObj{}, configObj)
+		want := ConfigObj{AccountID: "sentinel-account", AccessKey: "sentinel-key", ClusterName: "sentinel-cluster"}
+		configObj := want
+		assert.NoError(t, loadConfigFromFile(&configObj))
+		assert.Equal(t, want, configObj)
 	})
 
 	t.Run("existing file is loaded into configObj", func(t *testing.T) {
@@ -225,13 +226,35 @@ func Test_loadConfigFromFile(t *testing.T) {
 	})
 }
 
-func Test_loadUrlsFromFile_NoServicesFile(t *testing.T) {
-	// /etc/config/services.json is not expected to exist in the test environment,
-	// so loadUrlsFromFile should hit the "no config file" branch and return nil
-	// without modifying the passed-in ConfigObj.
-	configObj := &ConfigObj{}
-	assert.NoError(t, loadUrlsFromFile(configObj))
-	assert.Equal(t, &ConfigObj{}, configObj)
+func useTemporaryServicesConfigPath(t *testing.T, path string) {
+	t.Helper()
+	original := servicesConfigPath
+	servicesConfigPath = path
+	t.Cleanup(func() { servicesConfigPath = original })
+}
+
+func Test_loadUrlsFromFile(t *testing.T) {
+	t.Run("missing services file leaves configObj untouched", func(t *testing.T) {
+		useTemporaryServicesConfigPath(t, filepath.Join(t.TempDir(), "services.json"))
+
+		want := ConfigObj{AccountID: "sentinel-account", AccessKey: "sentinel-key", ClusterName: "sentinel-cluster"}
+		configObj := want
+		assert.NoError(t, loadUrlsFromFile(&configObj))
+		assert.Equal(t, want, configObj)
+	})
+
+	t.Run("valid services file populates cloud urls", func(t *testing.T) {
+		servicesPath := filepath.Join(t.TempDir(), "services.json")
+		useTemporaryServicesConfigPath(t, servicesPath)
+
+		payload := `{"version":"v2","response":{"api-server":"https://api.example.com","event-receiver-http":"https://report.example.com"}}`
+		require.NoError(t, os.WriteFile(servicesPath, []byte(payload), 0o600))
+
+		configObj := &ConfigObj{}
+		require.NoError(t, loadUrlsFromFile(configObj))
+		assert.Equal(t, "https://api.example.com", configObj.CloudAPIURL)
+		assert.Equal(t, "https://report.example.com", configObj.CloudReportURL)
+	})
 }
 
 func Test_NewClusterConfig(t *testing.T) {
@@ -271,9 +294,11 @@ func Test_GetTenantConfig(t *testing.T) {
 	getter.SetKSCloudAPIConnector(nil)
 	t.Cleanup(func() { getter.SetKSCloudAPIConnector(nil) })
 
+	originalConnected := k8sinterface.IsConnectedToCluster()
+	t.Cleanup(func() { k8sinterface.SetConnectedToCluster(originalConnected) })
+
 	t.Run("not connected to cluster returns LocalConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(false)
-		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
 
 		config := GetTenantConfig("account", "key", "cluster", "", nil)
 		_, ok := config.(*LocalConfig)
@@ -282,7 +307,6 @@ func Test_GetTenantConfig(t *testing.T) {
 
 	t.Run("connected to cluster with k8s client returns ClusterConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(true)
-		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
 
 		k8s := k8sinterface.NewKubernetesApiMock()
 		config := GetTenantConfig("account", "key", "cluster", "", k8s)
@@ -292,7 +316,6 @@ func Test_GetTenantConfig(t *testing.T) {
 
 	t.Run("connected to cluster without k8s client falls back to LocalConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(true)
-		t.Cleanup(func() { k8sinterface.SetConnectedToCluster(false) })
 
 		config := GetTenantConfig("account", "key", "cluster", "", nil)
 		_, ok := config.(*LocalConfig)


### PR DESCRIPTION
## Overview

Adds data-driven unit test coverage for `ClusterConfig` and `ConfigObj` loading in `core/cautils/customerloader.go` — cache lifecycle, config precedence, Kubernetes config-map/secret loading, local config-file loading, services-discovery URL loading, and `GetTenantConfig` dispatch. Previously several of these paths (`loadConfigFromFile`, `loadUrlsFromFile`, `GetTenantConfig`) had no tests at all.

This PR also makes one small production-code change: `loadUrlsFromFile` used to hardcode the in-cluster services path `/etc/config/services.json`, which made it untestable without touching a real host path. It's now a package-level var (`servicesConfigPath`), defaulting to the same path, that tests can point at a temp file.

## Additional Information

New file/changes in `core/cautils/customerloader_data_driven_test.go`, covering:
- `TestTenantConfigCacheLifecycleDataDriven` — cache write/read/delete lifecycle for both `LocalConfig` and `ClusterConfig`
- `TestNewLocalConfigPrecedenceDataDriven` — flag vs. env vs. detected-cluster precedence for `NewLocalConfig`
- `TestClusterConfigLoadsKubernetesSourcesDataDriven` — loading cluster config from labelled/legacy config maps and a credentials secret, including a malformed-data error case
- `Test_GetDefaultNS`
- `Test_loadConfigFromFile` — no file / existing file / malformed file, asserting the full `ConfigObj` is unchanged when no file is present
- `Test_loadUrlsFromFile` — missing services file (`ConfigObj` untouched) and a valid services.json fixture (`CloudAPIURL`/`CloudReportURL` populated), using the new `servicesConfigPath` seam
- `Test_NewClusterConfig`
- `Test_GetTenantConfig` — `LocalConfig` vs `ClusterConfig` dispatch based on cluster connectivity and k8s client presence, restoring the original `k8sinterface` connection state after the test

Production code change: `core/cautils/customerloader.go` — `loadUrlsFromFile` now reads from `servicesConfigPath` (a var defaulting to `/etc/config/services.json`) instead of a hardcoded string literal.

## How to Test

Run the new tests directly:
```
go test ./core/cautils/... -run 'TestTenantConfigCacheLifecycleDataDriven|TestNewLocalConfigPrecedenceDataDriven|TestClusterConfigLoadsKubernetesSourcesDataDriven|Test_GetDefaultNS|Test_loadConfigFromFile|Test_loadUrlsFromFile|Test_NewClusterConfig|Test_GetTenantConfig' -v
```
Or run the whole package:
```
go test ./core/cautils/...
```
