### PR TITLE
[fix] :  non-deterministic namespace bucketing caused by mid-scan resource count mutation

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -67,6 +67,11 @@ type OPAProcessor struct {
 	celEvaluator     *cel.Evaluator
 	celEvaluatorOnce sync.Once
 	celEvaluatorErr  error
+	// initialResourceCount is the size of AllResources snapshotted once before
+	// the control loop starts, so the large-cluster namespace-bucketing decision
+	// (see getNamespaceName) is made once per scan instead of drifting mid-scan
+	// as rules write aggregator-produced resources back into AllResources.
+	initialResourceCount int
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -132,6 +137,8 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 		progressListener.Start(len(policies.Controls))
 		defer progressListener.Stop()
 	}
+
+	opap.initialResourceCount = len(opap.AllResources)
 
 	var processErrs []error
 	for _, toPin := range policies.Controls {
@@ -253,7 +260,7 @@ func (opap *OPAProcessor) processRule(ctx context.Context, rule *reporthandling.
 	ruleRegoDependenciesData := opap.makeRegoDeps(rule.ControlConfigInputs, fixedControlInputs)
 
 	var evalErrs []error
-	resourcesPerNS := getAllSupportedObjects(opap.K8SResources, opap.ExternalResources, opap.AllResources, rule)
+	resourcesPerNS := getAllSupportedObjects(opap.K8SResources, opap.ExternalResources, opap.AllResources, rule, opap.initialResourceCount)
 	for i := range resourcesPerNS {
 		resourceToScan := resourcesPerNS[i]
 		if _, ok := resourcesPerNS[clusterScope]; ok && i != clusterScope {

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -74,6 +74,7 @@ type OPAProcessor struct {
 	initialResourceCount int
 }
 
+// NewOPAProcessor requires sessionObj.AllResources to already be fully collected (i.e. CollectResources must have already run), since it snapshots the resource count at construction.
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
 	if regoDependenciesData != nil && sessionObj != nil {
 		regoDependenciesData.PostureControlInputs = sessionObj.RegoInputData.PostureControlInputs

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -67,10 +67,10 @@ type OPAProcessor struct {
 	celEvaluator     *cel.Evaluator
 	celEvaluatorOnce sync.Once
 	celEvaluatorErr  error
-	// initialResourceCount is the size of AllResources snapshotted once before
-	// the control loop starts, so the large-cluster namespace-bucketing decision
-	// (see getNamespaceName) is made once per scan instead of drifting mid-scan
-	// as rules write aggregator-produced resources back into AllResources.
+	// initialResourceCount is the size of AllResources snapshotted once at
+	// construction, so the large-cluster namespace-bucketing decision (see
+	// getNamespaceName) is made once per scan instead of drifting mid-scan as
+	// rules write aggregator-produced resources back into AllResources.
 	initialResourceCount int
 }
 
@@ -78,6 +78,11 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 	if regoDependenciesData != nil && sessionObj != nil {
 		regoDependenciesData.PostureControlInputs = sessionObj.RegoInputData.PostureControlInputs
 		regoDependenciesData.DataControlInputs = sessionObj.RegoInputData.DataControlInputs
+	}
+
+	initialResourceCount := 0
+	if sessionObj != nil {
+		initialResourceCount = len(sessionObj.AllResources)
 	}
 
 	return &OPAProcessor{
@@ -90,6 +95,7 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		printEnabled:           enableRegoPrint,
 		compiledModules:        make(map[string]*ast.Compiler),
 		TimedOutControls:       make(map[string]string),
+		initialResourceCount:   initialResourceCount,
 	}
 }
 
@@ -137,8 +143,6 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 		progressListener.Start(len(policies.Controls))
 		defer progressListener.Stop()
 	}
-
-	opap.initialResourceCount = len(opap.AllResources)
 
 	var processErrs []error
 	for _, toPin := range policies.Controls {

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -166,7 +166,7 @@ func TestProcessRule_NamespaceBucketingStableAcrossAggregatorGrowth(t *testing.T
 	sess.K8SResources = cautils.K8SResources{
 		"rbac.authorization.k8s.io/v1/rolebindings": {binding.GetID()},
 		"rbac.authorization.k8s.io/v1/roles":        {role.GetID()},
-		"/v1/pods": {podA.GetID(), podB.GetID()},
+		"/v1/pods":                                  {podA.GetID(), podB.GetID()},
 	}
 	sess.AllResources[binding.GetID()] = binding
 	sess.AllResources[role.GetID()] = role

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -233,13 +233,107 @@ deny[msga] {
 	podAResult, ok := got[podA.GetID()]
 	assert.True(t, ok, "podA must appear in results")
 	if ok {
-		assert.NotEqual(t, apis.StatusFailed, podAResult.Status,
-			"podA was evaluated in isolation — bucketing drifted mid-scan; got=%+v", podAResult)
+		assert.Equal(t, apis.StatusPassed, podAResult.Status,
+			"podA was evaluated in isolation -- bucketing drifted mid-scan; got=%+v", podAResult)
 	}
 	podBResult, ok := got[podB.GetID()]
 	assert.True(t, ok, "podB must appear in results")
 	if ok {
-		assert.NotEqual(t, apis.StatusFailed, podBResult.Status,
-			"podB was evaluated in isolation — bucketing drifted mid-scan; got=%+v", podBResult)
+		assert.Equal(t, apis.StatusPassed, podBResult.Status,
+			"podB was evaluated in isolation -- bucketing drifted mid-scan; got=%+v", podBResult)
+	}
+}
+
+// TestProcess_NamespaceBucketingWiredFromConstruction drives the real
+// production path -- NewOPAProcessor followed by Process() -- instead of
+// hand-assigning opap.initialResourceCount, so that deleting the snapshot
+// assignment in NewOPAProcessor causes this test to fail. Two Pods, one per
+// namespace, are the only resources at construction time; the single control's
+// rule denies any Pod evaluated without its sibling in the same batch, which
+// only happens if per-namespace bucketing split them into separate batches.
+func TestProcess_NamespaceBucketingWiredFromConstruction(t *testing.T) {
+	origLarge := largeClusterSize
+	largeClusterSize = 1
+	t.Cleanup(func() { largeClusterSize = origLarge })
+
+	podA := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "pa", "namespace": "ns-a"},
+	})
+	podB := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "pb", "namespace": "ns-b"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"/v1/pods": {podA.GetID(), podB.GetID()},
+	}
+	sess.AllResources[podA.GetID()] = podA
+	sess.AllResources[podB.GetID()] = podB
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+
+	podRule := reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+
+deny[msga] {
+    pod := input[_]
+    pod.kind == "Pod"
+    pods := [p | p := input[_]; p.kind == "Pod"]
+    count(pods) < 2
+    msga := {
+        "alertMessage": "pod evaluated without its sibling",
+        "packagename":  "armo_builtins",
+        "alertScore":   5,
+        "fixPaths":     [],
+        "failedPaths":  [],
+        "alertObject":  {"k8sApiObjects": [pod]},
+    }
+}
+`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"Pod"},
+			},
+		},
+	}
+	podRule.Name = "pods-evaluated-together"
+
+	control := reporthandling.Control{ControlID: "C-TEST", Rules: []reporthandling.PolicyRule{podRule}}
+	policies := &cautils.Policies{Controls: map[string]reporthandling.Control{"C-TEST": control}}
+	opap.AllPolicies = policies
+
+	err := opap.Process(context.Background(), policies, nil)
+	assert.NoError(t, err)
+
+	podAResult, ok := opap.ResourcesResult[podA.GetID()]
+	assert.True(t, ok, "podA must appear in results")
+	if ok {
+		assert.Equal(t, 1, len(podAResult.AssociatedControls))
+		if len(podAResult.AssociatedControls) == 1 {
+			assert.Equal(t, 1, len(podAResult.AssociatedControls[0].ResourceAssociatedRules))
+			if len(podAResult.AssociatedControls[0].ResourceAssociatedRules) == 1 {
+				assert.Equal(t, apis.StatusFailed, podAResult.AssociatedControls[0].ResourceAssociatedRules[0].Status,
+					"podA was not evaluated in its own per-namespace batch -- initialResourceCount is not wired from NewOPAProcessor")
+			}
+		}
+	}
+	podBResult, ok := opap.ResourcesResult[podB.GetID()]
+	assert.True(t, ok, "podB must appear in results")
+	if ok {
+		assert.Equal(t, 1, len(podBResult.AssociatedControls))
+		if len(podBResult.AssociatedControls) == 1 {
+			assert.Equal(t, 1, len(podBResult.AssociatedControls[0].ResourceAssociatedRules))
+			if len(podBResult.AssociatedControls[0].ResourceAssociatedRules) == 1 {
+				assert.Equal(t, apis.StatusFailed, podBResult.AssociatedControls[0].ResourceAssociatedRules[0].Status,
+					"podB was not evaluated in its own per-namespace batch -- initialResourceCount is not wired from NewOPAProcessor")
+			}
+		}
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/stretchr/testify/assert"
 )
@@ -109,4 +110,136 @@ deny[msga] {
 		"ns-a path missing — pre-seed overwrite regressed; got paths=%v", crResult.Paths)
 	assert.True(t, failed["metadata.annotations.bound-by-ns-b"],
 		"ns-b path missing — pre-seed overwrite regressed; got paths=%v", crResult.Paths)
+}
+
+// TestProcessRule_NamespaceBucketingStableAcrossAggregatorGrowth guards
+// against a regression where the large-cluster namespace-bucketing decision
+// (getNamespaceName) was recomputed from the live size of opap.AllResources
+// on every rule. A subject-role-rolebinding aggregator rule writes newly
+// synthesized subject objects back into opap.AllResources (see the write-back
+// in processRule), which can push the live count past largeClusterSize
+// mid-scan. A later, unrelated rule would then see per-namespace bucketing
+// instead of the whole-cluster bucketing every earlier rule saw, even though
+// the cluster itself never changed.
+//
+// Setup: the initial resource count (RoleBinding + Role + two Pods, one per
+// namespace) sits exactly at largeClusterSize, so bucketing starts as
+// whole-cluster. The aggregator rule expands one RoleBinding/Role pair into
+// two synthetic subject objects, growing AllResources past the threshold. A
+// second rule then evaluates the two Pods, denying any Pod evaluated without
+// its sibling in the same batch — which only happens if the two Pods are
+// split into separate per-namespace batches. Both Pods must still pass,
+// proving the second rule was evaluated with the frozen initial count, not
+// the grown live count.
+func TestProcessRule_NamespaceBucketingStableAcrossAggregatorGrowth(t *testing.T) {
+	origLarge := largeClusterSize
+	largeClusterSize = 4
+	t.Cleanup(func() { largeClusterSize = origLarge })
+
+	binding := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "RoleBinding",
+		"metadata":   map[string]any{"name": "rb", "namespace": "ns-a"},
+		"roleRef":    map[string]any{"kind": "Role", "name": "my-role"},
+		"subjects": []any{
+			map[string]any{"kind": "ServiceAccount", "name": "sa1", "namespace": "ns-a"},
+			map[string]any{"kind": "ServiceAccount", "name": "sa2", "namespace": "ns-a"},
+		},
+	})
+	role := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "Role",
+		"metadata":   map[string]any{"name": "my-role", "namespace": "ns-a"},
+	})
+	podA := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "pa", "namespace": "ns-a"},
+	})
+	podB := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "pb", "namespace": "ns-b"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"rbac.authorization.k8s.io/v1/rolebindings": {binding.GetID()},
+		"rbac.authorization.k8s.io/v1/roles":        {role.GetID()},
+		"/v1/pods": {podA.GetID(), podB.GetID()},
+	}
+	sess.AllResources[binding.GetID()] = binding
+	sess.AllResources[role.GetID()] = role
+	sess.AllResources[podA.GetID()] = podA
+	sess.AllResources[podB.GetID()] = podB
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap.initialResourceCount = len(sess.AllResources)
+
+	assert.False(t, isLargeCluster(opap.initialResourceCount), "test setup must start below the large-cluster threshold")
+
+	aggregatorRule := &reporthandling.PolicyRule{
+		Rule:         "package armo_builtins\n\ndeny[msga] {\n    false\n    msga := {\"alertMessage\": \"unused\"}\n}\n",
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{
+				APIGroups:   []string{"rbac.authorization.k8s.io"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"RoleBinding", "Role"},
+			},
+		},
+	}
+	aggregatorRule.Name = "subject-role-rolebinding-aggregator"
+	aggregatorRule.Attributes = map[string]interface{}{"resourcesAggregator": "subject-role-rolebinding"}
+
+	_, err := opap.processRule(context.Background(), aggregatorRule, nil, "")
+	assert.NoError(t, err)
+
+	assert.True(t, isLargeCluster(len(opap.AllResources)),
+		"aggregator write-back must grow AllResources past the threshold for this test to be meaningful")
+
+	podRule := &reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+
+deny[msga] {
+    pod := input[_]
+    pod.kind == "Pod"
+    pods := [p | p := input[_]; p.kind == "Pod"]
+    count(pods) < 2
+    msga := {
+        "alertMessage": "pod evaluated without its sibling",
+        "packagename":  "armo_builtins",
+        "alertScore":   5,
+        "fixPaths":     [],
+        "failedPaths":  [],
+        "alertObject":  {"k8sApiObjects": [pod]},
+    }
+}
+`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"Pod"},
+			},
+		},
+	}
+	podRule.Name = "pods-evaluated-together"
+
+	got, err := opap.processRule(context.Background(), podRule, nil, "")
+	assert.NoError(t, err)
+
+	podAResult, ok := got[podA.GetID()]
+	assert.True(t, ok, "podA must appear in results")
+	if ok {
+		assert.NotEqual(t, apis.StatusFailed, podAResult.Status,
+			"podA was evaluated in isolation — bucketing drifted mid-scan; got=%+v", podAResult)
+	}
+	podBResult, ok := got[podB.GetID()]
+	assert.True(t, ok, "podB must appear in results")
+	if ok {
+		assert.NotEqual(t, apis.StatusFailed, podBResult.Status,
+			"podB was evaluated in isolation — bucketing drifted mid-scan; got=%+v", podBResult)
+	}
 }

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -121,6 +121,8 @@ func NewOPAProcessorMock(opaSessionObjMock string, resourcesMock []byte) *OPAPro
 	for i := range allResources {
 		opap.AllResources[i] = workloadinterface.NewWorkloadObj(allResources[i])
 	}
+	// mirror NewOPAProcessor: freeze the bucketing input after AllResources is populated
+	opap.initialResourceCount = len(opap.AllResources)
 
 	return opap
 }

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -206,8 +206,8 @@ func isEmptyResources(counters reportsummary.ICounters) bool {
 	return counters.Failed() == 0 && counters.Skipped() == 0 && counters.Passed() == 0
 }
 
-func getAllSupportedObjects(k8sResources cautils.K8SResources, externalResources cautils.ExternalResources, allResources map[string]workloadinterface.IMetadata, rule *reporthandling.PolicyRule) map[string][]workloadinterface.IMetadata {
-	k8sObjects := getKubernetesObjects(k8sResources, allResources, rule.Match)
+func getAllSupportedObjects(k8sResources cautils.K8SResources, externalResources cautils.ExternalResources, allResources map[string]workloadinterface.IMetadata, rule *reporthandling.PolicyRule, resourceCount int) map[string][]workloadinterface.IMetadata {
+	k8sObjects := getKubernetesObjects(k8sResources, allResources, rule.Match, resourceCount)
 	externalObjs := getKubernetesObjectsFromExternalResources(externalResources, allResources, rule.DynamicMatch)
 	if len(externalObjs) > 0 {
 		l, ok := k8sObjects[clusterScope]
@@ -243,7 +243,7 @@ func getKubernetesObjectsFromExternalResources(externalResources cautils.Externa
 	return k8sObjects
 }
 
-func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) map[string][]workloadinterface.IMetadata {
+func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects, resourceCount int) map[string][]workloadinterface.IMetadata {
 	k8sObjects := map[string][]workloadinterface.IMetadata{}
 
 	for m := range match {
@@ -256,7 +256,7 @@ func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[st
 							for i := range k8sObj {
 
 								obj := allResources[k8sObj[i]]
-								ns := getNamespaceName(obj, len(allResources))
+								ns := getNamespaceName(obj, resourceCount)
 
 								l, ok := k8sObjects[ns]
 								if !ok {

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -206,6 +206,7 @@ func isEmptyResources(counters reportsummary.ICounters) bool {
 	return counters.Failed() == 0 && counters.Skipped() == 0 && counters.Passed() == 0
 }
 
+// resourceCount must be the scan's frozen initial snapshot (OPAProcessor.initialResourceCount), not len(allResources).
 func getAllSupportedObjects(k8sResources cautils.K8SResources, externalResources cautils.ExternalResources, allResources map[string]workloadinterface.IMetadata, rule *reporthandling.PolicyRule, resourceCount int) map[string][]workloadinterface.IMetadata {
 	k8sObjects := getKubernetesObjects(k8sResources, allResources, rule.Match, resourceCount)
 	externalObjs := getKubernetesObjectsFromExternalResources(externalResources, allResources, rule.DynamicMatch)
@@ -243,6 +244,7 @@ func getKubernetesObjectsFromExternalResources(externalResources cautils.Externa
 	return k8sObjects
 }
 
+// resourceCount must be the scan's frozen initial snapshot (OPAProcessor.initialResourceCount), not len(allResources).
 func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects, resourceCount int) map[string][]workloadinterface.IMetadata {
 	k8sObjects := map[string][]workloadinterface.IMetadata{}
 


### PR DESCRIPTION
## Overview

This is the fix for #2575.

The whole-cluster vs per-namespace bucketing decision was re-derived from `len(opap.AllResources)` on every rule, but `processRule` also writes aggregator-produced synthetic resources back into that same map for report resolution. RBAC aggregator controls (`subject-role-rolebinding`) grow `AllResources` by one set of `(binding × role × subject)` triples, and if this pushes the count past `LARGE_CLUSTER_SIZE`, every subsequent rule in the scan gets bucketed per-namespace instead of whole-cluster. Since `Process` ranges over `policies.Controls` (a Go map), which control triggers this crossing point is non-deterministic across runs of the same binary against an unchanged cluster.

The fix freezes the bucketing decision once per scan instead of recomputing it per rule.

```go
// before -- live re-read on every rule
ns := getNamespaceName(obj, len(allResources))

// after -- frozen snapshot taken once before the control loop
opap.initialResourceCount = len(opap.AllResources) // in Process(), before control loop
...
ns := getNamespaceName(obj, resourceCount) // resourceCount threaded through from the snapshot
```

## Additional Information

The write-back at `processRule` (`opap.AllResources[inputResource.GetID()] = inputResource`) is completely untouched -- report resolution genuinely needs it. Only the input to the bucketing decision changed, from a live map length read to a frozen snapshot taken once before the control loop begins.

`initialResourceCount int` added to `OPAProcessor`. `getAllSupportedObjects` and `getKubernetesObjects` gained a `resourceCount int` parameter threaded straight through to `getNamespaceName`, replacing the live `len(allResources)` call.

## How to Test

Regression test `TestProcessRule_NamespaceBucketingStableAcrossAggregatorGrowth`:
- Starts with 4 resources at `largeClusterSize = 4` (exactly at the not-yet-large boundary)
- Runs a `subject-role-rolebinding` aggregator rule that writes 2 synthetic subject objects back into `AllResources`, growing it to 6 -- confirmed `isLargeCluster` flips to true on the live count while staying false on the frozen snapshot
- Runs a second rule against two Pods in different namespaces that only passes if both are evaluated together in one batch
- Asserts both Pods pass, proving the bucketing decision didn't drift mid-scan

Verified the test actually catches the regression: temporarily reintroduced the exact live-length bug, reran, both Pods failed with "evaluated without its sibling" exactly as predicted. Restored the fix, reran, passes.

`go build ./...`, `go vet ./core/pkg/opaprocessor/...`, and `go test ./core/pkg/opaprocessor/... -race` all pass cleanly.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized resource evaluation scope during scans, preventing results from changing unexpectedly as aggregated resources are added.
  * Ensured namespace and cluster-level evaluations consistently use the resource set captured at the start of processing.
  * Added regression coverage for stable Pod evaluations in large-cluster scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->