### PR TITLE
feat: spend one CEL cost budget per policy the way admission does

### DIFF
--- a/core/pkg/opaprocessor/cel/budget.go
+++ b/core/pkg/opaprocessor/cel/budget.go
@@ -1,0 +1,137 @@
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/google/cel-go/cel"
+)
+
+// errOutOfBudget marks a verdict we could not reach because the policy's shared
+// cost budget ran out. Callers match on it with errors.Is; the scanner treats it
+// like any other eval failure, an unknown verdict rather than a pass.
+var errOutOfBudget = errors.New("out of CEL cost budget")
+
+// costBudget is the cost budget one policy evaluation shares across every
+// expression it runs against one object: its variables, its validations and any
+// messageExpression. It mirrors the apiserver's RuntimeCELCostBudget accounting
+// (pkg/admission/plugin/cel/activation.go Evaluate, condition.go ForInput).
+//
+// The per-expression limit is a different, already-solved thing: the base env
+// bakes cel.CostLimit(PerCallLimit) into every program, so no single expression
+// can exceed 1M units offline or at admission. What the base env does NOT give
+// us is the ceiling on the SUM. A policy whose expressions each fit inside the
+// per-call limit but together run past 10M is accepted offline and rejected at
+// live admission, which is exactly the kind of divergence the scan/admission
+// guarantee is supposed to rule out.
+//
+// A nil *costBudget means unmetered, and the methods are nil-safe so call sites
+// do not have to branch. That is deliberate rather than lazy: path derivation
+// re-runs a validation once per list element against narrowed copies of the
+// object (see paths.go), work admission never does. Charging it here would let
+// a scan exhaust a budget that admission would not, turning a finding that
+// admission accepts into an unknown verdict. Those re-runs stay bounded by the
+// per-call limit the base env applies to every program.
+type costBudget struct {
+	// remaining is what is left of the policy's budget.
+	remaining int64
+	// pending is cost charged by variables that the expression currently
+	// running pulled in. Variables evaluate lazily inside another expression's
+	// evaluation, so their cost is collected here and settled by the expression
+	// that triggered them, matching the apiserver's compositionContext.
+	pending int64
+	// spent records that the budget ran out, so the caller can stop instead of
+	// evaluating expressions whose result it would have to discard anyway.
+	spent bool
+}
+
+func newCostBudget(limit int64) *costBudget {
+	return &costBudget{remaining: limit}
+}
+
+// exhausted reports whether the budget has already run out.
+func (b *costBudget) exhausted() bool {
+	return b != nil && b.spent
+}
+
+// err builds the error handed to every expression that does not get to run.
+func (b *costBudget) err() error {
+	return fmt.Errorf("%w: no further expressions in this policy were evaluated", errOutOfBudget)
+}
+
+// reportDetails records the cost of a variable evaluated lazily inside the
+// expression currently running. It does not settle against the budget itself;
+// charge does that, so a variable and the expression that pulled it in are
+// accounted together and in that order, as the apiserver does.
+//
+// A variable whose cost the runtime did not report is an error rather than a
+// free variable, matching the apiserver's variableAccessor.Callback. The error
+// surfaces as the variable's value, so it reaches only the validations that
+// actually referenced it.
+func (b *costBudget) reportDetails(details *cel.EvalDetails) error {
+	if b == nil {
+		return nil
+	}
+	if details == nil {
+		return errors.New("unable to get evaluation details")
+	}
+	actual := details.ActualCost()
+	if actual == nil {
+		return errors.New("unable to calculate cost")
+	}
+	cost := int64(math.MaxInt64)
+	if *actual <= math.MaxInt64 {
+		cost = int64(*actual)
+	}
+	b.pending += cost
+	return nil
+}
+
+// charge settles one expression against the budget: first the variables it
+// pulled in, then the expression's own cost. It is called even when the
+// expression errored, because a failed evaluation still consumed the units, and
+// admission charges it the same way.
+//
+// details comes straight from ContextEval. A nil details or a nil ActualCost
+// means the runtime did not report a cost, which we cannot distinguish from an
+// expensive expression, so it is treated as a failure rather than as free.
+func (b *costBudget) charge(details *cel.EvalDetails) error {
+	if b == nil {
+		return nil
+	}
+	if b.spent {
+		return b.err()
+	}
+
+	pending := b.pending
+	b.pending = 0
+	if pending > b.remaining {
+		b.spent = true
+		return b.err()
+	}
+	b.remaining -= pending
+
+	if details == nil {
+		b.spent = true
+		return fmt.Errorf("%w: runtime reported no cost details", errOutOfBudget)
+	}
+	actual := details.ActualCost()
+	if actual == nil {
+		b.spent = true
+		return fmt.Errorf("%w: runtime reported no cost", errOutOfBudget)
+	}
+	// Bound before converting, then convert once. A cost past MaxInt64 is far
+	// beyond any budget anyway, so it is out of budget by definition.
+	if *actual > math.MaxInt64 {
+		b.spent = true
+		return b.err()
+	}
+	cost := int64(*actual)
+	if cost > b.remaining {
+		b.spent = true
+		return b.err()
+	}
+	b.remaining -= cost
+	return nil
+}

--- a/core/pkg/opaprocessor/cel/budget.go
+++ b/core/pkg/opaprocessor/cel/budget.go
@@ -65,10 +65,13 @@ func (b *costBudget) err() error {
 // charge does that, so a variable and the expression that pulled it in are
 // accounted together and in that order, as the apiserver does.
 //
-// A variable whose cost the runtime did not report is an error rather than a
-// free variable, matching the apiserver's variableAccessor.Callback. The error
-// surfaces as the variable's value, so it reaches only the validations that
-// actually referenced it.
+// A variable that RAN and whose cost the runtime did not report is an error
+// rather than a free variable, matching the apiserver's
+// variableAccessor.Callback. The error surfaces as the variable's value, so it
+// reaches only the validations that actually referenced it. A variable that
+// never ran at all does not reach here: the caller returns its compile error
+// directly (see lazyVariables), so a broken variable reports what is actually
+// wrong with it instead of a missing cost.
 func (b *costBudget) reportDetails(details *cel.EvalDetails) error {
 	if b == nil {
 		return nil
@@ -93,9 +96,13 @@ func (b *costBudget) reportDetails(details *cel.EvalDetails) error {
 // expression errored, because a failed evaluation still consumed the units, and
 // admission charges it the same way.
 //
-// details comes straight from ContextEval. A nil details or a nil ActualCost
-// means the runtime did not report a cost, which we cannot distinguish from an
-// expensive expression, so it is treated as a failure rather than as free.
+// details comes straight from ContextEval, and only ever for an expression that
+// actually started evaluating: a compile failure is returned by the caller
+// before it gets here (see evalExpression), because an expression that never ran
+// spent nothing and must leave the rest of the policy its full budget. A nil
+// details or a nil ActualCost therefore means the runtime ran the expression and
+// did not tell us what it cost, which we cannot distinguish from an expensive
+// expression, so it is treated as a failure rather than as free.
 func (b *costBudget) charge(details *cel.EvalDetails) error {
 	if b == nil {
 		return nil

--- a/core/pkg/opaprocessor/cel/budget_test.go
+++ b/core/pkg/opaprocessor/cel/budget_test.go
@@ -1,0 +1,230 @@
+package cel
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+)
+
+// costOf measures what one expression actually costs against an object, so the
+// budget tests can be calibrated from the runtime instead of from magic numbers
+// that would drift the next time cel-go retunes its cost model.
+func costOf(t *testing.T, e *Evaluator, expr string, obj map[string]any, variables []Variable) int64 {
+	t.Helper()
+	activation := e.activationFor(context.Background(), obj, nil, nil, variables, nil)
+	_, details, err := e.run(context.Background(), expr, activation)
+	require.NoError(t, err)
+	require.NotNil(t, details, "base env must track cost")
+	actual := details.ActualCost()
+	require.NotNil(t, actual)
+	// Bounds-checked the same way charge does, so the helper cannot be the one
+	// place an overflowing cost slips through untyped.
+	require.LessOrEqual(t, *actual, uint64(math.MaxInt64), "cost does not fit int64")
+	cost := int64(math.MaxInt64)
+	if *actual <= math.MaxInt64 {
+		cost = int64(*actual)
+	}
+	return cost
+}
+
+func budgetPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "p", "namespace": "default"},
+		"spec": map[string]any{
+			"hostNetwork": true,
+			"containers": []any{
+				map[string]any{"name": "a", "image": "nginx"},
+				map[string]any{"name": "b", "image": "nginx"},
+			},
+		},
+	}
+}
+
+func TestDefaultBudgetMatchesTheApiserverRuntimeBudget(t *testing.T) {
+	// The whole point of the shared budget is that we spend what admission
+	// spends, so the default has to be the apiserver's constant, not a number
+	// of our own choosing.
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	assert.Equal(t, int64(celconfig.RuntimeCELCostBudget), e.budgetLimit())
+
+	tuned, err := NewEvaluator(WithCostBudget(42))
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), tuned.budgetLimit())
+}
+
+func TestBudgetIsSharedAcrossValidations(t *testing.T) {
+	// Two validations that each fit the per-expression limit easily but do not
+	// both fit the shared budget. This is the divergence the PR exists for: the
+	// base env's per-call limit says both are fine, admission says the policy is
+	// too expensive.
+	obj := budgetPod()
+	first := "object.spec.hostNetwork == false"
+	second := "object.spec.containers.all(c, c.image != 'nginx')"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	firstCost := costOf(t, e, first, obj, nil)
+	require.Greater(t, firstCost, int64(0))
+
+	// Exactly enough for the first expression and nothing after it.
+	metered, err := NewEvaluator(WithCostBudget(firstCost))
+	require.NoError(t, err)
+	results, err := metered.EvaluateOnObject(context.Background(), obj, nil, nil, nil,
+		[]Validation{{Expression: first, Message: "host network"}, {Expression: second, Message: "image"}})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// The first validation still reports its real verdict. Losing a confirmed
+	// violation because a later expression ran long would be a regression of
+	// the per-resource outcome handling.
+	assert.NoError(t, results[0].Err)
+	assert.False(t, results[0].Passed)
+	assert.Equal(t, "host network", results[0].Message)
+
+	// The second never ran, and reads as unknown rather than as a pass.
+	require.Error(t, results[1].Err)
+	assert.True(t, errors.Is(results[1].Err, errOutOfBudget))
+	assert.False(t, results[1].Passed)
+}
+
+func TestBudgetThatCoversEverythingChangesNothing(t *testing.T) {
+	obj := budgetPod()
+	first := "object.spec.hostNetwork == false"
+	second := "object.spec.containers.all(c, c.image != 'nginx')"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	total := costOf(t, e, first, obj, nil) + costOf(t, e, second, obj, nil)
+
+	metered, err := NewEvaluator(WithCostBudget(total))
+	require.NoError(t, err)
+	results, err := metered.EvaluateOnObject(context.Background(), obj, nil, nil, nil,
+		[]Validation{{Expression: first}, {Expression: second}})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for i, res := range results {
+		assert.NoError(t, res.Err, "validation %d", i)
+		assert.False(t, res.Passed, "validation %d", i)
+	}
+}
+
+func TestVariableCostIsChargedToTheBudget(t *testing.T) {
+	// A variable evaluates inside the validation that first reads it, so its
+	// cost has to land on the same budget. If it did not, a policy could push
+	// arbitrary work into variables: and scan under a budget admission never
+	// grants it.
+	obj := budgetPod()
+	vars := []Variable{{Name: "hostNet", Expression: "object.spec.hostNetwork"}}
+	validation := "variables.hostNet == false"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	validationCost := costOf(t, e, validation, obj, vars)
+	variableCost := costOf(t, e, vars[0].Expression, obj, nil)
+	require.Greater(t, variableCost, int64(0), "variable must cost something for this test to mean anything")
+
+	// Budget covers the validation but not the variable it pulls in.
+	tight, err := NewEvaluator(WithCostBudget(validationCost))
+	require.NoError(t, err)
+	results, err := tight.EvaluateOnObject(context.Background(), obj, nil, nil, vars,
+		[]Validation{{Expression: validation}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+	assert.True(t, errors.Is(results[0].Err, errOutOfBudget))
+
+	// Budget covers both, so the same policy evaluates cleanly.
+	enough, err := NewEvaluator(WithCostBudget(validationCost + variableCost))
+	require.NoError(t, err)
+	results, err = enough.EvaluateOnObject(context.Background(), obj, nil, nil, vars,
+		[]Validation{{Expression: validation}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Err)
+	assert.False(t, results[0].Passed)
+}
+
+func TestMemoizedVariableIsChargedOnce(t *testing.T) {
+	// Two validations read the same variable. It evaluates once and is charged
+	// once, exactly as the apiserver's composition map behaves, so a budget
+	// sized for one copy of the variable is enough.
+	obj := budgetPod()
+	vars := []Variable{{Name: "hostNet", Expression: "object.spec.hostNetwork"}}
+	first := "variables.hostNet == false"
+	second := "variables.hostNet != true"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	budget := costOf(t, e, first, obj, vars) +
+		costOf(t, e, second, obj, vars) +
+		costOf(t, e, vars[0].Expression, obj, nil)
+
+	metered, err := NewEvaluator(WithCostBudget(budget))
+	require.NoError(t, err)
+	results, err := metered.EvaluateOnObject(context.Background(), obj, nil, nil, vars,
+		[]Validation{{Expression: first}, {Expression: second}})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for i, res := range results {
+		assert.NoError(t, res.Err, "validation %d charged a second time for the same variable", i)
+	}
+}
+
+func TestPathDerivationDoesNotSpendTheBudget(t *testing.T) {
+	// Deriving remediation paths re-runs the validation once per container plus
+	// one baseline check. Admission never does that work, so charging it here
+	// would turn a violation admission accepts into an unknown verdict on any
+	// object with a few containers.
+	obj := budgetPod()
+	validation := "object.spec.containers.all(c, c.image != 'nginx')"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	cost := costOf(t, e, validation, obj, nil)
+
+	// Exactly one expression's worth of budget, with three re-runs to come.
+	metered, err := NewEvaluator(WithCostBudget(cost))
+	require.NoError(t, err)
+	results, err := metered.EvaluateOnObject(context.Background(), obj, nil, nil, nil,
+		[]Validation{{Expression: validation, Message: "bad image"}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.NoError(t, results[0].Err)
+	assert.False(t, results[0].Passed)
+	assert.NotEmpty(t, results[0].Paths, "paths must still be derived on an exhausted budget")
+}
+
+func TestCancelledContextInterruptsAComprehension(t *testing.T) {
+	// Guards cel.InterruptCheckFrequency being set on every program. Without it
+	// cel-go never plans an interruptable evaluation, and ContextEval ignores a
+	// cancelled context completely: it checks nothing before evaluating and
+	// nothing during, so a comprehension over a long list runs to completion
+	// whatever the caller does. The list is longer than CheckFrequency so the
+	// runtime reaches at least one check.
+	items := make([]any, 0, 5*celconfig.CheckFrequency)
+	for i := 0; i < 5*celconfig.CheckFrequency; i++ {
+		items = append(items, map[string]any{"name": "c", "image": "nginx"})
+	}
+	obj := map[string]any{"kind": "Pod", "spec": map[string]any{"containers": items}}
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results, err := e.EvaluateOnObject(ctx, obj, nil, nil, nil,
+		[]Validation{{Expression: "object.spec.containers.all(c, c.image == 'nginx')"}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err, "a cancelled scan must not keep evaluating CEL")
+	assert.False(t, results[0].Passed)
+}

--- a/core/pkg/opaprocessor/cel/budget_test.go
+++ b/core/pkg/opaprocessor/cel/budget_test.go
@@ -17,7 +17,9 @@ import (
 func costOf(t *testing.T, e *Evaluator, expr string, obj map[string]any, variables []Variable) int64 {
 	t.Helper()
 	activation := e.activationFor(context.Background(), obj, nil, nil, variables, nil)
-	_, details, err := e.run(context.Background(), expr, activation)
+	prog, err := e.programs.get(expr)
+	require.NoError(t, err)
+	_, details, err := e.run(context.Background(), prog, activation)
 	require.NoError(t, err)
 	require.NotNil(t, details, "base env must track cost")
 	actual := details.ActualCost()
@@ -202,6 +204,65 @@ func TestPathDerivationDoesNotSpendTheBudget(t *testing.T) {
 	assert.NotEmpty(t, results[0].Paths, "paths must still be derived on an exhausted budget")
 }
 
+func TestCompileFailureLeavesTheBudgetToTheRestOfThePolicy(t *testing.T) {
+	// An expression that does not compile never ran, so it spent nothing. Charging
+	// it would latch the budget and take every later validation down with it,
+	// while admission returns on the compile error before it touches the budget
+	// and keeps going. authorizer is deliberately undeclared in newEnv, so a
+	// policy referencing it is exactly the "should fail to compile and get
+	// skipped" case env.go describes.
+	obj := budgetPod()
+	broken := "authorizer.group('').resource('pods').check('create').allowed()"
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	results, err := e.EvaluateOnObject(context.Background(), obj, nil, nil, nil, []Validation{
+		{Expression: broken},
+		{Expression: "object.spec.hostNetwork == false", Message: "host network"},
+		{Expression: "object.metadata.name == 'p'"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	// The compile error is what the caller gets, not an out-of-budget error
+	// standing in for it.
+	require.Error(t, results[0].Err)
+	assert.False(t, errors.Is(results[0].Err, errOutOfBudget), "a compile failure must not read as an exhausted budget")
+	assert.Contains(t, results[0].Err.Error(), "compile")
+
+	// And the validations after it still get real verdicts.
+	assert.NoError(t, results[1].Err)
+	assert.False(t, results[1].Passed)
+	assert.Equal(t, "host network", results[1].Message)
+	assert.NoError(t, results[2].Err)
+	assert.True(t, results[2].Passed)
+}
+
+func TestVariableCompileFailureOnlyBreaksItsOwnValidation(t *testing.T) {
+	// Same rule on the variable path: a variable that never compiled has no cost
+	// to report, so the validation that read it must name the compile failure
+	// rather than a missing cost report, and validations that never touched it
+	// must be unaffected.
+	obj := budgetPod()
+	vars := []Variable{{Name: "bad", Expression: "authorizer.group('')"}}
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+	results, err := e.EvaluateOnObject(context.Background(), obj, nil, nil, vars, []Validation{
+		{Expression: "variables.bad == 1"},
+		{Expression: "object.spec.hostNetwork == false"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	require.Error(t, results[0].Err)
+	assert.Contains(t, results[0].Err.Error(), "compile")
+	assert.False(t, errors.Is(results[0].Err, errOutOfBudget))
+
+	assert.NoError(t, results[1].Err)
+	assert.False(t, results[1].Passed)
+}
+
 func TestCancelledContextInterruptsAComprehension(t *testing.T) {
 	// Guards cel.InterruptCheckFrequency being set on every program. Without it
 	// cel-go never plans an interruptable evaluation, and ContextEval ignores a
@@ -209,6 +270,10 @@ func TestCancelledContextInterruptsAComprehension(t *testing.T) {
 	// nothing during, so a comprehension over a long list runs to completion
 	// whatever the caller does. The list is longer than CheckFrequency so the
 	// runtime reaches at least one check.
+	//
+	// This goes at one expression rather than through EvaluateOnObject, which
+	// would refuse a cancelled context before evaluating anything (see the test
+	// below) and so would pass with or without the program option.
 	items := make([]any, 0, 5*celconfig.CheckFrequency)
 	for i := 0; i < 5*celconfig.CheckFrequency; i++ {
 		items = append(items, map[string]any{"name": "c", "image": "nginx"})
@@ -221,10 +286,32 @@ func TestCancelledContextInterruptsAComprehension(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	results, err := e.EvaluateOnObject(ctx, obj, nil, nil, nil,
-		[]Validation{{Expression: "object.spec.containers.all(c, c.image == 'nginx')"}})
+	_, err = e.evalExpression(ctx, "object.spec.containers.all(c, c.image == 'nginx')",
+		e.activationFor(ctx, obj, nil, nil, nil, nil), nil)
+	require.Error(t, err, "a cancelled scan must not keep evaluating CEL")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCancelledContextStopsTheRemainingValidations(t *testing.T) {
+	// InterruptCheckFrequency only makes the runtime check every N steps INSIDE
+	// one evaluation, so an ordinary policy of cheap expressions would run every
+	// one of them to completion after Ctrl+C. A scan over thousands of objects
+	// has to stop on the spot instead, whatever shape its expressions are.
+	e, err := NewEvaluator()
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	require.Error(t, results[0].Err, "a cancelled scan must not keep evaluating CEL")
-	assert.False(t, results[0].Passed)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results, err := e.EvaluateOnObject(ctx, budgetPod(), nil, nil, nil, []Validation{
+		{Expression: "object.spec.hostNetwork == false"},
+		{Expression: "object.metadata.name == 'p'"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for i, res := range results {
+		require.Error(t, res.Err, "validation %d kept evaluating after cancellation", i)
+		assert.ErrorIs(t, res.Err, context.Canceled)
+		assert.False(t, res.Passed, "validation %d", i)
+	}
 }

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -142,6 +142,10 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 // report a mixed outcome, and discarding a confirmed violation because a later
 // validation ran long would lose real information. The unreached validations
 // carry the out-of-budget error, so they read as unknown, never as passing.
+//
+// A cancelled context stops the loop the same way, and an expression that fails
+// to compile stops nothing at all: it never ran, so it costs the policy nothing
+// and the validations after it still get their verdicts.
 func (e *Evaluator) EvaluateOnObject(
 	ctx context.Context,
 	obj map[string]any,
@@ -155,6 +159,15 @@ func (e *Evaluator) EvaluateOnObject(
 
 	results := make([]ValidationResult, 0, len(validations))
 	for _, val := range validations {
+		// A cancelled scan stops here rather than partway through whichever
+		// expression happens to be long enough for the runtime to notice.
+		// InterruptCheckFrequency only makes cel-go check #interrupted every N
+		// steps INSIDE one evaluation, so without this an ordinary policy of
+		// cheap expressions runs every one of them to completion after Ctrl+C.
+		if err := ctx.Err(); err != nil {
+			results = append(results, ValidationResult{Expression: val.Expression, Err: fmt.Errorf("evaluation stopped: %w", err)})
+			continue
+		}
 		if budget.exhausted() {
 			results = append(results, ValidationResult{Expression: val.Expression, Err: budget.err()})
 			continue
@@ -251,12 +264,19 @@ func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, act
 	for _, v := range variables {
 		v := v // capture per iteration for the callback
 		lazyVars.Append(v.Name, func(*lazy.MapValue) ref.Val {
-			out, details, err := e.run(ctx, v.Expression, activation)
+			// Compiling first keeps a variable that never ran out of the cost
+			// accounting entirely: a compile failure is this variable's error to
+			// report, not a missing cost report to complain about.
+			prog, err := e.programs.get(v.Expression)
+			if err != nil {
+				return types.NewErr("variable %q: %v", v.Name, err)
+			}
+			out, details, evalErr := e.run(ctx, prog, activation)
 			if reportErr := budget.reportDetails(details); reportErr != nil {
 				return types.NewErr("variable %q: %v", v.Name, reportErr)
 			}
-			if err != nil {
-				return types.NewErr("variable %q: %v", v.Name, err)
+			if evalErr != nil {
+				return types.NewErr("variable %q: %v", v.Name, evalErr)
 			}
 			return out
 		})
@@ -340,15 +360,31 @@ func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, acti
 	return msg, true
 }
 
-// evalExpression evaluates one expression and settles it against the budget.
+// evalExpression compiles one expression, evaluates it and settles it against
+// the budget.
 //
-// The charge happens BEFORE the eval error is returned, on purpose: an
-// expression that ran and then failed still consumed the units, and admission
-// charges it the same way (activation.go Evaluate accounts for cost first and
-// only then inspects the error). Skipping the charge on error would let a
-// policy spend more offline than it can at admission.
+// Compiling is a separate step here, and it has to stay one: an expression that
+// does not compile never ran, so it spent nothing and must not touch the budget
+// at all. Admission works the same way, returning on compilationResult.Error
+// before it reaches the accounting (plugin/cel/activation.go Evaluate), which
+// leaves the rest of the policy free to evaluate on the untouched budget. Folding
+// the two steps together would charge a typo the whole remaining budget and take
+// every later validation in the policy down with it.
+//
+// Once the program does run, the charge happens BEFORE the eval error is
+// returned, also on purpose: an expression that ran and then failed still
+// consumed the units, and admission charges it the same way (cost first, error
+// second). Skipping the charge on error would let a policy spend more offline
+// than it can at admission.
 func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation map[string]any, budget *costBudget) (ref.Val, error) {
-	out, details, evalErr := e.run(ctx, expr, activation)
+	// Compiled on first use and reused for every later object, so this is a map
+	// lookup on all but the first (see cache.go).
+	prog, err := e.programs.get(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	out, details, evalErr := e.run(ctx, prog, activation)
 	if err := budget.charge(details); err != nil {
 		return nil, err
 	}
@@ -358,17 +394,17 @@ func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation 
 	return out, nil
 }
 
-// run evaluates a single CEL expression against the activation and hands back
-// the raw cost details alongside the result. The compiled program comes from
-// the cache (compiled on first use, reused for every later object; see
-// cache.go). Callers settle the cost themselves: a validation charges it, a
-// variable only reports it (see lazyVariables).
-func (e *Evaluator) run(ctx context.Context, expr string, activation map[string]any) (ref.Val, *cel.EvalDetails, error) {
-	prog, err := e.programs.get(expr)
-	if err != nil {
-		return nil, nil, err
-	}
-
+// run evaluates one already-compiled program against the activation and hands
+// back the raw cost details alongside the result. Callers settle the cost
+// themselves: a validation charges it, a variable only reports it (see
+// lazyVariables).
+//
+// Taking a program rather than an expression is what keeps "never compiled" and
+// "ran but reported no cost" apart for those callers. Anything that reaches here
+// starts evaluating, and cel-go reports the cost tracker to the observer before
+// it evaluates a single step, so the details returned are non-nil even when the
+// run is cut short by an interrupt or the per-call limit.
+func (e *Evaluator) run(ctx context.Context, prog cel.Program, activation map[string]any) (ref.Val, *cel.EvalDetails, error) {
 	out, details, err := prog.ContextEval(ctx, activation)
 	if err != nil {
 		return nil, details, fmt.Errorf("eval: %w", err)

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -63,21 +63,32 @@ type Evaluator struct {
 	// behind a violation's remediation paths happens once per expression rather
 	// than once per failing object (see paths.go).
 	plans *pathPlanCache
-	// costLimit overrides the per-evaluation CEL cost budget. Zero means "do not
-	// override", which leaves the budget the base env already bakes in
-	// (apiserver's PerCallLimit). When cost limits are wired up the real value
-	// flows through here, so that becomes a value change not a signature one.
-	costLimit uint64
+	// costBudget overrides the budget one policy evaluation shares across all of
+	// its expressions against one object. Zero means the apiserver's
+	// RuntimeCELCostBudget, which is what keeps us in step with admission; tests
+	// set it low to reach the exhausted path without writing a costly
+	// expression. The PER-EXPRESSION limit is not configurable here on purpose:
+	// the base env bakes in cel.CostLimit(PerCallLimit) and overriding it would
+	// mean scanning under a different ceiling than admission enforces.
+	costBudget int64
 }
 
 // Option configures an Evaluator.
 type Option func(*Evaluator)
 
-// WithCostLimit overrides the per-evaluation CEL cost budget. Leave it unset to
-// keep the base env's default (apiserver's PerCallLimit), which is what gives us
-// scan/admission parity.
-func WithCostLimit(limit uint64) Option {
-	return func(e *Evaluator) { e.costLimit = limit }
+// WithCostBudget overrides the shared per-policy-evaluation cost budget. Leave
+// it unset to keep the apiserver's RuntimeCELCostBudget, which is what gives us
+// scan/admission parity (see budget.go).
+func WithCostBudget(budget int64) Option {
+	return func(e *Evaluator) { e.costBudget = budget }
+}
+
+// budgetLimit is the shared budget a single object's evaluation starts with.
+func (e *Evaluator) budgetLimit() int64 {
+	if e.costBudget > 0 {
+		return e.costBudget
+	}
+	return celconfig.RuntimeCELCostBudget
 }
 
 // NewEvaluator builds an Evaluator over the offline VAP CEL env (see newEnv).
@@ -123,6 +134,14 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 // Each validation then yields one ValidationResult, in order. The error return is
 // reserved for setup failures; per-validation outcomes (including eval errors)
 // live on the result (see evaluateValidation).
+//
+// One shared cost budget covers the whole call, matching what admission spends
+// on this object (see budget.go). When it runs out we stop evaluating, as the
+// apiserver does, but unlike the apiserver we KEEP the verdicts already reached
+// instead of collapsing the policy into a single error: the scanner is built to
+// report a mixed outcome, and discarding a confirmed violation because a later
+// validation ran long would lose real information. The unreached validations
+// carry the out-of-budget error, so they read as unknown, never as passing.
 func (e *Evaluator) EvaluateOnObject(
 	ctx context.Context,
 	obj map[string]any,
@@ -131,11 +150,16 @@ func (e *Evaluator) EvaluateOnObject(
 	variables []Variable,
 	validations []Validation,
 ) ([]ValidationResult, error) {
-	activation := e.activationFor(ctx, obj, namespaceObject, params, variables)
+	budget := newCostBudget(e.budgetLimit())
+	activation := e.activationFor(ctx, obj, namespaceObject, params, variables, budget)
 
 	results := make([]ValidationResult, 0, len(validations))
 	for _, val := range validations {
-		res := e.evaluateValidation(ctx, val, activation)
+		if budget.exhausted() {
+			results = append(results, ValidationResult{Expression: val.Expression, Err: budget.err()})
+			continue
+		}
+		res := e.evaluateValidation(ctx, val, activation, budget)
 		if res.Err == nil && !res.Passed {
 			res.Paths = e.violationPaths(ctx, val.Expression, obj, namespaceObject, params, variables)
 		}
@@ -154,11 +178,14 @@ func (e *Evaluator) EvaluateOnObject(
 // narrowed, which is why this is separate: the lazy variables memoize against
 // the object they were built for, so a modified object needs its own bindings
 // rather than a reused map.
-func (e *Evaluator) activationFor(ctx context.Context, obj, namespaceObject map[string]any, params any, variables []Variable) map[string]any {
+//
+// budget is the cost budget the variables bound here charge against, and may be
+// nil for an unmetered activation (path derivation, see violationPaths).
+func (e *Evaluator) activationFor(ctx context.Context, obj, namespaceObject map[string]any, params any, variables []Variable, budget *costBudget) map[string]any {
 	activation := stubBindings(obj, namespaceObject)
 	activation["object"] = obj
 	activation["params"] = params
-	activation["variables"] = e.lazyVariables(ctx, variables, activation)
+	activation["variables"] = e.lazyVariables(ctx, variables, activation, budget)
 	return activation
 }
 
@@ -169,9 +196,16 @@ func (e *Evaluator) activationFor(ctx context.Context, obj, namespaceObject map[
 // element": an expression that errors or returns a non-bool on the narrowed
 // object tells us nothing, and blaming an element on a guess would put a wrong
 // path in front of the user.
+//
+// These re-runs are deliberately UNMETERED by the policy's shared cost budget
+// (nil budget). Admission never narrows an object and re-checks it, so charging
+// this work would let a scan run out of budget where admission does not, and
+// report unknown for a violation admission is happy to reject. Each re-run is
+// still capped by the per-expression limit the base env applies to every
+// program, and the whole loop only runs for an object that already failed.
 func (e *Evaluator) violationPaths(ctx context.Context, expr string, obj, namespaceObject map[string]any, params any, variables []Variable) []PathHint {
 	return e.plans.get(expr, variables).resolve(obj, func(narrowed map[string]any) bool {
-		out, err := e.evalExpression(ctx, expr, e.activationFor(ctx, narrowed, namespaceObject, params, variables))
+		out, err := e.evalExpression(ctx, expr, e.activationFor(ctx, narrowed, namespaceObject, params, variables, nil), nil)
 		if err != nil {
 			return false
 		}
@@ -206,12 +240,21 @@ const variablesTypeName = "kubescape.cel.variables"
 // part of, so a variable referencing variables.<earlier> triggers that earlier
 // variable's callback on demand. An eval/compile failure becomes a CEL error
 // value, which propagates only to the validation that referenced the variable.
-func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, activation map[string]any) *lazy.MapValue {
+// A variable's cost is REPORTED to the budget rather than charged against it
+// here: the variable runs inside whichever expression first referenced it, so
+// the two are settled together by that expression's charge, which is how the
+// apiserver's compositionContext accounts for them. Memoization means a second
+// validation reading the same variable pays nothing, offline and at admission
+// alike.
+func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, activation map[string]any, budget *costBudget) *lazy.MapValue {
 	lazyVars := lazy.NewMapValue(types.NewObjectType(variablesTypeName))
 	for _, v := range variables {
 		v := v // capture per iteration for the callback
 		lazyVars.Append(v.Name, func(*lazy.MapValue) ref.Val {
-			out, err := e.evalExpression(ctx, v.Expression, activation)
+			out, details, err := e.run(ctx, v.Expression, activation)
+			if reportErr := budget.reportDetails(details); reportErr != nil {
+				return types.NewErr("variable %q: %v", v.Name, reportErr)
+			}
 			if err != nil {
 				return types.NewErr("variable %q: %v", v.Name, err)
 			}
@@ -224,10 +267,10 @@ func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, act
 // evaluateValidation evaluates one validation against the prepared activation.
 // Only a compile/eval failure of the validation expression sets Err; everything
 // else resolves to a clean pass or a violation with a message.
-func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, activation map[string]any) ValidationResult {
+func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, activation map[string]any, budget *costBudget) ValidationResult {
 	res := ValidationResult{Expression: val.Expression}
 
-	out, err := e.evalExpression(ctx, val.Expression, activation)
+	out, err := e.evalExpression(ctx, val.Expression, activation, budget)
 	if err != nil {
 		res.Err = err
 		return res
@@ -241,7 +284,7 @@ func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, acti
 
 	res.Passed = passed
 	if !passed {
-		res.Message = e.resolveMessage(ctx, val, activation)
+		res.Message = e.resolveMessage(ctx, val, activation, budget)
 	}
 	return res
 }
@@ -255,9 +298,18 @@ func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, acti
 // violation, so we fall back rather than promote to Err. A messageExpression
 // result that is non-string, empty/whitespace-only, multi-line, or longer than
 // the apiserver's limit also falls back, matching what admission would accept.
-func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activation map[string]any) string {
+//
+// A messageExpression draws from the same budget, as it does at admission,
+// where it runs on whatever the validations left. Exhausting the budget here
+// still only costs the message: the violation stands with its fallback text,
+// and the validations that follow report the out-of-budget error instead.
+// (The apiserver runs every validation before any messageExpression; we
+// interleave them, so the two can differ in WHICH expression first finds the
+// budget empty. The set of expressions charged, and therefore whether the
+// policy fits, is the same.)
+func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activation map[string]any, budget *costBudget) string {
 	if val.MessageExpression != "" {
-		if msg, ok := e.evalMessageExpression(ctx, val.MessageExpression, activation); ok {
+		if msg, ok := e.evalMessageExpression(ctx, val.MessageExpression, activation, budget); ok {
 			return msg
 		}
 	}
@@ -272,8 +324,8 @@ func (e *Evaluator) resolveMessage(ctx context.Context, val Validation, activati
 // errors, is non-string, is empty/whitespace, exceeds the size limit, or spans
 // multiple lines; we apply the same guards so the message we report offline is
 // one admission would actually use.
-func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, activation map[string]any) (string, bool) {
-	out, err := e.evalExpression(ctx, expr, activation)
+func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, activation map[string]any, budget *costBudget) (string, bool) {
+	out, err := e.evalExpression(ctx, expr, activation, budget)
 	if err != nil {
 		return "", false
 	}
@@ -288,44 +340,69 @@ func (e *Evaluator) evalMessageExpression(ctx context.Context, expr string, acti
 	return msg, true
 }
 
-// evalExpression evaluates a single CEL expression against the activation. The
-// compiled program comes from the cache (compiled on first use, reused for
-// every later object; see cache.go). When cost reporting is added it surfaces
-// the EvalDetails this currently discards.
-func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation map[string]any) (ref.Val, error) {
-	prog, err := e.programs.get(expr)
-	if err != nil {
+// evalExpression evaluates one expression and settles it against the budget.
+//
+// The charge happens BEFORE the eval error is returned, on purpose: an
+// expression that ran and then failed still consumed the units, and admission
+// charges it the same way (activation.go Evaluate accounts for cost first and
+// only then inspects the error). Skipping the charge on error would let a
+// policy spend more offline than it can at admission.
+func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation map[string]any, budget *costBudget) (ref.Val, error) {
+	out, details, evalErr := e.run(ctx, expr, activation)
+	if err := budget.charge(details); err != nil {
 		return nil, err
 	}
-
-	out, _, err := prog.ContextEval(ctx, activation)
-	if err != nil {
-		return nil, fmt.Errorf("eval: %w", err)
+	if evalErr != nil {
+		return nil, evalErr
 	}
 	return out, nil
 }
 
+// run evaluates a single CEL expression against the activation and hands back
+// the raw cost details alongside the result. The compiled program comes from
+// the cache (compiled on first use, reused for every later object; see
+// cache.go). Callers settle the cost themselves: a validation charges it, a
+// variable only reports it (see lazyVariables).
+func (e *Evaluator) run(ctx context.Context, expr string, activation map[string]any) (ref.Val, *cel.EvalDetails, error) {
+	prog, err := e.programs.get(expr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out, details, err := prog.ContextEval(ctx, activation)
+	if err != nil {
+		return nil, details, fmt.Errorf("eval: %w", err)
+	}
+	return out, details, nil
+}
+
 // compileProgram compiles one expression into a runnable program. Callers go
 // through the program cache, never here directly, so each expression compiles
-// once. The cost-limit override is only applied when set; otherwise the base
-// env's baked-in PerCallLimit stands. InterruptCheckFrequency gets added here
-// later too.
+// once.
 //
-// Note for when the cost limit is turned on: this applies a fresh per-expression
-// budget. The apiserver instead shares one budget across all of a policy's
-// expressions (variables + validations) per evaluation, so that accounting, not
-// just the per-call value, is what needs to be matched then.
+// Two program options matter here, and only one of them is ours to set:
+//
+//   - the PER-EXPRESSION cost limit is already in place. MustBaseEnvSet bakes
+//     cel.CostLimit(PerCallLimit) in as a library option and cel-go applies it
+//     to every env.Program call, so no expression can exceed 1M units offline
+//     any more than it can at admission. Setting it again here would be a
+//     no-op at best and a parity break at worst, so we do not.
+//   - InterruptCheckFrequency is NOT in the base env set; the apiserver adds it
+//     in its own compiler (plugin/cel/compile.go). Without it ContextEval only
+//     notices a cancelled context between calls, so a comprehension over a long
+//     list ignores Ctrl+C until it finishes. With it the runtime checks every
+//     CheckFrequency steps, which is what makes an interrupted scan actually
+//     stop.
+//
+// The budget the base env cannot give us is the shared one across a policy's
+// expressions; that is accounted at evaluation time instead (see budget.go).
 func (e *Evaluator) compileProgram(expr string) (cel.Program, error) {
 	ast, issues := e.env.Compile(expr)
 	if issues != nil && issues.Err() != nil {
 		return nil, fmt.Errorf("compile: %w", issues.Err())
 	}
 
-	var opts []cel.ProgramOption
-	if e.costLimit > 0 {
-		opts = append(opts, cel.CostLimit(e.costLimit))
-	}
-	prog, err := e.env.Program(ast, opts...)
+	prog, err := e.env.Program(ast, cel.InterruptCheckFrequency(celconfig.CheckFrequency))
 	if err != nil {
 		return nil, fmt.Errorf("program: %w", err)
 	}

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -271,8 +271,8 @@ func resolvePlan(t *testing.T, expr string, obj map[string]any) []PathHint {
 	require.NoError(t, err)
 
 	violates := func(candidate map[string]any) bool {
-		activation := e.activationFor(context.Background(), candidate, nil, nil, nil)
-		out, err := e.evalExpression(context.Background(), expr, activation)
+		activation := e.activationFor(context.Background(), candidate, nil, nil, nil, nil)
+		out, err := e.evalExpression(context.Background(), expr, activation, nil)
 		require.NoError(t, err)
 		passed, ok := out.Value().(bool)
 		require.True(t, ok)


### PR DESCRIPTION
## Overview

We already match admission on the per-expression cost limit, since the base env bakes `cel.CostLimit(PerCallLimit)` into every program. What we do not match is the budget admission shares across a whole policy: the apiserver hands each
evaluation one `RuntimeCELCostBudget` (10M) and draws every variable, validation and messageExpression from it. So a policy whose expressions each fit under 1M but together run past 10M passes a scan and gets rejected at live admission,
which breaks the "if scan passes, admission passes" guarantee.

This adds that accounting in a new `budget.go`, one budget per object. A variable runs lazily inside whichever validation first reads it, so its cost is reported and settled together with that validation, matching the apiserver's
`compositionContext`. Programs also get `cel.InterruptCheckFrequency`, which the base env does not set. Without it cel-go never plans an interruptable evaluation and `ContextEval` checks the context neither before nor during a run, so today a
cancelled scan keeps grinding through a long comprehension.

Follows #2533 and stays inside the same per-object evaluation path.

Three calls worth flagging, none of them obvious from the diff:

1. **Running out of budget keeps the verdicts already reached.** The apiserver collapses the policy into one error, but that throws away a confirmed violation because a later validation ran long, the same thing rejected in the #2525 review. Validations that never ran carry the out of budget error, so they read as unknown and never as passing.

2. **Path derivation is deliberately unmetered.** It re-runs a validation once per list element against narrowed objects, work admission never does. Charging it would let a scan run out of budget where admission does not, and report
unknown for a violation admission is happy to reject. Each re-run is still capped by the per-call limit.

3. **messageExpression shares the budget but we interleave it.** The apiserver runs all validations then gives messages what is left; we resolve a message right after the validation that failed. Same expressions charged, so the same
policies fit, only which one first finds the budget empty can differ.

`WithCostLimit` becomes `WithCostBudget`. It was unused in the repo, and overriding the per-call limit only let you scan under a different ceiling than admission enforces, so it was a footgun rather than a feature.

## Testing

Seven tests in `budget_test.go`. They measure real expression cost through a helper rather than hardcoding numbers, so they will not drift when cel-go retunes its cost model. Each was checked by reverting the change it covers and confirming
it fails.

`go test ./core/pkg/opaprocessor/...` is green, cel package coverage 88.5%.

Part of #2001

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared CEL cost budgeting across all policy expressions evaluated for a single object, with a runtime default and configurable budget.
  * Evaluations stop once the shared budget is exhausted, and remaining validations are reported as out-of-budget.
  * Cost-budget behavior is now exposed via a cost-budget option (replacing the prior per-expression cost limit approach).
  * Context cancellation can interrupt long-running evaluations.

* **Bug Fixes**
  * Variable and memoized-variable costs are metered consistently across validations.
  * Violation path checks no longer consume evaluation budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->