### PR TITLE
fix: filter wrong-kind direct paths from inlined CEL variables

### DIFF
--- a/core/pkg/opaprocessor/cel/paths.go
+++ b/core/pkg/opaprocessor/cel/paths.go
@@ -700,6 +700,9 @@ func literalString(val ref.Val) (string, bool) {
 func (p pathPlan) resolve(obj map[string]any, violates func(map[string]any) bool) []PathHint {
 	hints := make([]PathHint, 0, len(p.direct))
 	for _, ref := range p.direct {
+		if !objectHasKindSegment(obj, ref.path) {
+			continue
+		}
 		hints = append(hints, PathHint{Path: ref.path, Value: ref.value})
 	}
 	if p.elements == nil || len(p.elements.fields) == 0 {
@@ -770,6 +773,30 @@ func lookupList(obj map[string]any, segments []string) ([]any, bool) {
 	}
 	list, ok := current.([]any)
 	return list, ok
+}
+
+var kindSegments = map[string]bool{
+	"template":    true,
+	"jobTemplate": true,
+}
+
+// objectHasKindSegment reports whether the kind-dependent prefix of path exists
+// on obj. When a variable's inlined ternary contributes paths for several kinds
+// (e.g. spec.securityContext for Pod, spec.template.spec.securityContext for
+// Deployment, spec.jobTemplate.spec.template.spec.securityContext for CronJob),
+// only the one matching obj's kind survives — the same rule resolveCollection
+// applies via lookupList for element lists, ported to direct paths.
+func objectHasKindSegment(obj map[string]any, path string) bool {
+	parts := strings.Split(path, ".")
+	if len(parts) < 2 || parts[0] != "spec" || !kindSegments[parts[1]] {
+		return true
+	}
+	spec, ok := obj["spec"].(map[string]any)
+	if !ok {
+		return true
+	}
+	_, exists := spec[parts[1]]
+	return exists
 }
 
 // narrow returns a copy of obj with the value at a dotted path replaced,

--- a/core/pkg/opaprocessor/cel/paths_test.go
+++ b/core/pkg/opaprocessor/cel/paths_test.go
@@ -3,6 +3,7 @@ package cel
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -484,6 +485,106 @@ func TestEveryDerivedBundlePathIsWellFormed(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestViolationPathsFilterWrongKindDirectPaths(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	expr := "variables.containers.all(container, (has(container.securityContext) && has(container.securityContext.seccompProfile) && has(container.securityContext.seccompProfile.type) ? container.securityContext.seccompProfile.type : (has(variables.podSecurityContext) && has(variables.podSecurityContext.seccompProfile) && has(variables.podSecurityContext.seccompProfile.type) ? variables.podSecurityContext.seccompProfile.type : 'Unconfined')) != 'Unconfined')"
+	variables := []Variable{
+		{
+			Name: "containers",
+			Expression: "object.kind == 'Pod' ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []) : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : []) : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : []) : []",
+		},
+		{
+			Name:       "podSecurityContext",
+			Expression: "object.kind == 'Pod' ? (has(object.spec.securityContext) ? object.spec.securityContext : {}) : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? (has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {}) : object.kind == 'CronJob' ? (has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {}) : {}",
+		},
+	}
+
+	plan := e.buildPathPlan(expr, variables)
+
+	t.Run("pod", func(t *testing.T) {
+		obj := map[string]any{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": map[string]any{"name": "p"},
+			"spec": map[string]any{
+				"securityContext": map[string]any{"seccompProfile": map[string]any{"type": "Unconfined"}},
+				"containers":     []any{map[string]any{"name": "app", "image": "nginx"}},
+			},
+		}
+		hints := plan.resolve(obj, nil)
+		found := false
+		for _, h := range hints {
+			assert.NotContains(t, h.Path, "template", "Pod should not get template-prefixed paths")
+			assert.NotContains(t, h.Path, "jobTemplate", "Pod should not get jobTemplate-prefixed paths")
+			if strings.Contains(h.Path, "spec.securityContext") {
+				found = true
+			}
+		}
+		assert.True(t, found, "Pod should get a spec.securityContext path")
+	})
+
+	t.Run("deployment", func(t *testing.T) {
+		obj := map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment",
+			"metadata": map[string]any{"name": "d"},
+			"spec": map[string]any{
+				"replicas": float64(1),
+				"selector": map[string]any{"matchLabels": map[string]any{"app": "test"}},
+				"template": map[string]any{
+					"metadata": map[string]any{"labels": map[string]any{"app": "test"}},
+					"spec": map[string]any{
+						"securityContext": map[string]any{"seccompProfile": map[string]any{"type": "Unconfined"}},
+						"containers":      []any{map[string]any{"name": "app", "image": "nginx"}},
+					},
+				},
+			},
+		}
+		hints := plan.resolve(obj, nil)
+		found := false
+		for _, h := range hints {
+			assert.NotContains(t, h.Path, "jobTemplate", "Deployment should not get jobTemplate-prefixed paths")
+			if strings.Contains(h.Path, "spec.template.spec.securityContext") {
+				found = true
+			}
+		}
+		assert.True(t, found, "Deployment should get a spec.template.spec.securityContext path")
+	})
+
+	t.Run("cronjob", func(t *testing.T) {
+		obj := map[string]any{
+			"apiVersion": "batch/v1", "kind": "CronJob",
+			"metadata": map[string]any{"name": "c"},
+			"spec": map[string]any{
+				"schedule": "*/5 * * * *",
+				"jobTemplate": map[string]any{
+					"spec": map[string]any{
+						"template": map[string]any{
+							"metadata": map[string]any{"labels": map[string]any{"app": "test"}},
+							"spec": map[string]any{
+								"securityContext": map[string]any{"seccompProfile": map[string]any{"type": "Unconfined"}},
+								"containers":      []any{map[string]any{"name": "app", "image": "nginx"}},
+							},
+						},
+					},
+				},
+			},
+		}
+		hints := plan.resolve(obj, nil)
+		found := false
+		for _, h := range hints {
+			if strings.Contains(h.Path, "template") {
+				assert.True(t, strings.HasPrefix(h.Path, "spec.jobTemplate."),
+					"CronJob template paths must be under jobTemplate, got %s", h.Path)
+			}
+			if strings.Contains(h.Path, "spec.jobTemplate.spec.template.spec.securityContext") {
+				found = true
+			}
+		}
+		assert.True(t, found, "CronJob should get a spec.jobTemplate.spec.template.spec.securityContext path")
+	})
 }
 
 // bundleFixValues is every (path, value) pair the current bundle produces a fix


### PR DESCRIPTION
## What

Fixes #2561, CEL direct paths include every kind variant, so a Pod gets told to look at `spec.template.spec...` and `spec.jobTemplate.spec.template.spec...`.

## Root cause

`inlineVariables` expands a variable's kind ternary into the validation expression, so all three branches land in the AST. `selectPaths` (paths.go:479) renders a path for every ternary branch, and `resolve()` emitted every one without checking whether the path's shape matches the object.

Element paths already had this gating, `resolveCollection` calls `lookupList` for each candidate collection, and paths that don't resolve on the object are skipped. Direct paths had no such check.

## Changes

- **paths.go**: `resolve()` calls `objectHasKindSegment(obj, path)` before emitting each direct hint. The check identifies kind-dependent path prefixes (`spec.template`, `spec.jobTemplate`) and drops the hint when the prefix doesn't exist on the object. Non-kind-dependent paths pass through untouched, missing optional fields that ARE the finding (e.g. `securityContext` absent on a container) are never filtered.
- **paths_test.go**: `TestViolationPathsFilterWrongKindDirectPaths`, builds C-0210's expression + variables from the bundle, resolves against Pod/Deployment/CronJob objects, and asserts each kind never gets the other shapes' template/jobTemplate paths. Test fails without the production change (verified).

## Verification

- `TestViolationPathsFilterWrongKindDirectPaths` fails without the fix (Pod/Deployment get jobTemplate paths, CronJob gets bare template prefix)
- All 113 CEL tests pass with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved violation path reporting for variable-based container and security-context expressions.
* Corrected path resolution across Pods, Deployments, and CronJobs.
* Prevented paths from unrelated resource types from appearing in results.
* Added support for workload-specific template and job template paths.

## Tests

* Added regression coverage for accurate path filtering across supported workload types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->