### PR TITLE
fix: correct grammar in download empty-response errors ("received an empty objects" → "received empty objects")

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -136,7 +136,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 		downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Target)
 	}
 	if controlInputs == nil {
-		return fmt.Errorf("failed to download controlInputs - received an empty objects")
+		return fmt.Errorf("failed to download controlInputs - received empty objects")
 	}
 	// save in file
 	err = getter.SaveInFile(controlInputs, filepath.Join(downloadInfo.Path, downloadInfo.FileName))
@@ -240,7 +240,7 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 			return err
 		}
 		if framework == nil {
-			return fmt.Errorf("failed to download framework - received an empty objects")
+			return fmt.Errorf("failed to download framework - received empty objects")
 		}
 		downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
 		err = getter.SaveInFile(framework, downloadTo)
@@ -277,7 +277,7 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) err
 		return fmt.Errorf("failed to download control id '%s',  %s", downloadInfo.Identifier, err.Error())
 	}
 	if controls == nil {
-		return fmt.Errorf("failed to download control id '%s' - received an empty objects", downloadInfo.Identifier)
+		return fmt.Errorf("failed to download control id '%s' - received empty objects", downloadInfo.Identifier)
 	}
 	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
 	err = getter.SaveInFile(controls, downloadTo)

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -352,7 +352,7 @@ func TestDownloadConfigInputs(t *testing.T) {
 		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: nil}, nil)
 
 		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
-		require.EqualError(t, err, "failed to download controlInputs - received an empty objects")
+		require.EqualError(t, err, "failed to download controlInputs - received empty objects")
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {
@@ -526,7 +526,7 @@ func TestDownloadFramework(t *testing.T) {
 		withPolicyGetter(t, &fakePolicyGetter{framework: nil}, nil)
 
 		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
-		require.EqualError(t, err, "failed to download framework - received an empty objects")
+		require.EqualError(t, err, "failed to download framework - received empty objects")
 	})
 
 	t.Run("with identifier: succeeds and derives the filename", func(t *testing.T) {
@@ -593,7 +593,7 @@ func TestDownloadControl(t *testing.T) {
 
 		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "C-0001")
-		require.ErrorContains(t, err, "received an empty objects")
+		require.ErrorContains(t, err, "received empty objects")
 	})
 
 	t.Run("returns error when SaveInFile fails", func(t *testing.T) {


### PR DESCRIPTION
## Overview

Fixes #2641 — download empty-response error messages used ungrammatical phrasing: "received an empty objects" (wrong article + plural agreement). Changed to "received empty objects".

## Changes

- **download.go**: 3 error strings updated (controlInputs, framework, control id paths)
- **download_test.go**: 3 matching test assertions updated

## How to Test

```bash
go test ./core/core/ -run Download
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected grammar in error messages shown when empty objects are received during downloads.
  * Updated related validation messages for control inputs, frameworks, and controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->