### PR TITLE
fix(git): support detached HEAD repository metadata

### DIFF
--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -29,10 +29,6 @@ func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
 		return nil, err
 	}
 
-	if !head.Name().IsBranch() {
-		return nil, fmt.Errorf("current HEAD reference is not a branch")
-	}
-
 	config, err := goGitRepo.Config()
 	if err != nil {
 		return nil, err
@@ -62,6 +58,9 @@ func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
 
 // GetBranchName get current branch name
 func (g *LocalGitRepository) GetBranchName() string {
+	if !g.head.Name().IsBranch() {
+		return ""
+	}
 	return g.head.Name().Short()
 }
 

--- a/core/cautils/localgitrepository_test.go
+++ b/core/cautils/localgitrepository_test.go
@@ -8,9 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	gitv5 "github.com/go-git/go-git/v5"
 	configv5 "github.com/go-git/go-git/v5/config"
 	plumbingv5 "github.com/go-git/go-git/v5/plumbing"
+	objectv5 "github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -197,4 +202,145 @@ func TestGetRemoteUrl(t *testing.T) {
 		},
 		)
 	}
+}
+
+func TestLocalGitRepositoryDetachedHead(t *testing.T) {
+	fixture := createDetachedRepositoryFixture(t, "origin", "https://github.com/kubescape/detached-head-fixture.git")
+
+	repository, err := NewLocalGitRepository(filepath.Join(fixture.root, "nested"))
+	require.NoError(t, err)
+	assert.Empty(t, repository.GetBranchName(), "a detached commit must not be reported as a branch")
+
+	remoteURL, err := repository.GetRemoteUrl()
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/kubescape/detached-head-fixture.git", remoteURL)
+	name, err := repository.GetName()
+	require.NoError(t, err)
+	assert.Equal(t, "detached-head-fixture", name)
+
+	root, err := repository.GetRootDir()
+	require.NoError(t, err)
+	wantRoot, err := filepath.EvalSymlinks(fixture.root)
+	require.NoError(t, err)
+	assert.Equal(t, wantRoot, root)
+
+	commit, err := repository.GetLastCommit()
+	require.NoError(t, err)
+	assert.Equal(t, fixture.commit.String(), commit.SHA)
+	assert.Equal(t, "fixture commit", commit.Message)
+	assert.Equal(t, "Fixture Author", commit.Author.Name)
+	assert.Equal(t, "Fixture Committer", commit.Committer.Name)
+	assert.True(t, fixture.when.Equal(commit.Committer.Date))
+}
+
+func TestDetachedHeadRemoteResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteName string
+		wantURL    string
+		wantError  string
+	}{
+		{
+			name:       "origin is the detached default",
+			remoteName: "origin",
+			wantURL:    "https://example.com/team/project.git",
+		},
+		{
+			name:       "a non-origin remote is not guessed",
+			remoteName: "upstream",
+			wantError:  "did not find a default remote with name 'origin'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := createDetachedRepositoryFixture(t, tt.remoteName, "https://example.com/team/project.git")
+			repository, err := NewLocalGitRepository(fixture.root)
+			require.NoError(t, err)
+
+			got, err := repository.GetRemoteUrl()
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURL, got)
+		})
+	}
+}
+
+func TestMetadataGitLocalDetachedHead(t *testing.T) {
+	t.Run("origin produces complete detached metadata", func(t *testing.T) {
+		fixture := createDetachedRepositoryFixture(t, "origin", "https://github.com/kubescape/detached-head-fixture.git")
+
+		metadata, err := metadataGitLocal(fixture.root)
+		require.NoError(t, err)
+		require.NotNil(t, metadata)
+		assert.Equal(t, "none", metadata.Branch)
+		assert.Equal(t, "none", metadata.DefaultBranch)
+		assert.Equal(t, "github", metadata.Provider)
+		assert.Equal(t, "kubescape", metadata.Owner)
+		assert.Equal(t, "detached-head-fixture", metadata.Repo)
+		assert.Equal(t, "https://github.com/kubescape/detached-head-fixture", metadata.RemoteURL)
+		wantRoot, rootErr := filepath.EvalSymlinks(fixture.root)
+		require.NoError(t, rootErr)
+		assert.Equal(t, wantRoot, metadata.LocalRootPath)
+		assert.Equal(t, fixture.commit.String(), metadata.LastCommit.Hash)
+		assert.Equal(t, "Fixture Committer", metadata.LastCommit.CommitterName)
+		assert.True(t, fixture.when.Equal(metadata.LastCommit.Date))
+	})
+
+	t.Run("remote lookup failure preserves safe partial metadata", func(t *testing.T) {
+		fixture := createDetachedRepositoryFixture(t, "upstream", "https://example.com/team/project.git")
+
+		metadata, err := metadataGitLocal(fixture.root)
+		require.EqualError(t, err, "did not find a default remote with name 'origin'")
+		require.NotNil(t, metadata)
+		assert.Equal(t, "none", metadata.Branch)
+		assert.Equal(t, "none", metadata.DefaultBranch)
+		wantRoot, rootErr := filepath.EvalSymlinks(fixture.root)
+		require.NoError(t, rootErr)
+		assert.Equal(t, wantRoot, metadata.LocalRootPath)
+	})
+}
+
+type detachedRepositoryFixture struct {
+	root   string
+	commit plumbingv5.Hash
+	when   time.Time
+}
+
+func createDetachedRepositoryFixture(t *testing.T, remoteName, remoteURL string) detachedRepositoryFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	repository, err := gitv5.PlainInit(root, false)
+	require.NoError(t, err)
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(filepath.Join(root, "nested"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("fixture\n"), 0o600))
+	_, err = worktree.Add("README.md")
+	require.NoError(t, err)
+
+	when := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commit, err := worktree.Commit("fixture commit", &gitv5.CommitOptions{
+		Author: &objectv5.Signature{
+			Name:  "Fixture Author",
+			Email: "author@example.com",
+			When:  when.Add(-time.Minute),
+		},
+		Committer: &objectv5.Signature{
+			Name:  "Fixture Committer",
+			Email: "committer@example.com",
+			When:  when,
+		},
+	})
+	require.NoError(t, err)
+	_, err = repository.CreateRemote(&configv5.RemoteConfig{Name: remoteName, URLs: []string{remoteURL}})
+	require.NoError(t, err)
+	require.NoError(t, repository.Storer.SetReference(plumbingv5.NewHashReference(plumbingv5.HEAD, commit)))
+
+	return detachedRepositoryFixture{root: root, commit: commit, when: when}
 }

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -537,25 +537,36 @@ func (scanInfo *ScanInfo) setContextMetadata(ctx context.Context, contextMetadat
 }
 
 func metadataGitLocal(input string) (*reporthandlingv2.RepoContextMetadata, error) {
+	repoContext := &reporthandlingv2.RepoContextMetadata{
+		Branch:        "none",
+		DefaultBranch: "none",
+		LocalRootPath: getAbsPath(input),
+	}
 	gitParser, err := NewLocalGitRepository(input)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return repoContext, fmt.Errorf("%w", err)
+	}
+	if root, rootErr := gitParser.GetRootDir(); rootErr == nil {
+		repoContext.LocalRootPath = root
 	}
 	remoteURL, err := gitParser.GetRemoteUrl()
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return repoContext, fmt.Errorf("%w", err)
 	}
-	repoContext := &reporthandlingv2.RepoContextMetadata{}
 	gitParserURL, err := giturl.NewGitURL(remoteURL)
 	if err != nil {
 		return repoContext, fmt.Errorf("%w", err)
 	}
-	gitParserURL.SetBranchName(gitParser.GetBranchName())
+	branchName := gitParser.GetBranchName()
+	if branchName != "" {
+		gitParserURL.SetBranchName(branchName)
+		repoContext.Branch = branchName
+		repoContext.DefaultBranch = ""
+	}
 
 	repoContext.Provider = gitParserURL.GetProvider()
 	repoContext.Repo = gitParserURL.GetRepoName()
 	repoContext.Owner = gitParserURL.GetOwnerName()
-	repoContext.Branch = gitParserURL.GetBranchName()
 	repoContext.RemoteURL = gitParserURL.GetURL().String()
 
 	commit, err := gitParser.GetLastCommit()
@@ -567,8 +578,6 @@ func metadataGitLocal(input string) (*reporthandlingv2.RepoContextMetadata, erro
 		Date:          commit.Committer.Date,
 		CommitterName: commit.Committer.Name,
 	}
-	repoContext.LocalRootPath, _ = gitParser.GetRootDir()
-
 	return repoContext, nil
 }
 func getHostname() string {

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -158,10 +158,15 @@ func isSupportedScanningTarget(report *reporthandlingv2.PostureReport) error {
 }
 
 func getLocalPath(report *reporthandlingv2.PostureReport) string {
-
+	if report == nil {
+		return ""
+	}
 	switch report.Metadata.ScanMetadata.ScanningTarget {
 	case reporthandlingv2.GitLocal:
-		return report.Metadata.ContextMetadata.RepoContextMetadata.LocalRootPath
+		if repo := report.Metadata.ContextMetadata.RepoContextMetadata; repo != nil {
+			return repo.LocalRootPath
+		}
+		return ""
 	case reporthandlingv2.Directory:
 		return report.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath
 	case reporthandlingv2.File:

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -632,6 +632,26 @@ func TestGetLocalPath(t *testing.T) {
 			want: os.TempDir(),
 		},
 		{
+			name: "Scan target GitLocal without repository metadata",
+			args: args{
+				report: &reporthandlingv2.PostureReport{
+					Metadata: reporthandlingv2.Metadata{
+						ScanMetadata: reporthandlingv2.ScanMetadata{
+							ScanningTarget: reporthandlingv2.GitLocal,
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "nil report",
+			args: args{
+				report: nil,
+			},
+			want: "",
+		},
+		{
 			name: "Scan target Directory",
 			args: args{
 				report: &reporthandlingv2.PostureReport{

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -440,9 +440,15 @@ func getDocIndex(opaSessionObj *cautils.OPASessionObj, resourceID string) (int, 
 }
 
 func getBasePathFromMetadata(opaSessionObj cautils.OPASessionObj) string {
+	if opaSessionObj.Metadata == nil {
+		return ""
+	}
 	switch opaSessionObj.Metadata.ScanMetadata.ScanningTarget {
 	case v2.GitLocal:
-		return opaSessionObj.Metadata.ContextMetadata.RepoContextMetadata.LocalRootPath
+		if repo := opaSessionObj.Metadata.ContextMetadata.RepoContextMetadata; repo != nil {
+			return repo.LocalRootPath
+		}
+		return ""
 	case v2.Directory:
 		return opaSessionObj.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath
 	case v2.File:

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -427,6 +427,22 @@ func TestGetBasePathFromMetadata(t *testing.T) {
 			want: tempDir,
 		},
 		{
+			name: "GitLocal without repository metadata",
+			session: cautils.OPASessionObj{
+				Metadata: &reporthandlingv2.Metadata{
+					ScanMetadata: reporthandlingv2.ScanMetadata{
+						ScanningTarget: reporthandlingv2.GitLocal,
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "missing metadata",
+			session: cautils.OPASessionObj{},
+			want:    "",
+		},
+		{
 			name: "Directory",
 			session: cautils.OPASessionObj{
 				Metadata: &reporthandlingv2.Metadata{


### PR DESCRIPTION
# fix(git): support detached HEAD repository metadata

## Summary

Kubescape rejected local Git repositories when `HEAD` pointed directly to a commit. This is common in CI, where jobs check out an exact commit or pull-request merge commit instead of a local branch.

This change lets those repositories keep their useful Git metadata without exposing `HEAD` as a branch or making downstream output paths unsafe when remote metadata is incomplete.

## What changed

- Allow local repositories with a detached `HEAD` to initialize normally.
- Keep `GetBranchName()` empty for non-branch references, while reporting the established `"none"` placeholder in submitted repository metadata.
- Report `DefaultBranch: "none"` for detached checkouts because there is no checked-out branch from which to infer one.
- Continue honoring branch-specific remote configuration for normal branch checkouts.
- Fall back to `origin` when a detached checkout has no branch configuration.
- Preserve safe partial metadata, including the repository root, when remote discovery fails.
- Guard SARIF path resolution and fix handling against absent repository metadata.
- Preserve exact author and committer information for the detached `HEAD` commit.

## Tests

- Build real temporary go-git repositories directly in the existing local repository test suite.
- Verify detached branch naming, repository name, root, origin URL, and exact `HEAD` commit metadata.
- Verify detached metadata uses `Branch: "none"` and `DefaultBranch: "none"`.
- Verify a detached checkout with only a non-`origin` remote returns safe, non-nil partial metadata.
- Verify SARIF and fix path helpers return an empty path instead of panicking when repository metadata is absent.

## Validation

```text
go test -race -count=1 ./core/cautils
go test -race -count=1 ./core/pkg/fixhandler
go test -race -count=1 ./core/pkg/resultshandling/printer/v2
go vet ./core/cautils ./core/pkg/fixhandler ./core/pkg/resultshandling/printer/v2
golangci-lint run --timeout 10m --new-from-rev FETCH_HEAD ./core/cautils ./core/pkg/fixhandler ./core/pkg/resultshandling/printer/v2
```

All affected tests pass with zero lint issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for git repositories in detached HEAD state.

* **Bug Fixes**
  * Added nil safety checks throughout metadata handling to prevent crashes when repository context information is missing.
  * Improved error handling and default value initialization to provide fallback information when metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->