### PR TITLE
fix(core): use restrictive permissions for created output directories

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -70,7 +70,7 @@ func DownloadSupportCommands() []string {
 
 func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) error {
 	setPathAndFilename(downloadInfo)
-	if err := os.MkdirAll(downloadInfo.Path, os.ModePerm); err != nil {
+	if err := os.MkdirAll(downloadInfo.Path, 0o750); err != nil {
 		return err
 	}
 	if err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc); err != nil {

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -22,6 +22,15 @@ const (
 	TargetFramework      = "framework"
 	TargetArtifacts      = "artifacts"
 	TargetAttackTracks   = "attack-tracks"
+
+	// downloadDirPerm matches the 0700 policy customerloader.go's
+	// updateConfigFile() already enforces (and re-tightens with chmod) on
+	// ~/.kubescape: setPathAndFilename() defaults downloadInfo.Path to that
+	// same directory (getter.GetDefaultPath("")) when no --output path is
+	// given, and it holds config.json's AccessKey. A more permissive mode
+	// here would race the config loader's own hardening and could leave the
+	// directory group-readable depending on which one runs first.
+	downloadDirPerm = 0700
 )
 
 var downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{
@@ -70,7 +79,7 @@ func DownloadSupportCommands() []string {
 
 func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) error {
 	setPathAndFilename(downloadInfo)
-	if err := os.MkdirAll(downloadInfo.Path, 0o750); err != nil {
+	if err := os.MkdirAll(downloadInfo.Path, downloadDirPerm); err != nil {
 		return err
 	}
 	if err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc); err != nil {

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -176,6 +176,27 @@ func TestDownload_UnknownTargetReturnsError(t *testing.T) {
 	assert.EqualError(t, err, "unknown command to download")
 }
 
+// TestDownload_CreatesOutputDirectoryWithRestrictivePermissions guards
+// against a regression back to os.ModePerm (0777, world-writable). Download()
+// creates downloadInfo.Path before dispatching to the target-specific
+// downloader, so an unknown target (which fails after directory creation) is
+// enough to exercise the MkdirAll call in isolation.
+func TestDownload_CreatesOutputDirectoryWithRestrictivePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "download-dir")
+
+	ks := NewKubescape(context.Background())
+	err := ks.Download(&metav1.DownloadInfo{
+		Target: "unknown",
+		Path:   path,
+	})
+	require.Error(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	mode := info.Mode().Perm()
+	assert.Zerof(t, mode&0o027, "directory %s has mode %o, more permissive than 0750", path, mode)
+}
+
 // ---------------------------------------------------------------------------
 // Fakes for the getter interfaces, used together with the policyGetterFunc /
 // exceptionsGetterFunc / attackTracksGetterFunc / configInputsGetterFunc /

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -177,10 +177,22 @@ func TestDownload_UnknownTargetReturnsError(t *testing.T) {
 }
 
 // TestDownload_CreatesOutputDirectoryWithRestrictivePermissions guards
-// against a regression back to os.ModePerm (0777, world-writable). Download()
-// creates downloadInfo.Path before dispatching to the target-specific
-// downloader, so an unknown target (which fails after directory creation) is
-// enough to exercise the MkdirAll call in isolation.
+// against a regression back to os.ModePerm (0777, world-writable), and
+// against Download() drifting from the 0700 policy customerloader.go's
+// updateConfigFile() already enforces on ~/.kubescape - which is where
+// Download() writes by default (setPathAndFilename falls back to
+// getter.GetDefaultPath("") when no --output path is given), and which
+// holds config.json's AccessKey. Download() applies that same 0700 to every
+// path it creates, not just the default one, so this holds even though the
+// test passes an explicit custom Path. Download() creates downloadInfo.Path
+// before dispatching to the target-specific downloader, so an unknown
+// target (which fails after directory creation) is enough to exercise the
+// MkdirAll call in isolation.
+//
+// The 0-bits-outside-0700 assertion below is a meaningful guard only when
+// the process umask doesn't already mask those bits out (see the identical
+// caveat on printer.assertDirNotMorePermissiveThan0750); CI's default umask
+// (022) makes it effective.
 func TestDownload_CreatesOutputDirectoryWithRestrictivePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "download-dir")
 
@@ -194,7 +206,7 @@ func TestDownload_CreatesOutputDirectoryWithRestrictivePermissions(t *testing.T)
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	mode := info.Mode().Perm()
-	assert.Zerof(t, mode&0o027, "directory %s has mode %o, more permissive than 0750", path, mode)
+	assert.Zerof(t, mode&0o077, "directory %s has mode %o, more permissive than 0700", path, mode)
 }
 
 // ---------------------------------------------------------------------------

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -42,9 +42,15 @@ type IPrinter interface {
 	Score(score float32)
 }
 
+// outputDirPerm restricts created output directories to the owner (rwx------
+// would be too tight for shared setups, so this keeps group read/traverse),
+// instead of os.ModePerm (0777, world-writable) which scan output/report
+// directories have no reason to be.
+const outputDirPerm = 0o750
+
 func GetWriter(ctx context.Context, outputFile string) *os.File {
 	if outputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(outputFile), outputDirPerm); err != nil {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to create directory, reason: %s", err.Error()))
 			return os.Stdout
 		}
@@ -67,7 +73,7 @@ func GetWriter(ctx context.Context, outputFile string) *os.File {
 // It never returns os.Stdout.
 func GetWriterNoStdoutFallback(ctx context.Context, outputFile, tempPattern string) *os.File {
 	if outputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err == nil {
+		if err := os.MkdirAll(filepath.Dir(outputFile), outputDirPerm); err == nil {
 			if f, err := os.Create(outputFile); err == nil {
 				return f
 			} else {

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -87,6 +87,19 @@ func TestGetWriter_ValidFileName(t *testing.T) {
 	t.Cleanup(func() { _ = f.Close() })
 
 	assert.Equal(t, target, f.Name())
+	assertDirNotMorePermissiveThan0750(t, filepath.Dir(target))
+}
+
+// assertDirNotMorePermissiveThan0750 fails the test if dir's permission bits
+// grant group-write or any access to others - i.e. it is no more permissive
+// than 0o750. This holds regardless of the process umask, since umask can
+// only strip bits from the mode requested at MkdirAll time, never add them.
+func assertDirNotMorePermissiveThan0750(t *testing.T, dir string) {
+	t.Helper()
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	mode := info.Mode().Perm()
+	assert.Zerof(t, mode&0o027, "directory %s has mode %o, more permissive than 0750", dir, mode)
 }
 
 // MkdirAll fails when a path component that should be a directory is actually
@@ -121,6 +134,7 @@ func TestGetWriterNoStdoutFallback_ValidFileName(t *testing.T) {
 
 	assert.Equal(t, target, f.Name())
 	assert.NotEqual(t, os.Stdout.Name(), f.Name())
+	assertDirNotMorePermissiveThan0750(t, filepath.Dir(target))
 }
 
 // MkdirAll fails when a path component that should be a directory is actually

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -92,8 +92,14 @@ func TestGetWriter_ValidFileName(t *testing.T) {
 
 // assertDirNotMorePermissiveThan0750 fails the test if dir's permission bits
 // grant group-write or any access to others - i.e. it is no more permissive
-// than 0o750. This holds regardless of the process umask, since umask can
-// only strip bits from the mode requested at MkdirAll time, never add them.
+// than 0o750. This is a meaningful regression guard only when the process
+// umask doesn't already mask out those bits: umask can strip bits from the
+// mode MkdirAll requests but never add them, so under a restrictive umask
+// (e.g. 077) even the old os.ModePerm (0777) code would satisfy this check,
+// producing a false pass. CI's default umask (022) does make this
+// effective; a locally reproducible false pass isn't worth the
+// platform-specific (Unix-only) umask control it would take to close, given
+// this repo also ships Windows builds.
 func assertDirNotMorePermissiveThan0750(t *testing.T, dir string) {
 	t.Helper()
 	info, err := os.Stat(dir)

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -25,6 +25,10 @@ const (
 	defaultMaxScanRequestBodyBytes = int64(1 << 20) // 1 MiB
 	scanQueueCapacityEnv           = "KS_SCAN_QUEUE_CAPACITY"
 	scanRequestMaxBytesEnv         = "KS_SCAN_REQUEST_MAX_BYTES"
+	// outputDirPerm restricts OutputDir/FailedOutputDir to the owner plus
+	// group read/traverse, instead of os.ModePerm (0777, world-writable),
+	// which scan output/failure directories have no reason to be.
+	outputDirPerm = 0o750
 )
 
 // A Scan Response object

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -355,7 +355,7 @@ func envToString(env string, defaultValue string) string {
 }
 
 func writeScanErrorToFile(err error, scanID string) (e error) {
-	if e = os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
+	if e = os.MkdirAll(FailedOutputDir, outputDirPerm); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to create directory. reason: %s", err.Error(), e.Error())
 	}
 	var f *os.File

--- a/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
@@ -62,3 +62,22 @@ func TestWriteScanErrorToFile(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Equal(t, "scan failed", string(got))
 }
+
+// TestWriteScanErrorToFile_CreatesDirectoryWithRestrictivePermissions guards
+// against a regression back to os.ModePerm (0777, world-writable) for
+// FailedOutputDir. FailedOutputDir must not already exist for this to
+// exercise the MkdirAll call - t.TempDir() itself always exists, so this
+// nests one level under it.
+func TestWriteScanErrorToFile_CreatesDirectoryWithRestrictivePermissions(t *testing.T) {
+	nested := filepath.Join(t.TempDir(), "failed")
+	oldFailedOutputDir := FailedOutputDir
+	FailedOutputDir = nested
+	defer func() { FailedOutputDir = oldFailedOutputDir }()
+
+	require.Error(t, writeScanErrorToFile(errors.New("scan failed"), "scan-id"))
+
+	info, err := os.Stat(nested)
+	require.NoError(t, err)
+	mode := info.Mode().Perm()
+	assert.Zerof(t, mode&0o027, "directory %s has mode %o, more permissive than 0750", nested, mode)
+}


### PR DESCRIPTION
## Summary
- `GetWriter()`, `GetWriterNoStdoutFallback()` (in `core/pkg/resultshandling/printer/printresults.go`), and `Download()` (in `core/core/download.go`) all called `os.MkdirAll(dir, os.ModePerm)` — mode `0777`, world-writable/readable — for directories holding scan output, reports, and downloaded artifacts.
- There's no reason these directories need to be group/world-writable; requesting the least-restrictive mode explicitly works against the process umask instead of relying on it.

## Fix
- Use `0750` (owner rwx, group r-x, no access for others) instead of `os.ModePerm`.

## Test plan
- [x] `go build ./core/...`
- [x] `go vet ./core/...`
- [x] `go test ./core/pkg/resultshandling/printer/... ./core/core/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Restricted permissions for downloaded files and generated output directories.
  * Improved protection against unintended access by replacing broadly permissive directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->