### PR TITLE
fix(httphandler): reject metrics requests when the scan queue is full

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -37,6 +37,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	defer handler.recover(r.Context(), w, scanID)
 
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -198,6 +198,7 @@ func TestMetrics_NonGetMethodReturns405WithoutScanning(t *testing.T) {
 			h.Metrics(w, rq)
 
 			require.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+			assert.Equal(t, http.MethodGet, w.Result().Header.Get("Allow"), "405 response must advertise the allowed method")
 			select {
 			case <-scanCalled:
 				t.Fatal("scan should not be invoked for non-GET metrics requests")


### PR DESCRIPTION
## Summary
- `Metrics()` sent to `handler.scanRequestChan` with a plain blocking channel send, unlike `Scan()` which already uses `select`/`default` to reject with `429` when the queue is full.
- `GET /v1/metrics` also had no method check and no auth, so repeated requests could fill the (default capacity-10) queue and pile up unbounded blocked goroutines/open connections that never time out — `ReadHeaderTimeout` doesn't help once headers are already read.

## Fix
- Mirrored `Scan()`'s pattern: use `select`/`default` on the channel send and return `429 Too Many Requests` with a `Retry-After` header when the queue is full, instead of blocking.
- Also reject non-`GET` methods, consistent with how `Status` already checks `r.Method`.

## Test plan
- [x] `go build ./...` / `go vet ./...` (httphandler module)
- [x] `go test ./... -race` (full httphandler module, no races/failures)
- [x] Added `TestMetrics_QueueFullReturns429` (queue-full request gets 429 immediately instead of blocking) and `TestMetrics_RejectsNonGet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics requests using methods other than GET now return HTTP 405 and indicate that GET is allowed.
  * When scan processing is busy, metrics requests return HTTP 429 with a retry instruction instead of waiting indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->