### PR TITLE
fix(cautils): return error when worktree root cannot be resolved in NewLocalGitRepository

### DIFF
--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -44,14 +44,16 @@ func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
 		config:    config,
 	}
 
-	if repoRoot, err := l.GetRootDir(); err == nil {
-		gitRepository, err := newGitRepository(repoRoot)
-		if err != nil {
-			return l, err
-		}
-
-		l.gitRepository = gitRepository
+	repoRoot, err := l.GetRootDir()
+	if err != nil {
+		return nil, err
 	}
+
+	gitRepository, err := newGitRepository(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	l.gitRepository = gitRepository
 
 	return l, nil
 }

--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -18,6 +18,15 @@ type LocalGitRepository struct {
 	config    *configv5.Config
 }
 
+// worktreeRoot resolves the repository's worktree root. It is a package-level
+// var (rather than a direct l.GetRootDir() call) purely so tests can swap in
+// a failing stub to exercise the defensive nil-on-error handling below: with
+// the pinned go-git version, Worktree() only fails when the repository was
+// opened without a worktree filesystem, which PlainOpenWithOptions's
+// DetectDotGit walk does not yield while Head()/Config() still resolve — so
+// no real on-disk fixture can reach that branch today.
+var worktreeRoot = (*LocalGitRepository).GetRootDir
+
 func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
 	goGitRepo, err := gitv5.PlainOpenWithOptions(path, &gitv5.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
@@ -44,11 +53,15 @@ func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
 		config:    config,
 	}
 
-	repoRoot, err := l.GetRootDir()
+	repoRoot, err := worktreeRoot(l)
 	if err != nil {
 		return nil, err
 	}
 
+	// newGitRepository (git_native_disabled.go) never actually returns a
+	// non-nil error today; this is propagated defensively rather than
+	// ignored so NewLocalGitRepository can't return a partially
+	// initialized *LocalGitRepository if that ever changes.
 	gitRepository, err := newGitRepository(repoRoot)
 	if err != nil {
 		return nil, err

--- a/core/cautils/localgitrepository_test.go
+++ b/core/cautils/localgitrepository_test.go
@@ -123,9 +123,11 @@ func (s *LocalGitRepositoryTestSuite) TearDownSuite() {
 }
 
 func (s *LocalGitRepositoryTestSuite) TestInvalidRepositoryPath() {
-	if _, err := NewLocalGitRepository("/invalidpath"); s.Error(err) {
+	repo, err := NewLocalGitRepository("/invalidpath")
+	if s.Error(err) {
 		s.Equal("repository does not exist", err.Error())
 	}
+	s.Nil(repo, "NewLocalGitRepository must not return a partially initialized repository on error")
 }
 
 func (s *LocalGitRepositoryTestSuite) TestRepositoryWithoutRemotes() {

--- a/core/cautils/localgitrepository_test.go
+++ b/core/cautils/localgitrepository_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -204,6 +205,26 @@ func TestGetRemoteUrl(t *testing.T) {
 		},
 		)
 	}
+}
+
+// TestNewLocalGitRepositoryRootDirFailure exercises the defensive nil-on-error
+// branch in NewLocalGitRepository for a worktreeRoot (GetRootDir) failure. No
+// on-disk fixture can drive go-git into that state with the pinned go-git
+// version (see the comment on the worktreeRoot var), so the failure is
+// injected via the seam instead.
+func TestNewLocalGitRepositoryRootDirFailure(t *testing.T) {
+	fixture := createDetachedRepositoryFixture(t, "origin", "https://example.com/team/project.git")
+
+	original := worktreeRoot
+	t.Cleanup(func() { worktreeRoot = original })
+	wantErr := errors.New("simulated worktree resolution failure")
+	worktreeRoot = func(*LocalGitRepository) (string, error) {
+		return "", wantErr
+	}
+
+	repo, err := NewLocalGitRepository(fixture.root)
+	require.Nil(t, repo, "NewLocalGitRepository must not return a partially initialized repository when the worktree root can't be resolved")
+	require.ErrorIs(t, err, wantErr)
 }
 
 func TestLocalGitRepositoryDetachedHead(t *testing.T) {


### PR DESCRIPTION
## Overview

- **Current Behavior:** If `GetRootDir()` or `newGitRepository()` failed, `NewLocalGitRepository` fell through to `return l, nil` with a `nil` embedded `*gitRepository` struct pointer. While `PlainOpenWithOptions` currently fails earlier on bare repositories in go-git v5.19.1 (preventing a live CLI panic), returning a partially initialized struct violates the constructor contract and creates a latent panic risk for callers invoking promoted `*gitRepository` methods.
- **Future Behavior:** Failures in `GetRootDir()` or `newGitRepository()` are propagated as explicit errors (`return nil, err`), ensuring `NewLocalGitRepository` never returns a partially initialized `*LocalGitRepository`.

## Additional Information

- Hardens the `NewLocalGitRepository` constructor contract so that any returned non-nil `*LocalGitRepository` is guaranteed to have a valid, initialized embedded `*gitRepository`.
- Added unit test `TestNewLocalGitRepositoryRootDirFailure` in `core/cautils` to verify that a `GetRootDir()` failure returns `(nil, err)` rather than an uninitialized struct.

## How to Test

Run unit tests and verification checks across affected packages:

```bash
go test -v ./core/cautils/...
go test -v ./core/pkg/resourcehandler/...
go vet ./core/cautils/...
go build ./...
```

## Examples/Screenshots

N/A (Defensive constructor hardening and error-handling fix)

## Related issues/PRs:

* Resolved #2650

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes