### PR TITLE
ci: run unit tests on every PR, not just tag pushes

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -46,11 +46,9 @@ jobs:
 
       - name: Test core pkg
         run: ${{ env.DOCKER_CMD }} go test -v ./...
-        if: startsWith(github.ref, 'refs/tags')
 
       - name: Test httphandler pkg
         run: ${{ env.DOCKER_CMD }} sh -c 'cd httphandler && go test -v ./...'
-        if: startsWith(github.ref, 'refs/tags')
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         name: Setup Syft


### PR DESCRIPTION
## Overview

The `go test` steps in `a-pr-scanner.yaml` were gated behind `startsWith(github.ref, 'refs/tags')`, so unit tests only ran on release tags and never on pull requests. PRs currently only get build + smoke test + lint, with no unit test signal before merge.

This job (added in #1624) replaced an earlier `scanners` job that ran `go test` unconditionally on PRs — that coverage was silently dropped when the job was reworked. This PR removes the tag gate so both `go test` steps (core pkg and httphandler pkg) run on PRs as well as tags.

## Related issues/PRs:

* Related to #1624 (where the tag gate was introduced)

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * The `httphandler` package test step now runs consistently in the automated validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->