### PR TITLE
fix(printer): parse SARIF doc index on the last colon, not the second field

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -427,12 +427,20 @@ func getDocIndex(opaSessionObj *cautils.OPASessionObj, resourceID string) (int, 
 		return 0, false
 	}
 
-	splittedPath := strings.Split(localworkload.GetPath(), ":")
-	if len(splittedPath) <= 1 {
+	// GetPath() is "<file path>:<document index>". Split on the *last* colon,
+	// not the first/second: strings.Split(path, ":")[1] silently picks the
+	// wrong segment for any path containing more than one colon (e.g. a
+	// Windows path like "C:\repo\deploy.yaml:0"), producing a non-numeric
+	// value that Atoi rejects and this function reporting "no doc index"
+	// even though one exists. This matches how fixhandler.getFilePathAndIndex
+	// parses the same convention.
+	path := localworkload.GetPath()
+	lastColon := strings.LastIndex(path, ":")
+	if lastColon == -1 {
 		return 0, false
 	}
 
-	docIndex, err := strconv.Atoi(splittedPath[1])
+	docIndex, err := strconv.Atoi(path[lastColon+1:])
 	if err != nil {
 		return 0, false
 	}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -401,6 +401,54 @@ func TestPrintConfigurationScan_InvocationStartTimeUsesReportGenerationTime(t *t
 		"startTimeUtc must reuse ReportGenerationTime, got %s want %s", inv.StartTimeUTC, preset)
 }
 
+// TestGetDocIndex_PathContainingColon guards against a regression where
+// getDocIndex parsed LocalWorkload.GetPath() ("<file path>:<document
+// index>") with strings.Split(path, ":")[1] instead of splitting on the last
+// colon. That silently picked the wrong segment whenever the file path
+// itself contained more than one colon (e.g. a Windows path like
+// "C:\repo\deploy.yaml:0"), so strconv.Atoi failed on a non-numeric segment
+// and getDocIndex reported "no document index" even though one exists. This
+// must match how fixhandler.getFilePathAndIndex parses the same convention
+// (splitting on the last colon).
+func TestGetDocIndex_PathContainingColon(t *testing.T) {
+	resourceID := "apps/v1/Deployment/default/demo"
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "demo"},
+		"spec":       map[string]interface{}{},
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		wantIndex int
+		wantOk    bool
+	}{
+		{name: "plain relative path, no colon in file path", path: "deploy.yaml:0", wantIndex: 0, wantOk: true},
+		{name: "nested relative path", path: "charts/app/deploy.yaml:2", wantIndex: 2, wantOk: true},
+		{name: "file path itself contains a colon", path: `C:\repo\deploy.yaml:3`, wantIndex: 3, wantOk: true},
+		{name: "no colon at all", path: "deploy.yaml", wantIndex: 0, wantOk: false},
+		{name: "trailing colon with non-numeric suffix", path: "deploy.yaml:abc", wantIndex: 0, wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lw := localworkload.NewLocalWorkload(obj)
+			lw.SetPath(tt.path)
+
+			session := cautils.NewOPASessionObjMock()
+			session.AllResources[resourceID] = lw
+
+			gotIndex, gotOk := getDocIndex(session, resourceID)
+			assert.Equal(t, tt.wantOk, gotOk)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantIndex, gotIndex)
+			}
+		})
+	}
+}
+
 func TestGetBasePathFromMetadata(t *testing.T) {
 	tempDir := t.TempDir()
 	absFilePath := filepath.Join(tempDir, "deploy.yaml")


### PR DESCRIPTION
## Summary
- `getDocIndex()` parsed `LocalWorkload.GetPath()` — which encodes `"<file path>:<document index>"` — with `strings.Split(path, ":")[1]`, picking the second element of a full split.
- That silently returns the wrong value whenever the file path itself contains more than one colon (e.g. a Windows path like `C:\repo\deploy.yaml:0`): the split produces more than two parts, `splittedPath[1]` is a path fragment rather than the index, `Atoi` fails on it, and `getDocIndex` reports "no document index" even though the resource has one. The caller then falls back to line 1 for the SARIF fix location instead of the actual finding location.
- `core/pkg/fixhandler`'s `getFilePathAndIndex` parses the exact same `"<path>:<index>"` convention correctly, via `strings.LastIndex` to find the index after the **last** colon.

## Fix
- Applied the same last-colon approach in `getDocIndex`, for consistency and correctness with the rest of the codebase.

## Test plan
- [x] `go build ./core/pkg/resultshandling/printer/...`
- [x] `go vet ./core/pkg/resultshandling/printer/...`
- [x] `go test ./core/pkg/resultshandling/printer/...` (full tree, all existing tests pass)
- [x] Added `TestGetDocIndex_PathContainingColon`, which fails against the old code on a path containing an embedded colon and passes on the common single-colon case either way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SARIF document index handling for workload paths containing additional colons.
  * Continued rejecting paths with missing separators or nonnumeric document indexes.

* **Tests**
  * Added coverage for nested paths, Windows-style paths, and malformed path values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->