### PR TITLE
fix(printer): separate name and version in package score map key

### DIFF
--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -296,8 +296,9 @@ func setSeverityToSummaryMap(cves []imageprinter.CVE, mapSeverityToSummary map[s
 
 func setPkgNameToScoreMap(matches match.Matches, pkgScores map[string]*imageprinter.PackageScore) {
 	for _, m := range matches.Sorted() {
-		// key is pkg name + version to avoid version conflicts
-		key := m.Package.Name + m.Package.Version
+		// key is pkg name + version, separated so that e.g. name="foo1",
+		// version="2.3" cannot collide with name="foo", version="12.3"
+		key := m.Package.Name + "@" + m.Package.Version
 
 		if _, ok := pkgScores[key]; !ok {
 			pkgScores[key] = &imageprinter.PackageScore{

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
@@ -294,11 +295,27 @@ func setSeverityToSummaryMap(cves []imageprinter.CVE, mapSeverityToSummary map[s
 	}
 }
 
+// pkgScoreKey builds a collision-free map key from a package name and
+// version. A plain "name@version" join is not enough on its own: Name and
+// Version are free-form strings from Grype, and real-world values can
+// contain "@" (e.g. npm scoped package names like "@angular/core"), so two
+// different (name, version) pairs could still join to the same string -
+// e.g. name="foo@bar", version="baz" and name="foo", version="bar@baz"
+// both become "foo@bar@baz". Escaping "@" (and the escape character
+// itself) in each part before joining ensures the delimiter "@" can always
+// be told apart from an escaped literal one, so distinct pairs never
+// collide.
+func pkgScoreKey(name, version string) string {
+	escape := func(s string) string {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		return strings.ReplaceAll(s, "@", `\@`)
+	}
+	return escape(name) + "@" + escape(version)
+}
+
 func setPkgNameToScoreMap(matches match.Matches, pkgScores map[string]*imageprinter.PackageScore) {
 	for _, m := range matches.Sorted() {
-		// key is pkg name + version, separated so that e.g. name="foo1",
-		// version="2.3" cannot collide with name="foo", version="12.3"
-		key := m.Package.Name + "@" + m.Package.Version
+		key := pkgScoreKey(m.Package.Name, m.Package.Version)
 
 		if _, ok := pkgScores[key]; !ok {
 			pkgScores[key] = &imageprinter.PackageScore{

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -287,8 +287,9 @@ func setSeverityToSummaryMap(cves []imageprinter.CVE, mapSeverityToSummary map[s
 
 func setPkgNameToScoreMap(matches match.Matches, pkgScores map[string]*imageprinter.PackageScore) {
 	for _, m := range matches.Sorted() {
-		// key is pkg name + version to avoid version conflicts
-		key := m.Package.Name + m.Package.Version
+		// key is pkg name + version, separated so that e.g. name="foo1",
+		// version="2.3" cannot collide with name="foo", version="12.3"
+		key := m.Package.Name + "@" + m.Package.Version
 
 		if _, ok := pkgScores[key]; !ok {
 			pkgScores[key] = &imageprinter.PackageScore{

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -219,7 +219,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"foo1.2.3": {
+				"foo@1.2.3": {
 					Name:    "foo",
 					Score:   4,
 					Version: "1.2.3",
@@ -270,7 +270,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version1",
@@ -278,7 +278,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Critical": 1,
 					},
 				},
-				"pkg21.2": {
+				"pkg2@1.2": {
 					Name:    "pkg2",
 					Score:   2,
 					Version: "1.2",
@@ -286,7 +286,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Low": 1,
 					},
 				},
-				"pkg31.2.3": {
+				"pkg3@1.2.3": {
 					Name:    "pkg3",
 					Score:   4,
 					Version: "1.2.3",
@@ -373,7 +373,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   8,
 					Version: "version1",
@@ -381,7 +381,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 2,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -389,7 +389,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Critical": 1,
 					},
 				},
-				"pkg31.2": {
+				"pkg3@1.2": {
 					Name:    "pkg3",
 					Score:   5,
 					Version: "1.2",
@@ -398,7 +398,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Low":    1,
 					},
 				},
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -454,7 +454,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			originalMap: map[string]*imageprinter.PackageScore{
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -464,7 +464,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			},
 			want: map[string]*imageprinter.PackageScore{
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -472,7 +472,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 1,
 					},
 				},
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   8,
 					Version: "version1",
@@ -480,7 +480,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 2,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -531,7 +531,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			originalMap: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   4,
 					Version: "version1",
@@ -541,7 +541,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			},
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   12,
 					Version: "version1",
@@ -549,7 +549,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 3,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -597,6 +597,52 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator verifies that two
+// distinct (name, version) pairs whose concatenation would be identical if no
+// separator were used between them - e.g. name="foo1"+version="2.3" and
+// name="foo"+version="12.3", both "foo12.3" - are kept as separate entries
+// instead of one silently overwriting the other's CVE data.
+func TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator(t *testing.T) {
+	matches := match.NewMatches([]match.Match{
+		{
+			Package: pkg.Package{
+				ID:      "1",
+				Name:    "foo1",
+				Version: "2.3",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "High",
+				},
+			},
+		},
+		{
+			Package: pkg.Package{
+				ID:      "2",
+				Name:    "foo",
+				Version: "12.3",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "Critical",
+				},
+			},
+		},
+	}...)
+
+	pkgScores := make(map[string]*imageprinter.PackageScore)
+	setPkgNameToScoreMap(matches, pkgScores)
+
+	require.Len(t, pkgScores, 2, "both packages must have their own entry, not collide into one")
+
+	names := make(map[string]string)
+	for _, score := range pkgScores {
+		names[score.Name+"/"+score.Version] = score.Name
+	}
+	assert.Contains(t, names, "foo1/2.3")
+	assert.Contains(t, names, "foo/12.3")
 }
 
 func TestSetSeverityToSummaryMap(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -222,7 +222,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"foo1.2.3": {
+				"foo@1.2.3": {
 					Name:    "foo",
 					Score:   4,
 					Version: "1.2.3",
@@ -273,7 +273,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version1",
@@ -281,7 +281,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Critical": 1,
 					},
 				},
-				"pkg21.2": {
+				"pkg2@1.2": {
 					Name:    "pkg2",
 					Score:   2,
 					Version: "1.2",
@@ -289,7 +289,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Low": 1,
 					},
 				},
-				"pkg31.2.3": {
+				"pkg3@1.2.3": {
 					Name:    "pkg3",
 					Score:   4,
 					Version: "1.2.3",
@@ -376,7 +376,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   8,
 					Version: "version1",
@@ -384,7 +384,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 2,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -392,7 +392,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Critical": 1,
 					},
 				},
-				"pkg31.2": {
+				"pkg3@1.2": {
 					Name:    "pkg3",
 					Score:   5,
 					Version: "1.2",
@@ -401,7 +401,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"Low":    1,
 					},
 				},
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -457,7 +457,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			originalMap: map[string]*imageprinter.PackageScore{
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -467,7 +467,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			},
 			want: map[string]*imageprinter.PackageScore{
-				"pkg41.2.3": {
+				"pkg4@1.2.3": {
 					Name:    "pkg4",
 					Score:   4,
 					Version: "1.2.3",
@@ -475,7 +475,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 1,
 					},
 				},
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   8,
 					Version: "version1",
@@ -483,7 +483,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 2,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -534,7 +534,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			}...),
 			originalMap: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   4,
 					Version: "version1",
@@ -544,7 +544,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 				},
 			},
 			want: map[string]*imageprinter.PackageScore{
-				"pkg1version1": {
+				"pkg1@version1": {
 					Name:    "pkg1",
 					Score:   12,
 					Version: "version1",
@@ -552,7 +552,7 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 						"High": 3,
 					},
 				},
-				"pkg1version2": {
+				"pkg1@version2": {
 					Name:    "pkg1",
 					Score:   5,
 					Version: "version2",
@@ -600,6 +600,52 @@ func TestSetPkgNameToScoreMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator verifies that two
+// distinct (name, version) pairs whose concatenation would be identical if no
+// separator were used between them - e.g. name="foo1"+version="2.3" and
+// name="foo"+version="12.3", both "foo12.3" - are kept as separate entries
+// instead of one silently overwriting the other's CVE data.
+func TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator(t *testing.T) {
+	matches := match.NewMatches([]match.Match{
+		{
+			Package: pkg.Package{
+				ID:      "1",
+				Name:    "foo1",
+				Version: "2.3",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "High",
+				},
+			},
+		},
+		{
+			Package: pkg.Package{
+				ID:      "2",
+				Name:    "foo",
+				Version: "12.3",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "Critical",
+				},
+			},
+		},
+	}...)
+
+	pkgScores := make(map[string]*imageprinter.PackageScore)
+	setPkgNameToScoreMap(matches, pkgScores)
+
+	require.Len(t, pkgScores, 2, "both packages must have their own entry, not collide into one")
+
+	names := make(map[string]string)
+	for _, score := range pkgScores {
+		names[score.Name+"/"+score.Version] = score.Name
+	}
+	assert.Contains(t, names, "foo1/2.3")
+	assert.Contains(t, names, "foo/12.3")
 }
 
 func TestSetSeverityToSummaryMap(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -648,6 +648,82 @@ func TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator(t *testing.T) {
 	assert.Contains(t, names, "foo/12.3")
 }
 
+// TestSetPkgNameToScoreMap_NoCollisionWithAtInNameOrVersion verifies that
+// the "@" delimiter itself does not reintroduce the collision class it was
+// meant to fix. Package names can legitimately contain "@" (e.g. npm scoped
+// packages such as "@angular/core"), so without escaping, name="foo@bar"
+// + version="baz" and name="foo" + version="bar@baz" would both join to the
+// same raw string "foo@bar@baz" and collide.
+func TestSetPkgNameToScoreMap_NoCollisionWithAtInNameOrVersion(t *testing.T) {
+	matches := match.NewMatches([]match.Match{
+		{
+			Package: pkg.Package{
+				ID:      "1",
+				Name:    "foo@bar",
+				Version: "baz",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "High",
+				},
+			},
+		},
+		{
+			Package: pkg.Package{
+				ID:      "2",
+				Name:    "foo",
+				Version: "bar@baz",
+			},
+			Vulnerability: vulnerability.Vulnerability{
+				Metadata: &vulnerability.Metadata{
+					Severity: "Critical",
+				},
+			},
+		},
+	}...)
+
+	pkgScores := make(map[string]*imageprinter.PackageScore)
+	setPkgNameToScoreMap(matches, pkgScores)
+
+	require.Len(t, pkgScores, 2, "both packages must have their own entry, not collide into one")
+
+	names := make(map[string]string)
+	for _, score := range pkgScores {
+		names[score.Name+"/"+score.Version] = score.Name
+	}
+	assert.Contains(t, names, "foo@bar/baz")
+	assert.Contains(t, names, "foo/bar@baz")
+}
+
+// TestPkgScoreKeyIsCollisionFree exercises pkgScoreKey directly against a
+// broader set of adversarial (name, version) pairs - including values
+// containing the delimiter and the escape character itself - and asserts
+// every pair maps to a distinct key.
+func TestPkgScoreKeyIsCollisionFree(t *testing.T) {
+	type nameVersion struct{ name, version string }
+	pairs := []nameVersion{
+		{"foo1", "2.3"},
+		{"foo", "12.3"},
+		{"foo@bar", "baz"},
+		{"foo", "bar@baz"},
+		{"@angular/core", "12.3"},
+		{"@angular/core@12", "3"},
+		{`foo\`, "bar"},
+		{"foo", `\bar`},
+		{`foo\@`, "bar"},
+		{"foo", `\@bar`},
+	}
+
+	seen := make(map[string]nameVersion)
+	for _, p := range pairs {
+		key := pkgScoreKey(p.name, p.version)
+		if prev, ok := seen[key]; ok {
+			t.Fatalf("key collision: (%q,%q) and (%q,%q) both produced key %q", prev.name, prev.version, p.name, p.version, key)
+		}
+		seen[key] = p
+	}
+}
+
 func TestSetSeverityToSummaryMap(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

`setPkgNameToScoreMap` (core/pkg/resultshandling/printer/v2/utils.go) builds its map key as:

```go
key := m.Package.Name + m.Package.Version
```

The two fields are concatenated with **no separator**, despite the adjacent comment claiming this is done "to avoid version conflicts". Without a separator, two distinct `(name, version)` pairs can produce the same key, e.g.:

- `name="foo1"`, `version="2.3"` → `"foo12.3"`
- `name="foo"`, `version="12.3"` → `"foo12.3"`

Both collide to the same key, so the second package silently overwrites the first entry in the map.

## Impact

This map is exposed directly as the `packageScores` field of the JSON scan report output (`opa-utils` `reportsummary.PackageScores`, `json:"packageScores"`) via `convertToPackageScores`. A collision means one of the two colliding packages' CVE counts and score are silently dropped from the report — vulnerabilities are understated for the overwritten package with no error, warning, or indication anything was lost.

This is realistic in practice: many real package names end in a digit (e.g. `python3`, `libssl1`, `nodejs18`), which is exactly the kind of name/version boundary that can produce a collision against another package+version pair.

## Fix

Join `Name` and `Version` with `@` instead of concatenating them directly:

```go
key := m.Package.Name + "@" + m.Package.Version
```

`@` cannot appear at a digit/non-digit boundary in a way that makes the two components reconstructable ambiguously, so this removes the collision class described above.

## Test plan

- Added `TestSetPkgNameToScoreMap_NoCollisionWithoutSeparator`, which constructs exactly the `foo1`/`2.3` vs `foo`/`12.3` collision case above, fails against the old (unseparated) key format, and passes with the fix.
- Updated the existing `TestSetPkgNameToScoreMap` table-driven test's expected map keys to the new `name@version` format.
- `go build ./...`, `go vet ./core/pkg/resultshandling/printer/v2/...`, and `go test ./core/pkg/resultshandling/...` all pass.

Signed-off-by DCO commit included.

## Update: `@` alone wasn't fully collision-free either

CodeRabbit correctly flagged that `name + "@" + version` can still collide, since `Package.Name`/`Package.Version` are free-form strings from Grype and can themselves contain `@` (e.g. npm scoped packages like `@angular/core`). For example `name="foo@bar", version="baz"` and `name="foo", version="bar@baz"` both still joined to `"foo@bar@baz"`.

Fixed by escaping `@` (and the escape character `\`) inside each part before joining, so the delimiter can always be told apart from an escaped literal one:

```go
func pkgScoreKey(name, version string) string {
	escape := func(s string) string {
		s = strings.ReplaceAll(s, `\`, `\\`)
		return strings.ReplaceAll(s, "@", `\@`)
	}
	return escape(name) + "@" + escape(version)
}
```

Added `TestSetPkgNameToScoreMap_NoCollisionWithAtInNameOrVersion` and `TestPkgScoreKeyIsCollisionFree` covering the scoped-package case and other adversarial inputs.

## Breaking Change

The `packageScores` map keys in the JSON scan report output (`opa-utils` `reportsummary.PackageScores`) change format as part of this PR:

- **Before:** `name` and `version` concatenated with no separator (e.g. `foo1.2.3`) — ambiguous and already silently lossy on collision.
- **After:** `name@version`, with `@`/`\` escaped inside each part when present (e.g. `foo@1.2.3`, or `foo\@bar@baz` if the name itself contains `@`).

Any downstream tooling that parses `packageScores` keys as raw strings (rather than reading the `name`/`version` fields already present on each `PackageScore`/`PackageSummary` value) will see a different key format after this merges. Per the [release process](https://github.com/kubescape/kubescape/blob/master/.github/workflows/README.md#release-process), this should go out with a **major** version bump rather than a routine minor bump, since it changes the JSON output contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package score tracking to reliably distinguish package names and versions.
  * Prevented collisions involving ambiguous combinations or special characters in package names and versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
