### PR TITLE
fix(core): parse digest-pinned image references correctly for exceptions

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -91,19 +91,30 @@ func getAttributesFromImage(imgName string) (Attributes, error) {
 	// reference. Split off any "@digest" suffix first: the digest itself
 	// contains a colon ("sha256:..."), so splitting nameAndTag on ":"
 	// without accounting for that left "@sha256" stuck onto imageName and
-	// the raw hash treated as the tag, which silently broke exception-policy
-	// matching (isTargetImage below) for digest-pinned images.
+	// the raw hash treated as the tag. Because regexStringMatch (below) is
+	// an unanchored match, unanchored policy patterns (the common case,
+	// e.g. "myimage") still matched the old broken ImageName; anchored
+	// patterns (e.g. "^myimage$") did not, and this fixes those.
 	beforeDigest := nameAndTag
 	imageTag := "latest"
 	if at := strings.Index(nameAndTag, "@"); at != -1 {
 		beforeDigest = nameAndTag[:at]
-		imageTag = nameAndTag[at+1:] // digest, used as a fallback "tag" below
+		// No explicit tag on a digest-pinned reference: fall back to the
+		// digest as ImageTag (deliberate choice, not Docker/OCI reference
+		// semantics - Docker resolves a "name:tag@digest" reference by the
+		// digest, ignoring the tag, but for *exception-policy matching* the
+		// tag the user wrote is what they meant to target). This means an
+		// exception policy that targets a specific ImageTag (e.g. "v3.*")
+		// cannot match a purely digest-pinned scan, since ImageTag will be
+		// the digest instead; only Registry/Organization/ImageName targets
+		// (and an ImageTag target of "" - "any tag") can match it.
+		imageTag = nameAndTag[at+1:]
 	}
 
 	imageName := beforeDigest
 	if colon := strings.LastIndex(beforeDigest, ":"); colon != -1 {
 		imageName = beforeDigest[:colon]
-		imageTag = beforeDigest[colon+1:] // an explicit tag wins over the digest
+		imageTag = beforeDigest[colon+1:] // an explicit tag wins over the digest fallback above
 	}
 
 	attributes := Attributes{

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -86,13 +86,24 @@ func getAttributesFromImage(imgName string) (Attributes, error) {
 		organization = strings.Join(tokens[1:len(tokens)-1], "/")
 	}
 
-	imageNameAndTag := strings.Split(nameAndTag, ":")
-	imageName := imageNameAndTag[0]
-
-	// Intialize the image tag with default value
+	// nameAndTag may be "name", "name:tag", "name@algo:digest" (e.g.
+	// "name@sha256:abc123..."), or "name:tag@algo:digest" - a digest-pinned
+	// reference. Split off any "@digest" suffix first: the digest itself
+	// contains a colon ("sha256:..."), so splitting nameAndTag on ":"
+	// without accounting for that left "@sha256" stuck onto imageName and
+	// the raw hash treated as the tag, which silently broke exception-policy
+	// matching (isTargetImage below) for digest-pinned images.
+	beforeDigest := nameAndTag
 	imageTag := "latest"
-	if len(imageNameAndTag) > 1 {
-		imageTag = imageNameAndTag[1]
+	if at := strings.Index(nameAndTag, "@"); at != -1 {
+		beforeDigest = nameAndTag[:at]
+		imageTag = nameAndTag[at+1:] // digest, used as a fallback "tag" below
+	}
+
+	imageName := beforeDigest
+	if colon := strings.LastIndex(beforeDigest, ":"); colon != -1 {
+		imageName = beforeDigest[:colon]
+		imageTag = beforeDigest[colon+1:] // an explicit tag wins over the digest
 	}
 
 	attributes := Attributes{

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -192,6 +192,18 @@ func TestGetAttributesFromImage(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// Docker Hub short form, digest only: exercises the "library"
+			// organization default landing alongside a digest fallback tag.
+			imageName: "alpine@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			expectedAttributes: Attributes{
+				Registry:     "docker.io",
+				Organization: "library",
+				ImageName:    "alpine",
+				ImageTag:     "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,6 +350,76 @@ func TestIsTargetImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.attributes.Registry+"/"+tt.attributes.ImageName, func(t *testing.T) {
 			assert.Equal(t, tt.expected, isTargetImage(tt.targets, tt.attributes))
+		})
+	}
+}
+
+// TestIsTargetImage_DigestPinnedImage exercises isTargetImage against
+// attributes computed by getAttributesFromImage from a real digest-pinned
+// image reference, rather than hand-built Attributes - a hand-built
+// Attributes{ImageName: "kubescape-cli"} would already encode the post-fix
+// parsing result and pass regardless of whether getAttributesFromImage is
+// actually fixed, defeating the point of a regression test.
+func TestIsTargetImage_DigestPinnedImage(t *testing.T) {
+	const digestPinnedImage = "quay.io/kubescape/kubescape-cli@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+	attributes, err := getAttributesFromImage(digestPinnedImage)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		target   Attributes
+		expected bool
+	}{
+		{
+			// regexStringMatch is unanchored, so an unanchored pattern
+			// matched even against the pre-fix parser (whose ImageName was
+			// "kubescape-cli@sha256") - this case is not a regression,
+			// unanchored patterns worked both before and after the fix.
+			name: "unanchored imageName target matches (not a regression)",
+			target: Attributes{
+				Registry:     "quay.io",
+				Organization: "kubescape",
+				ImageName:    "kubescape-cli",
+			},
+			expected: true,
+		},
+		{
+			// This is the case the parsing fix actually changes: pre-fix,
+			// ImageName was "kubescape-cli@sha256" and "^kubescape-cli$"
+			// would not match it; post-fix, ImageName is the clean
+			// "kubescape-cli" and the anchored pattern matches.
+			name: "anchored imageName target matches (the actual fix)",
+			target: Attributes{
+				Registry:     "quay.io",
+				Organization: "kubescape",
+				ImageName:    "^kubescape-cli$",
+			},
+			expected: true,
+		},
+		{
+			// Pins the documented ImageTag-fallback limitation: a policy
+			// that targets a specific tag (not "") cannot match a purely
+			// digest-pinned image, because ImageTag holds the digest rather
+			// than a tag the policy author could have written. This is a
+			// known, documented gap (see the ImageTag-fallback comment in
+			// getAttributesFromImage), not something this test expects to
+			// start passing.
+			name: "tag-targeting policy does not match (documented gap)",
+			target: Attributes{
+				Registry:     "quay.io",
+				Organization: "kubescape",
+				ImageName:    "kubescape-cli",
+				ImageTag:     "v3.*",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets := []Target{{Attributes: tt.target}}
+			assert.Equal(t, tt.expected, isTargetImage(targets, attributes))
 		})
 	}
 }

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -164,6 +164,34 @@ func TestGetAttributesFromImage(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// Regression: a digest-pinned reference's digest ("sha256:...")
+			// contains a colon. Splitting the name:tag segment on ":" without
+			// accounting for the digest used to leave "@sha256" stuck onto
+			// ImageName and the raw hash treated as ImageTag, which silently
+			// broke isTargetImage's exception-policy matching for these images.
+			imageName: "myregistry.io/myimage@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			expectedAttributes: Attributes{
+				Registry:     "myregistry.io",
+				Organization: "",
+				ImageName:    "myimage",
+				ImageTag:     "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			},
+			expectedErr: nil,
+		},
+		{
+			// Both an explicit tag and a digest: the explicit tag must win
+			// over the digest for ImageTag, and ImageName must still exclude
+			// both suffixes.
+			imageName: "myregistry.io/myimage:v1@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			expectedAttributes: Attributes{
+				Registry:     "myregistry.io",
+				Organization: "",
+				ImageName:    "myimage",
+				ImageTag:     "v1",
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `getAttributesFromImage()` split the `"name[:tag]"` segment of a normalized image reference on `":"` without accounting for digest-pinned references, whose digest itself contains a colon (`"sha256:<hex>"`).
- For an image like `myregistry.io/myimage@sha256:abcdef...`, this left `"@sha256"` stuck onto `ImageName` and the raw hash treated as `ImageTag`, instead of `ImageName="myimage"`.
- **Corrected impact statement:** `isTargetImage`'s matching (`regexStringMatch`) uses `re.MatchString`, which is *unanchored* - so an unanchored exception-policy pattern like `imageName: "myimage"` already matched the old broken value `"myimage@sha256"` just fine, both before and after this fix. What this bug actually broke was **anchored** patterns (e.g. `imageName: "^myimage$"`), which did not match the old value, plus general parse hygiene. The earlier version of this description overstated the impact as "exceptions would silently not apply" for the common case - that is not accurate; it only affected policies using anchored regex patterns.

## Fix
- Split off any `"@<digest>"` suffix before looking for a tag separator, and only fall back to the digest as `ImageTag` when there is no explicit tag (an explicit tag wins, since for *exception-policy matching* the tag the user wrote is what they meant to target - not because it mirrors how Docker itself resolves `name:tag@digest`, which actually resolves by the digest).
- Documented explicitly (in the code) that a digest-pinned image with no explicit tag yields `ImageTag` equal to the digest, so an exception policy that targets a specific `imageTag` (not `""`) still cannot match a purely digest-pinned scan - that gap is unchanged by this PR and is now a stated, tested limitation rather than an implicit one.

## Test plan
- [x] `go build ./core/core/...`
- [x] `go vet ./core/core/...`
- [x] `go test ./core/core/...` (full package, all existing tests pass)
- [x] `TestGetAttributesFromImage`: added a pure digest-pinned reference, a reference with both an explicit tag and a digest, and a Docker Hub short-form digest-only reference (`alpine@sha256:...`)
- [x] `TestIsTargetImage_DigestPinnedImage` (new): calls `getAttributesFromImage` on a real digest-pinned reference and checks `isTargetImage` against an unanchored pattern (matches both before/after - not a regression), an anchored pattern (the case this fix actually changes), and a tag-targeting policy (documents the still-open `ImageTag`-fallback gap). Mutation-verified: reverting the parser to the old colon-split logic makes only the anchored-pattern case fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of container image references pinned by digest.
  * Correctly preserves digest information when no tag is provided.
  * Ensures an explicit tag takes precedence when both a tag and digest are present.
  * Improved parsing of registry, organization, image name, and tag details.
  * Improved matching for digest-pinned images, including Docker Hub short-form references and anchored or unanchored image names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->