### PR TITLE
fix(fixhandler): guard nil resource lookup and off-by-one slice bound

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -222,6 +222,22 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		resourceID := result.ResourceID
 		resourceObj := resourceIdToResource[resourceID]
 		if resourceObj == nil {
+			// The report references a resource ID with no backing resource data.
+			// We cannot fix it, but it is still a failed control the user must
+			// remediate manually — surface it rather than dropping it.
+			logger.L().Ctx(ctx).Warning("Skipping result with no resource data in report: " + resourceID)
+			for i := range result.AssociatedControls {
+				ac := &result.AssociatedControls[i]
+				if !ac.GetStatus(nil).IsFailed() {
+					continue
+				}
+				h.unfixedControls = append(h.unfixedControls, UnfixedControl{
+					ControlID:    ac.GetID(),
+					ControlName:  ac.GetName(),
+					ResourceName: resourceID,
+					Reason:       "skipped: resource data missing from report",
+				})
+			}
 			continue
 		}
 		resourcePath := h.getPathFromRawResource(resourceObj.GetObject())
@@ -863,11 +879,7 @@ func determineNewlineSeparator(contents string) string {
 // - Since `yaml/v3` fails to serialize documents starting with a document
 // separator, we comment it out to be compatible.
 func sanitizeYaml(fileAsString string) string {
-	if len(fileAsString) < 3 {
-		return fileAsString
-	}
-
-	if fileAsString[:3] == "---" {
+	if strings.HasPrefix(fileAsString, "---") {
 		fileAsString = "# " + fileAsString
 	}
 	return fileAsString
@@ -877,11 +889,7 @@ func sanitizeYaml(fileAsString string) string {
 //
 // For sanitization details, refer to the sanitizeYaml() function.
 func revertSanitizeYaml(fixedYamlString string) string {
-	if len(fixedYamlString) < 5 {
-		return fixedYamlString
-	}
-
-	if fixedYamlString[:5] == "# ---" {
+	if strings.HasPrefix(fixedYamlString, "# ---") {
 		fixedYamlString = fixedYamlString[2:]
 	}
 	return fixedYamlString

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -221,6 +221,9 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 
 		resourceID := result.ResourceID
 		resourceObj := resourceIdToResource[resourceID]
+		if resourceObj == nil {
+			continue
+		}
 		resourcePath := h.getPathFromRawResource(resourceObj.GetObject())
 
 		// Determine an upfront reason if we already know this resource is not
@@ -874,7 +877,7 @@ func sanitizeYaml(fileAsString string) string {
 //
 // For sanitization details, refer to the sanitizeYaml() function.
 func revertSanitizeYaml(fixedYamlString string) string {
-	if len(fixedYamlString) < 3 {
+	if len(fixedYamlString) < 5 {
 		return fixedYamlString
 	}
 

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -524,6 +524,44 @@ metadata:
 	}
 }
 
+// TestRevertSanitizeYaml guards the `< 5` / `[:5]` pairing: the guard was
+// previously `< 3` while the slice was `[:5]`, so any 3-4 byte input panicked
+// with "slice bounds out of range". Covers every length from 0 up to and past
+// the "# ---" marker, since that boundary is exactly where the bug lived.
+func TestRevertSanitizeYaml(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "length 0", in: "", want: ""},
+		{name: "length 1", in: "-", want: "-"},
+		{name: "length 2", in: "--", want: "--"},
+		{name: "length 3 (previously panicked)", in: "# -", want: "# -"},
+		{name: "length 4 (previously panicked)", in: "# --", want: "# --"},
+		{name: "length 5, marker present", in: "# ---", want: "---"},
+		{name: "length 5, marker absent", in: "# abc", want: "# abc"},
+		{name: "marker with trailing content", in: "# ---\nkind: Pod\n", want: "---\nkind: Pod\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				got := revertSanitizeYaml(tt.in)
+				assert.Equal(t, tt.want, got)
+			})
+		})
+	}
+}
+
+// TestSanitizeYaml_RoundTrip confirms revertSanitizeYaml undoes sanitizeYaml
+// for the case both were built for: a document starting with "---".
+func TestSanitizeYaml_RoundTrip(t *testing.T) {
+	original := "---\napiVersion: v1\nkind: Pod\n"
+	sanitized := sanitizeYaml(original)
+	assert.Equal(t, "# ---\napiVersion: v1\nkind: Pod\n", sanitized)
+	assert.Equal(t, original, revertSanitizeYaml(sanitized))
+}
+
 func TestReduceYamlExpressions(t *testing.T) {
 	type args struct {
 		yamlExpressions []string

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -333,6 +333,43 @@ func TestPrepareResourcesToFix_MissingFile(t *testing.T) {
 	}
 }
 
+// TestPrepareResourcesToFix_UnresolvableResourceID guards against a panic
+// (nil pointer dereference on resourceObj.GetObject()) when a failed Result's
+// ResourceID has no backing resource — e.g. RawResource is nil and there is no
+// matching entry in the report's top-level Resources list, which can happen
+// with hand-edited or partially-trimmed report JSON. The fix must not merely
+// avoid the panic: the failed controls have to still show up in
+// UnfixedControls(), since dropping them silently reintroduces the
+// under-reporting bug from #2108.
+func TestPrepareResourcesToFix_UnresolvableResourceID(t *testing.T) {
+	dir := t.TempDir()
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID: "no-such-resource",
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged",
+					failedRuleWithFix("spec.privileged", "false"),
+				),
+				failedControl("C-0041", "HostNetwork", failedRuleNoFix()),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+
+	assert.NotPanics(t, func() {
+		rtf := h.PrepareResourcesToFix(context.Background())
+		assert.Empty(t, rtf)
+	})
+
+	if assert.Len(t, h.UnfixedControls(), 2) {
+		for _, u := range h.UnfixedControls() {
+			assert.Equal(t, "no-such-resource", u.ResourceName)
+			assert.Contains(t, u.Reason, "resource data missing")
+		}
+	}
+}
+
 func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
 	dir := t.TempDir()
 	manifest := writeManifest(t, dir, "deploy.json", "{}")


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Fixes two panics in `core/pkg/fixhandler/fixhandler.go`:

1. **Nil pointer dereference in `PrepareResourcesToFix`** — `resourceIdToResource[resourceID]` returns a nil `*reporthandling.Resource` when a `Result`'s `ResourceID` has no matching entry (e.g. `RawResource` is nil/omitted and there's no corresponding entry in the top-level `Resources` list, which can happen with hand-edited or partially-trimmed report JSON). Calling `.GetObject()` on the nil result panicked. Now such results are skipped, matching the existing `resourceObj == nil` guard already present in `PrepareHelmSuggestions`.

2. **Off-by-one bounds check in `revertSanitizeYaml`** — the guard checked `len(fixedYamlString) < 3` but then sliced `[:5]`, so any string of length 3 or 4 passed the guard and panicked with "slice bounds out of range". The guard now checks `< 5`, mirroring the correct `len < 3` / `[:3]` pairing already used in the companion `sanitizeYaml` function.

## Additional Information
No behavior change for the normal/happy path — both fixes only affect edge cases that previously crashed the process. In case 1, the result is now silently skipped (consistent with how `PrepareHelmSuggestions` already handles it); in case 2, very short input is now returned unchanged instead of panicking.

## How to Test
- Run `go test ./core/pkg/fixhandler/...` — existing suite passes.
- Case 1: run `kubescape fix` against a scan report where a `Result.ResourceID` doesn't correspond to any resource in the report's `Resources` list (or a resource with a nil `RawResource`) — previously panicked, now the result is skipped instead of crashing.
- Case 2: call `ApplyFixToContent` (or the underlying `revertSanitizeYaml`) with a 3-4 byte string, e.g. `"# -"` — previously panicked with a slice-bounds error, now returns the string unchanged.

## Related issues/PRs:
- #2596 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed resource references that cannot be resolved, preventing processing errors.
  * Corrected sanitization behavior for very short YAML content.
  * Ensured YAML documents beginning with `---` are restored correctly after processing.
  * Failed controls associated with missing resources are now clearly recorded with a missing-resource reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->