### PR TITLE
refactor(core): simplify grouping logic and add test coverage

### DIFF
--- a/core/pkg/resultshandling/printer/v2/summaryhelpers.go
+++ b/core/pkg/resultshandling/printer/v2/summaryhelpers.go
@@ -37,35 +37,19 @@ func groupByNamespaceOrKind(resources []WorkloadSummary, status func(workloadSum
 		if t == objectsenvelopes.TypeRegoResponseVectorObject && !isKindToBeGrouped(resources[i].resource.GetKind()) {
 			t = workloadinterface.TypeWorkloadObject
 		}
-		switch t { // TODO - find a better way to defind the groups
+		group := ""
+		switch t {
 		case workloadinterface.TypeWorkloadObject:
-			ns := ""
 			if resources[i].resource.GetNamespace() != "" {
-				ns = "Namespace " + resources[i].resource.GetNamespace()
-			}
-			if r, ok := mapResources[ns]; ok {
-				r = append(r, resources[i])
-				mapResources[ns] = r
-			} else {
-				mapResources[ns] = []WorkloadSummary{resources[i]}
+				group = "Namespace " + resources[i].resource.GetNamespace()
 			}
 		case objectsenvelopes.TypeRegoResponseVectorObject:
-			group := resources[i].resource.GetKind() + "s"
-			if r, ok := mapResources[group]; ok {
-				r = append(r, resources[i])
-				mapResources[group] = r
-			} else {
-				mapResources[group] = []WorkloadSummary{resources[i]}
-			}
+			group = resources[i].resource.GetKind() + "s"
 		default:
-			group, _ := k8sinterface.SplitApiVersion(resources[i].resource.GetApiVersion())
-			if r, ok := mapResources[group]; ok {
-				r = append(r, resources[i])
-				mapResources[group] = r
-			} else {
-				mapResources[group] = []WorkloadSummary{resources[i]}
-			}
+			group, _ = k8sinterface.SplitApiVersion(resources[i].resource.GetApiVersion())
 		}
+		mapResources[group] = append(mapResources[group], resources[i])
+
 	}
 	return mapResources
 }

--- a/core/pkg/resultshandling/printer/v2/summaryhelpers.go
+++ b/core/pkg/resultshandling/printer/v2/summaryhelpers.go
@@ -37,21 +37,25 @@ func groupByNamespaceOrKind(resources []WorkloadSummary, status func(workloadSum
 		if t == objectsenvelopes.TypeRegoResponseVectorObject && !isKindToBeGrouped(resources[i].resource.GetKind()) {
 			t = workloadinterface.TypeWorkloadObject
 		}
-		group := ""
-		switch t {
-		case workloadinterface.TypeWorkloadObject:
-			if resources[i].resource.GetNamespace() != "" {
-				group = "Namespace " + resources[i].resource.GetNamespace()
-			}
-		case objectsenvelopes.TypeRegoResponseVectorObject:
-			group = resources[i].resource.GetKind() + "s"
-		default:
-			group, _ = k8sinterface.SplitApiVersion(resources[i].resource.GetApiVersion())
-		}
+		group := groupKey(resources[i].resource, t)
 		mapResources[group] = append(mapResources[group], resources[i])
-
 	}
 	return mapResources
+}
+
+func groupKey(resource workloadinterface.IMetadata, t workloadinterface.ObjectType) string {
+	switch t {
+	case workloadinterface.TypeWorkloadObject:
+		if resource.GetNamespace() != "" {
+			return "Namespace " + resource.GetNamespace()
+		}
+	case objectsenvelopes.TypeRegoResponseVectorObject:
+		return resource.GetKind() + "s"
+	default:
+		group, _ := k8sinterface.SplitApiVersion(resource.GetApiVersion())
+		return group
+	}
+	return ""
 }
 
 func isKindToBeGrouped(kind string) bool {

--- a/core/pkg/resultshandling/printer/v2/summaryhelpers_test.go
+++ b/core/pkg/resultshandling/printer/v2/summaryhelpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 )
@@ -209,7 +210,7 @@ func TestGroupByNamespaceOrKind(t *testing.T) {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind":       "ClusterRole",
 		"metadata": map[string]interface{}{
-			"name": "clusterrole1",
+			"name": "clusterrole1", // Empty namespace workload case
 		},
 	})
 
@@ -222,23 +223,96 @@ func TestGroupByNamespaceOrKind(t *testing.T) {
 		},
 	})
 
-	resources := []WorkloadSummary{
-		{resource: w1, status: apis.StatusFailed},
-		{resource: w2, status: apis.StatusFailed},
-		{resource: w3, status: apis.StatusFailed},
-		{resource: r1, status: apis.StatusFailed},
+	// RegoResponseVectorObject not in the allowed Group/User to test fallthrough
+	rFallthrough := objectsenvelopes.NewRegoResponseVectorObject(map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "RoleBinding",
+		"metadata": map[string]interface{}{
+			"name": "rolebinding1",
+		},
+	})
+
+	// Non-workload envelope to test default apiGroup parsing branch
+	lw := localworkload.NewLocalWorkload(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "d1",
+			"namespace": "default",
+		},
+		"sourcePath":   "/tmp/a.yaml",
+		"relativePath": "a.yaml",
+	})
+
+	tests := []struct {
+		name            string
+		resources       []WorkloadSummary
+		filterFunc      func(*WorkloadSummary) bool
+		expectedBuckets map[string][]workloadinterface.IMetadata
+	}{
+		{
+			name: "StatusFailed filter with various resource types",
+			resources: []WorkloadSummary{
+				{resource: w1, status: apis.StatusFailed},
+				{resource: w2, status: apis.StatusFailed},
+				{resource: w3, status: apis.StatusFailed},
+				{resource: r1, status: apis.StatusFailed},
+				{resource: rFallthrough, status: apis.StatusFailed},
+				{resource: lw, status: apis.StatusFailed},
+			},
+			filterFunc: workloadSummaryFailed,
+			expectedBuckets: map[string][]workloadinterface.IMetadata{
+				"Namespace default":     {w1},
+				"Namespace kube-system": {w2},
+				"":                      {w3, rFallthrough},
+				"Users":                 {r1},
+				"apps":                  {lw},
+			},
+		},
+		{
+			name: "StatusPassed filter ensures StatusFailed are skipped",
+			resources: []WorkloadSummary{
+				{resource: w1, status: apis.StatusFailed},
+				{resource: w2, status: apis.StatusPassed},
+			},
+			filterFunc: workloadSummaryPassed,
+			expectedBuckets: map[string][]workloadinterface.IMetadata{
+				"Namespace kube-system": {w2},
+			},
+		},
 	}
 
-	result := groupByNamespaceOrKind(resources, workloadSummaryFailed)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := groupByNamespaceOrKind(tt.resources, tt.filterFunc)
 
-	assert.Len(t, result, 4)
-	assert.Contains(t, result, "Namespace default")
-	assert.Contains(t, result, "Namespace kube-system")
-	assert.Contains(t, result, "")
-	assert.Contains(t, result, "Users")
+			// Verify total cardinality to ensure nothing was grouped unexpectedly
+			expectedCount := 0
+			for _, expectedResList := range tt.expectedBuckets {
+				expectedCount += len(expectedResList)
+			}
+			actualCount := 0
+			for _, resList := range result {
+				actualCount += len(resList)
+			}
+			assert.Equal(t, expectedCount, actualCount, "Total number of resources grouped does not match")
 
-	assert.Len(t, result["Namespace default"], 1)
-	assert.Len(t, result["Namespace kube-system"], 1)
-	assert.Len(t, result[""], 1)
-	assert.Len(t, result["Users"], 1)
+			// Verify identity and exact bucket lengths
+			for group, expectedResList := range tt.expectedBuckets {
+				assert.Contains(t, result, group)
+				assert.Len(t, result[group], len(expectedResList))
+
+				for _, expectedRes := range expectedResList {
+					found := false
+					for _, res := range result[group] {
+						if res.resource == expectedRes {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "Expected to find specific resource in group %s", group)
+				}
+			}
+		})
+	}
 }

--- a/core/pkg/resultshandling/printer/v2/summaryhelpers_test.go
+++ b/core/pkg/resultshandling/printer/v2/summaryhelpers_test.go
@@ -3,6 +3,8 @@ package printer
 import (
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 )
@@ -181,4 +183,62 @@ func TestIsKindToBeGrouped(t *testing.T) {
 			assert.Equal(t, tt.want, isKindToBeGrouped(tt.kind))
 		})
 	}
+}
+
+func TestGroupByNamespaceOrKind(t *testing.T) {
+	// Create mock workloads
+	w1 := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"namespace": "default",
+			"name":      "pod1",
+		},
+	})
+
+	w2 := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"namespace": "kube-system",
+			"name":      "pod2",
+		},
+	})
+
+	w3 := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]interface{}{
+			"name": "clusterrole1",
+		},
+	})
+
+	// Create RegoResponseVectorObject
+	r1 := objectsenvelopes.NewRegoResponseVectorObject(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "User",
+		"metadata": map[string]interface{}{
+			"name": "user1",
+		},
+	})
+
+	resources := []WorkloadSummary{
+		{resource: w1, status: apis.StatusFailed},
+		{resource: w2, status: apis.StatusFailed},
+		{resource: w3, status: apis.StatusFailed},
+		{resource: r1, status: apis.StatusFailed},
+	}
+
+	result := groupByNamespaceOrKind(resources, workloadSummaryFailed)
+
+	assert.Len(t, result, 4)
+	assert.Contains(t, result, "Namespace default")
+	assert.Contains(t, result, "Namespace kube-system")
+	assert.Contains(t, result, "")
+	assert.Contains(t, result, "Users")
+
+	assert.Len(t, result["Namespace default"], 1)
+	assert.Len(t, result["Namespace kube-system"], 1)
+	assert.Len(t, result[""], 1)
+	assert.Len(t, result["Users"], 1)
 }


### PR DESCRIPTION
## Overview
This PR simplifies the workload grouping logic in `summaryhelpers.go` and introduces test coverage for the grouping logic. It directly resolves a maintainer `TODO` to "find a better way to defind the groups".

**Current Behavior:** 
The `groupByNamespaceOrKind` function utilizes a 30-line `switch` statement that manually checks for map key existence and manually allocates slices if the key doesn't exist. This verbose logic is repeated three separate times for different workload types.

**Future Behavior:** 
The `switch` statement now exclusively determines the grouping string. The map allocation relies entirely on Go's native `append()` slice allocation to construct the dictionary. This removes ~20 lines of repetitive code while preserving identical output behavior for WorkloadObjects, RegoResponseVectorObjects, and cluster-scoped resources (empty namespace).

## Additional Information

> Added a comprehensive unit test (`TestGroupByNamespaceOrKind`) to `summaryhelpers_test.go` to explicitly validate this grouping logic going forward, as this core function previously lacked test coverage.

## How to Test

> Run the test suite for the `printer/v2` package:
> `go test -v ./core/pkg/resultshandling/printer/v2/...`
> The newly added `TestGroupByNamespaceOrKind` explicitly validates that all resource types are bucketed into the correct namespace/kind strings.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summary grouping for failed and passed resources while preserving existing workload, response, and resource grouping behavior.
  * Ensured namespaced and cluster-scoped resources appear in the correct summary groups, including local workloads and fallback categories.

* **Tests**
  * Added coverage for Pods, local Deployments, cluster-scoped roles, User and RoleBinding responses, and Rego response envelopes.
  * Verified resource filtering, identity, bucket sizes, and overall grouping results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->