### PR TITLE
chore(deps): bump opa-utils to v0.0.302 to fix RBAC roleRef cross-namespace pairing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.301
+	github.com/kubescape/opa-utils v0.0.302
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1202,6 +1202,8 @@ github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixo
 github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.301 h1:SK+/O2ORWD07q75zEYoc0hhtXpWA5/OPvSEudAZTpQg=
 github.com/kubescape/opa-utils v0.0.301/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
+github.com/kubescape/opa-utils v0.0.302 h1:LY1duFRzQOUrVn4eJ3M/fPuklBc5nB+o5cHvC4qJkXk=
+github.com/kubescape/opa-utils v0.0.302/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Overview

Bump `github.com/kubescape/opa-utils` from v0.0.301 to v0.0.302.

v0.0.302 contains `fix(reporthandling): resolve roleRef within the binding's own namespace` (kubescape/opa-utils#177), which resolves the bug reported in #2579:

`AggregateResourcesBySubjects` paired a Binding with a Role on `roleRef.kind` + `roleRef.name` only, never comparing namespaces. Kubernetes resolves a RoleBinding's roleRef to a Role strictly within the binding's own namespace, so a same-named Role in a different namespace was wrongly paired and reported as a failed RBAC finding. 17 of the 19 RBAC attack-vector rules were affected because they delegate roleRef resolution entirely to this aggregator.

## Additional Information

The v0.0.301→v0.0.302 diff is limited to `reporthandling/regoresourcesaggregator.go` and its test, so the bump is minimal and additive.

## How to Test

`go build ./...` and `go test ./core/pkg/opaprocessor/...` pass with the bumped dependency.

## Related issues/PRs

* Resolved #2579


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to the latest patch version, with no user-facing feature or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->