### PR TITLE
fix: add epsilon tolerance to Float32ToIntFloor for float32 precision loss

### DIFF
--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -12,9 +12,16 @@ func Float32ToInt(x float32) int {
 	return Float64ToInt(float64(x))
 }
 
-// Float32ToIntFloor converts float32 to int by flooring, so a value never rounds up
+// Float32ToIntFloor converts float32 to int by flooring, so a value never
+// rounds up. float32 representation error means exact percentages like
+// 53/100 may render as 52.999996 — a small epsilon tolerance snaps those
+// back to the true integer before flooring, so 53.0/100.0 stays 53.
 func Float32ToIntFloor(x float32) int {
-	return int(math.Floor(float64(x)))
+	f := float64(x)
+	if r := math.Round(f); math.Abs(f-r) < 1e-4 {
+		return int(r)
+	}
+	return int(math.Floor(f))
 }
 
 // ComplianceScoreToInt converts a compliance score to a display-safe integer.

--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -2,6 +2,8 @@ package cautils
 
 import "math"
 
+const floorEpsilon = 1e-4
+
 // Float64ToInt convert float64 to int
 func Float64ToInt(x float64) int {
 	return int(math.Round(x))
@@ -12,13 +14,15 @@ func Float32ToInt(x float32) int {
 	return Float64ToInt(float64(x))
 }
 
-// Float32ToIntFloor converts float32 to int by flooring, so a value never
-// rounds up. float32 representation error means exact percentages like
-// 53/100 may render as 52.999996 — a small epsilon tolerance snaps those
-// back to the true integer before flooring, so 53.0/100.0 stays 53.
+// Float32ToIntFloor converts float32 to int by flooring. float32 representation
+// error can make float32(53)/float32(100)*100 evaluate to 52.999996, so values
+// within epsilon of an integer snap to that integer first. This is a deliberate
+// exception to flooring: a value just below an integer can snap up to it.
+// The snap only applies to non-negative values; negative inputs retain standard
+// math.Floor semantics.
 func Float32ToIntFloor(x float32) int {
 	f := float64(x)
-	if r := math.Round(f); math.Abs(f-r) < 1e-4 {
+	if r := math.Round(f); f >= 0 && math.Abs(f-r) < floorEpsilon {
 		return int(r)
 	}
 	return int(math.Floor(f))

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -75,3 +75,16 @@ func TestComplianceScoreToInt(t *testing.T) {
 		})
 	}
 }
+
+func TestFloat32ToIntFloor(t *testing.T) {
+	assert.Equal(t, 99, Float32ToIntFloor(99.5))
+	assert.Equal(t, 99, Float32ToIntFloor(99.9))
+	assert.Equal(t, 100, Float32ToIntFloor(100.0))
+	assert.Equal(t, 0, Float32ToIntFloor(0.5))
+}
+
+func TestFloat32ToIntFloor_Float32Precision(t *testing.T) {
+	assert.Equal(t, 53, Float32ToIntFloor(float32(53)/float32(100)*100))
+	assert.Equal(t, 59, Float32ToIntFloor(float32(59)/float32(100)*100))
+	assert.Equal(t, 53, Float32ToIntFloor(float32(106)/float32(200)*100))
+}

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -81,6 +81,14 @@ func TestFloat32ToIntFloor(t *testing.T) {
 	assert.Equal(t, 99, Float32ToIntFloor(99.9))
 	assert.Equal(t, 100, Float32ToIntFloor(100.0))
 	assert.Equal(t, 0, Float32ToIntFloor(0.5))
+	// boundary: inside epsilon snaps to integer
+	assert.Equal(t, 100, Float32ToIntFloor(100-float32(5e-5)))
+	// boundary: outside epsilon still floors
+	assert.Equal(t, 99, Float32ToIntFloor(100-float32(2e-3)))
+	// negative values preserve standard floor semantics
+	assert.Equal(t, -1, Float32ToIntFloor(-1e-5))
+	assert.Equal(t, -2, Float32ToIntFloor(-1.00005))
+	assert.Equal(t, -1, Float32ToIntFloor(-0.5))
 }
 
 func TestFloat32ToIntFloor_Float32Precision(t *testing.T) {

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -294,3 +294,22 @@ func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
+
+func TestComputeCoverageScore_Float32PrecisionLoss(t *testing.T) {
+	// 53 out of 100 evaluated controls: float32(53)/float32(100)*100
+	// evaluates to 52.999996 internally, but Float32ToIntFloor snaps it
+	// back to 53 so the displayed score is correct.
+	c := ScanCoverage{
+		NotEvaluatedControls: makeNotEvaluatedControls(47),
+	}
+	c.ComputeCoverageScore(100)
+	assert.Equal(t, 53, Float32ToIntFloor(c.CoverageScore))
+}
+
+func makeNotEvaluatedControls(n int) []NotEvaluatedControl {
+	ne := make([]NotEvaluatedControl, n)
+	for i := range ne {
+		ne[i] = NotEvaluatedControl{ControlID: string(rune('A' + i))}
+	}
+	return ne
+}


### PR DESCRIPTION
## Overview

`Float32ToIntFloor` uses `math.Floor` directly. Float32 division produces representation errors, e.g. `float32(53)/float32(100)*100` renders as `52.999996`. `math.Floor` turns that into `52`, losing a whole point on exact percentages.

## Additional Information

This adds an epsilon tolerance: snap to the nearest integer within `1e-4` before flooring. Exact percentages survive float32 precision loss while fractional values (99.5) still floor correctly.

Discovered during review of #2632, matthyx identified that `53/100 → 52` in 40 cases for total ≤ 2000. The epsilon fix was recommended there. This PR applies it to `Float32ToIntFloor` independently so it's correct regardless of call site.

## Changes

- **floatutils.go**: `Float32ToIntFloor` now snaps to `math.Round(f)` when `|f - Round(f)| < 1e-4`, floors otherwise
- **floatutils_test.go**: added `TestFloat32ToIntFloor` (99.5→99, 99.9→99, 100→100) and `TestFloat32ToIntFloor_Float32Precision` (53/100→53, 59/100→59, 106/200→53)

## How to Test

```bash
go test ./core/cautils/ -run Float32ToIntFloor
```

Test fails with epsilon=0 (bare floor gives 52 for 53/100). Passes with `1e-4`.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-negative values that are very close to whole numbers when converting decimals to integers.
  * Preserved standard flooring behavior for negative and other fractional values.
  * Corrected integer conversion for coverage scores affected by decimal precision.

* **Tests**
  * Added coverage for fractional, integral, zero, negative, boundary, and float-precision scenarios.
  * Added regression coverage for accurate conversion of coverage scores near whole-number values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->