### PR TITLE
fix(junit): report compliance scores in test suites

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -193,7 +193,7 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 		testSuite.Timestamp = timestamp
 		testSuite.ID = 0
 		testSuite.Name = "kubescape"
-		testSuite.Properties = properties(results.Report.SummaryDetails.Score)
+		testSuite.Properties = properties(results.Report.SummaryDetails.ComplianceScore)
 		testSuite.TestCases = testsCases(results, &results.Report.SummaryDetails.Controls, "Kubescape")
 		testSuites = append(testSuites, testSuite)
 		return testSuites
@@ -207,7 +207,7 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 		testSuite.Timestamp = timestamp
 		testSuite.ID = i
 		testSuite.Name = f.Name
-		testSuite.Properties = properties(f.Score)
+		testSuite.Properties = properties(f.GetComplianceScore())
 		testSuite.TestCases = testsCases(results, f.GetControls(), f.GetName())
 		testSuites = append(testSuites, testSuite)
 	}

--- a/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
@@ -1,0 +1,60 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTestsSuiteUsesComplianceScores(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary reportsummary.SummaryDetails
+		want    map[string]string
+	}{
+		{
+			name: "control scan uses overall compliance instead of risk",
+			summary: reportsummary.SummaryDetails{
+				Score:           12.25,
+				ComplianceScore: 87.75,
+			},
+			want: map[string]string{"kubescape": "87.75"},
+		},
+		{
+			name: "framework scan uses each framework compliance instead of risk or summary",
+			summary: reportsummary.SummaryDetails{
+				Score:           1,
+				ComplianceScore: 99,
+				Frameworks: []reportsummary.FrameworkSummary{
+					{Name: "NSA", Score: 10, ComplianceScore: 90},
+					{Name: "MITRE", Score: 80, ComplianceScore: 20},
+				},
+			},
+			want: map[string]string{
+				"NSA":   "90.00",
+				"MITRE": "20.00",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := cautils.NewOPASessionObjMock()
+			results.Report.SummaryDetails = tt.summary
+
+			suites := listTestsSuite(results)
+
+			require.Len(t, suites, len(tt.want))
+			for _, suite := range suites {
+				require.Len(t, suite.Properties, 1)
+				assert.Equal(t, JUnitProperty{
+					Name:  "complianceScore",
+					Value: tt.want[suite.Name],
+				}, suite.Properties[0])
+			}
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
+++ b/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
@@ -2,7 +2,7 @@
 <testsuites errors="0" failures="16" tests="24" name="Kubescape Scanning">
   <testsuite tests="24" name="NSA" errors="0" failures="16" id="0" skipped="3" timestamp="2024-03-14T09:15:26Z">
     <properties>
-      <property name="complianceScore" value="19.65"></property>
+      <property name="complianceScore" value="73.25"></property>
     </properties>
     <testcase classname="NSA" name="Exec into container">
       <failure message="Exec into container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0002&#xA;&#xA;</failure>

--- a/core/pkg/resultshandling/printer/v2/testdata/mock_summaryDetails.json
+++ b/core/pkg/resultshandling/printer/v2/testdata/mock_summaryDetails.json
@@ -991,7 +991,8 @@
                 "skippedResources": 89,
                 "excludedResources": 0
             },
-            "score": 19.654322
+            "score": 19.654322,
+            "complianceScore": 73.24568
         }
     ],
     "resourcesSeverityCounters": {
@@ -1012,5 +1013,6 @@
         "skippedResources": 89,
         "excludedResources": 0
     },
-    "score": 19.654322
+    "score": 19.654322,
+    "complianceScore": 73.24568
 }


### PR DESCRIPTION
## Summary

The JUnit exporter labels its suite property as `complianceScore`, but it was filling that property with Kubescape's risk score. Risk and compliance are separate values and can move in opposite directions, so CI systems consuming the XML could display a convincing but incorrect compliance result.

## What changed

- Use the report's overall `ComplianceScore` for control scans.
- Use each framework's `GetComplianceScore()` accessor for framework scans.
- Keep framework scores independent from the overall summary score.
- Update the golden report fixture with deliberately different risk and compliance values so this mix-up cannot hide behind equal test data.
- Preserve the existing two-decimal JUnit property format.

## Tests

- Uses one focused table covering overall and multi-framework reports with deliberately different risk and compliance values.
- Keeps full serialization coverage in the existing byte-for-byte golden test.
- Regenerates the golden fixture without a trailing newline, exactly matching `ActionPrint` and the documented `-update-golden` workflow.

## Validation

```text
go build ./...
go test -race -count=1 ./core/pkg/resultshandling/printer/v2/...
go vet ./core/pkg/resultshandling/printer/v2/...
golangci-lint run --timeout 10m --new-from-rev upstream/master ./core/pkg/resultshandling/printer/v2/...
```

All commands pass locally with zero lint issues.

Closes #2540.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JUnit reports now display compliance scores instead of risk scores for overall and framework test suites.
  * Corrected compliance score values in generated test report output.

* **Tests**
  * Added coverage to verify compliance scores are reported accurately across scan and framework results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->