### PR TITLE
fix(httphandler): stop sending wrong HTTP status from Status handler

### DIFF
--- a/httphandler/docs/swagger.yaml
+++ b/httphandler/docs/swagger.yaml
@@ -338,6 +338,8 @@ paths:
       responses:
         "200":
           $ref: '#/responses/scanResponse'
+        "400":
+          $ref: '#/responses/scanResponseBadRequest'
       summary: Returns a scan’s status
       tags:
       - scanning

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -44,7 +44,6 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	metricsQueryParams := &MetricsQueryParams{}
 	if err := schema.NewDecoder().Decode(metricsQueryParams, r.URL.Query()); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
 		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), scanID)
 		return
 	}

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -88,7 +88,10 @@ func (handler *HTTPHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	statusQueryParams := &StatusQueryParams{}
 	if err := schema.NewDecoder().Decode(statusQueryParams, r.URL.Query()); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		// writeError() sends the response header (400) itself; calling
+		// w.WriteHeader() here first made the second call inside writeError()
+		// a silent no-op, so the client always got 500 regardless of the
+		// intended 400.
 		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
 		return
 	}

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -88,10 +88,6 @@ func (handler *HTTPHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	statusQueryParams := &StatusQueryParams{}
 	if err := schema.NewDecoder().Decode(statusQueryParams, r.URL.Query()); err != nil {
-		// writeError() sends the response header (400) itself; calling
-		// w.WriteHeader() here first made the second call inside writeError()
-		// a silent no-op, so the client always got 500 regardless of the
-		// intended 400.
 		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
 		return
 	}

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -228,6 +228,24 @@ func TestStatus_NonGetMethod_Returns405(t *testing.T) {
 	}
 }
 
+// TestStatus_InvalidQueryParams_Returns400 guards against a regression where
+// Status called w.WriteHeader(500) before handler.writeError(), which itself
+// calls w.WriteHeader(400) - the second call is a silent no-op in net/http,
+// so the client always got 500 regardless of the intended 400.
+func TestStatus_InvalidQueryParams_Returns400(t *testing.T) {
+	h := &HTTPHandler{state: newServerState()}
+
+	// StatusQueryParams only declares "id"; an unknown key makes gorilla/schema's
+	// decoder return an error.
+	rq := httptest.NewRequest(http.MethodGet, "/status?unknownParam=x", nil)
+	w := httptest.NewRecorder()
+	h.Status(w, rq)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("Status with invalid query params = HTTP %d; want %d", w.Result().StatusCode, http.StatusBadRequest)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // executeScan error-path test
 //

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -243,6 +244,15 @@ func TestStatus_InvalidQueryParams_Returns400(t *testing.T) {
 
 	if w.Result().StatusCode != http.StatusBadRequest {
 		t.Errorf("Status with invalid query params = HTTP %d; want %d", w.Result().StatusCode, http.StatusBadRequest)
+	}
+
+	resp := decodeResponse(t, w)
+	if resp.Type != utilsapisv1.ErrorScanResponseType {
+		t.Errorf("Status with invalid query params: response.Type = %q; want %q", resp.Type, utilsapisv1.ErrorScanResponseType)
+	}
+	message, _ := resp.Response.(string)
+	if !strings.Contains(message, "failed to parse query params") {
+		t.Errorf("Status with invalid query params: response.Response = %q; want it to describe the decode failure", resp.Response)
 	}
 }
 


### PR DESCRIPTION
## Summary
- On a query-param decode error, `Status()` called `w.WriteHeader(http.StatusInternalServerError)` and then `handler.writeError()`, which itself calls `w.WriteHeader(http.StatusBadRequest)`.
- `net/http` silently no-ops the second `WriteHeader` call (logging "superfluous WriteHeader call"), so the client always received `500` regardless of the intended `400`, and the response body's declared error type/message diverged from the actual status code returned.

## Fix
- Drop the redundant `w.WriteHeader(500)` call and let `writeError()` set the status once — matching how `Scan()` already calls `writeError()` directly on its own parse-error path without a preceding `WriteHeader`.

## Test plan
- [x] `go build ./...` / `go vet ./...` (httphandler module)
- [x] `go test ./... -race` (full httphandler module)
- [x] Added `TestStatus_InvalidQueryParams_Returns400`, which fails against the old code (asserts 400, previously always got 500)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid query parameters for status and metrics endpoints now return the correct HTTP 400 error response instead of HTTP 500.

* **Documentation**
  * Updated the status endpoint API documentation to include its HTTP 400 error response.

* **Tests**
  * Added coverage verifying the corrected response and descriptive error message for unknown query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->