### PR TITLE
fix(cel): select remediation paths by workload kind

### DIFF
--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -58,6 +58,21 @@ type fieldRef struct {
 	value string
 }
 
+// fieldAlternative is one arm of an object-rooted ternary. base is the object
+// selected by that arm, while ref is the field read from it. Keeping the base
+// is important because the leaf is often absent precisely when it needs to be
+// remediated.
+type fieldAlternative struct {
+	base string
+	ref  fieldRef
+}
+
+// fieldAlternativeGroup contains exactly the arms of one ternary-derived
+// field read. It is recorded while walking the AST; unlike similarly shaped
+// dotted paths, these refs are known to be alternatives rather than inferred
+// to be alternatives later.
+type fieldAlternativeGroup []fieldAlternative
+
 // elementPlan describes a validation that iterates a list on the object, which
 // is the shape almost every workload policy in the bundle has
 // (`object.spec.containers.all(container, ...)`). fields are element-relative,
@@ -81,8 +96,14 @@ type elementPlan struct {
 // pathPlan is everything one validation expression can say about where it
 // failed, independent of any particular object.
 type pathPlan struct {
-	// direct are fields read straight off the object.
+	// direct are fields read straight off the object. Ternary-derived reads are
+	// also kept flattened here for diagnostics; directAlternatives identifies
+	// the exact subsets that resolve must choose between for one object.
 	direct []fieldRef
+	// directAlternatives preserves each object-rooted ternary arm group found
+	// while building the plan. Independent fields never enter these groups even
+	// when their dotted paths happen to share a suffix.
+	directAlternatives []fieldAlternativeGroup
 	// elements is set only when the expression iterates exactly one list on the
 	// object AND narrowing that list to one element and re-checking is an exact
 	// test of that element (see narrowingIsExact). With no such list there is
@@ -239,7 +260,7 @@ func newPathPlan(ast *cel.Ast) pathPlan {
 	// The iterated list itself is not a direct hint: either we are about to
 	// point at one of its elements, or we could not tell which list failed and
 	// naming them all would just be noise.
-	plan.direct = fieldsRootedAt(native, root, "object", ranges)
+	plan.direct, plan.directAlternatives = fieldsAndAlternativesRootedAt(native, root, "object", ranges)
 	return plan
 }
 
@@ -337,26 +358,77 @@ func quantifierIsAll(c celast.ComprehensionExpr) (isAll bool, ok bool) {
 // leaf is noise. So chains that another chain extends are dropped. Scope guards
 // and the excluded paths (an iterated collection) never become fields.
 func fieldsRootedAt(native *celast.AST, root celast.NavigableExpr, ident string, exclude map[string]bool) []fieldRef {
+	refs, _ := fieldsAndAlternativesRootedAt(native, root, ident, exclude)
+	return refs
+}
+
+// fieldsAndAlternativesRootedAt returns the same flattened refs as
+// fieldsRootedAt and, separately, the exact groups produced by selecting a
+// field from an object-rooted ternary. The flattened view keeps plan
+// inspection simple; resolve uses the groups to choose only the arm that can
+// apply to the concrete object.
+func fieldsAndAlternativesRootedAt(native *celast.AST, root celast.NavigableExpr, ident string, exclude map[string]bool) ([]fieldRef, []fieldAlternativeGroup) {
 	var refs []fieldRef
+	var groups []fieldAlternativeGroup
 	for _, node := range celast.MatchDescendants(root, celast.KindMatcher(celast.SelectKind)) {
 		// A select whose parent is a select is the operand of a longer chain;
 		// the outermost one carries the full path.
 		if parent, ok := node.Parent(); ok && parent.Kind() == celast.SelectKind {
 			continue
 		}
-		paths, ok := selectPaths(node, ident)
+		paths, bases, ok := selectPathAlternatives(node, ident)
 		if !ok {
 			continue
 		}
 		value := requiredValue(native, node, ident)
-		for _, path := range paths {
+		group := make(fieldAlternativeGroup, 0, len(paths))
+		for i, path := range paths {
 			if path == "" || scopeGuardFields[path] || exclude[path] {
 				continue
 			}
-			refs = append(refs, fieldRef{path: path, value: value})
+			ref := fieldRef{path: path, value: value}
+			refs = append(refs, ref)
+			if len(bases) > 0 {
+				group = append(group, fieldAlternative{base: bases[i], ref: ref})
+			}
+		}
+		if len(group) > 1 {
+			groups = append(groups, group)
 		}
 	}
-	return dedupeRefs(refs)
+
+	refs = dedupeRefs(refs)
+	final := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		final[ref.path] = ref.value
+	}
+
+	// Reconcile the groups with dedupeRefs: base-object reads encountered while
+	// walking the ternary are prefixes of the actual leaf refs and disappear,
+	// and a presence read may have gained the value from a sibling equality.
+	seen := make(map[string]bool)
+	keptGroups := make([]fieldAlternativeGroup, 0, len(groups))
+	for _, group := range groups {
+		kept := make(fieldAlternativeGroup, 0, len(group))
+		var key strings.Builder
+		for _, alternative := range group {
+			value, ok := final[alternative.ref.path]
+			if !ok {
+				continue
+			}
+			alternative.ref.value = value
+			kept = append(kept, alternative)
+			key.WriteString(alternative.base)
+			key.WriteByte('\x00')
+			key.WriteString(alternative.ref.path)
+			key.WriteByte('\x00')
+		}
+		if len(kept) > 1 && !seen[key.String()] {
+			seen[key.String()] = true
+			keptGroups = append(keptGroups, kept)
+		}
+	}
+	return refs, keptGroups
 }
 
 // dedupeRefs drops duplicates and any path another path extends, then orders
@@ -430,55 +502,127 @@ func selectPath(expr celast.Expr, ident string) (string, bool) {
 // as that catch-all rather than disqualifying the whole chain, since resolve
 // only ever uses a candidate that actually is a list on the object it checks.
 func objectRootedPaths(expr celast.Expr, ident string) ([]string, bool) {
+	paths, _, ok := objectRootedPathCandidates(expr, ident)
+	return paths, ok
+}
+
+// objectRootedPathCandidates is objectRootedPaths with an extra flag reporting
+// whether every ternary condition is an explicit scope dispatch on kind or API
+// version. Plain paths return true for that flag as the neutral recursive case.
+func objectRootedPathCandidates(expr celast.Expr, ident string) (paths []string, scopeDispatch bool, ok bool) {
 	if path, ok := selectPath(expr, ident); ok {
-		return []string{path}, true
+		return []string{path}, true, true
 	}
 	if expr.Kind() != celast.CallKind {
-		return nil, false
+		return nil, false, false
 	}
 	call := expr.AsCall()
 	if call.FunctionName() != operators.Conditional || len(call.Args()) != 3 {
-		return nil, false
+		return nil, false, false
 	}
 
-	truePaths, ok := objectRootedPaths(call.Args()[1], ident)
+	truePaths, trueScopeDispatch, ok := objectRootedPathCandidates(call.Args()[1], ident)
 	if !ok {
-		return nil, false
+		return nil, false, false
 	}
 
 	elseBranch := call.Args()[2]
+	conditionDispatch := scopeDispatchCondition(call.Args()[0], ident)
+	if !conditionDispatch {
+		conditionDispatch = presenceDefaultCondition(call.Args()[0], call.Args()[1], elseBranch, ident)
+	}
+	scopeDispatch = conditionDispatch && trueScopeDispatch
+
 	if elseBranch.Kind() == celast.CallKind && elseBranch.AsCall().FunctionName() == operators.Conditional {
-		elsePaths, ok := objectRootedPaths(elseBranch, ident)
+		elsePaths, elseScopeDispatch, ok := objectRootedPathCandidates(elseBranch, ident)
 		if !ok {
-			return nil, false
+			return nil, false, false
 		}
-		return append(truePaths, elsePaths...), true
+		return append(truePaths, elsePaths...), scopeDispatch && elseScopeDispatch, true
 	}
 	if path, ok := selectPath(elseBranch, ident); ok {
-		return append(truePaths, path), true
+		return append(truePaths, path), scopeDispatch, true
 	}
-	return truePaths, true
+	return truePaths, scopeDispatch, true
 }
 
-// selectPaths generalizes selectPath to a select chain whose base does not
-// bottom out at ident directly but at an object-rooted ternary of paths (see
-// objectRootedPaths) - the shape inlineVariables leaves behind when a
-// variable's own expression picks the right object by kind
-// (`(object.kind == 'Pod' ? object.spec.securityContext : ...).runAsUser`).
-// Each candidate base contributes one path, base-plus-the-peeled-suffix; a
-// plain chain still resolves to its one path, same as selectPath.
+// presenceDefaultCondition recognizes the safe presence-guard shape used by
+// the policy bundle: `has(object.path) ? object.path : {}`. It is neutral when
+// nested beneath a kind or API-version dispatch because it does not choose
+// between different remediation paths; it only supplies an empty default when
+// the already-selected path is absent. Other has()-guarded ternaries remain
+// ordinary conditions so their arms are preserved rather than guessed.
+func presenceDefaultCondition(condition, trueBranch, elseBranch celast.Expr, ident string) bool {
+	if condition.Kind() != celast.SelectKind || !condition.AsSelect().IsTestOnly() {
+		return false
+	}
+	guardedPath, ok := selectPath(condition, ident)
+	if !ok {
+		return false
+	}
+	selectedPath, ok := selectPath(trueBranch, ident)
+	if !ok || selectedPath != guardedPath {
+		return false
+	}
+	return elseBranch.Kind() == celast.MapKind && len(elseBranch.AsMap().Entries()) == 0
+}
+
+// scopeDispatchCondition reports whether a ternary condition is composed only
+// of comparisons on object.kind or object.apiVersion. Those fields select the
+// policy's resource scope; other conditions can choose between arbitrary paths,
+// for which path depth says nothing about the branch actually evaluated.
+func scopeDispatchCondition(expr celast.Expr, ident string) bool {
+	if expr.Kind() != celast.CallKind {
+		return false
+	}
+	call := expr.AsCall()
+	switch call.FunctionName() {
+	case operators.Equals, operators.NotEquals, operators.In:
+		found := false
+		for _, arg := range call.Args() {
+			path, ok := selectPath(arg, ident)
+			if !ok {
+				if arg.Kind() != celast.LiteralKind && arg.Kind() != celast.ListKind {
+					return false
+				}
+				continue
+			}
+			if !scopeGuardFields[path] {
+				return false
+			}
+			found = true
+		}
+		return found
+	case operators.LogicalAnd, operators.LogicalOr:
+		if len(call.Args()) == 0 {
+			return false
+		}
+		for _, arg := range call.Args() {
+			if !scopeDispatchCondition(arg, ident) {
+				return false
+			}
+		}
+		return true
+	case operators.LogicalNot:
+		return len(call.Args()) == 1 && scopeDispatchCondition(call.Args()[0], ident)
+	default:
+		return false
+	}
+}
+
+// selectPathAlternatives generalizes selectPath to a select chain whose base
+// is an object-rooted ternary. Each candidate base contributes its composed
+// leaf path. bases is aligned with paths only when the ternary explicitly
+// dispatches on kind or API version; for any other condition it is nil so the
+// caller conservatively keeps every arm instead of selecting by path shape.
 //
-// The bare base paths are not returned, only the composed ones - a caller
-// that (like fieldsRootedAt, walking every select in the tree) also visits
-// the base's own select nodes as their own chains gets the bare paths
-// separately, and dedupeRefs drops each one once the corresponding composed
-// path here makes it a prefix of something more specific. Without that, a
-// ternary base half-resolved through a further field select would report the
-// object it picks - "spec.securityContext" - as if that whole object were
-// the fix, instead of the one field the validation actually reads off it.
-func selectPaths(expr celast.Expr, ident string) ([]string, bool) {
+// Bare base paths are not returned. The AST walk also sees those selects on
+// their own, and dedupeRefs removes them once the composed leaf exists. This
+// avoids reporting an entire selected object such as spec.securityContext as
+// the fix when the validation actually reads one field below it.
+func selectPathAlternatives(expr celast.Expr, ident string) ([]string, []string, bool) {
 	if path, ok := selectPath(expr, ident); ok {
-		return []string{path}, true
+		return []string{path}, nil, true
 	}
 
 	var suffix []string
@@ -488,11 +632,11 @@ func selectPaths(expr celast.Expr, ident string) ([]string, bool) {
 		expr = sel.Operand()
 	}
 	if len(suffix) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
-	bases, ok := objectRootedPaths(expr, ident)
+	bases, scopeDispatch, ok := objectRootedPathCandidates(expr, ident)
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
 	for i, j := 0, len(suffix)-1; i < j; i, j = i+1, j-1 {
@@ -504,7 +648,10 @@ func selectPaths(expr celast.Expr, ident string) ([]string, bool) {
 	for i, base := range bases {
 		paths[i] = base + "." + tail
 	}
-	return paths, true
+	if !scopeDispatch {
+		bases = nil
+	}
+	return paths, bases, true
 }
 
 // requiredValue returns the literal a field read is compared against, but only
@@ -699,7 +846,7 @@ func literalString(val ref.Val) (string, bool) {
 // differ). Worth doing, but as its own change.
 func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool) []PathHint {
 	hints := make([]PathHint, 0, len(p.direct))
-	for _, ref := range p.direct {
+	for _, ref := range p.resolveDirect(obj) {
 		hints = append(hints, PathHint{Path: ref.path, Value: ref.value})
 	}
 	if p.elements == nil || len(p.elements.fields) == 0 {
@@ -732,6 +879,75 @@ func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool
 		}
 	}
 	return hints
+}
+
+// resolveDirect selects the applicable arm from each ternary-derived group and
+// preserves every independent direct field. Groups that cannot be resolved
+// are deliberately kept intact: an extra review hint is safer than silently
+// deleting every remediation path.
+func (p pathPlan) resolveDirect(obj map[string]any) []fieldRef {
+	grouped := make(map[string]bool)
+	for _, group := range p.directAlternatives {
+		for _, alternative := range group {
+			grouped[alternative.ref.path] = true
+		}
+	}
+
+	refs := make([]fieldRef, 0, len(p.direct))
+	for _, ref := range p.direct {
+		if !grouped[ref.path] {
+			refs = append(refs, ref)
+		}
+	}
+	for _, group := range p.directAlternatives {
+		refs = append(refs, resolveAlternativeGroup(group, obj)...)
+	}
+	return dedupeRefs(refs)
+}
+
+// resolveAlternativeGroup chooses the most specific base that exists on the
+// object. Candidate bases are commonly nested prefixes (spec,
+// spec.template.spec, ...), so the deepest match is the branch-specific one.
+// A tie or no match is ambiguous and therefore preserves every candidate.
+func resolveAlternativeGroup(group fieldAlternativeGroup, obj map[string]any) []fieldRef {
+	maxDepth := -1
+	var selected []fieldRef
+	for _, alternative := range group {
+		if !objectPathExists(obj, alternative.base) {
+			continue
+		}
+		depth := strings.Count(alternative.base, ".") + 1
+		switch {
+		case depth > maxDepth:
+			maxDepth = depth
+			selected = []fieldRef{alternative.ref}
+		case depth == maxDepth:
+			selected = append(selected, alternative.ref)
+		}
+	}
+	if len(selected) == 1 {
+		return selected
+	}
+	refs := make([]fieldRef, 0, len(group))
+	for _, alternative := range group {
+		refs = append(refs, alternative.ref)
+	}
+	return refs
+}
+
+func objectPathExists(obj map[string]any, path string) bool {
+	var current any = obj
+	for _, segment := range strings.Split(path, ".") {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = mapping[segment]
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // resolveCollection picks which candidate list path is a real list on obj. The

--- a/core/pkg/opaprocessor/cel/paths_kind_test.go
+++ b/core/pkg/opaprocessor/cel/paths_kind_test.go
@@ -1,0 +1,296 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathPlanRetainsDirectTernaryArmGroups(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name: "podSpec",
+		Expression: "object.kind == 'Pod' ? object.spec : " +
+			"object.kind in ['CronJob'] ? object.spec.jobTemplate.spec.template.spec : object.spec.template.spec",
+	}}
+
+	plan := evaluator.buildPathPlan(
+		"!has(variables.podSpec.hostNetwork) || variables.podSpec.hostNetwork == false",
+		variables,
+	)
+	require.Len(t, plan.directAlternatives, 1)
+	assert.Equal(t, fieldAlternativeGroup{
+		{base: "spec", ref: fieldRef{path: "spec.hostNetwork", value: "false"}},
+		{base: "spec.jobTemplate.spec.template.spec", ref: fieldRef{path: "spec.jobTemplate.spec.template.spec.hostNetwork", value: "false"}},
+		{base: "spec.template.spec", ref: fieldRef{path: "spec.template.spec.hostNetwork", value: "false"}},
+	}, plan.directAlternatives[0])
+}
+
+func TestPathPlanRecognizesAPIVersionDispatch(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name:       "target",
+		Expression: "object.apiVersion == 'v1' ? object.spec : object.spec.template.spec",
+	}}
+
+	plan := evaluator.buildPathPlan("variables.target.hostNetwork == false", variables)
+	require.Len(t, plan.directAlternatives, 1)
+}
+
+func TestPresenceDefaultWithinScopeDispatchRetainsAlternativeGroup(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name: "securityContext",
+		Expression: "object.kind == 'Pod' ? " +
+			"(has(object.spec.securityContext) ? object.spec.securityContext : {}) : " +
+			"object.kind in ['Deployment', 'ReplicaSet', 'DaemonSet', 'StatefulSet', 'Job'] ? " +
+			"(has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {}) : " +
+			"object.kind == 'CronJob' ? " +
+			"(has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {}) : {}",
+	}}
+
+	plan := evaluator.buildPathPlan("variables.securityContext.runAsUser == 1000", variables)
+	require.Len(t, plan.directAlternatives, 1)
+	assert.Equal(t, fieldAlternativeGroup{
+		{base: "spec.securityContext", ref: fieldRef{path: "spec.securityContext.runAsUser", value: "1000"}},
+		{base: "spec.template.spec.securityContext", ref: fieldRef{path: "spec.template.spec.securityContext.runAsUser", value: "1000"}},
+		{base: "spec.jobTemplate.spec.template.spec.securityContext", ref: fieldRef{path: "spec.jobTemplate.spec.template.spec.securityContext.runAsUser", value: "1000"}},
+	}, plan.directAlternatives[0])
+}
+
+func TestPresenceGuardChoosingDifferentPathsIsNotAScopeDispatch(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name:       "target",
+		Expression: "has(object.spec.selector) ? object.spec.deep.nested : object.spec.shallow",
+	}}
+
+	plan := evaluator.buildPathPlan("variables.target.flag == false", variables)
+	assert.Empty(t, plan.directAlternatives)
+}
+
+func TestResolveDirectSelectsTheMostSpecificPresentTernaryBase(t *testing.T) {
+	group := fieldAlternativeGroup{
+		{base: "spec", ref: fieldRef{path: "spec.hostNetwork", value: "false"}},
+		{base: "spec.template.spec", ref: fieldRef{path: "spec.template.spec.hostNetwork", value: "false"}},
+		{base: "spec.jobTemplate.spec.template.spec", ref: fieldRef{path: "spec.jobTemplate.spec.template.spec.hostNetwork", value: "false"}},
+	}
+	plan := pathPlan{
+		direct:             []fieldRef{group[0].ref, group[1].ref, group[2].ref},
+		directAlternatives: []fieldAlternativeGroup{group},
+	}
+
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want fieldRef
+	}{
+		{name: "pod", obj: podSpecObject("Pod", map[string]any{}), want: group[0].ref},
+		{name: "controller", obj: podSpecObject("Deployment", map[string]any{}), want: group[1].ref},
+		{name: "shape is selected without a kind table", obj: podSpecObject("ThirdPartyWorkload", map[string]any{}), want: group[1].ref},
+		{name: "cron job", obj: podSpecObject("CronJob", map[string]any{}), want: group[2].ref},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, []fieldRef{tt.want}, plan.resolveDirect(tt.obj))
+		})
+	}
+}
+
+func TestResolveDirectPreservesAnUnresolvedPartialArmSet(t *testing.T) {
+	group := fieldAlternativeGroup{
+		{base: "spec.pod", ref: fieldRef{path: "spec.pod.hostNetwork", value: "false"}},
+		{base: "spec.controller", ref: fieldRef{path: "spec.controller.hostNetwork", value: "false"}},
+	}
+	plan := pathPlan{
+		direct:             []fieldRef{group[0].ref, group[1].ref},
+		directAlternatives: []fieldAlternativeGroup{group},
+	}
+
+	assert.Equal(t, []fieldRef{group[1].ref, group[0].ref}, plan.resolveDirect(map[string]any{
+		"spec": map[string]any{"cronJob": map[string]any{}},
+	}))
+}
+
+func TestIndependentFieldsWithTheSameSuffixAreNotAlternatives(t *testing.T) {
+	plan := planFor(t, "object.spec.activeDeadlineSeconds == 600 && "+
+		"object.spec.template.spec.activeDeadlineSeconds == 600")
+
+	assert.Empty(t, plan.directAlternatives)
+	assert.Equal(t, []fieldRef{
+		{path: "spec.activeDeadlineSeconds", value: "600"},
+		{path: "spec.template.spec.activeDeadlineSeconds", value: "600"},
+	}, plan.resolveDirect(podSpecObject("Job", map[string]any{})))
+}
+
+func TestNonScopeTernaryPreservesEveryRemediationPath(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name:       "target",
+		Expression: "object.spec.replicas > 5 ? object.spec.deep.nested : object.spec.shallow",
+	}}
+	validations := []Validation{{Expression: "variables.target.flag == false"}}
+	obj := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "fixture"},
+		"spec": map[string]any{
+			"replicas": int64(1),
+			"deep":     map[string]any{"nested": map[string]any{"flag": false}},
+			"shallow":  map[string]any{"flag": true},
+		},
+	}
+
+	plan := evaluator.buildPathPlan(validations[0].Expression, variables)
+	assert.Empty(t, plan.directAlternatives)
+
+	results, err := evaluator.EvaluateOnObject(context.Background(), obj, nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	require.NoError(t, results[0].Err)
+	assert.ElementsMatch(t, []PathHint{
+		{Path: "spec.deep.nested.flag", Value: "false"},
+		{Path: "spec.replicas"},
+		{Path: "spec.shallow.flag", Value: "false"},
+	}, results[0].Paths)
+}
+
+func TestVariableTernaryReportsOnlyApplicableRemediationPath(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name: "podSpec",
+		Expression: "object.kind == 'Pod' ? object.spec : " +
+			"object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec : object.spec.template.spec",
+	}}
+	validations := []Validation{{
+		Expression: "!has(variables.podSpec.hostNetwork) || variables.podSpec.hostNetwork == false",
+		Message:    "host networking must be disabled",
+	}}
+
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want string
+	}{
+		{name: "pod", obj: podSpecObject("Pod", map[string]any{"hostNetwork": true}), want: "spec.hostNetwork"},
+		{name: "deployment", obj: podSpecObject("Deployment", map[string]any{"hostNetwork": true}), want: "spec.template.spec.hostNetwork"},
+		{name: "cron job", obj: podSpecObject("CronJob", map[string]any{"hostNetwork": true}), want: "spec.jobTemplate.spec.template.spec.hostNetwork"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := evaluator.EvaluateOnObject(context.Background(), tt.obj, nil, nil, variables, validations)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.False(t, results[0].Passed)
+			require.NoError(t, results[0].Err)
+			assert.Equal(t, []PathHint{{Path: tt.want, Value: "false"}}, results[0].Paths)
+		})
+	}
+}
+
+func TestGuardedVariableTernaryReportsOnlyApplicableRemediationPath(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name: "securityContext",
+		Expression: "object.kind == 'Pod' ? " +
+			"(has(object.spec.securityContext) ? object.spec.securityContext : {}) : " +
+			"object.kind in ['Deployment', 'ReplicaSet', 'DaemonSet', 'StatefulSet', 'Job'] ? " +
+			"(has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {}) : " +
+			"object.kind == 'CronJob' ? " +
+			"(has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {}) : {}",
+	}}
+	validations := []Validation{{Expression: "variables.securityContext.runAsUser == 1000"}}
+	obj := podSpecObject("Deployment", map[string]any{
+		"securityContext": map[string]any{"runAsUser": int64(0)},
+	})
+
+	results, err := evaluator.EvaluateOnObject(context.Background(), obj, nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	require.NoError(t, results[0].Err)
+	assert.Equal(t, []PathHint{{Path: "spec.template.spec.securityContext.runAsUser", Value: "1000"}}, results[0].Paths)
+}
+
+func TestTwoArmTernaryOnCronJobKeepsARemediationPath(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	variables := []Variable{{
+		Name:       "podSpec",
+		Expression: "object.kind == 'Pod' ? object.spec : object.spec.template.spec",
+	}}
+	validations := []Validation{{
+		Expression: "!has(variables.podSpec.hostNetwork) || variables.podSpec.hostNetwork == false",
+	}}
+	obj := map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "CronJob",
+		"metadata":   map[string]any{"name": "fixture"},
+		"spec": map[string]any{
+			"template": map[string]any{"spec": map[string]any{"hostNetwork": true}},
+		},
+	}
+
+	results, err := evaluator.EvaluateOnObject(context.Background(), obj, nil, nil, variables, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	require.NoError(t, results[0].Err)
+	assert.Equal(t, []PathHint{{Path: "spec.template.spec.hostNetwork", Value: "false"}}, results[0].Paths)
+}
+
+func TestEndToEndIndependentJobFieldsBothSurvive(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	require.NoError(t, err)
+	validations := []Validation{{
+		Expression: "object.spec.activeDeadlineSeconds == 600 && " +
+			"object.spec.template.spec.activeDeadlineSeconds == 600",
+	}}
+	obj := podSpecObject("Job", map[string]any{"activeDeadlineSeconds": int64(30)})
+	obj["spec"].(map[string]any)["activeDeadlineSeconds"] = int64(60)
+
+	results, err := evaluator.EvaluateOnObject(context.Background(), obj, nil, nil, nil, validations)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+	assert.ElementsMatch(t, []PathHint{
+		{Path: "spec.activeDeadlineSeconds", Value: "600"},
+		{Path: "spec.template.spec.activeDeadlineSeconds", Value: "600"},
+	}, results[0].Paths)
+}
+
+func podSpecObject(kind string, podSpec map[string]any) map[string]any {
+	object := map[string]any{
+		"apiVersion": "v1",
+		"kind":       kind,
+		"metadata":   map[string]any{"name": "fixture"},
+	}
+	switch kind {
+	case "Pod":
+		object["spec"] = podSpec
+	case "CronJob":
+		object["spec"] = map[string]any{
+			"jobTemplate": map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{"spec": podSpec},
+				},
+			},
+		}
+	default:
+		object["spec"] = map[string]any{
+			"template": map[string]any{"spec": podSpec},
+		}
+	}
+	return object
+}


### PR DESCRIPTION
# fix(cel): select remediation paths by workload kind

## Summary

CEL policies often use one variable to point at a Pod spec across Pods, controllers, and CronJobs. The policy evaluates only the branch for the current workload, but the remediation-path analyzer was collecting fields from every branch.

That meant a failed Deployment could report Pod and CronJob paths alongside its real `spec.template.spec` path. Those extra hints are especially risky because `kubescape fix` may write them back into a manifest.

## What changed

- Preserve the exact alternative-path groups while walking each CEL ternary instead of reconstructing them later from path strings.
- Only select among ternary arms when every condition explicitly dispatches on `object.kind` or `object.apiVersion`.
- Treat `has(path) ? path : {}` as a safe presence default inside a scope dispatch without treating unrelated `has()` ternaries as workload dispatches.
- Resolve an alternative through the most specific base object that exists on the workload, so the leaf may still be absent when it needs remediation.
- Keep the selection structural and API-agnostic; there is no workload-kind table to maintain.
- Preserve every arm of non-scope ternaries, where path depth cannot identify the branch CEL evaluated.
- Preserve every candidate when an alternative group cannot be resolved safely rather than silently dropping all remediation hints.
- Leave independent fields untouched even when their paths happen to share the same suffix.

## Tests

- Verifies the planner retains real ternary arm boundaries and their base paths.
- Covers equality, membership, and API-version scope dispatch conditions.
- Covers structural selection for Pod, controller, CronJob, and third-party workload shapes.
- Verifies unresolved partial arm sets are preserved rather than discarded.
- Confirms independent Job fields with the same suffix both survive.
- Confirms a replicas-based ternary preserves its evaluated shallow arm instead of selecting an unrelated deeper arm.
- Runs real CEL variable ternaries end to end for Pod, Deployment, and CronJob objects.
- Exercises a two-arm ternary on a CronJob and confirms the failed validation still has a remediation path.
- Reproduces the guarded `podSecurityContext` shape used by the embedded bundle and verifies the applicable Deployment path is retained end to end.
- Confirms a presence test that chooses between different paths remains conservative and keeps every candidate.

## Validation

```text
go test ./core/pkg/opaprocessor/...
go test -race -count=1 ./core/pkg/opaprocessor/cel
go vet ./core/pkg/opaprocessor/cel/...
golangci-lint run --timeout 10m --new-from-rev upstream/master ./core/pkg/opaprocessor/cel/...
```

All commands pass locally with zero lint issues.

Closes #2561.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation path selection for ternary-based variables across different Kubernetes resource kinds.
  * Remediation output now reports only the path applicable to the detected resource structure when scope-based conditions are used.
  * Preserved all relevant remediation paths for non-scope ternaries and independent field validations.
  * Improved handling of nested resource specifications, API-version dispatch, guarded expressions, and partially unresolved paths.

* **Tests**
  * Added comprehensive coverage for ternary path planning, resolution, and remediation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->