### PR TITLE
fix(fixhandler): prevent path traversal when resolving resource paths

### DIFF
--- a/cmd/fix/fix.go
+++ b/cmd/fix/fix.go
@@ -18,6 +18,12 @@ var fixCmdExamples = fmt.Sprintf(`
   1) %[1]s scan . --format json --output output.json
   2) %[1]s fix output.json
 
+  The report file's own recorded scan location is trusted by default. If the
+  report comes from a source you don't fully trust (e.g. a shared CI
+  artifact), pass --base-path to require that location to resolve inside a
+  directory you control:
+  3) %[1]s fix output.json --base-path .
+
 `, cautils.ExecName())
 
 func GetFixCmd(ks meta.IKubescape) *cobra.Command {
@@ -41,6 +47,7 @@ func GetFixCmd(ks meta.IKubescape) *cobra.Command {
 	fixCmd.PersistentFlags().BoolVar(&fixInfo.NoConfirm, "no-confirm", false, "No confirmation will be given to the user before applying the fix (default false)")
 	fixCmd.PersistentFlags().BoolVar(&fixInfo.DryRun, "dry-run", false, "No changes will be applied (default false)")
 	fixCmd.PersistentFlags().BoolVar(&fixInfo.SkipUserValues, "skip-user-values", true, "Changes which involve user-defined values will be skipped")
+	fixCmd.PersistentFlags().StringVar(&fixInfo.BasePath, "base-path", "", "Restrict fixes to this directory: the report's own recorded scan location must resolve inside it. Use this when the report file comes from a source you don't fully trust (e.g. a shared CI artifact); without it, the report's recorded location is trusted as-is")
 
 	return fixCmd
 }

--- a/core/meta/datastructures/v1/fix.go
+++ b/core/meta/datastructures/v1/fix.go
@@ -5,4 +5,11 @@ type FixInfo struct {
 	NoConfirm      bool   // if true, no confirmation will be given to the user before applying the fix
 	SkipUserValues bool   // if true, user values will not be changed
 	DryRun         bool   // if true, no changes will be applied
+	// BasePath, if set, restricts fixes to this directory: the report's own
+	// recorded scan location (which the report itself controls) must resolve
+	// inside it, or NewFixHandler refuses to proceed. Use this when the
+	// report file comes from a source you don't fully trust (e.g. a shared
+	// CI artifact) - without it, the report's recorded location is trusted
+	// as-is, as it always has been.
+	BasePath string
 }

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -66,6 +66,28 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 		return nil, err
 	}
 
+	// localPath comes straight out of the report (RepoContextMetadata.LocalRootPath /
+	// DirectoryContextMetadata.BasePath / dirname(FileContextMetadata.FilePath)), which
+	// is untrusted input if fixInfo.ReportFile came from somewhere the caller doesn't
+	// fully control. By default we still trust it, exactly as before - kubescape fix
+	// has no other way to know where a report's files live. If the caller passed
+	// --base-path, though, require the report's claimed location to actually resolve
+	// inside it before accepting it as the fix root.
+	if fixInfo.BasePath != "" {
+		resolvedLocalPath, err := filepath.EvalSymlinks(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve report's scan path %q: %w", localPath, err)
+		}
+		resolvedBasePath, err := filepath.EvalSymlinks(fixInfo.BasePath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --base-path %q: %w", fixInfo.BasePath, err)
+		}
+		if !isPathContained(resolvedBasePath, resolvedLocalPath) {
+			return nil, fmt.Errorf("report's scan path %q is outside --base-path %q; refusing to trust the report's location claim", localPath, fixInfo.BasePath)
+		}
+		localPath = resolvedLocalPath
+	}
+
 	backendLoggerLeveled := logging.AddModuleLevel(logging.NewLogBackend(logger.L().GetWriter(), "", 0))
 	backendLoggerLeveled.SetLevel(logging.ERROR, "")
 	yqlib.GetLogger().SetBackend(backendLoggerLeveled)
@@ -230,7 +252,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 			// The report references a resource ID with no backing resource data.
 			// We cannot fix it, but it is still a failed control the user must
 			// remediate manually — surface it rather than dropping it.
-			logger.L().Ctx(ctx).Warning("Skipping result with no resource data in report: " + resourceID)
+			logger.L().Ctx(ctx).Warning("Skipping result with no resource data in report: " + sanitizeForLog(resourceID))
 			for i := range result.AssociatedControls {
 				ac := &result.AssociatedControls[i]
 				if !ac.GetStatus(nil).IsFailed() {
@@ -261,20 +283,23 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		if skipReason == "" {
 			relativePath, idx, err := h.getFilePathAndIndex(resourcePath)
 			if err != nil {
-				logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + resourcePath)
+				logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + sanitizeForLog(resourcePath))
 				skipReason = "skipped: invalid resource path"
 			} else {
 				candidatePath := filepath.Join(h.localBasePath, relativePath)
-				if !isPathContained(h.localBasePath, candidatePath) {
-					logger.L().Ctx(ctx).Warning("Skipping resource path that escapes the scanned directory: " + resourcePath)
+				if _, err := os.Stat(candidatePath); err != nil {
+					// Checked before containment so EvalSymlinks (inside
+					// isPathContained) has something to resolve, and so a
+					// missing file is reported as such rather than as
+					// "escapes scanned directory".
+					logger.L().Ctx(ctx).Warning("Skipping missing file: " + sanitizeForLog(candidatePath))
+					skipReason = "skipped: file not found"
+				} else if !isPathContained(h.localBasePath, candidatePath) {
+					logger.L().Ctx(ctx).Warning("Skipping resource path that escapes the scanned directory: " + sanitizeForLog(resourcePath))
 					skipReason = "skipped: resource path escapes scanned directory"
 				} else {
 					absolutePath = candidatePath
 					documentIndex = idx
-					if _, err := os.Stat(absolutePath); err != nil {
-						logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)
-						skipReason = "skipped: file not found"
-					}
 				}
 			}
 		}
@@ -290,7 +315,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 					ControlName:  ac.GetName(),
 					ResourceName: resourceObj.GetName(),
 					ResourceKind: resourceObj.GetKind(),
-					FilePath:     resourcePath,
+					FilePath:     sanitizeForLog(resourcePath),
 					Reason:       skipReason,
 				})
 			}
@@ -344,7 +369,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 					ControlName:  ac.GetName(),
 					ResourceName: resourceObj.GetName(),
 					ResourceKind: resourceObj.GetKind(),
-					FilePath:     absolutePath,
+					FilePath:     sanitizeForLog(absolutePath),
 					Reason:       reason,
 				},
 				ac: ac,
@@ -598,13 +623,42 @@ func (h *FixHandler) ApplyChanges(ctx context.Context, resourcesToFix []Resource
 
 // isPathContained reports whether target resolves to a path inside base,
 // preventing a resource path from the (untrusted) scan report from escaping
-// the local scan directory via "../" traversal.
+// the local scan directory. Both operands are resolved with
+// filepath.EvalSymlinks before comparing: filepath.Rel alone is purely
+// lexical and never touches the filesystem, so a symlink inside base that
+// points outside it - or a dangling symlink - would otherwise be reported as
+// "contained" even though the file it actually reads/writes lives elsewhere,
+// or doesn't resolve at all. Resolution failure (nonexistent path, dangling
+// symlink, permission error) is treated as not contained rather than
+// silently allowed.
 func isPathContained(base, target string) bool {
-	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(target))
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return false
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedBase, resolvedTarget)
 	if err != nil {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// sanitizeForLog strips ASCII control characters (including \r and \n) from
+// report-derived strings before they are interpolated into a log message.
+// The default CLI logger prints messages as plain text, so an
+// attacker-controlled resource path or resource ID containing "\r\n" could
+// otherwise forge additional, spoofed-looking log lines.
+func sanitizeForLog(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 func (h *FixHandler) getFilePathAndIndex(filePathWithIndex string) (filePath string, documentIndex int, err error) {

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -264,11 +264,17 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 				logger.L().Ctx(ctx).Warning("Skipping invalid resource path: " + resourcePath)
 				skipReason = "skipped: invalid resource path"
 			} else {
-				absolutePath = filepath.Join(h.localBasePath, relativePath)
-				documentIndex = idx
-				if _, err := os.Stat(absolutePath); err != nil {
-					logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)
-					skipReason = "skipped: file not found"
+				candidatePath := filepath.Join(h.localBasePath, relativePath)
+				if !isPathContained(h.localBasePath, candidatePath) {
+					logger.L().Ctx(ctx).Warning("Skipping resource path that escapes the scanned directory: " + resourcePath)
+					skipReason = "skipped: resource path escapes scanned directory"
+				} else {
+					absolutePath = candidatePath
+					documentIndex = idx
+					if _, err := os.Stat(absolutePath); err != nil {
+						logger.L().Ctx(ctx).Warning("Skipping missing file: " + absolutePath)
+						skipReason = "skipped: file not found"
+					}
 				}
 			}
 		}
@@ -588,6 +594,17 @@ func (h *FixHandler) ApplyChanges(ctx context.Context, resourcesToFix []Resource
 	}
 
 	return len(updatedFiles), errors
+}
+
+// isPathContained reports whether target resolves to a path inside base,
+// preventing a resource path from the (untrusted) scan report from escaping
+// the local scan directory via "../" traversal.
+func isPathContained(base, target string) bool {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(target))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (h *FixHandler) getFilePathAndIndex(filePathWithIndex string) (filePath string, documentIndex int, err error) {

--- a/core/pkg/fixhandler/pathcontainment_test.go
+++ b/core/pkg/fixhandler/pathcontainment_test.go
@@ -1,0 +1,245 @@
+package fixhandler
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// skipOnWindowsSymlink skips a test that requires creating a symlink, since
+// doing so on Windows requires elevated privileges the CI runner may not have.
+func skipOnWindowsSymlink(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+}
+
+func TestIsPathContained(t *testing.T) {
+	t.Run("plain relative traversal is rejected", func(t *testing.T) {
+		base := t.TempDir()
+		outside := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(outside, "victim.yaml"), []byte("x"), 0o600))
+
+		target := filepath.Join(base, "..", filepath.Base(outside), "victim.yaml")
+		assert.False(t, isPathContained(base, target))
+	})
+
+	t.Run("absolute path outside base is rejected", func(t *testing.T) {
+		base := t.TempDir()
+		outside := t.TempDir()
+		victim := filepath.Join(outside, "victim.yaml")
+		require.NoError(t, os.WriteFile(victim, []byte("x"), 0o600))
+
+		assert.False(t, isPathContained(base, victim))
+	})
+
+	t.Run("plain subpath is contained", func(t *testing.T) {
+		base := t.TempDir()
+		nested := filepath.Join(base, "a", "b.yaml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(nested), 0o750))
+		require.NoError(t, os.WriteFile(nested, []byte("x"), 0o600))
+
+		assert.True(t, isPathContained(base, nested))
+	})
+
+	t.Run("base equals target", func(t *testing.T) {
+		base := t.TempDir()
+		assert.True(t, isPathContained(base, base))
+	})
+
+	t.Run("nonexistent target is rejected, not silently allowed", func(t *testing.T) {
+		base := t.TempDir()
+		assert.False(t, isPathContained(base, filepath.Join(base, "ghost.yaml")))
+	})
+
+	// Regression for the symlink bypass found in review: filepath.Rel is
+	// purely lexical, so a symlink inside base pointing outside it used to
+	// be reported as "contained" even though writes through it land outside
+	// the scanned directory.
+	t.Run("symlink inside base pointing outside it is rejected", func(t *testing.T) {
+		skipOnWindowsSymlink(t)
+		base := t.TempDir()
+		outside := t.TempDir()
+		victim := filepath.Join(outside, "victim.yaml")
+		require.NoError(t, os.WriteFile(victim, []byte("x"), 0o600))
+		require.NoError(t, os.Symlink(outside, filepath.Join(base, "link")))
+
+		target := filepath.Join(base, "link", "victim.yaml")
+		assert.False(t, isPathContained(base, target),
+			"a symlink inside base that resolves outside it must not be treated as contained")
+	})
+
+	t.Run("symlink inside base pointing back inside it is accepted", func(t *testing.T) {
+		skipOnWindowsSymlink(t)
+		base := t.TempDir()
+		realDir := filepath.Join(base, "real")
+		require.NoError(t, os.Mkdir(realDir, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(realDir, "in.yaml"), []byte("x"), 0o600))
+		require.NoError(t, os.Symlink(realDir, filepath.Join(base, "link")))
+
+		target := filepath.Join(base, "link", "in.yaml")
+		assert.True(t, isPathContained(base, target))
+	})
+
+	t.Run("dangling symlink is rejected", func(t *testing.T) {
+		skipOnWindowsSymlink(t)
+		base := t.TempDir()
+		require.NoError(t, os.Symlink(filepath.Join(base, "does-not-exist"), filepath.Join(base, "dangling")))
+
+		assert.False(t, isPathContained(base, filepath.Join(base, "dangling")))
+	})
+}
+
+func TestSanitizeForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain path unaffected", in: "a/b/c.yaml", want: "a/b/c.yaml"},
+		{name: "CRLF stripped", in: "a.yaml\r\n[success] forged line", want: "a.yaml[success] forged line"},
+		{name: "bare CR stripped", in: "a\rb", want: "ab"},
+		{name: "bare LF stripped", in: "a\nb", want: "ab"},
+		{name: "DEL stripped", in: "a\x7fb", want: "ab"},
+		{name: "empty string", in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeForLog(tt.in))
+		})
+	}
+}
+
+// buildDirectoryReport writes a minimal valid PostureReport JSON file whose
+// scanning target is a Directory with the given basePath, and returns the
+// report file's path.
+func buildDirectoryReport(t *testing.T, reportDir, basePath string) string {
+	t.Helper()
+	report := reporthandlingv2.PostureReport{
+		Metadata: reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reporthandlingv2.Directory,
+			},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+					BasePath: basePath,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(report)
+	require.NoError(t, err)
+	reportFile := filepath.Join(reportDir, "scan.json")
+	require.NoError(t, os.WriteFile(reportFile, b, 0o600))
+	return reportFile
+}
+
+func TestNewFixHandler_NoBasePathFlag_TrustsReportsOwnPath(t *testing.T) {
+	// Documents current, unchanged-by-default behavior: without --base-path,
+	// the report's own recorded scan location is trusted regardless of where
+	// the report file itself lives - exactly as before this fix.
+	reportDir := t.TempDir()
+	scannedDir := t.TempDir()
+	reportFile := buildDirectoryReport(t, reportDir, scannedDir)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile})
+	require.NoError(t, err)
+	assert.Equal(t, scannedDir, h.localBasePath)
+}
+
+func TestNewFixHandler_BasePathFlag_RejectsReportPathOutsideBasePath(t *testing.T) {
+	// The core anchoring fix: when --base-path is set, a report can no
+	// longer point kubescape fix at an arbitrary directory just by setting
+	// its own basePath - it must resolve inside the caller-supplied root.
+	reportDir := t.TempDir()
+	attackerChosenDir := t.TempDir()
+	trustedRoot := t.TempDir()
+	reportFile := buildDirectoryReport(t, reportDir, attackerChosenDir)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile, BasePath: trustedRoot})
+	assert.Error(t, err)
+	assert.Nil(t, h)
+	assert.ErrorContains(t, err, "outside --base-path")
+}
+
+func TestNewFixHandler_BasePathFlag_AcceptsReportPathInsideBasePath(t *testing.T) {
+	trustedRoot := t.TempDir()
+	scannedDir := filepath.Join(trustedRoot, "subdir")
+	require.NoError(t, os.Mkdir(scannedDir, 0o750))
+	reportFile := buildDirectoryReport(t, trustedRoot, scannedDir)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile, BasePath: trustedRoot})
+	require.NoError(t, err)
+	assert.Equal(t, scannedDir, h.localBasePath)
+}
+
+func TestNewFixHandler_BasePathFlag_ReportPathEqualsBasePathIsAccepted(t *testing.T) {
+	trustedRoot := t.TempDir()
+	reportFile := buildDirectoryReport(t, trustedRoot, trustedRoot)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile, BasePath: trustedRoot})
+	require.NoError(t, err)
+	assert.Equal(t, trustedRoot, h.localBasePath)
+}
+
+func TestNewFixHandler_BasePathFlag_InvalidBasePathErrors(t *testing.T) {
+	reportDir := t.TempDir()
+	scannedDir := t.TempDir()
+	reportFile := buildDirectoryReport(t, reportDir, scannedDir)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile, BasePath: filepath.Join(reportDir, "does-not-exist")})
+	assert.Error(t, err)
+	assert.Nil(t, h)
+	assert.ErrorContains(t, err, "invalid --base-path")
+}
+
+// TestPrepareResourcesToFix_SymlinkEscapeIsSkipped reproduces the second
+// review bypass: a symlink inside the scanned directory pointing outside it.
+// Before the isPathContained fix, this was accepted as "contained" (lexical
+// check only) and ApplyChanges would write through the symlink to the file
+// outside the scanned tree. This holds even for a fully trusted report/base
+// path - e.g. scanning a cloned third-party repo containing such a symlink.
+func TestPrepareResourcesToFix_SymlinkEscapeIsSkipped(t *testing.T) {
+	skipOnWindowsSymlink(t)
+	ctx := context.Background()
+
+	base := t.TempDir()
+	outside := t.TempDir()
+	victimContent := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: x\nspec:\n  hostNetwork: true\n"
+	victim := filepath.Join(outside, "victim.yaml")
+	require.NoError(t, os.WriteFile(victim, []byte(victimContent), 0o600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(base, "link")))
+
+	res := buildResource(t, base, filepath.Join("link", "victim.yaml"), "Pod", "x", 0)
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0001", "host network", failedRuleWithFix("spec.hostNetwork", "false")),
+			},
+		},
+	}
+
+	h := newHandlerForResources(base, results, []reporthandling.Resource{*res}, false)
+	toFix := h.PrepareResourcesToFix(ctx)
+
+	assert.Empty(t, toFix, "resource path escaping the scanned directory via a symlink must not be accepted")
+	require.Len(t, h.UnfixedControls(), 1)
+	assert.Equal(t, "skipped: resource path escapes scanned directory", h.UnfixedControls()[0].Reason)
+
+	unchanged, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, victimContent, string(unchanged), "file outside the scanned directory must not be modified")
+}


### PR DESCRIPTION
## Summary
- `kubescape fix` reads resource file paths from the scan report JSON, which is untrusted input (e.g. a shared CI artifact).
- `PrepareResourcesToFix()` joined the report-provided relative path onto `localBasePath` with `filepath.Join`, which resolves `..` segments, with no containment check.
- A crafted report entry like `../../../../home/user/.bashrc:0` could cause `kubescape fix` to write outside the scanned directory — arbitrary file write.

## Fix
- Added `isPathContained(base, target)` which uses `filepath.Rel` to confirm the resolved absolute path stays inside `localBasePath`.
- Resources whose path escapes the scanned directory are now skipped and reported as unfixed, instead of being written to.

## Test plan
- [x] `go build ./core/pkg/fixhandler/...`
- [x] `go vet ./core/pkg/fixhandler/...`
- [x] `go test ./core/pkg/fixhandler/...` (all existing tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource patching security by rejecting paths that resolve outside the scanned directory, including through symlinks.
  * Rejected traversal attempts are now recorded as unfixed issues with a clear reason.
  * File checks now occur only after path safety validation.
  * Log output is sanitized to remove control characters from report-derived values.

* **New Features**
  * Added an optional `--base-path` setting to restrict fixes to a specified directory.
  * Updated fix command documentation with guidance and examples for using this restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->