### PR TITLE
fix(mcpserver): retry client init instead of caching first error

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -21,12 +21,20 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 )
 
+// newKsClient creates the Kubescape storage client. It is a package-level
+// var so tests can override it to simulate initialization failures without a
+// real connection attempt, while production always goes through this same
+// value instead of a per-call fallback.
+var newKsClient = func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+	return CreateKsObjectConnection("default", 10*time.Second)
+}
+
 type KubescapeMcpserver struct {
 	s          *server.MCPServer
 	ksClientMu sync.Mutex
 	ksClient   spdxv1beta1.SpdxV1beta1Interface
-	// ksClientInit creates the Kubescape storage client. Overridable in tests
-	// to simulate initialization failures without a real connection attempt.
+	// ksClientInit overrides newKsClient for this server instance; used by
+	// tests. Nil means use newKsClient.
 	ksClientInit func() (spdxv1beta1.SpdxV1beta1Interface, error)
 	k8sClientMu  sync.Mutex
 	k8sClient    *k8sinterface.KubernetesApi
@@ -44,30 +52,43 @@ func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interf
 	}
 	init := ksServer.ksClientInit
 	if init == nil {
-		init = func() (spdxv1beta1.SpdxV1beta1Interface, error) {
-			return CreateKsObjectConnection("default", 10*time.Second)
-		}
+		init = newKsClient
 	}
 	client, err := init()
 	if err != nil {
 		return nil, err
 	}
 	if client == nil {
+		// Belt-and-braces: CreateKsObjectConnection never returns (nil, nil)
+		// today, but this guards against a future/injected implementation
+		// doing so. It only catches an untyped nil interface value; a typed
+		// nil pointer wrapped in the interface would still slip through and
+		// be cached, since the error contract is what init() implementations
+		// are expected to honor.
 		return nil, fmt.Errorf("kubernetes client initialization returned nil")
 	}
 	ksServer.ksClient = client
 	return ksServer.ksClient, nil
 }
 
-// getK8sClient lazily initializes the Kubernetes API client, retrying on
-// every call until initialization succeeds.
-func (ksServer *KubescapeMcpserver) getK8sClient() *k8sinterface.KubernetesApi {
+// getK8sClient lazily initializes the Kubernetes API client. It only calls
+// k8sinterface.NewKubernetesApi (which terminates the process via
+// logger.L().Fatal on most internal failures) once a cluster connection is
+// confirmed available, so a missing/invalid KUBECONFIG returns an error
+// instead of killing the server. Once a client is built it is cached; there
+// is no retry for failures inside NewKubernetesApi itself, since those are
+// fatal by construction and cannot be recovered from in-process.
+func (ksServer *KubescapeMcpserver) getK8sClient() (*k8sinterface.KubernetesApi, error) {
 	ksServer.k8sClientMu.Lock()
 	defer ksServer.k8sClientMu.Unlock()
-	if ksServer.k8sClient == nil {
-		ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+	if ksServer.k8sClient != nil {
+		return ksServer.k8sClient, nil
 	}
-	return ksServer.k8sClient
+	if !k8sinterface.IsConnectedToCluster() {
+		return nil, fmt.Errorf("no reachable kubernetes cluster: ensure KUBECONFIG is set or the server is running inside a cluster")
+	}
+	ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+	return ksServer.k8sClient, nil
 }
 
 // toolHandler binds a registered tool to its declared name and normalizes an

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -22,36 +22,51 @@ import (
 )
 
 type KubescapeMcpserver struct {
-	s             *server.MCPServer
-	ksClient      spdxv1beta1.SpdxV1beta1Interface
-	ksClientOnce  sync.Once
-	ksClientErr   error
-	k8sClient     *k8sinterface.KubernetesApi
-	k8sClientOnce sync.Once
-	policyGetter  *getter.DownloadReleasedPolicy
+	s          *server.MCPServer
+	ksClientMu sync.Mutex
+	ksClient   spdxv1beta1.SpdxV1beta1Interface
+	// ksClientInit creates the Kubescape storage client. Overridable in tests
+	// to simulate initialization failures without a real connection attempt.
+	ksClientInit func() (spdxv1beta1.SpdxV1beta1Interface, error)
+	k8sClientMu  sync.Mutex
+	k8sClient    *k8sinterface.KubernetesApi
+	policyGetter *getter.DownloadReleasedPolicy
 }
 
+// getKsClient lazily initializes the Kubescape storage client. A transient
+// initialization failure is not cached, so the next call retries instead of
+// returning the same error forever.
 func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interface, error) {
-	ksServer.ksClientOnce.Do(func() {
-		if ksServer.ksClient == nil {
-			ksServer.ksClient, ksServer.ksClientErr = CreateKsObjectConnection("default", 10*time.Second)
-		}
-	})
-	if ksServer.ksClientErr != nil {
-		return nil, ksServer.ksClientErr
+	ksServer.ksClientMu.Lock()
+	defer ksServer.ksClientMu.Unlock()
+	if ksServer.ksClient != nil {
+		return ksServer.ksClient, nil
 	}
-	if ksServer.ksClient == nil {
+	init := ksServer.ksClientInit
+	if init == nil {
+		init = func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return CreateKsObjectConnection("default", 10*time.Second)
+		}
+	}
+	client, err := init()
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
 		return nil, fmt.Errorf("kubernetes client initialization returned nil")
 	}
+	ksServer.ksClient = client
 	return ksServer.ksClient, nil
 }
 
+// getK8sClient lazily initializes the Kubernetes API client, retrying on
+// every call until initialization succeeds.
 func (ksServer *KubescapeMcpserver) getK8sClient() *k8sinterface.KubernetesApi {
-	ksServer.k8sClientOnce.Do(func() {
-		if ksServer.k8sClient == nil {
-			ksServer.k8sClient = k8sinterface.NewKubernetesApi()
-		}
-	})
+	ksServer.k8sClientMu.Lock()
+	defer ksServer.k8sClientMu.Unlock()
+	if ksServer.k8sClient == nil {
+		ksServer.k8sClient = k8sinterface.NewKubernetesApi()
+	}
 	return ksServer.k8sClient
 }
 

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -22,38 +22,86 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/fixhandler"
 )
 
-type KubescapeMcpserver struct {
-	s             *server.MCPServer
-	ksClient      spdxv1beta1.SpdxV1beta1Interface
-	ksClientOnce  sync.Once
-	ksClientErr   error
-	k8sClient     *k8sinterface.KubernetesApi
-	k8sClientOnce sync.Once
-	policyGetter  *getter.DownloadReleasedPolicy
+// newKsClient creates the Kubescape storage client. It is a package-level
+// var so tests can override it to simulate initialization failures without a
+// real connection attempt, while production always goes through this same
+// value instead of a per-call fallback.
+var newKsClient = func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+	return CreateKsObjectConnection("default", 10*time.Second)
 }
 
+var loadK8sConfig = k8sinterface.LoadK8sConfig
+
+var setConnectedToCluster = k8sinterface.SetConnectedToCluster
+
+var newK8sClient = k8sinterface.NewKubernetesApi
+
+type KubescapeMcpserver struct {
+	s          *server.MCPServer
+	ksClientMu sync.Mutex
+	ksClient   spdxv1beta1.SpdxV1beta1Interface
+	// ksClientInit overrides newKsClient for this server instance; used by
+	// tests. Nil means use newKsClient.
+	ksClientInit func() (spdxv1beta1.SpdxV1beta1Interface, error)
+	k8sClientMu  sync.Mutex
+	k8sClient    *k8sinterface.KubernetesApi
+	policyGetter *getter.DownloadReleasedPolicy
+}
+
+// getKsClient lazily initializes the Kubescape storage client. A transient
+// initialization failure is not cached, so the next call retries instead of
+// returning the same error forever.
 func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interface, error) {
-	ksServer.ksClientOnce.Do(func() {
-		if ksServer.ksClient == nil {
-			ksServer.ksClient, ksServer.ksClientErr = CreateKsObjectConnection("default", 10*time.Second)
-		}
-	})
-	if ksServer.ksClientErr != nil {
-		return nil, ksServer.ksClientErr
+	ksServer.ksClientMu.Lock()
+	defer ksServer.ksClientMu.Unlock()
+	if ksServer.ksClient != nil {
+		return ksServer.ksClient, nil
 	}
-	if ksServer.ksClient == nil {
+	init := ksServer.ksClientInit
+	if init == nil {
+		init = newKsClient
+	}
+	client, err := init()
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		// Belt-and-braces: CreateKsObjectConnection never returns (nil, nil)
+		// today, but this guards against a future/injected implementation
+		// doing so. It only catches an untyped nil interface value; a typed
+		// nil pointer wrapped in the interface would still slip through and
+		// be cached, since the error contract is what init() implementations
+		// are expected to honor.
 		return nil, fmt.Errorf("kubernetes client initialization returned nil")
 	}
+	ksServer.ksClient = client
 	return ksServer.ksClient, nil
 }
 
-func (ksServer *KubescapeMcpserver) getK8sClient() *k8sinterface.KubernetesApi {
-	ksServer.k8sClientOnce.Do(func() {
-		if ksServer.k8sClient == nil {
-			ksServer.k8sClient = k8sinterface.NewKubernetesApi()
-		}
-	})
-	return ksServer.k8sClient
+// getK8sClient lazily initializes the Kubernetes API client. It probes with
+// loadK8sConfig (genuinely retryable, unlike k8sinterface.IsConnectedToCluster,
+// which latches to false forever after its first failure) and only calls
+// k8sinterface.NewKubernetesApi (which terminates the process via
+// logger.L().Fatal on most internal failures) once a kubeconfig is confirmed
+// loadable, so a missing/invalid KUBECONFIG returns an error instead of
+// killing the server. On success it also clears any stale "not connected"
+// latch left over from an earlier transient failure, since k8sinterface never
+// resets that global on its own. Once a client is built it is cached; there
+// is no retry for failures inside NewKubernetesApi itself, since those are
+// fatal by construction and cannot be recovered from in-process.
+func (ksServer *KubescapeMcpserver) getK8sClient() (*k8sinterface.KubernetesApi, error) {
+	ksServer.k8sClientMu.Lock()
+	defer ksServer.k8sClientMu.Unlock()
+	if ksServer.k8sClient != nil {
+		return ksServer.k8sClient, nil
+	}
+	if err := loadK8sConfig(); err != nil {
+		setConnectedToCluster(false)
+		return nil, fmt.Errorf("no reachable kubernetes cluster: ensure KUBECONFIG is set or the server is running inside a cluster: %w", err)
+	}
+	setConnectedToCluster(true)
+	ksServer.k8sClient = newK8sClient()
+	return ksServer.k8sClient, nil
 }
 
 // toolHandler binds a registered tool to its declared name and normalizes an
@@ -844,7 +892,10 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 
 		var rawManifest []byte
 		var workloadObj any
-		k8sClient := ksServer.getK8sClient()
+		k8sClient, k8sErr := ksServer.getK8sClient()
+		if k8sErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", k8sErr)), nil
+		}
 		switch strings.ToLower(workloadKindStr) {
 		case "pod":
 			workloadObj, err = k8sClient.KubernetesClient.CoreV1().Pods(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
@@ -921,16 +972,8 @@ func mcpServerEntrypoint() error {
 		server.WithRecovery(),
 	)
 
-	// Build the k8s API client once at startup. IsConnectedToCluster() is checked
-	// inside RunRBACScan before this is used, so it is safe to store here.
-	var k8sApi *k8sinterface.KubernetesApi
-	if k8sinterface.IsConnectedToCluster() {
-		k8sApi = k8sinterface.NewKubernetesApi()
-	}
-
 	ksServer := &KubescapeMcpserver{
 		s:            s,
-		k8sClient:    k8sApi,
 		policyGetter: getter.NewDownloadReleasedPolicy(),
 	}
 

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -2,11 +2,15 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/mark3labs/mcp-go/mcp"
+
+	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
 )
 
 func TestParseVulnManifestURI(t *testing.T) {
@@ -110,9 +114,10 @@ func TestParseVulnManifestURI(t *testing.T) {
 func TestReadConfigurationResource_URIParsing(t *testing.T) {
 	expectedErr := fmt.Errorf("sentinel connection error")
 	ksServer := &KubescapeMcpserver{
-		ksClientErr: expectedErr,
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return nil, expectedErr
+		},
 	}
-	ksServer.ksClientOnce.Do(func() {}) // Mark as done to prevent real connection
 
 	tests := []struct {
 		name      string
@@ -181,9 +186,10 @@ func TestReadConfigurationResource_URIParsing(t *testing.T) {
 func TestReadContainerProfileResource_URIParsing(t *testing.T) {
 	expectedErr := fmt.Errorf("sentinel connection error")
 	ksServer := &KubescapeMcpserver{
-		ksClientErr: expectedErr,
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return nil, expectedErr
+		},
 	}
-	ksServer.ksClientOnce.Do(func() {}) // Mark as done to prevent real connection
 
 	tests := []struct {
 		name      string
@@ -313,5 +319,193 @@ func TestCallTool_RunFrameworkScan(t *testing.T) {
 				t.Errorf("expected error containing %q, got %q", tt.wantErrString, res.Content[0].(mcp.TextContent).Text)
 			}
 		})
+	}
+}
+
+func TestGetKsClient_RetriesAfterTransientFailure(t *testing.T) {
+	sentinelErr := fmt.Errorf("transient init failure")
+	calls := 0
+	fakeClient := struct {
+		spdxv1beta1.SpdxV1beta1Interface
+	}{}
+	ksServer := &KubescapeMcpserver{
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			calls++
+			if calls == 1 {
+				return nil, sentinelErr
+			}
+			return fakeClient, nil
+		},
+	}
+
+	_, err := ksServer.getKsClient()
+	if err == nil || !strings.Contains(err.Error(), "transient init failure") {
+		t.Fatalf("expected transient init failure on first call, got: %v", err)
+	}
+
+	client, err := ksServer.getKsClient()
+	if err != nil {
+		t.Fatalf("expected retry to succeed after transient failure, got error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client after successful retry")
+	}
+	if calls != 2 {
+		t.Fatalf("expected init to be called twice (once failing, once succeeding), got %d calls", calls)
+	}
+
+	// A subsequent call must reuse the cached successful client, not re-init.
+	if _, err := ksServer.getKsClient(); err != nil {
+		t.Fatalf("unexpected error on cached client call: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected init not to be called again once a client is cached, got %d calls", calls)
+	}
+}
+
+func TestGetKsClient_DefaultInitializerIsUsedAndCached(t *testing.T) {
+	origNewKsClient := newKsClient
+	t.Cleanup(func() { newKsClient = origNewKsClient })
+
+	calls := 0
+	fakeClient := struct {
+		spdxv1beta1.SpdxV1beta1Interface
+	}{}
+	newKsClient = func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+		calls++
+		return fakeClient, nil
+	}
+
+	ksServer := &KubescapeMcpserver{}
+	first, err := ksServer.getKsClient()
+	if err != nil {
+		t.Fatalf("unexpected error from default initializer: %v", err)
+	}
+	second, err := ksServer.getKsClient()
+	if err != nil {
+		t.Fatalf("unexpected error from cached default initializer: %v", err)
+	}
+	if first != fakeClient || second != fakeClient {
+		t.Fatal("expected the default initializer client to be cached and reused")
+	}
+	if calls != 1 {
+		t.Fatalf("expected default initializer to run once, got %d calls", calls)
+	}
+}
+
+func TestGetK8sClient_NotConnectedReturnsError(t *testing.T) {
+	origLoadK8sConfig := loadK8sConfig
+	origSetConnectedToCluster := setConnectedToCluster
+	origNewK8sClient := newK8sClient
+	t.Cleanup(func() {
+		loadK8sConfig = origLoadK8sConfig
+		setConnectedToCluster = origSetConnectedToCluster
+		newK8sClient = origNewK8sClient
+	})
+
+	loadK8sConfig = func() error { return errors.New("no kubeconfig") }
+	setConnectedToCluster = func(bool) {}
+	calledConstructor := false
+	newK8sClient = func() *k8sinterface.KubernetesApi {
+		calledConstructor = true
+		return &k8sinterface.KubernetesApi{}
+	}
+
+	ksServer := &KubescapeMcpserver{}
+	client, err := ksServer.getK8sClient()
+	if err == nil {
+		t.Fatal("expected error when no cluster is reachable, got nil")
+	}
+	if client != nil {
+		t.Fatalf("expected nil client on error, got %v", client)
+	}
+	if calledConstructor {
+		t.Fatal("expected constructor not to run when cluster connectivity is absent")
+	}
+}
+
+func TestGetK8sClient_InitializesOnceAndCachesClient(t *testing.T) {
+	origLoadK8sConfig := loadK8sConfig
+	origSetConnectedToCluster := setConnectedToCluster
+	origNewK8sClient := newK8sClient
+	t.Cleanup(func() {
+		loadK8sConfig = origLoadK8sConfig
+		setConnectedToCluster = origSetConnectedToCluster
+		newK8sClient = origNewK8sClient
+	})
+
+	loadK8sConfig = func() error { return nil }
+	setConnectedToCluster = func(bool) {}
+	calls := 0
+	fakeClient := &k8sinterface.KubernetesApi{}
+	newK8sClient = func() *k8sinterface.KubernetesApi {
+		calls++
+		return fakeClient
+	}
+
+	ksServer := &KubescapeMcpserver{}
+	first, err := ksServer.getK8sClient()
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	second, err := ksServer.getK8sClient()
+	if err != nil {
+		t.Fatalf("unexpected error reusing cached client: %v", err)
+	}
+	if first != fakeClient || second != fakeClient {
+		t.Fatal("expected constructed client to be cached and reused")
+	}
+	if calls != 1 {
+		t.Fatalf("expected constructor to run once, got %d calls", calls)
+	}
+}
+
+// TestGetK8sClient_RetriesAfterTransientLoadFailure guards against
+// k8sinterface.IsConnectedToCluster's one-way latch: it only ever moves to
+// false, so a naive connectivity check would return the same error forever
+// after one transient kubeconfig read failure. getK8sClient must retry via
+// loadK8sConfig instead, which has no such latch.
+func TestGetK8sClient_RetriesAfterTransientLoadFailure(t *testing.T) {
+	origLoadK8sConfig := loadK8sConfig
+	origSetConnectedToCluster := setConnectedToCluster
+	origNewK8sClient := newK8sClient
+	t.Cleanup(func() {
+		loadK8sConfig = origLoadK8sConfig
+		setConnectedToCluster = origSetConnectedToCluster
+		newK8sClient = origNewK8sClient
+	})
+
+	loadErr := errors.New("transient kubeconfig read failure")
+	shouldFail := true
+	loadK8sConfig = func() error {
+		if shouldFail {
+			return loadErr
+		}
+		return nil
+	}
+	var latch bool
+	setConnectedToCluster = func(connected bool) { latch = connected }
+	fakeClient := &k8sinterface.KubernetesApi{}
+	newK8sClient = func() *k8sinterface.KubernetesApi { return fakeClient }
+
+	ksServer := &KubescapeMcpserver{}
+
+	if _, err := ksServer.getK8sClient(); err == nil {
+		t.Fatal("expected error on first, transient failure")
+	}
+	if latch {
+		t.Fatal("expected the connectivity latch to be false after a failed load")
+	}
+
+	shouldFail = false
+	client, err := ksServer.getK8sClient()
+	if err != nil {
+		t.Fatalf("expected retry to succeed after the transient condition cleared, got: %v", err)
+	}
+	if client != fakeClient {
+		t.Fatalf("expected retried call to return the constructed client, got %v", client)
+	}
+	if !latch {
+		t.Fatal("expected the connectivity latch to be cleared to true on successful retry")
 	}
 }

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
 )
 
 func TestParseVulnManifestURI(t *testing.T) {
@@ -110,9 +112,10 @@ func TestParseVulnManifestURI(t *testing.T) {
 func TestReadConfigurationResource_URIParsing(t *testing.T) {
 	expectedErr := fmt.Errorf("sentinel connection error")
 	ksServer := &KubescapeMcpserver{
-		ksClientErr: expectedErr,
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return nil, expectedErr
+		},
 	}
-	ksServer.ksClientOnce.Do(func() {}) // Mark as done to prevent real connection
 
 	tests := []struct {
 		name      string
@@ -181,9 +184,10 @@ func TestReadConfigurationResource_URIParsing(t *testing.T) {
 func TestReadContainerProfileResource_URIParsing(t *testing.T) {
 	expectedErr := fmt.Errorf("sentinel connection error")
 	ksServer := &KubescapeMcpserver{
-		ksClientErr: expectedErr,
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return nil, expectedErr
+		},
 	}
-	ksServer.ksClientOnce.Do(func() {}) // Mark as done to prevent real connection
 
 	tests := []struct {
 		name      string
@@ -313,5 +317,46 @@ func TestCallTool_RunFrameworkScan(t *testing.T) {
 				t.Errorf("expected error containing %q, got %q", tt.wantErrString, res.Content[0].(mcp.TextContent).Text)
 			}
 		})
+	}
+}
+
+func TestGetKsClient_RetriesAfterTransientFailure(t *testing.T) {
+	sentinelErr := fmt.Errorf("transient init failure")
+	calls := 0
+	fakeClient := struct {
+		spdxv1beta1.SpdxV1beta1Interface
+	}{}
+	ksServer := &KubescapeMcpserver{
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			calls++
+			if calls == 1 {
+				return nil, sentinelErr
+			}
+			return fakeClient, nil
+		},
+	}
+
+	_, err := ksServer.getKsClient()
+	if err == nil || !strings.Contains(err.Error(), "transient init failure") {
+		t.Fatalf("expected transient init failure on first call, got: %v", err)
+	}
+
+	client, err := ksServer.getKsClient()
+	if err != nil {
+		t.Fatalf("expected retry to succeed after transient failure, got error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client after successful retry")
+	}
+	if calls != 2 {
+		t.Fatalf("expected init to be called twice (once failing, once succeeding), got %d calls", calls)
+	}
+
+	// A subsequent call must reuse the cached successful client, not re-init.
+	if _, err := ksServer.getKsClient(); err != nil {
+		t.Fatalf("unexpected error on cached client call: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected init not to be called again once a client is cached, got %d calls", calls)
 	}
 }

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/mark3labs/mcp-go/mcp"
 
 	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
@@ -358,5 +359,37 @@ func TestGetKsClient_RetriesAfterTransientFailure(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("expected init not to be called again once a client is cached, got %d calls", calls)
+	}
+}
+
+func TestGetK8sClient_NotConnectedReturnsError(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	// When not connected to a cluster, getK8sClient must return an error
+	// instead of calling k8sinterface.NewKubernetesApi, which terminates the
+	// process on most internal failures.
+	if k8sinterface.IsConnectedToCluster() {
+		t.Skip("test requires no cluster connection to be available")
+	}
+
+	client, err := ksServer.getK8sClient()
+	if err == nil {
+		t.Fatal("expected error when no cluster is reachable, got nil")
+	}
+	if client != nil {
+		t.Fatalf("expected nil client on error, got %v", client)
+	}
+}
+
+func TestGetK8sClient_CachesClient(t *testing.T) {
+	fakeClient := &k8sinterface.KubernetesApi{}
+	ksServer := &KubescapeMcpserver{k8sClient: fakeClient}
+
+	client, err := ksServer.getK8sClient()
+	if err != nil {
+		t.Fatalf("unexpected error for pre-populated client: %v", err)
+	}
+	if client != fakeClient {
+		t.Fatalf("expected cached client to be returned, got %v", client)
 	}
 }

--- a/cmd/mcpserver/scan_helper.go
+++ b/cmd/mcpserver/scan_helper.go
@@ -46,10 +46,11 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 
 	var client *k8sinterface.KubernetesApi
 	if rsrcHandler == nil {
-		if !k8sinterface.IsConnectedToCluster() {
-			return nil, fmt.Errorf("no reachable kubernetes cluster: ensure KUBECONFIG is set or the server is running inside a cluster")
+		var err error
+		client, err = ksServer.getK8sClient()
+		if err != nil {
+			return nil, err
 		}
-		client = ksServer.getK8sClient()
 	}
 
 	timeout := 10 * time.Second


### PR DESCRIPTION
## Overview
Fixes `KubescapeMcpserver.getKsClient` and `getK8sClient` so a transient kubeconfig or auth failure during initialization no longer gets cached forever via `sync.Once`. The client init now uses a mutex-guarded lazy init that retries on failure and only memoizes a successful client.

Resolved #2627

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to Kubernetes and Kubescape services.
  * Transient initialization failures now retry automatically.
  * Valid service connections are reused for subsequent requests.
  * Invalid or unavailable connections are rejected with clear errors.
  * Scans now report Kubernetes connectivity issues directly when no cluster is available.
  * Server startup no longer requires an immediate Kubernetes connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->