### PR TITLE
fix(cautils): stop port-forward on readiness failure

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -95,7 +95,7 @@ func (p *portForward) waitForPortForwardReadiness() error {
 }
 
 func (p *portForward) GetPortForwardLocalhost() string {
-	return "localhost:" + getPortForwardingPort()
+	return "localhost:" + p.localPort
 }
 
 func (p *portForward) StopPortForwarder() {

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -222,7 +222,7 @@ func Test_GetPortForwardLocalhost(t *testing.T) {
 			assert.Equal(t, nil, err)
 
 			result := pf.GetPortForwardLocalhost()
-			assert.Equal(t, tc.result+":"+getPortForwardingPort(), result)
+			assert.Equal(t, tc.result+":"+tc.port, result)
 		})
 	}
 }

--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -105,6 +105,7 @@ func (a *OperatorAdapter) httpPostOperatorScanRequest(body apis.Commands) (strin
 
 	err = a.StartPortForwarder()
 	if err != nil {
+		a.StopPortForwarder()
 		return "", err
 	}
 	defer a.StopPortForwarder()


### PR DESCRIPTION
<h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-p7qtub ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">PR description</h3><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="-electron-corner-smoothing: 60%; word-break: break-word; padding: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">Stop the port-forward when<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="-electron-corner-smoothing: 60%; border-radius: 5px; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); color: rgb(240, 240, 240); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">StartPortForwarder()</code><span> </span>fails in the operator scan flow</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="-electron-corner-smoothing: 60%; word-break: break-word; padding: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">Use the bound<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="-electron-corner-smoothing: 60%; border-radius: 5px; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); color: rgb(240, 240, 240); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">localPort</code><span> </span>in<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="-electron-corner-smoothing: 60%; border-radius: 5px; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); color: rgb(240, 240, 240); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">GetPortForwardLocalhost()</code><span> </span>instead of re-reading the env var</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="-electron-corner-smoothing: 60%; word-break: break-word; padding: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">Update test assertion to match stored port semantics</li></ul><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Motivation</h2><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; word-break: break-word; margin-bottom: 10px; margin-top: 10px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Failure paths should not leak background goroutines, especially in repeated operator scan attempts or long-lived processes.</p><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk ui-tr57km ui-14beivq ui-13xjzxd ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-1043rbw ui-14l7nz5 ui-zboxd6" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; --scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; border-radius: 8px; display: grid; position: relative; border-color: color(srgb 0.941176 0.941176 0.941176 / 0.28); border-style: solid; border-width: 1px; margin-bottom: 1em; margin-top: 1em; overflow: hidden; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" style="-electron-corner-smoothing: 60%; grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none !important; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); box-sizing: border-box;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="-electron-corner-smoothing: 60%; box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: 100%; min-height: 100%; min-width: 100%; width: auto; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin;">
File | Change
-- | --
core/core/clusterconnector.go | Call StopPortForwarder() before returning on readiness error
core/cautils/portforwarder.go | GetPortForwardLocalhost() uses p.localPort
core/cautils/portforwarder_test.go | Assert against bound port

</div></div></div><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-3ct3a4 ui-1uhho1l contains-task-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; gap: 6px; display: flex; flex-direction: column; list-style-type: none; margin-bottom: 10px; margin-top: 10px; padding-left: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-13faqbe ui-ez2fb ui-1n2onr6 ui-1aw4gp8 task-list-item" data-md-list-item="" style="-electron-corner-smoothing: 60%; position: relative; word-break: break-word; padding: 0px 0px 0px 22px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span class="ui-markdown__task-checkbox ui-10l6tqk ui-u96u03 ui-13vifvy ui-g2ss61 ui-78zum5 ui-6s0dn4 ui-47corl" style="-electron-corner-smoothing: 60%; align-items: center; display: flex; pointer-events: none; position: absolute; height: 1lh; left: 0px; top: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span data-unchecked="" data-readonly="" role="checkbox" tabindex="-1" id="base-ui-_r_4ef_" aria-checked="false" aria-readonly="true" aria-disabled="true" aria-label="Incomplete task" data-component="checkbox" data-size="md" data-variant="neutral" class="ui-checkbox ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1c4vz4f ui-2lah0s ui-dl72j9 ui-xymvpz ui-1n2onr6 ui-1k57tk5 ui-1t137rt ui-ggy1nq ui-1cpjm7i ui-1hmns74 ui-1lc8iih ui-2hztxu ui-t0e3qv ui--default-marker" style="-electron-corner-smoothing: 60%; align-items: center; cursor: default; display: inline-flex; flex: 0 0 auto; justify-content: center; outline-style: none; outline-width: 0px; position: relative; touch-action: manipulation; vertical-align: middle; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span aria-hidden="true" class="ui-checkbox__box ui-1n2onr6 ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-9f619 ui-1k57tk5 ui-1gv1zob ui-1t137rt ui-1rsevuf ui-1uczgqu ui-14qs42y ui-1wfwxd8 ui-1i57s2w ui-1hc1fzr ui-1goyyu5 ui-mkeg23 ui-1y0btm7 ui-12oqio5 ui-1lriclw ui-i07v4r ui-190xqy7 ui-1tjqsyf ui-14ytyh1 ui-3oybdh ui-78fr0e ui-1g0ag68 ui-1lxufdw ui-2krxs4 ui-sagj69 ui-6ekqhr ui-ek66a6 ui-1q5geii ui-1rpsy8r ui-mtpsoh ui-qnctk6" style="-electron-corner-smoothing: 60%; --ui-checkbox-bg: color-mix(in srgb, #F0F0F0 14%, transparent); --ui-checkbox-border: color-mix(in srgb, #F0F0F0 48%, transparent); --ui-checkbox-glyph: color-mix(in srgb, #F0F0F0 84%, transparent); border-color: color(srgb 0.941176 0.941176 0.941176 / 0.48); border-radius: 4px; border-style: solid; border-width: 1px; align-items: center; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); box-sizing: border-box; color: color(srgb 0.941176 0.941176 0.941176 / 0.84); display: inline-flex; justify-content: center; opacity: 1; outline: transparent none 0px; outline-offset: 0px; position: relative; transform-origin: center center; transform: scale(1); transition-duration: 0.1s, 0.1s, 0.05s; transition-property: background-color, border-color, transform; transition-timing-function: ease; height: 14px; width: 14px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin;"><span data-unchecked="" data-readonly="" class="ui-checkbox__icon ui-10l6tqk ui-10a8y8t ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1g0ag68 ui-n9if97 ui-7pq1vu ui-sagj69 ui-6ekqhr ui-g01cxk ui-hhdk15 ui-nyzrob ui-h98lc ui-1nrvvgt ui-cntms" style="-electron-corner-smoothing: 60%; inset: 0px; align-items: center; display: inline-flex; filter: blur(1px); justify-content: center; opacity: 0; position: absolute; transform-origin: center center; transform: scale(0.75); transition-duration: 0.1s; transition-property: opacity, filter, transform; transition-timing-function: ease; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"></span></span></span><input tabindex="-1" aria-hidden="true" type="checkbox" style="padding: 0px; margin: -1px; -electron-corner-smoothing: 60%; font-family: inherit; font-weight: 400; color: inherit; font-size: 14px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; width: 1px; height: 1px; position: fixed; top: 0px; left: 0px;"></span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="-electron-corner-smoothing: 60%; border-radius: 5px; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); color: rgb(240, 240, 240); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">go test ./core/cautils -run 'Test_GetPortForwardLocalhost|TestStopPortForwarder' -count=1</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-13faqbe ui-ez2fb ui-1n2onr6 ui-1aw4gp8 task-list-item" data-md-list-item="" style="-electron-corner-smoothing: 60%; position: relative; word-break: break-word; padding: 0px 0px 0px 22px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span class="ui-markdown__task-checkbox ui-10l6tqk ui-u96u03 ui-13vifvy ui-g2ss61 ui-78zum5 ui-6s0dn4 ui-47corl" style="-electron-corner-smoothing: 60%; align-items: center; display: flex; pointer-events: none; position: absolute; height: 1lh; left: 0px; top: 0px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span data-unchecked="" data-readonly="" role="checkbox" tabindex="-1" id="base-ui-_r_4ei_" aria-checked="false" aria-readonly="true" aria-disabled="true" aria-label="Incomplete task" data-component="checkbox" data-size="md" data-variant="neutral" class="ui-checkbox ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1c4vz4f ui-2lah0s ui-dl72j9 ui-xymvpz ui-1n2onr6 ui-1k57tk5 ui-1t137rt ui-ggy1nq ui-1cpjm7i ui-1hmns74 ui-1lc8iih ui-2hztxu ui-t0e3qv ui--default-marker" style="-electron-corner-smoothing: 60%; align-items: center; cursor: default; display: inline-flex; flex: 0 0 auto; justify-content: center; outline-style: none; outline-width: 0px; position: relative; touch-action: manipulation; vertical-align: middle; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"><span aria-hidden="true" class="ui-checkbox__box ui-1n2onr6 ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-9f619 ui-1k57tk5 ui-1gv1zob ui-1t137rt ui-1rsevuf ui-1uczgqu ui-14qs42y ui-1wfwxd8 ui-1i57s2w ui-1hc1fzr ui-1goyyu5 ui-mkeg23 ui-1y0btm7 ui-12oqio5 ui-1lriclw ui-i07v4r ui-190xqy7 ui-1tjqsyf ui-14ytyh1 ui-3oybdh ui-78fr0e ui-1g0ag68 ui-1lxufdw ui-2krxs4 ui-sagj69 ui-6ekqhr ui-ek66a6 ui-1q5geii ui-1rpsy8r ui-mtpsoh ui-qnctk6" style="-electron-corner-smoothing: 60%; --ui-checkbox-bg: color-mix(in srgb, #F0F0F0 14%, transparent); --ui-checkbox-border: color-mix(in srgb, #F0F0F0 48%, transparent); --ui-checkbox-glyph: color-mix(in srgb, #F0F0F0 84%, transparent); border-color: color(srgb 0.941176 0.941176 0.941176 / 0.48); border-radius: 4px; border-style: solid; border-width: 1px; align-items: center; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); box-sizing: border-box; color: color(srgb 0.941176 0.941176 0.941176 / 0.84); display: inline-flex; justify-content: center; opacity: 1; outline: transparent none 0px; outline-offset: 0px; position: relative; transform-origin: center center; transform: scale(1); transition-duration: 0.1s, 0.1s, 0.05s; transition-property: background-color, border-color, transform; transition-timing-function: ease; height: 14px; width: 14px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin;"><span data-unchecked="" data-readonly="" class="ui-checkbox__icon ui-10l6tqk ui-10a8y8t ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1g0ag68 ui-n9if97 ui-7pq1vu ui-sagj69 ui-6ekqhr ui-g01cxk ui-hhdk15 ui-nyzrob ui-h98lc ui-1nrvvgt ui-cntms" style="-electron-corner-smoothing: 60%; inset: 0px; align-items: center; display: inline-flex; filter: blur(1px); justify-content: center; opacity: 0; position: absolute; transform-origin: center center; transform: scale(0.75); transition-duration: 0.1s; transition-property: opacity, filter, transform; transition-timing-function: ease; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;"></span></span></span><input tabindex="-1" aria-hidden="true" type="checkbox" style="padding: 0px; margin: -1px; -electron-corner-smoothing: 60%; font-family: inherit; font-weight: 400; color: inherit; font-size: 14px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; width: 1px; height: 1px; position: fixed; top: 0px; left: 0px;"></span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="-electron-corner-smoothing: 60%; border-radius: 5px; background-color: color(srgb 0.941176 0.941176 0.941176 / 0.14); color: rgb(240, 240, 240); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box;">go test ./core/core -run clusterconnector -count=1</code><span> </span>(if cluster mocks available)</li></ul><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Backward compatibility</h2><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; -electron-corner-smoothing: 60%; word-break: break-word; margin-bottom: 10px; margin-top: 10px; scrollbar-color: color(srgb 0.941176 0.941176 0.941176 / 0.28) rgba(0, 0, 0, 0); scrollbar-width: thin; box-sizing: border-box; color: rgb(240, 240, 240); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(10, 10, 10); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fully backward compatible on success paths. Failure paths now clean up correctly.</p>
<img width="1026" height="87" alt="image" src="https://github.com/user-attachments/assets/1b62ecbc-6b01-4220-b3bd-ed4c1336b174" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved port-forwarding behavior by consistently using the configured local port.
  - Ensured port-forwarding is properly stopped when an operator scan request cannot be started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->