### PR TITLE
fix(mcpserver): handle malformed tool arguments safely

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -55,6 +55,23 @@ func (ksServer *KubescapeMcpserver) getK8sClient() *k8sinterface.KubernetesApi {
 	return ksServer.k8sClient
 }
 
+// toolHandler binds a registered tool to its declared name and normalizes an
+// omitted arguments object. A non-null value of any other JSON shape is a
+// client error: silently treating it as an empty object could discard scope
+// filters and unintentionally widen a query.
+func (ksServer *KubescapeMcpserver) toolHandler(name string) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok && request.Params.Arguments != nil {
+			return mcp.NewToolResultError("arguments must be a JSON object"), nil
+		}
+		if args == nil {
+			args = map[string]any{}
+		}
+		return ksServer.CallTool(ctx, name, args)
+	}
+}
+
 func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 	// Tool to list vulnerability manifests
 	listManifestsTool := mcp.NewTool(
@@ -69,9 +86,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(listManifestsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool(ctx, "list_vulnerability_manifests", request.Params.Arguments.(map[string]any))
-	})
+	ksServer.s.AddTool(listManifestsTool, ksServer.toolHandler(listManifestsTool.Name))
 
 	listVulnerabilitiesTool := mcp.NewTool(
 		"list_vulnerabilities_in_manifest",
@@ -85,9 +100,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(listVulnerabilitiesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool(ctx, "list_vulnerabilities_in_manifest", request.Params.Arguments.(map[string]any))
-	})
+	ksServer.s.AddTool(listVulnerabilitiesTool, ksServer.toolHandler(listVulnerabilitiesTool.Name))
 
 	listVulnerabilityMatchesForCVE := mcp.NewTool(
 		"list_vulnerability_matches_for_cve",
@@ -105,9 +118,7 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(listVulnerabilityMatchesForCVE, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool(ctx, "list_vulnerability_matches_for_cve", request.Params.Arguments.(map[string]any))
-	})
+	ksServer.s.AddTool(listVulnerabilityMatchesForCVE, ksServer.toolHandler(listVulnerabilityMatchesForCVE.Name))
 
 	vulnerabilityManifestTemplate := mcp.NewResourceTemplate(
 		"kubescape://vulnerability-manifests/{namespace}/{manifest_name}",
@@ -130,9 +141,7 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(listConfigsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool(ctx, "list_configuration_security_scan_manifests", request.Params.Arguments.(map[string]any))
-	})
+	ksServer.s.AddTool(listConfigsTool, ksServer.toolHandler(listConfigsTool.Name))
 
 	getConfigDetailsTool := mcp.NewTool(
 		"get_configuration_security_scan_manifest",
@@ -146,9 +155,7 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(getConfigDetailsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return ksServer.CallTool(ctx, "get_configuration_security_scan_manifest", request.Params.Arguments.(map[string]any))
-	})
+	ksServer.s.AddTool(getConfigDetailsTool, ksServer.toolHandler(getConfigDetailsTool.Name))
 
 	configManifestTemplate := mcp.NewResourceTemplate(
 		"kubescape://configuration-manifests/{namespace}/{manifest_name}",
@@ -170,13 +177,7 @@ func createRuntimeToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(listContainerProfilesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "list_container_profiles", args)
-	})
+	ksServer.s.AddTool(listContainerProfilesTool, ksServer.toolHandler(listContainerProfilesTool.Name))
 
 	getContainerProfileTool := mcp.NewTool(
 		"get_container_profile",
@@ -190,13 +191,7 @@ func createRuntimeToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(getContainerProfileTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "get_container_profile", args)
-	})
+	ksServer.s.AddTool(getContainerProfileTool, ksServer.toolHandler(getContainerProfileTool.Name))
 
 	containerProfileTemplate := mcp.NewResourceTemplate(
 		"kubescape://container-profiles/{namespace}/{profile_name}",
@@ -868,18 +863,7 @@ func createRBACScanningTools(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(runRBACScanTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Blocker 3 fix: use comma-ok pattern to prevent panic when namespace is
-		// omitted (tool is callable with no arguments since namespace is optional).
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok && request.Params.Arguments != nil {
-			return mcp.NewToolResultError("arguments must be a JSON object"), nil
-		}
-		if args == nil {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "run_rbac_security_scan", args)
-	})
+	ksServer.s.AddTool(runRBACScanTool, ksServer.toolHandler(runRBACScanTool.Name))
 }
 
 func createNetworkScanningTools(ksServer *KubescapeMcpserver) {
@@ -891,16 +875,7 @@ func createNetworkScanningTools(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(runNetworkScanTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok && request.Params.Arguments != nil {
-			return mcp.NewToolResultError("arguments must be a JSON object"), nil
-		}
-		if args == nil {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "run_network_security_scan", args)
-	})
+	ksServer.s.AddTool(runNetworkScanTool, ksServer.toolHandler(runNetworkScanTool.Name))
 }
 
 func createFrameworkScanningTools(ksServer *KubescapeMcpserver) {
@@ -916,16 +891,7 @@ func createFrameworkScanningTools(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(runFrameworkScanTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok && request.Params.Arguments != nil {
-			return mcp.NewToolResultError("arguments must be a JSON object"), nil
-		}
-		if args == nil {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "run_framework_security_scan", args)
-	})
+	ksServer.s.AddTool(runFrameworkScanTool, ksServer.toolHandler(runFrameworkScanTool.Name))
 }
 
 func createIaCScanningTools(ksServer *KubescapeMcpserver) {
@@ -941,16 +907,7 @@ func createIaCScanningTools(ksServer *KubescapeMcpserver) {
 		),
 	)
 
-	ksServer.s.AddTool(iacScanTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args, ok := request.Params.Arguments.(map[string]any)
-		if !ok && request.Params.Arguments != nil {
-			return mcp.NewToolResultError("arguments must be a JSON object"), nil
-		}
-		if args == nil {
-			args = map[string]any{}
-		}
-		return ksServer.CallTool(ctx, "scan_local_iac", args)
-	})
+	ksServer.s.AddTool(iacScanTool, ksServer.toolHandler(iacScanTool.Name))
 }
 
 func GetMCPServerCmd() *cobra.Command {

--- a/cmd/mcpserver/mcpserver_arguments_test.go
+++ b/cmd/mcpserver/mcpserver_arguments_test.go
@@ -1,0 +1,181 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	storagefake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRegisteredStorageToolsRejectMalformedArguments(t *testing.T) {
+	tools := []string{
+		"list_vulnerability_manifests",
+		"list_vulnerabilities_in_manifest",
+		"list_vulnerability_matches_for_cve",
+		"list_configuration_security_scan_manifests",
+		"get_configuration_security_scan_manifest",
+	}
+	malformed := []struct {
+		name      string
+		arguments any
+	}{
+		{name: "string", arguments: "namespace=default"},
+		{name: "array", arguments: []any{"default"}},
+		{name: "number", arguments: float64(42)},
+		{name: "boolean", arguments: true},
+	}
+	ksServer := newRegisteredStorageToolTestServer()
+
+	for _, tool := range tools {
+		t.Run(tool, func(t *testing.T) {
+			for _, tt := range malformed {
+				t.Run(tt.name, func(t *testing.T) {
+					result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, tool, tt.arguments))
+					assert.True(t, result.IsError)
+					assert.Equal(t, "arguments must be a JSON object", toolResultText(t, result))
+				})
+			}
+		})
+	}
+}
+
+func TestRegisteredStorageToolsAcceptNullAsNoArguments(t *testing.T) {
+	ksServer := newRegisteredStorageToolTestServer()
+	for _, tool := range []string{
+		"list_vulnerability_manifests",
+		"list_configuration_security_scan_manifests",
+	} {
+		t.Run(tool, func(t *testing.T) {
+			result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, tool, nil))
+			assert.False(t, result.IsError)
+		})
+	}
+}
+
+func TestRegisteredStorageToolsDispatchToTheirDeclaredNames(t *testing.T) {
+	vulnerabilityManifest := &storagev1beta1.VulnerabilityManifest{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "security"},
+		Spec: storagev1beta1.VulnerabilityManifestSpec{
+			Payload: storagev1beta1.GrypeDocument{Matches: []storagev1beta1.Match{
+				{Vulnerability: storagev1beta1.Vulnerability{
+					VulnerabilityMetadata: storagev1beta1.VulnerabilityMetadata{ID: "CVE-2026-1000"},
+				}},
+			}},
+		},
+	}
+	configurationManifest := &storagev1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "deployment-nginx", Namespace: "security"},
+	}
+	ksServer := newRegisteredStorageToolTestServer(vulnerabilityManifest, configurationManifest)
+
+	tests := []struct {
+		name       string
+		tool       string
+		arguments  map[string]any
+		assertJSON func(*testing.T, any)
+	}{
+		{
+			name: "list vulnerability manifests", tool: "list_vulnerability_manifests",
+			arguments: map[string]any{"namespace": "security", "level": "both"},
+			assertJSON: func(t *testing.T, value any) {
+				manifests := value.(map[string]any)["vulnerability_manifests"].(map[string]any)["manifests"].([]any)
+				require.Len(t, manifests, 1)
+				assert.Equal(t, "nginx", manifests[0].(map[string]any)["manifest_name"])
+			},
+		},
+		{
+			name: "list vulnerabilities", tool: "list_vulnerabilities_in_manifest",
+			arguments: map[string]any{"namespace": "security", "manifest_name": "nginx"},
+			assertJSON: func(t *testing.T, value any) {
+				vulnerabilities := value.([]any)
+				require.Len(t, vulnerabilities, 1)
+				assert.Equal(t, "CVE-2026-1000", vulnerabilities[0].(map[string]any)["id"])
+			},
+		},
+		{
+			name: "list CVE matches", tool: "list_vulnerability_matches_for_cve",
+			arguments: map[string]any{"namespace": "security", "manifest_name": "nginx", "cve_id": "CVE-2026-1000"},
+			assertJSON: func(t *testing.T, value any) {
+				matches := value.([]any)
+				require.Len(t, matches, 1)
+				vulnerability := matches[0].(map[string]any)["vulnerability"].(map[string]any)
+				assert.Equal(t, "CVE-2026-1000", vulnerability["id"])
+			},
+		},
+		{
+			name: "list configuration manifests", tool: "list_configuration_security_scan_manifests",
+			arguments: map[string]any{"namespace": "security"},
+			assertJSON: func(t *testing.T, value any) {
+				manifests := value.(map[string]any)["configuration_manifests"].(map[string]any)["manifests"].([]any)
+				require.Len(t, manifests, 1)
+				assert.Equal(t, "deployment-nginx", manifests[0].(map[string]any)["manifest_name"])
+			},
+		},
+		{
+			name: "get configuration manifest", tool: "get_configuration_security_scan_manifest",
+			arguments: map[string]any{"namespace": "security", "manifest_name": "deployment-nginx"},
+			assertJSON: func(t *testing.T, value any) {
+				metadata := value.(map[string]any)["metadata"].(map[string]any)
+				assert.Equal(t, "deployment-nginx", metadata["name"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, tt.tool, tt.arguments))
+			require.False(t, result.IsError)
+			var value any
+			require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &value))
+			tt.assertJSON(t, value)
+		})
+	}
+}
+
+func dispatchRegisteredTool(t *testing.T, ksServer *KubescapeMcpserver, tool string, arguments any) mcp.JSONRPCMessage {
+	t.Helper()
+	message, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      tool,
+			"arguments": arguments,
+		},
+	})
+	require.NoError(t, err)
+	return ksServer.s.HandleMessage(context.Background(), message)
+}
+
+func registeredToolResult(t *testing.T, message mcp.JSONRPCMessage) *mcp.CallToolResult {
+	t.Helper()
+	response, ok := message.(mcp.JSONRPCResponse)
+	require.True(t, ok, "tool call returned a protocol error: %#v", message)
+	result, ok := response.Result.(mcp.CallToolResult)
+	require.True(t, ok)
+	return &result
+}
+
+func newRegisteredStorageToolTestServer(objects ...runtime.Object) *KubescapeMcpserver {
+	client := storagefake.NewClientset(objects...)
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		ksClient: client.SpdxV1beta1(),
+	}
+	createVulnerabilityToolsAndResources(ksServer)
+	createConfigurationsToolsAndResources(ksServer)
+	return ksServer
+}


### PR DESCRIPTION
# fix(mcpserver): handle malformed tool arguments safely

## Summary

Five storage-backed MCP tools directly asserted that incoming arguments were a JSON object. A non-object value triggered a panic inside the handler; the server's recovery middleware kept the process running but returned a protocol-level internal error containing the Go type-assertion failure.

This change turns malformed client input into a readable tool-level validation error. It also ensures a malformed namespace filter can never be discarded and silently widened into a cluster-wide query.

## What changed

- Route every registered tool through one small handler factory so argument handling is consistent.
- Accept `null` as an omitted optional arguments object and normalize it to an empty object.
- Reject strings, arrays, numbers, and booleans with `arguments must be a JSON object`.
- Preserve scope filters rather than silently replacing malformed input with cluster-wide defaults.
- Keep required-field and field-type validation in `CallTool` unchanged.
- Bind every handler from its declared `mcp.Tool.Name`, eliminating duplicated tool-name literals at registration sites.

The fix covers vulnerability-manifest listing, vulnerability listing, CVE match lookup, configuration-manifest listing, and configuration-manifest retrieval.

## Tests

- Dispatches real JSON-RPC `tools/call` messages through the registered MCP server.
- Verifies strings, arrays, numbers, and booleans return a tool-level validation error for every affected storage tool.
- Verifies `null` remains valid for tools whose arguments are fully optional.
- Uses the generated storage fake to prove each registered handler reaches the correct bound operation and preserves valid filters.
- Exercises registration, request decoding, dispatch, argument validation, and recovery middleware together.

## Validation

```text
go test -race -count=1 ./cmd/mcpserver
go vet ./cmd/mcpserver
golangci-lint run --timeout 10m --new-from-rev upstream/master ./cmd/mcpserver/...
```

Both commands pass locally with zero lint issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool request handling by validating that `arguments` (when provided) are a JSON object and returning a clear error when not.
  * Treated `arguments: null` as “no arguments” for relevant listing tools.
  * Ensured tool calls are dispatched using the tool’s declared name and forward parsed argument filters correctly.

* **Tests**
  * Added/rewrote coverage for registered storage tool argument validation, dispatch behavior, and response field forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->