### PR TITLE
anonymizer: pin and document the intentional cross-prefix hash-suffix sharing (was: hash prefix+value)

### DIFF
--- a/core/pkg/anonymizer/mapping.go
+++ b/core/pkg/anonymizer/mapping.go
@@ -28,8 +28,8 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 	// name-based references that are not backed by a resource ID lookup -
 	// e.g. a Secret's own name is transformed with prefix "res"
 	// (session.go transformResourceMetadata) while the same name referenced
-	// via imagePullSecrets or a ConfigMap/Secret volume source is
-	// transformed separately with prefix "ref" (container.go). Hashing
+	// via imagePullSecrets or a ServiceAccount name is transformed
+	// separately with prefix "ref"/"sa" (container.go). Hashing
 	// prefix+value instead would give those two pseudonyms unrelated
 	// suffixes, silently severing the ability to tell from a --hide report
 	// alone that a pod pulls a given Secret or runs as a given
@@ -39,17 +39,33 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 	// This does mean a value that happens to be reused across semantically
 	// unrelated categories (e.g. a namespace named the same as a resource)
 	// produces a matching suffix too, which lets an observer infer the two
-	// values are equal without learning what either is. That is a real,
-	// narrower channel than it may look: the documented --hide threat model
-	// (docs/cli-reference.md) already concedes that any individual
-	// pseudonym can be reversed by hashing candidate values from a small or
-	// guessable set, so an observer who can already recover "default" from
-	// "ns-<hash>" gains little from cross-prefix suffix comparison. Closing
-	// this channel for real (independent of guessability) would require a
-	// per-run random salt/HMAC key, which conflicts with the documented
-	// property that identical values produce identical pseudonyms across
-	// separate reports/runs - that trade-off needs an explicit decision,
-	// not a change made incidentally here.
+	// values are equal without learning what either is. The cost is larger
+	// than just those two values, though: because the suffix is derived
+	// from value alone, it is a single identifier for that value shared
+	// across every prefix in the whole report. Any one cleartext occurrence
+	// of the value anywhere (e.g. container.go does not currently transform
+	// spec.volumes, so a Secret/ConfigMap name used there stays in
+	// cleartext even when the same name is anonymized via imagePullSecrets)
+	// de-anonymizes every pseudonym sharing that suffix at once, not just
+	// the one field it leaked from. That is a real, but still narrower than
+	// it may look: the documented --hide threat model (docs/cli-reference.md)
+	// already concedes that any individual pseudonym can be reversed by
+	// hashing candidate values from a small or guessable set, so an
+	// observer who can already recover "default" from "ns-<hash>" gains
+	// little from cross-prefix suffix comparison for guessable values -
+	// this channel mainly matters for values that are not guessable but do
+	// leak in cleartext somewhere.
+	//
+	// A secret salt or HMAC key would reduce offline guessing, and a
+	// per-run random key would additionally close this cross-prefix/
+	// cross-leak channel entirely - but a per-run key also breaks the
+	// documented property that identical values produce identical
+	// pseudonyms across separate reports/runs. Neither a fixed nor a
+	// per-run key removes the equality on its own; that requires
+	// prefix/domain-separated hashing (i.e. going back to hashing
+	// prefix+value), which is exactly what breaks the referential linkage
+	// this function exists to preserve. That combined trade-off needs an
+	// explicit decision, not a change made incidentally here.
 	hash := sha256.Sum256([]byte(value))
 	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:8]
 

--- a/core/pkg/anonymizer/mapping.go
+++ b/core/pkg/anonymizer/mapping.go
@@ -22,15 +22,35 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 		return existing
 	}
 
-	// Hash prefix+value together, not value alone: the same raw value
-	// mapped under two different prefixes (e.g. a namespace and a resource
-	// name that happen to be identical strings) must not produce the same
-	// hash suffix. Hashing value alone let that identical suffix leak
-	// through the "<prefix>-<suffix>" pseudo-ID, letting an observer
-	// correlate two differently-prefixed pseudo-IDs as sharing the same
-	// original value even without knowing what that value was - exactly
-	// the kind of cross-reference an anonymizer must not permit.
-	hash := sha256.Sum256([]byte(key))
+	// Deliberately hash value alone, not prefix+value: transformSession
+	// (session.go) relies on the same raw value producing the same hash
+	// suffix under different prefixes to preserve referential integrity for
+	// name-based references that are not backed by a resource ID lookup -
+	// e.g. a Secret's own name is transformed with prefix "res"
+	// (session.go transformResourceMetadata) while the same name referenced
+	// via imagePullSecrets or a ConfigMap/Secret volume source is
+	// transformed separately with prefix "ref" (container.go). Hashing
+	// prefix+value instead would give those two pseudonyms unrelated
+	// suffixes, silently severing the ability to tell from a --hide report
+	// alone that a pod pulls a given Secret or runs as a given
+	// ServiceAccount - the report would still list both objects, just with
+	// no visible connection between them.
+	//
+	// This does mean a value that happens to be reused across semantically
+	// unrelated categories (e.g. a namespace named the same as a resource)
+	// produces a matching suffix too, which lets an observer infer the two
+	// values are equal without learning what either is. That is a real,
+	// narrower channel than it may look: the documented --hide threat model
+	// (docs/cli-reference.md) already concedes that any individual
+	// pseudonym can be reversed by hashing candidate values from a small or
+	// guessable set, so an observer who can already recover "default" from
+	// "ns-<hash>" gains little from cross-prefix suffix comparison. Closing
+	// this channel for real (independent of guessability) would require a
+	// per-run random salt/HMAC key, which conflicts with the documented
+	// property that identical values produce identical pseudonyms across
+	// separate reports/runs - that trade-off needs an explicit decision,
+	// not a change made incidentally here.
+	hash := sha256.Sum256([]byte(value))
 	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:8]
 
 	m.data[key] = pseudo

--- a/core/pkg/anonymizer/mapping.go
+++ b/core/pkg/anonymizer/mapping.go
@@ -22,7 +22,15 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 		return existing
 	}
 
-	hash := sha256.Sum256([]byte(value))
+	// Hash prefix+value together, not value alone: the same raw value
+	// mapped under two different prefixes (e.g. a namespace and a resource
+	// name that happen to be identical strings) must not produce the same
+	// hash suffix. Hashing value alone let that identical suffix leak
+	// through the "<prefix>-<suffix>" pseudo-ID, letting an observer
+	// correlate two differently-prefixed pseudo-IDs as sharing the same
+	// original value even without knowing what that value was - exactly
+	// the kind of cross-reference an anonymizer must not permit.
+	hash := sha256.Sum256([]byte(key))
 	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:8]
 
 	m.data[key] = pseudo

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -1,9 +1,11 @@
 package anonymizer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapping_GetOrCreate(t *testing.T) {
@@ -80,4 +82,35 @@ func TestMapping_GetOrCreate_PrefixIsolationAcrossMultiplePrefixes(t *testing.T)
 	assert.NotEqual(t, resource, namespace)
 	assert.NotEqual(t, resource, label)
 	assert.NotEqual(t, namespace, label)
+}
+
+// pseudoIDSuffix returns the hash portion of a "<prefix>-<suffix>" pseudo-ID.
+func pseudoIDSuffix(t *testing.T, pseudoID, prefix string) string {
+	t.Helper()
+	suffix := strings.TrimPrefix(pseudoID, prefix+"-")
+	require.NotEqual(t, pseudoID, suffix, "pseudo-ID %q must start with %q-", pseudoID, prefix)
+	return suffix
+}
+
+// TestMapping_GetOrCreate_HashSuffixDoesNotLeakAcrossPrefixes guards against a
+// regression where GetOrCreate hashed only the raw value, not prefix+value.
+// The pseudo-ID's display prefix always differs across categories, so the
+// full string was always distinct - but the hash *suffix* was identical
+// whenever the same raw value was mapped under two different prefixes (e.g.
+// a namespace and a resource name that happen to be the same string). That
+// let an observer notice "res-a1b2c3d4" and "ns-a1b2c3d4" share a suffix and
+// infer the two original values were equal, without ever learning what the
+// value was - exactly the cross-category correlation an anonymizer must not
+// allow.
+func TestMapping_GetOrCreate_HashSuffixDoesNotLeakAcrossPrefixes(t *testing.T) {
+	mapping := NewMapping()
+
+	resource := mapping.GetOrCreate("res", "same-value")
+	namespace := mapping.GetOrCreate("ns", "same-value")
+
+	resourceSuffix := pseudoIDSuffix(t, resource, "res")
+	namespaceSuffix := pseudoIDSuffix(t, namespace, "ns")
+
+	assert.NotEqual(t, resourceSuffix, namespaceSuffix,
+		"hash suffix must not be identical across prefixes for the same raw value - it leaks that the two original values are equal")
 }

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -110,22 +110,18 @@ func pseudoIDSuffix(t *testing.T, pseudoID, prefix string) string {
 // *same raw value* must produce the *same hash suffix* regardless of
 // prefix, even though the display prefix differs. A resource's own name is
 // transformed with prefix "res" (session.go transformResourceMetadata), but
-// a reference to that same name elsewhere - an imagePullSecrets entry, a
-// ConfigMap/Secret volume source, a ServiceAccount name - is transformed
-// separately with prefix "ref"/"sa" (container.go), with no shared lookup
-// table between the two call sites. The shared hash suffix is the only
-// thing that lets a reader of a --hide report tell that a pod actually
-// pulls a specific Secret or runs as a specific ServiceAccount, without the
-// report ever revealing the real name.
+// a reference to that same name elsewhere - an imagePullSecrets entry or a
+// ServiceAccount name - is transformed separately with prefix "ref"/"sa"
+// (container.go), with no shared lookup table between the two call sites.
+// The shared hash suffix is the only thing that lets a reader of a --hide
+// report tell that a pod actually pulls a specific Secret or runs as a
+// specific ServiceAccount, without the report ever revealing the real name.
 //
-// This was previously untested at the suffix level (existing tests below
-// only assert the full "<prefix>-<suffix>" strings differ, which is always
-// true just from the differing prefix text, regardless of whether the
-// suffix matches) - see the discussion on PR #2687 for how that test gap
-// let a well-intentioned but incorrect "fix" (hashing prefix+value) merge
-// review as a plausible bug fix while actually breaking this cross-reference
-// linkage. Hashing value alone is deliberate, not an oversight; see the
-// doc comment on GetOrCreate for the accepted trade-off this implies.
+// Previously untested at the suffix level: existing tests only compare full
+// "<prefix>-<suffix>" strings, which differ from the prefix text alone
+// regardless of whether the suffix matches. See #2687. Hashing value alone
+// is deliberate, not an oversight; see the doc comment on GetOrCreate for
+// the accepted trade-off this implies.
 func TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes(t *testing.T) {
 	mapping := NewMapping()
 

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -72,6 +72,19 @@ func TestMapping_GetOrCreate(t *testing.T) {
 	}
 }
 
+// TestMapping_GetOrCreate_DeterministicAcrossInstances pins the property the
+// docs promise ("identical values produce identical pseudonyms across
+// reports"): two independent Mapping instances - standing in for two
+// separate scan runs - must produce the same pseudonym for the same
+// (prefix, value) pair. A within-instance-only check (same Mapping, called
+// twice) would also pass for a construction that is deterministic only
+// because of the map cache, not because the hash itself is stable.
+func TestMapping_GetOrCreate_DeterministicAcrossInstances(t *testing.T) {
+	assert.Equal(t,
+		NewMapping().GetOrCreate("res", "same-value"),
+		NewMapping().GetOrCreate("res", "same-value"))
+}
+
 func TestMapping_GetOrCreate_PrefixIsolationAcrossMultiplePrefixes(t *testing.T) {
 	mapping := NewMapping()
 
@@ -92,25 +105,40 @@ func pseudoIDSuffix(t *testing.T, pseudoID, prefix string) string {
 	return suffix
 }
 
-// TestMapping_GetOrCreate_HashSuffixDoesNotLeakAcrossPrefixes guards against a
-// regression where GetOrCreate hashed only the raw value, not prefix+value.
-// The pseudo-ID's display prefix always differs across categories, so the
-// full string was always distinct - but the hash *suffix* was identical
-// whenever the same raw value was mapped under two different prefixes (e.g.
-// a namespace and a resource name that happen to be the same string). That
-// let an observer notice "res-a1b2c3d4" and "ns-a1b2c3d4" share a suffix and
-// infer the two original values were equal, without ever learning what the
-// value was - exactly the cross-category correlation an anonymizer must not
-// allow.
-func TestMapping_GetOrCreate_HashSuffixDoesNotLeakAcrossPrefixes(t *testing.T) {
+// TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes pins a
+// property transformSession (session.go) architecturally depends on: the
+// *same raw value* must produce the *same hash suffix* regardless of
+// prefix, even though the display prefix differs. A resource's own name is
+// transformed with prefix "res" (session.go transformResourceMetadata), but
+// a reference to that same name elsewhere - an imagePullSecrets entry, a
+// ConfigMap/Secret volume source, a ServiceAccount name - is transformed
+// separately with prefix "ref"/"sa" (container.go), with no shared lookup
+// table between the two call sites. The shared hash suffix is the only
+// thing that lets a reader of a --hide report tell that a pod actually
+// pulls a specific Secret or runs as a specific ServiceAccount, without the
+// report ever revealing the real name.
+//
+// This was previously untested at the suffix level (existing tests below
+// only assert the full "<prefix>-<suffix>" strings differ, which is always
+// true just from the differing prefix text, regardless of whether the
+// suffix matches) - see the discussion on PR #2687 for how that test gap
+// let a well-intentioned but incorrect "fix" (hashing prefix+value) merge
+// review as a plausible bug fix while actually breaking this cross-reference
+// linkage. Hashing value alone is deliberate, not an oversight; see the
+// doc comment on GetOrCreate for the accepted trade-off this implies.
+func TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes(t *testing.T) {
 	mapping := NewMapping()
 
 	resource := mapping.GetOrCreate("res", "same-value")
-	namespace := mapping.GetOrCreate("ns", "same-value")
+	reference := mapping.GetOrCreate("ref", "same-value")
+	serviceAccount := mapping.GetOrCreate("sa", "same-value")
 
 	resourceSuffix := pseudoIDSuffix(t, resource, "res")
-	namespaceSuffix := pseudoIDSuffix(t, namespace, "ns")
+	referenceSuffix := pseudoIDSuffix(t, reference, "ref")
+	serviceAccountSuffix := pseudoIDSuffix(t, serviceAccount, "sa")
 
-	assert.NotEqual(t, resourceSuffix, namespaceSuffix,
-		"hash suffix must not be identical across prefixes for the same raw value - it leaks that the two original values are equal")
+	assert.Equal(t, resourceSuffix, referenceSuffix,
+		"a resource's own pseudonym (\"res\") and a reference to the same raw name elsewhere (\"ref\") must share a hash suffix, or the report loses the ability to show that the reference points at that resource")
+	assert.Equal(t, resourceSuffix, serviceAccountSuffix,
+		"a resource's own pseudonym (\"res\") and a ServiceAccount name reference (\"sa\") to the same raw name must share a hash suffix, for the same reason")
 }


### PR DESCRIPTION
## Original claim (retracted)

This PR originally changed `Mapping.GetOrCreate` to hash `prefix+value` instead of `value` alone, on the theory that the same raw value mapped under two different prefixes producing the same hash suffix was a cross-category correlation leak.

**matthyx's review showed that premise doesn't hold up**, with concrete before/after hash values:

| | before | after (original PR) |
|---|---|---|
| Secret `my-secret` as a resource (`res`) | `res-186ef76e` | `res-ba683655` |
| ...referenced via `imagePullSecrets` (`ref`) | `ref-186ef76e` | `ref-29305a6e` |
| ServiceAccount `my-sa` as a resource (`res`) | `res-44bd3efd` | `res-380a5fa9` |
| ...in `podSpec.serviceAccountName` (`sa`) | `sa-44bd3efd` | `sa-cb22b300` |

`transformSession` (`session.go`) relies on the shared hash suffix to link a resource's own pseudonym (`res`, set in `transformResourceMetadata`) to name-based references to that same resource elsewhere (`ref`/`sa`, set independently in `container.go` for imagePullSecrets, ConfigMap/Secret volume sources, and ServiceAccount names) - there is no shared lookup table between those call sites, only the hash. Hashing `prefix+value` silently severed that: a `--hide` report would still list both the Secret and the pod that pulls it, with no way to tell they're related.

matthyx also showed the security benefit was weaker than claimed: `docs/cli-reference.md` already documents that `--hide` pseudonyms can be reversed by hashing candidate values from a small/guessable set, so an observer who can already recover `"default"` from `ns-<hash>` gains little from cross-prefix suffix comparison. A fix that actually closes that channel would need a per-run random salt/HMAC key, which conflicts with the documented "identical values produce identical pseudonyms across reports" contract - an explicit maintainer decision, not something to change incidentally in a bug-fix PR.

## What this PR does now

Reverted `GetOrCreate`'s hash input back to `value` alone - verified byte-identical functional behavior to `master` (only comments and tests differ from the pre-PR state). What's left, which is genuinely valuable independent of the retracted claim above:

- **Documented the trade-off explicitly** in `GetOrCreate`'s doc comment: why value-only hashing is deliberate (the cross-reference linkage above), and the accepted, narrower correlation channel this implies (covered by the existing `--hide` threat-model docs).
- **Added a real regression test for the property that's actually relied upon**: `TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes` pins that `res`/`ref`/`sa` pseudonyms for the same raw value share a hash suffix. This was previously untested - the existing "prefix isolation" tests only ever compared full `<prefix>-<suffix>` strings, which differ from the prefix text alone regardless of whether the suffix matches, so neither the old nor new behavior was actually pinned. That gap is exactly why the original (incorrect) "fix" looked plausible. Mutation-verified: re-applying the prefix+value hash makes this new test fail.
- **Added `TestMapping_GetOrCreate_DeterministicAcrossInstances`**, pinning cross-instance (cross-run) determinism specifically, per matthyx's note that a within-instance-only check could pass for a construction that's deterministic only because of the map cache rather than a stable hash.

## Left open for maintainers

- Whether cross-run pseudo-ID stability is a contract worth keeping if a stronger (salted) fix is ever wanted - matthyx asked this explicitly and it's unresolved.
- The `ApplyEncrypted`/`resolveMappedID` gap matthyx flagged as separately out of scope (falls back to `ref-<sha256>` pseudonyms rather than ciphertext for IDs not backed by a resource object).

## Test plan
- [x] `go build ./core/pkg/anonymizer/...`
- [x] `go vet ./core/pkg/anonymizer/...`
- [x] `go test ./core/pkg/anonymizer/...` (full package, all tests pass)
- [x] Confirmed `mapping.go`'s functional code is byte-identical to `master` (diff with comments/blank lines stripped is empty)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how anonymized identifiers maintain consistent relationships for identical values across different contexts.

* **Tests**
  * Added coverage confirming deterministic identifier generation and consistent hash suffixes while preserving distinct displayed prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->