### PR TITLE
fix(tableprinter): truncate control/resource names on a rune boundary

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
@@ -67,12 +67,7 @@ func generateCategoryStatusRow(controlSummary reportsummary.IControlSummary) tab
 
 	rows[0] = utils.GetStatusIcon(controlSummary.GetStatus().Status())
 
-	name := controlSummary.GetName()
-	if len(name) > 50 {
-		rows[1] = name[:50] + "..." //nolint:gosec // Safe: rows has length 3, accessing index 1
-	} else {
-		rows[1] = name //nolint:gosec // Safe: rows has length 3, accessing index 1
-	}
+	rows[1] = utils.TruncateName(controlSummary.GetName(), 50) //nolint:gosec // Safe: rows has length 3, accessing index 1
 
 	rows[2] = getDocsForControl(controlSummary)
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/categorytable.go
@@ -67,7 +67,7 @@ func generateCategoryStatusRow(controlSummary reportsummary.IControlSummary) tab
 
 	rows[0] = utils.GetStatusIcon(controlSummary.GetStatus().Status())
 
-	rows[1] = utils.TruncateName(controlSummary.GetName(), 50) //nolint:gosec // Safe: rows has length 3, accessing index 1
+	rows[1] = utils.TruncateName(controlSummary.GetName(), utils.MaxControlNameLen)
 
 	rows[2] = getDocsForControl(controlSummary)
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -71,11 +71,7 @@ func GenerateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo [
 	}
 
 	row[summaryColumnSeverity] = GetSeverityColumn(controlSummary)
-	if len(controlSummary.GetName()) > 50 {
-		row[summaryColumnName] = controlSummary.GetName()[:50] + "..." //nolint:gosec // Safe: row has length _summaryRowLen (5), accessing index 1
-	} else {
-		row[summaryColumnName] = controlSummary.GetName() //nolint:gosec // Safe: row has length _summaryRowLen (5), accessing index 1
-	}
+	row[summaryColumnName] = utils.TruncateName(controlSummary.GetName(), 50) //nolint:gosec // Safe: row has length _summaryRowLen (5), accessing index 1
 	row[summaryColumnCounterFailed] = fmt.Sprintf("%d", controlSummary.NumberOfResources().Failed())
 	row[summaryColumnCounterAll] = fmt.Sprintf("%d", controlSummary.NumberOfResources().All())
 	row[summaryColumnComplianceScore] = GetComplianceScoreColumn(controlSummary, infoToPrintInfo)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -71,7 +71,7 @@ func GenerateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfo [
 	}
 
 	row[summaryColumnSeverity] = GetSeverityColumn(controlSummary)
-	row[summaryColumnName] = utils.TruncateName(controlSummary.GetName(), 50) //nolint:gosec // Safe: row has length _summaryRowLen (5), accessing index 1
+	row[summaryColumnName] = utils.TruncateName(controlSummary.GetName(), utils.MaxControlNameLen)
 	row[summaryColumnCounterFailed] = fmt.Sprintf("%d", controlSummary.NumberOfResources().Failed())
 	row[summaryColumnCounterAll] = fmt.Sprintf("%d", controlSummary.NumberOfResources().All())
 	row[summaryColumnComplianceScore] = GetComplianceScoreColumn(controlSummary, infoToPrintInfo)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
@@ -178,7 +178,13 @@ func CheckShortTerminalWidth(rows []table.Row, headers table.Row) bool {
 	return termWidth <= maxWidth
 }
 
-// TruncateName truncates name to at most maxLen runes, appending "...".
+// MaxControlNameLen is the truncation limit shared by the category and
+// summary table control-name columns, so the two stay in sync.
+const MaxControlNameLen = 50
+
+// TruncateName returns name unchanged if it is at most maxLen runes long,
+// otherwise truncates it to maxLen runes plus an appended "..." (so the
+// result is maxLen+3 runes when truncation happens).
 // Slicing a string by byte index (name[:maxLen]) can split a multi-byte
 // UTF-8 rune in half when name contains non-ASCII characters (e.g. non-Latin
 // script, accented characters, emoji in resource/control names), producing

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
@@ -178,6 +178,20 @@ func CheckShortTerminalWidth(rows []table.Row, headers table.Row) bool {
 	return termWidth <= maxWidth
 }
 
+// TruncateName truncates name to at most maxLen runes, appending "...".
+// Slicing a string by byte index (name[:maxLen]) can split a multi-byte
+// UTF-8 rune in half when name contains non-ASCII characters (e.g. non-Latin
+// script, accented characters, emoji in resource/control names), producing
+// invalid UTF-8 and garbled table output. Truncating by rune count avoids
+// that.
+func TruncateName(name string, maxLen int) string {
+	runes := []rune(name)
+	if len(runes) <= maxLen {
+		return name
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
 func GetColorForVulnerabilitySeverity(severity string) func(...string) string {
 	switch severity {
 	case apis.SeverityCriticalString:

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jwalton/gchalk"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncateName(t *testing.T) {
@@ -34,15 +35,14 @@ func TestTruncateName(t *testing.T) {
 	// must never do that.
 	t.Run("multi-byte UTF-8 name is truncated on a rune boundary", func(t *testing.T) {
 		name := strings.Repeat("héllo-世界-", 10) // multi-byte runes throughout, > 50 bytes and > 50 runes
-		require := assert.New(t)
-		require.Greater(len([]byte(name)), 50)
-		require.Greater(len([]rune(name)), 50)
+		require.Greater(t, len([]byte(name)), 50)
+		require.Greater(t, len([]rune(name)), 50)
 
 		got := TruncateName(name, 50)
 
-		require.True(utf8.ValidString(got), "truncated name must be valid UTF-8")
-		require.True(strings.HasSuffix(got, "..."))
-		require.Equal(50, len([]rune(strings.TrimSuffix(got, "..."))), "must truncate by rune count, not byte count")
+		require.True(t, utf8.ValidString(got), "truncated name must be valid UTF-8")
+		require.True(t, strings.HasSuffix(got, "..."))
+		require.Equal(t, 50, len([]rune(strings.TrimSuffix(got, "..."))), "must truncate by rune count, not byte count")
 	})
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils_test.go
@@ -3,13 +3,48 @@ package utils
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jwalton/gchalk"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestTruncateName(t *testing.T) {
+	t.Run("short name is unchanged", func(t *testing.T) {
+		assert.Equal(t, "short", TruncateName("short", 50))
+	})
+
+	t.Run("ASCII name longer than max is truncated with ellipsis", func(t *testing.T) {
+		name := strings.Repeat("a", 60)
+		got := TruncateName(name, 50)
+		assert.Equal(t, strings.Repeat("a", 50)+"...", got)
+	})
+
+	t.Run("name exactly at max length is unchanged", func(t *testing.T) {
+		name := strings.Repeat("a", 50)
+		assert.Equal(t, name, TruncateName(name, 50))
+	})
+
+	// Regression: byte-index slicing (name[:50]) can split a multi-byte
+	// UTF-8 rune in half, producing invalid UTF-8. Truncating by rune count
+	// must never do that.
+	t.Run("multi-byte UTF-8 name is truncated on a rune boundary", func(t *testing.T) {
+		name := strings.Repeat("héllo-世界-", 10) // multi-byte runes throughout, > 50 bytes and > 50 runes
+		require := assert.New(t)
+		require.Greater(len([]byte(name)), 50)
+		require.Greater(len([]rune(name)), 50)
+
+		got := TruncateName(name, 50)
+
+		require.True(utf8.ValidString(got), "truncated name must be valid UTF-8")
+		require.True(strings.HasSuffix(got, "..."))
+		require.Equal(50, len([]rune(strings.TrimSuffix(got, "..."))), "must truncate by rune count, not byte count")
+	})
+}
 
 func TestGetColor(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary
- `generateCategoryStatusRow()` (`categorytable.go`) and `GenerateRow()` (`summarytable.go`) both truncated long control names with `name[:50]` — a **byte-index** slice.
- For a name containing multi-byte UTF-8 characters (non-Latin script, accented characters, emoji — all valid in Kubernetes resource/control names), byte index 50 can land in the middle of a multi-byte rune, producing invalid UTF-8 and garbled ("mojibake") output in the pretty-printed table.

## Fix
- Added `utils.TruncateName(name, maxLen)`, which truncates by **rune count** via a `[]rune` conversion, and used it from both call sites instead of the duplicated byte-slicing logic.

## Test plan
- [x] `go build ./core/pkg/resultshandling/printer/...`
- [x] `go vet ./core/pkg/resultshandling/printer/...`
- [x] `go test ./core/pkg/resultshandling/printer/...` (full tree, all existing tests pass)
- [x] Added `TestTruncateName` covering: short name unchanged, ASCII truncation, exact-length boundary, and a multi-byte UTF-8 name — asserting the result is valid UTF-8 and truncated by rune count, not byte count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of long control names in category and summary tables.
  * Ensured names are truncated safely at character boundaries, including for non-ASCII text.
  * Added ellipses to indicate when names have been shortened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->