### PR TITLE
feat : add DELETE /v1/scan to cancel an in-flight scan

### DIFF
--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
 )
 
 func useTemporaryConfigStore(t *testing.T) {
@@ -297,6 +298,9 @@ func Test_GetTenantConfig(t *testing.T) {
 	originalConnected := k8sinterface.IsConnectedToCluster()
 	t.Cleanup(func() { k8sinterface.SetConnectedToCluster(originalConnected) })
 
+	originalK8SConfig := k8sinterface.K8SConfig
+	t.Cleanup(func() { k8sinterface.K8SConfig = originalK8SConfig })
+
 	t.Run("not connected to cluster returns LocalConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(false)
 
@@ -306,6 +310,7 @@ func Test_GetTenantConfig(t *testing.T) {
 	})
 
 	t.Run("connected to cluster with k8s client returns ClusterConfig", func(t *testing.T) {
+		k8sinterface.K8SConfig = &restclient.Config{}
 		k8sinterface.SetConnectedToCluster(true)
 
 		k8s := k8sinterface.NewKubernetesApiMock()

--- a/httphandler/docs/swagger.yaml
+++ b/httphandler/docs/swagger.yaml
@@ -269,6 +269,26 @@ paths:
       tags:
       - scanning
   /v1/scan:
+    delete:
+      description: Cancels an in-flight scan, releasing it so a new scan can
+        run in its place.
+      operationId: cancelScan
+      parameters:
+      - description: ID of the scan to cancel. If empty, the latest scan is
+          cancelled.
+        format: uuid4
+        in: query
+        name: id
+        type: string
+        x-go-name: ScanID
+      responses:
+        "200":
+          $ref: '#/responses/scanResponse'
+        "404":
+          $ref: '#/responses/scanResponseNotFound'
+      summary: Cancels a scan
+      tags:
+      - scanning
     post:
       description: The server will return a scan ID and execute the scan.
       operationId: triggerScan
@@ -451,6 +471,60 @@ responses:
       A Scan Response that indicates no response body.
 
       Kubescape generates this response, for example, when results with given ID do not exist.
+  scanResponseNotFound:
+    description: A Scan Response that occures when no in-flight scan matches
+      the given ID
+    schema:
+      allOf:
+      - properties:
+          id:
+            description: ID of the scan
+            example: d13791eb-19b1-4222-867b-9a7c1799cfac
+            format: uuid4
+            type: string
+            x-go-name: ID
+          response:
+            description: The actual Response payload
+            example: d13791eb-19b1-4222-867b-9a7c1799cfac
+            type: object
+            x-go-name: Response
+          type:
+            description: |-
+              Type of this response
+              id IDScanResponseType  Deprecated: will return busy / notBusy instead
+              error ErrorScanResponseType  ErrorScanResponseType indicates a response that reports an error
+              v1results ResultsV1ScanResponseType  ResultsV1ScanResponseType indicates a response that carries a v1 Results object as payload
+              busy BusyScanResponseType  BusyScanResponseType indicates that a server is busy with a previous request
+              notBusy NotBusyScanResponseType  NotBusyScanResponseType indicates that a server is not busy with a previous request
+              ready ReadyScanResponseType  ReadyScanResponseType indicates that a server has successfully completed a request
+            enum:
+            - id
+            - error
+            - v1results
+            - busy
+            - notBusy
+            - ready
+            example: busy
+            type: string
+            x-go-enum-desc: |-
+              id IDScanResponseType  Deprecated: will return busy / notBusy instead
+              error ErrorScanResponseType  ErrorScanResponseType indicates a response that reports an error
+              v1results ResultsV1ScanResponseType  ResultsV1ScanResponseType indicates a response that carries a v1 Results object as payload
+              busy BusyScanResponseType  BusyScanResponseType indicates that a server is busy with a previous request
+              notBusy NotBusyScanResponseType  NotBusyScanResponseType indicates that a server is not busy with a previous request
+              ready ReadyScanResponseType  ReadyScanResponseType indicates that a server has successfully completed a request
+            x-go-name: Type
+        type: object
+      - properties:
+          response:
+            example: no in-flight scan found for 'd13791eb-19b1-4222-867b-9a7c1799cfac'
+            type: object
+            x-go-name: Resp
+          type:
+            example: error
+            type: string
+            x-go-name: Type
+        type: object
 schemes:
 - http
 swagger: "2.0"

--- a/httphandler/handlerequests/v1/cancel_test.go
+++ b/httphandler/handlerequests/v1/cancel_test.go
@@ -308,8 +308,7 @@ func TestCancelScan_WaitFalse_NoFailedArtifactLeftBehind(t *testing.T) {
 	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
-		writeScanErrorToFile(ctx.Err(), scanID)
-		return nil, ctx.Err()
+		return nil, writeScanErrorToFile(ctx.Err(), scanID)
 	}
 
 	h := NewHTTPHandler(false)

--- a/httphandler/handlerequests/v1/cancel_test.go
+++ b/httphandler/handlerequests/v1/cancel_test.go
@@ -1,0 +1,190 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+// ---------------------------------------------------------------------------
+// HTTPHandler.CancelScan endpoint tests
+//
+// CancelScan is the only way to stop a scan once it has been accepted: the
+// scan context is otherwise detached from the request via
+// context.WithoutCancel, so a stuck scan can only be cleared by cancelling
+// its stored context. These tests drive a real in-flight scan through the
+// watchForScan goroutine to prove cancellation actually reaches scanImpl.
+// ---------------------------------------------------------------------------
+
+func TestCancelScan_UnblocksBlockedScan_ReturnsErrorType(t *testing.T) {
+	withTempOutputDirs(t)
+
+	scanStarted := make(chan struct{})
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		close(scanStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := NewHTTPHandler(false)
+
+	scanDone := make(chan *http.Response, 1)
+	go func() {
+		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+		w := httptest.NewRecorder()
+		h.Scan(w, rq)
+		scanDone <- w.Result()
+	}()
+
+	select {
+	case <-scanStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan was never picked up by watchForScan")
+	}
+
+	scanID := h.state.getLatestID()
+
+	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+scanID, nil)
+	cancelW := httptest.NewRecorder()
+	h.CancelScan(cancelW, cancelRq)
+
+	if cancelW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("CancelScan status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
+	}
+
+	select {
+	case rs := <-scanDone:
+		var resp utilsmetav1.Response
+		if err := json.NewDecoder(rs.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode Scan response: %v", err)
+		}
+		if resp.Type != utilsapisv1.ErrorScanResponseType {
+			t.Errorf("Scan response type after cancellation = %v, want %v", resp.Type, utilsapisv1.ErrorScanResponseType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked scan did not unblock after cancellation")
+	}
+}
+
+func TestCancelScan_MarksNotBusy(t *testing.T) {
+	withTempOutputDirs(t)
+
+	scanStarted := make(chan struct{})
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		close(scanStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := NewHTTPHandler(false)
+
+	scanDone := make(chan *http.Response, 1)
+	go func() {
+		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+		w := httptest.NewRecorder()
+		h.Scan(w, rq)
+		scanDone <- w.Result()
+	}()
+
+	select {
+	case <-scanStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan was never picked up by watchForScan")
+	}
+
+	scanID := h.state.getLatestID()
+
+	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+scanID, nil)
+	cancelW := httptest.NewRecorder()
+	h.CancelScan(cancelW, cancelRq)
+
+	if h.state.isBusy(scanID) {
+		t.Errorf("isBusy(%q) after CancelScan = true; want false", scanID)
+	}
+
+	// Drain the goroutine so it doesn't leak past the test.
+	<-scanDone
+}
+
+func TestCancelScan_UnknownID_Returns404(t *testing.T) {
+	h := &HTTPHandler{state: newServerState()}
+
+	rq := httptest.NewRequest(http.MethodDelete, "/scan?id=does-not-exist", nil)
+	w := httptest.NewRecorder()
+	h.CancelScan(w, rq)
+
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Errorf("CancelScan with unknown ID = HTTP %d; want %d", w.Result().StatusCode, http.StatusNotFound)
+	}
+
+	var resp utilsmetav1.Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode CancelScan response: %v", err)
+	}
+	if resp.Type != utilsapisv1.ErrorScanResponseType {
+		t.Errorf("CancelScan with unknown ID: response.Type = %q; want %q", resp.Type, utilsapisv1.ErrorScanResponseType)
+	}
+}
+
+func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
+	withTempOutputDirs(t)
+
+	scanStarted := make(chan struct{})
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		close(scanStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := NewHTTPHandler(false)
+
+	scanDone := make(chan *http.Response, 1)
+	go func() {
+		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+		w := httptest.NewRecorder()
+		h.Scan(w, rq)
+		scanDone <- w.Result()
+	}()
+
+	select {
+	case <-scanStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan was never picked up by watchForScan")
+	}
+
+	scanID := h.state.getLatestID()
+
+	// No ?id= query param: must resolve to the latest (only) running scan.
+	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan", nil)
+	cancelW := httptest.NewRecorder()
+	h.CancelScan(cancelW, cancelRq)
+
+	if cancelW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("CancelScan with empty ID status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
+	}
+
+	var resp utilsmetav1.Response
+	if err := json.NewDecoder(cancelW.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode CancelScan response: %v", err)
+	}
+	if resp.ID != scanID {
+		t.Errorf("CancelScan with empty ID: response.ID = %q; want %q (latest scan)", resp.ID, scanID)
+	}
+
+	select {
+	case <-scanDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked scan did not unblock after cancelling via empty ID")
+	}
+}

--- a/httphandler/handlerequests/v1/cancel_test.go
+++ b/httphandler/handlerequests/v1/cancel_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -79,10 +81,12 @@ func TestCancelScan_MarksNotBusy(t *testing.T) {
 	withTempOutputDirs(t)
 
 	scanStarted := make(chan struct{})
+	releaseScan := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
 	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
+		<-releaseScan
 		return nil, ctx.Err()
 	}
 
@@ -108,12 +112,28 @@ func TestCancelScan_MarksNotBusy(t *testing.T) {
 	cancelW := httptest.NewRecorder()
 	h.CancelScan(cancelW, cancelRq)
 
-	if h.state.isBusy(scanID) {
-		t.Errorf("isBusy(%q) after CancelScan = true; want false", scanID)
+	if cancelW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("CancelScan status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
 	}
 
-	// Drain the goroutine so it doesn't leak past the test.
-	<-scanDone
+	// cancel() only invokes the CancelFunc and marks the entry cancelled; it
+	// must not remove it. The scan stays busy until executeScan itself calls
+	// setNotBusy once scanImpl actually returns.
+	if !h.state.isBusy(scanID) {
+		t.Errorf("isBusy(%q) immediately after CancelScan = false; want true: entry must survive until executeScan calls setNotBusy", scanID)
+	}
+
+	close(releaseScan)
+
+	select {
+	case <-scanDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan did not complete after being released")
+	}
+
+	if h.state.isBusy(scanID) {
+		t.Errorf("isBusy(%q) after executeScan completes = true; want false", scanID)
+	}
 }
 
 func TestCancelScan_UnknownID_Returns404(t *testing.T) {
@@ -165,7 +185,7 @@ func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
 
 	scanID := h.state.getLatestID()
 
-	// No ?id= query param: must resolve to the latest (only) running scan.
+	// No ?id= query param: must resolve to the currently-executing user scan.
 	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan", nil)
 	cancelW := httptest.NewRecorder()
 	h.CancelScan(cancelW, cancelRq)
@@ -179,7 +199,7 @@ func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
 		t.Fatalf("failed to decode CancelScan response: %v", err)
 	}
 	if resp.ID != scanID {
-		t.Errorf("CancelScan with empty ID: response.ID = %q; want %q (latest scan)", resp.ID, scanID)
+		t.Errorf("CancelScan with empty ID: response.ID = %q; want %q (currently executing scan)", resp.ID, scanID)
 	}
 
 	select {
@@ -189,7 +209,14 @@ func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
 	}
 }
 
-func TestCancelScan_DrainsQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
+// TestCancelScan_SkipsCancelledQueuedRequest_UnblocksWaitingCaller cancels a
+// request that is still sitting in scanRequestChan, behind another scan that
+// is currently executing. watchForScan must not run scanImpl for it once
+// dequeued; it must instead respond with an error and release the busy slot.
+// The second request is submitted directly (bypassing Scan's HTTP path) via a
+// signal channel closed once it lands in scanRequestChan, so the test does
+// not depend on timing.
+func TestCancelScan_SkipsCancelledQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
 	withTempOutputDirs(t)
 
 	firstStarted := make(chan struct{})
@@ -217,24 +244,28 @@ func TestCancelScan_DrainsQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
 	}
 	firstID := h.state.getLatestID()
 
-	secondDone := make(chan *http.Response, 1)
+	secondID := "22222222-3333-4444-5555-666666666666"
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	secondResp := make(chan *utilsmetav1.Response, 1)
+
+	submitted := make(chan struct{})
 	go func() {
-		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
-		w := httptest.NewRecorder()
-		h.Scan(w, rq)
-		secondDone <- w.Result()
+		h.state.setBusy(secondID, secondCancel)
+		h.scanRequestChan <- &scanRequestParams{
+			scanID:          secondID,
+			scanInfo:        &cautils.ScanInfo{},
+			scanQueryParams: &ScanQueryParams{ReturnResults: true},
+			ctx:             secondCtx,
+			resp:            secondResp,
+			isUserScan:      true,
+		}
+		close(submitted)
 	}()
 
-	var secondID string
-	for i := 0; i < 200; i++ {
-		if h.state.len() == 2 {
-			secondID = h.state.getLatestID()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if secondID == "" || secondID == firstID {
-		t.Fatalf("second scan was never queued (secondID=%q, firstID=%q)", secondID, firstID)
+	select {
+	case <-submitted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second request was never submitted to scanRequestChan")
 	}
 
 	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+secondID, nil)
@@ -245,12 +276,13 @@ func TestCancelScan_DrainsQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
 		t.Fatalf("CancelScan status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
 	}
 
+	cleanupRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+firstID, nil)
+	cleanupW := httptest.NewRecorder()
+	h.CancelScan(cleanupW, cleanupRq)
+	<-firstDone
+
 	select {
-	case rs := <-secondDone:
-		var resp utilsmetav1.Response
-		if err := json.NewDecoder(rs.Body).Decode(&resp); err != nil {
-			t.Fatalf("failed to decode second Scan response: %v", err)
-		}
+	case resp := <-secondResp:
 		if resp.Type != utilsapisv1.ErrorScanResponseType {
 			t.Errorf("queued scan response type = %v, want %v", resp.Type, utilsapisv1.ErrorScanResponseType)
 		}
@@ -258,8 +290,67 @@ func TestCancelScan_DrainsQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
 		t.Fatal("queued scan caller blocked forever after cancellation")
 	}
 
-	cleanupRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+firstID, nil)
-	cleanupW := httptest.NewRecorder()
-	h.CancelScan(cleanupW, cleanupRq)
-	<-firstDone
+	if h.state.isBusy(secondID) {
+		t.Errorf("isBusy(%q) after skipped cancelled scan = true; want false", secondID)
+	}
+}
+
+// TestCancelScan_WaitFalse_NoFailedArtifactLeftBehind covers a wait=false
+// scan whose scanImpl writes a failure artifact before observing
+// cancellation (mirroring what the real scan() does via
+// writeScanErrorToFile). executeScan must remove that artifact on genuine
+// cancellation rather than leave it in FailedOutputDir.
+func TestCancelScan_WaitFalse_NoFailedArtifactLeftBehind(t *testing.T) {
+	withTempOutputDirs(t)
+
+	scanStarted := make(chan struct{})
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		close(scanStarted)
+		<-ctx.Done()
+		writeScanErrorToFile(ctx.Err(), scanID)
+		return nil, ctx.Err()
+	}
+
+	h := NewHTTPHandler(false)
+
+	rq := httptest.NewRequest(http.MethodPost, "/scan", testBody(t)) // wait=false
+	w := httptest.NewRecorder()
+	h.Scan(w, rq)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("Scan (wait=false) status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+	var acceptResp utilsmetav1.Response
+	if err := json.NewDecoder(w.Body).Decode(&acceptResp); err != nil {
+		t.Fatalf("failed to decode Scan (wait=false) response: %v", err)
+	}
+	scanID := acceptResp.ID
+
+	select {
+	case <-scanStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan was never picked up by watchForScan")
+	}
+
+	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+scanID, nil)
+	cancelW := httptest.NewRecorder()
+	h.CancelScan(cancelW, cancelRq)
+
+	if cancelW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("CancelScan status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for h.state.isBusy(scanID) {
+		if time.Now().After(deadline) {
+			t.Fatal("scan never released its busy slot after cancellation")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	failedPath := filepath.Join(FailedOutputDir, scanID)
+	if _, err := os.Stat(failedPath); err == nil {
+		t.Errorf("FailedOutputDir artifact %q exists after cancellation; want it removed", failedPath)
+	}
 }

--- a/httphandler/handlerequests/v1/cancel_test.go
+++ b/httphandler/handlerequests/v1/cancel_test.go
@@ -188,3 +188,78 @@ func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
 		t.Fatal("blocked scan did not unblock after cancelling via empty ID")
 	}
 }
+
+func TestCancelScan_DrainsQueuedRequest_UnblocksWaitingCaller(t *testing.T) {
+	withTempOutputDirs(t)
+
+	firstStarted := make(chan struct{})
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		close(firstStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := NewHTTPHandler(false)
+
+	firstDone := make(chan *http.Response, 1)
+	go func() {
+		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+		w := httptest.NewRecorder()
+		h.Scan(w, rq)
+		firstDone <- w.Result()
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first scan was never picked up by watchForScan")
+	}
+	firstID := h.state.getLatestID()
+
+	secondDone := make(chan *http.Response, 1)
+	go func() {
+		rq := httptest.NewRequest(http.MethodPost, "/scan?wait=true", testBody(t))
+		w := httptest.NewRecorder()
+		h.Scan(w, rq)
+		secondDone <- w.Result()
+	}()
+
+	var secondID string
+	for i := 0; i < 200; i++ {
+		if h.state.len() == 2 {
+			secondID = h.state.getLatestID()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if secondID == "" || secondID == firstID {
+		t.Fatalf("second scan was never queued (secondID=%q, firstID=%q)", secondID, firstID)
+	}
+
+	cancelRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+secondID, nil)
+	cancelW := httptest.NewRecorder()
+	h.CancelScan(cancelW, cancelRq)
+
+	if cancelW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("CancelScan status = %d, want %d", cancelW.Result().StatusCode, http.StatusOK)
+	}
+
+	select {
+	case rs := <-secondDone:
+		var resp utilsmetav1.Response
+		if err := json.NewDecoder(rs.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode second Scan response: %v", err)
+		}
+		if resp.Type != utilsapisv1.ErrorScanResponseType {
+			t.Errorf("queued scan response type = %v, want %v", resp.Type, utilsapisv1.ErrorScanResponseType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued scan caller blocked forever after cancellation")
+	}
+
+	cleanupRq := httptest.NewRequest(http.MethodDelete, "/scan?id="+firstID, nil)
+	cleanupW := httptest.NewRecorder()
+	h.CancelScan(cleanupW, cleanupRq)
+	<-firstDone
+}

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -36,7 +36,10 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	scanID := uuid.NewString()
 	defer handler.recover(r.Context(), w, scanID)
 
-	handler.state.setBusy(scanID)
+	scanCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
+	defer cancel()
+
+	handler.state.setBusy(scanID, cancel)
 	defer handler.state.setNotBusy(scanID)
 
 	metricsQueryParams := &MetricsQueryParams{}
@@ -58,7 +61,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		},
 		scanInfo: scanInfo,
 		scanID:   scanID,
-		ctx:      context.WithoutCancel(r.Context()),
+		ctx:      scanCtx,
 		resp:     make(chan *utilsmetav1.Response, 1),
 	}
 

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -80,6 +80,7 @@ type scanRequestParams struct {
 	ctx             context.Context
 	resp            chan *utilsmetav1.Response // Respose chan; nil if not interested.
 	callbackURL     string                     // validated scan-completion callback URL; empty if not requested.
+	isUserScan      bool                       // true when submitted via the Scan handler, not Metrics
 }
 
 // swagger:parameters triggerScan
@@ -110,6 +111,7 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 		scanID:          scanID,
 		scanQueryParams: &ScanQueryParams{},
 		scanInfo:        getScanCommand(scanRequest, scanID),
+		isUserScan:      true,
 	}
 	if err := schema.NewDecoder().Decode(p.scanQueryParams, r.URL.Query()); err != nil {
 		return p, fmt.Errorf("failed to parse query params, reason: %s", err.Error())

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -63,6 +63,15 @@ type StatusQueryParams struct {
 	ScanID string `schema:"id" json:"id"`
 }
 
+// swagger:parameters cancelScan
+type CancelScanQueryParams struct {
+	// ID of the scan to cancel. If empty, the latest scan is cancelled.
+	//
+	// in:query
+	// swagger:strfmt uuid4
+	ScanID string `schema:"id" json:"id"`
+}
+
 // scanRequestParams params passed to channel
 type scanRequestParams struct {
 	scanInfo        *cautils.ScanInfo // request as received from api

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -140,14 +140,15 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		handler.writeError(w, err, "")
 		return
 	}
-	scanRequestParams.ctx = context.WithoutCancel(r.Context())
+	cancelCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
+	scanRequestParams.ctx = cancelCtx
 
 	if handler.offline {
 		scanRequestParams.scanInfo.UseDefault = true
 		scanRequestParams.scanInfo.UseArtifactsFrom = getter.DefaultLocalStore
 	}
 
-	handler.state.setBusy(scanID)
+	handler.state.setBusy(scanID, cancel)
 
 	select {
 	case handler.scanRequestChan <- scanRequestParams:
@@ -198,6 +199,70 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(statusCode)
 	w.Write(responseToBytes(response))
+}
+
+// CancelScan handles DELETE /v1/scan
+func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	defer handler.recover(r.Context(), w, "")
+	defer r.Body.Close()
+
+	cancelQueryParams := &CancelScanQueryParams{}
+	if err := schema.NewDecoder().Decode(cancelQueryParams, r.URL.Query()); err != nil {
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
+		return
+	}
+
+	scanID := cancelQueryParams.ScanID
+	if scanID == "" {
+		scanID = handler.state.getLatestID()
+	}
+
+	logger.L().Info("requesting scan cancellation", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
+
+	if !handler.state.cancel(scanID) {
+		logger.L().Info("cancel: no in-flight scan", helpers.String("ID", scanID))
+		w.WriteHeader(http.StatusNotFound)
+		response := utilsmetav1.Response{
+			Response: fmt.Sprintf("no in-flight scan found for '%s'", scanID),
+			Type:     utilsapisv1.ErrorScanResponseType,
+		}
+		w.Write(responseToBytes(&response))
+		return
+	}
+
+	handler.drainQueuedScan(scanID)
+
+	logger.L().Info("scan cancelled", helpers.String("ID", scanID))
+	w.WriteHeader(http.StatusOK)
+	response := utilsmetav1.Response{
+		ID:       scanID,
+		Response: fmt.Sprintf("scan '%s' cancelled", scanID),
+		Type:     utilsapisv1.NotBusyScanResponseType,
+	}
+	w.Write(responseToBytes(&response))
+}
+
+// drainQueuedScan removes a not-yet-started scan request for id from the
+// pending queue, if it is still sitting there. It is best-effort: a request
+// already picked up by watchForScan is unaffected and relies on the
+// cancelled context to stop it promptly instead.
+func (handler *HTTPHandler) drainQueuedScan(id string) {
+	pending := make([]*scanRequestParams, 0, len(handler.scanRequestChan))
+	for {
+		select {
+		case req := <-handler.scanRequestChan:
+			if req.scanID == id {
+				continue
+			}
+			pending = append(pending, req)
+		default:
+			for _, req := range pending {
+				handler.scanRequestChan <- req
+			}
+			return
+		}
+	}
 }
 
 // ============================================== RESULTS ========================================================

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -149,7 +149,6 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler.state.setBusy(scanID, cancel)
-	handler.state.setLatestUserScanID(scanID)
 
 	select {
 	case handler.scanRequestChan <- scanRequestParams:
@@ -232,8 +231,6 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	handler.drainQueuedScan(scanID)
-
 	logger.L().Info("scan cancelled", helpers.String("ID", scanID))
 	w.WriteHeader(http.StatusOK)
 	response := utilsmetav1.Response{
@@ -242,38 +239,6 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 		Type:     utilsapisv1.NotBusyScanResponseType,
 	}
 	w.Write(responseToBytes(&response))
-}
-
-// drainQueuedScan removes a not-yet-started scan request for id from the
-// pending queue, if it is still sitting there. It is best-effort: a request
-// already picked up by watchForScan is unaffected and relies on the
-// cancelled context to stop it promptly instead.
-func (handler *HTTPHandler) drainQueuedScan(id string) {
-	pending := make([]*scanRequestParams, 0, len(handler.scanRequestChan))
-	for {
-		select {
-		case req := <-handler.scanRequestChan:
-			if req.scanID == id {
-				if req.resp != nil {
-					select {
-					case req.resp <- &utilsmetav1.Response{
-						ID:       req.scanID,
-						Type:     utilsapisv1.ErrorScanResponseType,
-						Response: fmt.Sprintf("scan '%s' was cancelled", req.scanID),
-					}:
-					default:
-					}
-				}
-				continue
-			}
-			pending = append(pending, req)
-		default:
-			for _, req := range pending {
-				handler.scanRequestChan <- req
-			}
-			return
-		}
-	}
 }
 
 // ============================================== RESULTS ========================================================

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -149,6 +149,7 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler.state.setBusy(scanID, cancel)
+	handler.state.setLatestUserScanID(scanID)
 
 	select {
 	case handler.scanRequestChan <- scanRequestParams:
@@ -215,7 +216,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 
 	scanID := cancelQueryParams.ScanID
 	if scanID == "" {
-		scanID = handler.state.getLatestID()
+		scanID = handler.state.getLatestUserScanID()
 	}
 
 	logger.L().Info("requesting scan cancellation", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
@@ -253,6 +254,16 @@ func (handler *HTTPHandler) drainQueuedScan(id string) {
 		select {
 		case req := <-handler.scanRequestChan:
 			if req.scanID == id {
+				if req.resp != nil {
+					select {
+					case req.resp <- &utilsmetav1.Response{
+						ID:       req.scanID,
+						Type:     utilsapisv1.ErrorScanResponseType,
+						Response: fmt.Sprintf("scan '%s' was cancelled", req.scanID),
+					}:
+					default:
+					}
+				}
 				continue
 			}
 			pending = append(pending, req)

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -62,10 +62,18 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
 	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {
-		logger.L().Ctx(scanReq.ctx).Error("scanning failed", helpers.String("ID", scanReq.scanID), helpers.Error(err))
-		if scanReq.scanQueryParams.ReturnResults {
-			response.Type = utilsapisv1.ErrorScanResponseType
-			response.Response = err.Error()
+		if scanReq.ctx.Err() == context.Canceled {
+			logger.L().Ctx(scanReq.ctx).Info("scan cancelled", helpers.String("ID", scanReq.scanID))
+			if scanReq.scanQueryParams.ReturnResults {
+				response.Type = utilsapisv1.ErrorScanResponseType
+				response.Response = fmt.Sprintf("scan '%s' was cancelled", scanReq.scanID)
+			}
+		} else {
+			logger.L().Ctx(scanReq.ctx).Error("scanning failed", helpers.String("ID", scanReq.scanID), helpers.Error(err))
+			if scanReq.scanQueryParams.ReturnResults {
+				response.Type = utilsapisv1.ErrorScanResponseType
+				response.Response = err.Error()
+			}
 		}
 	} else {
 		logger.L().Ctx(scanReq.ctx).Success("done scanning", helpers.String("ID", scanReq.scanID))

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -64,7 +64,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
 	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {
-		if errors.Is(err, context.Canceled) && errors.Is(scanReq.ctx.Err(), context.Canceled) {
+		if errors.Is(scanReq.ctx.Err(), context.Canceled) {
 			logger.L().Ctx(scanReq.ctx).Info("scan cancelled", helpers.String("ID", scanReq.scanID))
 			removeResultsFile(scanReq.scanID)
 			if scanReq.scanQueryParams.ReturnResults {
@@ -133,6 +133,21 @@ func (handler *HTTPHandler) watchForScan() {
 				default:
 				}
 			}
+			if scanReq.callbackURL != "" {
+				payload := scanCallbackPayload{ID: scanReq.scanID, Status: callbackStatusFailed, Error: "scan cancelled"}
+				cbCtx := context.WithoutCancel(scanReq.ctx)
+				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							logger.L().Ctx(cbCtx).Error("scan completion callback panicked", helpers.String("ID", scanReq.scanID), helpers.Error(fmt.Errorf("%v", r)))
+						}
+					}()
+					if cbErr := postScanCallback(cbCtx, scanReq.callbackURL, payload); cbErr != nil {
+						logger.L().Ctx(cbCtx).Error("failed to deliver scan completion callback", helpers.String("ID", scanReq.scanID), helpers.Error(cbErr))
+					}
+				}()
+			}
+			handler.state.releaseCancel(scanReq.scanID)
 			handler.state.setNotBusy(scanReq.scanID)
 			continue
 		}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -47,6 +48,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 				logger.L().Ctx(scanReq.ctx).Error("failed to persist panic error to file", helpers.String("ID", scanReq.scanID), helpers.Error(persistErr))
 				responseMsg = persistErr.Error()
 			}
+			handler.state.releaseCancel(scanReq.scanID)
 			handler.state.setNotBusy(scanReq.scanID)
 			if scanReq.scanQueryParams.ReturnResults {
 				response.Type = utilsapisv1.ErrorScanResponseType
@@ -62,8 +64,9 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
 	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {
-		if scanReq.ctx.Err() == context.Canceled {
+		if errors.Is(err, context.Canceled) && errors.Is(scanReq.ctx.Err(), context.Canceled) {
 			logger.L().Ctx(scanReq.ctx).Info("scan cancelled", helpers.String("ID", scanReq.scanID))
+			removeResultsFile(scanReq.scanID)
 			if scanReq.scanQueryParams.ReturnResults {
 				response.Type = utilsapisv1.ErrorScanResponseType
 				response.Response = fmt.Sprintf("scan '%s' was cancelled", scanReq.scanID)
@@ -82,6 +85,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 		}
 	}
 
+	handler.state.releaseCancel(scanReq.scanID)
 	handler.state.setNotBusy(scanReq.scanID)
 
 	// return results, if someone's waiting for them; never block.
@@ -114,6 +118,24 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 func (handler *HTTPHandler) watchForScan() {
 	for {
 		scanReq := <-handler.scanRequestChan
+		if scanReq.isUserScan {
+			handler.state.setLatestUserScanID(scanReq.scanID)
+		}
+		if handler.state.isCancelled(scanReq.scanID) {
+			logger.L().Info("skipping cancelled scan", helpers.String("scanID", scanReq.scanID))
+			if scanReq.resp != nil {
+				select {
+				case scanReq.resp <- &utilsmetav1.Response{
+					ID:       scanReq.scanID,
+					Type:     utilsapisv1.ErrorScanResponseType,
+					Response: fmt.Sprintf("scan '%s' was cancelled", scanReq.scanID),
+				}:
+				default:
+				}
+			}
+			handler.state.setNotBusy(scanReq.scanID)
+			continue
+		}
 		logger.L().Info("triggering scan", helpers.String("scanID", scanReq.scanID))
 		handler.executeScan(scanReq)
 	}

--- a/httphandler/handlerequests/v1/results_handler_test.go
+++ b/httphandler/handlerequests/v1/results_handler_test.go
@@ -90,7 +90,7 @@ func TestResults_DeleteAll_RefusedWhileScanInProgress(t *testing.T) {
 	}
 
 	h := newResultsHandler(false)
-	h.state.setBusy("scan-in-flight") // simulate an active scan
+	h.state.setBusy("scan-in-flight", func() {}) // simulate an active scan
 
 	rq := httptest.NewRequest(http.MethodDelete, "/results?all=true", nil)
 	w := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestResults_GetWhileBusy_ReturnsBusyResponse(t *testing.T) {
 
 	h := newResultsHandler(false)
 	id := "123e4567-e89b-12d3-a456-426614174000"
-	h.state.setBusy(id)
+	h.state.setBusy(id, func() {})
 
 	rq := httptest.NewRequest(http.MethodGet, "/results?id="+id, nil)
 	w := httptest.NewRecorder()
@@ -258,7 +258,7 @@ func TestResults_GetEmptyID_OfflineFallback_TableDriven(t *testing.T) {
 			h := newResultsHandler(true) // offline = true
 
 			if c.seedLatest {
-				h.state.setBusy(validUUID)
+				h.state.setBusy(validUUID, func() {})
 				h.state.setNotBusy(validUUID) // latestID survives, scan finished
 			}
 			resultFile := filepath.Join(out, validUUID)
@@ -316,7 +316,7 @@ func TestResults_DeleteEmptyID_OfflineRejected(t *testing.T) {
 	out := withTempOutputDirs(t)
 
 	h := newResultsHandler(true)
-	h.state.setBusy(validUUID)
+	h.state.setBusy(validUUID, func() {})
 	h.state.setNotBusy(validUUID) // latestID == validUUID, scan idle
 
 	resultFile := filepath.Join(out, validUUID)

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -7,9 +7,10 @@ import (
 )
 
 type serverState struct {
-	statusID map[string]context.CancelFunc
-	latestID string
-	mtx      sync.RWMutex
+	statusID         map[string]context.CancelFunc
+	latestID         string
+	latestUserScanID string
+	mtx              sync.RWMutex
 }
 
 // isBusy is server busy with ID, if id is empty will check for latest ID
@@ -39,6 +40,22 @@ func (s *serverState) setNotBusy(id string) {
 func (s *serverState) getLatestID() string {
 	s.mtx.RLock()
 	id := s.latestID
+	s.mtx.RUnlock()
+	return id
+}
+
+// setLatestUserScanID records id as the latest user-triggered scan (via the
+// Scan handler). Internal scans (e.g. Metrics) do not call this, so it stays
+// distinct from latestID, which any caller of setBusy can advance.
+func (s *serverState) setLatestUserScanID(id string) {
+	s.mtx.Lock()
+	s.latestUserScanID = id
+	s.mtx.Unlock()
+}
+
+func (s *serverState) getLatestUserScanID() string {
+	s.mtx.RLock()
+	id := s.latestUserScanID
 	s.mtx.RUnlock()
 	return id
 }

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -6,8 +6,13 @@ import (
 	"sync"
 )
 
+type scanEntry struct {
+	cancel    context.CancelFunc
+	cancelled bool
+}
+
 type serverState struct {
-	statusID         map[string]context.CancelFunc
+	statusID         map[string]*scanEntry
 	latestID         string
 	latestUserScanID string
 	mtx              sync.RWMutex
@@ -26,7 +31,7 @@ func (s *serverState) isBusy(id string) bool {
 
 func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 	s.mtx.Lock()
-	s.statusID[id] = cancel
+	s.statusID[id] = &scanEntry{cancel: cancel}
 	s.latestID = id
 	s.mtx.Unlock()
 }
@@ -34,6 +39,9 @@ func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 func (s *serverState) setNotBusy(id string) {
 	s.mtx.Lock()
 	delete(s.statusID, id)
+	if s.latestUserScanID == id {
+		s.latestUserScanID = ""
+	}
 	s.mtx.Unlock()
 }
 
@@ -44,9 +52,10 @@ func (s *serverState) getLatestID() string {
 	return id
 }
 
-// setLatestUserScanID records id as the latest user-triggered scan (via the
-// Scan handler). Internal scans (e.g. Metrics) do not call this, so it stays
-// distinct from latestID, which any caller of setBusy can advance.
+// setLatestUserScanID records id as the scan currently executing on behalf of
+// the Scan handler (not Metrics). watchForScan calls this when it dequeues a
+// user-submitted request, so it always reflects the scan actually running,
+// not merely the last one accepted into the queue.
 func (s *serverState) setLatestUserScanID(id string) {
 	s.mtx.Lock()
 	s.latestUserScanID = id
@@ -77,34 +86,54 @@ func (s *serverState) removeAllIfIdle(removeFn func()) error {
 	return nil
 }
 
-// cancel invokes the CancelFunc stored for id and removes it from the busy
-// set. It returns false if id has no in-flight scan, either because it is
-// unknown or the scan has already finished.
-func (s *serverState) cancel(id string) bool {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-	cancelFunc, ok := s.statusID[id]
+// releaseLocked invokes the CancelFunc for id and marks it cancelled, if
+// present. Must be called with mtx held. It never removes the entry --
+// setNotBusy owns removal, so isBusy/isCancelled stay accurate until the
+// scan has actually stopped running.
+func (s *serverState) releaseLocked(id string) bool {
+	entry, ok := s.statusID[id]
 	if !ok {
 		return false
 	}
-	cancelFunc()
-	delete(s.statusID, id)
+	entry.cancelled = true
+	entry.cancel()
 	return true
 }
 
-// cancelAll invokes every stored CancelFunc and clears the busy set.
-func (s *serverState) cancelAll() {
+// cancel invokes the CancelFunc stored for id and marks it cancelled. It
+// returns false if id has no in-flight scan, either because it is unknown or
+// the scan has already finished.
+func (s *serverState) cancel(id string) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	for id, cancelFunc := range s.statusID {
-		cancelFunc()
-		delete(s.statusID, id)
+	return s.releaseLocked(id)
+}
+
+// releaseCancel invokes the CancelFunc for id, if present, without regard to
+// whether it was already cancelled. executeScan calls this on every
+// completion path (success, failure, or cancellation) so a scan's cancel
+// func is always released once it stops running.
+func (s *serverState) releaseCancel(id string) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.releaseLocked(id)
+}
+
+// isCancelled reports whether id was cancelled while still queued or while
+// running. It stays true after cancel() until setNotBusy removes the entry.
+func (s *serverState) isCancelled(id string) bool {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	entry, ok := s.statusID[id]
+	if !ok {
+		return false
 	}
+	return entry.cancelled
 }
 
 func newServerState() *serverState {
 	return &serverState{
-		statusID: make(map[string]context.CancelFunc),
+		statusID: make(map[string]*scanEntry),
 		mtx:      sync.RWMutex{},
 	}
 }

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -1,12 +1,13 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
 
 type serverState struct {
-	statusID map[string]bool
+	statusID map[string]context.CancelFunc
 	latestID string
 	mtx      sync.RWMutex
 }
@@ -17,14 +18,14 @@ func (s *serverState) isBusy(id string) bool {
 	if id == "" {
 		id = s.latestID
 	}
-	busy := s.statusID[id]
+	_, busy := s.statusID[id]
 	s.mtx.RUnlock()
 	return busy
 }
 
-func (s *serverState) setBusy(id string) {
+func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 	s.mtx.Lock()
-	s.statusID[id] = true
+	s.statusID[id] = cancel
 	s.latestID = id
 	s.mtx.Unlock()
 }
@@ -59,9 +60,34 @@ func (s *serverState) removeAllIfIdle(removeFn func()) error {
 	return nil
 }
 
+// cancel invokes the CancelFunc stored for id and removes it from the busy
+// set. It returns false if id has no in-flight scan, either because it is
+// unknown or the scan has already finished.
+func (s *serverState) cancel(id string) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	cancelFunc, ok := s.statusID[id]
+	if !ok {
+		return false
+	}
+	cancelFunc()
+	delete(s.statusID, id)
+	return true
+}
+
+// cancelAll invokes every stored CancelFunc and clears the busy set.
+func (s *serverState) cancelAll() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for id, cancelFunc := range s.statusID {
+		cancelFunc()
+		delete(s.statusID, id)
+	}
+}
+
 func newServerState() *serverState {
 	return &serverState{
-		statusID: make(map[string]bool),
+		statusID: make(map[string]context.CancelFunc),
 		mtx:      sync.RWMutex{},
 	}
 }

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -42,7 +42,7 @@ func TestServerState_InitialState(t *testing.T) {
 
 func TestServerState_SetBusyMakesIDReachable(t *testing.T) {
 	s := newServerState()
-	s.setBusy("scan-abc")
+	s.setBusy("scan-abc", func() {})
 
 	// After setBusy the ID must be visible.
 	if !s.isBusy("scan-abc") {
@@ -64,7 +64,7 @@ func TestServerState_SetBusyMakesIDReachable(t *testing.T) {
 
 func TestServerState_SetNotBusyClearsID(t *testing.T) {
 	s := newServerState()
-	s.setBusy("scan-xyz")
+	s.setBusy("scan-xyz", func() {})
 	s.setNotBusy("scan-xyz")
 
 	// After completion the scan must report not-busy.
@@ -88,8 +88,8 @@ func TestServerState_SetNotBusyClearsID(t *testing.T) {
 
 func TestServerState_LatestIDTracksLastRegisteredScan(t *testing.T) {
 	s := newServerState()
-	s.setBusy("first")
-	s.setBusy("second")
+	s.setBusy("first", func() {})
+	s.setBusy("second", func() {})
 
 	// latestID must always reflect the most recent setBusy call.
 	if id := s.getLatestID(); id != "second" {
@@ -150,7 +150,7 @@ func TestStatus_WhenNoScanHasRun_ReturnsNotBusy(t *testing.T) {
 
 func TestStatus_WhenScanIsRunning_WithExplicitID_ReturnsBusy(t *testing.T) {
 	h := &HTTPHandler{state: newServerState()}
-	h.state.setBusy("scan-123")
+	h.state.setBusy("scan-123", func() {})
 
 	rq := httptest.NewRequest(http.MethodGet, "/status?id=scan-123", nil)
 	w := httptest.NewRecorder()
@@ -176,7 +176,7 @@ func TestStatus_WhenScanIsRunning_WithEmptyID_ResolvesViaLatestID(t *testing.T) 
 	// isBusy("") resolves to statusID[latestID], and then the handler
 	// populates the response ID from getLatestID(). Both steps are untested.
 	h := &HTTPHandler{state: newServerState()}
-	h.state.setBusy("scan-456")
+	h.state.setBusy("scan-456", func() {})
 
 	rq := httptest.NewRequest(http.MethodGet, "/status", nil) // no ?id= param
 	w := httptest.NewRecorder()
@@ -198,7 +198,7 @@ func TestStatus_AfterScanCompletes_ReturnsNotBusy(t *testing.T) {
 	// Without this test a regression where setNotBusy fails to clear the state
 	// would cause the operator to believe a scan is running indefinitely.
 	h := &HTTPHandler{state: newServerState()}
-	h.state.setBusy("scan-789")
+	h.state.setBusy("scan-789", func() {})
 	h.state.setNotBusy("scan-789") // scan finished
 
 	rq := httptest.NewRequest(http.MethodGet, "/status?id=scan-789", nil)

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -67,7 +67,8 @@ func SetupHTTPListener() error {
 	v1SubRouter := rtr.PathPrefix(v1PathPrefix).Subrouter()
 	v1SubRouter.Use(otelMiddleware)
 	v1SubRouter.HandleFunc(v1PrometheusMetricsPath, httpHandler.Metrics) // deprecated
-	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.Scan)
+	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.Scan).Methods(http.MethodPost)
+	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.CancelScan).Methods(http.MethodDelete)
 	v1SubRouter.HandleFunc(v1StatusPath, httpHandler.Status)
 	v1SubRouter.HandleFunc(v1ResultsPath, httpHandler.GetResults).Methods(http.MethodGet)
 	v1SubRouter.HandleFunc(v1ResultsPath, httpHandler.DeleteResults).Methods(http.MethodDelete)


### PR DESCRIPTION
## Overview

This is the fix for #2554 .

Once a scan was accepted by the HTTP server nothing could stop it. `context.WithoutCancel` at line 143 permanently severed the scan from every cancellation signal with no deadline replacing it. `serverState` tracked only `map[string]bool` so no `CancelFunc` was retained anywhere. The route table had no cancel endpoint and `DELETE /v1/results` deleted artifacts, not running scans.

The scan pipeline itself was already fully cancellable across PRs #2305, #2372, #2386. Only the in-cluster operator path had neither a timeout nor a cancel. One stuck scan head-of-line-blocked the entire server -- once the buffer filled every subsequent request got 429 with no recovery short of `kubectl delete pod`, which also destroyed queued scans and unpersisted results.

Added `DELETE /v1/scan?id=<scanID>` that cancels the running scan, drains any queued-but-unstarted entry for that ID, flips state to not-busy, and surfaces the cancelled scan as `ErrorScanResponseType`. Empty `id` resolves to the latest scan. Returns 200 on success, 404 when the ID is unknown or already finished.

## Additional Information

Files changed:

- `serverstate.go` -- `statusID` changed from `map[string]bool` to `map[string]context.CancelFunc`. `setBusy` now takes and stores a `CancelFunc`. Added `cancel(id)` and `cancelAll()`.
- `requestparser.go` -- added `CancelScanQueryParams` mirroring `StatusQueryParams`.
- `requestshandler.go` -- `Scan` derives a cancellable context via `context.WithCancel(context.WithoutCancel(r.Context()))` and hands the `CancelFunc` to `setBusy`. Added `CancelScan` handler and `drainQueuedScan` best-effort queue sweep.
- `prometheus.go` -- `Metrics` updated to the new `setBusy` signature, giving Prometheus-triggered scans the same real cancellability.
- `requestshandlerutils.go` -- cancelled scans surface "scan was cancelled" instead of the raw error.
- `listener/setup.go` -- constrained `/v1/scan` to `POST` and registered `CancelScan` on `DELETE`.

Closes the last gap in the context-cancellation work already landed across #2305/#2372/#2386/#2375 and supplies the missing primitive graceful shutdown (#2220) needs to drain in-flight scans.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scan cancellation via `DELETE /v1/scan` (with `id` to cancel a specific scan, or cancels the latest when omitted).
  * Scan execution now supports request cancellation for in-flight scans.
* **Bug Fixes**
  * Cancelled scans produce a dedicated cancellation response type.
  * Unknown scan IDs return `404 Not Found`.
  * Cancellation cleanup avoids leaving failure artifacts when `wait=false`.
* **Tests**
  * Added coverage for cancelling blocked/queued scans, unblocking waiters, and busy-state transitions.
* **Documentation**
  * Updated Swagger spec with the new endpoint and “not found” response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->