### PR TITLE
fix: two crash bugs in fixhandler — nil resource and off-by-one slice

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -221,6 +221,9 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 
 		resourceID := result.ResourceID
 		resourceObj := resourceIdToResource[resourceID]
+		if resourceObj == nil {
+			continue
+		}
 		resourcePath := h.getPathFromRawResource(resourceObj.GetObject())
 
 		// Determine an upfront reason if we already know this resource is not
@@ -874,7 +877,7 @@ func sanitizeYaml(fileAsString string) string {
 //
 // For sanitization details, refer to the sanitizeYaml() function.
 func revertSanitizeYaml(fixedYamlString string) string {
-	if len(fixedYamlString) < 3 {
+	if len(fixedYamlString) < 5 {
 		return fixedYamlString
 	}
 

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -1029,3 +1029,40 @@ func TestNewFixHandler_AcceptsValidReport(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, h)
 }
+
+func TestPrepareResourcesToFix_MissingResourceDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  "nonexistent-resource-id",
+			RawResource: nil,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0001", "some-control", failedRuleNoFix()),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, []reporthandling.Resource{*res}, false)
+	rtf := h.PrepareResourcesToFix(context.Background())
+	assert.Empty(t, rtf)
+}
+
+func TestRevertSanitizeYaml_ShortInputDoesNotPanic(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"ab", "ab"},
+		{"abc", "abc"},
+		{"# -", "# -"},
+		{"# ---", "---"},
+		{"# ---hello", "---hello"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, revertSanitizeYaml(c.in), "input %q", c.in)
+	}
+}


### PR DESCRIPTION
## What

Fixes #2596 — two panics in `core/pkg/fixhandler/fixhandler.go`:

1. **Nil pointer dereference** in `PrepareResourcesToFix` (line 223): `resourceIdToResource` lookup returns nil when a result's ResourceID has no matching entry in the report's Resources list. Calling `.GetObject()` on nil panicked.

2. **Off-by-one slice bounds panic** in `revertSanitizeYaml` (line 882): the length guard checked `len < 3` but the slice read `[:5]`, strings of length 3-4 passed the guard then panicked with "slice bounds out of range".

## Changes

- **fixhandler.go**: `PrepareResourcesToFix` now guards with `if resourceObj == nil { continue }`, matching the pattern already used in `PrepareHelmSuggestions` ~30 lines later in the same file.
- **fixhandler.go**: `revertSanitizeYaml` guard changed from `< 3` to `< 5`, matching the 5-byte read against the sanitization marker `"# ---"`.
- **unfixed_test.go**: `TestPrepareResourcesToFix_MissingResourceDoesNotPanic`, creates a handler with a result referencing a nonexistent resource ID, asserts no panic and empty fix list.
- **unfixed_test.go**: `TestRevertSanitizeYaml_ShortInputDoesNotPanic`, table test covering 0-4 byte inputs and the 5-byte sanitization marker. All pass without panic.

## Verification

- Test 1 panics with "nil pointer dereference" without the fix ✓
- Test 2 panics with "slice bounds out of range [:5] with length 3" without the fix ✓
- All 180 fixhandler tests pass with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when processing failed results for resources that are unavailable.
  * Improved handling of short or minimally formatted YAML input during restoration.

* **Tests**
  * Added regression coverage for missing resources and short YAML input to help prevent these crashes from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->