### PR TITLE
fix(locationresolver): add context to YAML evaluation errors

### DIFF
--- a/core/pkg/resultshandling/locationresolver/locationresolver.go
+++ b/core/pkg/resultshandling/locationresolver/locationresolver.go
@@ -68,7 +68,7 @@ func (l *FixPathLocationResolver) ResolveLocation(fixPath string, nodeIndex int)
 	for strings.HasPrefix(yamlExpression, ".") && len(yamlExpression) > 1 {
 		candidateNodes, err := l.yqlibEvaluator.EvaluateNodes(yamlExpression, l.yamlNodes[nodeIndex])
 		if err != nil {
-			return Location{}, err
+			return Location{}, fmt.Errorf("failed to evaluate yaml expression %q: %w", yamlExpression, err)
 		}
 
 		if backElement := candidateNodes.Back(); backElement != nil {
@@ -83,6 +83,7 @@ func (l *FixPathLocationResolver) ResolveLocation(fixPath string, nodeIndex int)
 		yamlExpression = regexp.MustCompile(`(.*)(\.[^.]*)`).ReplaceAllString(yamlExpression, `${1}`)
 	}
 	return Location{}, nil
+
 }
 
 func FixPathToValidYamlExpression(fixPath string) string {

--- a/core/pkg/resultshandling/locationresolver/locationresolver_test.go
+++ b/core/pkg/resultshandling/locationresolver/locationresolver_test.go
@@ -63,8 +63,8 @@ func TestResolveLocation(t *testing.T) {
 		assert.Equalf(t, expected.Line, location.Line, "fixPath %s, expected line: %d, actual line: %d", fixPath, expected.Line, location.Line)
 		assert.Equalf(t, expected.Column, location.Column, "fixPath %s, expected column: %d, actual column: %d", fixPath, expected.Column, location.Column)
 	}
-
 	_, err := resolver.ResolveLocation("some invalid string as an input", 0)
+	assert.ErrorContains(t, err, "failed to evaluate yaml expression")
 	assert.ErrorContains(t, err, "invalid input")
 
 }


### PR DESCRIPTION
## Summary

Improve error messages in the location resolver by wrapping YAML evaluation errors with the evaluated YAML expression.

## Changes

- Wrap `EvaluateNodes` errors with additional context using `%w`.
- Update tests to verify the wrapped error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML expression evaluation errors by including the evaluated expression as context while preserving the original error details.
  * Clarified error messages for invalid input to make troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->