### PR TITLE
fix(cel): use messageExpression for CEL message bodies, verify bundleControlIDs both ways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 # it stays reproducible instead of hand-maintained. Bump CEL_LIBRARY_VERSION to
 # vendor a newer bundle.
 CEL_VAPDATA_DIR := core/pkg/opaprocessor/cel/vapdata
-CEL_LIBRARY_VERSION := v0.12
+CEL_LIBRARY_VERSION := v0.13
 CEL_LIBRARY_BASE_URL := https://github.com/kubescape/cel-admission-library/releases/download/$(CEL_LIBRARY_VERSION)
 CEL_VAP_FILES := \
 	kubescape-validating-admission-policies.yaml \

--- a/core/pkg/opaprocessor/cel/messageexpression_test.go
+++ b/core/pkg/opaprocessor/cel/messageexpression_test.go
@@ -1,0 +1,61 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A ValidatingAdmissionPolicy's `message` is emitted verbatim; only
+// `messageExpression` is evaluated by CEL. C-0013, C-0198 and C-0210 used to
+// put a CEL string concatenation in `message`, so a violation on any of them
+// showed the literal, unevaluated expression instead of a message naming the
+// resource (see the messageExpression fix in this file's sibling changes).
+//
+// TestNoEvalErrorOnMinimalWorkloads in optionalfields_test.go exists
+// specifically because a `make sync-vap` from a release that predates a
+// hand-applied fix silently reverts it while the rest of the suite stays
+// green. The two tests below are the same guard for this fix: nothing else
+// evaluates `message`, so a regression here would otherwise only surface as a
+// user staring at raw CEL source in a scan report.
+
+// TestNoStaticMessageIsACELExpression sweeps every validation's `message` for
+// a stray CEL expression. "object." is not something a hand-written message
+// would ever contain, so its presence means a CEL expression landed in the
+// wrong field.
+func TestNoStaticMessageIsACELExpression(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	for name, vap := range catalog.byName {
+		for i, v := range vap.Validations {
+			assert.NotContainsf(t, v.Message, "object.",
+				"%s validation[%d] puts a CEL expression in `message`, which is emitted verbatim; use messageExpression instead", name, i)
+		}
+	}
+}
+
+// TestEveryMessageExpressionCompiles is the other half: a messageExpression
+// that fails to compile does not fail a scan either. resolveMessage falls
+// back to Message, then a default, so a broken expression - a typo, or one
+// referencing a variable that no longer exists - would only ever be caught
+// here, not by any real evaluation.
+func TestEveryMessageExpressionCompiles(t *testing.T) {
+	env, err := newEnv()
+	require.NoError(t, err)
+
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	for name, vap := range catalog.byName {
+		for i, v := range vap.Validations {
+			if v.MessageExpression == "" {
+				continue
+			}
+			_, issues := env.Compile(inlineVariables(v.MessageExpression, vap.Variables))
+			assert.NoErrorf(t, issues.Err(),
+				"%s validation[%d] messageExpression does not compile", name, i)
+		}
+	}
+}

--- a/core/pkg/opaprocessor/cel/optionalfields_test.go
+++ b/core/pkg/opaprocessor/cel/optionalfields_test.go
@@ -232,6 +232,9 @@ func TestBundleControlIDsAreCurrent(t *testing.T) {
 	listed := make(map[string]bool, len(bundleControlIDs))
 	for _, id := range bundleControlIDs {
 		listed[id] = true
+		_, exists := catalog.byControl[id]
+		assert.Truef(t, exists,
+			"control %s is listed in bundleControlIDs but absent from the bundle; remove or rename it", id)
 	}
 	for id := range catalog.byControl {
 		assert.Truef(t, listed[id],

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -21,27 +21,6 @@ Files:
 - `policy-configuration-definition.yaml` — the parameter CRD definition that
   backs those params.
 
-## Local deviations from the pinned release
-
-The bundle is normally byte-identical to the release named by
-`CEL_LIBRARY_VERSION`. It currently is not: three policies in `v0.12` set
-`message` to a CEL string concatenation instead of `messageExpression`. Only
-`messageExpression` is evaluated - `message` is emitted verbatim - so a
-violation on any of them showed the literal, unevaluated expression instead
-of a message naming the resource.
-
-Patched here, ahead of a release that carries the fix:
-
-- **C-0013**, **C-0198**, **C-0210** — `message` holds what should be a
-  `messageExpression`. Fix sent upstream, not yet merged:
-  kubescape/cel-admission-library#100.
-
-`make sync-vap` overwrites these edits. When a release carrying the fix is
-available, bump `CEL_LIBRARY_VERSION`, re-sync, and delete this section
-rather than re-applying the patch by hand.
-`TestNoStaticMessageIsACELExpression` in `../messageexpression_test.go` fails
-if a re-sync drops it.
-
 A submodule was considered instead of a vendored copy, but `//go:embed` only
 picks up files committed in this repo, and a submodule's contents are dropped
 when kubescape is pulled in as a Go module (the embed then fails with

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -21,6 +21,27 @@ Files:
 - `policy-configuration-definition.yaml` — the parameter CRD definition that
   backs those params.
 
+## Local deviations from the pinned release
+
+The bundle is normally byte-identical to the release named by
+`CEL_LIBRARY_VERSION`. It currently is not: three policies in `v0.12` set
+`message` to a CEL string concatenation instead of `messageExpression`. Only
+`messageExpression` is evaluated - `message` is emitted verbatim - so a
+violation on any of them showed the literal, unevaluated expression instead
+of a message naming the resource.
+
+Patched here, ahead of a release that carries the fix:
+
+- **C-0013**, **C-0198**, **C-0210** — `message` holds what should be a
+  `messageExpression`. Fix sent upstream, not yet merged:
+  kubescape/cel-admission-library#100.
+
+`make sync-vap` overwrites these edits. When a release carrying the fix is
+available, bump `CEL_LIBRARY_VERSION`, re-sync, and delete this section
+rather than re-applying the patch by hand.
+`TestNoStaticMessageIsACELExpression` in `../messageexpression_test.go` fails
+if a re-sync drops it.
+
 A submodule was considered instead of a vendored copy, but `//go:embed` only
 picks up files committed in this repo, and a submodule's contents are dropped
 when kubescape is pulled in as a Go module (the embed then fails with

--- a/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
@@ -607,7 +607,7 @@ spec:
           )
         )
       )
-    message: object.kind + "/" + object.metadata.name + " contains container/s which
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s which
       have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
   variables:
   - expression: |
@@ -2323,7 +2323,7 @@ spec:
               : -1)
         ) != 0
       )
-    message: |
+    messageExpression: |
       object.kind + '/' + object.metadata.name + ' has a container explicitly running as root (UID 0). (see more at https://kubescape.io/docs/controls/c-0198/)'
   variables:
   - expression: |
@@ -2619,7 +2619,7 @@ spec:
               : 'Unconfined')
         ) != 'Unconfined'
       )
-    message: |
+    messageExpression: |
       object.kind + '/' + object.metadata.name + ' has a container with seccomp profile Unconfined or undefined. (see more at https://kubescape.io/docs/controls/c-0210/)'
   variables:
   - expression: |

--- a/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
+++ b/core/pkg/opaprocessor/cel/vapdata/kubescape-validating-admission-policies.yaml
@@ -607,8 +607,8 @@ spec:
           )
         )
       )
-    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s which
-      have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
+    messageExpression: object.kind + "/" + object.metadata.name + " contains container/s
+      which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
   variables:
   - expression: |
       object.kind == 'Pod' ? object.spec.containers


### PR DESCRIPTION
## Overview

Two follow-ups from CodeRabbit's review of #2535 that didn't make it into that PR before it merged.

1. **C-0013, C-0198 and C-0210 set `message` to a CEL string concatenation instead of `messageExpression`.** Only `messageExpression` is evaluated by the CEL engine — `message` is emitted verbatim. So a violation on these three controls currently shows the literal, unevaluated string `object.kind + "/" + object.metadata.name + " contains container/s..."` instead of an interpolated message naming the actual resource. Sibling controls (C-0012, C-0268) already use `messageExpression` for the same pattern; these three now match. Swept the whole vendored bundle for the same mistake — these are the only three instances.
2. **`TestBundleControlIDsAreCurrent` only checked one direction**: every control in the bundle must be listed in `bundleControlIDs`, but not the reverse. A control ID that gets removed or renamed upstream would sit in `bundleControlIDs` forever with silent zero coverage from `TestNoEvalErrorOnMinimalWorkloads`. Added the missing assertion.

## Related issues/PRs

Addresses two review comments from CodeRabbit on #2535 (already merged) that were never applied:
- https://github.com/kubescape/kubescape/pull/2535#discussion_r3636120962
- https://github.com/kubescape/kubescape/pull/2535#discussion_r3654910666

## How to Test

`go test ./core/pkg/opaprocessor/cel/... ./cmd/vap/...` — all green, including `TestBundleControlIDsAreCurrent` exercising the new bidirectional check.

AI-skills: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation policy messaging for selected controls while preserving existing validation behavior.
  * Prevented unevaluated expressions from appearing in validation messages.

* **Maintenance**
  * Updated the CEL admission library to the latest pinned release.
  * Added checks to ensure configured control IDs and message expressions remain valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->