### PR TITLE
fix(core): escape inner quotes in FixPathToValidYamlExpression string values

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -822,9 +822,11 @@ func FixPathToValidYamlExpression(fixPath, value string, documentIndexInYaml int
 		isStringValue = false
 	}
 
-	// Strings should be quoted
+	// Strings should be quoted. Escape only `"` — yq's expression lexer
+	// (lexer_participle.go stringValue) unescapes \" and nothing else, so any
+	// other Go-style escape would be written to the file literally.
 	if isStringValue {
-		value = fmt.Sprintf("%q", value)
+		value = `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
 	}
 
 	// select document index and add a dot for the root node

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -824,7 +824,7 @@ func FixPathToValidYamlExpression(fixPath, value string, documentIndexInYaml int
 
 	// Strings should be quoted
 	if isStringValue {
-		value = fmt.Sprintf("\"%s\"", value)
+		value = fmt.Sprintf("%q", value)
 	}
 
 	// select document index and add a dot for the root node

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -272,6 +272,15 @@ func Test_fixPathToValidYamlExpression(t *testing.T) {
 			want: "select(di==0).metadata.namespace |= \"YOUR_NAMESPACE\"",
 		},
 		{
+			name: "fix path with string containing quotes",
+			args: args{
+				fixPath:             "spec.template.spec.containers[0].command[1]",
+				value:               "app=\"web\"",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).spec.template.spec.containers[0].command[1] |= \"app=\\\"web\\\"\"",
+		},
+		{
 			name: "fix path with number",
 			args: args{
 				fixPath:             "xxx.yyy",

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -281,6 +281,33 @@ func Test_fixPathToValidYamlExpression(t *testing.T) {
 			want: "select(di==0).spec.template.spec.containers[0].command[1] |= \"app=\\\"web\\\"\"",
 		},
 		{
+			name: "fix path with string containing backslash",
+			args: args{
+				fixPath:             "path",
+				value:               "C:\\path\\to",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).path |= \"C:\\path\\to\"",
+		},
+		{
+			name: "fix path with string containing newline",
+			args: args{
+				fixPath:             "path",
+				value:               "line1\nline2",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).path |= \"line1\nline2\"",
+		},
+		{
+			name: "fix path with string containing tab",
+			args: args{
+				fixPath:             "path",
+				value:               "a\tb",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).path |= \"a\tb\"",
+		},
+		{
 			name: "fix path with number",
 			args: args{
 				fixPath:             "xxx.yyy",


### PR DESCRIPTION
Fixes #2668

### Description
When generating `yq` expressions in `FixPathToValidYamlExpression`, the function previously relied on `fmt.Sprintf("\"%s\"", value)` to quote strings. However, if the fix value itself contained quotes (e.g., `app="web"`), the inner quotes were not escaped, resulting in malformed YAML/yq syntax that caused the auto-remediation step to abort entirely.

This PR updates the string formatter to `%q` to properly escape any inner quotes.

### Changes
- Updated string formatting in `FixPathToValidYamlExpression`.
- Added a unit test covering fix paths with string values containing inner quotes.

Signed-off-by: Shivansh Gohem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML expression generation by correctly escaping special characters, including quotation marks, backslashes, newlines, and tabs, in string values.

* **Tests**
  * Added coverage to verify proper escaping and preservation of special characters in string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->