### PR TITLE
test: add TestFloat32ToIntFloor for floor conversion helper

### DIFF
--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -25,3 +25,11 @@ func TestFloat32ToInt(t *testing.T) {
 	assert.Equal(t, -4, Float32ToInt(-3.5))
 	assert.Equal(t, -4, Float32ToInt(-3.51))
 }
+
+func TestFloat32ToIntFloor(t *testing.T) {
+	assert.Equal(t, 99, Float32ToIntFloor(99.5))
+	assert.Equal(t, 99, Float32ToIntFloor(99.9))
+	assert.Equal(t, 100, Float32ToIntFloor(100.0))
+	assert.Equal(t, 0, Float32ToIntFloor(0.5))
+	assert.Equal(t, 0, Float32ToIntFloor(0.0))
+}


### PR DESCRIPTION
## Overview

`Float32ToIntFloor` had no dedicated unit test — it was only exercised indirectly through printer output tests. Adds direct table-driven coverage for floor conversion semantics.

## Additional Information

The function is used for coverage scores and compliance scores to ensure fractional values never round up (99.5 → 99, not 100). Testing it in isolation catches regressions before they propagate to printer output.

## Changes

- **floatutils_test.go**: added `TestFloat32ToIntFloor` covering fractional flooring (99.5→99, 99.9→99), boundary values (100→100, 0.5→0, 0.0→0)

## How to Test

```bash
go test ./core/cautils/ -run Float32ToIntFloor
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for converting positive fractional, whole-number, and zero floating-point values to integers using floor/truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->