### PR TITLE
fix(httphandler): harden metrics query handling

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -36,6 +36,11 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	scanID := uuid.NewString()
 	defer handler.recover(r.Context(), w, scanID)
 
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	scanCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
 	defer cancel()
 
@@ -48,8 +53,6 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), scanID)
 		return
 	}
-	skipPersistence := r.URL.Query().Get("skipPersistence") == "true"
-
 	resultsFile := filepath.Join(OutputDir, scanID)
 	scanInfo := getPrometheusDefaultScanCommand(scanID, resultsFile, metricsQueryParams.Frameworks)
 
@@ -57,7 +60,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		scanQueryParams: &ScanQueryParams{
 			ReturnResults:   true,
 			KeepResults:     false,
-			SkipPersistence: skipPersistence,
+			SkipPersistence: metricsQueryParams.SkipPersistence,
 		},
 		scanInfo: scanInfo,
 		scanID:   scanID,
@@ -67,7 +70,16 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	// send to scan queue
 	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/metrics"))
-	handler.scanRequestChan <- scanParams
+	select {
+	case handler.scanRequestChan <- scanParams:
+	default:
+		handler.state.setNotBusy(scanID)
+		w.Header().Set("Retry-After", "1")
+		handler.writeErrorWithStatus(w,
+			fmt.Errorf("scan queue is full; retry the request later"),
+			"", http.StatusTooManyRequests)
+		return
+	}
 
 	// wait for scan to complete
 	results := <-scanParams.resp
@@ -109,9 +121,8 @@ func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string
 	scanInfo.Format = envToString("KS_FORMAT", "prometheus") // default output format is prometheus
 
 	// Check if specific frameworks are requested via query parameter
-	if frameworksParam != "" {
-		// Scan specific frameworks (comma-separated list)
-		frameworks := splitAndTrim(frameworksParam, ",")
+	frameworks := splitAndTrim(frameworksParam, ",")
+	if len(frameworks) > 0 {
 		scanInfo.SetPolicyIdentifiers(frameworks, utilsapisv1.KindFramework)
 	} else {
 		// Default: scan all available frameworks (including CIS)

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -2,56 +2,74 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPrometheusDefaultScanCommand(t *testing.T) {
-	t.Run("default behavior - scan all frameworks", func(t *testing.T) {
-		scanID := "1234"
-		outputFile := filepath.Join(OutputDir, scanID)
-		scanInfo := getPrometheusDefaultScanCommand(scanID, outputFile, "")
+	tests := []struct {
+		name             string
+		frameworksParam  string
+		wantScanAll      bool
+		wantFrameworkIDs []string
+	}{
+		{
+			name:        "default behavior - scan all frameworks",
+			wantScanAll: true,
+		},
+		{
+			name:             "specific frameworks via query parameter",
+			frameworksParam:  "nsa,mitre,cis-v1.10.0",
+			wantFrameworkIDs: []string{"nsa", "mitre", "cis-v1.10.0"},
+		},
+		{
+			name:            "empty framework entries fall back to scanning all",
+			frameworksParam: " , , ",
+			wantScanAll:     true,
+		},
+		{
+			name:             "specific frameworks ignore empty entries",
+			frameworksParam:  "nsa, , mitre",
+			wantFrameworkIDs: []string{"nsa", "mitre"},
+		},
+	}
 
-		assert.Equal(t, scanID, scanInfo.ScanID)
-		assert.Equal(t, outputFile, scanInfo.Output)
-		assert.Equal(t, "prometheus", scanInfo.Format)
-		assert.False(t, scanInfo.Submit.GetBool())
-		assert.True(t, scanInfo.Local)
-		assert.True(t, scanInfo.FrameworkScan)
-		assert.True(t, scanInfo.ScanAll) // Scan all available frameworks by default
-		assert.False(t, scanInfo.HostSensorEnabled.GetBool())
-		assert.Equal(t, getter.DefaultLocalStore, scanInfo.UseArtifactsFrom)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanID := "1234"
+			outputFile := filepath.Join(OutputDir, scanID)
+			scanInfo := getPrometheusDefaultScanCommand(scanID, outputFile, tt.frameworksParam)
 
-	t.Run("specific frameworks via query parameter", func(t *testing.T) {
-		scanID := "5678"
-		outputFile := filepath.Join(OutputDir, scanID)
-		scanInfo := getPrometheusDefaultScanCommand(scanID, outputFile, "nsa,mitre,cis-v1.10.0")
+			assert.Equal(t, scanID, scanInfo.ScanID)
+			assert.Equal(t, outputFile, scanInfo.Output)
+			assert.Equal(t, "prometheus", scanInfo.Format)
+			assert.False(t, scanInfo.Submit.GetBool())
+			assert.True(t, scanInfo.Local)
+			assert.True(t, scanInfo.FrameworkScan)
+			assert.Equal(t, tt.wantScanAll, scanInfo.ScanAll)
+			assert.False(t, scanInfo.HostSensorEnabled.GetBool())
+			assert.Equal(t, getter.DefaultLocalStore, scanInfo.UseArtifactsFrom)
+			assert.Len(t, scanInfo.PolicyIdentifier, len(tt.wantFrameworkIDs))
 
-		assert.Equal(t, scanID, scanInfo.ScanID)
-		assert.Equal(t, outputFile, scanInfo.Output)
-		assert.Equal(t, "prometheus", scanInfo.Format)
-		assert.False(t, scanInfo.Submit.GetBool())
-		assert.True(t, scanInfo.Local)
-		assert.True(t, scanInfo.FrameworkScan)
-		assert.False(t, scanInfo.ScanAll) // Don't scan all when specific frameworks are set
-		assert.False(t, scanInfo.HostSensorEnabled.GetBool())
-		assert.Equal(t, getter.DefaultLocalStore, scanInfo.UseArtifactsFrom)
-
-		// Verify specific frameworks are set
-		assert.Len(t, scanInfo.PolicyIdentifier, 3)
-		assert.Equal(t, "nsa", scanInfo.PolicyIdentifier[0].Identifier)
-		assert.Equal(t, "mitre", scanInfo.PolicyIdentifier[1].Identifier)
-		assert.Equal(t, "cis-v1.10.0", scanInfo.PolicyIdentifier[2].Identifier)
-	})
+			for i, wantFrameworkID := range tt.wantFrameworkIDs {
+				assert.Equal(t, wantFrameworkID, scanInfo.PolicyIdentifier[i].Identifier)
+			}
+		})
+	}
 }
 
 // TestMetrics_ScanContextDecoupledFromRequest ensures the metrics scan is not
@@ -89,6 +107,179 @@ func TestMetrics_ScanContextDecoupledFromRequest(t *testing.T) {
 	case <-handlerDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("handler did not complete")
+	}
+}
+
+func TestMetrics_UsesDecodedSkipPersistenceQueryParam(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "absent", raw: "", want: false},
+		{name: "lowercase true", raw: "true", want: true},
+		{name: "titlecase true", raw: "True", want: true},
+		{name: "numeric true", raw: "1", want: true},
+		{name: "lowercase false", raw: "false", want: false},
+		{name: "titlecase false", raw: "False", want: false},
+		{name: "numeric false", raw: "0", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTempOutputDirs(t)
+
+			defer func(o scanner) { scanImpl = o }(scanImpl)
+			gotSkipPersistence := make(chan bool, 1)
+			scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
+				gotSkipPersistence <- skipPersistence
+				require.NoError(t, os.WriteFile(scanInfo.Output, []byte("# metrics\n"), 0o600))
+				return nil, nil
+			}
+
+			h := NewHTTPHandler(false)
+			target := "/v1/metrics"
+			if tt.raw != "" {
+				target += "?skipPersistence=" + url.QueryEscape(tt.raw)
+			}
+			rq := httptest.NewRequest(http.MethodGet, target, nil)
+			w := httptest.NewRecorder()
+
+			h.Metrics(w, rq)
+
+			require.Equal(t, http.StatusOK, w.Result().StatusCode)
+			select {
+			case got := <-gotSkipPersistence:
+				assert.Equal(t, tt.want, got)
+			case <-time.After(5 * time.Second):
+				t.Fatal("scan was not invoked")
+			}
+		})
+	}
+}
+
+func TestMetrics_InvalidSkipPersistenceQueryParam(t *testing.T) {
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanCalled := make(chan struct{}, 1)
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		scanCalled <- struct{}{}
+		return nil, nil
+	}
+
+	h := NewHTTPHandler(false)
+	rq := httptest.NewRequest(http.MethodGet, "/v1/metrics?skipPersistence=definitely", nil)
+	w := httptest.NewRecorder()
+
+	h.Metrics(w, rq)
+
+	require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	select {
+	case <-scanCalled:
+		t.Fatal("scan should not be invoked when query parsing fails")
+	default:
+	}
+}
+
+func TestMetrics_NonGetMethodReturns405WithoutScanning(t *testing.T) {
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	scanCalled := make(chan struct{}, 1)
+	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+		scanCalled <- struct{}{}
+		return nil, nil
+	}
+
+	h := NewHTTPHandler(false)
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			rq := httptest.NewRequest(method, "/v1/metrics", nil)
+			w := httptest.NewRecorder()
+
+			h.Metrics(w, rq)
+
+			require.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+			select {
+			case <-scanCalled:
+				t.Fatal("scan should not be invoked for non-GET metrics requests")
+			default:
+			}
+		})
+	}
+}
+
+func TestMetricsQueueRejectsRequestsWhenCapacityIsExhausted(t *testing.T) {
+	withTempOutputDirs(t)
+
+	originalScanImpl := scanImpl
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var releaseOnce sync.Once
+	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
+	scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+		once.Do(func() { close(started) })
+		<-release
+		require.NoError(t, os.WriteFile(scanInfo.Output, []byte("# metrics\n"), 0o600))
+		return nil, nil
+	}
+	handler := newHTTPHandler(false, 1, defaultMaxScanRequestBodyBytes)
+	t.Cleanup(func() {
+		releaseScans()
+		require.Eventually(t, func() bool { return handlerStateIsDrained(handler) }, time.Second, 10*time.Millisecond)
+		scanImpl = originalScanImpl
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		recorder := httptest.NewRecorder()
+		handler.Metrics(recorder, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
+		close(firstDone)
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first metrics scan did not start")
+	}
+
+	secondQueued := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		recorder := httptest.NewRecorder()
+		handler.Metrics(recorder, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
+		close(secondDone)
+	}()
+	require.Eventually(t, func() bool {
+		if len(handler.scanRequestChan) == 1 {
+			close(secondQueued)
+			return true
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+
+	rejected := httptest.NewRecorder()
+	handler.Metrics(rejected, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
+
+	assert.Equal(t, http.StatusTooManyRequests, rejected.Code)
+	assert.Equal(t, "1", rejected.Header().Get("Retry-After"))
+	response := decodeScanResponse(t, rejected)
+	assert.Equal(t, utilsapisv1.ErrorScanResponseType, response.Type)
+	assert.Contains(t, fmt.Sprint(response.Response), "scan queue is full")
+
+	releaseScans()
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first metrics request did not complete")
+	}
+	select {
+	case <-secondQueued:
+	default:
+		t.Fatal("second metrics request was not queued")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second metrics request did not complete")
 	}
 }
 


### PR DESCRIPTION
## Overview
Harden `/v1/metrics` request handling around query parsing and admission:

- use the decoded `skipPersistence` boolean instead of re-reading the raw query as exactly `"true"`
- treat framework filters with only empty entries (for example `frameworks= , , `) as the default scan-all behavior
- reject non-GET metrics requests before starting a scan
- return `429 Too Many Requests` with `Retry-After: 1` when the scan queue is full instead of blocking the request

## Reproduction
Before this change:

- `/v1/metrics?skipPersistence=True` and `/v1/metrics?skipPersistence=1` parsed successfully but passed `skipPersistence=false` into the scan path
- `/v1/metrics?frameworks=,%20,` disabled `ScanAll` while setting zero framework identifiers
- non-GET requests to `/v1/metrics` could enqueue scans
- a full scan queue could block metrics requests instead of returning backpressure

## How to Test
- `cd httphandler && go test ./handlerequests/v1 -run 'TestGetPrometheusDefaultScanCommand|TestMetrics_UsesDecodedSkipPersistenceQueryParam|TestMetrics_InvalidSkipPersistenceQueryParam|TestMetrics_NonGetMethodReturns405WithoutScanning|TestMetricsQueueRejectsRequestsWhenCapacityIsExhausted|TestSplitAndTrim'`\n- `cd httphandler && go test ./handlerequests/v1`\n- `cd httphandler && go test ./storage .`\n- `cd httphandler && go test ./config`\n\n`cd httphandler && go test ./...` was also attempted, but an unrelated existing listener test timed out in `TestSetupHTTPListener/fails_fast_over_plain_HTTP_when_the_port_is_already_bound` while blocked in `Server.ListenAndServe`.\n\n## Related issues/PRs\nNo matching open issue or PR found for these `/v1/metrics` query/admission behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prometheus metrics requests now accept only GET requests.
  - Invalid query parameters return clearer error responses.
  - Scan requests receive a retry response when the scan queue is full.
  - Framework selection now correctly handles empty or whitespace-only values.
  - Persistence options are parsed consistently from request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->