### PR TITLE
fix(opaprocessor): move opaRegisterOnce to package level to prevent re-registration per scan

### DIFF
--- a/core/pkg/opaprocessor/builtin_registration_test.go
+++ b/core/pkg/opaprocessor/builtin_registration_test.go
@@ -1,0 +1,41 @@
+package opaprocessor
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegisterOPABuiltins_OnlyRegistersOncePerProcess guards against a
+// regression where the sync.Once guarding rego.RegisterBuiltin1/2 lived on
+// OPAProcessor as a struct field instead of at package level. Because
+// RegisterBuiltin mutates OPA's process-global ast.Builtins/ast.BuiltinMap, a
+// per-instance Once gave every new OPAProcessor (i.e. every scan) its own,
+// never-fired Once, so the registration ran again on every scan: unbounded
+// growth of ast.Builtins for the life of a long-running process (httphandler,
+// MCP server), and one concurrency change away from the "concurrent map
+// read/write panic" OPA's own docs warn RegisterBuiltin can cause after
+// initialization.
+func TestRegisterOPABuiltins_OnlyRegistersOncePerProcess(t *testing.T) {
+	// Establish the baseline after at least one registration (init() already
+	// triggered this before any test runs, but calling it again here keeps
+	// the test correct even if that ever changes) so the assertion below is
+	// independent of test ordering and doesn't hardcode the builtin count.
+	registerOPABuiltins()
+	countAfterFirst := len(ast.Builtins)
+
+	// Simulate what used to happen once per scan: registerOPABuiltins is
+	// invoked repeatedly, as if from several independent OPAProcessor
+	// instances/runRegoOnK8s calls across the life of a long-running process.
+	for i := 0; i < 5; i++ {
+		registerOPABuiltins()
+	}
+
+	assert.Equal(t, countAfterFirst, len(ast.Builtins),
+		"registerOPABuiltins must not add builtins after the first call")
+
+	assert.NotNil(t, ast.BuiltinMap[cosignVerifySignatureDeclaration.Name], "cosign.verify must be registered")
+	assert.NotNil(t, ast.BuiltinMap[cosignHasSignatureDeclaration.Name], "cosign.has_signature must be registered")
+	assert.NotNil(t, ast.BuiltinMap[imageNameNormalizeDeclaration.Name], "image.parse_normalized_name must be registered")
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -47,7 +47,6 @@ type OPAProcessor struct {
 	regoDependenciesData *resources.RegoDependenciesData
 	*cautils.OPASessionObj
 	exceptionEventRecorder record.EventRecorder
-	opaRegisterOnce        sync.Once
 	excludeNamespaces      []string
 	includeNamespaces      []string
 	printEnabled           bool
@@ -735,13 +734,40 @@ func celResourceID(obj map[string]any) string {
 	return "<unknown>"
 }
 
-// runRegoOnK8s compiles an OPA PolicyRule and evaluates its against k8s
-func (opap *OPAProcessor) runRegoOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData) ([]reporthandling.RuleResponse, error) {
-	opap.opaRegisterOnce.Do(func() {
+// opaRegisterOnce guards rego.RegisterBuiltin1/2 below. Those calls mutate
+// OPA's process-global builtin registry (ast.Builtins/ast.BuiltinMap), which
+// the OPA docs call out as not thread-safe and unsupported to call more than
+// once per process. This must stay a package-level sync.Once: a field on
+// OPAProcessor would give every new instance (i.e. every scan) its own,
+// never-fired Once, defeating the "only once" guarantee it exists to provide.
+var opaRegisterOnce sync.Once
+
+// registerOPABuiltins registers kubescape's custom Rego builtins with the OPA
+// runtime exactly once for the lifetime of the process, regardless of how
+// many OPAProcessor instances (scans) are created. It stays idempotent (via
+// opaRegisterOnce) even though init() below already calls it eagerly,
+// because runRegoOnK8s and tests also call it directly.
+func registerOPABuiltins() {
+	opaRegisterOnce.Do(func() {
 		rego.RegisterBuiltin2(cosignVerifySignatureDeclaration, cosignVerifySignatureDefinition)
 		rego.RegisterBuiltin1(cosignHasSignatureDeclaration, cosignHasSignatureDefinition)
 		rego.RegisterBuiltin1(imageNameNormalizeDeclaration, imageNameNormalizeDefinition)
 	})
+}
+
+// Registering eagerly at package init, rather than lazily on the first scan,
+// removes the (currently unused, but latent) window where a concurrent
+// scan-triggering path could race the first call to registerOPABuiltins.
+// The declarations/definitions it references are plain package-level vars
+// with no runtime dependency, so they are already initialized by the time
+// any init() func runs.
+func init() {
+	registerOPABuiltins()
+}
+
+// runRegoOnK8s compiles an OPA PolicyRule and evaluates its against k8s
+func (opap *OPAProcessor) runRegoOnK8s(ctx context.Context, rule *reporthandling.PolicyRule, k8sObjects []map[string]any, getRuleData func(*reporthandling.PolicyRule) string, ruleRegoDependenciesData resources.RegoDependenciesData) ([]reporthandling.RuleResponse, error) {
+	registerOPABuiltins()
 
 	ruleData := getRuleData(rule)
 	compiled, err := opap.getCompiledRule(ctx, rule.Name, ruleData, opap.printEnabled)


### PR DESCRIPTION
fix(opaprocessor): register OPA builtins once per process via init()

## Overview

- **Current Behavior:** `opaRegisterOnce` was scoped as a struct field on `OPAProcessor`. Because a new `OPAProcessor` is constructed on every scan, custom OPA builtins re-registered on every execution. In long-running modes (`httphandler` and the MCP server), this caused the global `ast.Builtins` slice to leak 3 entries per scan without bound.
- **Future Behavior:** Custom OPA builtins are registered eagerly at package `init()` and guarded by a package-level `var opaRegisterOnce sync.Once`. This fixes the `ast.Builtins` memory leak and hardens the package against latent concurrency issues if future scanning paths run in parallel.

Fixes #2622

## Proposed Changes

- Moved `opaRegisterOnce` to package scope in `processorhandler.go` and registered builtins eagerly during package `init()`.
- Kept `registerOPABuiltins()` idempotent via `sync.Once` so calls from `runRegoOnK8s` or tests remain safe.
- Added regression test `TestRegisterOPABuiltins_OnlyRegistersOncePerProcess` in `builtin_registration_test.go` to verify `ast.Builtins` experiences no further growth after initial registration.

## How to Test

```bash
go test -race -count=1 -v ./core/pkg/opaprocessor/...
```

## Related issues/PRs

* Resolves #2622

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes