### PR TITLE
fix(httphandler): use a scoped viper instance in LoadConfig

### DIFF
--- a/httphandler/config/config.go
+++ b/httphandler/config/config.go
@@ -12,18 +12,25 @@ type Config struct {
 
 // LoadConfig reads configuration from file or environment variables.
 func LoadConfig(path string) (Config, error) {
-	viper.AddConfigPath(path)
-	viper.SetConfigName("clusterData")
-	viper.SetConfigType("json")
+	// A scoped instance instead of the viper package-level singleton: the
+	// singleton accumulates state across calls (e.g. AddConfigPath appends
+	// rather than replacing), so a second LoadConfig call in the same
+	// process - a second cluster/namespace config, or just a test calling it
+	// more than once - would read stale settings left over from a previous
+	// call instead of a clean state.
+	v := viper.New()
+	v.AddConfigPath(path)
+	v.SetConfigName("clusterData")
+	v.SetConfigType("json")
 
-	viper.AutomaticEnv()
+	v.AutomaticEnv()
 
-	err := viper.ReadInConfig()
+	err := v.ReadInConfig()
 	if err != nil {
 		return Config{}, err
 	}
 
 	var config Config
-	err = viper.Unmarshal(&config)
+	err = v.Unmarshal(&config)
 	return config, err
 }

--- a/httphandler/config/config_test.go
+++ b/httphandler/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Loads configuration from file successfully
@@ -22,4 +25,45 @@ func TestLoadConfigFromFileSuccessfully(t *testing.T) {
 	// Check the result
 	assert.Equal(t, expectedConfig, config)
 	assert.NotNil(t, err)
+}
+
+func writeClusterDataJSON(t *testing.T, dir, namespace, clusterName string) {
+	t.Helper()
+	body := `{"namespace":"` + namespace + `","clusterName":"` + clusterName + `","continuousPostureScan":true}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "clusterData.json"), []byte(body), 0o600))
+}
+
+func TestLoadConfig_ReadsValuesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	writeClusterDataJSON(t, dir, "ns-a", "cluster-a")
+
+	got, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, Config{Namespace: "ns-a", ClusterName: "cluster-a", ContinuousPostureScan: true}, got)
+}
+
+// TestLoadConfig_SequentialCallsDoNotLeakState guards against a regression
+// where LoadConfig used the global viper singleton (package-level
+// viper.AddConfigPath/SetConfigName/... functions), which accumulates state
+// across calls instead of starting clean. A second call with a different
+// config directory could then pick up stale search paths or settings left
+// over from the first call. LoadConfig now uses a scoped viper.New()
+// instance per call, so two calls with different directories must each
+// return only their own directory's values.
+func TestLoadConfig_SequentialCallsDoNotLeakState(t *testing.T) {
+	dirA := t.TempDir()
+	writeClusterDataJSON(t, dirA, "ns-a", "cluster-a")
+
+	dirB := t.TempDir()
+	writeClusterDataJSON(t, dirB, "ns-b", "cluster-b")
+
+	gotA, err := LoadConfig(dirA)
+	require.NoError(t, err)
+	assert.Equal(t, "ns-a", gotA.Namespace)
+	assert.Equal(t, "cluster-a", gotA.ClusterName)
+
+	gotB, err := LoadConfig(dirB)
+	require.NoError(t, err)
+	assert.Equal(t, "ns-b", gotB.Namespace, "second call must read dirB's own values, not stale state from dirA")
+	assert.Equal(t, "cluster-b", gotB.ClusterName)
 }


### PR DESCRIPTION
## Summary
- `LoadConfig()` called the `viper` package-level functions (`viper.AddConfigPath`/`SetConfigName`/`SetConfigType`/`AutomaticEnv`/`ReadInConfig`/`Unmarshal`), which operate on viper's **global singleton** instance.
- That instance accumulates state across calls — e.g. `AddConfigPath` appends a search path rather than replacing it — so a second `LoadConfig` call in the same process (a second cluster/namespace config, or a test invoking it more than once) could pick up stale search paths or settings left over from a prior call instead of starting clean.
- Only called once today (`main.go`), so there's no user-visible symptom yet, but it's a latent correctness trap for the next caller, and it made the function untestable for the "called twice" case.

## Fix
- Use `viper.New()` to get an instance scoped to the call instead of the global singleton.

## Test plan
- [x] `go build ./...` / `go vet ./...` (httphandler module)
- [x] `go test ./... -race` (full httphandler module)
- [x] Added `TestLoadConfig_ReadsValuesFromFile` and `TestLoadConfig_SequentialCallsDoNotLeakState` — the latter calls `LoadConfig` twice with two different config directories and asserts each call returns only its own directory's values (fails against the old global-singleton code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading to prevent settings from one directory from affecting subsequent loads.
  * Ensured configuration values are read consistently from the specified configuration file.

* **Tests**
  * Added coverage for loading configuration files and isolating sequential configuration requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->