### PR TITLE
Added variables for default port

### DIFF
--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -28,6 +28,10 @@ const (
 	// healtcheck paths
 	livePath  = "/livez"
 	readyPath = "/readyz"
+
+	// default ports
+	defaultHTTPServerPort = "8080"
+	defaultPprofPort      = "6060"
 )
 
 // SetupHTTPListener set up listening http servers
@@ -110,7 +114,7 @@ func getPort() string {
 	if p := os.Getenv("KS_PORT"); p != "" {
 		return p
 	}
-	return "8080"
+	return defaultHTTPServerPort
 }
 
 func getCertFile() string {
@@ -125,8 +129,8 @@ func servePprof() {
 	go func() {
 		// start pprof server -> https://pkg.go.dev/net/http/pprof
 		if logger.L().GetLevel() == helpers.DebugLevel.String() {
-			logger.L().Info("starting pprof server", helpers.String("port", "6060"))
-			logger.L().Error(http.ListenAndServe(":6060", nil).Error())
+			logger.L().Info("starting pprof server", helpers.String("port", defaultPprofPort))
+			logger.L().Error(http.ListenAndServe(":"+defaultPprofPort, nil).Error())
 		}
 	}()
 }


### PR DESCRIPTION
## Discription 
Instead of hard code the value of default port added new variable for default port.
## Summary of Changes:
1. Added constants to the const block (lines 32-34):
go
// default ports
defaultHTTPServerPort = "8080"
defaultPprofPort      = "6060"
2. Updated getPort() function (line 117):
Changed return "8080" to return defaultHTTPServerPort
3. Updated servePprof() function (lines 132-133):
Changed helpers.String("port", "6060") to helpers.String("port", defaultPprofPort)
Changed http.ListenAndServe(":6060", nil) to http.ListenAndServe(":"+defaultPprofPort, nil)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized default HTTP and profiling server port configuration.
  * Improved consistency between displayed and actual profiling server port settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->