### PR TITLE
Recover from panics in readJsonFile

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -440,8 +440,18 @@ func isYAMLDocumentSeparator(line []byte) bool {
 	return len(rest) == 0 || rest[0] == '#'
 }
 
-func readJsonFile(jsonFile []byte) ([]workloadinterface.IMetadata, error) {
-	workloads := []workloadinterface.IMetadata{}
+func readJsonFile(jsonFile []byte) (workloads []workloadinterface.IMetadata, err error) {
+	workloads = []workloadinterface.IMetadata{}
+	// The object envelopes do unchecked type assertions on the decoded
+	// document, so a well formed but wrongly typed manifest panics. Recover
+	// the same way readYamlFile does, so one bad file fails that file rather
+	// than the whole scan.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic during JSON parsing: %v", r)
+		}
+	}()
+
 	var jsonObj any
 	if err := json.Unmarshal(jsonFile, &jsonObj); err != nil {
 		return workloads, err

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -567,6 +567,16 @@ func TestReadJsonFile(t *testing.T) {
 			content:   `{}`,
 			wantCount: 0,
 		},
+		{
+			name: "wrongly typed kind is an error, not a panic",
+			content: `{
+				"apiVersion": "v1",
+				"kind": 123,
+				"metadata": {"name": "test-pod", "namespace": "default"}
+			}`,
+			wantCount: 0,
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

`readYamlFile` in `core/cautils/fileutils.go` wraps its parse in a `defer`/`recover` and turns a panic into `panic during YAML parsing: ...`. `readJsonFile` right below it does not, even though both hand the decoded document to the same `objectsenvelopes.NewObject`, which does unchecked type assertions on fields it expects to be strings.

So a JSON manifest whose `kind` is a number takes the whole scan down:

```
panic: interface conversion: interface {} is float64, not string
```

```json
{"apiVersion": "v1", "kind": 123, "metadata": {"name": "test-pod", "namespace": "default"}}
```

The same document written as YAML is handled cleanly, because of the recover. Since `kubescape scan` walks a directory and reads whatever it finds, one bad or hand-edited file in a repo aborts the run rather than being reported and skipped.

This gives `readJsonFile` the same treatment: named returns plus a deferred recover, so the failure stays scoped to the file being read.

## How to Test

`go test ./core/cautils/ -run TestReadJsonFile`. The new case, `wrongly typed kind is an error, not a panic`, panics on master and passes with this change. The rest of the package is green.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed JSON files so invalid object fields return a parsing error instead of causing a crash.
  - Ensured failed JSON parsing returns no workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->