### PR TITLE
remove unused PostRun hook from scan command

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -121,9 +121,6 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 			return nil
 		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			// TODO - revert context
-		},
 	}
 
 	scanInfo.TriggeredByCLI = true


### PR DESCRIPTION
## Solution Description:
 Removed the empty PostRun function from scan.go (lines 124-126) that contained only a TODO comment for context revert logic.

## Changes:

Removed the empty PostRun function with the TODO comment
Context cleanup is already properly handled in the applyTimeout function which is used in securityScan
The PostRun function was vestigial code that reduced code clarity
## Impact:
Improved code clarity by removing confusing empty function with unimplemented TODO
No functional changes - context management remains properly implemented
Cleaner codebase without vestigial code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan command completion by removing an unnecessary post-run callback and its related context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->