### PR TITLE
fix(mcpserver): reject empty resource URI segments

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -314,7 +314,7 @@ func (ksServer *KubescapeMcpserver) ReadConfigurationResource(ctx context.Contex
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 	parts := strings.Split(uri[len("kubescape://configuration-manifests/"):], "/")
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 	namespace := parts[0]
@@ -343,7 +343,7 @@ func (ksServer *KubescapeMcpserver) ReadContainerProfileResource(ctx context.Con
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 	parts := strings.Split(uri[len("kubescape://container-profiles/"):], "/")
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("invalid URI: %s", uri)
 	}
 	namespace := parts[0]

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -140,6 +140,16 @@ func TestReadConfigurationResource_URIParsing(t *testing.T) {
 			uri:     "kubescape://configuration-manifests/ns/manifest/extra",
 			wantErr: "invalid URI",
 		},
+		{
+			name:    "empty namespace",
+			uri:     "kubescape://configuration-manifests//manifest",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty manifest name",
+			uri:     "kubescape://configuration-manifests/ns/",
+			wantErr: "invalid URI",
+		},
 	}
 
 	for _, tt := range tests {
@@ -199,6 +209,16 @@ func TestReadContainerProfileResource_URIParsing(t *testing.T) {
 		{
 			name:    "too many parts",
 			uri:     "kubescape://container-profiles/ns/manifest/extra",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty namespace",
+			uri:     "kubescape://container-profiles//profile",
+			wantErr: "invalid URI",
+		},
+		{
+			name:    "empty profile name",
+			uri:     "kubescape://container-profiles/ns/",
 			wantErr: "invalid URI",
 		},
 	}


### PR DESCRIPTION
## Overview
Reject MCP configuration-manifest and container-profile resource URIs with empty namespace or resource-name segments before attempting to create/use a Kubernetes client. This matches the existing vulnerability manifest URI validation behavior and keeps malformed URIs returning `invalid URI`.

## Reproduction
Added regression cases for:
- `kubescape://configuration-manifests//manifest`
- `kubescape://configuration-manifests/ns/`
- `kubescape://container-profiles//profile`
- `kubescape://container-profiles/ns/`

Before the fix, these cases failed with `failed to connect to Kubernetes cluster: sentinel connection error`, showing the malformed URI had passed parsing.

## How to Test
- `go test ./cmd/mcpserver`
- `go test ./cmd/...`
- `go test ./...` was also run; it reaches the touched package successfully but fails in unrelated `core/pkg/resultshandling/printer` tests on this macOS environment because the test expects `/var/.../T/` while `os.TempDir()` returns `/var/.../T`.

## Related issues/PRs
No matching open issue or PR found for the empty MCP resource URI segment behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for configuration-manifest and container-profile resource URIs.
  * URIs with missing namespaces or resource names are now rejected with a clear invalid-URI error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->