### PR TITLE
fix(policyhandler): remove unreachable post-set expiry check in TimedCache

### DIFF
--- a/core/pkg/policyhandler/cache.go
+++ b/core/pkg/policyhandler/cache.go
@@ -59,10 +59,6 @@ func (c *TimedCache[T]) Set(value T) {
 	c.isSet = true
 	c.value = value
 	c.expiration = time.Now().Add(c.ttl)
-
-	if time.Now().After(c.expiration) {
-		c.invalidateLocked()
-	}
 }
 
 func (c *TimedCache[T]) Get() (T, bool) {

--- a/core/pkg/policyhandler/cache_test.go
+++ b/core/pkg/policyhandler/cache_test.go
@@ -85,6 +85,29 @@ func TestCache_SetAndGet(t *testing.T) {
 	}
 }
 
+// TestCache_SetNeverImmediatelySelfInvalidates pins the documented behavior
+// of Set(): a value it just stored must be immediately readable via Get(),
+// repeatedly, for a small ttl. Set() used to compute
+// expiration = time.Now().Add(ttl) and then immediately re-check
+// `if time.Now().After(expiration) { invalidateLocked() }` - a check that
+// can only ever fire if the gap between those two time.Now() calls exceeds
+// ttl itself. For any realistic ttl (this codebase only ever uses
+// seconds-scale values) that gap is always negative, so the check was dead
+// code; this test exercises Set()+Get() back-to-back many times at a small
+// ttl to keep that documented.
+func TestCache_SetNeverImmediatelySelfInvalidates(t *testing.T) {
+	cache := NewTimedCache[int](50 * time.Millisecond)
+	t.Cleanup(cache.Stop)
+
+	for i := range 1000 {
+		cache.Set(i)
+		value, exists := cache.Get()
+		if !exists || value != i {
+			t.Fatalf("iteration %d: Set() followed immediately by Get() must return the just-set value; got value=%d exists=%v", i, value, exists)
+		}
+	}
+}
+
 func TestCache_Expiration(t *testing.T) {
 	cache := NewTimedCache[int](time.Millisecond * 500)
 


### PR DESCRIPTION
## Summary
- `TimedCache.Set()` computed `expiration = time.Now().Add(c.ttl)` — reaching that line requires `c.ttl > 0`, since `c.ttl == 0` already returns earlier — and then immediately re-checked `if time.Now().After(c.expiration) { c.invalidateLocked() }`.
- That check can only ever fire if the gap between the two `time.Now()` calls exceeds `ttl` itself. For every ttl this codebase actually uses (seconds-scale), that never happens, so the branch was unreachable dead code masquerading as a real safeguard.

## Fix
- Removed the dead branch. Behavior is unchanged for any realistic ttl (a value `Set()` just stored is always immediately readable via `Get()`, which existing tests like `TestCache_SetAndGet` already covered).

## Test plan
- [x] `go build ./core/pkg/policyhandler/...`
- [x] `go vet ./core/pkg/policyhandler/...`
- [x] `go test ./core/pkg/policyhandler/... -race` (full package, including the existing TOCTOU/invalidate-race regression tests, all pass)
- [x] Added `TestCache_SetNeverImmediatelySelfInvalidates`, which exercises `Set()` immediately followed by `Get()` 1000 times at a small (50ms) ttl and asserts the just-set value is always readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where newly stored cache values could be immediately invalidated.
  * Cache entries now remain available as expected for their configured time-to-live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->