### PR TITLE
fix(cautils): add warning log for invalid useUntilKubescapeVersion semver

### DIFF
--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -2,6 +2,8 @@ package cautils
 
 import (
 	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -98,6 +100,9 @@ func isRuleKubescapeVersionCompatible(attributes map[string]any, version string)
 	if until, ok := attributes["useUntilKubescapeVersion"]; ok && until != nil {
 		switch suntil := until.(type) {
 		case string:
+			if normalizedVersion != "" && !semver.IsValid(suntil) {
+				logger.L().Warning("invalid useUntilKubescapeVersion in rule attributes", helpers.String("useUntilKubescapeVersion", suntil))
+			}
 			if normalizedVersion == "" || (semver.IsValid(normalizedVersion) && semver.Compare(normalizedVersion, suntil) >= 0) {
 				return false
 			}

--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -39,7 +39,7 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRul
 					}
 				}
 
-				if shouldSkipRule(control, control.Rules[r], scanningScope, warned) {
+				if ShouldSkipRuleWithWarned(control, control.Rules[r], scanningScope, warned) {
 					continue
 				}
 				// if isRuleKubescapeVersionCompatible(control.Rules[r].Attributes, version) && isControlFitToScanScope(control, scanningScope) {
@@ -69,10 +69,14 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRul
 //  1. Rule is compatible with the current kubescape version
 //  2. Rule fits the current scanning scope
 func ShouldSkipRule(control reporthandling.Control, rule reporthandling.PolicyRule, scanningScope reporthandling.ScanningScopeType) bool {
-	return shouldSkipRule(control, rule, scanningScope, make(map[string]struct{}))
+	return ShouldSkipRuleWithWarned(control, rule, scanningScope, make(map[string]struct{}))
 }
 
-func shouldSkipRule(control reporthandling.Control, rule reporthandling.PolicyRule, scanningScope reporthandling.ScanningScopeType, warned map[string]struct{}) bool {
+// ShouldSkipRuleWithWarned is like ShouldSkipRule but accepts a warned map for
+// deduplicating malformed-version-bound warnings across multiple calls (e.g.
+// when iterating over frameworks/controls/rules in a loop). Callers should
+// create the map once before the loop and pass the same instance to every call.
+func ShouldSkipRuleWithWarned(control reporthandling.Control, rule reporthandling.PolicyRule, scanningScope reporthandling.ScanningScopeType, warned map[string]struct{}) bool {
 	if !isRuleKubescapeVersionCompatible(rule.Name, rule.Attributes, versioncheck.BuildNumber, warned) {
 		return true
 	}
@@ -94,7 +98,7 @@ func isRuleKubescapeVersionCompatible(ruleName string, attributes map[string]any
 	if from, ok := attributes["useFromKubescapeVersion"]; ok && from != nil {
 		switch sfrom := from.(type) {
 		case string:
-			if normalizedVersion != "" && semver.IsValid(normalizedVersion) && !semver.IsValid(sfrom) {
+			if !semver.IsValid(sfrom) {
 				key := ruleName + ":useFromKubescapeVersion:" + sfrom
 				if _, seen := warned[key]; !seen {
 					warned[key] = struct{}{}
@@ -107,8 +111,12 @@ func isRuleKubescapeVersionCompatible(ruleName string, attributes map[string]any
 				return false
 			}
 		default:
-			logger.L().Warning("non-string useFromKubescapeVersion in rule attributes, skipping rule",
-				helpers.String("rule", ruleName))
+			key := ruleName + ":useFromKubescapeVersion:non-string"
+			if _, seen := warned[key]; !seen {
+				warned[key] = struct{}{}
+				logger.L().Warning("non-string useFromKubescapeVersion in rule attributes, skipping rule",
+					helpers.String("rule", ruleName))
+			}
 			return false
 		}
 	}
@@ -130,8 +138,12 @@ func isRuleKubescapeVersionCompatible(ruleName string, attributes map[string]any
 				return false
 			}
 		default:
-			logger.L().Warning("non-string useUntilKubescapeVersion in rule attributes, skipping rule",
-				helpers.String("rule", ruleName))
+			key := ruleName + ":useUntilKubescapeVersion:non-string"
+			if _, seen := warned[key]; !seen {
+				warned[key] = struct{}{}
+				logger.L().Warning("non-string useUntilKubescapeVersion in rule attributes, skipping rule",
+					helpers.String("rule", ruleName))
+			}
 			return false
 		}
 	}

--- a/core/cautils/datastructuresmethods.go
+++ b/core/cautils/datastructuresmethods.go
@@ -18,6 +18,7 @@ func NewPolicies() *Policies {
 }
 
 func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRules map[string]bool, scanningScope reporthandling.ScanningScopeType) {
+	warned := make(map[string]struct{})
 	for i := range frameworks {
 		if !isFrameworkFitToScanScope(frameworks[i], scanningScope) {
 			continue
@@ -38,7 +39,7 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRul
 					}
 				}
 
-				if ShouldSkipRule(control, control.Rules[r], scanningScope) {
+				if shouldSkipRule(control, control.Rules[r], scanningScope, warned) {
 					continue
 				}
 				// if isRuleKubescapeVersionCompatible(control.Rules[r].Attributes, version) && isControlFitToScanScope(control, scanningScope) {
@@ -68,7 +69,11 @@ func (policies *Policies) Set(frameworks []reporthandling.Framework, excludedRul
 //  1. Rule is compatible with the current kubescape version
 //  2. Rule fits the current scanning scope
 func ShouldSkipRule(control reporthandling.Control, rule reporthandling.PolicyRule, scanningScope reporthandling.ScanningScopeType) bool {
-	if !isRuleKubescapeVersionCompatible(rule.Attributes, versioncheck.BuildNumber) {
+	return shouldSkipRule(control, rule, scanningScope, make(map[string]struct{}))
+}
+
+func shouldSkipRule(control reporthandling.Control, rule reporthandling.PolicyRule, scanningScope reporthandling.ScanningScopeType, warned map[string]struct{}) bool {
+	if !isRuleKubescapeVersionCompatible(rule.Name, rule.Attributes, versioncheck.BuildNumber, warned) {
 		return true
 	}
 	if !isControlFitToScanScope(control, scanningScope) {
@@ -80,7 +85,7 @@ func ShouldSkipRule(control reporthandling.Control, rule reporthandling.PolicyRu
 // Checks that kubescape version is in range of use for this rule
 // In local build (BuildNumber = ""):
 // returns true only if rule doesn't have the "until" attribute
-func isRuleKubescapeVersionCompatible(attributes map[string]any, version string) bool {
+func isRuleKubescapeVersionCompatible(ruleName string, attributes map[string]any, version string, warned map[string]struct{}) bool {
 	normalizedVersion := version
 	if version != "" && !semver.IsValid(version) {
 		normalizedVersion = "v" + version
@@ -89,10 +94,21 @@ func isRuleKubescapeVersionCompatible(attributes map[string]any, version string)
 	if from, ok := attributes["useFromKubescapeVersion"]; ok && from != nil {
 		switch sfrom := from.(type) {
 		case string:
+			if normalizedVersion != "" && semver.IsValid(normalizedVersion) && !semver.IsValid(sfrom) {
+				key := ruleName + ":useFromKubescapeVersion:" + sfrom
+				if _, seen := warned[key]; !seen {
+					warned[key] = struct{}{}
+					logger.L().Warning("invalid useFromKubescapeVersion in rule attributes, rule may run on unintended versions",
+						helpers.String("useFromKubescapeVersion", sfrom),
+						helpers.String("rule", ruleName))
+				}
+			}
 			if normalizedVersion != "" && semver.IsValid(normalizedVersion) && semver.Compare(normalizedVersion, sfrom) == -1 {
 				return false
 			}
 		default:
+			logger.L().Warning("non-string useFromKubescapeVersion in rule attributes, skipping rule",
+				helpers.String("rule", ruleName))
 			return false
 		}
 	}
@@ -100,13 +116,22 @@ func isRuleKubescapeVersionCompatible(attributes map[string]any, version string)
 	if until, ok := attributes["useUntilKubescapeVersion"]; ok && until != nil {
 		switch suntil := until.(type) {
 		case string:
-			if normalizedVersion != "" && !semver.IsValid(suntil) {
-				logger.L().Warning("invalid useUntilKubescapeVersion in rule attributes", helpers.String("useUntilKubescapeVersion", suntil))
+			if !semver.IsValid(suntil) {
+				key := ruleName + ":useUntilKubescapeVersion:" + suntil
+				if _, seen := warned[key]; !seen {
+					warned[key] = struct{}{}
+					logger.L().Warning("invalid useUntilKubescapeVersion in rule attributes, skipping rule",
+						helpers.String("useUntilKubescapeVersion", suntil),
+						helpers.String("rule", ruleName))
+				}
+				return false
 			}
-			if normalizedVersion == "" || (semver.IsValid(normalizedVersion) && semver.Compare(normalizedVersion, suntil) >= 0) {
+			if normalizedVersion == "" || semver.Compare(normalizedVersion, suntil) >= 0 {
 				return false
 			}
 		default:
+			logger.L().Warning("non-string useUntilKubescapeVersion in rule attributes, skipping rule",
+				helpers.String("rule", ruleName))
 			return false
 		}
 	}

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -1,13 +1,18 @@
 package cautils
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/go-logger"
 	"github.com/kubescape/opa-utils/reporthandling"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsScanningScopeMatchToControlScope(t *testing.T) {
@@ -259,42 +264,42 @@ func TestIsRuleKubescapeVersionCompatible(t *testing.T) {
 
 	// should not crash when the value of useUntilKubescapeVersion is not a string
 	buildNumberMock := "v1.0.135"
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_invalid_from.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_invalid_until.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_invalid_from.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_invalid_until.Attributes, buildNumberMock, make(map[string]struct{})))
 	// should use only rules that don't have "until"
 	buildNumberMock = ""
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
-	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_131.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_132.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_133.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.True(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_134.Attributes, buildNumberMock, make(map[string]struct{})))
 
 	// should only use rules that version is in range of use
 	buildNumberMock = "v1.0.130"
-	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+	assert.True(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_131.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_132.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_133.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_134.Attributes, buildNumberMock, make(map[string]struct{})))
 
 	// should only use rules that version is in range of use
 	buildNumberMock = "v1.0.132"
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
-	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_131.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.True(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_132.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_133.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_134.Attributes, buildNumberMock, make(map[string]struct{})))
 
 	// should only use rules that version is in range of use
 	buildNumberMock = "v1.0.133"
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
-	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_131.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_132.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.True(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_133.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_134.Attributes, buildNumberMock, make(map[string]struct{})))
 
 	// should only use rules that version is in range of use
 	buildNumberMock = "v1.0.135"
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_131.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_132.Attributes, buildNumberMock))
-	assert.False(t, isRuleKubescapeVersionCompatible(rule_v1_0_133.Attributes, buildNumberMock))
-	assert.True(t, isRuleKubescapeVersionCompatible(rule_v1_0_134.Attributes, buildNumberMock))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_131.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_132.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.False(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_133.Attributes, buildNumberMock, make(map[string]struct{})))
+	assert.True(t, isRuleKubescapeVersionCompatible("test-rule", rule_v1_0_134.Attributes, buildNumberMock, make(map[string]struct{})))
 }
 
 // TestPoliciesSetDoesNotMutateCallerFrameworks guards against a regression where Set
@@ -402,18 +407,65 @@ func TestIsRuleKubescapeVersionCompatible_BadSemverBounds(t *testing.T) {
 			buildNumber: "v1.0.133",
 			want:        false,
 		},
-		{
-			name:        "rule with only valid from bound is not excluded at higher version",
-			attributes:  map[string]interface{}{"useFromKubescapeVersion": "v1.0.130"},
-			buildNumber: "v1.0.133",
-			want:        true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isRuleKubescapeVersionCompatible(tt.attributes, tt.buildNumber)
+			got := isRuleKubescapeVersionCompatible("test-rule", tt.attributes, tt.buildNumber, make(map[string]struct{}))
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestIsRuleKubescapeVersionCompatible_WarnsOnInvalidUntil(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "log"))
+	require.NoError(t, err)
+	defer f.Close()
+	prev := logger.L().GetWriter()
+	logger.L().SetWriter(f)
+	defer logger.L().SetWriter(prev)
+
+	assert.False(t, isRuleKubescapeVersionCompatible("c-0001", map[string]any{"useUntilKubescapeVersion": "not-a-version"}, "v1.0.133", make(map[string]struct{})))
+
+	require.NoError(t, f.Sync())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "invalid useUntilKubescapeVersion")
+	assert.Contains(t, string(b), "c-0001")
+}
+
+func TestIsRuleKubescapeVersionCompatible_WarnsOnInvalidFrom(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "log"))
+	require.NoError(t, err)
+	defer f.Close()
+	prev := logger.L().GetWriter()
+	logger.L().SetWriter(f)
+	defer logger.L().SetWriter(prev)
+
+	assert.True(t, isRuleKubescapeVersionCompatible("c-0002", map[string]any{"useFromKubescapeVersion": "not-a-version"}, "v1.0.133", make(map[string]struct{})))
+
+	require.NoError(t, f.Sync())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "invalid useFromKubescapeVersion")
+	assert.Contains(t, string(b), "c-0002")
+}
+
+func TestIsRuleKubescapeVersionCompatible_DedupWarnings(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "log"))
+	require.NoError(t, err)
+	defer f.Close()
+	prev := logger.L().GetWriter()
+	logger.L().SetWriter(f)
+	defer logger.L().SetWriter(prev)
+
+	warned := make(map[string]struct{})
+	for range 3 {
+		isRuleKubescapeVersionCompatible("dedup-rule", map[string]any{"useUntilKubescapeVersion": "bad-semver"}, "v1.0.133", warned)
+	}
+
+	require.NoError(t, f.Sync())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, 1, bytes.Count(b, []byte("invalid useUntilKubescapeVersion")), "expected exactly one warning, got duplicates")
 }

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -379,3 +379,41 @@ func TestGetScanningScope(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRuleKubescapeVersionCompatible_BadSemverBounds(t *testing.T) {
+	tests := []struct {
+		name        string
+		attributes  map[string]interface{}
+		buildNumber string
+		want        bool
+	}{
+		{
+			name:        "invalid useUntilKubescapeVersion excludes the rule (fail-closed)",
+			attributes:  map[string]interface{}{"useUntilKubescapeVersion": "not-a-version"},
+			buildNumber: "v1.0.133",
+			want:        false,
+		},
+		{
+			name: "valid from, invalid until excludes the rule (mixed case)",
+			attributes: map[string]interface{}{
+				"useFromKubescapeVersion":  "v1.0.130",
+				"useUntilKubescapeVersion": "not-a-version",
+			},
+			buildNumber: "v1.0.133",
+			want:        false,
+		},
+		{
+			name:        "rule with only valid from bound is not excluded at higher version",
+			attributes:  map[string]interface{}{"useFromKubescapeVersion": "v1.0.130"},
+			buildNumber: "v1.0.133",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRuleKubescapeVersionCompatible(tt.attributes, tt.buildNumber)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/core/cautils/datastructuresmethods_test.go
+++ b/core/cautils/datastructuresmethods_test.go
@@ -442,7 +442,7 @@ func TestIsRuleKubescapeVersionCompatible_WarnsOnInvalidFrom(t *testing.T) {
 	logger.L().SetWriter(f)
 	defer logger.L().SetWriter(prev)
 
-	assert.True(t, isRuleKubescapeVersionCompatible("c-0002", map[string]any{"useFromKubescapeVersion": "not-a-version"}, "v1.0.133", make(map[string]struct{})))
+	assert.True(t, isRuleKubescapeVersionCompatible("c-0002", map[string]any{"useFromKubescapeVersion": "not-a-version"}, "", make(map[string]struct{})))
 
 	require.NoError(t, f.Sync())
 	b, err := os.ReadFile(f.Name())
@@ -468,4 +468,13 @@ func TestIsRuleKubescapeVersionCompatible_DedupWarnings(t *testing.T) {
 	b, err := os.ReadFile(f.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, bytes.Count(b, []byte("invalid useUntilKubescapeVersion")), "expected exactly one warning, got duplicates")
+}
+
+func TestIsRuleKubescapeVersionCompatible_UnparseableBuildNumberAndInvalidUntil(t *testing.T) {
+	// when both BuildNumber and useUntilKubescapeVersion are invalid semver,
+	// the rule is correctly excluded (fail-closed). Master kept the rule in
+	// this scenario because semver.IsValid(normalizedVersion) was false and
+	// the comparison was skipped; this branch now consistently fail-closes.
+	assert.False(t, isRuleKubescapeVersionCompatible(
+		"r", map[string]any{"useUntilKubescapeVersion": "not-a-version"}, "not-a-version", make(map[string]struct{})))
 }

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -43,12 +43,13 @@ func getQueryableResourceMapFromPolicies(frameworks []reporthandling.Framework, 
 	queryableResources := make(QueryableResources)
 	excludedRulesMap := make(map[string]bool)
 	namespace := getScannedResourceNamespace(resource)
+	warned := make(map[string]struct{})
 
 	for _, framework := range frameworks {
 		for _, control := range framework.Controls {
 			for _, rule := range control.Rules {
 				// check if the rule should be skipped according to the scanning scope and the rule attributes
-				if cautils.ShouldSkipRule(control, rule, scanningScope) {
+				if cautils.ShouldSkipRuleWithWarned(control, rule, scanningScope, warned) {
 					continue
 				}
 


### PR DESCRIPTION
When a rule has a malformed `useUntilKubescapeVersion` (e.g. `"not-a-version"`), semver.Compare treats invalid < valid, which causes the rule to be excluded — but silently. This PR adds an explicit `logger.L().Warning` for this case so malformed bounds don't go unnoticed.

**changes:**
* added `logger.L().Warning(...)` for both `until` and `from` bounds when the semver string is invalid. also threaded `ruleName` into the logs so they are actually actionable.
* added explicit warnings for malformed `useFromKubescapeVersion` bounds so they don't silently fail open (and dropped the dead code claim from the original draft).
* set up a shared `warned` map via `ShouldSkipRuleWithWarned` to deduplicate log spam across the entire scan session.
* **semantic fix:** dropped the `semver.IsValid(normalizedVersion)` guard. this means if both the local `versioncheck.BuildNumber` and the `until` bound are unparseable, the rule now correctly fails closed (excluded) instead of being silently kept.
* added table-driven tests pinning all these behaviors, including the local-build blindspot and the unparseable edge case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or non-string version compatibility values.
  * Added warnings when malformed version limits are encountered.
  * Ensured invalid version bounds safely skip affected rules.
  * Prevented duplicate warnings for the same rule and issue.

* **Tests**
  * Added coverage for malformed, mixed, and valid version-bound scenarios.
  * Added tests confirming warning generation and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->