### PR TITLE
fix(cautils): remove dead nil-check in setHeaders

### DIFF
--- a/core/cautils/getter/getpoliciesutils.go
+++ b/core/cautils/getter/getpoliciesutils.go
@@ -107,10 +107,9 @@ func HttpGetter(httpClient *http.Client, fullURL string, headers map[string]stri
 }
 
 func setHeaders(req *http.Request, headers map[string]string) {
-	if len(headers) >= 0 { // might be nil
-		for k, v := range headers {
-			req.Header.Set(k, v)
-		}
+	// range over a nil map is a no-op, so headers being nil needs no guard here.
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 }
 

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -285,3 +285,27 @@ func TestHttpRespToString_ErrorCodeLessThan200(t *testing.T) {
 	assert.EqualError(t, err, "http-error: '', reason: 'test response'")
 	assert.Equal(t, "test response", result)
 }
+
+func TestSetHeaders(t *testing.T) {
+	t.Run("sets every header on the request", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+
+		setHeaders(req, map[string]string{"Authorization": "token abc", "X-Custom": "value"})
+
+		assert.Equal(t, "token abc", req.Header.Get("Authorization"))
+		assert.Equal(t, "value", req.Header.Get("X-Custom"))
+	})
+
+	// Regression: setHeaders used to gate the range loop behind
+	// `if len(headers) >= 0`, a condition that is always true (len() is
+	// never negative) - a nil map must still be handled without panicking,
+	// which ranging over nil already does safely in Go.
+	t.Run("nil headers map does not panic and sets nothing", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() { setHeaders(req, nil) })
+		assert.Empty(t, req.Header)
+	})
+}


### PR DESCRIPTION
## Summary
- `setHeaders()` in `core/cautils/getter/getpoliciesutils.go` gated its range loop behind `if len(headers) >= 0 { // might be nil }`.
- `len()` on any map (including a nil one) is never negative, so this condition is **always true** — it's dead code that looks like it protects against a nil `headers` map but does nothing.
- Ranging over a nil map is already a documented no-op in Go, so no guard was ever needed here — the comment's intent doesn't match what the code actually does.

## Fix
- Removed the tautological condition; added a one-line comment explaining why no nil guard is needed.
- Purely a dead-code cleanup — behavior is unchanged (nil headers still safely result in no headers being set).

## Test plan
- [x] `go build ./core/cautils/...`
- [x] `go vet ./core/cautils/...`
- [x] `go test ./core/cautils/...` (full tree, all existing tests pass)
- [x] Added `TestSetHeaders` covering the normal case and an explicit nil map (asserting no panic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying request headers, including safe handling when no headers are provided.

* **Tests**
  * Added coverage for multiple header values and empty header scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->