### PR TITLE
fix(core): return error when io.ReadAll fails in NewFixHandler

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -41,7 +41,10 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 		return nil, err
 	}
 	defer jsonFile.Close()
-	byteValue, _ := io.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read report file: %w", err)
+	}
 
 	var reportObj reporthandlingv2.PostureReport
 	if err = json.Unmarshal(byteValue, &reportObj); err != nil {


### PR DESCRIPTION
Fixes #2705

### Description
In `core/pkg/fixhandler/fixhandler.go`, `NewFixHandler` previously ignored the error returned by `io.ReadAll(jsonFile)` when reading the report file. If an I/O error occurred (e.g. truncated file, disk read error), the function would silently proceed with partial or corrupted bytes, causing the subsequent JSON decoder to fail with a cryptic `unexpected end of JSON input` error (or fall back to a confusing YAML heuristic).

This PR ensures the error from `io.ReadAll` is checked and properly returned so users get accurate diagnostics for file read failures.

### Changes
- Updated `NewFixHandler` to check and return the `err` from `io.ReadAll`.

Signed-off-by: Shivansh Gohem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a report file cannot be read.
  * Users now receive a clear error instead of the issue being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->