### PR TITLE
fix(httphandler): make pprof debug server opt-in and loopback-only

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -291,6 +291,8 @@ Configure the HTTP handler using environment variables:
 | `KS_DOWNLOAD_ARTIFACTS` | Download artifacts on each scan | `true`, `false` |
 | `KS_SCAN_QUEUE_CAPACITY` | Maximum number of scans waiting behind the active scan | `10` |
 | `KS_SCAN_REQUEST_MAX_BYTES` | Maximum size in bytes of a `POST /v1/scan` request body | `1048576` |
+| `KS_PPROF_ENABLED` | Enable the pprof debug server (off by default; binds to loopback only) | `true`, `false` |
+| `KS_PPROF_ADDR` | Address the pprof debug server binds to when enabled | `127.0.0.1:6060` |
 
 ---
 
@@ -322,18 +324,27 @@ export KS_LOGGER_LEVEL=debug
 
 ### Performance Profiling
 
-The HTTP handler exposes pprof endpoints for performance analysis:
+The pprof debug server is **off by default** and binds to `127.0.0.1` only, so it's
+reachable from inside the pod's network namespace but not from the network. Enable it
+and reach it via `kubectl port-forward`:
 
 ```bash
+export KS_PPROF_ENABLED=true
+# then, e.g.: kubectl port-forward <pod> 6060:6060
+
 # Heap profile
-go tool pprof http://localhost:6060/debug/pprof/heap
+go tool pprof http://127.0.0.1:6060/debug/pprof/heap
 
 # CPU profile
-go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
 
 # Goroutine profile
-go tool pprof http://localhost:6060/debug/pprof/goroutine
+go tool pprof http://127.0.0.1:6060/debug/pprof/goroutine
 ```
+
+Set `KS_PPROF_ADDR` to change the bind address (e.g. if `6060` collides with a sidecar
+in the pod). Binding to anything other than loopback is a deliberate, explicit choice —
+do so only on a trusted network.
 
 For more information on pprof, see the [pprof documentation](https://pkg.go.dev/net/http/pprof).
 

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"strconv"
 
 	"github.com/google/uuid"

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -156,27 +156,20 @@ func getPprofAddr() string {
 // relying on that means these endpoints exist only because some other,
 // unrelated package blank-imports "net/http/pprof" - remove that import as
 // dead code and this server would silently start logging success while
-// serving 404s. Registering explicitly here also keeps profiling handlers
-// off the global DefaultServeMux, so a future handler-less http.Server
-// elsewhere in this binary can't accidentally re-expose them.
+// serving 404s. Registering explicitly here makes that dependency
+// self-contained and compiler-enforced.
+//
+// Note: importing net/http/pprof anywhere in the binary registers these
+// routes on http.DefaultServeMux via that package's init(); serving our own
+// mux does not undo that. It's inert here because SetupHTTPListener always
+// sets server.Handler, so no server in this binary falls back to the global
+// mux - but a future handler-less http.Server would expose them.
 func servePprof() {
 	if !getPprofEnabled() {
 		return
 	}
 	addr := getPprofAddr()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second, // same slowloris guard as the main server
-	}
+	srv := newPprofServer(addr)
 
 	go func() {
 		logger.L().Info("starting pprof server", helpers.String("address", addr))
@@ -184,4 +177,24 @@ func servePprof() {
 			logger.L().Error("pprof server stopped", helpers.Error(err))
 		}
 	}()
+}
+
+// newPprofServer builds the pprof debug *http.Server on its own dedicated
+// mux, so tests can assert on the handler directly instead of probing it
+// over the wire (a wire probe can't distinguish a dedicated mux from
+// http.DefaultServeMux, since importing net/http/pprof populates the latter
+// too - see the DefaultServeMux note on servePprof).
+func newPprofServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second, // same slowloris guard as the main server
+	}
 }

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -128,22 +130,57 @@ func getKeyFile() string {
 	return os.Getenv("KS_KEY_FILE")
 }
 
+func getPprofEnabled() bool {
+	return strings.EqualFold(os.Getenv("KS_PPROF_ENABLED"), "true")
+}
+
+func getPprofAddr() string {
+	if a := os.Getenv("KS_PPROF_ADDR"); a != "" {
+		return a
+	}
+	return "127.0.0.1:6060"
+}
+
 // servePprof starts the net/http/pprof debug server, but only when
 // explicitly opted into via KS_PPROF_ENABLED=true. It used to start
 // automatically whenever the logger level was "debug", which is the
 // server's default log level - meaning every deployment exposed
 // unauthenticated pprof endpoints (heap dumps, CPU profiling, ...) on
-// :6060 by default. It now also binds to loopback only, so it's reachable
-// only via port-forward/exec into the pod, not from the network.
+// :6060 by default. It now also binds to loopback only by default (override
+// via KS_PPROF_ADDR), so it's reachable only via port-forward/exec into the
+// pod, not from the network.
+//
+// The handlers are registered on a dedicated mux rather than passing nil to
+// http.ListenAndServe (which serves off http.DefaultServeMux): the pprof
+// package normally self-registers on DefaultServeMux via its own init(), so
+// relying on that means these endpoints exist only because some other,
+// unrelated package blank-imports "net/http/pprof" - remove that import as
+// dead code and this server would silently start logging success while
+// serving 404s. Registering explicitly here also keeps profiling handlers
+// off the global DefaultServeMux, so a future handler-less http.Server
+// elsewhere in this binary can't accidentally re-expose them.
 func servePprof() {
-	if os.Getenv("KS_PPROF_ENABLED") != "true" {
+	if !getPprofEnabled() {
 		return
 	}
+	addr := getPprofAddr()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second, // same slowloris guard as the main server
+	}
+
 	go func() {
-		// start pprof server -> https://pkg.go.dev/net/http/pprof
-		addr := "127.0.0.1:6060"
 		logger.L().Info("starting pprof server", helpers.String("address", addr))
-		if err := http.ListenAndServe(addr, nil); err != nil {
+		if err := srv.ListenAndServe(); err != nil {
 			logger.L().Error("pprof server stopped", helpers.Error(err))
 		}
 	}()

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -128,12 +128,23 @@ func getKeyFile() string {
 	return os.Getenv("KS_KEY_FILE")
 }
 
+// servePprof starts the net/http/pprof debug server, but only when
+// explicitly opted into via KS_PPROF_ENABLED=true. It used to start
+// automatically whenever the logger level was "debug", which is the
+// server's default log level - meaning every deployment exposed
+// unauthenticated pprof endpoints (heap dumps, CPU profiling, ...) on
+// :6060 by default. It now also binds to loopback only, so it's reachable
+// only via port-forward/exec into the pod, not from the network.
 func servePprof() {
+	if os.Getenv("KS_PPROF_ENABLED") != "true" {
+		return
+	}
 	go func() {
 		// start pprof server -> https://pkg.go.dev/net/http/pprof
-		if logger.L().GetLevel() == helpers.DebugLevel.String() {
-			logger.L().Info("starting pprof server", helpers.String("port", "6060"))
-			logger.L().Error(http.ListenAndServe(":6060", nil).Error())
+		addr := "127.0.0.1:6060"
+		logger.L().Info("starting pprof server", helpers.String("address", addr))
+		if err := http.ListenAndServe(addr, nil); err != nil {
+			logger.L().Error("pprof server stopped", helpers.Error(err))
 		}
 	}()
 }

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -258,25 +259,28 @@ func TestGetPprofAddr(t *testing.T) {
 	})
 }
 
-// TestServePprof_RegistersOwnMuxNotDefaultServeMux guards against a
-// regression back to http.ListenAndServe(addr, nil): serving off
-// http.DefaultServeMux means these endpoints only exist because some
-// unrelated package blank-imports net/http/pprof. If that import were
-// removed as dead code, servePprof would keep logging success while every
-// request 404s. Registering on a dedicated mux makes the dependency
-// self-contained and keeps profiling handlers off the global
-// DefaultServeMux.
-func TestServePprof_RegistersOwnMuxNotDefaultServeMux(t *testing.T) {
+// TestNewPprofServer_UsesItsOwnMux guards against a regression back to
+// http.ListenAndServe(addr, nil) / Handler: nil: a nil Handler falls back to
+// http.DefaultServeMux, which - because net/http/pprof is imported - also
+// answers /debug/pprof/ with 200. A live HTTP probe against the listening
+// server can't tell the two muxes apart, so this asserts on the handler
+// itself instead.
+func TestNewPprofServer_UsesItsOwnMux(t *testing.T) {
+	srv := newPprofServer("127.0.0.1:0")
+
+	require.NotNil(t, srv.Handler)
+	require.NotSame(t, http.DefaultServeMux, srv.Handler)
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestServePprof_ListensWhenEnabled proves servePprof actually binds and
+// serves when KS_PPROF_ENABLED=true.
+func TestServePprof_ListensWhenEnabled(t *testing.T) {
 	t.Setenv("KS_PPROF_ENABLED", "true")
-	port := func() string {
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
-		defer ln.Close()
-		_, p, err := net.SplitHostPort(ln.Addr().String())
-		require.NoError(t, err)
-		return p
-	}()
-	addr := "127.0.0.1:" + port
+	addr := "127.0.0.1:" + freePort(t)
 	t.Setenv("KS_PPROF_ADDR", addr)
 
 	servePprof()
@@ -288,5 +292,35 @@ func TestServePprof_RegistersOwnMuxNotDefaultServeMux(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
-	}, time.Second, 10*time.Millisecond, "pprof server did not come up serving its own mux")
+	}, time.Second, 10*time.Millisecond, "pprof server did not come up")
+}
+
+// TestServePprof_DoesNotListenWhenDisabled is the negative case: the
+// security property this feature exists to establish is that pprof stays
+// off unless explicitly opted into.
+func TestServePprof_DoesNotListenWhenDisabled(t *testing.T) {
+	t.Setenv("KS_PPROF_ENABLED", "")
+	addr := "127.0.0.1:" + freePort(t)
+	t.Setenv("KS_PPROF_ADDR", addr)
+
+	servePprof()
+
+	require.Never(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 250*time.Millisecond, 25*time.Millisecond, "pprof server must not listen when KS_PPROF_ENABLED is unset")
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	_, p, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	return p
 }

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -209,4 +210,83 @@ func TestGetOffline(t *testing.T) {
 			t.Fatal("getOffline() = true, want false")
 		}
 	})
+}
+
+func TestGetPprofEnabled(t *testing.T) {
+	t.Run("returns false when unset", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ENABLED", "")
+		if getPprofEnabled() {
+			t.Fatal("getPprofEnabled() = true, want false")
+		}
+	})
+
+	t.Run("returns true for lowercase true", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ENABLED", "true")
+		if !getPprofEnabled() {
+			t.Fatal("getPprofEnabled() = false, want true")
+		}
+	})
+
+	t.Run("returns true case-insensitively", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ENABLED", "TRUE")
+		if !getPprofEnabled() {
+			t.Fatal("getPprofEnabled() = false, want true — this is a security-relevant knob an operator sets by hand, so it must not silently no-op on a differently-cased value")
+		}
+	})
+
+	t.Run("returns false for other values", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ENABLED", "1")
+		if getPprofEnabled() {
+			t.Fatal("getPprofEnabled() = true, want false")
+		}
+	})
+}
+
+func TestGetPprofAddr(t *testing.T) {
+	t.Run("returns default when unset", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ADDR", "")
+		if got := getPprofAddr(); got != "127.0.0.1:6060" {
+			t.Fatalf("getPprofAddr() = %q, want %q", got, "127.0.0.1:6060")
+		}
+	})
+
+	t.Run("returns env var when set", func(t *testing.T) {
+		t.Setenv("KS_PPROF_ADDR", "127.0.0.1:7070")
+		if got := getPprofAddr(); got != "127.0.0.1:7070" {
+			t.Fatalf("getPprofAddr() = %q, want %q", got, "127.0.0.1:7070")
+		}
+	})
+}
+
+// TestServePprof_RegistersOwnMuxNotDefaultServeMux guards against a
+// regression back to http.ListenAndServe(addr, nil): serving off
+// http.DefaultServeMux means these endpoints only exist because some
+// unrelated package blank-imports net/http/pprof. If that import were
+// removed as dead code, servePprof would keep logging success while every
+// request 404s. Registering on a dedicated mux makes the dependency
+// self-contained and keeps profiling handlers off the global
+// DefaultServeMux.
+func TestServePprof_RegistersOwnMuxNotDefaultServeMux(t *testing.T) {
+	t.Setenv("KS_PPROF_ENABLED", "true")
+	port := func() string {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+		_, p, err := net.SplitHostPort(ln.Addr().String())
+		require.NoError(t, err)
+		return p
+	}()
+	addr := "127.0.0.1:" + port
+	t.Setenv("KS_PPROF_ADDR", addr)
+
+	servePprof()
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://" + addr + "/debug/pprof/")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, time.Second, 10*time.Millisecond, "pprof server did not come up serving its own mux")
 }


### PR DESCRIPTION
## Summary
- `servePprof()` started the `net/http/pprof` server on `:6060` (all interfaces) whenever the logger level was `debug` — which is the httphandler server's **default** log level (`KS_LOGGER_LEVEL` unset, see `main.go`).
- Net effect: every deployment exposed unauthenticated pprof endpoints (`/debug/pprof/heap`, `/debug/pprof/profile`, `/debug/pprof/trace`, ...) on the network out of the box. Heap dumps can leak in-memory access keys/credentials loaded at startup, and `/debug/pprof/profile` or `/trace` can be used to peg CPU as a DoS vector.

## Fix
- `servePprof()` now requires an explicit `KS_PPROF_ENABLED=true` opt-in before starting at all.
- Even when enabled, it now binds to `127.0.0.1:6060` instead of all interfaces, so it's reachable only via port-forward/exec into the pod, not directly from the network.

## Test plan
- [x] `go build ./...` (httphandler module)
- [x] `go vet ./...` (httphandler module)
- [x] `go test ./listener/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit configuration to enable the pprof diagnostic server.
  * pprof is disabled by default and binds to `127.0.0.1:6060` when enabled.
  * Added support for configuring the pprof listening address.

* **Bug Fixes**
  * Prevented unintended startup based on debug logging settings.
  * Improved profiling endpoint isolation and server error reporting.
  * Added safer request timeout handling.

* **Documentation**
  * Documented pprof configuration, local access, port forwarding, and address-binding security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->