### PR TITLE
feat(scan): support parsing apiVersion in workload identifier

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -57,7 +57,6 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         name: Build
-        if: ${{ inputs.RELEASE != '' }}
         with:
           distribution: goreleaser
           version: latest
@@ -68,7 +67,6 @@ jobs:
           CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
 
       - name: Smoke Testing
-        if: ${{ inputs.RELEASE != '' }}
         env:
           RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -57,6 +57,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         name: Build
+        if: ${{ inputs.RELEASE != '' }}
         with:
           distribution: goreleaser
           version: latest
@@ -67,6 +68,7 @@ jobs:
           CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
 
       - name: Smoke Testing
+        if: ${{ inputs.RELEASE != '' }}
         env:
           RELEASE: ${{ inputs.RELEASE }}
           KUBESCAPE_SKIP_UPDATE_CHECK: "true"

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -19,33 +19,36 @@ var (
 	workloadExample = fmt.Sprintf(`
   Scan a workload for misconfigurations and image vulnerabilities.
 
-  # Scan an workload
-  %[1]s scan workload <kind>/<name>
+  # Scan a workload
+  %[1]s scan workload <kind>[.<version>[.<group>]]/<name>
 	
-  # Scan an workload in a specific namespace
-  %[1]s scan workload <kind>/<name> --namespace <namespace>
+  # Scan a specific kind, version, and group
+  %[1]s scan workload Deployment.v1.apps/nginx
 
-  # Scan an workload from a file path
-  %[1]s scan workload <kind>/<name> --file-path <file path>
+  # Scan a workload in a specific namespace
+  %[1]s scan workload <kind>[.<version>[.<group>]]/<name> --namespace <namespace>
+
+  # Scan a workload from a file path
+  %[1]s scan workload <kind>[.<version>[.<group>]]/<name> --file-path <file path>
   
-  # Scan an workload from a helm-chart template
-  %[1]s scan workload <kind>/<name> --chart-path <chart path> --file-path <file path>
+  # Scan a workload from a helm-chart template
+  %[1]s scan workload <kind>[.<version>[.<group>]]/<name> --chart-path <chart path> --file-path <file path>
 
 
 `, cautils.ExecName())
 
-	ErrInvalidWorkloadIdentifier = errors.New("invalid workload identifier")
+	ErrInvalidWorkloadIdentifier = errors.New("invalid workload identifier, expected <kind>[.<version>[.<group>]]/<name>")
 )
 
 // controlCmd represents the control command
 func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
 	workloadCmd := &cobra.Command{
-		Use:     "workload <kind>/<name> [`<glob pattern>`/`-`] [flags]",
+		Use:     "workload <kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]",
 		Short:   "Scan a workload for misconfigurations and image vulnerabilities",
 		Example: workloadExample,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("usage: <kind>/<name> [`<glob pattern>`/`-`] [flags]")
+				return fmt.Errorf("usage: <kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]")
 			}
 
 			// Looks strange, a bug maybe????

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -181,8 +181,5 @@ func parseKindAndApiVersion(kindStr string) (kind, apiVersion string, err error)
 		group := strings.Join(parts[2:], ".")
 		return parts[0], group + "/" + parts[1], nil // kind.version.group -> group/version
 	}
-	if len(parts) == 2 {
-		return parts[0], parts[1], nil // kind.version -> version
-	}
-	return kindStr, "", nil
+	return parts[0], parts[1], nil // kind.version -> version
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -71,7 +71,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}
-			namespace, kind, name, err := parseWorkloadIdentifierString(args[0])
+			namespace, kind, name, apiVersion, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %w", err)
 			}
@@ -80,9 +80,8 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				scanInfo.Namespace = namespace
 			}
 
-			setWorkloadScanInfo(scanInfo, kind, name)
+			setWorkloadScanInfo(scanInfo, apiVersion, kind, name)
 
-			// todo: add api version if provided
 			results, err := ks.Scan(scanInfo)
 			if err != nil {
 				logger.L().Fatal(err.Error())
@@ -106,12 +105,15 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 	return workloadCmd
 }
 
-func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, kind string, name string) {
+func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, apiVersion string, kind string, name string) {
 	scanInfo.SetScanType(cautils.ScanTypeWorkload)
 	scanInfo.ScanImages = true
 
 	scanInfo.ScanObject = &objectsenvelopes.ScanObject{}
 	scanInfo.ScanObject.SetNamespace(scanInfo.Namespace)
+	if apiVersion != "" {
+		scanInfo.ScanObject.SetApiVersion(apiVersion)
+	}
 	scanInfo.ScanObject.SetKind(kind)
 	scanInfo.ScanObject.SetName(name)
 
@@ -123,26 +125,48 @@ func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, kind string, name string) {
 }
 
 func validateWorkloadIdentifier(workloadIdentifier string) error {
-	_, _, _, err := parseWorkloadIdentifierString(workloadIdentifier)
+	_, _, _, _, err := parseWorkloadIdentifierString(workloadIdentifier)
 	return err
 }
 
-func parseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, name string, err error) {
+func parseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, name, apiVersion string, err error) {
 	// workloadIdentifier is in the form of kind/name or namespace/kind/name
 	// example: default/Deployment/nginx-deployment
 	x := strings.Split(workloadIdentifier, "/")
 	if len(x) == 2 {
 		if x[0] == "" || x[1] == "" {
-			return "", "", "", ErrInvalidWorkloadIdentifier
+			return "", "", "", "", ErrInvalidWorkloadIdentifier
 		}
-		return "", x[0], x[1], nil
+		parsedKind, parsedApiVersion := parseKindAndApiVersion(x[0])
+		return "", parsedKind, x[1], parsedApiVersion, nil
 	}
 	if len(x) == 3 {
 		if x[0] == "" || x[1] == "" || x[2] == "" {
-			return "", "", "", ErrInvalidWorkloadIdentifier
+			return "", "", "", "", ErrInvalidWorkloadIdentifier
 		}
-		return x[0], x[1], x[2], nil
+		parsedKind, parsedApiVersion := parseKindAndApiVersion(x[1])
+		return x[0], parsedKind, x[2], parsedApiVersion, nil
 	}
 
-	return "", "", "", ErrInvalidWorkloadIdentifier
+	return "", "", "", "", ErrInvalidWorkloadIdentifier
+}
+
+func parseKindAndApiVersion(kindStr string) (kind, apiVersion string) {
+	parts := strings.Split(kindStr, ".")
+	
+	// Reject empty components
+	for _, part := range parts {
+		if part == "" {
+			return kindStr, ""
+		}
+	}
+
+	if len(parts) >= 3 {
+		group := strings.Join(parts[2:], ".")
+		return parts[0], group + "/" + parts[1] // kind.version.group -> group/version
+	}
+	if len(parts) == 2 {
+		return parts[0], parts[1] // kind.version -> version
+	}
+	return kindStr, ""
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -137,36 +138,51 @@ func parseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, 
 		if x[0] == "" || x[1] == "" {
 			return "", "", "", "", ErrInvalidWorkloadIdentifier
 		}
-		parsedKind, parsedApiVersion := parseKindAndApiVersion(x[0])
+		parsedKind, parsedApiVersion, err := parseKindAndApiVersion(x[0])
+		if err != nil {
+			return "", "", "", "", err
+		}
 		return "", parsedKind, x[1], parsedApiVersion, nil
 	}
 	if len(x) == 3 {
 		if x[0] == "" || x[1] == "" || x[2] == "" {
 			return "", "", "", "", ErrInvalidWorkloadIdentifier
 		}
-		parsedKind, parsedApiVersion := parseKindAndApiVersion(x[1])
+		parsedKind, parsedApiVersion, err := parseKindAndApiVersion(x[1])
+		if err != nil {
+			return "", "", "", "", err
+		}
 		return x[0], parsedKind, x[2], parsedApiVersion, nil
 	}
 
 	return "", "", "", "", ErrInvalidWorkloadIdentifier
 }
 
-func parseKindAndApiVersion(kindStr string) (kind, apiVersion string) {
+var apiVersionPattern = regexp.MustCompile(`^v\d+((alpha|beta)\d+)?$`)
+
+func parseKindAndApiVersion(kindStr string) (kind, apiVersion string, err error) {
 	parts := strings.Split(kindStr, ".")
-	
+	if len(parts) == 1 {
+		return kindStr, "", nil
+	}
+
 	// Reject empty components
 	for _, part := range parts {
 		if part == "" {
-			return kindStr, ""
+			return "", "", fmt.Errorf("%w: empty component in %q", ErrInvalidWorkloadIdentifier, kindStr)
 		}
+	}
+
+	if !apiVersionPattern.MatchString(parts[1]) {
+		return "", "", fmt.Errorf("%w: %q is not a valid API version in %q", ErrInvalidWorkloadIdentifier, parts[1], kindStr)
 	}
 
 	if len(parts) >= 3 {
 		group := strings.Join(parts[2:], ".")
-		return parts[0], group + "/" + parts[1] // kind.version.group -> group/version
+		return parts[0], group + "/" + parts[1], nil // kind.version.group -> group/version
 	}
 	if len(parts) == 2 {
-		return parts[0], parts[1] // kind.version -> version
+		return parts[0], parts[1], nil // kind.version -> version
 	}
-	return kindStr, ""
+	return kindStr, "", nil
 }

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -135,11 +135,7 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanObject.Metadata.Namespace, tc.want.ScanObject.Metadata.Namespace)
 				}
 
-				if tc.apiVersion != "" {
-					if scanInfo.ScanObject.GetApiVersion() != tc.want.ScanObject.GetApiVersion() {
-						t.Errorf("got: %v, want: %v", scanInfo.ScanObject.GetApiVersion(), tc.want.ScanObject.GetApiVersion())
-					}
-				}
+				assert.Equal(t, tc.want.ScanObject.GetApiVersion(), scanInfo.ScanObject.GetApiVersion())
 
 				if tc.filePath == "" {
 					assert.Len(t, scanInfo.InputPatterns, 0)
@@ -292,13 +288,24 @@ func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 			WantErr:        false,
 		},
 		{
-			Description:    "invalid empty dotted component",
-			Input:          "Deployment..apps/nginx",
-			WantNamespace:  "",
-			WantKind:       "Deployment..apps",
-			WantName:       "nginx",
-			WantApiVersion: "",
-			WantErr:        false,
+			Description: "invalid empty dotted component",
+			Input:       "Deployment..apps/nginx",
+			WantErr:     true,
+		},
+		{
+			Description: "invalid empty trailing component",
+			Input:       "Deployment./nginx",
+			WantErr:     true,
+		},
+		{
+			Description: "invalid missing apiVersion",
+			Input:       "Deployment.apps/nginx",
+			WantErr:     true,
+		},
+		{
+			Description: "invalid apiVersion segment",
+			Input:       "Deployment.bogus/nginx",
+			WantErr:     true,
 		},
 		{
 			Description: "too many segments",

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -172,12 +172,12 @@ func TestGetWorkloadCmd_ChartPathAndFilePathEmpty(t *testing.T) {
 	scanInfo.FilePath = ""
 
 	// Verify the command name and short description
-	assert.Equal(t, "workload <kind>/<name> [`<glob pattern>`/`-`] [flags]", cmd.Use)
+	assert.Equal(t, "workload <kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]", cmd.Use)
 	assert.Equal(t, "Scan a workload for misconfigurations and image vulnerabilities", cmd.Short)
 	assert.Equal(t, workloadExample, cmd.Example)
 
 	err := cmd.Args(&cobra.Command{}, []string{})
-	expectedErrorMessage := "usage: <kind>/<name> [`<glob pattern>`/`-`] [flags]"
+	expectedErrorMessage := "usage: <kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]"
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = cmd.Args(&cobra.Command{}, []string{"nginx"})

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -14,6 +14,7 @@ import (
 func TestSetWorkloadScanInfo(t *testing.T) {
 	tests := []struct {
 		Description string
+		apiVersion  string
 		kind        string
 		name        string
 		namespace   string
@@ -74,6 +75,37 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 				InputPatterns: []string{"manifests/pod.yaml"},
 			},
 		},
+		{
+			Description: "Set workload scan info with apiVersion",
+			apiVersion:  "apps/v1",
+			kind:        "Deployment",
+			name:        "api",
+			namespace:   "default",
+			filePath:    "manifests/deployment.yaml",
+			want: &cautils.ScanInfo{
+				PolicyIdentifier: []cautils.PolicyIdentifier{
+					{
+						Identifier: "workloadscan",
+						Kind:       v1.KindFramework,
+					},
+					{
+						Identifier: "allcontrols",
+						Kind:       v1.KindFramework,
+					},
+				},
+				ScanType:   cautils.ScanTypeWorkload,
+				ScanImages: true,
+				ScanObject: &objectsenvelopes.ScanObject{
+					ApiVersion: "apps/v1",
+					Kind:       "Deployment",
+					Metadata: objectsenvelopes.ScanObjectMetadata{
+						Name:      "api",
+						Namespace: "default",
+					},
+				},
+				InputPatterns: []string{"manifests/deployment.yaml"},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -81,7 +113,7 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 			tc.Description,
 			func(t *testing.T) {
 				scanInfo := &cautils.ScanInfo{FilePath: tc.filePath, Namespace: tc.namespace}
-				setWorkloadScanInfo(scanInfo, tc.kind, tc.name)
+				setWorkloadScanInfo(scanInfo, tc.apiVersion, tc.kind, tc.name)
 
 				if scanInfo.ScanType != tc.want.ScanType {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanType, tc.want.ScanType)
@@ -101,6 +133,12 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 
 				if scanInfo.ScanObject.Metadata.Namespace != tc.want.ScanObject.Metadata.Namespace {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanObject.Metadata.Namespace, tc.want.ScanObject.Metadata.Namespace)
+				}
+
+				if tc.apiVersion != "" {
+					if scanInfo.ScanObject.GetApiVersion() != tc.want.ScanObject.GetApiVersion() {
+						t.Errorf("got: %v, want: %v", scanInfo.ScanObject.GetApiVersion(), tc.want.ScanObject.GetApiVersion())
+					}
 				}
 
 				if tc.filePath == "" {
@@ -172,7 +210,7 @@ func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, _, err := parseWorkloadIdentifierString(tt.input)
+			_, _, _, _, err := parseWorkloadIdentifierString(tt.input)
 			assert.Error(t, err)
 		})
 	}
@@ -180,38 +218,87 @@ func Test_parseWorkloadIdentifierString_Invalid(t *testing.T) {
 
 func Test_parseWorkloadIdentifierString_Valid(t *testing.T) {
 	t.Run("valid identifier", func(t *testing.T) {
-		namespace, kind, name, err := parseWorkloadIdentifierString("default/Deployment/nginx-deployment")
+		namespace, kind, name, apiVersion, err := parseWorkloadIdentifierString("default/Deployment/nginx-deployment")
 		assert.NoError(t, err)
 		assert.Equal(t, "default", namespace)
 		assert.Equal(t, "Deployment", kind)
 		assert.Equal(t, "nginx-deployment", name)
+		assert.Equal(t, "", apiVersion)
 	})
 }
 
 func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 	testCases := []struct {
-		Description   string
-		Input         string
-		WantNamespace string
-		WantKind      string
-		WantName      string
-		WantErr       bool
+		Description    string
+		Input          string
+		WantNamespace  string
+		WantKind       string
+		WantName       string
+		WantApiVersion string
+		WantErr        bool
 	}{
 		{
-			Description:   "valid kind and name",
-			Input:         "Deployment/nginx",
-			WantNamespace: "",
-			WantKind:      "Deployment",
-			WantName:      "nginx",
-			WantErr:       false,
+			Description:    "valid kind and name",
+			Input:          "Deployment/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
 		},
 		{
-			Description:   "valid namespace kind and name",
-			Input:         "default/Deployment/nginx",
-			WantNamespace: "default",
-			WantKind:      "Deployment",
-			WantName:      "nginx",
-			WantErr:       false,
+			Description:    "valid namespace kind and name",
+			Input:          "default/Deployment/nginx",
+			WantNamespace:  "default",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "valid kind.version and name",
+			Input:          "Pod.v1/nginx",
+			WantNamespace:  "",
+			WantKind:       "Pod",
+			WantName:       "nginx",
+			WantApiVersion: "v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "valid kind.version.group and name",
+			Input:          "Deployment.v1.apps/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "apps/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "valid namespace kind.version.group and name",
+			Input:          "default/Deployment.v1.apps/nginx",
+			WantNamespace:  "default",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "apps/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "valid multi-label group",
+			Input:          "Ingress.v1.networking.k8s.io/name",
+			WantNamespace:  "",
+			WantKind:       "Ingress",
+			WantName:       "name",
+			WantApiVersion: "networking.k8s.io/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "invalid empty dotted component",
+			Input:          "Deployment..apps/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment..apps",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
 		},
 		{
 			Description: "too many segments",
@@ -222,7 +309,7 @@ func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
-			namespace, kind, name, err := parseWorkloadIdentifierString(tc.Input)
+			namespace, kind, name, apiVersion, err := parseWorkloadIdentifierString(tc.Input)
 			if tc.WantErr {
 				assert.Error(t, err)
 				return
@@ -231,6 +318,7 @@ func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 			assert.Equal(t, tc.WantNamespace, namespace)
 			assert.Equal(t, tc.WantKind, kind)
 			assert.Equal(t, tc.WantName, name)
+			assert.Equal(t, tc.WantApiVersion, apiVersion)
 		})
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -201,8 +201,10 @@ Scan a specific workload.
 ### Synopsis
 
 ```bash
-kubescape scan workload <kind>/<name> [flags]
+kubescape scan workload <kind>[.<version>[.<group>]]/<name> [flags]
 ```
+
+Unlike `kubectl`'s `TYPE.VERSION.GROUP` (which takes a plural resource), this command requires a **Kind** (e.g. `Deployment.v1.apps`, not `deployments.v1.apps`).
 
 ### Flags
 
@@ -214,6 +216,7 @@ kubescape scan workload <kind>/<name> [flags]
 
 ```bash
 kubescape scan workload Deployment/nginx --namespace default
+kubescape scan workload Deployment.v1.apps/nginx
 kubescape scan workload DaemonSet/fluentd --namespace logging
 ```
 


### PR DESCRIPTION
## Overview
Currently, the `kubescape scan workload` command parses identifiers using `namespace/kind/name` but lacks support for extracting the `apiVersion`, leaving a lingering `// todo: add api version if provided` comment in the codebase. 

To prevent parsing ambiguities between slashes (e.g. `namespace` vs `apiVersion`), this PR updates the `parseWorkloadIdentifierString` function to parse the `kind` segment using the `kubectl` syntax convention: `kind.version.group` or `kind.version`. It extracts the `apiVersion` and maps it directly to the `ScanObject`.

## Additional Information

> Example of how the new parsing works:
> - `Deployment.v1.apps/nginx` -> `kind: Deployment`, `apiVersion: apps/v1`
> - `Pod.v1/nginx` -> `kind: Pod`, `apiVersion: v1`

## How to Test

1. Build the binary locally:
   `go build -o kubescape main.go`
2. Run a workload scan using the new identifier format (with a `.version.group`):
   `./kubescape scan workload Deployment.v1.apps/nginx-deployment`
3. Verify that the scan successfully runs without throwing an "invalid workload identifier" error.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload identifiers can now include Kubernetes-style `apiVersion`, and scan configuration will carry it through when provided.
* **Bug Fixes**
  * Strengthened parsing and validation of workload identifiers, including consistent rejection of malformed or incomplete version formats.
  * Invalid dotted `apiVersion` syntaxes are now rejected reliably.
* **Tests**
  * Expanded and adjusted unit test coverage for the new `apiVersion` parsing and scan configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->