### PR TITLE
fix(patch): surface package install failures instead of exporting an empty image

### DIFF
--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -306,9 +306,8 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 
 		log.Infof("Patching %d vulnerabilities", len(updates.Updates))
 		patchedImageState, errPkgs, err := manager.InstallUpdates(ctx, updates, ignoreError)
-		log.Infof("Error is: %v", err)
 		if err != nil {
-			return nil, nil
+			return nil, fmt.Errorf("copa: error installing updates :: %w", err)
 		}
 
 		platform := platforms.Normalize(platforms.DefaultSpec())

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -111,14 +111,12 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	sout, serr := os.Stdout, os.Stderr
 	if logger.L().GetLevel() != "debug" {
 		disableCopaLogger()
+		defer func() { os.Stdout, os.Stderr = sout, serr }()
 	}
 
 	if err = copaPatch(ks.Context(), patchInfo.Timeout, patchInfo.BuildkitAddress, patchInfo.Image, fileName, patchedImageName, "", patchInfo.IgnoreError, patchInfo.OutputMode, patchInfo.OutputPath, patchInfo.BuildKitOpts); err != nil {
 		return false, err
 	}
-
-	// Restore the output streams
-	os.Stdout, os.Stderr = sout, serr
 
 	switch patchInfo.OutputMode {
 	case "image":

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -108,13 +108,10 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 		return false, err
 	}
 
-	sout, serr := os.Stdout, os.Stderr
-	if logger.L().GetLevel() != "debug" {
-		disableCopaLogger()
-		defer func() { os.Stdout, os.Stderr = sout, serr }()
-	}
-
-	if err = copaPatch(ks.Context(), patchInfo.Timeout, patchInfo.BuildkitAddress, patchInfo.Image, fileName, patchedImageName, "", patchInfo.IgnoreError, patchInfo.OutputMode, patchInfo.OutputPath, patchInfo.BuildKitOpts); err != nil {
+	err = runWithCopaLoggerMuted(logger.L().GetLevel() == "debug", func() error {
+		return copaPatch(ks.Context(), patchInfo.Timeout, patchInfo.BuildkitAddress, patchInfo.Image, fileName, patchedImageName, "", patchInfo.IgnoreError, patchInfo.OutputMode, patchInfo.OutputPath, patchInfo.BuildKitOpts)
+	})
+	if err != nil {
 		return false, err
 	}
 
@@ -182,6 +179,22 @@ func disableCopaLogger() {
 	os.Stdout, os.Stderr = nil, nil
 	null, _ := os.Open(os.DevNull)
 	log.SetOutput(null)
+}
+
+// runWithCopaLoggerMuted mutes copa's logrus output (which writes directly to
+// os.Stdout/os.Stderr) for the duration of fn, unless debug is set. The
+// streams are always restored before this function returns, so callers can
+// safely keep using os.Stdout/os.Stderr regardless of whether fn succeeds.
+func runWithCopaLoggerMuted(debug bool, fn func() error) error {
+	if debug {
+		return fn()
+	}
+
+	sout, serr := os.Stdout, os.Stderr
+	defer func() { os.Stdout, os.Stderr = sout, serr }()
+
+	disableCopaLogger()
+	return fn()
 }
 
 // copaPatch is a slightly modified copy of the Patch function from the original "project-copacetic/copacetic" repo

--- a/core/core/patch_test.go
+++ b/core/core/patch_test.go
@@ -3,9 +3,11 @@ package core
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/moby/buildkit/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,4 +291,42 @@ VERSION_ID=2023
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+// TestRunWithCopaLoggerMuted guards against a regression where Patch() left
+// os.Stdout/os.Stderr nil through the printer setup that follows copaPatch().
+// GetUIPrinter calls os.Stdout.Name(), which has no nil-receiver guard and
+// panics, so runWithCopaLoggerMuted must restore the streams before it
+// returns, on both the success and error paths.
+func TestRunWithCopaLoggerMuted(t *testing.T) {
+	sout, serr := os.Stdout, os.Stderr
+	defer func() { os.Stdout, os.Stderr = sout, serr }()
+
+	t.Run("success", func(t *testing.T) {
+		err := runWithCopaLoggerMuted(false, func() error { return nil })
+		require.NoError(t, err)
+		require.NotNil(t, os.Stdout)
+		require.NotNil(t, os.Stderr)
+
+		scanInfo := &cautils.ScanInfo{}
+		scanInfo.SetScanType(cautils.ScanTypeImage)
+		assert.NotPanics(t, func() {
+			_ = GetUIPrinter(context.Background(), scanInfo, "")
+		})
+	})
+
+	t.Run("error", func(t *testing.T) {
+		wantErr := errors.New("install failed")
+		err := runWithCopaLoggerMuted(false, func() error { return wantErr })
+		require.ErrorIs(t, err, wantErr)
+		require.NotNil(t, os.Stdout)
+		require.NotNil(t, os.Stderr)
+	})
+
+	t.Run("debug bypasses muting", func(t *testing.T) {
+		err := runWithCopaLoggerMuted(true, func() error { return nil })
+		require.NoError(t, err)
+		require.NotNil(t, os.Stdout)
+		require.NotNil(t, os.Stderr)
+	})
 }


### PR DESCRIPTION
Motivation:
When `kubescape patch` failed to install packages inside the buildkit
solve (e.g. `apk add --no-cache ...` exiting non-zero), the error was
logged at debug level but then discarded: the buildkit gateway build
function returned `(nil, nil)` instead of `(nil, err)`. Returning a nil
error tells buildkit the build succeeded with no result, so it exports
whatever comes out of that (an empty/invalid image), and `kubescape
patch` reports "Patched image successfully" and proceeds to re-scan the
broken image, even though the underlying patch operation failed.

Approach:
In the buildkit gateway build function inside patchWithContext
(core/core/patch.go), wrap and return the error from
`manager.InstallUpdates` instead of swallowing it, matching the
existing inline `fmt.Errorf(...: %w...)` convention used a few lines
above for `pkgmgr.GetPackageManager` errors in the same function. The
error now propagates through `bkClient.Build` -> `patchWithContext` ->
`copaPatch` -> `Patch()` -> the `patch` command's RunE -> cobra, so the
CLI exits non-zero with a clear error instead of silently continuing.
Also removed the now-redundant debug-only `log.Infof("Error is: %v",
err)` line, since the error is no longer discarded and is guaranteed
to reach the user via the normal error path regardless of log level.

Validation:
go build ./core/...
go test ./core/core/...  (all passing, including existing patch unit
tests covering buildPatchExport, dockerLoad, tryParseScanReport, and
early-error paths of patchWithContext/copaPatch)

Fixes #2569

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patch operations now fail immediately when update installation encounters an error, instead of being silently ignored.
  * Improved patching output behavior by reliably restoring standard output/error after the patch run when not in debug mode.
* **Tests**
  * Added coverage to ensure standard output/error handling behaves correctly for success, error, and debug scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->