### PR TITLE
fix(httphandler): add opt-in API key auth for /v1 endpoints

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -1,10 +1,12 @@
 package listener
 
 import (
+	"crypto/subtle"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -66,6 +68,13 @@ func SetupHTTPListener() error {
 	otelMiddleware := otelmux.Middleware("kubescape-svc")
 	v1SubRouter := rtr.PathPrefix(v1PathPrefix).Subrouter()
 	v1SubRouter.Use(otelMiddleware)
+
+	apiKey := getAPIKey()
+	if apiKey == "" {
+		logger.L().Warning("KS_API_KEY is not set - /v1 endpoints (scan, results, status, metrics) are reachable without authentication")
+	}
+	v1SubRouter.Use(apiKeyMiddleware(apiKey))
+
 	v1SubRouter.HandleFunc(v1PrometheusMetricsPath, httpHandler.Metrics) // deprecated
 	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.Scan).Methods(http.MethodPost)
 	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.CancelScan).Methods(http.MethodDelete)
@@ -120,6 +129,41 @@ func getCertFile() string {
 
 func getKeyFile() string {
 	return os.Getenv("KS_KEY_FILE")
+}
+
+func getAPIKey() string {
+	return os.Getenv("KS_API_KEY")
+}
+
+// apiKeyMiddleware enforces the KS_API_KEY bearer token on /v1/* routes when
+// apiKey is non-empty. It is opt-in (via the KS_API_KEY env var) rather than
+// mandatory, to avoid breaking existing deployments that don't set it - but
+// its absence is logged at startup so operators are aware that every /v1/*
+// endpoint (including triggering/cancelling scans and deleting all results)
+// is otherwise reachable by any network caller without authentication.
+func apiKeyMiddleware(apiKey string) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		if apiKey == "" {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !validAPIKey(r, apiKey) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func validAPIKey(r *http.Request, apiKey string) bool {
+	if key := r.Header.Get("X-API-Key"); key != "" {
+		return subtle.ConstantTimeCompare([]byte(key), []byte(apiKey)) == 1
+	}
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(auth, "Bearer ")), []byte(apiKey)) == 1
+	}
+	return false
 }
 
 func servePprof() {

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -209,5 +211,70 @@ func TestGetOffline(t *testing.T) {
 		if getOffline() {
 			t.Fatal("getOffline() = true, want false")
 		}
+	})
+}
+
+func TestGetAPIKey(t *testing.T) {
+	t.Setenv("KS_API_KEY", "s3cr3t")
+	if got := getAPIKey(); got != "s3cr3t" {
+		t.Fatalf("getAPIKey() = %q, want %q", got, "s3cr3t")
+	}
+}
+
+func TestAPIKeyMiddleware(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("no api key configured allows any request", func(t *testing.T) {
+		handler := apiKeyMiddleware("")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("rejects request with no credentials", func(t *testing.T) {
+		handler := apiKeyMiddleware("s3cr3t")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("rejects request with wrong key", func(t *testing.T) {
+		handler := apiKeyMiddleware("s3cr3t")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		req.Header.Set("X-API-Key", "wrong")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("accepts request with correct X-API-Key header", func(t *testing.T) {
+		handler := apiKeyMiddleware("s3cr3t")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		req.Header.Set("X-API-Key", "s3cr3t")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("accepts request with correct Authorization bearer token", func(t *testing.T) {
+		handler := apiKeyMiddleware("s3cr3t")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		req.Header.Set("Authorization", "Bearer s3cr3t")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("rejects malformed Authorization header", func(t *testing.T) {
+		handler := apiKeyMiddleware("s3cr3t")(next)
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		req.Header.Set("Authorization", "s3cr3t")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
 }


### PR DESCRIPTION
## Summary
- None of the `/v1/*` endpoints (`scan`, cancel scan, `status`, get/delete `results` — including delete-all via `?all=true` — and `metrics`) had any authentication or authorization.
- Any network-reachable caller could trigger scans, cancel other users' scans, or wipe all stored results.

## Fix
- Added an opt-in `KS_API_KEY` env var and an `apiKeyMiddleware` applied to the `/v1` subrouter.
- When `KS_API_KEY` is set, requests must present it via the `X-API-Key` header or `Authorization: Bearer <key>` (compared with `crypto/subtle.ConstantTimeCompare`), or they get `401 Unauthorized`.
- When unset, behavior is unchanged (no breaking change for existing deployments), but a warning is logged at startup so operators know the endpoints are otherwise open.
- `/livez`, `/readyz`, and the OpenAPI docs stay outside the `/v1` subrouter and remain unauthenticated, since they carry no sensitive data or side effects.

This is intentionally opt-in rather than mandatory, to avoid breaking existing deployments that rely on calling these endpoints without credentials (e.g. from a trusted in-cluster network). Happy to make it mandatory-by-default in a follow-up if maintainers prefer.

## Test plan
- [x] `go build ./...` (httphandler module)
- [x] `go vet ./...` (httphandler module)
- [x] `go test ./...` (httphandler module, all packages)
- [x] Added `TestGetAPIKey` and `TestAPIKeyMiddleware` covering: no key configured, missing credentials, wrong key, correct `X-API-Key`, correct `Authorization: Bearer`, malformed `Authorization` header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional API-key authentication for `/v1` API routes.
  * Supports credentials through the `X-API-Key` header or a Bearer token.
  * Requests with missing or invalid credentials receive an unauthorized response.
  * Authentication remains disabled when no API key is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->