### PR TITLE
fix(printer): fix status mislabeling and nil-panic in v1 PrometheusPrinter

### DIFF
--- a/core/pkg/resultshandling/printer/v1/printer_extra_test.go
+++ b/core/pkg/resultshandling/printer/v1/printer_extra_test.go
@@ -113,6 +113,73 @@ func TestPrometheusPrinterPrintDetails(t *testing.T) {
 	}
 }
 
+// TestPrometheusPrinterPrintDetails_StatusDrivesMetricName guards against a
+// regression where printDetails always emitted "kubescape_object_failed_count"
+// regardless of the status argument. printResources calls printDetails once
+// per status ("failed", "excluded", "passed"), so excluded and (in verbose
+// mode) passed resources were silently counted as failed in the emitted
+// Prometheus metrics.
+func TestPrometheusPrinterPrintDetails_StatusDrivesMetricName(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"deploy-1": workload("apps/v1", "Deployment", "default", "api"),
+	}
+
+	for _, status := range []string{"failed", "excluded", "passed"} {
+		t.Run(status, func(t *testing.T) {
+			outputFile := filepath.Join(t.TempDir(), "prometheus.out")
+			writer, err := os.Create(outputFile)
+			require.NoError(t, err)
+
+			p := NewPrometheusPrinter(false)
+			p.writer = writer
+			p.printDetails(allResources, []string{"deploy-1"}, "fw", "ctrl", status)
+			require.NoError(t, writer.Close())
+
+			got, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+
+			wantMetric := "kubescape_object_" + status + "_count{"
+			assert.Contains(t, string(got), wantMetric)
+
+			for _, other := range []string{"failed", "excluded", "passed"} {
+				if other == status {
+					continue
+				}
+				assert.NotContains(t, string(got), "kubescape_object_"+other+"_count{",
+					"printDetails(status=%q) must not emit a %q-labeled metric", status, other)
+			}
+		})
+	}
+}
+
+// TestPrometheusPrinterPrintDetails_UnknownResourceIDDoesNotPanic guards
+// against a regression where printDetails looked up resourceID in
+// allResources without checking the map's "ok" result. A resourceID absent
+// from allResources produced the zero value of the
+// workloadinterface.IMetadata interface (nil), and calling GetApiVersion()
+// on it panicked with a nil pointer dereference instead of being skipped.
+func TestPrometheusPrinterPrintDetails_UnknownResourceIDDoesNotPanic(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"deploy-1": workload("apps/v1", "Deployment", "default", "api"),
+	}
+
+	outputFile := filepath.Join(t.TempDir(), "prometheus.out")
+	writer, err := os.Create(outputFile)
+	require.NoError(t, err)
+
+	p := NewPrometheusPrinter(false)
+	p.writer = writer
+
+	assert.NotPanics(t, func() {
+		p.printDetails(allResources, []string{"deploy-1", "does-not-exist"}, "fw", "ctrl", "failed")
+	})
+	require.NoError(t, writer.Close())
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `kubescape_object_failed_count{framework="fw",control="ctrl",namespace="default",name="api",groupVersionKind="apps/v1/Deployment"} 1`)
+}
+
 func TestNewPrometheusPrinterStoresVerboseMode(t *testing.T) {
 	assert.False(t, NewPrometheusPrinter(false).verboseMode)
 	assert.True(t, NewPrometheusPrinter(true).verboseMode)

--- a/core/pkg/resultshandling/printer/v1/printer_extra_test.go
+++ b/core/pkg/resultshandling/printer/v1/printer_extra_test.go
@@ -141,6 +141,12 @@ func TestPrometheusPrinterPrintDetails_StatusDrivesMetricName(t *testing.T) {
 			wantMetric := "kubescape_object_" + status + "_count{"
 			assert.Contains(t, string(got), wantMetric)
 
+			// The "failed" comment must stay byte-identical to the pre-fix
+			// output ("# Failed object ..."), not lowercase to "# failed
+			// object ..." as a raw %s interpolation of status would produce.
+			wantLabel := map[string]string{"failed": "Failed", "excluded": "Excluded", "passed": "Passed"}[status]
+			assert.Contains(t, string(got), `# `+wantLabel+` object from "fw" control "ctrl"`)
+
 			for _, other := range []string{"failed", "excluded", "passed"} {
 				if other == status {
 					continue

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -42,7 +42,14 @@ func (p *PrometheusPrinter) printResources(allResources map[string]workloadinter
 func (p *PrometheusPrinter) printDetails(allResources map[string]workloadinterface.IMetadata, resourcesIDs []string, frameworkName, controlName, status string) {
 	objs := make(map[string]map[string]map[string]int)
 	for _, resourceID := range resourcesIDs {
-		resource := allResources[resourceID]
+		// allResources may not contain every ID resourcesIDs lists (e.g. a
+		// resource pruned after the report was built): skip it rather than
+		// calling methods on the nil workloadinterface.IMetadata the map
+		// lookup would otherwise return, which panics.
+		resource, ok := allResources[resourceID]
+		if !ok {
+			continue
+		}
 
 		gvk := fmt.Sprintf("%s/%s", resource.GetApiVersion(), resource.GetKind())
 
@@ -57,11 +64,17 @@ func (p *PrometheusPrinter) printDetails(allResources map[string]workloadinterfa
 	for gvk, namespaces := range objs {
 		for namespace, names := range namespaces {
 			for name, value := range names {
-				fmt.Fprintf(p.writer, "# Failed object from \"%s\" control \"%s\"\n", frameworkName, controlName)
+				// status ("failed", "excluded", or "passed") must drive both
+				// the comment and the metric name: this function used to
+				// hardcode "Failed"/kubescape_object_failed_count
+				// unconditionally, so callers reporting excluded or (in
+				// verbose mode) passed resources silently mislabeled them as
+				// failed in the emitted Prometheus metrics.
+				fmt.Fprintf(p.writer, "# %s object from \"%s\" control \"%s\"\n", status, frameworkName, controlName)
 				if namespace != "" {
-					fmt.Fprintf(p.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",namespace=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, namespace, name, gvk, value)
+					fmt.Fprintf(p.writer, "kubescape_object_%s_count{framework=\"%s\",control=\"%s\",namespace=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", status, frameworkName, controlName, namespace, name, gvk, value)
 				} else {
-					fmt.Fprintf(p.writer, "kubescape_object_failed_count{framework=\"%s\",control=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", frameworkName, controlName, name, gvk, value)
+					fmt.Fprintf(p.writer, "kubescape_object_%s_count{framework=\"%s\",control=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", status, frameworkName, controlName, name, gvk, value)
 				}
 			}
 		}

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
@@ -15,6 +16,18 @@ import (
 type PrometheusPrinter struct {
 	writer      *os.File
 	verboseMode bool
+}
+
+// statusLabel maps a printDetails status ("failed", "excluded", "passed")
+// to its display form for the "# <label> object from ..." comment. Kept
+// separate from the metric name (which uses status as-is, lowercase) so the
+// "failed" path's comment stays byte-identical to the pre-fix output
+// ("# Failed object ..."), instead of a raw %s interpolation silently
+// lowercasing it to "# failed object ...".
+var statusLabel = map[string]string{
+	"failed":   "Failed",
+	"excluded": "Excluded",
+	"passed":   "Passed",
 }
 
 func NewPrometheusPrinter(verboseMode bool) *PrometheusPrinter {
@@ -48,6 +61,16 @@ func (p *PrometheusPrinter) printDetails(allResources map[string]workloadinterfa
 		// lookup would otherwise return, which panics.
 		resource, ok := allResources[resourceID]
 		if !ok {
+			// Skipping means this control's kubescape_object_<status>_count
+			// lines under-count relative to printReports' own
+			// kubescape_resources_<status>_count line for the same control,
+			// which is computed from the report rather than allResources -
+			// worth a trace when the two disagree in a scrape.
+			logger.L().Debug("resource ID missing from allResources, skipping object-level metric",
+				helpers.String("resourceID", resourceID),
+				helpers.String("status", status),
+				helpers.String("framework", frameworkName),
+				helpers.String("control", controlName))
 			continue
 		}
 
@@ -70,7 +93,7 @@ func (p *PrometheusPrinter) printDetails(allResources map[string]workloadinterfa
 				// unconditionally, so callers reporting excluded or (in
 				// verbose mode) passed resources silently mislabeled them as
 				// failed in the emitted Prometheus metrics.
-				fmt.Fprintf(p.writer, "# %s object from \"%s\" control \"%s\"\n", status, frameworkName, controlName)
+				fmt.Fprintf(p.writer, "# %s object from \"%s\" control \"%s\"\n", statusLabel[status], frameworkName, controlName)
 				if namespace != "" {
 					fmt.Fprintf(p.writer, "kubescape_object_%s_count{framework=\"%s\",control=\"%s\",namespace=\"%s\",name=\"%s\",groupVersionKind=\"%s\"} %d\n", status, frameworkName, controlName, namespace, name, gvk, value)
 				} else {


### PR DESCRIPTION
## Summary
`PrometheusPrinter.printDetails()` (`core/pkg/resultshandling/printer/v1`, part of the package's exported API) had two bugs:

1. **Status mislabeling.** It accepted a `status` argument (`"failed"`, `"excluded"`, or `"passed"` — `printResources` calls it once per status) but never used it: the emitted comment and metric name were hardcoded to `"Failed"`/`kubescape_object_failed_count` regardless. Excluded resources, and passed resources in verbose mode, were silently counted as failed in the emitted Prometheus metrics — exactly the kind of thing a dashboard or alert built on this output would get wrong without anyone noticing, since the metric still looks well-formed.
2. **Nil-panic on unknown resource ID.** `resource := allResources[resourceID]` did not check the map's `ok` result. `workloadinterface.IMetadata` is an interface; a `resourceID` absent from `allResources` yields its nil zero value, and the very next line calls `resource.GetApiVersion()` on it, which panics with a nil pointer dereference instead of skipping the missing resource.

**Correction:** `printDetails` is unexported, so an external importer cannot call it directly as an earlier version of this description claimed. The reachable path from outside the package is `ActionPrint` (exported), which calls `printReports` → `printResources` → `printDetails` internally — both bugs are still externally reachable, just via that path, not by calling `printDetails` itself.

`printerv1.PrometheusPrinter` has zero in-repo callers today: `results.go` wires `--format prometheus` to `printerv2.NewPrometheusPrinter`, not this v1 type. For anyone still importing v1 directly, though, this PR changes the output shape: it shrinks `kubescape_object_failed_count` (previously inflated by excluded/passed resources incorrectly labeled as failed) and introduces two new metric families, `kubescape_object_excluded_count` and `kubescape_object_passed_count`. Any dashboard/alert built on the old v1 output would need updating. **Whether v1's `PrometheusPrinter` should be hardened (this PR) or removed since nothing in-repo reaches it is a maintainer call** — flagging it explicitly rather than deciding it here.

## Fix
- Skip `resourceID`s missing from `allResources` instead of dereferencing a nil interface, with a debug-level trace so a mismatch between this metric and `printReports`' own resource-count line is diagnosable from logs.
- Build the comment and metric name from the `status` argument instead of a hardcoded `"failed"`, using a small display-label map so the pre-existing "failed" path's comment text (`"# Failed object ..."`) stays byte-identical rather than being lowercased by a raw `%s` interpolation of `status`.

## Test plan
- [x] `go build ./core/pkg/resultshandling/printer/...`
- [x] `go vet ./core/pkg/resultshandling/printer/...`
- [x] `go test ./core/pkg/resultshandling/...` (full tree, all existing tests pass unchanged)
- [x] `TestPrometheusPrinterPrintDetails_StatusDrivesMetricName` (all three statuses produce their own metric name and comment label, and none other) and `TestPrometheusPrinterPrintDetails_UnknownResourceIDDoesNotPanic`
- [x] Mutation-verified: reverting the status-label fix locally makes the comment-text assertion fail for all three statuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus metrics now accurately reflect whether resources passed, failed, or were excluded.
  * Unknown resource IDs are safely skipped instead of causing an error during detail output.
  * Prometheus output remains available for all recognized resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->