### PR TITLE
fix(operator): propagate --namespace flag to scan subcommands- #2

### DIFF
--- a/cmd/operator/configscan.go
+++ b/cmd/operator/configscan.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
-	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +18,8 @@ var operatorScanConfigExamples = fmt.Sprintf(`
 `, cautils.ExecName())
 
 func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
+	configScanInfo := &cautils.ConfigScanInfo{}
+
 	configCmd := &cobra.Command{
 		Use:     "configurations",
 		Short:   "Trigger configuration scanning from the Kubescape Operator microservice",
@@ -29,7 +30,7 @@ func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo *cautils.Operator
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			operatorAdapter, err := core.NewOperatorAdapter(operatorInfo.OperatorScanInfo, operatorInfo.Namespace)
+			operatorAdapter, err := newOperatorAdapter(configScanInfo, operatorInfo.Namespace)
 			if err != nil {
 				return err
 			}
@@ -43,9 +44,6 @@ func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo *cautils.Operator
 			return nil
 		},
 	}
-
-	configScanInfo := &cautils.ConfigScanInfo{}
-	operatorInfo.OperatorScanInfo = configScanInfo
 
 	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.IncludedNamespaces, "include-namespaces", nil, "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.ExcludedNamespaces, "exclude-namespaces", nil, "Namespaces to exclude from scanning. e.g: --exclude-namespaces ns-a,ns-b. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")

--- a/cmd/operator/configscan.go
+++ b/cmd/operator/configscan.go
@@ -18,7 +18,7 @@ var operatorScanConfigExamples = fmt.Sprintf(`
 
 `, cautils.ExecName())
 
-func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
+func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:     "configurations",
 		Short:   "Trigger configuration scanning from the Kubescape Operator microservice",

--- a/cmd/operator/configscan_test.go
+++ b/cmd/operator/configscan_test.go
@@ -16,7 +16,7 @@ func TestGetOperatorScanConfigCmd(t *testing.T) {
 		Namespace: "namespace",
 	}
 
-	cmd := getOperatorScanConfigCmd(mockKubescape, operatorInfo)
+	cmd := getOperatorScanConfigCmd(mockKubescape, &operatorInfo)
 
 	// Verify the command name and short description
 	assert.Equal(t, "configurations", cmd.Use)

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -53,7 +53,7 @@ func GetOperatorCmd(ks meta.IKubescape) *cobra.Command {
 		},
 	}
 
-	operatorCmd.AddCommand(getOperatorScanCmd(ks, operatorInfo))
+	operatorCmd.AddCommand(getOperatorScanCmd(ks, &operatorInfo))
 	operatorCmd.AddCommand(getOperatorRemediateCmd(ks, operatorInfo))
 
 	return operatorCmd

--- a/cmd/operator/scan.go
+++ b/cmd/operator/scan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,12 @@ const (
 	vulnerabilitiesSubCommand string = "vulnerabilities"
 	configurationsSubCommand  string = "configurations"
 )
+
+// newOperatorAdapter is a seam over core.NewOperatorAdapter: the "configurations"
+// and "vulnerabilities" child commands call it to reach the cluster. Tests
+// substitute it to assert on the (scanInfo, namespace) a child actually sends
+// without connecting to a real cluster.
+var newOperatorAdapter = core.NewOperatorAdapter
 
 func getOperatorScanCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
 	operatorCmd := &cobra.Command{

--- a/cmd/operator/scan.go
+++ b/cmd/operator/scan.go
@@ -14,7 +14,7 @@ const (
 	configurationsSubCommand  string = "configurations"
 )
 
-func getOperatorScanCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
+func getOperatorScanCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
 	operatorCmd := &cobra.Command{
 		Use:     "scan",
 		Short:   "Scan your cluster using the Kubescape-operator within the cluster components",

--- a/cmd/operator/scan_test.go
+++ b/cmd/operator/scan_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"io"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -16,7 +17,7 @@ func TestGetOperatorScanCmd(t *testing.T) {
 		Namespace: "namespace",
 	}
 
-	cmd := getOperatorScanCmd(mockKubescape, operatorInfo)
+	cmd := getOperatorScanCmd(mockKubescape, &operatorInfo)
 
 	// Verify the command name and short description
 	assert.Equal(t, "scan", cmd.Use)
@@ -43,4 +44,26 @@ func TestGetOperatorScanCmd(t *testing.T) {
 	err = cmd.RunE(&cobra.Command{}, []string{"random"})
 	expectedErrorMessage = "for the operator sub-command, only " + vulnerabilitiesSubCommand + " and " + configurationsSubCommand + " are supported. Refer to the examples above"
 	assert.Equal(t, expectedErrorMessage, err.Error())
+}
+
+// TestOperatorScanCmd_NamespaceFlagPropagatesToChildCommands guards against a
+// regression where operatorInfo was passed by value into the "configurations"
+// and "vulnerabilities" child commands: the child received a copy frozen at
+// the flag's default value, so a user-supplied --namespace was silently
+// ignored by the command that actually reads it.
+func TestOperatorScanCmd_NamespaceFlagPropagatesToChildCommands(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	operatorInfo := &cautils.OperatorInfo{}
+
+	cmd := getOperatorScanCmd(mockKubescape, operatorInfo)
+	cmd.SetArgs([]string{"configurations", "--namespace", "custom-ns"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	// Execution itself fails without a live cluster connection; we only care
+	// that flag parsing wrote through to the same OperatorInfo the child
+	// command's RunE reads from.
+	_ = cmd.Execute()
+
+	assert.Equal(t, "custom-ns", operatorInfo.Namespace)
 }

--- a/cmd/operator/scan_test.go
+++ b/cmd/operator/scan_test.go
@@ -1,13 +1,16 @@
 package operator
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOperatorScanCmd(t *testing.T) {
@@ -51,19 +54,35 @@ func TestGetOperatorScanCmd(t *testing.T) {
 // and "vulnerabilities" child commands: the child received a copy frozen at
 // the flag's default value, so a user-supplied --namespace was silently
 // ignored by the command that actually reads it.
+//
+// It substitutes newOperatorAdapter instead of calling into core.NewOperatorAdapter,
+// both to avoid touching a real cluster (which can hang or os.Exit via
+// logger.L().Fatal on an unusable kubeconfig) and to assert on the exact
+// (scanInfo, namespace) pair the child hands to it — the parent's
+// operatorInfo.Namespace alone doesn't prove the child read it.
 func TestOperatorScanCmd_NamespaceFlagPropagatesToChildCommands(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	operatorInfo := &cautils.OperatorInfo{}
+
+	var gotScanInfo cautils.OperatorScanInfo
+	var gotNamespace string
+	prevAdapter := newOperatorAdapter
+	newOperatorAdapter = func(scanInfo cautils.OperatorScanInfo, ns string) (*core.OperatorAdapter, error) {
+		gotScanInfo = scanInfo
+		gotNamespace = ns
+		return nil, errors.New("stub: no real cluster in unit tests")
+	}
+	t.Cleanup(func() { newOperatorAdapter = prevAdapter })
 
 	cmd := getOperatorScanCmd(mockKubescape, operatorInfo)
 	cmd.SetArgs([]string{"configurations", "--namespace", "custom-ns"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
-	// Execution itself fails without a live cluster connection; we only care
-	// that flag parsing wrote through to the same OperatorInfo the child
-	// command's RunE reads from.
-	_ = cmd.Execute()
+	err := cmd.Execute()
+	require.Error(t, err) // the stub always errors; we only care what it was called with
 
 	assert.Equal(t, "custom-ns", operatorInfo.Namespace)
+	assert.Equal(t, "custom-ns", gotNamespace)
+	assert.IsType(t, &cautils.ConfigScanInfo{}, gotScanInfo)
 }

--- a/cmd/operator/vulnerabilitiesscan.go
+++ b/cmd/operator/vulnerabilitiesscan.go
@@ -19,7 +19,7 @@ var operatorScanVulnerabilitiesExamples = fmt.Sprintf(`
 
 `, cautils.ExecName())
 
-func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
+func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:     "vulnerabilities",
 		Short:   "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components",

--- a/cmd/operator/vulnerabilitiesscan.go
+++ b/cmd/operator/vulnerabilitiesscan.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
-	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +19,10 @@ var operatorScanVulnerabilitiesExamples = fmt.Sprintf(`
 `, cautils.ExecName())
 
 func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
+	vulnerabilitiesScanInfo := &cautils.VulnerabilitiesScanInfo{
+		ClusterName: k8sinterface.GetContextName(),
+	}
+
 	configCmd := &cobra.Command{
 		Use:     "vulnerabilities",
 		Short:   "Scan your cluster for vulnerabilities using the Kubescape Operator in-cluster components",
@@ -30,7 +33,7 @@ func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			operatorAdapter, err := core.NewOperatorAdapter(operatorInfo.OperatorScanInfo, operatorInfo.Namespace)
+			operatorAdapter, err := newOperatorAdapter(vulnerabilitiesScanInfo, operatorInfo.Namespace)
 			if err != nil {
 				return err
 			}
@@ -44,11 +47,6 @@ func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils
 			return err
 		},
 	}
-
-	vulnerabilitiesScanInfo := &cautils.VulnerabilitiesScanInfo{
-		ClusterName: k8sinterface.GetContextName(),
-	}
-	operatorInfo.OperatorScanInfo = vulnerabilitiesScanInfo
 
 	configCmd.PersistentFlags().StringSliceVar(&vulnerabilitiesScanInfo.IncludeNamespaces, "include-namespaces", nil, "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 

--- a/cmd/operator/vulnerabilitiesscan_test.go
+++ b/cmd/operator/vulnerabilitiesscan_test.go
@@ -16,7 +16,7 @@ func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
 		Namespace: "namespace",
 	}
 
-	cmd := getOperatorScanVulnerabilitiesCmd(mockKubescape, operatorInfo)
+	cmd := getOperatorScanVulnerabilitiesCmd(mockKubescape, &operatorInfo)
 
 	// Verify the command name and short description
 	assert.Equal(t, "vulnerabilities", cmd.Use)


### PR DESCRIPTION
## Summary
- `getOperatorScanCmd` (cmd/operator/scan.go) binds the `--namespace` persistent flag to its own local `operatorInfo`, then passes `operatorInfo` **by value** into `getOperatorScanConfigCmd`/`getOperatorScanVulnerabilitiesCmd`.
- Each child command gets an independent copy of the struct frozen at construction time (i.e. the flag's default `"kubescape"`). Cobra later writes the user's `--namespace` value into the parent's copy only — the child's `RunE`, which is what actually calls `core.NewOperatorAdapter(..., operatorInfo.Namespace)`, never sees it.
- Result: `kubescape operator scan configurations --namespace my-ns` (and the `vulnerabilities` variant) silently keep looking in the default `kubescape` namespace.
- Fix: thread `*cautils.OperatorInfo` through `operator.go` → `scan.go` → `configscan.go`/`vulnerabilitiesscan.go` instead of passing by value, so flag parsing and consumption share the same struct.

## Test plan
- [x] `go build ./cmd/...`
- [x] `go test ./cmd/operator/...` (existing tests updated for the new pointer signature)
- [x] Added `TestOperatorScanCmd_NamespaceFlagPropagatesToChildCommands`, which simulates `configurations --namespace custom-ns` and asserts the child command's `OperatorInfo.Namespace` reflects it (fails without the fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator configuration and vulnerability scans to consistently use the selected namespace.
  * Improved propagation of scan settings across operator scan commands.
  * Ensured scan configuration is initialized reliably before execution.

* **Tests**
  * Added coverage verifying namespace settings reach configuration scan commands and their underlying operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->