### PR TITLE
refactor: use slice instead of fixed-size array for kustomizationFile…

### DIFF
--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -18,7 +18,7 @@ type KustomizeDirectory struct {
 }
 
 // Used for checking if there is "Kustomization" file in the given Directory
-var kustomizationFileMatchers = [3]string{"kustomization.yml", "kustomization.yaml", "Kustomization"}
+var kustomizationFileMatchers = []string{"kustomization.yml", "kustomization.yaml", "Kustomization"}
 
 func isKustomizeDirectory(path string) bool {
 	if ok := isDir(path); !ok {


### PR DESCRIPTION
## Solution Description:
 Changed the kustomizationFileMatchers variable in kustomizedirectory.go from a fixed-size array [3]string to a flexible slice []string to improve code maintainability.

## Changes:

Line 21: Changed var kustomizationFileMatchers = [3]string{...} to var kustomizationFileMatchers = []string{...}
Impact:

Improved code maintainability - easier to add or remove file matchers without needing to update the array size
More flexible and idiomatic Go code
No functional changes - the code works identically
Simple single-character change with clear benefit
#2654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal flexibility for processing kustomization file patterns without changing matching behavior or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->