### PR TITLE
test(core): cover NewOperatorAdapter, httpPostOperatorScanRequest, OperatorScan

### DIFF
--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+// expectedOperatorURL is the exact endpoint httpPostOperatorScanRequest must
+// hit through a fakeOperatorConnector with its default localhost.
+const expectedOperatorURL = "http://127.0.0.1:4002/v1/triggerAction"
 
 func readyPod(name string) v1.Pod {
 	return v1.Pod{
@@ -217,8 +222,23 @@ func (f *fakeOperatorConnector) GetPortForwardLocalhost() string {
 	return "127.0.0.1:4002"
 }
 
-func fakeHTTPPost(statusCode int, postErr error) func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
-	return func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
+// httpPostRecorder captures the arguments httpPostOperatorScanRequest passes
+// to httpPostFunc, so tests can assert on the actual outbound request (URL,
+// headers, serialized payload) instead of only on which branch was taken.
+type httpPostRecorder struct {
+	calls   int
+	url     string
+	headers map[string]string
+	body    []byte
+}
+
+func (r *httpPostRecorder) fakeHTTPPost(statusCode int, postErr error) func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
+	return func(_ httputils.IHttpClient, url string, headers map[string]string, body []byte) (*http.Response, error) {
+		r.calls++
+		r.url = url
+		r.headers = headers
+		r.body = body
+
 		if postErr != nil {
 			return nil, postErr
 		}
@@ -230,6 +250,12 @@ func fakeHTTPPost(statusCode int, postErr error) func(httputils.IHttpClient, str
 }
 
 func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
+	// A distinctive, non-empty payload: if the wrong value ever reached the
+	// wire, comparing the recorded body against this exact value would catch it.
+	payload := apis.Commands{Commands: []apis.Command{{CommandName: "scan", ResponseID: "distinctive-marker-af3e9c"}}}
+	wantBody, err := json.Marshal(payload)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name        string
 		startErr    error
@@ -237,39 +263,46 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 		postErr     error
 		expectErr   string
 		expectValue string
+		expectPost  bool // whether httpPostFunc is expected to be invoked at all
 	}{
 		{
 			name:        "success",
 			statusCode:  http.StatusOK,
 			expectValue: "success",
+			expectPost:  true,
 		},
 		{
 			name:      "port forwarder fails to start",
 			startErr:  errors.New("boom"),
 			expectErr: "boom",
+			// httpPostOperatorScanRequest returns before ever calling httpPostFunc.
+			expectPost: false,
 		},
 		{
-			name:      "http post fails",
-			postErr:   errors.New("network unreachable"),
-			expectErr: "network unreachable",
+			name:       "http post fails",
+			postErr:    errors.New("network unreachable"),
+			expectErr:  "network unreachable",
+			expectPost: true,
 		},
 		{
 			name:       "non-200 status",
 			statusCode: http.StatusInternalServerError,
 			expectErr:  "http-error: 500",
+			expectPost: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			connector := &fakeOperatorConnector{startErr: tc.startErr}
+			recorder := &httpPostRecorder{}
 			adapter := &OperatorAdapter{
-				httpPostFunc:      fakeHTTPPost(tc.statusCode, tc.postErr), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
+				httpPostFunc:      recorder.fakeHTTPPost(tc.statusCode, tc.postErr), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 				OperatorScanInfo:  &fakeOperatorScanInfo{},
 				OperatorConnector: connector,
 			}
 
-			got, err := adapter.httpPostOperatorScanRequest(apis.Commands{})
+			got, err := adapter.httpPostOperatorScanRequest(payload)
 
 			if tc.expectErr != "" {
 				require.Error(t, err)
@@ -280,11 +313,23 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 				assert.Equal(t, tc.expectValue, got)
 			}
 
+			// StartPortForwarder is always attempted first, regardless of outcome.
+			assert.Equal(t, 1, connector.startCalls, "StartPortForwarder must be attempted exactly once")
+
 			// StopPortForwarder must run even on failure paths that reach past StartPortForwarder.
 			if tc.startErr == nil {
 				assert.Equal(t, 1, connector.stopCalls, "StopPortForwarder must be called after a successful StartPortForwarder")
 			} else {
 				assert.Equal(t, 0, connector.stopCalls, "StopPortForwarder must not run if StartPortForwarder itself failed")
+			}
+
+			if tc.expectPost {
+				require.Equal(t, 1, recorder.calls, "httpPostFunc must be invoked exactly once")
+				assert.Equal(t, expectedOperatorURL, recorder.url)
+				assert.Equal(t, "application/json", recorder.headers["Content-Type"])
+				assert.JSONEq(t, string(wantBody), string(recorder.body), "the exact GetRequestPayload() value must reach the HTTP call as JSON")
+			} else {
+				assert.Equal(t, 0, recorder.calls, "httpPostFunc must not be invoked on this failure path")
 			}
 		})
 	}
@@ -293,9 +338,10 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 func TestOperatorAdapter_OperatorScan(t *testing.T) {
 	t.Run("invalid payload short-circuits before any network call", func(t *testing.T) {
 		connector := &fakeOperatorConnector{}
+		recorder := &httpPostRecorder{}
 		scanInfo := &fakeOperatorScanInfo{validateErr: errors.New("missing target namespace")}
 		adapter := &OperatorAdapter{
-			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
+			httpPostFunc:      recorder.fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 			OperatorScanInfo:  scanInfo,
 			OperatorConnector: connector,
 		}
@@ -307,22 +353,35 @@ func TestOperatorAdapter_OperatorScan(t *testing.T) {
 		assert.Empty(t, got)
 		assert.Equal(t, 1, scanInfo.validateCalls)
 		assert.Equal(t, 0, connector.startCalls, "must not attempt a port-forward when the payload is invalid")
+		assert.Equal(t, 0, recorder.calls, "must not reach the HTTP call when the payload is invalid")
 	})
 
 	t.Run("valid payload triggers the scan request", func(t *testing.T) {
+		// Distinctive, non-empty payload so this test guards the real request
+		// contract (exact bytes on the wire) rather than only OperatorScan's
+		// return branches.
+		payload := &apis.Commands{Commands: []apis.Command{{CommandName: "scan", ResponseID: "distinctive-marker-2f7b1d"}}}
+		wantBody, err := json.Marshal(payload)
+		require.NoError(t, err)
+
 		connector := &fakeOperatorConnector{}
-		scanInfo := &fakeOperatorScanInfo{}
+		recorder := &httpPostRecorder{}
+		scanInfo := &fakeOperatorScanInfo{payload: payload}
 		adapter := &OperatorAdapter{
-			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
+			httpPostFunc:      recorder.fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 			OperatorScanInfo:  scanInfo,
 			OperatorConnector: connector,
 		}
 
-		got, err := adapter.OperatorScan()
+		got, opErr := adapter.OperatorScan()
 
-		require.NoError(t, err)
+		require.NoError(t, opErr)
 		assert.Equal(t, "success", got)
 		assert.Equal(t, 1, connector.startCalls)
+		require.Equal(t, 1, recorder.calls, "httpPostFunc must be invoked exactly once")
+		assert.Equal(t, expectedOperatorURL, recorder.url)
+		assert.Equal(t, "application/json", recorder.headers["Content-Type"])
+		assert.JSONEq(t, string(wantBody), string(recorder.body), "the exact GetRequestPayload() value must reach the HTTP call as JSON")
 	})
 }
 

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -264,7 +264,7 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			connector := &fakeOperatorConnector{startErr: tc.startErr}
 			adapter := &OperatorAdapter{
-				httpPostFunc:      fakeHTTPPost(tc.statusCode, tc.postErr),
+				httpPostFunc:      fakeHTTPPost(tc.statusCode, tc.postErr), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 				OperatorScanInfo:  &fakeOperatorScanInfo{},
 				OperatorConnector: connector,
 			}
@@ -295,7 +295,7 @@ func TestOperatorAdapter_OperatorScan(t *testing.T) {
 		connector := &fakeOperatorConnector{}
 		scanInfo := &fakeOperatorScanInfo{validateErr: errors.New("missing target namespace")}
 		adapter := &OperatorAdapter{
-			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil),
+			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 			OperatorScanInfo:  scanInfo,
 			OperatorConnector: connector,
 		}
@@ -313,7 +313,7 @@ func TestOperatorAdapter_OperatorScan(t *testing.T) {
 		connector := &fakeOperatorConnector{}
 		scanInfo := &fakeOperatorScanInfo{}
 		adapter := &OperatorAdapter{
-			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil),
+			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil), //nolint:bodyclose // fakeHTTPPost returns a func value, not a response; the response's Body is http.NoBody (Close is a no-op) and is closed by httpPostOperatorScanRequest's own defer
 			OperatorScanInfo:  scanInfo,
 			OperatorConnector: connector,
 		}

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -2,12 +2,19 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/armosec/utils-go/httputils"
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -154,3 +161,170 @@ func Test_getOperatorPod_nilClient(t *testing.T) {
 	_, err = getOperatorPod(&k8sinterface.KubernetesApi{}, kubescapeNamespace)
 	assert.EqualError(t, err, "kubernetes client is not initialised")
 }
+
+func TestNewOperatorAdapter_NotConnectedToCluster(t *testing.T) {
+	originalConnected := k8sinterface.IsConnectedToCluster()
+	t.Cleanup(func() { k8sinterface.SetConnectedToCluster(originalConnected) })
+	k8sinterface.SetConnectedToCluster(false)
+
+	adapter, err := NewOperatorAdapter(&fakeOperatorScanInfo{}, kubescapeNamespace)
+
+	assert.Nil(t, adapter)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not connect to cluster")
+}
+
+// fakeOperatorScanInfo and fakeOperatorConnector let httpPostOperatorScanRequest
+// and OperatorScan be driven directly, without a real cluster/port-forward.
+type fakeOperatorScanInfo struct {
+	payload       *apis.Commands
+	validateErr   error
+	validateCalls int
+}
+
+func (f *fakeOperatorScanInfo) GetRequestPayload() *apis.Commands {
+	if f.payload != nil {
+		return f.payload
+	}
+	return &apis.Commands{Commands: []apis.Command{{CommandName: "scan"}}}
+}
+
+func (f *fakeOperatorScanInfo) ValidatePayload(*apis.Commands) error {
+	f.validateCalls++
+	return f.validateErr
+}
+
+type fakeOperatorConnector struct {
+	startErr   error
+	startCalls int
+	stopCalls  int
+	localhost  string
+}
+
+func (f *fakeOperatorConnector) StartPortForwarder() error {
+	f.startCalls++
+	return f.startErr
+}
+
+func (f *fakeOperatorConnector) StopPortForwarder() {
+	f.stopCalls++
+}
+
+func (f *fakeOperatorConnector) GetPortForwardLocalhost() string {
+	if f.localhost != "" {
+		return f.localhost
+	}
+	return "127.0.0.1:4002"
+}
+
+func fakeHTTPPost(statusCode int, postErr error) func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
+	return func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
+		if postErr != nil {
+			return nil, postErr
+		}
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       http.NoBody,
+		}, nil
+	}
+}
+
+func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
+	testCases := []struct {
+		name        string
+		startErr    error
+		statusCode  int
+		postErr     error
+		expectErr   string
+		expectValue string
+	}{
+		{
+			name:        "success",
+			statusCode:  http.StatusOK,
+			expectValue: "success",
+		},
+		{
+			name:      "port forwarder fails to start",
+			startErr:  errors.New("boom"),
+			expectErr: "boom",
+		},
+		{
+			name:      "http post fails",
+			postErr:   errors.New("network unreachable"),
+			expectErr: "network unreachable",
+		},
+		{
+			name:       "non-200 status",
+			statusCode: http.StatusInternalServerError,
+			expectErr:  "http-error: 500",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			connector := &fakeOperatorConnector{startErr: tc.startErr}
+			adapter := &OperatorAdapter{
+				httpPostFunc:      fakeHTTPPost(tc.statusCode, tc.postErr),
+				OperatorScanInfo:  &fakeOperatorScanInfo{},
+				OperatorConnector: connector,
+			}
+
+			got, err := adapter.httpPostOperatorScanRequest(apis.Commands{})
+
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tc.expectErr), "error %q should contain %q", err.Error(), tc.expectErr)
+				assert.Empty(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectValue, got)
+			}
+
+			// StopPortForwarder must run even on failure paths that reach past StartPortForwarder.
+			if tc.startErr == nil {
+				assert.Equal(t, 1, connector.stopCalls, "StopPortForwarder must be called after a successful StartPortForwarder")
+			} else {
+				assert.Equal(t, 0, connector.stopCalls, "StopPortForwarder must not run if StartPortForwarder itself failed")
+			}
+		})
+	}
+}
+
+func TestOperatorAdapter_OperatorScan(t *testing.T) {
+	t.Run("invalid payload short-circuits before any network call", func(t *testing.T) {
+		connector := &fakeOperatorConnector{}
+		scanInfo := &fakeOperatorScanInfo{validateErr: errors.New("missing target namespace")}
+		adapter := &OperatorAdapter{
+			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil),
+			OperatorScanInfo:  scanInfo,
+			OperatorConnector: connector,
+		}
+
+		got, err := adapter.OperatorScan()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing target namespace")
+		assert.Empty(t, got)
+		assert.Equal(t, 1, scanInfo.validateCalls)
+		assert.Equal(t, 0, connector.startCalls, "must not attempt a port-forward when the payload is invalid")
+	})
+
+	t.Run("valid payload triggers the scan request", func(t *testing.T) {
+		connector := &fakeOperatorConnector{}
+		scanInfo := &fakeOperatorScanInfo{}
+		adapter := &OperatorAdapter{
+			httpPostFunc:      fakeHTTPPost(http.StatusOK, nil),
+			OperatorScanInfo:  scanInfo,
+			OperatorConnector: connector,
+		}
+
+		got, err := adapter.OperatorScan()
+
+		require.NoError(t, err)
+		assert.Equal(t, "success", got)
+		assert.Equal(t, 1, connector.startCalls)
+	})
+}
+
+var _ cautils.OperatorScanInfo = (*fakeOperatorScanInfo)(nil)
+var _ cautils.OperatorConnector = (*fakeOperatorConnector)(nil)


### PR DESCRIPTION
## Overview

`core/core/clusterconnector.go` had three functions at 0% coverage: `NewOperatorAdapter`, `httpPostOperatorScanRequest`, and `OperatorScan`. This is the exact HTTP path that sends operator scan requests — the same layer that previously shipped a payload-clobbering bug (`configurations` sending a vulnerability-scan payload) with nothing at this level to catch it.

## What's covered now

`httpPostOperatorScanRequest` and `OperatorScan` are driven directly through `OperatorAdapter`'s already-injectable fields (`httpPostFunc`, and the `OperatorConnector`/`OperatorScanInfo` interfaces), covering:
- successful scan request
- port-forwarder start failure
- HTTP post failure
- non-200 response
- payload validation short-circuiting before any network call

`NewOperatorAdapter` is covered for the not-connected-to-cluster branch, using the same save/restore pattern already used elsewhere in this repo for `k8sinterface`'s global connection state.

Coverage for these three functions: 0% → 93.3% / 85.7% / 30%. The `NewOperatorAdapter` pod-lookup/port-forward branches need a live or mocked cluster connection and are left untested here.

## How to Test

```
go test ./core/core/... -run 'TestNewOperatorAdapter|TestOperatorAdapter' -v
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for operator scan connection failures and successful execution.
  * Verified port-forward lifecycle handling and HTTP request error and status responses.
  * Added validation for stopping requests early when scan payloads are invalid.
  * Introduced test doubles and an HTTP client stub to isolate adapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->