### PR TITLE
fix(listener): fail fast when server port is busy

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -36,8 +37,13 @@ func SetupHTTPListener() error {
 	if err != nil {
 		return err
 	}
+	addr := fmt.Sprintf(":%s", getPort())
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
 	server := &http.Server{
-		Addr: fmt.Sprintf(":%s", getPort()), // TODO - support loading port from config/env
+		Addr: addr, // TODO - support loading port from config/env
 		// ReadHeaderTimeout defends against slowloris-style attacks without
 		// capping handler duration. ReadTimeout and WriteTimeout are left at 0
 		// because the synchronous scan path (POST /v1/scan?wait=true) blocks
@@ -83,9 +89,9 @@ func SetupHTTPListener() error {
 	servePprof()
 
 	if keyPair != nil {
-		return server.ListenAndServeTLS("", "")
+		return server.ServeTLS(ln, "", "")
 	}
-	return server.ListenAndServe()
+	return server.Serve(ln)
 }
 
 func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -81,13 +81,12 @@ func TestGetKeyFile(t *testing.T) {
 	})
 }
 
-// occupyPort binds a loopback listener on a free port so a subsequent bind to
-// ":<port>" (all interfaces) fails immediately with "address already in use",
-// letting SetupHTTPListener's server-start path be exercised without actually
-// serving traffic.
+// occupyPort binds the same wildcard address shape used by SetupHTTPListener
+// so a subsequent bind to ":<port>" fails immediately with "address already in
+// use", letting the server-start path be exercised without serving traffic.
 func occupyPort(t *testing.T) (net.Listener, string) {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	_, port, err := net.SplitHostPort(ln.Addr().String())
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview
Make `SetupHTTPListener` bind its TCP listener before building handlers and starting listener-side setup, then serve on that listener. This makes a busy `KS_PORT` fail immediately before side-effect goroutines are started.

The listener port-conflict test now reserves the same wildcard address shape that `SetupHTTPListener` uses (`:<port>`), instead of reserving only `127.0.0.1:<port>`. On macOS, the old test could still allow the wildcard bind to succeed, accidentally starting a real server and hanging until the Go test timeout.

## Reproduction
Before this change, this command timed out while blocked in `Server.ListenAndServe`:

```sh
cd httphandler && go test ./listener -run 'TestSetupHTTPListener/fails_fast_over_plain_HTTP_when_the_port_is_already_bound' -timeout 15s\n```\n\n## How to Test\n- `cd httphandler && go test ./listener -timeout 30s`\n- `cd httphandler && go test ./...`\n\n## Related issues/PRs\nNo matching open issue or PR found for this listener port-conflict test hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP listener startup and error handling.
  * Ensured HTTP and HTTPS serving use the same configured listener.
  * Improved compatibility when binding to wildcard network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->