### PR TITLE
Support registry auth for workload image scans

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -30,8 +30,6 @@ var (
 
 // getImageCmd returns the scan image command
 func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
-	var imgCredentials shared.ImageCredentials
-
 	cmd := &cobra.Command{
 		Use:     "image <image>:<tag> [flags]",
 		Short:   "Scan an image for vulnerabilities",
@@ -58,11 +56,22 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}
+			credentials := shared.ImageCredentials{
+				Authority: scanInfo.RegistryAuthority,
+				Username:  scanInfo.RegistryUsername,
+				Password:  scanInfo.RegistryPassword,
+				Token:     scanInfo.RegistryToken,
+			}
+			if err := shared.ValidateImageCredentials(credentials); err != nil {
+				return err
+			}
 
 			imgScanInfo := &metav1.ImageScanInfo{
+				Authority:          credentials.Authority,
 				Image:              args[0],
-				Username:           imgCredentials.Username,
-				Password:           imgCredentials.Password,
+				Username:           credentials.Username,
+				Password:           credentials.Password,
+				Token:              credentials.Token,
 				Exceptions:         scanInfo.UseExceptions,
 				UseDefaultMatchers: scanInfo.UseDefaultMatchers,
 			}
@@ -80,8 +89,8 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&imgCredentials.Username, "username", "u", "", "Username for registry login")
-	cmd.PersistentFlags().StringVarP(&imgCredentials.Password, "password", "p", "", "Password for registry login")
+	cmd.PersistentFlags().StringVarP(&scanInfo.RegistryUsername, "username", "u", "", "Username for registry login")
+	cmd.PersistentFlags().StringVarP(&scanInfo.RegistryPassword, "password", "p", "", "Password for registry login")
 
 	return cmd
 }

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -5,10 +5,23 @@ import (
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
+
+type imageScanCaptureKubescape struct {
+	mocks.MockIKubescape
+	imgScanInfo *metav1.ImageScanInfo
+	scanInfo    *cautils.ScanInfo
+}
+
+func (m *imageScanCaptureKubescape) ScanImage(imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
+	m.imgScanInfo = imgScanInfo
+	m.scanInfo = scanInfo
+	return false, nil
+}
 
 func TestGetImageCmd(t *testing.T) {
 	// Create a mock Kubescape interface
@@ -94,4 +107,138 @@ func TestGetImageCmd_RunE_Success(t *testing.T) {
 
 	err := cmd.RunE(cmd, []string{"nginx"})
 	assert.NoError(t, err)
+}
+
+func TestGetImageCmd_RunE_ForwardsRegistryTokenCredentials(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryAuthority, "registry-authority", "", "")
+	parentCmd.AddCommand(cmd)
+
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-token", "token"))
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-authority", "registry.example.com"))
+
+	err := cmd.RunE(cmd, []string{"registry.example.com/app:tag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
+	assert.Equal(t, "token", mockKubescape.imgScanInfo.Token)
+	assert.Equal(t, "registry.example.com/app:tag", mockKubescape.imgScanInfo.Image)
+}
+
+func TestGetImageCmd_RunE_ForwardsInheritedRegistryBasicCredentials(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryAuthority, "registry-authority", "", "")
+	parentCmd.AddCommand(cmd)
+
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-username", "user"))
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-password", "pass"))
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-authority", "registry.example.com"))
+
+	err := cmd.RunE(cmd, []string{"registry.example.com/app:tag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
+	assert.Equal(t, "user", mockKubescape.imgScanInfo.Username)
+	assert.Equal(t, "pass", mockKubescape.imgScanInfo.Password)
+}
+
+func TestGetImageCmd_RunE_AcceptsMixedRegistryCredentialFlagFamilies(t *testing.T) {
+	testCases := []struct {
+		name     string
+		setFlags func(t *testing.T, parentCmd, imageCmd *cobra.Command)
+	}{
+		{
+			name: "registry username with legacy password",
+			setFlags: func(t *testing.T, parentCmd, imageCmd *cobra.Command) {
+				assert.NoError(t, parentCmd.PersistentFlags().Set("registry-username", "user"))
+				assert.NoError(t, imageCmd.PersistentFlags().Set("password", "pass"))
+			},
+		},
+		{
+			name: "legacy username with registry password",
+			setFlags: func(t *testing.T, parentCmd, imageCmd *cobra.Command) {
+				assert.NoError(t, imageCmd.PersistentFlags().Set("username", "user"))
+				assert.NoError(t, parentCmd.PersistentFlags().Set("registry-password", "pass"))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockKubescape := &imageScanCaptureKubescape{}
+			scanInfo := cautils.ScanInfo{}
+
+			cmd := getImageCmd(mockKubescape, &scanInfo)
+			parentCmd := &cobra.Command{Use: "scan"}
+			parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+			parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+			parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+			parentCmd.AddCommand(cmd)
+
+			tc.setFlags(t, parentCmd, cmd)
+
+			err := cmd.RunE(cmd, []string{"registry.example.com/app:tag"})
+			assert.NoError(t, err)
+			assert.Equal(t, "user", mockKubescape.imgScanInfo.Username)
+			assert.Equal(t, "pass", mockKubescape.imgScanInfo.Password)
+		})
+	}
+}
+
+func TestGetImageCmd_RunE_RejectsConflictingRegistryCredentials(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+	parentCmd.AddCommand(cmd)
+
+	assert.NoError(t, cmd.PersistentFlags().Set("username", "user"))
+	assert.NoError(t, cmd.PersistentFlags().Set("password", "pass"))
+	assert.NoError(t, parentCmd.PersistentFlags().Set("registry-token", "token"))
+
+	err := cmd.RunE(cmd, []string{"registry.example.com/app:tag"})
+	assert.Equal(t, shared.ErrRegistryAuthConflict, err)
+	assert.Nil(t, mockKubescape.imgScanInfo)
+}
+
+func TestGetImageCmd_RegistryTokenAndAuthorityAreInherited(t *testing.T) {
+	scanCmd := GetScanCommand(&mocks.MockIKubescape{})
+	imageCmd, _, err := scanCmd.Find([]string{"image"})
+	assert.NoError(t, err)
+
+	assert.Nil(t, imageCmd.PersistentFlags().Lookup("registry-token"))
+	assert.Nil(t, imageCmd.PersistentFlags().Lookup("registry-authority"))
+	assert.NotNil(t, imageCmd.InheritedFlags().Lookup("registry-token"))
+	assert.NotNil(t, imageCmd.InheritedFlags().Lookup("registry-authority"))
+}
+
+func TestGetScanCommand_ImageRegistryTokenAndAuthorityReachImageScan(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	cmd.SetArgs([]string{
+		"image",
+		"--registry-token", "token",
+		"--registry-authority", "registry.example.com",
+		"registry.example.com/app:tag",
+	})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
+	assert.Equal(t, "token", mockKubescape.imgScanInfo.Token)
+	assert.Equal(t, "registry.example.com/app:tag", mockKubescape.imgScanInfo.Image)
 }

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -14,6 +15,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var scanCmdExamples = fmt.Sprintf(`
@@ -67,6 +69,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					scanInfo.ControlsVersion,
 				)
 			}
+			applyRegistryCredentialsFromEnv(cmd, &scanInfo)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -92,6 +95,19 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				shared.ScanFormats,
 			); err != nil {
 				return err
+			}
+			if scanInfo.ScanImages {
+				if err := shared.ValidateImageScanInfo(&scanInfo); err != nil {
+					return err
+				}
+				if err := shared.ValidateWorkloadImageCredentials(shared.ImageCredentials{
+					Authority: scanInfo.RegistryAuthority,
+					Username:  scanInfo.RegistryUsername,
+					Password:  scanInfo.RegistryPassword,
+					Token:     scanInfo.RegistryToken,
+				}); err != nil {
+					return err
+				}
 			}
 
 			if scanInfo.EncryptionEnabled {
@@ -185,7 +201,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.EnableRegoPrint, "enable-rego-prints", "", false, "Enable sending to rego prints to the logs (use with debug log level: -l debug)")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ScanImages, "scan-images", "", false, "Scan resources images")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.UseDefaultMatchers, "use-default-matchers", "", true, "Use default matchers (true) or CPE matchers (false) for image scanning")
-	scanCmd.PersistentFlags().StringToStringVar(&scanInfo.RegistryMapping, "registry-mapping", nil, "Map internal registry hosts to reachable ones, e.g. --registry-mapping image-registry.openshift-image-registry.svc:5000=registry.company.com (host[:port], no scheme; mapped registry must allow anonymous pulls on cluster/workload scan paths)")
+	scanCmd.PersistentFlags().StringToStringVar(&scanInfo.RegistryMapping, "registry-mapping", nil, "Map internal registry hosts to reachable ones, e.g. --registry-mapping image-registry.openshift-image-registry.svc:5000=registry.company.com (host[:port], no scheme)")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "Username for image registry login when no docker config or credential helper is available; can also be set with KUBESCAPE_REGISTRY_USERNAME")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "Password for image registry login when no docker config or credential helper is available; can also be set with KUBESCAPE_REGISTRY_PASSWORD")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "Bearer token for image registry login when no docker config or credential helper is available; can also be set with KUBESCAPE_REGISTRY_TOKEN")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.RegistryAuthority, "registry-authority", "", "Registry host[:port] the --scan-images credentials apply to")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Replace sensitive report metadata with deterministic pseudonyms")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Encrypt sensitive report metadata using the KUBESCAPE_MASTER_KEY environment variable")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
@@ -224,6 +244,39 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.AddCommand(getImageCmd(ks, &scanInfo))
 
 	return scanCmd
+}
+
+func applyRegistryCredentialsFromEnv(cmd *cobra.Command, scanInfo *cautils.ScanInfo) {
+	if scanInfo == nil {
+		return
+	}
+	usernameFlagChanged := registryCredentialFlagChanged(cmd, "registry-username", "username")
+	passwordFlagChanged := registryCredentialFlagChanged(cmd, "registry-password", "password")
+	tokenFlagChanged := registryCredentialFlagChanged(cmd, "registry-token")
+
+	if !tokenFlagChanged && !usernameFlagChanged && scanInfo.RegistryUsername == "" {
+		scanInfo.RegistryUsername = os.Getenv("KUBESCAPE_REGISTRY_USERNAME")
+	}
+	if !tokenFlagChanged && !passwordFlagChanged && scanInfo.RegistryPassword == "" {
+		scanInfo.RegistryPassword = os.Getenv("KUBESCAPE_REGISTRY_PASSWORD")
+	}
+	if !tokenFlagChanged && !usernameFlagChanged && !passwordFlagChanged && scanInfo.RegistryToken == "" {
+		scanInfo.RegistryToken = os.Getenv("KUBESCAPE_REGISTRY_TOKEN")
+	}
+}
+
+func registryCredentialFlagChanged(cmd *cobra.Command, names ...string) bool {
+	if cmd == nil {
+		return false
+	}
+	for _, name := range names {
+		for _, flags := range []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.InheritedFlags()} {
+			if flag := flags.Lookup(name); flag != nil && flag.Changed {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -379,6 +381,10 @@ func TestGetScanCommand(t *testing.T) {
 	assert.Equal(t, scanCmdExamples, cmd.Example)
 }
 
+func registryFixtureValue(parts ...string) string {
+	return strings.Join(parts, "-")
+}
+
 func TestSubmitFlag_TracksExplicitCommandLineUse(t *testing.T) {
 	// Regression test for https://github.com/kubescape/kubescape/issues/2555:
 	// --submit is bound directly as a cautils.BoolPtrFlag (like --enable-host-scan),
@@ -600,6 +606,124 @@ func TestSecurityScan_ZeroTimeoutNoDeadline(t *testing.T) {
 
 	_, hasDeadline := ks.scanCalledWith.Deadline()
 	assert.False(t, hasDeadline, "Scan() must not receive a deadline when ScanTimeout is 0")
+}
+
+func TestGetScanCommand_RegistryCredentialFlags(t *testing.T) {
+	cmd := GetScanCommand(&mocks.MockIKubescape{})
+
+	for _, name := range []string{"registry-username", "registry-password", "registry-token", "registry-authority"} {
+		flag := cmd.PersistentFlags().Lookup(name)
+		require.NotNil(t, flag, "expected %s flag to be registered", name)
+	}
+
+	registryMapping := cmd.PersistentFlags().Lookup("registry-mapping")
+	require.NotNil(t, registryMapping)
+	assert.NotContains(t, registryMapping.Usage, "anonymous")
+}
+
+func TestGetScanCommand_RunE_RejectsUnscopedRegistryCredentialsForScanImages(t *testing.T) {
+	cmd := GetScanCommand(&mocks.MockIKubescape{})
+
+	require.NoError(t, cmd.PersistentFlags().Set("scan-images", "true"))
+	require.NoError(t, cmd.PersistentFlags().Set("registry-username", "user"))
+	require.NoError(t, cmd.PersistentFlags().Set("registry-password", registryFixtureValue("scan", "credential")))
+
+	err := cmd.RunE(cmd, []string{})
+	assert.Equal(t, shared.ErrRegistryAuthorityMissing, err)
+}
+
+func TestApplyRegistryCredentialsFromEnv(t *testing.T) {
+	envUser := registryFixtureValue("env", "user")
+	envCredential := registryFixtureValue("env", "credential")
+	envBearer := registryFixtureValue("env", "bearer")
+
+	t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+	t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+	t.Setenv("KUBESCAPE_REGISTRY_TOKEN", envBearer)
+
+	scanInfo := cautils.ScanInfo{}
+	cmd := &cobra.Command{Use: "scan"}
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+
+	applyRegistryCredentialsFromEnv(cmd, &scanInfo)
+
+	assert.Equal(t, envUser, scanInfo.RegistryUsername)
+	assert.Equal(t, envCredential, scanInfo.RegistryPassword)
+	assert.Equal(t, envBearer, scanInfo.RegistryToken)
+}
+
+func TestApplyRegistryCredentialsFromEnv_KeepsFlagPrecedence(t *testing.T) {
+	envUser := registryFixtureValue("env", "user")
+	envCredential := registryFixtureValue("env", "credential")
+	envBearer := registryFixtureValue("env", "bearer")
+	flagUser := registryFixtureValue("flag", "user")
+	flagCredential := registryFixtureValue("flag", "credential")
+
+	t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+	t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+	t.Setenv("KUBESCAPE_REGISTRY_TOKEN", envBearer)
+
+	scanInfo := cautils.ScanInfo{}
+	cmd := &cobra.Command{Use: "scan"}
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+	cmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+
+	require.NoError(t, cmd.PersistentFlags().Set("registry-username", flagUser))
+	require.NoError(t, cmd.PersistentFlags().Set("registry-password", flagCredential))
+	require.NoError(t, cmd.PersistentFlags().Set("registry-token", ""))
+
+	applyRegistryCredentialsFromEnv(cmd, &scanInfo)
+
+	assert.Equal(t, flagUser, scanInfo.RegistryUsername)
+	assert.Equal(t, flagCredential, scanInfo.RegistryPassword)
+	assert.Empty(t, scanInfo.RegistryToken)
+}
+
+func TestApplyRegistryCredentialsFromEnv_KeepsExplicitAuthMode(t *testing.T) {
+	envUser := registryFixtureValue("env", "user")
+	envCredential := registryFixtureValue("env", "credential")
+	envBearer := registryFixtureValue("env", "bearer")
+
+	t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+	t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+	t.Setenv("KUBESCAPE_REGISTRY_TOKEN", envBearer)
+
+	t.Run("token flag suppresses basic env credentials", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		cmd := &cobra.Command{Use: "scan"}
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+
+		flagBearer := registryFixtureValue("flag", "bearer")
+		require.NoError(t, cmd.PersistentFlags().Set("registry-token", flagBearer))
+
+		applyRegistryCredentialsFromEnv(cmd, &scanInfo)
+
+		assert.Empty(t, scanInfo.RegistryUsername)
+		assert.Empty(t, scanInfo.RegistryPassword)
+		assert.Equal(t, flagBearer, scanInfo.RegistryToken)
+	})
+
+	t.Run("basic flag suppresses token env credential", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		cmd := &cobra.Command{Use: "scan"}
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryUsername, "registry-username", "", "")
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryPassword, "registry-password", "", "")
+		cmd.PersistentFlags().StringVar(&scanInfo.RegistryToken, "registry-token", "", "")
+
+		flagUser := registryFixtureValue("flag", "user")
+		require.NoError(t, cmd.PersistentFlags().Set("registry-username", flagUser))
+
+		applyRegistryCredentialsFromEnv(cmd, &scanInfo)
+
+		assert.Equal(t, flagUser, scanInfo.RegistryUsername)
+		assert.Equal(t, envCredential, scanInfo.RegistryPassword)
+		assert.Empty(t, scanInfo.RegistryToken)
+	})
 }
 
 // coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we

--- a/cmd/shared/image_scan.go
+++ b/cmd/shared/image_scan.go
@@ -1,10 +1,23 @@
 package shared
 
-import "github.com/kubescape/kubescape/v3/core/cautils"
+import (
+	"errors"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+)
+
+var (
+	ErrRegistryUsernamePassword = errors.New("registry username and password must be provided together")
+	ErrRegistryAuthConflict     = errors.New("registry token cannot be used together with registry username/password")
+	ErrRegistryAuthorityNoAuth  = errors.New("registry authority requires registry credentials")
+	ErrRegistryAuthorityMissing = errors.New("registry credentials for --scan-images require registry authority")
+)
 
 type ImageCredentials struct {
-	Username string
-	Password string
+	Authority string
+	Username  string
+	Password  string
+	Token     string
 }
 
 // ValidateImageScanInfo validates the ScanInfo struct for image scanning commands
@@ -18,4 +31,40 @@ func ValidateImageScanInfo(scanInfo *cautils.ScanInfo) error {
 		return err
 	}
 	return nil
+}
+
+func ValidateImageCredentials(credentials ImageCredentials) error {
+	return ValidateRegistryCredentials(credentials.Username, credentials.Password, credentials.Token, credentials.Authority)
+}
+
+func ValidateWorkloadImageCredentials(credentials ImageCredentials) error {
+	if err := ValidateImageCredentials(credentials); err != nil {
+		return err
+	}
+	if credentials.Authority == "" && hasRegistryAuthenticator(credentials.Username, credentials.Password, credentials.Token) {
+		return ErrRegistryAuthorityMissing
+	}
+	return nil
+}
+
+func ValidateRegistryCredentials(username, password, token, authority string) error {
+	hasUsernamePassword := username != "" || password != ""
+	hasCompleteUsernamePassword := username != "" && password != ""
+	hasToken := token != ""
+
+	if hasUsernamePassword && !hasCompleteUsernamePassword {
+		return ErrRegistryUsernamePassword
+	}
+	if hasCompleteUsernamePassword && hasToken {
+		return ErrRegistryAuthConflict
+	}
+	if authority != "" && !hasCompleteUsernamePassword && !hasToken {
+		return ErrRegistryAuthorityNoAuth
+	}
+
+	return nil
+}
+
+func hasRegistryAuthenticator(username, password, token string) bool {
+	return token != "" || (username != "" && password != "")
 }

--- a/cmd/shared/image_scan_test.go
+++ b/cmd/shared/image_scan_test.go
@@ -105,3 +105,98 @@ func TestValidateImageScanInfo(t *testing.T) {
 		)
 	}
 }
+
+func TestValidateImageCredentials(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Credentials ImageCredentials
+		Want        error
+	}{
+		{
+			Description: "Empty credentials are valid",
+			Credentials: ImageCredentials{},
+			Want:        nil,
+		},
+		{
+			Description: "Registry username and password should be accepted",
+			Credentials: ImageCredentials{Username: "user", Password: "pass"},
+			Want:        nil,
+		},
+		{
+			Description: "Registry token should be accepted",
+			Credentials: ImageCredentials{Token: "token"},
+			Want:        nil,
+		},
+		{
+			Description: "Registry authority with token should be accepted",
+			Credentials: ImageCredentials{Authority: "registry.example.com", Token: "token"},
+			Want:        nil,
+		},
+		{
+			Description: "Registry username without password should be invalid",
+			Credentials: ImageCredentials{Username: "user"},
+			Want:        ErrRegistryUsernamePassword,
+		},
+		{
+			Description: "Registry password without username should be invalid",
+			Credentials: ImageCredentials{Password: "pass"},
+			Want:        ErrRegistryUsernamePassword,
+		},
+		{
+			Description: "Registry token with username and password should be invalid",
+			Credentials: ImageCredentials{Username: "user", Password: "pass", Token: "token"},
+			Want:        ErrRegistryAuthConflict,
+		},
+		{
+			Description: "Registry authority without credentials should be invalid",
+			Credentials: ImageCredentials{Authority: "registry.example.com"},
+			Want:        ErrRegistryAuthorityNoAuth,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert.Equal(t, tc.Want, ValidateImageCredentials(tc.Credentials))
+		})
+	}
+}
+
+func TestValidateWorkloadImageCredentialsRequiresAuthority(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Credentials ImageCredentials
+		Want        error
+	}{
+		{
+			Description: "Username and password without authority are rejected",
+			Credentials: ImageCredentials{Username: "user", Password: "pass"},
+			Want:        ErrRegistryAuthorityMissing,
+		},
+		{
+			Description: "Token without authority is rejected",
+			Credentials: ImageCredentials{Token: "token"},
+			Want:        ErrRegistryAuthorityMissing,
+		},
+		{
+			Description: "Username and password with authority are accepted",
+			Credentials: ImageCredentials{Authority: "registry.example.com", Username: "user", Password: "pass"},
+			Want:        nil,
+		},
+		{
+			Description: "Token with authority is accepted",
+			Credentials: ImageCredentials{Authority: "registry.example.com", Token: "token"},
+			Want:        nil,
+		},
+		{
+			Description: "Partial credentials keep the more specific validation error",
+			Credentials: ImageCredentials{Authority: "registry.example.com", Username: "user"},
+			Want:        ErrRegistryUsernamePassword,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert.Equal(t, tc.Want, ValidateWorkloadImageCredentials(tc.Credentials))
+		})
+	}
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -173,6 +173,10 @@ type ScanInfo struct {
 	cleanups              []func()
 	ListingURL            string            //Grype vulnerability database URL
 	RegistryMapping       map[string]string // Map internal registry URLs to external ones
+	RegistryAuthority     string            // Registry host[:port] explicit credentials apply to
+	RegistryUsername      string            // Username for workload image registry authentication
+	RegistryPassword      string            // Password for workload image registry authentication
+	RegistryToken         string            // Bearer token for workload image registry authentication
 }
 
 type Getters struct {

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -250,9 +250,13 @@ func isResolutionError(err error) bool {
 // scanWithRegistryMapping attempts to scan an image and, on a resolution error,
 // retries using a mapped registry if one is configured. It returns the scan
 // results or a combined error preserving both the original and fallback context.
+type imageScanService interface {
+	Scan(context.Context, string, imagescan.RegistryCredentials, []string, []string) (*cautils.ImageScanData, error)
+}
+
 func scanWithRegistryMapping(
 	ctx context.Context,
-	svc *imagescan.Service,
+	svc imageScanService,
 	img string,
 	creds imagescan.RegistryCredentials,
 	registryMapping map[string]string,
@@ -301,8 +305,10 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 	defer svc.Close()
 
 	creds := imagescan.RegistryCredentials{
-		Username: imgScanInfo.Username,
-		Password: imgScanInfo.Password,
+		Authority: imgScanInfo.Authority,
+		Username:  imgScanInfo.Username,
+		Password:  imgScanInfo.Password,
+		Token:     imgScanInfo.Token,
 	}
 
 	var vulnerabilityExceptions []string

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -394,7 +394,7 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 
 	for img := range imagesToScan.Iter() {
 		logger.L().Start("Scanning", helpers.String("image", img))
-		if err := scanSingleImage(ctx, img, svc, resultsHandling, scanInfo.RegistryMapping); err != nil {
+		if err := scanSingleImage(ctx, img, svc, resultsHandling, scanInfo.RegistryMapping, registryCredentialsFromScanInfo(scanInfo)); err != nil {
 			logger.L().StopError("failed to scan", helpers.String("image", img), helpers.Error(err))
 			continue
 		}
@@ -402,10 +402,22 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 	}
 }
 
-func scanSingleImage(ctx context.Context, img string, svc *imagescan.Service, resultsHandling *resultshandling.ResultsHandler, registryMapping map[string]string) error {
+func registryCredentialsFromScanInfo(scanInfo *cautils.ScanInfo) imagescan.RegistryCredentials {
+	if scanInfo == nil {
+		return imagescan.RegistryCredentials{}
+	}
+	return imagescan.RegistryCredentials{
+		Authority: scanInfo.RegistryAuthority,
+		Username:  scanInfo.RegistryUsername,
+		Password:  scanInfo.RegistryPassword,
+		Token:     scanInfo.RegistryToken,
+	}
+}
+
+func scanSingleImage(ctx context.Context, img string, svc imageScanService, resultsHandling *resultshandling.ResultsHandler, registryMapping map[string]string, creds imagescan.RegistryCredentials) error {
 
 	scanResults, err := scanWithRegistryMapping(
-		ctx, svc, img, imagescan.RegistryCredentials{},
+		ctx, svc, img, creds,
 		registryMapping, nil, nil,
 	)
 	if err != nil {

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -2,12 +2,30 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	"github.com/stretchr/testify/assert"
 )
+
+type recordingImageScanService struct {
+	image              string
+	credentials        imagescan.RegistryCredentials
+	registryMappingErr error
+}
+
+func (s *recordingImageScanService) Scan(_ context.Context, image string, credentials imagescan.RegistryCredentials, _, _ []string) (*cautils.ImageScanData, error) {
+	s.image = image
+	s.credentials = credentials
+	if s.registryMappingErr != nil {
+		return nil, s.registryMappingErr
+	}
+	return &cautils.ImageScanData{Image: image}, nil
+}
 
 func TestGetOutputPrinters(t *testing.T) {
 	ctx := context.Background()
@@ -72,6 +90,54 @@ func TestIsPrioritizationScanType(t *testing.T) {
 			assert.Equal(t, tt.want, isPrioritizationScanType(tt.name))
 		})
 	}
+}
+
+func TestRegistryCredentialsFromScanInfo(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{
+		RegistryAuthority: "registry.example.com",
+		RegistryUsername:  "user",
+		RegistryPassword:  "pass",
+		RegistryToken:     "token",
+	}
+
+	creds := registryCredentialsFromScanInfo(scanInfo)
+
+	assert.Equal(t, imagescan.RegistryCredentials{
+		Authority: "registry.example.com",
+		Username:  "user",
+		Password:  "pass",
+		Token:     "token",
+	}, creds)
+	assert.Equal(t, imagescan.RegistryCredentials{}, registryCredentialsFromScanInfo(nil))
+}
+
+func TestScanSingleImageForwardsRegistryCredentials(t *testing.T) {
+	svc := &recordingImageScanService{}
+	results := &resultshandling.ResultsHandler{}
+	creds := imagescan.RegistryCredentials{
+		Authority: "registry.example.com",
+		Username:  "user",
+		Password:  "pass",
+	}
+
+	err := scanSingleImage(context.Background(), "registry.example.com/app:tag", svc, results, nil, creds)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com/app:tag", svc.image)
+	assert.Equal(t, creds, svc.credentials)
+	assert.Len(t, results.ImageScanData, 1)
+	assert.Equal(t, "registry.example.com/app:tag", results.ImageScanData[0].Image)
+}
+
+func TestScanSingleImageReturnsScannerError(t *testing.T) {
+	expectedErr := errors.New("scan failed")
+	svc := &recordingImageScanService{registryMappingErr: expectedErr}
+	results := &resultshandling.ResultsHandler{}
+
+	err := scanSingleImage(context.Background(), "registry.example.com/app:tag", svc, results, nil, imagescan.RegistryCredentials{})
+
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, results.ImageScanData)
 }
 
 func TestIsAirGappedMode(t *testing.T) {

--- a/core/meta/datastructures/v1/image_scan.go
+++ b/core/meta/datastructures/v1/image_scan.go
@@ -1,8 +1,10 @@
 package v1
 
 type ImageScanInfo struct {
+	Authority          string
 	Username           string
 	Password           string
+	Token              string
 	Image              string
 	Exceptions         string
 	UseDefaultMatchers bool

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -228,18 +228,22 @@ Ensure your kubeconfig user has sufficient permissions. At minimum, you need rea
 
 **Solutions:**
 
-1. Verify credentials work with docker:
+1. Verify credentials work with docker. Kubescape uses your docker config and configured credential helpers by default:
    ```bash
    docker login myregistry.io
    docker pull myregistry.io/myimage:tag
    ```
 
-2. Use environment variables for credentials:
+2. Use environment variables for credentials when a docker config or credential helper is not available:
    ```bash
-   export KUBESCAPE_REGISTRY_USERNAME=myuser
-   export KUBESCAPE_REGISTRY_PASSWORD=mypassword
+   export KUBESCAPE_REGISTRY_USERNAME=<registry-username>
+   export KUBESCAPE_REGISTRY_PASSWORD=<registry-password>
    kubescape scan image myregistry.io/myimage:tag
    ```
+
+   If your registry uses bearer tokens, set `KUBESCAPE_REGISTRY_TOKEN` instead of username/password.
+
+   For `kubescape scan --scan-images`, also pass `--registry-authority myregistry.io` so the credentials are only used for that registry.
 
 ### Vulnerability database outdated
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -36,12 +36,14 @@ const (
 )
 
 type RegistryCredentials struct {
-	Username string
-	Password string
+	Authority string
+	Username  string
+	Password  string
+	Token     string
 }
 
-func (c RegistryCredentials) IsEmpty() bool {
-	return c.Username == "" || c.Password == ""
+func (c RegistryCredentials) hasAuthenticator() bool {
+	return c.Token != "" || (c.Username != "" && c.Password != "")
 }
 
 func NewDefaultDBConfig(grypeURL string) (distribution.Config, installation.Config, bool, error) {
@@ -131,7 +133,15 @@ func validateDBLoad(loadErr error, status *vulnerability.ProviderStatus) error {
 }
 
 func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
-	syftCreds := []image.RegistryCredentials{{Username: creds.Username, Password: creds.Password}}
+	var syftCreds []image.RegistryCredentials
+	if creds.hasAuthenticator() {
+		syftCreds = append(syftCreds, image.RegistryCredentials{
+			Authority: creds.Authority,
+			Username:  creds.Username,
+			Password:  creds.Password,
+			Token:     creds.Token,
+		})
+	}
 	regOpts := &image.RegistryOptions{
 		Credentials: syftCreds,
 	}

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/grype/grype/match"
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -151,61 +152,11 @@ func TestParseSeverity(t *testing.T) {
 	}
 }
 
-func TestIsEmpty(t *testing.T) {
-	tests := []struct {
-		name  string
-		creds RegistryCredentials
-		want  bool
-	}{
-		{
-			name: "Both Non Empty",
-			creds: RegistryCredentials{
-				Username: "username",
-				Password: "password",
-			},
-			want: false,
-		},
-		{
-			name: "Password Empty",
-			creds: RegistryCredentials{
-				Username: "username",
-				Password: "",
-			},
-			want: true,
-		},
-		{
-			name: "Username Empty",
-			creds: RegistryCredentials{
-				Username: "",
-				Password: "password",
-			},
-			want: true,
-		},
-		{
-			name: "Both empty",
-			creds: RegistryCredentials{
-				Username: "",
-				Password: "",
-			},
-			want: true,
-		},
-		{
-			name:  "Empty struct",
-			creds: RegistryCredentials{},
-			want:  true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.creds.IsEmpty())
-		})
-	}
-}
-
 func TestGetProviderConfig(t *testing.T) {
 	tests := []struct {
-		name  string
-		creds RegistryCredentials
+		name      string
+		creds     RegistryCredentials
+		wantCreds []image.RegistryCredentials
 	}{
 		{
 			name: "Both Non Empty",
@@ -213,6 +164,7 @@ func TestGetProviderConfig(t *testing.T) {
 				Username: "username",
 				Password: "password",
 			},
+			wantCreds: []image.RegistryCredentials{{Username: "username", Password: "password"}},
 		},
 		{
 			name: "Password Empty",
@@ -220,6 +172,7 @@ func TestGetProviderConfig(t *testing.T) {
 				Username: "username",
 				Password: "",
 			},
+			wantCreds: nil,
 		},
 		{
 			name: "Username Empty",
@@ -227,6 +180,7 @@ func TestGetProviderConfig(t *testing.T) {
 				Username: "",
 				Password: "password",
 			},
+			wantCreds: nil,
 		},
 		{
 			name: "Both empty",
@@ -234,6 +188,15 @@ func TestGetProviderConfig(t *testing.T) {
 				Username: "",
 				Password: "",
 			},
+			wantCreds: nil,
+		},
+		{
+			name: "Token with authority",
+			creds: RegistryCredentials{
+				Authority: "registry.example.com",
+				Token:     "token",
+			},
+			wantCreds: []image.RegistryCredentials{{Authority: "registry.example.com", Token: "token"}},
 		},
 	}
 	for _, tt := range tests {
@@ -241,6 +204,7 @@ func TestGetProviderConfig(t *testing.T) {
 			providerConfig := getProviderConfig(tt.creds)
 			assert.NotNil(t, providerConfig)
 			assert.Equal(t, true, providerConfig.GenerateMissingCPEs)
+			assert.Equal(t, tt.wantCreds, providerConfig.RegistryOptions.Credentials)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #2695.

- add registry auth fields for `scan --scan-images`: `--registry-username`, `--registry-password`, `--registry-token`, and `--registry-authority`
- pass workload image scan credentials through `scanSingleImage` and registry-mapping retry paths
- extend direct `scan image` credential handling with token/authority support while preserving `-u/--username` and `-p/--password`
- only pass explicit credentials to Syft/Stereoscope when an authenticator is configured, preserving default keychain fallback
- add validation for incomplete or conflicting registry auth options

## Tests

```sh
go test ./cmd/scan ./cmd/shared ./pkg/imagescan ./core/core
go test ./cmd/... ./pkg/imagescan ./core/core ./core/cautils
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry authentication for image scans using username/password or bearer tokens.
  * Added registry authority and credential options through command-line flags and environment variables.
  * Explicit command-line credentials take precedence over environment-based credentials.
  * Added validation for incomplete, conflicting, or improperly scoped credentials.
  * Registry credentials now propagate through image scanning, including registry mappings.
* **Documentation**
  * Expanded private-registry troubleshooting guidance, including credential configuration and debug-log collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->