### PR TITLE
fix: skip StopSuccess log message on image scan error

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -396,6 +396,7 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 		logger.L().Start("Scanning", helpers.String("image", img))
 		if err := scanSingleImage(ctx, img, svc, resultsHandling); err != nil {
 			logger.L().StopError("failed to scan", helpers.String("image", img), helpers.Error(err))
+			continue
 		}
 		logger.L().StopSuccess("Done scanning", helpers.String("image", img))
 	}


### PR DESCRIPTION
This PR implements the fix proposed in #2630.

### Description
In `core/core/scan.go`, when scanning images in the batch loop, `StopSuccess("Done scanning")` fires **unconditionally** — even when `scanSingleImage` just returned an error and `StopError` was already logged.

This PR adds a `continue` statement after `StopError` to correctly skip the success message and proceed to the next image, mirroring the behavior already present in `image_scan.go`.

### Verification
- `core/core` tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

