### PR TITLE
feat: Add support for OpenShift external registry route fallback

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -183,6 +183,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
+	scanCmd.PersistentFlags().StringToStringVar(&scanInfo.RegistryMapping, "registry-mapping", nil, "Map internal registry hosts to reachable ones, e.g. --registry-mapping image-registry.openshift-image-registry.svc:5000=registry.company.com (host[:port], no scheme; mapped registry must allow anonymous pulls on cluster/workload scan paths)")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Replace sensitive report metadata with deterministic pseudonyms")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Encrypt sensitive report metadata using the KUBESCAPE_MASTER_KEY environment variable")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -158,7 +158,8 @@ type ScanInfo struct {
 	LabelsToCopy          []string // Labels to copy from workloads to scan reports
 	scanningContext       *ScanningContext
 	cleanups              []func()
-	ListingURL            string //Grype vulnerability database URL
+	ListingURL            string            //Grype vulnerability database URL
+	RegistryMapping       map[string]string // Map internal registry URLs to external ones
 }
 
 type Getters struct {

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -1,11 +1,17 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strings"
+	"syscall"
+
+	"github.com/distribution/reference"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -188,6 +194,97 @@ func getUniqueVulnerabilitiesAndSeverities(policies []VulnerabilitiesIgnorePolic
 	return uniqueVulnsList, uniqueSeversList
 }
 
+// applyRegistryMapping replaces the registry part of the image name if a match
+// is found in the provided mapping. The returned bool indicates whether a
+// mapping key actually matched; callers should only retry when matched is true.
+func applyRegistryMapping(imgName string, registryMapping map[string]string) (string, bool, error) {
+	if len(registryMapping) == 0 {
+		return imgName, false, nil
+	}
+	canonicalImageName, err := cautils.NormalizeImageName(imgName)
+	if err != nil {
+		return "", false, err
+	}
+	tokens := strings.Split(canonicalImageName, "/")
+	registry := tokens[0]
+	if altRegistry, ok := registryMapping[registry]; ok {
+		tokens[0] = altRegistry
+		mappedName := strings.Join(tokens, "/")
+		if _, err := reference.ParseNormalizedNamed(mappedName); err != nil {
+			return "", false, fmt.Errorf("invalid image reference after applying registry mapping: %w", err)
+		}
+		return mappedName, true, nil
+	}
+	return imgName, false, nil
+}
+
+// isResolutionError checks if the error is related to unreachable registry hosts
+// (DNS resolution failures, connection refused, timeouts). It uses typed error
+// checks first and falls back to substring matching for wrapped errors.
+func isResolutionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Typed error checks — stable across Go and library versions.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// Belt-and-braces: substring fallback for deeply wrapped errors where
+	// the typed original has been lost.
+	errStr := err.Error()
+	return strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "i/o timeout")
+}
+
+// scanWithRegistryMapping attempts to scan an image and, on a resolution error,
+// retries using a mapped registry if one is configured. It returns the scan
+// results or a combined error preserving both the original and fallback context.
+func scanWithRegistryMapping(
+	ctx context.Context,
+	svc *imagescan.Service,
+	img string,
+	creds imagescan.RegistryCredentials,
+	registryMapping map[string]string,
+	vulnExceptions, sevExceptions []string,
+) (*cautils.ImageScanData, error) {
+	scanData, err := svc.Scan(ctx, img, creds, vulnExceptions, sevExceptions)
+	if err == nil {
+		return scanData, nil
+	}
+
+	if len(registryMapping) == 0 || !isResolutionError(err) {
+		return nil, err
+	}
+
+	logger.L().Warning(fmt.Sprintf("Failed to scan image %s: %s. Trying registry mapping...", img, err))
+
+	mappedImage, matched, mapErr := applyRegistryMapping(img, registryMapping)
+	if mapErr != nil {
+		return nil, fmt.Errorf("scan failed for %s (%w) and failed to construct mapped image: %w", img, err, mapErr)
+	}
+	if !matched {
+		return nil, err
+	}
+
+	logger.L().Info(fmt.Sprintf("Scanning mapped image %s (original: %s)...", mappedImage, img))
+	scanData, fallbackErr := svc.Scan(ctx, mappedImage, creds, vulnExceptions, sevExceptions)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("scan failed for %s (%w) and for mapped image %s: %w", img, err, mappedImage, fallbackErr)
+	}
+	return scanData, nil
+}
+
 func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
 	logger.L().Start(fmt.Sprintf("Scanning image %s...", imgScanInfo.Image))
 
@@ -220,9 +317,12 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 		vulnerabilityExceptions, severityExceptions = getUniqueVulnerabilitiesAndSeverities(exceptionPolicies, imgScanInfo.Image)
 	}
 
-	imageScanData, err := svc.Scan(ks.Context(), imgScanInfo.Image, creds, vulnerabilityExceptions, severityExceptions)
+	imageScanData, err := scanWithRegistryMapping(
+		ks.Context(), svc, imgScanInfo.Image, creds,
+		scanInfo.RegistryMapping, vulnerabilityExceptions, severityExceptions,
+	)
 	if err != nil {
-		logger.L().StopError(fmt.Sprintf("Failed to scan image: %s", imgScanInfo.Image))
+		logger.L().StopError(fmt.Sprintf("Failed to scan image %s: %s", imgScanInfo.Image, err))
 		return false, err
 	}
 

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -1,7 +1,11 @@
 package core
 
 import (
+	"errors"
+	"fmt"
+	"net"
 	"sort"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -581,6 +585,160 @@ func TestGetVulnerabilitiesAndSeverities(t *testing.T) {
 			sort.Strings(vulnerabilities)
 			assert.Equal(t, tt.expectedVulnerabilities, vulnerabilities)
 			assert.Equal(t, tt.expectedSeverities, severities)
+		})
+	}
+}
+
+func TestApplyRegistryMapping(t *testing.T) {
+	tests := []struct {
+		name            string
+		image           string
+		registryMapping map[string]string
+		expected        string
+		expectMatched   bool
+		expectErr       bool
+	}{
+		{
+			name:            "OpenShift internal to external",
+			image:           "image-registry.openshift-image-registry.svc:5000/namespace/image:tag",
+			registryMapping: map[string]string{"image-registry.openshift-image-registry.svc:5000": "registry.company.com"},
+			expected:        "registry.company.com/namespace/image:tag",
+			expectMatched:   true,
+		},
+		{
+			name:            "Docker Hub short to alternative",
+			image:           "nginx",
+			registryMapping: map[string]string{"docker.io": "my.registry.local:8080"},
+			expected:        "my.registry.local:8080/library/nginx",
+			expectMatched:   true,
+		},
+		{
+			name:            "Quay to alternative",
+			image:           "quay.io/kubescape/kubescape:latest",
+			registryMapping: map[string]string{"quay.io": "internal.quay.mirror"},
+			expected:        "internal.quay.mirror/kubescape/kubescape:latest",
+			expectMatched:   true,
+		},
+		{
+			name:            "No mapping matched — fully qualified",
+			image:           "quay.io/kubescape/kubescape:latest",
+			registryMapping: map[string]string{"docker.io": "internal.quay.mirror"},
+			expected:        "quay.io/kubescape/kubescape:latest",
+			expectMatched:   false,
+		},
+		{
+			name:            "No mapping matched — short name returns original",
+			image:           "nginx",
+			registryMapping: map[string]string{"quay.io": "mirror.local"},
+			expected:        "nginx",
+			expectMatched:   false,
+		},
+		{
+			name:            "Empty mapping returns original",
+			image:           "nginx",
+			registryMapping: map[string]string{},
+			expected:        "nginx",
+			expectMatched:   false,
+		},
+		{
+			name:            "Invalid fallback registry with scheme",
+			image:           "image-registry.openshift-image-registry.svc:5000/namespace/image:tag",
+			registryMapping: map[string]string{"image-registry.openshift-image-registry.svc:5000": "https://registry.company.com"},
+			expectErr:       true,
+		},
+		{
+			name:            "Invalid fallback registry with trailing slash",
+			image:           "image-registry.openshift-image-registry.svc:5000/namespace/image:tag",
+			registryMapping: map[string]string{"image-registry.openshift-image-registry.svc:5000": "registry.company.com/"},
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, matched, err := applyRegistryMapping(tt.image, tt.registryMapping)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+				assert.Equal(t, tt.expectMatched, matched)
+			}
+		})
+	}
+}
+
+func TestIsResolutionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "DNS error (typed)",
+			err:      fmt.Errorf("get descriptor: %w", &net.DNSError{Err: "no such host", Name: "registry.svc", IsNotFound: true}),
+			expected: true,
+		},
+		{
+			name:     "connection refused (typed)",
+			err:      fmt.Errorf("dial tcp 10.0.0.1:5000: %w", syscall.ECONNREFUSED),
+			expected: true,
+		},
+		{
+			name:     "host unreachable (typed)",
+			err:      fmt.Errorf("dial tcp: %w", syscall.EHOSTUNREACH),
+			expected: true,
+		},
+		{
+			name:     "timeout (net.Error interface)",
+			err:      fmt.Errorf("connect: %w", &net.DNSError{Err: "i/o timeout", IsTimeout: true}),
+			expected: true,
+		},
+		{
+			name:     "string fallback — no such host",
+			err:      errors.New("Get https://registry.svc:5000/v2/: dial tcp: lookup registry.svc: no such host"),
+			expected: true,
+		},
+		{
+			name:     "string fallback — connection refused",
+			err:      errors.New("Get https://registry.svc:5000/v2/: dial tcp 10.0.0.1:5000: connect: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "string fallback — i/o timeout",
+			err:      errors.New("Get https://registry.svc:5000/v2/: dial tcp 10.0.0.1:5000: i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "auth failure — should NOT match",
+			err:      errors.New("UNAUTHORIZED: authentication required"),
+			expected: false,
+		},
+		{
+			name:     "manifest not found — should NOT match",
+			err:      errors.New("name unknown: manifest unknown"),
+			expected: false,
+		},
+		{
+			name:     "bad certificate — should NOT match",
+			err:      errors.New("x509: certificate signed by unknown authority"),
+			expected: false,
+		},
+		{
+			name:     "rate limited — should NOT match",
+			err:      errors.New("TOOMANYREQUESTS: retry later"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isResolutionError(tt.err))
 		})
 	}
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -394,16 +394,19 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 
 	for img := range imagesToScan.Iter() {
 		logger.L().Start("Scanning", helpers.String("image", img))
-		if err := scanSingleImage(ctx, img, svc, resultsHandling); err != nil {
+		if err := scanSingleImage(ctx, img, svc, resultsHandling, scanInfo.RegistryMapping); err != nil {
 			logger.L().StopError("failed to scan", helpers.String("image", img), helpers.Error(err))
 		}
 		logger.L().StopSuccess("Done scanning", helpers.String("image", img))
 	}
 }
 
-func scanSingleImage(ctx context.Context, img string, svc *imagescan.Service, resultsHandling *resultshandling.ResultsHandler) error {
+func scanSingleImage(ctx context.Context, img string, svc *imagescan.Service, resultsHandling *resultshandling.ResultsHandler, registryMapping map[string]string) error {
 
-	scanResults, err := svc.Scan(ctx, img, imagescan.RegistryCredentials{}, nil, nil)
+	scanResults, err := scanWithRegistryMapping(
+		ctx, svc, img, imagescan.RegistryCredentials{},
+		registryMapping, nil, nil,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2563.

Added support for an external registry route fallback when scanning images by introducing `--alternative-image-registry-url` flag. This allows Kubescape to scan external routes instead of the internal svc route if it's unresolvable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `--registry-mapping` option to map internal container registry hosts to reachable external registries.
  - Image scans now retry automatically using the mapped registry when the original image cannot be resolved.

- **Bug Fixes**
  - Improved classification of resolution/DNS/connectivity failures to trigger safe fallback behavior.
  - Better error reporting by combining mapping/construction errors with fallback scan failures when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->