### PR TITLE
fix(core): remove racy re-check of global cluster connection state

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -151,7 +151,16 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 	hostSensorVal := scanInfo.HostSensorEnabled.Get()
 
 	switch {
-	case !k8sinterface.IsConnectedToCluster() || k8s == nil: // TODO(fred): fix race condition on global KSConfig there
+	case k8s == nil:
+		// k8s is nil exactly when this scan never connected to a cluster (a
+		// non-cluster scan, or getKubernetesApi() failing - which exits the
+		// process via logger.Fatal before we'd get here). Re-checking
+		// k8sinterface.IsConnectedToCluster() here as well used to read the
+		// same global connection state a second time, at a later point than
+		// when k8s was obtained, with no synchronization between the two
+		// reads - a caller could observe k8s and IsConnectedToCluster()
+		// disagree. k8s == nil is already a complete, single-read proxy for
+		// "no cluster connection", so the second read added nothing but risk.
 		return hostsensorutils.NewHostSensorHandlerMock()
 
 	case hostSensorVal != nil && *hostSensorVal:


### PR DESCRIPTION
## Overview

`getHostSensorHandler`'s first switch case checked both `k8s == nil` and `k8sinterface.IsConnectedToCluster()`, with a `TODO(fred): fix race condition on global KSConfig there` flagging the issue.

## Root cause

`k8s` is only ever non-nil when `getInterfaces` already called `getKubernetesApi()`, which itself checks `IsConnectedToCluster()` once and returns `nil` if it's false; if that same check fails on a cluster-context scan, `getInterfaces` exits the process via `logger.Fatal` before `getHostSensorHandler` is ever reached. So `k8s == nil` already fully and exclusively captures "no cluster connection" for every caller.

`k8sinterface.IsConnectedToCluster()` reads two plain package-level globals (`K8SConfig`, `connectedToCluster`) with no synchronization whatsoever. Calling it a second time here, at a later point than when `k8s` was obtained, read that same unsynchronized global state again instead of reusing the single value already captured in `k8s` — a redundant read that could disagree with `k8s` depending on what else touched that global state in between, with no lock to make the two reads consistent.

## Fix

Dropping the redundant check leaves `k8s == nil` as the sole, single-read determinant, which needs no synchronization with anything since it's a local parameter. The underlying lack of synchronization inside `k8s-interface`'s global connection state is a separate, out-of-repo concern (vendored dependency); this removes the one place in this repo's own code that read it twice inconsistently.

## Test plan

- [x] Verified against the existing `TestGetSensorHandler` suite — all four cases still pass, including under `go test -race`
- [x] Full `core/core` test run passes
- [x] Behavior is unchanged for every case already covered by existing tests

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability by refactoring internal connection-state handling to eliminate potential race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->