### PR TITLE
fix: return error when control inputs are nil or empty

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -261,7 +261,7 @@ func (policyHandler *PolicyHandler) getControlInputs() (map[string][]string, err
 	}
 
 	controlInputs, err := policyHandler.getters.ControlsInputsGetter.GetControlsInputs(policyHandler.clusterName)
-	if err == nil {
+	if err == nil && controlInputs != nil {
 		policyHandler.cachedControlInputs.Set(controlInputs)
 	}
 

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -261,9 +261,13 @@ func (policyHandler *PolicyHandler) getControlInputs() (map[string][]string, err
 	}
 
 	controlInputs, err := policyHandler.getters.ControlsInputsGetter.GetControlsInputs(policyHandler.clusterName)
-	if err == nil && controlInputs != nil {
-		policyHandler.cachedControlInputs.Set(controlInputs)
+	if err != nil {
+		return nil, err
+	}
+	if len(controlInputs) == 0 {
+		return nil, fmt.Errorf("no control configuration inputs available")
 	}
 
-	return controlInputs, err
+	policyHandler.cachedControlInputs.Set(controlInputs)
+	return controlInputs, nil
 }

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -267,3 +267,25 @@ func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, files)
 }
+
+type ControlsInputsGetterNilMock struct{}
+
+func (mock *ControlsInputsGetterNilMock) GetControlsInputs(clusterName string) (map[string][]string, error) {
+	return nil, nil
+}
+
+func TestGetControlInputs_NilReturnsNotCached(t *testing.T) {
+	policyHandler := NewPolicyHandler("test-cluster")
+	policyHandler.cachedControlInputs.Invalidate()
+	policyHandler.getters = &cautils.Getters{
+		ControlsInputsGetter: &ControlsInputsGetterNilMock{},
+	}
+
+	controlInputs, err := policyHandler.getControlInputs()
+
+	assert.NoError(t, err)
+	assert.Nil(t, controlInputs)
+
+	_, cacheHit := policyHandler.cachedControlInputs.Get()
+	assert.False(t, cacheHit, "nil control inputs should not be cached")
+}

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -268,24 +268,42 @@ func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 	assert.Empty(t, files)
 }
 
-type ControlsInputsGetterNilMock struct{}
+type ControlsInputsGetterEmptyMock struct{}
 
-func (mock *ControlsInputsGetterNilMock) GetControlsInputs(clusterName string) (map[string][]string, error) {
+func (mock *ControlsInputsGetterEmptyMock) GetControlsInputs(clusterName string) (map[string][]string, error) {
 	return nil, nil
 }
 
-func TestGetControlInputs_NilReturnsNotCached(t *testing.T) {
-	policyHandler := NewPolicyHandler("test-cluster")
-	policyHandler.cachedControlInputs.Invalidate()
+func TestGetControlInputs_EmptyReturnsErrorNotCached(t *testing.T) {
+	t.Setenv("POLICIES_CACHE_TTL", "10")
+	policyHandler := NewRequestScopedPolicyHandler("test-cluster")
+	defer policyHandler.Close()
 	policyHandler.getters = &cautils.Getters{
-		ControlsInputsGetter: &ControlsInputsGetterNilMock{},
+		ControlsInputsGetter: &ControlsInputsGetterEmptyMock{},
+	}
+
+	controlInputs, err := policyHandler.getControlInputs()
+
+	assert.Error(t, err)
+	assert.Nil(t, controlInputs)
+
+	_, cacheHit := policyHandler.cachedControlInputs.Get()
+	assert.False(t, cacheHit, "empty control inputs should not be cached")
+}
+
+func TestGetControlInputs_NonNilResultIsCached(t *testing.T) {
+	t.Setenv("POLICIES_CACHE_TTL", "10")
+	policyHandler := NewRequestScopedPolicyHandler("test-cluster")
+	defer policyHandler.Close()
+	policyHandler.getters = &cautils.Getters{
+		ControlsInputsGetter: &ControlsInputsGetterMock{},
 	}
 
 	controlInputs, err := policyHandler.getControlInputs()
 
 	assert.NoError(t, err)
-	assert.Nil(t, controlInputs)
+	assert.Equal(t, CachedControlInputs, controlInputs)
 
 	_, cacheHit := policyHandler.cachedControlInputs.Get()
-	assert.False(t, cacheHit, "nil control inputs should not be cached")
+	assert.True(t, cacheHit, "non-nil control inputs should be cached")
 }


### PR DESCRIPTION
## What

Fixes the remaining gap in #2513 — when `getControlInputs` receives nil or empty control inputs, it now returns an error instead of silently passing `(nil, nil)` through the success branch.

The fallback-to-cache and nil-guard-on-download work already landed in #2515. This PR closes the final hole: `getControlInputs` itself must surface empty results as errors so the `PolicyDegradation` path fires and `DefaultControlInputs()` kicks in.

## Root cause

Three implementations can return nil/empty without an error:

1. **KSCloudAPI.GetControlsInputs** — returns `(nil, nil)` when the account config carries no posture control inputs
2. **LoadPolicy.GetControlsInputs** — returns `(nil, nil)` on a corrupt or truncated `controls-inputs.json`
3. **CRDControlInputs.GetControlsInputs** — returns `(map[string][]string{}, nil)` when the CR has no spec or spec.controls

`getControlInputs` treated all three as success, so `getPolicies` logged "Loaded account configurations" and never recorded a `PolicyDegradation`. Result: config-driven controls evaluated against empty lists, `coverageScore` stayed 100.

## Changes

- **handlepullpolicies.go**: `getControlInputs` returns error on `len == 0` instead of caching and returning nil. Error propagates to `getPolicies` which records a `PolicyDegradation` and falls back to `DefaultControlInputs()`
- **handlepullpolicies_test.go**: replaced vacuous singleton test with two scoped-handler tests
  - `TestGetControlInputs_EmptyReturnsErrorNotCached` — asserts error and no cache write, uses `POLICIES_CACHE_TTL=10` so cache is observable
  - `TestGetControlInputs_NonNilResultIsCached` — asserts non-empty results ARE cached (positive control)

## Verification

- `TestGetControlInputs_EmptyReturnsErrorNotCached` fails without the production change (verified)
- All 59 policyhandler tests pass with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty control-input results from being stored in the cache.
  * Ensured subsequent requests can retry retrieving control inputs when no data is returned.
  * Improved handling of errors encountered while retrieving control inputs.

* **Tests**
  * Added coverage for caching valid results and excluding empty results from the cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->