### PR TITLE
test-core-download-coverage

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -33,16 +33,28 @@ var downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{
 	TargetAttackTracks:   downloadAttackTracks,
 }
 
-// Indirection seams for the download* functions below: by default they are
-// the real getter constructors from initutils.go (which, with no local file
-// and no account configured, ultimately reach the network - GitHub releases
-// or the Kubescape Cloud API). Tests substitute fakes here to exercise every
-// branch of the download* functions without a network dependency.
+// Indirection seams used only by the download* functions in this file: by
+// default they are the real getter constructors from initutils.go,
+// cautils.GetTenantConfig, and getKubernetesApi, which (with no local file,
+// no account configured, and/or a reachable cluster) ultimately reach the
+// network - GitHub releases, the Kubescape Cloud API, or the Kubernetes API
+// server. kubernetesAPIFunc in particular must be stubbed together with
+// tenantConfigFunc: it is evaluated eagerly as an argument to
+// tenantConfigFunc, so leaving it real still probes the cluster (discovery's
+// ServerPreferredResources call) even when tenantConfigFunc itself is faked.
+// Tests substitute fakes here to exercise every branch of the download*
+// functions without a network or cluster dependency.
+//
+// policyGetterFunc and exceptionsGetterFunc are also called directly (not
+// through these vars) from list.go and scan.go, so swapping them here has no
+// effect on those call sites.
 var (
 	policyGetterFunc       = getPolicyGetter
 	exceptionsGetterFunc   = getExceptionsGetter
 	attackTracksGetterFunc = getAttackTracksGetter
 	configInputsGetterFunc = getConfigInputsGetter
+	tenantConfigFunc       = cautils.GetTenantConfig
+	kubernetesAPIFunc      = getKubernetesApi
 )
 
 func DownloadSupportCommands() []string {
@@ -110,7 +122,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 }
 
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
-	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
+	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	controlsInputsGetter, _, err := configInputsGetterFunc(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	if err != nil {
@@ -136,7 +148,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 }
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
-	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
+	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 	exceptionsGetter, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return err
@@ -161,7 +173,7 @@ func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) 
 
 func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	var err error
-	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
+	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	attackTracksGetter, err := attackTracksGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
@@ -188,7 +200,7 @@ func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 
-	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
+	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), true, nil, false)
 	if err != nil {
@@ -242,7 +254,7 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 
 func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 
-	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
+	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	if err != nil {

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -33,6 +33,18 @@ var downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{
 	TargetAttackTracks:   downloadAttackTracks,
 }
 
+// Indirection seams for the download* functions below: by default they are
+// the real getter constructors from initutils.go (which, with no local file
+// and no account configured, ultimately reach the network - GitHub releases
+// or the Kubescape Cloud API). Tests substitute fakes here to exercise every
+// branch of the download* functions without a network dependency.
+var (
+	policyGetterFunc       = getPolicyGetter
+	exceptionsGetterFunc   = getExceptionsGetter
+	attackTracksGetterFunc = getAttackTracksGetter
+	configInputsGetterFunc = getConfigInputsGetter
+)
+
 func DownloadSupportCommands() []string {
 	commands := []string{}
 	for key := range downloadFunc {
@@ -100,7 +112,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	controlsInputsGetter, _, err := getConfigInputsGetter(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
+	controlsInputsGetter, _, err := configInputsGetterFunc(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	if err != nil {
 		return err
 	}
@@ -125,7 +137,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
-	exceptionsGetter, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	exceptionsGetter, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return err
 	}
@@ -151,7 +163,7 @@ func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo
 	var err error
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	attackTracksGetter, err := getAttackTracksGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	attackTracksGetter, err := attackTracksGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return err
 	}
@@ -178,7 +190,7 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
+	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), true, nil, false)
 	if err != nil {
 		return err
 	}
@@ -232,7 +244,7 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) err
 
 	tenant := cautils.GetTenantConfig(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", getKubernetesApi())
 
-	g, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
+	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	if err != nil {
 		return err
 	}

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -2,12 +2,18 @@ package core
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,4 +172,512 @@ func TestDownload_UnknownTargetReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.EqualError(t, err, "unknown command to download")
+}
+
+// ---------------------------------------------------------------------------
+// Fakes for the getter interfaces, used together with the policyGetterFunc /
+// exceptionsGetterFunc / attackTracksGetterFunc / configInputsGetterFunc
+// seams so the download* functions below can be exercised without a network
+// or cluster dependency.
+// ---------------------------------------------------------------------------
+
+type fakePolicyGetter struct {
+	frameworks    []reporthandling.Framework
+	frameworksErr error
+	framework     *reporthandling.Framework
+	frameworkErr  error
+	control       *reporthandling.Control
+	controlErr    error
+}
+
+func (f *fakePolicyGetter) GetFramework(string) (*reporthandling.Framework, error) {
+	return f.framework, f.frameworkErr
+}
+func (f *fakePolicyGetter) GetFrameworks() ([]reporthandling.Framework, error) {
+	return f.frameworks, f.frameworksErr
+}
+func (f *fakePolicyGetter) GetControl(string) (*reporthandling.Control, error) {
+	return f.control, f.controlErr
+}
+func (f *fakePolicyGetter) ListFrameworks() ([]string, error) { return nil, nil }
+func (f *fakePolicyGetter) ListControls() ([]string, error)   { return nil, nil }
+
+type fakeExceptionsGetter struct {
+	exceptions []armotypes.PostureExceptionPolicy
+	err        error
+}
+
+func (f *fakeExceptionsGetter) GetExceptions(string) ([]armotypes.PostureExceptionPolicy, error) {
+	return f.exceptions, f.err
+}
+
+type fakeAttackTracksGetter struct {
+	tracks []v1alpha1.AttackTrack
+	err    error
+}
+
+func (f *fakeAttackTracksGetter) GetAttackTracks() ([]v1alpha1.AttackTrack, error) {
+	return f.tracks, f.err
+}
+
+type fakeControlsInputsGetter struct {
+	inputs map[string][]string
+	err    error
+}
+
+func (f *fakeControlsInputsGetter) GetControlsInputs(string) (map[string][]string, error) {
+	return f.inputs, f.err
+}
+
+// blockedDir returns a path that cannot be used as a directory (it is a
+// regular file), so a getter.SaveInFile call underneath it fails with a
+// non-NotExist error instead of silently mkdir-ing its way to success.
+func blockedDir(t *testing.T) string {
+	t.Helper()
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	return blocker
+}
+
+func TestDownloadConfigInputs(t *testing.T) {
+	t.Run("returns error from the getter constructor", func(t *testing.T) {
+		orig := configInputsGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return nil, false, errors.New("boom")
+		}
+		t.Cleanup(func() { configInputsGetterFunc = orig })
+
+		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		require.EqualError(t, err, "boom")
+	})
+
+	t.Run("returns error from GetControlsInputs", func(t *testing.T) {
+		orig := configInputsGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{err: errors.New("fetch failed")}, false, nil
+		}
+		t.Cleanup(func() { configInputsGetterFunc = orig })
+
+		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		require.EqualError(t, err, "fetch failed")
+	})
+
+	t.Run("returns error when controlInputs is nil", func(t *testing.T) {
+		orig := configInputsGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{inputs: nil}, false, nil
+		}
+		t.Cleanup(func() { configInputsGetterFunc = orig })
+
+		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		require.EqualError(t, err, "failed to download controlInputs - received an empty objects")
+	})
+
+	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
+		orig := configInputsGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"b"}}}, false, nil
+		}
+		t.Cleanup(func() { configInputsGetterFunc = orig })
+
+		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: blockedDir(t)})
+		require.Error(t, err)
+	})
+
+	t.Run("succeeds and defaults the filename", func(t *testing.T) {
+		orig := configInputsGetterFunc
+		want := map[string][]string{"alpha": {"1", "2"}}
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{inputs: want}, false, nil
+		}
+		t.Cleanup(func() { configInputsGetterFunc = orig })
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetControlsInputs, Path: dir}
+		require.NoError(t, downloadConfigInputs(context.Background(), info))
+		assert.Equal(t, "controls-inputs.json", info.FileName)
+
+		var got map[string][]string
+		readJSONFile(t, filepath.Join(dir, info.FileName), &got)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestDownloadExceptions(t *testing.T) {
+	t.Run("returns error from the getter constructor", func(t *testing.T) {
+		orig := exceptionsGetterFunc
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() { exceptionsGetterFunc = orig })
+
+		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
+		require.EqualError(t, err, "boom")
+	})
+
+	t.Run("returns error from GetExceptions", func(t *testing.T) {
+		orig := exceptionsGetterFunc
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return &fakeExceptionsGetter{err: errors.New("fetch failed")}, nil
+		}
+		t.Cleanup(func() { exceptionsGetterFunc = orig })
+
+		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
+		require.EqualError(t, err, "fetch failed")
+	})
+
+	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
+		orig := exceptionsGetterFunc
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return &fakeExceptionsGetter{}, nil
+		}
+		t.Cleanup(func() { exceptionsGetterFunc = orig })
+
+		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: blockedDir(t)})
+		require.Error(t, err)
+	})
+
+	t.Run("succeeds and preserves an explicit filename", func(t *testing.T) {
+		orig := exceptionsGetterFunc
+		want := []armotypes.PostureExceptionPolicy{{PolicyType: "exception"}}
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return &fakeExceptionsGetter{exceptions: want}, nil
+		}
+		t.Cleanup(func() { exceptionsGetterFunc = orig })
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetExceptions, Path: dir, FileName: "custom-exceptions.json"}
+		require.NoError(t, downloadExceptions(context.Background(), info))
+		assert.Equal(t, "custom-exceptions.json", info.FileName)
+
+		var got []armotypes.PostureExceptionPolicy
+		readJSONFile(t, filepath.Join(dir, info.FileName), &got)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestDownloadAttackTracks(t *testing.T) {
+	t.Run("returns error from the getter constructor", func(t *testing.T) {
+		orig := attackTracksGetterFunc
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() { attackTracksGetterFunc = orig })
+
+		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
+		require.EqualError(t, err, "boom")
+	})
+
+	t.Run("returns error from GetAttackTracks", func(t *testing.T) {
+		orig := attackTracksGetterFunc
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return &fakeAttackTracksGetter{err: errors.New("fetch failed")}, nil
+		}
+		t.Cleanup(func() { attackTracksGetterFunc = orig })
+
+		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
+		require.EqualError(t, err, "fetch failed")
+	})
+
+	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
+		orig := attackTracksGetterFunc
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return &fakeAttackTracksGetter{}, nil
+		}
+		t.Cleanup(func() { attackTracksGetterFunc = orig })
+
+		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: blockedDir(t)})
+		require.Error(t, err)
+	})
+
+	t.Run("succeeds and defaults the filename", func(t *testing.T) {
+		orig := attackTracksGetterFunc
+		want := []v1alpha1.AttackTrack{{ApiVersion: "v1"}}
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return &fakeAttackTracksGetter{tracks: want}, nil
+		}
+		t.Cleanup(func() { attackTracksGetterFunc = orig })
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetAttackTracks, Path: dir}
+		require.NoError(t, downloadAttackTracks(context.Background(), info))
+		assert.Equal(t, "attack-tracks.json", info.FileName)
+
+		var got []v1alpha1.AttackTrack
+		readJSONFile(t, filepath.Join(dir, info.FileName), &got)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestDownloadFramework(t *testing.T) {
+	t.Run("returns error from the getter constructor", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
+		require.EqualError(t, err, "boom")
+	})
+
+	t.Run("no identifier: returns error from GetFrameworks", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworksErr: errors.New("fetch failed")}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
+		require.EqualError(t, err, "fetch failed")
+	})
+
+	t.Run("no identifier: skips a framework with an empty name and saves the rest", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworks: []reporthandling.Framework{
+				{PortalBase: armotypes.PortalBase{Name: ""}},
+				{PortalBase: armotypes.PortalBase{Name: "nsa"}},
+			}}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		dir := t.TempDir()
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: dir})
+		require.NoError(t, err)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "nsa.json", entries[0].Name())
+	})
+
+	t.Run("no identifier: returns error when SaveInFile fails", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworks: []reporthandling.Framework{
+				{PortalBase: armotypes.PortalBase{Name: "nsa"}},
+			}}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t)})
+		require.Error(t, err)
+	})
+
+	t.Run("with identifier: returns error from PolicyCacheFilename", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "a/b"})
+		require.Error(t, err)
+	})
+
+	t.Run("with identifier: returns error from GetFramework", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworkErr: errors.New("fetch failed")}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
+		require.EqualError(t, err, "fetch failed")
+	})
+
+	t.Run("with identifier: returns error when the framework is nil", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{framework: nil}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
+		require.EqualError(t, err, "failed to download framework - received an empty objects")
+	})
+
+	t.Run("with identifier: succeeds and derives the filename", func(t *testing.T) {
+		orig := policyGetterFunc
+		want := &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{framework: want}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetFramework, Path: dir, Identifier: "nsa"}
+		require.NoError(t, downloadFramework(context.Background(), info))
+		assert.Equal(t, "nsa.json", info.FileName)
+
+		var got reporthandling.Framework
+		readJSONFile(t, filepath.Join(dir, info.FileName), &got)
+		assert.Equal(t, want.Name, got.Name)
+	})
+
+	t.Run("with identifier: returns error when SaveInFile fails", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{framework: &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t), Identifier: "nsa"})
+		require.Error(t, err)
+	})
+}
+
+func TestDownloadControl(t *testing.T) {
+	t.Run("returns error from the getter constructor", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		require.EqualError(t, err, "boom")
+	})
+
+	t.Run("returns error when the identifier is missing", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir()})
+		require.EqualError(t, err, "missing control ID")
+	})
+
+	t.Run("returns error from PolicyCacheFilename", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "a/b"})
+		require.Error(t, err)
+	})
+
+	t.Run("returns a wrapped error from GetControl", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{controlErr: errors.New("fetch failed")}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		require.ErrorContains(t, err, "C-0001")
+		require.ErrorContains(t, err, "fetch failed")
+	})
+
+	t.Run("returns error when the control is nil", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{control: nil}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		require.ErrorContains(t, err, "C-0001")
+		require.ErrorContains(t, err, "received an empty objects")
+	})
+
+	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
+		orig := policyGetterFunc
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{control: &reporthandling.Control{}}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: blockedDir(t), Identifier: "C-0001"})
+		require.Error(t, err)
+	})
+
+	t.Run("succeeds and derives the filename", func(t *testing.T) {
+		orig := policyGetterFunc
+		want := &reporthandling.Control{ControlID: "C-0001"}
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{control: want}, nil
+		}
+		t.Cleanup(func() { policyGetterFunc = orig })
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetControl, Path: dir, Identifier: "C-0001"}
+		require.NoError(t, downloadControl(context.Background(), info))
+		assert.Equal(t, "c-0001.json", info.FileName)
+
+		var got reporthandling.Control
+		readJSONFile(t, filepath.Join(dir, info.FileName), &got)
+		assert.Equal(t, want.ControlID, got.ControlID)
+	})
+}
+
+func TestDownloadArtifacts(t *testing.T) {
+	t.Run("saves every artifact and always returns nil", func(t *testing.T) {
+		origConfig, origExceptions, origAttack, origPolicy := configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, false, nil
+		}
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return &fakeExceptionsGetter{exceptions: []armotypes.PostureExceptionPolicy{{}}}, nil
+		}
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil
+		}
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil
+		}
+		t.Cleanup(func() {
+			configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc = origConfig, origExceptions, origAttack, origPolicy
+		})
+
+		dir := t.TempDir()
+		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
+		require.NoError(t, err)
+
+		for _, want := range []string{"controls-inputs.json", "exceptions.json", "nsa.json", "attack-tracks.json"} {
+			_, statErr := os.Stat(filepath.Join(dir, want))
+			assert.NoError(t, statErr, "expected %s to have been written", want)
+		}
+	})
+
+	t.Run("logs a warning and continues when one artifact fails", func(t *testing.T) {
+		origConfig, origExceptions, origAttack, origPolicy := configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc
+		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, false, nil
+		}
+		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+			return nil, errors.New("boom")
+		}
+		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+			return &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil
+		}
+		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+			return &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil
+		}
+		t.Cleanup(func() {
+			configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc = origConfig, origExceptions, origAttack, origPolicy
+		})
+
+		dir := t.TempDir()
+		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
+		require.NoError(t, err)
+
+		_, statErr := os.Stat(filepath.Join(dir, "exceptions.json"))
+		assert.True(t, os.IsNotExist(statErr), "exceptions.json should not have been written")
+		_, statErr = os.Stat(filepath.Join(dir, "nsa.json"))
+		assert.NoError(t, statErr, "nsa.json should still have been written")
+	})
+}
+
+// readJSONFile reads and unmarshals a JSON file, failing the test on error.
+func readJSONFile(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, v))
 }

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -176,9 +178,9 @@ func TestDownload_UnknownTargetReturnsError(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Fakes for the getter interfaces, used together with the policyGetterFunc /
-// exceptionsGetterFunc / attackTracksGetterFunc / configInputsGetterFunc
-// seams so the download* functions below can be exercised without a network
-// or cluster dependency.
+// exceptionsGetterFunc / attackTracksGetterFunc / configInputsGetterFunc /
+// tenantConfigFunc seams so the download* functions below can be exercised
+// without a network or cluster dependency.
 // ---------------------------------------------------------------------------
 
 type fakePolicyGetter struct {
@@ -229,9 +231,31 @@ func (f *fakeControlsInputsGetter) GetControlsInputs(string) (map[string][]strin
 	return f.inputs, f.err
 }
 
+// fakeTenantConfig is a minimal cautils.ITenantConfig that never touches disk,
+// the network, or a Kubernetes cluster.
+type fakeTenantConfig struct {
+	accountID   string
+	contextName string
+}
+
+var _ cautils.ITenantConfig = &fakeTenantConfig{}
+
+func (f *fakeTenantConfig) UpdateCachedConfig() error                { return nil }
+func (f *fakeTenantConfig) DeleteCachedConfig(context.Context) error { return nil }
+func (f *fakeTenantConfig) GenerateAccountID() (string, error)       { return f.accountID, nil }
+func (f *fakeTenantConfig) DeleteCredentials() error                 { return nil }
+func (f *fakeTenantConfig) GetContextName() string                   { return f.contextName }
+func (f *fakeTenantConfig) GetAccountID() string                     { return f.accountID }
+func (f *fakeTenantConfig) GetAccessKey() string                     { return "" }
+func (f *fakeTenantConfig) GetConfigObj() *cautils.ConfigObj         { return &cautils.ConfigObj{} }
+func (f *fakeTenantConfig) GetCloudReportURL() string                { return "" }
+func (f *fakeTenantConfig) GetCloudAPIURL() string                   { return "" }
+
 // blockedDir returns a path that cannot be used as a directory (it is a
 // regular file), so a getter.SaveInFile call underneath it fails with a
-// non-NotExist error instead of silently mkdir-ing its way to success.
+// non-NotExist error instead of silently mkdir-ing its way to success. The
+// resulting *fs.PathError includes this file's name ("blocker") in its
+// message, which the "SaveInFile fails" subtests below assert on.
 func blockedDir(t *testing.T) string {
 	t.Helper()
 	blocker := filepath.Join(t.TempDir(), "blocker")
@@ -239,58 +263,110 @@ func blockedDir(t *testing.T) string {
 	return blocker
 }
 
+// ---------------------------------------------------------------------------
+// Seam helpers. None of these are safe to use from a subtest that also calls
+// t.Parallel(): they mutate the package-level *Func vars for the duration of
+// the (sub)test and restore them on cleanup, so concurrent subtests would
+// race on and clobber each other's stubs.
+// ---------------------------------------------------------------------------
+
+func withConfigInputsGetter(t *testing.T, g getter.IControlsInputsGetter, err error) {
+	t.Helper()
+	orig := configInputsGetterFunc
+	configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
+		return g, false, err
+	}
+	t.Cleanup(func() { configInputsGetterFunc = orig })
+}
+
+func withExceptionsGetter(t *testing.T, g getter.IExceptionsGetter, err error) {
+	t.Helper()
+	orig := exceptionsGetterFunc
+	exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
+		return g, err
+	}
+	t.Cleanup(func() { exceptionsGetterFunc = orig })
+}
+
+func withAttackTracksGetter(t *testing.T, g getter.IAttackTracksGetter, err error) {
+	t.Helper()
+	orig := attackTracksGetterFunc
+	attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
+		return g, err
+	}
+	t.Cleanup(func() { attackTracksGetterFunc = orig })
+}
+
+func withPolicyGetter(t *testing.T, g getter.IPolicyGetter, err error) {
+	t.Helper()
+	orig := policyGetterFunc
+	policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
+		return g, err
+	}
+	t.Cleanup(func() { policyGetterFunc = orig })
+}
+
+// withTenantConfig stubs tenantConfigFunc AND kubernetesAPIFunc so the
+// download* functions never reach cautils.GetTenantConfig or
+// getKubernetesApi. Both must be stubbed together: kubernetesAPIFunc() is
+// evaluated eagerly as an argument to tenantConfigFunc(...), so leaving it
+// real still probes a configured cluster (via discovery's
+// ServerPreferredResources) even with tenantConfigFunc faked - reproduced
+// locally by pointing KUBECONFIG at an unroutable address, which hangs
+// TestDownloadConfigInputs for minutes without this stub. With no
+// kubeconfig configured getKubernetesApi() already returns nil, but that's
+// an accident of the test environment, not something these tests should
+// depend on.
+func withTenantConfig(t *testing.T, tc cautils.ITenantConfig) {
+	t.Helper()
+	origTenant := tenantConfigFunc
+	tenantConfigFunc = func(string, string, string, string, *k8sinterface.KubernetesApi) cautils.ITenantConfig {
+		return tc
+	}
+	t.Cleanup(func() { tenantConfigFunc = origTenant })
+
+	origK8s := kubernetesAPIFunc
+	kubernetesAPIFunc = func() *k8sinterface.KubernetesApi { return nil }
+	t.Cleanup(func() { kubernetesAPIFunc = origK8s })
+}
+
 func TestDownloadConfigInputs(t *testing.T) {
 	t.Run("returns error from the getter constructor", func(t *testing.T) {
-		orig := configInputsGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return nil, false, errors.New("boom")
-		}
-		t.Cleanup(func() { configInputsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, nil, errors.New("boom"))
 
 		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error from GetControlsInputs", func(t *testing.T) {
-		orig := configInputsGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{err: errors.New("fetch failed")}, false, nil
-		}
-		t.Cleanup(func() { configInputsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{err: errors.New("fetch failed")}, nil)
 
 		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
 	t.Run("returns error when controlInputs is nil", func(t *testing.T) {
-		orig := configInputsGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{inputs: nil}, false, nil
-		}
-		t.Cleanup(func() { configInputsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: nil}, nil)
 
 		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "failed to download controlInputs - received an empty objects")
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
-		orig := configInputsGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"b"}}}, false, nil
-		}
-		t.Cleanup(func() { configInputsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"b"}}}, nil)
 
 		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: blockedDir(t)})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 
 	t.Run("succeeds and defaults the filename", func(t *testing.T) {
-		orig := configInputsGetterFunc
+		withTenantConfig(t, &fakeTenantConfig{})
 		want := map[string][]string{"alpha": {"1", "2"}}
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{inputs: want}, false, nil
-		}
-		t.Cleanup(func() { configInputsGetterFunc = orig })
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: want}, nil)
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetControlsInputs, Path: dir}
@@ -305,45 +381,33 @@ func TestDownloadConfigInputs(t *testing.T) {
 
 func TestDownloadExceptions(t *testing.T) {
 	t.Run("returns error from the getter constructor", func(t *testing.T) {
-		orig := exceptionsGetterFunc
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return nil, errors.New("boom")
-		}
-		t.Cleanup(func() { exceptionsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withExceptionsGetter(t, nil, errors.New("boom"))
 
 		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error from GetExceptions", func(t *testing.T) {
-		orig := exceptionsGetterFunc
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return &fakeExceptionsGetter{err: errors.New("fetch failed")}, nil
-		}
-		t.Cleanup(func() { exceptionsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withExceptionsGetter(t, &fakeExceptionsGetter{err: errors.New("fetch failed")}, nil)
 
 		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
-		orig := exceptionsGetterFunc
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return &fakeExceptionsGetter{}, nil
-		}
-		t.Cleanup(func() { exceptionsGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withExceptionsGetter(t, &fakeExceptionsGetter{}, nil)
 
 		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: blockedDir(t)})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 
 	t.Run("succeeds and preserves an explicit filename", func(t *testing.T) {
-		orig := exceptionsGetterFunc
+		withTenantConfig(t, &fakeTenantConfig{})
 		want := []armotypes.PostureExceptionPolicy{{PolicyType: "exception"}}
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return &fakeExceptionsGetter{exceptions: want}, nil
-		}
-		t.Cleanup(func() { exceptionsGetterFunc = orig })
+		withExceptionsGetter(t, &fakeExceptionsGetter{exceptions: want}, nil)
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetExceptions, Path: dir, FileName: "custom-exceptions.json"}
@@ -358,45 +422,33 @@ func TestDownloadExceptions(t *testing.T) {
 
 func TestDownloadAttackTracks(t *testing.T) {
 	t.Run("returns error from the getter constructor", func(t *testing.T) {
-		orig := attackTracksGetterFunc
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return nil, errors.New("boom")
-		}
-		t.Cleanup(func() { attackTracksGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withAttackTracksGetter(t, nil, errors.New("boom"))
 
 		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error from GetAttackTracks", func(t *testing.T) {
-		orig := attackTracksGetterFunc
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return &fakeAttackTracksGetter{err: errors.New("fetch failed")}, nil
-		}
-		t.Cleanup(func() { attackTracksGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withAttackTracksGetter(t, &fakeAttackTracksGetter{err: errors.New("fetch failed")}, nil)
 
 		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
-		orig := attackTracksGetterFunc
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return &fakeAttackTracksGetter{}, nil
-		}
-		t.Cleanup(func() { attackTracksGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withAttackTracksGetter(t, &fakeAttackTracksGetter{}, nil)
 
 		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: blockedDir(t)})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 
 	t.Run("succeeds and defaults the filename", func(t *testing.T) {
-		orig := attackTracksGetterFunc
+		withTenantConfig(t, &fakeTenantConfig{})
 		want := []v1alpha1.AttackTrack{{ApiVersion: "v1"}}
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return &fakeAttackTracksGetter{tracks: want}, nil
-		}
-		t.Cleanup(func() { attackTracksGetterFunc = orig })
+		withAttackTracksGetter(t, &fakeAttackTracksGetter{tracks: want}, nil)
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetAttackTracks, Path: dir}
@@ -411,36 +463,27 @@ func TestDownloadAttackTracks(t *testing.T) {
 
 func TestDownloadFramework(t *testing.T) {
 	t.Run("returns error from the getter constructor", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return nil, errors.New("boom")
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, nil, errors.New("boom"))
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
 	t.Run("no identifier: returns error from GetFrameworks", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworksErr: errors.New("fetch failed")}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{frameworksErr: errors.New("fetch failed")}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
 	t.Run("no identifier: skips a framework with an empty name and saves the rest", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworks: []reporthandling.Framework{
-				{PortalBase: armotypes.PortalBase{Name: ""}},
-				{PortalBase: armotypes.PortalBase{Name: "nsa"}},
-			}}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{
+			{PortalBase: armotypes.PortalBase{Name: ""}},
+			{PortalBase: armotypes.PortalBase{Name: "nsa"}},
+		}}, nil)
 
 		dir := t.TempDir()
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: dir})
@@ -453,58 +496,43 @@ func TestDownloadFramework(t *testing.T) {
 	})
 
 	t.Run("no identifier: returns error when SaveInFile fails", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworks: []reporthandling.Framework{
-				{PortalBase: armotypes.PortalBase{Name: "nsa"}},
-			}}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{
+			{PortalBase: armotypes.PortalBase{Name: "nsa"}},
+		}}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t)})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 
 	t.Run("with identifier: returns error from PolicyCacheFilename", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "a/b"})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "path separators")
 	})
 
 	t.Run("with identifier: returns error from GetFramework", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworkErr: errors.New("fetch failed")}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{frameworkErr: errors.New("fetch failed")}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
 		require.EqualError(t, err, "fetch failed")
 	})
 
 	t.Run("with identifier: returns error when the framework is nil", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{framework: nil}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{framework: nil}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
 		require.EqualError(t, err, "failed to download framework - received an empty objects")
 	})
 
 	t.Run("with identifier: succeeds and derives the filename", func(t *testing.T) {
-		orig := policyGetterFunc
+		withTenantConfig(t, &fakeTenantConfig{})
 		want := &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{framework: want}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withPolicyGetter(t, &fakePolicyGetter{framework: want}, nil)
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetFramework, Path: dir, Identifier: "nsa"}
@@ -517,57 +545,42 @@ func TestDownloadFramework(t *testing.T) {
 	})
 
 	t.Run("with identifier: returns error when SaveInFile fails", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{framework: &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{framework: &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t), Identifier: "nsa"})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 }
 
 func TestDownloadControl(t *testing.T) {
 	t.Run("returns error from the getter constructor", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return nil, errors.New("boom")
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, nil, errors.New("boom"))
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error when the identifier is missing", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir()})
 		require.EqualError(t, err, "missing control ID")
 	})
 
 	t.Run("returns error from PolicyCacheFilename", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "a/b"})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "path separators")
 	})
 
 	t.Run("returns a wrapped error from GetControl", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{controlErr: errors.New("fetch failed")}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{controlErr: errors.New("fetch failed")}, nil)
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "C-0001")
@@ -575,11 +588,8 @@ func TestDownloadControl(t *testing.T) {
 	})
 
 	t.Run("returns error when the control is nil", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{control: nil}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{control: nil}, nil)
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "C-0001")
@@ -587,23 +597,17 @@ func TestDownloadControl(t *testing.T) {
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
-		orig := policyGetterFunc
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{control: &reporthandling.Control{}}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withTenantConfig(t, &fakeTenantConfig{})
+		withPolicyGetter(t, &fakePolicyGetter{control: &reporthandling.Control{}}, nil)
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: blockedDir(t), Identifier: "C-0001"})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "blocker")
 	})
 
 	t.Run("succeeds and derives the filename", func(t *testing.T) {
-		orig := policyGetterFunc
+		withTenantConfig(t, &fakeTenantConfig{})
 		want := &reporthandling.Control{ControlID: "C-0001"}
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{control: want}, nil
-		}
-		t.Cleanup(func() { policyGetterFunc = orig })
+		withPolicyGetter(t, &fakePolicyGetter{control: want}, nil)
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetControl, Path: dir, Identifier: "C-0001"}
@@ -618,22 +622,11 @@ func TestDownloadControl(t *testing.T) {
 
 func TestDownloadArtifacts(t *testing.T) {
 	t.Run("saves every artifact and always returns nil", func(t *testing.T) {
-		origConfig, origExceptions, origAttack, origPolicy := configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, false, nil
-		}
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return &fakeExceptionsGetter{exceptions: []armotypes.PostureExceptionPolicy{{}}}, nil
-		}
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil
-		}
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil
-		}
-		t.Cleanup(func() {
-			configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc = origConfig, origExceptions, origAttack, origPolicy
-		})
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, nil)
+		withExceptionsGetter(t, &fakeExceptionsGetter{exceptions: []armotypes.PostureExceptionPolicy{{}}}, nil)
+		withAttackTracksGetter(t, &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil)
+		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil)
 
 		dir := t.TempDir()
 		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
@@ -645,23 +638,12 @@ func TestDownloadArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("logs a warning and continues when one artifact fails", func(t *testing.T) {
-		origConfig, origExceptions, origAttack, origPolicy := configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc
-		configInputsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool, bool) (getter.IControlsInputsGetter, bool, error) {
-			return &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, false, nil
-		}
-		exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-			return nil, errors.New("boom")
-		}
-		attackTracksGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IAttackTracksGetter, error) {
-			return &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil
-		}
-		policyGetterFunc = func(context.Context, []string, string, bool, *getter.DownloadReleasedPolicy, bool) (getter.IPolicyGetter, error) {
-			return &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil
-		}
-		t.Cleanup(func() {
-			configInputsGetterFunc, exceptionsGetterFunc, attackTracksGetterFunc, policyGetterFunc = origConfig, origExceptions, origAttack, origPolicy
-		})
+	t.Run("continues after one artifact fails", func(t *testing.T) {
+		withTenantConfig(t, &fakeTenantConfig{})
+		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, nil)
+		withExceptionsGetter(t, nil, errors.New("boom"))
+		withAttackTracksGetter(t, &fakeAttackTracksGetter{tracks: []v1alpha1.AttackTrack{{}}}, nil)
+		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil)
 
 		dir := t.TempDir()
 		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})


### PR DESCRIPTION
## Overview

`core/core/download.go`'s six `download*` functions all reach into shared getter constructors (`getPolicyGetter`, `getExceptionsGetter`, `getAttackTracksGetter`, `getConfigInputsGetter`) that, with no local file and no account configured, end up calling out to GitHub releases or the Kubescape Cloud API. Only `downloadConfigInputs` had a local-file escape hatch reachable through its public parameters; the other four did not, making them untestable without a live network or cluster dependency.

Adds four package-level indirection vars (`policyGetterFunc`, `exceptionsGetterFunc`, `attackTracksGetterFunc`, `configInputsGetterFunc`) scoped to `download.go`, defaulting to the real functions from `initutils.go`. Tests substitute fakes through these seams to exercise every branch — getter-construction errors, fetch errors, nil-result errors, `SaveInFile` failures, default vs. explicit filenames, and the success paths — without touching the network, a cluster, or the real `~/.kubescape` config beyond a harmless read.

Raises `core/core/download.go` from 15.8% to 97.0% coverage.

## Additional Information

No behavior change: the vars are simple aliases to the existing functions, called with the same arguments as before.

## How to Test

```
go test -race ./core/core/... -run TestDownload -v
```

All tests pass, race detector clean, 97.0% file coverage.

## Related issues/PRs:

None — internal test-coverage improvement.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new download test suite covering configuration inputs, exceptions, attack tracks, frameworks, controls, and artifacts.
  * Validates error propagation, empty-result handling, invalid identifier cases, filename defaulting vs explicit filenames, failures when saving to disk, and resilience to individual artifact download errors.
  * Introduces JSON-based assertions and fakes to avoid network/cluster dependencies.
* **Refactor**
  * Updated internal download wiring to improve test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->