### PR TITLE
fix(printer): avoid perfect score rounding

### DIFF
--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -16,3 +16,14 @@ func Float32ToInt(x float32) int {
 func Float32ToIntFloor(x float32) int {
 	return int(math.Floor(float64(x)))
 }
+
+// ComplianceScoreToInt converts a compliance score to a display-safe integer.
+// It preserves the existing rounded display for ordinary scores while ensuring
+// a score below 100 never appears perfect because of rounding.
+func ComplianceScoreToInt(x float32) int {
+	i := Float32ToInt(x)
+	if i >= 100 && x < 100 {
+		return 99
+	}
+	return i
+}

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -25,3 +25,53 @@ func TestFloat32ToInt(t *testing.T) {
 	assert.Equal(t, -4, Float32ToInt(-3.5))
 	assert.Equal(t, -4, Float32ToInt(-3.51))
 }
+
+func TestComplianceScoreToInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  int
+	}{
+		{
+			name:  "ordinary fractional score still rounds",
+			score: 20.7,
+			want:  21,
+		},
+		{
+			name:  "almost perfect score does not round to perfect",
+			score: 99.5,
+			want:  99,
+		},
+		{
+			name:  "near-perfect score does not round to perfect",
+			score: 99.99,
+			want:  99,
+		},
+		{
+			name:  "perfect score remains perfect",
+			score: 100,
+			want:  100,
+		},
+		{
+			name:  "unscored sentinel remains negative",
+			score: -1,
+			want:  -1,
+		},
+		{
+			name:  "integer score from 53 of 100 avoids float32 underflow",
+			score: (float32(53) / float32(100)) * 100,
+			want:  53,
+		},
+		{
+			name:  "integer score from 59 of 100 avoids float32 underflow",
+			score: (float32(59) / float32(100)) * 100,
+			want:  59,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ComplianceScoreToInt(tt.score))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -41,7 +41,7 @@ func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string
 }
 
 func (jsonPrinter *JsonPrinter) Score(score float32) {
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (jsonPrinter *JsonPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v1/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter_test.go
@@ -29,6 +29,7 @@ func TestJsonPrinterScore(t *testing.T) {
 		want  string
 	}{
 		{name: "rounds fractional score", score: 20.7, want: "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n"},
+		{name: "fractional score below perfect", score: 99.5, want: "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n"},
 		{name: "zero score", score: 0, want: "\nOverall compliance-score (100- Excellent, 0- All failed): 0\n"},
 		{name: "perfect score", score: 100, want: "\nOverall compliance-score (100- Excellent, 0- All failed): 100\n"},
 	}

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -28,7 +28,7 @@ func (p *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 }
 
 func (p *PrometheusPrinter) Score(score float32) {
-	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Printf("\n# Overall compliance-score (100- Excellent, 0- All failed)\nkubescape_score %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (p *PrometheusPrinter) printResources(allResources map[string]workloadinterface.IMetadata, resourcesIDs *reporthandling.ResourcesIDs, frameworkName, controlName string) {

--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -51,10 +51,10 @@ func getComplianceScoreColumn(controlSummary reportsummary.IControlSummary, info
 	if controlSummary.GetStatus().IsSkipped() {
 		return fmt.Sprintf("%s %s", "Action Required", getInfoColumn(controlSummary, infoToPrintInfo))
 	}
-	if compliance := cautils.Float32ToInt(controlSummary.GetComplianceScore()); compliance < 0 {
+	if compliance := cautils.ComplianceScoreToInt(controlSummary.GetComplianceScore()); compliance < 0 {
 		return "N/A"
 	} else {
-		return fmt.Sprintf("%d", cautils.Float32ToInt(controlSummary.GetComplianceScore())) + "%"
+		return fmt.Sprintf("%d", compliance) + "%"
 	}
 
 }

--- a/core/pkg/resultshandling/printer/v2/controltable_test.go
+++ b/core/pkg/resultshandling/printer/v2/controltable_test.go
@@ -66,6 +66,15 @@ func Test_generateRowPdf(t *testing.T) {
 
 }
 
+func TestGetComplianceScoreColumnDoesNotRoundFractionalScoreToPerfect(t *testing.T) {
+	score := float32(99.5)
+	controlSummary := &reportsummary.ControlSummary{
+		ComplianceScore: &score,
+	}
+
+	assert.Equal(t, "99%", getComplianceScoreColumn(controlSummary, nil))
+}
+
 func mockSummaryDetails() (*reportsummary.SummaryDetails, error) {
 	data, err := os.ReadFile(filepath.Join(testutils.CurrentDir(), "testdata", "mock_summaryDetails.json"))
 	if err != nil {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -54,7 +54,7 @@ func (jp *JsonPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 
 }
 func (jp *JsonPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) (*imageprinter.ImageScanSummary, error) {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -30,6 +30,11 @@ func TestScore_Json(t *testing.T) {
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n",
 		},
 		{
+			name:  "Fractional score below perfect",
+			score: 99.5,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n",
+		},
+		{
 			name:  "Score less than 0",
 			score: -20.0,
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 0\n",

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -118,7 +118,7 @@ func (jp *JunitPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (jp *JunitPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -47,6 +47,11 @@ func TestScore_Junit(t *testing.T) {
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n",
 		},
 		{
+			name:  "Fractional score below perfect",
+			score: 99.5,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n",
+		},
+		{
 			name:  "Score less than 0",
 			score: -20.0,
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 0\n",

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -59,7 +59,7 @@ func (pp *PdfPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (pp *PdfPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -27,6 +27,11 @@ func TestScore_Pdf(t *testing.T) {
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n",
 		},
 		{
+			name:  "Fractional score below perfect",
+			score: 99.5,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n",
+		},
+		{
 			name:  "Score less than 0",
 			score: -20.0,
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 0\n",

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -87,7 +87,7 @@ func GetComplianceScoreColumn(controlSummary reportsummary.IControlSummary, info
 	if controlSummary.GetStatus().IsSkipped() {
 		return fmt.Sprintf("%s %s", "Action Required", GetInfoColumn(controlSummary, infoToPrintInfo))
 	}
-	return fmt.Sprintf("%d", cautils.Float32ToInt(controlSummary.GetComplianceScore())) + "%"
+	return fmt.Sprintf("%d", cautils.ComplianceScoreToInt(controlSummary.GetComplianceScore())) + "%"
 }
 
 func GetInfoColumn(controlSummary reportsummary.IControlSummary, infoToPrintInfo []utils.InfoStars) string {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
@@ -226,6 +226,15 @@ func TestGenerateFooter_Full(t *testing.T) {
 	}
 }
 
+func TestGetComplianceScoreColumnDoesNotRoundFractionalScoreToPerfect(t *testing.T) {
+	score := float32(99.5)
+	controlSummary := &reportsummary.ControlSummary{
+		ComplianceScore: &score,
+	}
+
+	assert.Equal(t, "99%", GetComplianceScoreColumn(controlSummary, nil))
+}
+
 func TestGenerateFooter_ShortVsFullDiffer(t *testing.T) {
 	sd := reportsummary.SummaryDetails{ComplianceScore: 50}
 	short := GenerateFooter(&sd, true)

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -60,7 +60,7 @@ func (pp *PrometheusPrinter) Score(score float32) {
 
 	fmt.Fprintf(pp.writer, "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n")
 	fmt.Fprintf(pp.writer, "# TYPE kubescape_score gauge\n")
-	fmt.Fprintf(pp.writer, "kubescape_score %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(pp.writer, "kubescape_score %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (pp *PrometheusPrinter) generatePrometheusFormat(

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -77,6 +77,11 @@ func TestScore(t *testing.T) {
 			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 50\n",
 		},
 		{
+			name:  "Fractional score below perfect",
+			score: 99.5,
+			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 99\n",
+		},
+		{
 			name:  "Zero Score",
 			score: 0.0,
 			want:  "# HELP kubescape_score Overall compliance score (100 Excellent, 0 All failed)\n# TYPE kubescape_score gauge\nkubescape_score 0\n",

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -325,12 +325,12 @@ func (mcrs *mControlComplianceScore) set(resources reportsummary.ICounters) {
 func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetails) {
 	m.rs.set(summaryDetails.NumberOfResources(), summaryDetails.NumberOfControls())
 	// GetScore() returns the risk score; the metric is the compliance score.
-	m.rs.complianceScore = cautils.Float32ToInt(summaryDetails.ComplianceScore)
+	m.rs.complianceScore = cautils.ComplianceScoreToInt(summaryDetails.ComplianceScore)
 
 	for _, fw := range summaryDetails.ListFrameworks() {
 		mfrs := mFrameworkComplianceScore{
 			frameworkName:   fw.GetName(),
-			complianceScore: cautils.Float32ToInt(fw.GetComplianceScore()),
+			complianceScore: cautils.ComplianceScoreToInt(fw.GetComplianceScore()),
 		}
 		mfrs.set(fw.NumberOfResources(), fw.NumberOfControls())
 		m.listFrameworks = append(m.listFrameworks, mfrs)
@@ -340,7 +340,7 @@ func (m *Metrics) setComplianceScores(summaryDetails *reportsummary.SummaryDetai
 		mcrs := mControlComplianceScore{
 			controlName:     control.GetName(),
 			controlID:       control.GetID(),
-			complianceScore: cautils.Float32ToInt(control.GetComplianceScore()),
+			complianceScore: cautils.ComplianceScoreToInt(control.GetComplianceScore()),
 			link:            cautils.GetControlLink(control.GetID()),
 			severity:        apis.ControlSeverityToString(control.GetScoreFactor()),
 			remediation:     control.GetRemediation(),

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -426,3 +426,32 @@ func TestSetComplianceScores_ControlMetricsUseComplianceScore(t *testing.T) {
 	assert.NotContains(t, output, "kubescape_control_complianceScore{name=\"Unset Control\"")
 	assert.Contains(t, output, "kubescape_control_count_resources_failed{name=\"Unset Control\"")
 }
+
+func TestSetComplianceScoresDoNotRoundFractionalScoresToPerfect(t *testing.T) {
+	controlScore := float32(99.5)
+	summaryDetails := &reportsummary.SummaryDetails{
+		ComplianceScore: 99.5,
+		Frameworks: []reportsummary.FrameworkSummary{
+			{
+				Name:            "Almost Perfect",
+				ComplianceScore: 99.5,
+			},
+		},
+		Controls: reportsummary.ControlSummaries{
+			"C-ALMOST": {
+				ControlID:       "C-ALMOST",
+				Name:            "Almost Perfect Control",
+				ComplianceScore: &controlScore,
+			},
+		},
+	}
+
+	m := &Metrics{}
+	m.setComplianceScores(summaryDetails)
+	output := m.String()
+
+	assert.Contains(t, output, "kubescape_cluster_complianceScore{} 99")
+	assert.Contains(t, output, "kubescape_framework_complianceScore{name=\"Almost Perfect\"} 99")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^kubescape_control_complianceScore\{name="Almost Perfect Control".*\} 99$`), output)
+	assert.NotContains(t, output, "complianceScore{} 100")
+}


### PR DESCRIPTION
## Summary
- Fixes #2626
- Prevent integer compliance-score renderers from displaying a sub-100 score as a perfect 100
- Preserve existing round-to-nearest behavior for ordinary fractional scores, including exact integer scores produced with float32 ratio math
- Keep the HTML risk-score helper on its existing rounding behavior
- Add regression coverage for 99.5 scores and float32-derived 53/100 and 59/100 integer scores

## Testing
- go test ./core/cautils
- go test ./core/pkg/resultshandling/printer/v1
- go test ./core/pkg/resultshandling/printer/v2
- go test ./core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter
- go test ./core/pkg/resultshandling/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compliance scores below 100% no longer display as 100% after rounding. For example, 99.5% is consistently shown as 99%.
  - Corrected score formatting across JSON, Prometheus, JUnit, PDF, table, and summary outputs.
  - Preserved existing handling for perfect scores and unavailable values.

- **Tests**
  - Added regression coverage for fractional, perfect, unavailable, and calculated compliance scores across supported output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->