### PR TITLE
fix(output): drop the truncated image label from scan hints

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -243,11 +243,10 @@ func printImageScanningSummary(writer *os.File, summary imageprinter.ImageScanSu
 
 func printImagesCommands(writer *os.File, summary imageprinter.ImageScanSummary) {
 	if len(summary.Images) > 3 {
-		cautils.SimpleDisplay(writer, "Receive full report by running: kubescape scan image <image>\n")
+		cautils.SimpleDisplay(writer, "Receive a full report by running: kubescape scan image <image>\n")
 	} else {
 		for _, img := range summary.Images {
-			imgWithoutTag, _, _ := strings.Cut(img, ":")
-			cautils.SimpleDisplay(writer, fmt.Sprintf("Receive a full report for %s by running: %s\n", imgWithoutTag, getCallToActionString(fmt.Sprintf("'$ kubescape scan image %s'", img))))
+			cautils.SimpleDisplay(writer, fmt.Sprintf("Receive a full report by running: %s\n", getCallToActionString(fmt.Sprintf("'$ kubescape scan image %s'", img))))
 		}
 	}
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
@@ -1,12 +1,16 @@
 package prettyprinter
 
 import (
+	"io"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterComplianceFrameworks(t *testing.T) {
@@ -49,6 +53,69 @@ func TestFilterComplianceFrameworks(t *testing.T) {
 			assert.True(t, reflect.DeepEqual(complianceFws, tt.expectedSummaryDetails.ListFrameworks()))
 		})
 	}
+}
+
+func TestPrintImagesCommandsUsesFullImageReference(t *testing.T) {
+	tests := []struct {
+		name        string
+		images      []string
+		wantGeneric bool
+	}{
+		{
+			name:   "tagged short names remain distinct",
+			images: []string{"nginx:1.25", "nginx:1.27"},
+		},
+		{
+			name:   "registry port is preserved",
+			images: []string{"localhost:5000/team/api:v1"},
+		},
+		{
+			name: "digest is preserved",
+			images: []string{
+				"registry.example.com/team/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+		{
+			name:        "large image sets keep the generic hint",
+			images:      []string{"one:v1", "two:v2", "three:v3", "four:v4"},
+			wantGeneric: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := capturePrintImagesCommands(t, tt.images)
+			if tt.wantGeneric {
+				assert.Contains(t, output, "Receive a full report by running: kubescape scan image <image>")
+				for _, image := range tt.images {
+					assert.NotContains(t, output, image)
+				}
+				return
+			}
+
+			for _, image := range tt.images {
+				assert.Equal(t, 1, strings.Count(output, image),
+					"the command should contain the full image reference exactly once")
+			}
+			assert.NotContains(t, output, "Receive a full report for ")
+		})
+	}
+}
+
+func capturePrintImagesCommands(t *testing.T, images []string) string {
+	t.Helper()
+
+	output, err := os.CreateTemp(t.TempDir(), "image-commands-*.txt")
+	require.NoError(t, err)
+	defer output.Close()
+
+	printImagesCommands(output, imageprinter.ImageScanSummary{Images: images})
+	require.NoError(t, output.Sync())
+	_, err = output.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	contents, err := io.ReadAll(output)
+	require.NoError(t, err)
+	return string(contents)
 }
 
 func TestGetWorkloadPrefixForCmd(t *testing.T) {


### PR DESCRIPTION
# fix(output): drop the truncated image label from scan hints

## Summary

The pretty-printer shortened image names by cutting at the first colon. That works for `nginx:latest`, but it breaks private registries with ports: `localhost:5000/team/api:v1` was displayed as only `localhost`.

The suggested command already contained the full image reference. This change removes the redundant label and leaves that unambiguous command as the hint, so private registry ports are not truncated and separate tags such as `nginx:1.25` and `nginx:1.27` remain distinguishable.

## What changed

- Drop the lossy image label from per-image scan hints.
- Keep the full registry, repository, tag, or digest in the executable command.
- Avoid maintaining a second image-reference parsing rule in the pretty-printer.
- Keep the existing generic hint for reports containing more than three images.
- Use consistent “Receive a full report” wording in both hint branches.

## Tests

- Adds one focused table to the existing `utils_test.go` suite.
- Covers distinct tagged short names, a private registry port, a digest reference, and the existing large-image generic hint.
- Confirms each per-image hint contains the complete reference exactly once and the old label is absent.

## Validation

```text
go test -race -count=1 ./core/pkg/resultshandling/printer/v2/...
go vet ./core/pkg/resultshandling/printer/v2/...
golangci-lint run --timeout 10m --new-from-rev upstream/master ./core/pkg/resultshandling/printer/v2/...
```

All commands pass locally with zero lint issues.
