### PR TITLE
fix(prometheus): report compliance scores in gauges

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -104,7 +104,10 @@ func (mcrs *mControlComplianceScore) metrics() []string {
 
 	m := []string{}
 	// overall
-	m = append(m, toRowInMetrics(fmt.Sprintf("%s_%s", mcrs.prefix(), metricsScore), mcrs.labels(), mcrs.complianceScore))
+	// GetComplianceScore returns -1 when a control has no calculated score.
+	if mcrs.complianceScore >= 0 {
+		m = append(m, toRowInMetrics(fmt.Sprintf("%s_%s", mcrs.prefix(), metricsScore), mcrs.labels(), mcrs.complianceScore))
+	}
 
 	// resources
 	m = append(m, toRowInMetrics(fmt.Sprintf("%s_%s_%s_%s", mcrs.prefix(), metricsCount, metricsResources, metricsFailed), mcrs.labels(), mcrs.resourcesCountFailed))
@@ -337,7 +340,7 @@ func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetai
 		mcrs := mControlComplianceScore{
 			controlName:     control.GetName(),
 			controlID:       control.GetID(),
-			complianceScore: cautils.Float32ToInt(control.GetScore()),
+			complianceScore: cautils.Float32ToInt(control.GetComplianceScore()),
 			link:            cautils.GetControlLink(control.GetID()),
 			severity:        apis.ControlSeverityToString(control.GetScoreFactor()),
 			remediation:     control.GetRemediation(),

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -321,7 +321,8 @@ func (mcrs *mControlComplianceScore) set(resources reportsummary.ICounters) {
 }
 func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetails) {
 	m.rs.set(summaryDetails.NumberOfResources(), summaryDetails.NumberOfControls())
-	m.rs.complianceScore = cautils.Float32ToInt(summaryDetails.GetScore())
+	// GetScore() returns the risk score; the metric is the compliance score.
+	m.rs.complianceScore = cautils.Float32ToInt(summaryDetails.ComplianceScore)
 
 	for _, fw := range summaryDetails.ListFrameworks() {
 		mfrs := mFrameworkComplianceScore{

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -370,4 +371,17 @@ func TestMetrics_String_MultiItem_NoDuplicateHeaders(t *testing.T) {
 	// verify both resource series are present
 	assert.Contains(t, output, "kubescape_resource_count_controls_failed{apiVersion=\"v1\",kind=\"Pod\",namespace=\"ns1\",name=\"Resource A\"} 2")
 	assert.Contains(t, output, "kubescape_resource_count_controls_failed{apiVersion=\"v1\",kind=\"Pod\",namespace=\"ns2\",name=\"Resource B\"} 4")
+}
+
+func TestSetComplianceScores_ClusterMetricUsesComplianceScore(t *testing.T) {
+	// The cluster gauge is named complianceScore, so it must not be fed the risk score.
+	summaryDetails := &reportsummary.SummaryDetails{
+		Score:           42,
+		ComplianceScore: 77,
+	}
+
+	m := &Metrics{}
+	m.setComplianceScores(summaryDetails)
+
+	assert.Equal(t, 77, m.rs.complianceScore)
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -102,6 +102,18 @@ func TestControlComplianceScore_MetricsLabelsAndPrefix(t *testing.T) {
 			expectedMetrics: []string{"kubescape_control_complianceScore{name=\"Test Control\",severity=\"high\",link=\"https://test-link.com\"} 37", "kubescape_control_count_resources_failed{name=\"Test Control\",severity=\"high\",link=\"https://test-link.com\"} 17", "kubescape_control_count_resources_skipped{name=\"Test Control\",severity=\"high\",link=\"https://test-link.com\"} 27", "kubescape_control_count_resources_passed{name=\"Test Control\",severity=\"high\",link=\"https://test-link.com\"} 7"},
 			expectedLabels:  "name=\"Test Control\",severity=\"high\",link=\"https://test-link.com\"",
 		},
+		{
+			name: "Unset compliance score omits only the score metric",
+			mcrs: mControlComplianceScore{
+				controlName:           "Unset Control",
+				resourcesCountPassed:  7,
+				resourcesCountFailed:  17,
+				resourcesCountSkipped: 27,
+				complianceScore:       -1,
+			},
+			expectedMetrics: []string{"kubescape_control_count_resources_failed{name=\"Unset Control\",severity=\"\",link=\"\"} 17", "kubescape_control_count_resources_skipped{name=\"Unset Control\",severity=\"\",link=\"\"} 27", "kubescape_control_count_resources_passed{name=\"Unset Control\",severity=\"\",link=\"\"} 7"},
+			expectedLabels:  "name=\"Unset Control\",severity=\"\",link=\"\"",
+		},
 	}
 
 	for _, tt := range tests {
@@ -384,4 +396,33 @@ func TestSetComplianceScores_ClusterMetricUsesComplianceScore(t *testing.T) {
 	m.setComplianceScores(summaryDetails)
 
 	assert.Equal(t, 77, m.rs.complianceScore)
+	assert.Contains(t, m.String(), "kubescape_cluster_complianceScore{} 77")
+}
+
+func TestSetComplianceScores_ControlMetricsUseComplianceScore(t *testing.T) {
+	complianceScore := float32(65)
+	summaryDetails := &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{
+			"C-SET": {
+				ControlID:       "C-SET",
+				Name:            "Set Control",
+				Score:           10,
+				ComplianceScore: &complianceScore,
+			},
+			"C-UNSET": {
+				ControlID: "C-UNSET",
+				Name:      "Unset Control",
+				Score:     20,
+			},
+		},
+	}
+
+	m := &Metrics{}
+	m.setComplianceScores(summaryDetails)
+	output := m.String()
+
+	assert.Contains(t, output, "kubescape_control_complianceScore{name=\"Set Control\"")
+	assert.Contains(t, output, "} 65")
+	assert.NotContains(t, output, "kubescape_control_complianceScore{name=\"Unset Control\"")
+	assert.Contains(t, output, "kubescape_control_count_resources_failed{name=\"Unset Control\"")
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -421,8 +422,7 @@ func TestSetComplianceScores_ControlMetricsUseComplianceScore(t *testing.T) {
 	m.setComplianceScores(summaryDetails)
 	output := m.String()
 
-	assert.Contains(t, output, "kubescape_control_complianceScore{name=\"Set Control\"")
-	assert.Contains(t, output, "} 65")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^kubescape_control_complianceScore\{name="Set Control".*\} 65$`), output)
 	assert.NotContains(t, output, "kubescape_control_complianceScore{name=\"Unset Control\"")
 	assert.Contains(t, output, "kubescape_control_count_resources_failed{name=\"Unset Control\"")
 }


### PR DESCRIPTION
Fixes #2578

The Prometheus exporter was feeding metrics named `complianceScore` with the risk score returned by `GetScore()`.

This PR now keeps the score domains separate at every affected level:

- `kubescape_cluster_complianceScore` reads `SummaryDetails.ComplianceScore`.
- `kubescape_control_complianceScore` reads `control.GetComplianceScore()`.
- Framework metrics already used `fw.GetComplianceScore()` and remain unchanged.

For controls, `GetComplianceScore()` returns `-1` when no compliance score was calculated. In that case the exporter omits only the control compliance-score gauge; it still emits that control's resource counters. This avoids publishing either the risk score or a misleading `-1` as compliance.

### Regression coverage

- cluster risk `42` / compliance `77`: the internal value and rendered `kubescape_cluster_complianceScore{} 77` sample are asserted;
- populated control risk `10` / compliance `65`: the rendered control gauge contains `65`;
- unset control compliance: no compliance gauge is emitted, while its resource counters remain.

Focused validation on Go 1.26:

```text
go test -mod=readonly ./core/pkg/resultshandling/printer/v2 -run 'Test(ControlComplianceScore|SetComplianceScores|Metrics_String)' -count=1
ok github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2
```

The complete printer-v2 package also runs through the changed tests; its existing `TestJunitGoldenFile` fails in the Linux container over this Windows checkout only because the checked-out golden file is CRLF while generated XML is LF.

AI-assisted (LLM used for drafting); the implementation and validation were reviewed before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Prometheus compliance metrics to report compliance scores instead of risk scores.
  * Control-level compliance metrics are now omitted when no compliance score is available.
  * Control resource count metrics continue to be reported even when compliance scores are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Breaking change for existing dashboards/alerts

`kubescape_cluster_complianceScore` and `kubescape_control_complianceScore` previously carried the risk score (higher = worse). After this PR they carry the compliance score (higher = better), consistent with `kubescape_score` and the JUnit output (#2565). Alert rules and Grafana thresholds built on the old direction need to be inverted.

Additionally, controls with an unset compliance score (internal `-1` sentinel) are now omitted from `kubescape_control_complianceScore` instead of being exported as `-1`.
