### PR TITLE
fix: change break to continue in helm workloads loader

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -301,7 +301,7 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 			url, err := gitRepo.GetRemoteUrl()
 			if err != nil {
 				logger.L().Warning("failed to get remote url", helpers.Error(err))
-				break
+				continue
 			}
 			helmChart.Path = strings.TrimSuffix(url, ".git")
 			repoRoot = ""

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -194,6 +194,21 @@ func getWorkloadSourceHelmChart(repoRoot string, source string, gitRepo *cautils
 	}
 }
 
+// resolveHelmRemotePath returns the repository-level remote path used to rewrite helm
+// chart provenance, or "" when this is not a cloned-repo scan or the remote URL is
+// unavailable — in which case callers fall back to local paths.
+func resolveHelmRemotePath(clonedRepo string, gitRepo *cautils.LocalGitRepository) string {
+	if clonedRepo == "" || gitRepo == nil {
+		return ""
+	}
+	url, err := gitRepo.GetRemoteUrl()
+	if err != nil {
+		logger.L().Warning("failed to get remote url, helm sources will use local paths", helpers.Error(err))
+		return ""
+	}
+	return strings.TrimSuffix(url, ".git")
+}
+
 func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
 	workloadIDToSource := make(map[string]reporthandling.Source)
 	var workloads []workloadinterface.IMetadata
@@ -292,23 +307,21 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		logger.L().Debug("files found in local storage", helpers.Int("files", len(sourceToWorkloads)), helpers.Int("workloads", len(workloads)))
 	}
 
+	helmRemotePath := resolveHelmRemotePath(clonedRepo, gitRepo)
+
 	// process the helm charts rendered above
 	for source, ws := range helmSourceToWorkloads {
 		workloads = append(workloads, ws...)
 		helmChart := helmSourceToChart[source]
 
-		if clonedRepo != "" && gitRepo != nil {
-			url, err := gitRepo.GetRemoteUrl()
-			if err != nil {
-				logger.L().Warning("failed to get remote url", helpers.Error(err))
-				continue
-			}
-			helmChart.Path = strings.TrimSuffix(url, ".git")
-			repoRoot = ""
+		chartRoot := repoRoot
+		if helmRemotePath != "" {
+			helmChart.Path = helmRemotePath
+			chartRoot = ""
 			source = strings.TrimPrefix(source, fmt.Sprintf("%s/", clonedRepo))
 		}
 
-		workloadSource := getWorkloadSourceHelmChart(repoRoot, source, gitRepo, helmChart)
+		workloadSource := getWorkloadSourceHelmChart(chartRoot, source, gitRepo, helmChart)
 
 		for i := range ws {
 			workloadIDToSource[ws[i].GetID()] = workloadSource

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -57,6 +57,76 @@ func TestGetResourcesFromPath_ScansTemplatesOfChartThatFailedToRender(t *testing
 	assert.True(t, found, "a static template of a chart that failed to render must still be scanned")
 }
 
+func createMockGitRepo(t *testing.T, hasOrigin bool) string {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	require.NoError(t, os.MkdirAll(filepath.Join(gitDir, "refs", "heads"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/master\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "refs", "heads", "master"), []byte("0000000000000000000000000000000000000000\n"), 0o600))
+
+	configContent := `[core]
+	repositoryformatversion = 0
+[remote "upstream"]
+	url = https://example.com/upstream.git
+`
+	if hasOrigin {
+		configContent += `[remote "origin"]
+	url = https://example.com/origin.git
+`
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte(configContent), 0o600))
+	return dir
+}
+
+func TestResolveHelmRemotePath(t *testing.T) {
+	healthyRepo := createMockGitRepo(t, true)
+	gitHealthy, err := cautils.NewLocalGitRepository(healthyRepo)
+	require.NoError(t, err)
+
+	brokenRepo := createMockGitRepo(t, false)
+	gitBroken, err := cautils.NewLocalGitRepository(brokenRepo)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		clonedRepo string
+		gitRepo    *cautils.LocalGitRepository
+		want       string
+	}{
+		{
+			name:       "empty clonedRepo",
+			clonedRepo: "",
+			gitRepo:    gitHealthy,
+			want:       "",
+		},
+		{
+			name:       "nil gitRepo",
+			clonedRepo: "some-repo",
+			gitRepo:    nil,
+			want:       "",
+		},
+		{
+			name:       "repo whose remote lookup fails",
+			clonedRepo: "some-repo",
+			gitRepo:    gitBroken,
+			want:       "",
+		},
+		{
+			name:       "healthy repo",
+			clonedRepo: "some-repo",
+			gitRepo:    gitHealthy,
+			want:       "https://example.com/origin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHelmRemotePath(tt.clonedRepo, tt.gitRepo)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // A chart that renders cleanly has its templates covered by the render, so the plain-YAML loader must
 // not scan them again (no duplicate, no malformed-template warnings), while crds/ and files outside
 // templates/ stay plainly scanned.


### PR DESCRIPTION
## Overview
Replaces `break` with `continue` in `core/pkg/resourcehandler/filesloader.go` when processing helm charts. When git remote URL lookup fails for one chart source, `break` exits the entire loop, silently dropping all unvisited helm workloads from the scan. `continue` ensures only the current source's provenance lookup is skipped.

## Related issues/PRs:
Resolves #2598

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm source metadata processing by resolving repository information once before chart processing.
  * Charts now retain valid local repository paths when remote repository lookup fails.
  * Prevented repository lookup errors from interrupting processing of remaining Helm charts.
  * Improved chart provenance by using the resolved remote repository URL when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->