### PR TITLE
Guard against unresolvable group/version in resource handler

### DIFF
--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -20,13 +20,9 @@ func addSingleResourceToResourceMaps(k8sResources cautils.K8SResources, allResou
 
 	allResources[wl.GetID()] = wl
 
-	// ResourceGroupToSlice returns an empty slice (not an error) when the
-	// workload's group/version don't match any group/version this library
-	// knows for its kind. Every current caller only passes a workload that
-	// already cleared k8sinterface.IsTypeWorkload, which makes this
-	// unreachable today, but that's an invariant this function has no way to
-	// enforce on its own - indexing [0] unconditionally made it a latent
-	// panic waiting for a caller that doesn't uphold it.
+	// ResourceGroupToSlice can return an empty slice for a group/version/kind
+	// it can't resolve; every current caller gates on IsTypeWorkload first, so
+	// this is unreachable today, but the guard doesn't depend on that holding.
 	groups := k8sinterface.ResourceGroupToSlice(wl.GetGroup(), wl.GetVersion(), wl.GetKind())
 	if len(groups) == 0 {
 		logger.L().Warning("failed to resolve resource group for workload, skipping",
@@ -35,6 +31,10 @@ func addSingleResourceToResourceMaps(k8sResources cautils.K8SResources, allResou
 		return
 	}
 
+	// [0] is a deliberate pick when multiple groups resolve (only possible
+	// with an empty group and >1 group serving the resource at that version);
+	// current callers can't reach that case either, since IsTypeWorkload also
+	// requires exactly one match.
 	resourceGroup := groups[0]
 	k8sResources[resourceGroup] = append(k8sResources[resourceGroup], wl.GetID())
 }

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -1,6 +1,8 @@
 package resourcehandler
 
 import (
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -18,7 +20,22 @@ func addSingleResourceToResourceMaps(k8sResources cautils.K8SResources, allResou
 
 	allResources[wl.GetID()] = wl
 
-	resourceGroup := k8sinterface.ResourceGroupToSlice(wl.GetGroup(), wl.GetVersion(), wl.GetKind())[0]
+	// ResourceGroupToSlice returns an empty slice (not an error) when the
+	// workload's group/version don't match any group/version this library
+	// knows for its kind. Every current caller only passes a workload that
+	// already cleared k8sinterface.IsTypeWorkload, which makes this
+	// unreachable today, but that's an invariant this function has no way to
+	// enforce on its own - indexing [0] unconditionally made it a latent
+	// panic waiting for a caller that doesn't uphold it.
+	groups := k8sinterface.ResourceGroupToSlice(wl.GetGroup(), wl.GetVersion(), wl.GetKind())
+	if len(groups) == 0 {
+		logger.L().Warning("failed to resolve resource group for workload, skipping",
+			helpers.String("id", wl.GetID()), helpers.String("kind", wl.GetKind()),
+			helpers.String("apiVersion", wl.GetApiVersion()))
+		return
+	}
+
+	resourceGroup := groups[0]
 	k8sResources[resourceGroup] = append(k8sResources[resourceGroup], wl.GetID())
 }
 

--- a/core/pkg/resourcehandler/resourcehandlerutils_test.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils_test.go
@@ -118,20 +118,10 @@ func mockWorkload(apiVersion, kind, namespace, name string) workloadinterface.IW
 }
 
 // TestAddSingleResourceToResourceMaps_UnresolvableApiVersion is a defense-in-
-// depth guard: k8sinterface.ResourceGroupToSlice can return an empty slice
-// (not an error) for a group/version/kind combination it can't resolve, and
-// this function used to index [0] into that result unconditionally, which
-// panics on an empty slice.
-//
-// In practice every current caller of this function only ever supplies a
-// workload that has already passed k8sinterface.IsTypeWorkload (see
-// filesloaderutils.findScanObjectResource, k8sresourcesutils.getWorkloadFromScanObject,
-// and (*K8sResourceHandler).findScanObjectResource) - and IsTypeWorkload
-// resolves the exact same group/version/kind lookup, so a workload that
-// clears that gate is already guaranteed a non-empty result here. This test
-// bypasses that gate deliberately (unlike mockWorkload, which enforces it) to
-// pin the function's own behavior against future callers that might not gate
-// on IsTypeWorkload first.
+// depth guard (see the comment above the `groups :=` guard in
+// resourcehandlerutils.go for why this is unreachable via current callers).
+// It bypasses the IsTypeWorkload gate deliberately (unlike mockWorkload,
+// which enforces it) to pin the function's own behavior on its own.
 func TestAddSingleResourceToResourceMaps_UnresolvableApiVersion(t *testing.T) {
 	k8sinterface.InitializeMapResourcesMock()
 

--- a/core/pkg/resourcehandler/resourcehandlerutils_test.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 )
@@ -114,6 +115,72 @@ func mockWorkload(apiVersion, kind, namespace, name string) workloadinterface.IW
 	}
 
 	return mock
+}
+
+// TestAddSingleResourceToResourceMaps_UnresolvableApiVersion is a defense-in-
+// depth guard: k8sinterface.ResourceGroupToSlice can return an empty slice
+// (not an error) for a group/version/kind combination it can't resolve, and
+// this function used to index [0] into that result unconditionally, which
+// panics on an empty slice.
+//
+// In practice every current caller of this function only ever supplies a
+// workload that has already passed k8sinterface.IsTypeWorkload (see
+// filesloaderutils.findScanObjectResource, k8sresourcesutils.getWorkloadFromScanObject,
+// and (*K8sResourceHandler).findScanObjectResource) - and IsTypeWorkload
+// resolves the exact same group/version/kind lookup, so a workload that
+// clears that gate is already guaranteed a non-empty result here. This test
+// bypasses that gate deliberately (unlike mockWorkload, which enforces it) to
+// pin the function's own behavior against future callers that might not gate
+// on IsTypeWorkload first.
+func TestAddSingleResourceToResourceMaps_UnresolvableApiVersion(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	obj := map[string]any{
+		"apiVersion": "v2", // no known group serves "deployments" at version "v2"
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "nginx",
+			"namespace": "default",
+		},
+	}
+	wl := workloadinterface.NewWorkloadObj(obj)
+	k8sResources := cautils.K8SResources{}
+	allResources := map[string]workloadinterface.IMetadata{}
+
+	assert.NotPanics(t, func() {
+		addSingleResourceToResourceMaps(k8sResources, allResources, wl)
+	})
+
+	// The resource is still recorded for lookup purposes (e.g. by ID)...
+	assert.Contains(t, allResources, wl.GetID())
+	// ...but is not added under any resource group, since none could be resolved.
+	for group, ids := range k8sResources {
+		assert.NotContains(t, ids, wl.GetID(), "workload with unresolvable apiVersion must not be added under group %q", group)
+	}
+}
+
+func TestAddSingleResourceToResourceMaps_KnownApiVersion(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	wl := mockWorkload("apps/v1", "Deployment", "default", "nginx")
+	k8sResources := cautils.K8SResources{}
+	allResources := map[string]workloadinterface.IMetadata{}
+
+	addSingleResourceToResourceMaps(k8sResources, allResources, wl)
+
+	assert.Contains(t, allResources, wl.GetID())
+	assert.Contains(t, k8sResources["apps/v1/deployments"], wl.GetID())
+}
+
+func TestAddSingleResourceToResourceMaps_NilWorkload(t *testing.T) {
+	k8sResources := cautils.K8SResources{}
+	allResources := map[string]workloadinterface.IMetadata{}
+
+	assert.NotPanics(t, func() {
+		addSingleResourceToResourceMaps(k8sResources, allResources, nil)
+	})
+	assert.Empty(t, allResources)
+	assert.Empty(t, k8sResources)
 }
 
 func TestGetQueryableResourceMapFromPolicies(t *testing.T) {


### PR DESCRIPTION
## Overview

`k8sinterface.ResourceGroupToSlice(group, version, kind)` returns an empty slice, not an error, whenever the given group/version don't match any group/version it knows for that kind. `addSingleResourceToResourceMaps` indexed `[0]` into that result unconditionally, which panics on an empty slice.

This is not currently reachable: every caller (`filesloaderutils.findScanObjectResource`, `k8sresourcesutils.getWorkloadFromScanObject`, and `(*K8sResourceHandler).findScanObjectResource`) only ever hands this function a workload that already passed `k8sinterface.IsTypeWorkload`, which resolves the identical group/version/kind lookup, so a workload that clears that gate is already guaranteed a non-empty result here — confirmed by tracing all three call sites and by driving the file-based path end to end with a deliberately unresolvable `apiVersion`, which returns a clean "resource not found" error well before reaching this function.

Guard it anyway: the correctness of the `[0]` index depends entirely on an invariant upheld by every *current* caller, which this function has no way to enforce or even see. Add the guard so a future caller that doesn't uphold it degrades to skipping the resource (with a warning) instead of crashing the process, and add a test that exercises this function directly with an object that bypasses the `IsTypeWorkload` gate, pinning that behavior against regressions in either direction.

## How to Test

```
go test ./core/pkg/resourcehandler/... -run 'TestAddSingleResourceToResourceMaps' -v
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented a potential crash when resource metadata cannot be resolved.
  - Added safer handling for empty or missing resource information.
- **Tests**
  - Added coverage for unresolved API versions, valid workloads, and nil inputs to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
