### PR TITLE
fix(cautils): stop Policies.Set from mutating the caller's frameworks slice

### DIFF
--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -24,32 +24,35 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRul
 			policies.Frameworks = append(policies.Frameworks, frameworks[i].Name)
 		}
 		for j := range frameworks[i].Controls {
+			// operate on a local copy so we never mutate the caller's backing array -
+			// frameworks may be a cached slice reused across scans (see PolicyHandler's cachedFrameworks)
+			control := frameworks[i].Controls[j]
 			compatibleRules := []reporthandling.PolicyRule{}
-			for r := range frameworks[i].Controls[j].Rules {
+			for r := range control.Rules {
 				if excludedRules != nil {
-					ruleName := frameworks[i].Controls[j].Rules[r].Name
+					ruleName := control.Rules[r].Name
 					if _, exclude := excludedRules[ruleName]; exclude {
 						continue
 					}
 				}
 
-				if ShouldSkipRule(frameworks[i].Controls[j], frameworks[i].Controls[j].Rules[r], scanningScope) {
+				if ShouldSkipRule(control, control.Rules[r], scanningScope) {
 					continue
 				}
-				// if isRuleKubescapeVersionCompatible(frameworks[i].Controls[j].Rules[r].Attributes, version) && isControlFitToScanScope(frameworks[i].Controls[j], scanningScope) {
-				compatibleRules = append(compatibleRules, frameworks[i].Controls[j].Rules[r])
+				// if isRuleKubescapeVersionCompatible(control.Rules[r].Attributes, version) && isControlFitToScanScope(control, scanningScope) {
+				compatibleRules = append(compatibleRules, control.Rules[r])
 				// }
 			}
 			if len(compatibleRules) > 0 {
-				frameworks[i].Controls[j].Rules = compatibleRules
-				policies.Controls[frameworks[i].Controls[j].ControlID] = frameworks[i].Controls[j]
+				control.Rules = compatibleRules
+				policies.Controls[control.ControlID] = control
 			} else { // if the control type is manual review, add it to the list of controls
-				actionRequiredStr := frameworks[i].Controls[j].GetActionRequiredAttribute()
+				actionRequiredStr := control.GetActionRequiredAttribute()
 				if actionRequiredStr == "" {
 					continue
 				}
 				if actionRequiredStr == string(apis.SubStatusManualReview) {
-					policies.Controls[frameworks[i].Controls[j].ControlID] = frameworks[i].Controls[j]
+					policies.Controls[control.ControlID] = control
 				}
 			}
 

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -297,6 +297,47 @@ func TestIsRuleKubescapeVersionCompatible(t *testing.T) {
 	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
 }
 
+// TestPoliciesSetDoesNotMutateCallerFrameworks guards against a regression where Set
+// filtered a control's rules into a new slice but wrote it back through the caller's
+// slice header, permanently deleting excluded rules from the caller's data (e.g.
+// PolicyHandler's cached frameworks, reused across scans while POLICIES_CACHE_TTL is set).
+func TestPoliciesSetDoesNotMutateCallerFrameworks(t *testing.T) {
+	buildFrameworks := func() []reporthandling.Framework {
+		return []reporthandling.Framework{
+			{
+				PortalBase: armotypes.PortalBase{Name: "test-framework"},
+				Controls: []reporthandling.Control{
+					{
+						ControlID: "control-1",
+						Rules: []reporthandling.PolicyRule{
+							{PortalBase: armotypes.PortalBase{Name: "rule-a"}},
+							{PortalBase: armotypes.PortalBase{Name: "rule-b"}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	frameworks := buildFrameworks()
+	originalRuleCount := len(frameworks[0].Controls[0].Rules)
+
+	// first scan excludes "rule-a"
+	firstScanPolicies := NewPolicies()
+	firstScanPolicies.Set(frameworks, map[string]bool{"rule-a": true}, "")
+	assert.Len(t, firstScanPolicies.Controls["control-1"].Rules, 1)
+
+	// the caller's original slice must be untouched by the first Set call
+	assert.Len(t, frameworks[0].Controls[0].Rules, originalRuleCount,
+		"Set must not mutate the caller's frameworks slice")
+
+	// a second scan reusing the same frameworks slice (e.g. a cache hit) with no
+	// exclusions must see all rules, not the previous scan's filtered-down set
+	secondScanPolicies := NewPolicies()
+	secondScanPolicies.Set(frameworks, nil, "")
+	assert.Len(t, secondScanPolicies.Controls["control-1"].Rules, originalRuleCount)
+}
+
 func TestGetScanningScope(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Motivation:
Policies.Set filtered each control's rules into a new compatibleRules
slice, then wrote that slice back through the caller's data:
frameworks[i].Controls[j].Rules = compatibleRules. Since
Framework.Controls is []Control (a value-type slice), this indexed
write lands in the caller's backing array, not a local copy.

The caller chain (convertFrameworksToPolicies -> opap.Policies) can be
PolicyHandler's cachedFrameworks slice, which is reused across scans
in the same process while POLICIES_CACHE_TTL is set. A scan that
excludes rules (e.g. because CollectResources determined those rules
don't apply to a single-workload scan's target kind) permanently
deletes those rules from the cached frameworks, so every later
cache-hit scan in that process inherits the previous scan's
exclusions until the cache entry expires. Note POLICIES_CACHE_TTL
defaults to unset (no caching), so this only affects processes that
explicitly enable it, such as a long-running server that reuses a
PolicyHandler across requests.

Approach:
Copy frameworks[i].Controls[j] into a local `control` variable before
filtering its rules, and operate on that local copy for the rest of
the loop body. Control is a plain struct, so the copy is independent
of the caller's backing array; assigning control.Rules only affects
the local copy that gets stored in policies.Controls. No other field
of Control is mutated by this function, so the shallow copy is
sufficient.

Validation:
- go test ./core/cautils/... -run TestPoliciesSetDoesNotMutateCallerFrameworks -v
  passes with the fix. Reverting only the fix (keeping the new test)
  reproduces the reported bug: the test fails because the caller's
  frameworks slice ends up with 1 rule instead of 2 after Set excludes
  one rule.
- go build ./... passes.
- go test ./core/cautils/... and go test ./core/pkg/policyhandler/...
  (the direct caller of PolicyHandler.cachedFrameworks.Set and
  convertFrameworksToPolicies) both pass.

Report: https://github.com/kubescape/kubescape/issues/2680
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #2680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented policy filtering from modifying the original framework data.
  * Ensured rules remain available when the same framework is reused for a later scan.

* **Tests**
  * Added regression coverage confirming framework rules are preserved across scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->