### PR TITLE
fix: prevent compliance score below 100 from rounding up to 100

### DIFF
--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -21,3 +21,14 @@ func Float16ToInt(x float32) int {
 func Float32ToIntFloor(x float32) int {
 	return int(math.Floor(float64(x)))
 }
+
+// Float32ToIntComplianceScore converts a compliance score to int so a non-perfect score never displays as 100
+func Float32ToIntComplianceScore(score float32) int {
+	if score >= 100 {
+		return 100
+	}
+	if score > 99 {
+		return 99
+	}
+	return Float32ToInt(score)
+}

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -35,3 +35,24 @@ func TestFloat16ToInt(t *testing.T) {
 	assert.Equal(t, -4, Float16ToInt(-3.5))
 	assert.Equal(t, -4, Float16ToInt(-3.51))
 }
+
+func TestFloat32ToIntComplianceScore(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  int
+	}{
+		{name: "perfect score stays 100", score: 100.0, want: 100},
+		{name: "99.5 does not round up to 100", score: 99.5, want: 99},
+		{name: "99.9 does not round up to 100", score: 99.9, want: 99},
+		{name: "99.0 stays 99", score: 99.0, want: 99},
+		{name: "50.4 rounds normally", score: 50.4, want: 50},
+		{name: "0.4 rounds normally", score: 0.4, want: 0},
+		{name: "0.0 stays 0", score: 0.0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Float32ToIntComplianceScore(tt.score))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -41,7 +41,7 @@ func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string
 }
 
 func (jsonPrinter *JsonPrinter) Score(score float32) {
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToIntComplianceScore(score))
 }
 
 func (jsonPrinter *JsonPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -28,7 +28,7 @@ func (p *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 }
 
 func (p *PrometheusPrinter) Score(score float32) {
-	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToIntComplianceScore(score))
 }
 
 func (p *PrometheusPrinter) printResources(allResources map[string]workloadinterface.IMetadata, resourcesIDs *reporthandling.ResourcesIDs, frameworkName, controlName string) {

--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -51,10 +51,10 @@ func getComplianceScoreColumn(controlSummary reportsummary.IControlSummary, info
 	if controlSummary.GetStatus().IsSkipped() {
 		return fmt.Sprintf("%s %s", "Action Required", getInfoColumn(controlSummary, infoToPrintInfo))
 	}
-	if compliance := cautils.Float32ToInt(controlSummary.GetComplianceScore()); compliance < 0 {
+	if compliance := cautils.Float32ToIntComplianceScore(controlSummary.GetComplianceScore()); compliance < 0 {
 		return "N/A"
 	} else {
-		return fmt.Sprintf("%d", cautils.Float32ToInt(controlSummary.GetComplianceScore())) + "%"
+		return fmt.Sprintf("%d", cautils.Float32ToIntComplianceScore(controlSummary.GetComplianceScore())) + "%"
 	}
 
 }

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -54,7 +54,7 @@ func (jp *JsonPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToIntComplianceScore(score))
 
 }
 func (jp *JsonPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) (*imageprinter.ImageScanSummary, error) {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -54,6 +54,11 @@ func TestScore_Json(t *testing.T) {
 			score: 100,
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 100\n",
 		},
+		{
+			name:  "Non-perfect score does not round up to 100",
+			score: 99.5,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n",
+		},
 	}
 
 	jp := NewJsonPrinter()

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -118,7 +118,7 @@ func (jp *JunitPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToIntComplianceScore(score))
 }
 
 func (jp *JunitPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -59,7 +59,7 @@ func (pp *PdfPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToIntComplianceScore(score))
 }
 
 func (pp *PdfPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -87,7 +87,7 @@ func GetComplianceScoreColumn(controlSummary reportsummary.IControlSummary, info
 	if controlSummary.GetStatus().IsSkipped() {
 		return fmt.Sprintf("%s %s", "Action Required", GetInfoColumn(controlSummary, infoToPrintInfo))
 	}
-	return fmt.Sprintf("%d", cautils.Float32ToInt(controlSummary.GetComplianceScore())) + "%"
+	return fmt.Sprintf("%d", cautils.Float32ToIntComplianceScore(controlSummary.GetComplianceScore())) + "%"
 }
 
 func GetInfoColumn(controlSummary reportsummary.IControlSummary, infoToPrintInfo []utils.InfoStars) string {

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -60,7 +60,7 @@ func (pp *PrometheusPrinter) Score(score float32) {
 
 	fmt.Fprintf(pp.writer, "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n")
 	fmt.Fprintf(pp.writer, "# TYPE kubescape_score gauge\n")
-	fmt.Fprintf(pp.writer, "kubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(pp.writer, "kubescape_score %d\n", cautils.Float32ToIntComplianceScore(score))
 }
 
 func (pp *PrometheusPrinter) generatePrometheusFormat(

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -86,6 +86,11 @@ func TestScore(t *testing.T) {
 			score: 100,
 			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 100\n",
 		},
+		{
+			name:  "Non-perfect score does not round up to 100",
+			score: 99.5,
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 99\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -325,12 +325,12 @@ func (mcrs *mControlComplianceScore) set(resources reportsummary.ICounters) {
 func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetails) {
 	m.rs.set(summaryDetails.NumberOfResources(), summaryDetails.NumberOfControls())
 	// GetScore() returns the risk score; the metric is the compliance score.
-	m.rs.complianceScore = cautils.Float32ToInt(summaryDetails.ComplianceScore)
+	m.rs.complianceScore = cautils.Float32ToIntComplianceScore(summaryDetails.ComplianceScore)
 
 	for _, fw := range summaryDetails.ListFrameworks() {
 		mfrs := mFrameworkComplianceScore{
 			frameworkName:   fw.GetName(),
-			complianceScore: cautils.Float32ToInt(fw.GetComplianceScore()),
+			complianceScore: cautils.Float32ToIntComplianceScore(fw.GetComplianceScore()),
 		}
 		mfrs.set(fw.NumberOfResources(), fw.NumberOfControls())
 		m.listFrameworks = append(m.listFrameworks, mfrs)
@@ -340,7 +340,7 @@ func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetai
 		mcrs := mControlComplianceScore{
 			controlName:     control.GetName(),
 			controlID:       control.GetID(),
-			complianceScore: cautils.Float32ToInt(control.GetComplianceScore()),
+			complianceScore: cautils.Float32ToIntComplianceScore(control.GetComplianceScore()),
 			link:            cautils.GetControlLink(control.GetID()),
 			severity:        apis.ControlSeverityToString(control.GetScoreFactor()),
 			remediation:     control.GetRemediation(),


### PR DESCRIPTION
## Overview

`Float32ToInt` uses `math.Round`, so a real compliance score of 99.5 rounded up to 100 on several display surfaces, falsely signaling perfect compliance while a resource was still failing.

Adds `Float32ToIntComplianceScore` which returns 100 only for a genuine score of 100 or above, floors anything in the (99, 100) band to 99 so a non-perfect score never shows 100, and rounds normally otherwise. Applied to the compliance-score surfaces only:

- the "Overall compliance-score" console banner
- the Prometheus cluster, framework, and per-control compliance gauges
- the pretty per-control table cell

JSON and the pretty footer already emit the correct fractional value and are left unchanged as the source of truth. Risk score and coverage callers keep their existing rounding.

## How to Test

```bash
go test -v ./core/cautils/... ./core/pkg/resultshandling/...
```

End to end with 199 passing pods and 1 failing pod (true score 99.5):

```bash
kubescape scan control C-0057 scale.yaml --format json       --output s.json
kubescape scan control C-0057 scale.yaml --format prometheus --output s.prom
```

Before the fix the console banner and `kubescape_cluster_complianceScore` showed 100. After the fix they show 99, while JSON still reports 99.5.

## Additional Information

New table-driven test `TestFloat32ToIntComplianceScore` covers 100→100, 99.5→99, 99.9→99, 99.0→99, 50.4→50, 0.4→0, 0.0→0. The prometheus and json score tests were extended with a 99.5→99 case.

## Related issues/PRs

* Resolved #2626

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compliance scores just below 100% now consistently display as 99%, preventing them from being shown as a perfect score.
  * Scores of exactly 100% remain displayed as 100%.
  * Updated score formatting across JSON, Prometheus, JUnit, PDF, table, and human-readable outputs.
* **Tests**
  * Added coverage for boundary values and standard score rounding.
  * Added regression checks confirming that 99.5% is reported as 99%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->