### PR TITLE
fix(resourcehandler): check HTTP status code in httpGet (dead-code hardening)

### DIFF
--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -61,6 +61,12 @@ func NewGitHubRepository() *GitHubRepository {
 	}
 }
 
+// ScanRepository lists YAML/JSON manifest paths in a GitHub repository via
+// the GitHub REST API. As of this writing nothing in this repository calls
+// it - `kubescape scan <github-url>` resolves through cautils.CloneGitRepo
+// (go-git clone) instead, which never reaches this file. It's kept as
+// exported API surface for external importers of this module; if that's not
+// actually needed, this file is a candidate for deletion.
 func ScanRepository(command string, branchOptional string) ([]string, error) {
 	repo, err := getRepository(command)
 	if err != nil {
@@ -212,20 +218,16 @@ func httpGet(client *http.Client, url string, headers map[string]string) ([]byte
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		const maxBodyInError = 1024
-		if len(body) > maxBodyInError {
-			body = body[:maxBodyInError]
-		}
-		return nil, fmt.Errorf("request to %q failed with status %q: %s", url, resp.Status, body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyInError))
+		// Bounding the read can cut a multi-byte UTF-8 rune in half at the
+		// 1024-byte boundary; drop the resulting invalid trailing bytes
+		// rather than embedding a mangled rune in the error string.
+		return nil, fmt.Errorf("request to %q failed with status %q: %s", url, resp.Status, strings.ToValidUTF8(string(body), ""))
 	}
 
-	return body, nil
+	return io.ReadAll(resp.Body)
 }
 func (g *GitHubRepository) setTree() error {
 	if g.isFile {

--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -211,7 +211,21 @@ func httpGet(client *http.Client, url string, headers map[string]string) ([]byte
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		const maxBodyInError = 1024
+		if len(body) > maxBodyInError {
+			body = body[:maxBodyInError]
+		}
+		return nil, fmt.Errorf("request to %q failed with status %q: %s", url, resp.Status, body)
+	}
+
+	return body, nil
 }
 func (g *GitHubRepository) setTree() error {
 	if g.isFile {

--- a/core/pkg/resourcehandler/repositoryscanner_test.go
+++ b/core/pkg/resourcehandler/repositoryscanner_test.go
@@ -221,6 +221,67 @@ func TestGithubParse(t *testing.T) {
 	}
 }
 
+// roundTripFunc lets a test supply a RoundTrip implementation inline.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// TestHttpGet_NonSuccessStatusReturnsError guards against a regression where
+// httpGet returned the response body as-is regardless of the HTTP status
+// code. An upstream error response (e.g. GitHub's 404/403/401 JSON error
+// body) would previously be parsed as if it were a successful response,
+// silently producing an empty/wrong result instead of a clear error.
+func TestHttpGet_NonSuccessStatusReturnsError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		status     string
+		body       string
+	}{
+		{name: "not found", statusCode: http.StatusNotFound, status: "404 Not Found", body: `{"message":"Not Found"}`},
+		{name: "forbidden / rate limited", statusCode: http.StatusForbidden, status: "403 Forbidden", body: `{"message":"API rate limit exceeded"}`},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, status: "401 Unauthorized", body: `{"message":"Bad credentials"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     tt.status,
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
+						Header:     make(http.Header),
+					}, nil
+				}),
+			}
+
+			body, err := httpGet(client, "https://api.github.com/repos/owner/repo", nil)
+			assert.Error(t, err)
+			assert.Nil(t, body)
+			assert.Contains(t, err.Error(), tt.status)
+			assert.Contains(t, err.Error(), tt.body, tt.name+": error should surface the response body for diagnosis")
+		})
+	}
+}
+
+func TestHttpGet_SuccessReturnsBody(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"default_branch":"main"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	body, err := httpGet(client, "https://api.github.com/repos/owner/repo", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"default_branch":"main"}`, string(body))
+}
+
 func TestGetFilesFromTree(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/core/pkg/resourcehandler/repositoryscanner_test.go
+++ b/core/pkg/resourcehandler/repositoryscanner_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -263,6 +264,55 @@ func TestHttpGet_NonSuccessStatusReturnsError(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.body, tt.name+": error should surface the response body for diagnosis")
 		})
 	}
+}
+
+// TestHttpGet_NonSuccessStatusReturnsError_URLInError checks that the
+// request URL, not just the status and body, appears in the returned error -
+// the other half of the error contract, alongside truncation, that's easy to
+// regress silently.
+func TestHttpGet_NonSuccessStatusReturnsError_URLInError(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "404 Not Found",
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"Not Found"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	const url = "https://api.github.com/repos/owner/repo"
+	body, err := httpGet(client, url, nil)
+	assert.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), url)
+}
+
+// TestHttpGet_NonSuccessStatusReturnsError_TruncatesLargeBody guards the
+// 1024-byte cap on the error body: without it, an oversized upstream error
+// response (or one that never closes) would grow the returned error
+// unbounded.
+func TestHttpGet_NonSuccessStatusReturnsError_TruncatesLargeBody(t *testing.T) {
+	const maxBodyInError = 1024
+	oversized := strings.Repeat("a", maxBodyInError*4) + "TAIL-SHOULD-BE-CUT"
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "500 Internal Server Error",
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(bytes.NewBufferString(oversized)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	body, err := httpGet(client, "https://api.github.com/repos/owner/repo", nil)
+	assert.Error(t, err)
+	assert.Nil(t, body)
+	assert.NotContains(t, err.Error(), "TAIL-SHOULD-BE-CUT")
+	assert.LessOrEqual(t, len(err.Error()), maxBodyInError+256, "error message should stay close to the 1024-byte body cap, not grow with the response size")
 }
 
 func TestHttpGet_SuccessReturnsBody(t *testing.T) {


### PR DESCRIPTION
## Summary

`httpGet()` in `core/pkg/resourcehandler/repositoryscanner.go` is used by `GitHubRepository.setBranch()`/`setTree()`, which are called only from `ScanRepository()`.

**This PR does *not* fix a live `kubescape scan <github-url>` bug.** As matthyx found in review, `ScanRepository` has no caller anywhere in this repository outside its own test file — `kubescape scan <github-url>` actually resolves through `cautils.CloneGitRepo` (go-git clone, `core/cautils/scaninfo.go:413`), which never touches the GitHub REST API or this file. `git grep ScanRepository -- '*.go'` confirms this. So the fix below is defensive hardening of a currently-unreferenced helper, not a fix to an observable CLI behavior. (An earlier version of this description incorrectly claimed `kubescape scan <github-url>` would silently report "no files found" because of this bug — that claim is wrong and has been removed; it does not describe any code path that runs today.)

Whether `repositoryscanner.go` should be deleted entirely, or is intentionally kept as exported API for external importers of this module, is a maintainer call — a doc comment on `ScanRepository` records the situation rather than deciding it here.

- `httpGet()` read the response body and returned it **regardless of the HTTP status code**. A non-2xx response from the GitHub API (404/403/401) returns a JSON error body, which was then unmarshaled as if it were success, so `setBranch`/`setTree` would silently proceed with zero-valued fields instead of surfacing an error.
- Inconsistent with this codebase's other HTTP helpers (`core/cautils/getter/getpoliciesutils.go`'s `httpRespToString()`, `core/cautils/getter/kscloudapi.go`'s `HTTPPost()`), which do check `resp.StatusCode`.

## Fix

- Return an error (including the response status and a bounded prefix of the body) for any non-2xx response.
- Bound the error-path body read with `io.LimitReader` *before* reading (rather than reading the full body unconditionally and truncating after), and apply `strings.ToValidUTF8` to the truncated slice so a 1024-byte cut can't embed half a multi-byte UTF-8 rune in the error string.
- Added a doc comment on `ScanRepository` documenting that it currently has no in-repo caller.

## Test plan

- `go build ./core/pkg/resourcehandler/...`
- `go vet ./core/pkg/resourcehandler/...`
- `go test ./core/pkg/resourcehandler/...` (full package, all tests pass)
- Tests: `TestHttpGet_NonSuccessStatusReturnsError` (404/403/401), `TestHttpGet_SuccessReturnsBody`, `TestHttpGet_NonSuccessStatusReturnsError_URLInError`, `TestHttpGet_NonSuccessStatusReturnsError_TruncatesLargeBody`
