### PR TITLE
test: add GetControlsInputs coverage for CRDControlInputs getter

### DIFF
--- a/core/cautils/getter/crdcontrolinputs_test.go
+++ b/core/cautils/getter/crdcontrolinputs_test.go
@@ -4,8 +4,49 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
 )
+
+func TestGetControlsInputs_WithControls(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewSimpleDynamicClient(scheme,
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       "ControlInput",
+				"metadata": map[string]any{
+					"name": "default",
+				},
+				"spec": map[string]any{
+					"controls": map[string]any{
+						"untrustedRegistries": []any{"docker.io", "quay.io"},
+						"insecureCapabilities": []any{"NET_RAW", "SYS_ADMIN"},
+					},
+				},
+			},
+		},
+	)
+
+	getter := &CRDControlInputs{client: client}
+	inputs, err := getter.GetControlsInputs("")
+	require.NoError(t, err)
+	assert.Len(t, inputs, 2)
+	assert.Equal(t, []string{"docker.io", "quay.io"}, inputs["untrustedRegistries"])
+	assert.Equal(t, []string{"NET_RAW", "SYS_ADMIN"}, inputs["insecureCapabilities"])
+}
+
+func TestGetControlsInputs_MissingDefault(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewSimpleDynamicClient(scheme)
+
+	getter := &CRDControlInputs{client: client}
+	_, err := getter.GetControlsInputs("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get ControlInput CRD")
+}
 
 func TestExtractControlsInputs_EmptyObject(t *testing.T) {
 	obj := &unstructured.Unstructured{

--- a/core/cautils/getter/crdcontrolinputs_test.go
+++ b/core/cautils/getter/crdcontrolinputs_test.go
@@ -22,7 +22,7 @@ func TestGetControlsInputs_WithControls(t *testing.T) {
 				},
 				"spec": map[string]any{
 					"controls": map[string]any{
-						"untrustedRegistries": []any{"docker.io", "quay.io"},
+						"untrustedRegistries":  []any{"docker.io", "quay.io"},
 						"insecureCapabilities": []any{"NET_RAW", "SYS_ADMIN"},
 					},
 				},
@@ -43,8 +43,8 @@ func TestGetControlsInputs_MissingDefault(t *testing.T) {
 	client := fake.NewSimpleDynamicClient(scheme)
 
 	getter := &CRDControlInputs{client: client}
-	_, err := getter.GetControlsInputs("")
-	assert.Error(t, err)
+	_, err := getter.GetControlsInputs("") // clusterName is unused by the implementation
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get ControlInput CRD")
 }
 


### PR DESCRIPTION
## Overview

`CRDControlInputs.GetControlsInputs` had 0% test coverage — only the internal `extractControlsInputs` parser was tested. The public method queries the cluster for a ControlInput CRD named "default" and parses its spec.controls into a `map[string][]string`.

## Additional Information

Uses `fake.NewSimpleDynamicClient` to register a ControlInput resource, matching the test pattern already used by `crdexceptionsgetter_test.go`. Covers both the successful path (controls returned from CRD) and the error path (default resource not found).

## Changes

- **crdcontrolinputs_test.go**: added `TestGetControlsInputs_WithControls` (verifies control inputs are parsed from a fake CRD) and `TestGetControlsInputs_MissingDefault` (verifies error when default resource is absent)

## How to Test

```bash
go test ./core/cautils/getter/ -run TestGetControlsInputs
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for retrieving and converting configured control inputs.
  * Added validation for the error shown when the default control input resource is unavailable.
  * Improves confidence that control configuration is handled consistently in both successful and missing-resource scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->