### PR TITLE
chore: remove dead Float16ToInt function

### DIFF
--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -12,11 +12,6 @@ func Float32ToInt(x float32) int {
 	return Float64ToInt(float64(x))
 }
 
-// Float16ToInt convert float16 to int
-func Float16ToInt(x float32) int {
-	return Float64ToInt(float64(x))
-}
-
 // Float32ToIntFloor converts float32 to int by flooring, so a value never rounds up
 func Float32ToIntFloor(x float32) int {
 	return int(math.Floor(float64(x)))

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -25,13 +25,3 @@ func TestFloat32ToInt(t *testing.T) {
 	assert.Equal(t, -4, Float32ToInt(-3.5))
 	assert.Equal(t, -4, Float32ToInt(-3.51))
 }
-
-func TestFloat16ToInt(t *testing.T) {
-	assert.Equal(t, 3, Float16ToInt(3.49))
-	assert.Equal(t, 4, Float16ToInt(3.5))
-	assert.Equal(t, 4, Float16ToInt(3.51))
-	assert.Equal(t, 0, Float16ToInt(0.0))
-	assert.Equal(t, -3, Float16ToInt(-3.49))
-	assert.Equal(t, -4, Float16ToInt(-3.5))
-	assert.Equal(t, -4, Float16ToInt(-3.51))
-}


### PR DESCRIPTION
## Overview

Removes `Float16ToInt` from `core/cautils/floatutils.go`. The function has zero non-test callers across the entire codebase, takes `float32` despite its name, and delegates to `Float64ToInt`. Identified as dead code during review of #2632.

## Changes

- **floatutils.go**: removed `Float16ToInt` function
- **floatutils_test.go**: removed `TestFloat16ToInt`

## How to Test

```bash
go test ./core/cautils/ -run Float
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused numeric conversion utility and its associated tests.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->