### PR TITLE
fix(core): allow operator scan with multiple app=operator pods

### DIFF
--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -38,11 +38,37 @@ func getOperatorPod(k8sClient *k8sinterface.KubernetesApi, ns string) (*v1.Pod, 
 	if err != nil {
 		return nil, err
 	}
-	if len(pods.Items) != 1 {
-		return nil, errors.New("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
-	}
 
-	return &pods.Items[0], nil
+	notFoundErr := errors.New("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
+
+	switch len(pods.Items) {
+	case 0:
+		return nil, notFoundErr
+	case 1:
+		return &pods.Items[0], nil
+	default:
+		// More than one operator pod can be present during HA deployments or
+		// rolling upgrades, so pick the first one that is actually ready
+		// instead of failing outright.
+		for i := range pods.Items {
+			if isPodReady(&pods.Items[i]) {
+				return &pods.Items[i], nil
+			}
+		}
+		return nil, notFoundErr
+	}
+}
+
+func isPodReady(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func NewOperatorAdapter(scanInfo cautils.OperatorScanInfo, ns string) (*OperatorAdapter, error) {

--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -27,6 +27,8 @@ type OperatorAdapter struct {
 	cautils.OperatorConnector
 }
 
+var errOperatorNotFound = errors.New("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
+
 func getOperatorPod(k8sClient *k8sinterface.KubernetesApi, ns string) (*v1.Pod, error) {
 	if k8sClient == nil || k8sClient.KubernetesClient == nil {
 		return nil, errors.New("kubernetes client is not initialised")
@@ -39,27 +41,30 @@ func getOperatorPod(k8sClient *k8sinterface.KubernetesApi, ns string) (*v1.Pod, 
 		return nil, err
 	}
 
-	notFoundErr := errors.New("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
-
-	switch len(pods.Items) {
-	case 0:
-		return nil, notFoundErr
-	case 1:
-		return &pods.Items[0], nil
-	default:
-		// More than one operator pod can be present during HA deployments or
-		// rolling upgrades, so pick the first one that is actually ready
-		// instead of failing outright.
-		for i := range pods.Items {
-			if isPodReady(&pods.Items[i]) {
-				return &pods.Items[i], nil
-			}
-		}
-		return nil, notFoundErr
+	if len(pods.Items) == 0 {
+		return nil, errOperatorNotFound
 	}
+
+	// More than one operator pod can be present during HA deployments or
+	// rolling upgrades. The operator has no leader election, so any ready
+	// replica can serve v1/triggerAction: picking the first ready pod is a
+	// deliberate choice, not an approximation. A single pod goes through the
+	// same check, so a not-yet-ready lone pod is reported instead of being
+	// handed to CreatePortForwarder.
+	for i := range pods.Items {
+		if isPodReady(&pods.Items[i]) {
+			return &pods.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("found %d Kubescape Operator pod(s) in namespace %q, but none are running and ready", len(pods.Items), ns)
 }
 
 func isPodReady(pod *v1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		// A terminating pod keeps reporting Ready=True for the whole
+		// termination grace period, so it must not be selected.
+		return false
+	}
 	if pod.Status.Phase != v1.PodRunning {
 		return false
 	}

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
@@ -12,30 +13,114 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_getOperatorPod(t *testing.T) {
+func readyPod(name string) v1.Pod {
+	return v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"app": "operator"},
+		},
+		Status: v1.PodStatus{
+			Phase:      v1.PodRunning,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		},
+	}
+}
+
+func notReadyPod(name string) v1.Pod {
+	return v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"app": "operator"},
+		},
+		Status: v1.PodStatus{
+			Phase:      v1.PodRunning,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}},
+		},
+	}
+}
+
+func Test_isPodReady(t *testing.T) {
+	terminating := readyPod("terminating")
+	deletionTimestamp := metav1.NewTime(time.Unix(0, 0))
+	terminating.DeletionTimestamp = &deletionTimestamp
+
 	testCases := []struct {
-		name                                  string
-		createOperatorPod                     bool
-		createAnotherOperatorPodWithSameLabel bool
-		expectedError                         error
+		name string
+		pod  v1.Pod
+		want bool
 	}{
 		{
-			name:                                  "test error no operator exist",
-			createOperatorPod:                     false,
-			createAnotherOperatorPodWithSameLabel: false,
-			expectedError:                         fmt.Errorf("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts"),
+			name: "running and ready",
+			pod:  readyPod("p"),
+			want: true,
 		},
 		{
-			name:                                  "test error several operators exist",
-			createOperatorPod:                     true,
-			createAnotherOperatorPodWithSameLabel: true,
-			expectedError:                         fmt.Errorf("could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts"),
+			name: "running but ready condition is false",
+			pod:  notReadyPod("p"),
+			want: false,
 		},
 		{
-			name:                                  "test no error",
-			createOperatorPod:                     true,
-			createAnotherOperatorPodWithSameLabel: false,
-			expectedError:                         nil,
+			name: "running with no ready condition at all",
+			pod:  v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning}},
+			want: false,
+		},
+		{
+			name: "pending with ready condition true",
+			pod: v1.Pod{Status: v1.PodStatus{
+				Phase:      v1.PodPending,
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			}},
+			want: false,
+		},
+		{
+			name: "terminating pod stays running and ready but must not be selected",
+			pod:  terminating,
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPodReady(&tc.pod))
+		})
+	}
+}
+
+func Test_getOperatorPod(t *testing.T) {
+	notReadyErr := func(count int) error {
+		return fmt.Errorf("found %d Kubescape Operator pod(s) in namespace %q, but none are running and ready", count, kubescapeNamespace)
+	}
+
+	testCases := []struct {
+		name         string
+		pods         []v1.Pod
+		expectedErr  error
+		expectedName string
+	}{
+		{
+			name:        "no operator pod exists",
+			pods:        nil,
+			expectedErr: errOperatorNotFound,
+		},
+		{
+			name:         "single ready pod is returned",
+			pods:         []v1.Pod{readyPod("first")},
+			expectedName: "first",
+		},
+		{
+			name:        "single not-ready pod is reported, not handed to the caller",
+			pods:        []v1.Pod{notReadyPod("first")},
+			expectedErr: notReadyErr(1),
+		},
+		{
+			name:         "multiple pods, the ready one is selected even when it sorts after the not-ready one",
+			pods:         []v1.Pod{notReadyPod("aaa-not-ready"), readyPod("zzz-ready")},
+			expectedName: "zzz-ready",
+		},
+		{
+			name:        "multiple pods, none ready",
+			pods:        []v1.Pod{notReadyPod("first"), notReadyPod("second")},
+			expectedErr: notReadyErr(2),
 		},
 	}
 
@@ -46,105 +131,20 @@ func Test_getOperatorPod(t *testing.T) {
 				Context:          context.Background(),
 			}
 
-			var createdOperatorPod *v1.Pod
-			if tc.createOperatorPod {
-				operatorPod := v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "first",
-						Labels: map[string]string{
-							"app": "operator",
-						},
-					},
-				}
-				var err error
-				createdOperatorPod, err = k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &operatorPod, metav1.CreateOptions{})
-				assert.Equal(t, nil, err)
-			}
-			if tc.createAnotherOperatorPodWithSameLabel {
-				operatorPod := v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "second",
-						Labels: map[string]string{
-							"app": "operator",
-						},
-					},
-				}
-				_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &operatorPod, metav1.CreateOptions{})
-				assert.Equal(t, nil, err)
+			for i := range tc.pods {
+				_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &tc.pods[i], metav1.CreateOptions{})
+				assert.NoError(t, err)
 			}
 
 			pod, err := getOperatorPod(&k8sClient, kubescapeNamespace)
-			assert.Equal(t, err, tc.expectedError)
-			if tc.expectedError == nil {
-				assert.Equal(t, pod, createdOperatorPod)
+			if tc.expectedErr != nil {
+				assert.EqualError(t, err, tc.expectedErr.Error())
+				return
 			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedName, pod.Name)
 		})
 	}
-}
-
-func Test_getOperatorPod_multiplePods_oneReady(t *testing.T) {
-	k8sClient := k8sinterface.KubernetesApi{
-		KubernetesClient: fake.NewClientset(),
-		Context:          context.Background(),
-	}
-
-	notReadyPod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "old",
-			Labels: map[string]string{"app": "operator"},
-		},
-		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-			Conditions: []v1.PodCondition{
-				{Type: v1.PodReady, Status: v1.ConditionFalse},
-			},
-		},
-	}
-	_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &notReadyPod, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	readyPod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "new",
-			Labels: map[string]string{"app": "operator"},
-		},
-		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-			Conditions: []v1.PodCondition{
-				{Type: v1.PodReady, Status: v1.ConditionTrue},
-			},
-		},
-	}
-	createdReadyPod, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &readyPod, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	pod, err := getOperatorPod(&k8sClient, kubescapeNamespace)
-	assert.NoError(t, err)
-	assert.Equal(t, createdReadyPod, pod)
-}
-
-func Test_getOperatorPod_multiplePods_noneReady(t *testing.T) {
-	k8sClient := k8sinterface.KubernetesApi{
-		KubernetesClient: fake.NewClientset(),
-		Context:          context.Background(),
-	}
-
-	for _, name := range []string{"first", "second"} {
-		pod := v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: map[string]string{"app": "operator"},
-			},
-			Status: v1.PodStatus{
-				Phase: v1.PodPending,
-			},
-		}
-		_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &pod, metav1.CreateOptions{})
-		assert.NoError(t, err)
-	}
-
-	_, err := getOperatorPod(&k8sClient, kubescapeNamespace)
-	assert.EqualError(t, err, "could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
 }
 
 func Test_getOperatorPod_nilClient(t *testing.T) {

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -82,6 +82,71 @@ func Test_getOperatorPod(t *testing.T) {
 	}
 }
 
+func Test_getOperatorPod_multiplePods_oneReady(t *testing.T) {
+	k8sClient := k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewClientset(),
+		Context:          context.Background(),
+	}
+
+	notReadyPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "old",
+			Labels: map[string]string{"app": "operator"},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionFalse},
+			},
+		},
+	}
+	_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &notReadyPod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	readyPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "new",
+			Labels: map[string]string{"app": "operator"},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+	createdReadyPod, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &readyPod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	pod, err := getOperatorPod(&k8sClient, kubescapeNamespace)
+	assert.NoError(t, err)
+	assert.Equal(t, createdReadyPod, pod)
+}
+
+func Test_getOperatorPod_multiplePods_noneReady(t *testing.T) {
+	k8sClient := k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewClientset(),
+		Context:          context.Background(),
+	}
+
+	for _, name := range []string{"first", "second"} {
+		pod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"app": "operator"},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+			},
+		}
+		_, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &pod, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	_, err := getOperatorPod(&k8sClient, kubescapeNamespace)
+	assert.EqualError(t, err, "could not find the Kubescape Operator chart, please validate that the Kubescape Operator helm chart is installed and running -> https://github.com/kubescape/helm-charts")
+}
+
 func Test_getOperatorPod_nilClient(t *testing.T) {
 	_, err := getOperatorPod(nil, kubescapeNamespace)
 	assert.EqualError(t, err, "kubernetes client is not initialised")


### PR DESCRIPTION
## Overview
`kubescape operator scan` required exactly one pod matching label `app=operator` in the target namespace. This made scans fail during HA deployments (multiple operator replicas) or rolling upgrades, where old and new operator pods briefly overlap.

This PR updates `getOperatorPod` in `core/core/clusterconnector.go` to select the first ready pod when more than one pod matches the selector, instead of failing outright.

## How to Test

Run the updated unit tests:

```
go test ./core/core/... -run Test_getOperatorPod -v
```

## Related issues/PRs:

Resolved #2592

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operator pod detection when multiple matching pods exist.
  - The system now selects the first pod that is running, ready, and not terminating.
  - Added clearer error handling when no matching pod exists or when all matching pods are unavailable.

- **Tests**
  - Expanded coverage for pod readiness, including missing readiness conditions, non-running pods, and terminating pods.
  - Added scenarios covering multiple matching pods with and without an available ready pod.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->