### PR TITLE
fix(opaprocessor): resolve namespaceObject for CEL admission evaluation

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	opaprint "github.com/open-policy-agent/opa/v1/topdown/print"
 	"go.opentelemetry.io/otel"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -1123,11 +1122,11 @@ func (opap *OPAProcessor) getCELEvaluator() (*cel.Evaluator, error) {
 // the same one stub.go's isNamespaced applies to the same object a moment
 // later: a non-empty metadata.namespace.
 func (opap *OPAProcessor) celNamespaceObjectFor(obj map[string]any) map[string]any {
-	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
-	if namespace == "" {
+	meta := objectsenvelopes.NewObject(obj)
+	if meta == nil || meta.GetNamespace() == "" {
 		return nil
 	}
-	return opap.celNamespaceIndex[namespace]
+	return opap.celNamespaceIndex[meta.GetNamespace()]
 }
 
 // celRuleResponse builds the RuleResponse for one object that violated a CEL

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -67,6 +67,11 @@ type OPAProcessor struct {
 	celEvaluator     *cel.Evaluator
 	celEvaluatorOnce sync.Once
 	celEvaluatorErr  error
+	// namespaceObjects caches Namespace resources from AllResources keyed by
+	// name, built once per scan so CEL evaluation can resolve the real
+	// namespaceObject for namespaced resources instead of always binding nil.
+	namespaceObjects     map[string]map[string]any
+	namespaceObjectsOnce sync.Once
 }
 
 func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *resources.RegoDependenciesData, clusterName string, excludeNamespaces string, includeNamespaces string, enableRegoPrint bool, exceptionEventRecorder record.EventRecorder) *OPAProcessor {
@@ -537,6 +542,28 @@ type skippedCELResource struct {
 	err error
 }
 
+// getNamespaceObject returns the collected Namespace resource matching name,
+// or nil for cluster-scoped resources (name == "") or namespaces that were
+// not collected in this scan. The lookup table is built once per OPAProcessor
+// from AllResources, since scanning it per object would be wasteful.
+func (opap *OPAProcessor) getNamespaceObject(name string) map[string]any {
+	if name == "" {
+		return nil
+	}
+	opap.namespaceObjectsOnce.Do(func() {
+		namespaces := make(map[string]map[string]any)
+		if opap.OPASessionObj != nil {
+			for _, resource := range opap.AllResources {
+				if resource.GetKind() == "Namespace" {
+					namespaces[resource.GetName()] = resource.GetObject()
+				}
+			}
+		}
+		opap.namespaceObjects = namespaces
+	})
+	return opap.namespaceObjects[name]
+}
+
 // runCELOnK8s evaluates a CEL-based PolicyRule against k8s objects by loading
 // the control's ValidatingAdmissionPolicy from the embedded bundle and running
 // its validations. controlID is threaded down from processControl (not read off
@@ -571,10 +598,12 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 			return nil, celOutcome{}, err
 		}
 
-		// namespaceObject is not resolved yet: policies referencing it eval-error
-		// and their resources are skipped (parity-safe), never passed. Wiring the
-		// real namespace object is a follow-up.
-		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, nil)
+		// Resolve the real namespace object for namespaced resources so policies
+		// referencing namespaceObject.* can evaluate instead of always erroring.
+		// Cluster-scoped resources and resources whose namespace was not
+		// collected still bind nil, matching prior behavior.
+		namespaceObject := opap.getNamespaceObject(workloadinterface.NewBaseObject(obj).GetNamespace())
+		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, namespaceObject)
 		if err != nil {
 			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 		}

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -1065,6 +1065,19 @@ func TestCELNamespaceObjectFor(t *testing.T) {
 		assert.Nil(t, opap.celNamespaceObjectFor(podIn("")))
 	})
 
+	t.Run("enveloped resource resolves through object metadata accessors", func(t *testing.T) {
+		enveloped := objectsenvelopes.NewRegoResponseVectorObject(map[string]any{
+			"apiVersion":     "v1",
+			"kind":           "Pod",
+			"name":           "p",
+			"namespace":      "prod",
+			"relatedObjects": []map[string]any{},
+		})
+		got := opap.celNamespaceObjectFor(enveloped.GetObject())
+		require.NotNil(t, got)
+		assert.Equal(t, "prod", got["metadata"].(map[string]any)["name"])
+	})
+
 	t.Run("no session resolves to nil without panicking", func(t *testing.T) {
 		// Both the zero value and a constructor call with no session: the second
 		// is the one a caller can actually reach.

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -847,3 +847,42 @@ func TestRunCELOnK8s(t *testing.T) {
 		assert.Empty(t, outcome.excluded)
 	})
 }
+
+func TestGetNamespaceObject(t *testing.T) {
+	t.Run("cluster-scoped resource resolves to nil without touching AllResources", func(t *testing.T) {
+		opap := &OPAProcessor{}
+		assert.Nil(t, opap.getNamespaceObject(""))
+	})
+
+	t.Run("namespace collected in AllResources is resolved by name", func(t *testing.T) {
+		nsObj := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata":   map[string]any{"name": "prod", "labels": map[string]any{"environment": "prod"}},
+		}
+		ns := objectsenvelopes.NewObject(nsObj)
+		opap := &OPAProcessor{
+			OPASessionObj: &cautils.OPASessionObj{
+				AllResources: map[string]workloadinterface.IMetadata{ns.GetID(): ns},
+			},
+		}
+
+		got := opap.getNamespaceObject("prod")
+		require.NotNil(t, got)
+		assert.Equal(t, "prod", got["metadata"].(map[string]any)["name"])
+	})
+
+	t.Run("namespace not collected resolves to nil", func(t *testing.T) {
+		opap := &OPAProcessor{
+			OPASessionObj: &cautils.OPASessionObj{
+				AllResources: map[string]workloadinterface.IMetadata{},
+			},
+		}
+		assert.Nil(t, opap.getNamespaceObject("missing"))
+	})
+
+	t.Run("nil OPASessionObj does not panic and resolves to nil", func(t *testing.T) {
+		opap := &OPAProcessor{}
+		assert.Nil(t, opap.getNamespaceObject("default"))
+	})
+}

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -69,11 +69,28 @@ func getQueryableResourceMapFromPoliciesWithWarned(frameworks []reporthandling.F
 				for i := range rule.Match {
 					updateQueryableResourcesMapFromRuleMatchObject(&rule.Match[i], resourcesFilterMap, queryableResources, namespace, resolver)
 				}
+				addCELNamespaceQuery(rule, resource, namespace, queryableResources, resolver)
 			}
 		}
 	}
 
 	return queryableResources, excludedRulesMap
+}
+
+func addCELNamespaceQuery(rule reporthandling.PolicyRule, resource workloadinterface.IWorkload, namespace string, queryableResources QueryableResources, resolver resourceResolver) {
+	if rule.RuleLanguage != reporthandling.CELLanguage {
+		return
+	}
+	if resource != nil && namespace == "" {
+		return
+	}
+
+	namespaceMatch := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{""},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"Namespace"},
+	}
+	updateQueryableResourcesMapFromRuleMatchObject(&namespaceMatch, nil, queryableResources, namespace, resolver)
 }
 
 // getScannedResourceNamespace returns the namespace of the scanned resource.

--- a/core/pkg/resourcehandler/resourcehandlerutils_test.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils_test.go
@@ -86,6 +86,12 @@ func mockRule(ruleName string, matches []reporthandling.RuleMatchObjects, ruleRe
 	return rule
 }
 
+func mockCELRule(ruleName string, matches []reporthandling.RuleMatchObjects) reporthandling.PolicyRule {
+	rule := mockRule(ruleName, matches, "")
+	rule.RuleLanguage = reporthandling.CELLanguage
+	return rule
+}
+
 func mockControl(controlName string, rules []reporthandling.PolicyRule) reporthandling.Control {
 	return reporthandling.Control{
 		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", controlName, nil),
@@ -263,6 +269,34 @@ func TestGetQueryableResourceMapFromPolicies(t *testing.T) {
 				"/v1/namespaces",
 				"apps/v1/deployments",
 				"apps/v1/replicasets",
+			},
+		},
+		{
+			name:     "CEL rule adds namespace lookup for namespaced workload scans",
+			workload: mockWorkload("apps/v1", "Deployment", "ns1", "deploy1"),
+			controls: []reporthandling.Control{
+				mockControl("1", []reporthandling.PolicyRule{
+					mockCELRule("cel-rule", []reporthandling.RuleMatchObjects{mockMatch(2)}),
+				}),
+			},
+			expectedExcludedRules: []string{},
+			expectedResourceGroups: []string{
+				"/v1/namespaces/metadata.name=ns1",
+			},
+		},
+		{
+			name:     "CEL rule adds namespace lookup for cluster scans",
+			workload: nil,
+			controls: []reporthandling.Control{
+				mockControl("1", []reporthandling.PolicyRule{
+					mockCELRule("cel-rule", []reporthandling.RuleMatchObjects{mockMatch(2)}),
+				}),
+			},
+			expectedExcludedRules: []string{},
+			expectedResourceGroups: []string{
+				"apps/v1/deployments",
+				"apps/v1/replicasets",
+				"/v1/namespaces",
 			},
 		},
 	}


### PR DESCRIPTION
## Overview
Resolve the real namespace object for CEL offline admission evaluation instead of always binding nil. `runCELOnK8s` previously called `evaluator.EvaluateControl(ctx, controlID, obj, nil)` unconditionally, so CEL policies referencing `namespaceObject.*` always eval-errored for namespaced resources. This adds a `getNamespaceObject` lookup that resolves the collected `Namespace` resource from `AllResources` by name, built once per scan, and passes it through for namespaced resources. Cluster-scoped resources and resources whose namespace was not collected keep the current nil behavior.

Resolved #2602

## How to Test
`go test ./core/pkg/opaprocessor/...`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy evaluation for namespaced resources by providing matching Namespace information.
  * Added automatic Namespace lookups for policy checks involving namespaced and cluster-wide scans.
  * Preserved correct behavior for cluster-scoped resources and resources with unavailable or undetermined namespaces.
  * Improved handling when scan session information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->