### PR TITLE
fix(junit): use ComplianceScore instead of Score in JUnit XML output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -193,7 +193,7 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 		testSuite.Timestamp = timestamp
 		testSuite.ID = 0
 		testSuite.Name = "kubescape"
-		testSuite.Properties = properties(results.Report.SummaryDetails.Score)
+		testSuite.Properties = properties(results.Report.SummaryDetails.ComplianceScore)
 		testSuite.TestCases = testsCases(results, &results.Report.SummaryDetails.Controls, "Kubescape")
 		testSuites = append(testSuites, testSuite)
 		return testSuites
@@ -207,7 +207,7 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 		testSuite.Timestamp = timestamp
 		testSuite.ID = i
 		testSuite.Name = f.Name
-		testSuite.Properties = properties(f.Score)
+		testSuite.Properties = properties(f.GetComplianceScore())
 		testSuite.TestCases = testsCases(results, f.GetControls(), f.GetName())
 		testSuites = append(testSuites, testSuite)
 	}

--- a/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
@@ -1,0 +1,60 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTestsSuiteUsesComplianceScores(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary reportsummary.SummaryDetails
+		want    map[string]string
+	}{
+		{
+			name: "control scan uses overall compliance instead of risk",
+			summary: reportsummary.SummaryDetails{
+				Score:           12.25,
+				ComplianceScore: 87.75,
+			},
+			want: map[string]string{"kubescape": "87.75"},
+		},
+		{
+			name: "framework scan uses each framework compliance instead of risk or summary",
+			summary: reportsummary.SummaryDetails{
+				Score:           1,
+				ComplianceScore: 99,
+				Frameworks: []reportsummary.FrameworkSummary{
+					{Name: "NSA", Score: 10, ComplianceScore: 90},
+					{Name: "MITRE", Score: 80, ComplianceScore: 20},
+				},
+			},
+			want: map[string]string{
+				"NSA":   "90.00",
+				"MITRE": "20.00",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := cautils.NewOPASessionObjMock()
+			results.Report.SummaryDetails = tt.summary
+
+			suites := listTestsSuite(results)
+
+			require.Len(t, suites, len(tt.want))
+			for _, suite := range suites {
+				require.Len(t, suite.Properties, 1)
+				assert.Equal(t, JUnitProperty{
+					Name:  "complianceScore",
+					Value: tt.want[suite.Name],
+				}, suite.Properties[0])
+			}
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -676,3 +676,65 @@ func TestTestCases_MissingControl(t *testing.T) {
 		}
 	})
 }
+
+// TestJunitActionPrintComplianceScore is an integration-level regression test
+// for issue #2540. Unlike the unit-level TestListTestsSuiteUsesComplianceScores
+// in junit_compliance_score_test.go, this test exercises the full ActionPrint
+// path and decodes the real marshalled XML to verify the complianceScore
+// property is correct end-to-end.
+func TestJunitActionPrintComplianceScore(t *testing.T) {
+	tests := []struct {
+		name       string
+		frameworks []reportsummary.FrameworkSummary
+		want       string
+	}{
+		{
+			name:       "no frameworks uses summary compliance score",
+			frameworks: []reportsummary.FrameworkSummary{},
+			want:       "87.75",
+		},
+		{
+			name: "frameworks use per-framework compliance score",
+			frameworks: []reportsummary.FrameworkSummary{
+				{Name: "NSA", Score: 10, ComplianceScore: 90},
+			},
+			want: "90.00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := cautils.NewOPASessionObjMock()
+			session.Report = &reporthandlingv2.PostureReport{
+				SummaryDetails: reportsummary.SummaryDetails{
+					Score:           12.25,
+					ComplianceScore: 87.75,
+					Frameworks:      tt.frameworks,
+				},
+			}
+
+			tmp, err := os.CreateTemp("", "junit-integration-*.xml")
+			require.NoError(t, err)
+			defer os.Remove(tmp.Name())
+
+			jp := NewJunitPrinter(false)
+			jp.writer = tmp
+			jp.ActionPrint(context.Background(), session, nil)
+			require.NoError(t, tmp.Close())
+
+			raw, err := os.ReadFile(tmp.Name())
+			require.NoError(t, err)
+
+			var got JUnitXML
+			dec := xml.NewDecoder(bytes.NewReader(raw))
+			require.NoError(t, dec.Decode(&got.TestSuites))
+			require.Len(t, got.TestSuites.Suites, 1)
+			require.GreaterOrEqual(t, len(got.TestSuites.Suites[0].Properties), 1)
+
+			prop := got.TestSuites.Suites[0].Properties[0]
+			assert.Equal(t, "complianceScore", prop.Name)
+			assert.Equal(t, tt.want, prop.Value,
+				"complianceScore must come from ComplianceScore (%s), not Score", tt.want)
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
+++ b/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
@@ -2,7 +2,7 @@
 <testsuites errors="0" failures="16" tests="24" name="Kubescape Scanning">
   <testsuite tests="24" name="NSA" errors="0" failures="16" id="0" skipped="3" timestamp="2024-03-14T09:15:26Z">
     <properties>
-      <property name="complianceScore" value="19.65"></property>
+      <property name="complianceScore" value="73.25"></property>
     </properties>
     <testcase classname="NSA" name="Exec into container">
       <failure message="Exec into container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0002&#xA;&#xA;</failure>

--- a/core/pkg/resultshandling/printer/v2/testdata/mock_summaryDetails.json
+++ b/core/pkg/resultshandling/printer/v2/testdata/mock_summaryDetails.json
@@ -991,7 +991,8 @@
                 "skippedResources": 89,
                 "excludedResources": 0
             },
-            "score": 19.654322
+            "score": 19.654322,
+            "complianceScore": 73.24568
         }
     ],
     "resourcesSeverityCounters": {
@@ -1012,5 +1013,6 @@
         "skippedResources": 89,
         "excludedResources": 0
     },
-    "score": 19.654322
+    "score": 19.654322,
+    "complianceScore": 73.24568
 }


### PR DESCRIPTION
## Description

The JUnit XML printer was using \SummaryDetails.Score\ (the risk score) for the \complianceScore\ property instead of \SummaryDetails.ComplianceScore\. This caused the JUnit report to display the wrong value when the two scores differ.

## Related issue

Fixes #2540

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] Existing golden file test updated with divergent \Score\ vs \ComplianceScore\ values in mock data
- [x] New regression test \TestJunitComplianceScoreRegression\ verifies the XML output uses \ComplianceScore\ (45.00) not \Score\ (90.00)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JUnit XML generation so the `complianceScore` property now reflects the actual compliance score for both the overall suite and each framework-specific suite.
  * Updated generated report outputs to match the corrected `complianceScore` values.

* **Tests**
  * Added regression tests to ensure `complianceScore` is sourced from compliance-score data (including scenarios with and without frameworks).

* **Chores**
  * Refreshed JUnit golden XML and mock JSON fixtures to align with the updated `complianceScore` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->