### PR TITLE
fix: resolve actual value for assisted remediation paths

### DIFF
--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -142,7 +142,8 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 					helpers.String("resourceID", resourceID))
 				continue
 			}
-			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails)
+			root, hasRoot := resolveResourceObject(resource)
+			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails, root, hasRoot)
 			resourceTableView = append(resourceTableView, ResourceResult{resource, ctlResults})
 		}
 	}
@@ -150,17 +151,20 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 	return resourceTableView
 }
 
-func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary) ResourceControlResult {
+func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary, root interface{}, hasRoot bool) ResourceControlResult {
 	ctlSeverity := apis.ControlSeverityToString(control.GetScoreFactor())
 	ctlName := resourceControl.GetName()
 	ctlID := resourceControl.GetID()
 	ctlURL := cautils.GetControlLink(resourceControl.GetID())
 	failedPaths := AssistedRemediationPathsToString(&resourceControl)
+	if hasRoot {
+		addValueToAssistedRemediation(root, &resourceControl, &failedPaths)
+	}
 
 	return ResourceControlResult{ctlSeverity, ctlName, ctlID, ctlURL, failedPaths}
 }
 
-func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails) []ResourceControlResult {
+func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, root interface{}, hasRoot bool) []ResourceControlResult {
 	var ctlResults []ResourceControlResult
 	for _, resourceControl := range resourceControls {
 		if resourceControl.GetStatus(nil).IsFailed() {
@@ -168,7 +172,7 @@ func buildResourceControlResultTable(resourceControls []resourcesresults.Resourc
 			if control == nil {
 				continue
 			}
-			ctlResult := buildResourceControlResult(resourceControl, control)
+			ctlResult := buildResourceControlResult(resourceControl, control, root, hasRoot)
 
 			ctlResults = append(ctlResults, ctlResult)
 		}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -86,7 +86,7 @@ func TestBuildResourceControlResultTable_MissingControl(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails)
+		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails, nil, false)
 		assert.Empty(t, results)
 	})
 }

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -1,6 +1,8 @@
 package printer
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -17,6 +19,17 @@ import (
 )
 
 var specContainerRegex = regexp.MustCompile(`spec\.containers\[(\d+)]`)
+var pathIndexRegex = regexp.MustCompile(`^([^\[]+)\[(\d+)]$`)
+
+// credentialDetectingControls lists controls whose failed/delete paths
+// point directly at a secret value (e.g. an env var already known to hold
+// a credential). Value resolution is skipped entirely for these controls,
+// so we never print the very secret the scan flagged as sensitive.
+var credentialDetectingControls = map[string]bool{
+	"C-0012": true, // Applications credentials in configuration files
+	"C-0207": true, // same rule family (rule-secrets-in-env-var / rule-credentials-in-env-var)
+	"C-0259": true, // same rule family (rule-secrets-in-env-var / rule-credentials-in-env-var)
+}
 
 const (
 	resourceColumnSeverity = iota
@@ -76,6 +89,8 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata) []table.Row {
 	var rows []table.Row
 
+	root, hasRoot := resolveResourceObject(resource)
+
 	for i := range controls {
 		row := make(table.Row, _resourceRowLen)
 
@@ -85,6 +100,9 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 
 		row[resourceColumnURL] = cautils.GetControlLink(controls[i].GetID())
 		paths := AssistedRemediationPathsToString(&controls[i])
+		if hasRoot {
+			addValueToAssistedRemediation(root, &controls[i], &paths)
+		}
 		addContainerNameToAssistedRemediation(resource, &paths)
 		row[resourceColumnPath] = strings.Join(paths, "\n")
 		row[resourceColumnName] = controls[i].GetName()
@@ -119,6 +137,91 @@ func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata,
 			continue
 		}
 		(*paths)[i] += " (" + containers[index].Name + ")"
+	}
+}
+
+func resolveResourceObject(resource workloadinterface.IMetadata) (interface{}, bool) {
+	raw, err := json.Marshal(resource.GetObject())
+	if err != nil {
+		return nil, false
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	var root interface{}
+	if err := dec.Decode(&root); err != nil {
+		return nil, false
+	}
+
+	return root, true
+}
+
+func resolveValueAtPath(root interface{}, path string) (interface{}, bool) {
+	current := root
+
+	for _, seg := range strings.Split(path, ".") {
+		key, index, hasIndex := splitIndex(seg)
+
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		next, ok := m[key]
+		if !ok {
+			return nil, false
+		}
+		current = next
+
+		if hasIndex {
+			list, ok := current.([]interface{})
+			if !ok || index >= len(list) {
+				return nil, false
+			}
+			current = list[index]
+		}
+	}
+
+	return current, true
+}
+
+func splitIndex(segment string) (key string, index int, hasIndex bool) {
+	match := pathIndexRegex.FindStringSubmatch(segment)
+	if match == nil {
+		return segment, 0, false
+	}
+	index, _ = strconv.Atoi(match[2])
+	return match[1], index, true
+}
+
+func isScalarValue(v interface{}) bool {
+	switch v.(type) {
+	case string, bool, json.Number, nil:
+		return true
+	default:
+		return false
+	}
+}
+
+func addValueToAssistedRemediation(root interface{}, control *resourcesresults.ResourceAssociatedControl, paths *[]string) {
+	if credentialDetectingControls[control.GetID()] {
+		return
+	}
+
+	alreadyValued := make(map[string]bool)
+	for _, p := range fixPathsToString(control, false) {
+		alreadyValued[p] = true
+	}
+
+	for i := range *paths {
+		if alreadyValued[(*paths)[i]] {
+			continue
+		}
+		value, ok := resolveValueAtPath(root, (*paths)[i])
+		if !ok || !isScalarValue(value) {
+			continue
+		}
+		(*paths)[i] = fmt.Sprintf("%s=%v", (*paths)[i], value)
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -622,3 +622,228 @@ func TestAddContainerNameToAssistedRemediation_OutOfBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestAddValueToAssistedRemediation(t *testing.T) {
+	simpleControl := &resourcesresults.ResourceAssociatedControl{ControlID: "control-1"}
+	credentialControl := &resourcesresults.ResourceAssociatedControl{ControlID: "C-0012"}
+	credentialControlC0207 := &resourcesresults.ResourceAssociatedControl{ControlID: "C-0207"}
+	controlWithFixPath := &resourcesresults.ResourceAssociatedControl{
+		ControlID: "control-1",
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Paths: []armotypes.PosturePaths{
+					{
+						FixPath: armotypes.FixPath{
+							Path:  "spec.containers[0].resources.limits.cpu",
+							Value: "YOUR_VALUE",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		resourceObj   map[string]interface{}
+		control       *resourcesresults.ResourceAssociatedControl
+		paths         []string
+		expectedPaths []string
+	}{
+		{
+			name: "simple path resolves value",
+			resourceObj: map[string]interface{}{
+				"kind": "Deployment",
+				"spec": map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.replicas"},
+			expectedPaths: []string{"spec.replicas=1"},
+		},
+		{
+			name: "path with container index resolves value",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "nginx",
+							"securityContext": map[string]interface{}{
+								"privileged": true,
+							},
+						},
+					},
+				},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.containers[0].securityContext.privileged"},
+			expectedPaths: []string{"spec.containers[0].securityContext.privileged=true"},
+		},
+		{
+			name: "path that does not exist is left unchanged",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.doesNotExist"},
+			expectedPaths: []string{"spec.doesNotExist"},
+		},
+		{
+			name: "out of bounds container index is left unchanged",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{"name": "nginx"},
+					},
+				},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.containers[5].securityContext.privileged"},
+			expectedPaths: []string{"spec.containers[5].securityContext.privileged"},
+		},
+		{
+			name: "path that already has a fixPath value is left unchanged",
+			resourceObj: map[string]interface{}{
+				"kind": "Deployment",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"resources": map[string]interface{}{
+								"limits": map[string]interface{}{
+									"cpu": "500m",
+								},
+							},
+						},
+					},
+				},
+			},
+			control:       controlWithFixPath,
+			paths:         []string{"spec.containers[0].resources.limits.cpu=YOUR_VALUE"},
+			expectedPaths: []string{"spec.containers[0].resources.limits.cpu=YOUR_VALUE"},
+		},
+		{
+			name: "credential-detecting control skips resolution entirely",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "DB_PASSWORD",
+									"value": "not-a-real-secret-placeholder",
+								},
+							},
+						},
+					},
+				},
+			},
+			control:       credentialControl,
+			paths:         []string{"spec.containers[0].env[0].value"},
+			expectedPaths: []string{"spec.containers[0].env[0].value"},
+		},
+		{
+			name: "C-0207 also skips resolution entirely (same rule family as C-0012)",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "API_TOKEN",
+									"value": "not-a-real-secret-placeholder",
+								},
+							},
+						},
+					},
+				},
+			},
+			control:       credentialControlC0207,
+			paths:         []string{"spec.containers[0].env[0].value"},
+			expectedPaths: []string{"spec.containers[0].env[0].value"},
+		},
+		{
+			name: "large integer keeps original precision",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"securityContext": map[string]interface{}{
+						"runAsUser": 1000660000,
+					},
+				},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.securityContext.runAsUser"},
+			expectedPaths: []string{"spec.securityContext.runAsUser=1000660000"},
+		},
+		{
+			name: "non-scalar value is left unchanged",
+			resourceObj: map[string]interface{}{
+				"kind": "Pod",
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"resources": map[string]interface{}{
+								"limits": map[string]interface{}{
+									"cpu":    "100m",
+									"memory": "128Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+			control:       simpleControl,
+			paths:         []string{"spec.containers[0].resources"},
+			expectedPaths: []string{"spec.containers[0].resources"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := workloadinterface.NewWorkloadObj(tt.resourceObj)
+			root, ok := resolveResourceObject(resource)
+			assert.True(t, ok)
+			paths := tt.paths
+			addValueToAssistedRemediation(root, tt.control, &paths)
+			assert.Equal(t, tt.expectedPaths, paths)
+		})
+	}
+}
+
+func TestSplitIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		segment       string
+		expectedKey   string
+		expectedIndex int
+		expectedHas   bool
+	}{
+		{
+			name:          "plain segment has no index",
+			segment:       "spec",
+			expectedKey:   "spec",
+			expectedIndex: 0,
+			expectedHas:   false,
+		},
+		{
+			name:          "segment with index",
+			segment:       "containers[2]",
+			expectedKey:   "containers",
+			expectedIndex: 2,
+			expectedHas:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, index, hasIndex := splitIndex(tt.segment)
+			assert.Equal(t, tt.expectedKey, key)
+			assert.Equal(t, tt.expectedIndex, index)
+			assert.Equal(t, tt.expectedHas, hasIndex)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2691

## Overview

`AssistedRemediationPathsToString()` in `resourcetable.go` only returned
the raw JSON path of a failed check (e.g.
`spec.containers[0].securityContext.privileged`), never the actual value
currently at that path. This is what feeds both the default pretty-printer
table and the HTML printer, so this is what most users see by default.

This PR adds a small resolver that walks the path against the resource
object already available in memory, and appends the resolved value to the
path string (e.g. `spec.containers[0].securityContext.privileged = true`).
Paths that already carry a suggested value (from `fixPathsToString`, e.g.
`...cpu=YOUR_VALUE`) are left untouched.

## Additional Information

The resource object isn't uniformly `map[string]interface{}`/`[]interface{}`
internally — some fields (e.g. `containers`) come through as strongly-typed
Kubernetes structs (`[]v1.Container`) depending on how the resource was
constructed. To avoid special-casing every possible concrete type, the
resolver round-trips the resource through `encoding/json` once before
walking the path, so it only ever has to handle plain maps/slices.

This does not attempt line-number resolution (like the existing
`locationresolver` used by `sarifprinter.go`/`gitlabsastprinter.go`) since
that requires an on-disk file and wouldn't work for live cluster scans,
which this printer also serves. Line-number resolution for file scans could
be a natural follow-up.

## How to Test

```bash
cat <<'EOF' > bad-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-deploy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: test-container
        image: nginx:latest
        securityContext:
          privileged: true
EOF

kubescape scan control C-0057 bad-deployment.yaml -v
```

Before: `Assisted Remediation : spec.template.spec.containers[0].securityContext.privileged (test-container)`

After: `Assisted Remediation : spec.template.spec.containers[0].securityContext.privileged = true (test-container)`

## Related issues/PRs:

* Resolved #2691

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assisted-remediation resource paths now display resolved scalar values when available.
  * Supports indexed paths, such as specific containers within a resource.
  * Preserves paths that already include values for consistent reporting.

* **Bug Fixes**
  * Invalid, missing, non-scalar, or out-of-range resource paths are safely skipped.
  * Credential-detecting controls no longer resolve or expose resource values.
  * Resource details are resolved correctly when generating control result tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->