### PR TITLE
fix(fixhandler): preserve accepted base path spelling

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -85,7 +85,6 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 		if !isPathContained(resolvedBasePath, resolvedLocalPath) {
 			return nil, fmt.Errorf("report's scan path %q is outside --base-path %q; refusing to trust the report's location claim", localPath, fixInfo.BasePath)
 		}
-		localPath = resolvedLocalPath
 	}
 
 	backendLoggerLeveled := logging.AddModuleLevel(logging.NewLogBackend(logger.L().GetWriter(), "", 0))

--- a/core/pkg/fixhandler/pathcontainment_test.go
+++ b/core/pkg/fixhandler/pathcontainment_test.go
@@ -193,6 +193,22 @@ func TestNewFixHandler_BasePathFlag_ReportPathEqualsBasePathIsAccepted(t *testin
 	assert.Equal(t, trustedRoot, h.localBasePath)
 }
 
+func TestNewFixHandler_BasePathFlag_PreservesAcceptedReportBasePathSpelling(t *testing.T) {
+	skipOnWindowsSymlink(t)
+
+	trustedRoot := t.TempDir()
+	realScannedDir := filepath.Join(trustedRoot, "real")
+	require.NoError(t, os.Mkdir(realScannedDir, 0o750))
+	reportBasePath := filepath.Join(trustedRoot, "alias")
+	require.NoError(t, os.Symlink(realScannedDir, reportBasePath))
+	reportFile := buildDirectoryReport(t, trustedRoot, reportBasePath)
+
+	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile, BasePath: trustedRoot})
+	require.NoError(t, err)
+	assert.Equal(t, reportBasePath, h.localBasePath)
+	assert.NotEqual(t, realScannedDir, h.localBasePath)
+}
+
 func TestNewFixHandler_BasePathFlag_InvalidBasePathErrors(t *testing.T) {
 	reportDir := t.TempDir()
 	scannedDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Fixes #2677
- Keep using symlink-resolved paths for --base-path containment validation
- Preserve the accepted report scan path as the fix handler base path instead of rewriting /var to /private/var on macOS

## Testing
- go test ./core/pkg/fixhandler -run 'TestNewFixHandler_BasePathFlag_(AcceptsReportPathInsideBasePath|ReportPathEqualsBasePathIsAccepted)'
- go test ./core/pkg/fixhandler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report path handling when a base path is provided, preserving the expected local path while maintaining path validation and safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->