### PR TITLE
fix(printer): clean temp dir in fallback tests

### DIFF
--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -58,7 +58,7 @@ func TestGetWriterNoStdoutFallback_UnwritableTargetFallsBackToTemp(t *testing.T)
 		_ = os.Remove(f.Name())
 	})
 
-	assert.Equal(t, os.TempDir(), filepath.Dir(f.Name()))
+	assert.Equal(t, filepath.Clean(os.TempDir()), filepath.Dir(f.Name()))
 	assert.True(t, strings.HasPrefix(filepath.Base(f.Name()), "kubescape-report-"))
 	assert.True(t, strings.HasSuffix(f.Name(), ".pdf"))
 	_, err := f.WriteString("pdf-bytes") // the handle must be usable, not a discard sink
@@ -140,7 +140,7 @@ func TestGetWriterNoStdoutFallback_MkdirAllFailsFallsBackToTemp(t *testing.T) {
 		_ = os.Remove(f.Name())
 	})
 
-	assert.Equal(t, os.TempDir(), filepath.Dir(f.Name()))
+	assert.Equal(t, filepath.Clean(os.TempDir()), filepath.Dir(f.Name()))
 	assert.True(t, strings.HasPrefix(filepath.Base(f.Name()), "kubescape-report-"))
 	assert.True(t, strings.HasSuffix(f.Name(), ".pdf"))
 	_, err := f.WriteString("pdf-bytes") // the handle must be usable, not a discard sink


### PR DESCRIPTION
## Overview
Normalize the expected temp directory in `GetWriterNoStdoutFallback` fallback tests with `filepath.Clean(os.TempDir())`. On macOS, `os.TempDir()` can include a trailing separator while `filepath.Dir(f.Name())` returns the cleaned directory path, causing otherwise valid temp-file fallback tests to fail.

## Reproduction
Before this change, `go test ./core/pkg/resultshandling/printer` failed with comparisons like:

```
expected: "/var/folders/.../T/"
actual  : "/var/folders/.../T"
```

## How to Test
- `go test ./core/pkg/resultshandling/printer`
- `go test ./core/pkg/resultshandling/...`
- `go test ./...`

## Related issues/PRs
No matching open issue or PR found for this temp directory assertion behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary-directory path checks to work consistently across platforms.
  * Preserved validation of fallback path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->