### PR TITLE
feat(mcpserver): add scan_container_image tool for on-demand vulnerability scanning (KS-INT-03)

### DIFF
--- a/cmd/mcpserver/image_scan.go
+++ b/cmd/mcpserver/image_scan.go
@@ -1,0 +1,81 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/anchore/clio"
+	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/kubescape/v3/pkg/imagescan"
+)
+
+type imageScanResponse struct {
+	Image           string                 `json:"image"`
+	Matches         []models.Match         `json:"matches"`
+	Vulnerabilities []models.Vulnerability `json:"vulnerabilities"`
+	Severities      map[string]int         `json:"severities"`
+}
+
+func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName, username, regSecret string) ([]byte, error) {
+	logger.L().Info(fmt.Sprintf("Starting on-demand MCP container image scan for %s", imageName))
+
+	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
+	}
+
+	svc, err := imagescan.NewScanService(distCfg, installCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize image scan service: %w", err)
+	}
+	defer svc.Close()
+
+	creds := imagescan.RegistryCredentials{
+		Username: username,
+		Password: regSecret,
+	}
+
+	scanResults, err := svc.Scan(ctx, imageName, creds, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan container image %s: %w", imageName, err)
+	}
+
+	doc, err := models.NewDocument(
+		clio.Identification{},
+		scanResults.Packages,
+		scanResults.Context,
+		scanResults.Matches,
+		scanResults.IgnoredMatches,
+		scanResults.VulnerabilityProvider,
+		nil,
+		nil,
+		models.DefaultSortStrategy,
+		false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate vulnerability document: %w", err)
+	}
+
+	vulnerabilities := make([]models.Vulnerability, 0)
+	seenVulns := make(map[string]bool)
+	severities := make(map[string]int)
+
+	for _, m := range doc.Matches {
+		if !seenVulns[m.Vulnerability.ID] {
+			seenVulns[m.Vulnerability.ID] = true
+			vulnerabilities = append(vulnerabilities, m.Vulnerability)
+		}
+		severities[m.Vulnerability.Severity]++
+	}
+
+	response := imageScanResponse{
+		Image:           imageName,
+		Matches:         doc.Matches,
+		Vulnerabilities: vulnerabilities,
+		Severities:      severities,
+	}
+
+	return json.Marshal(response)
+}

--- a/cmd/mcpserver/image_scan.go
+++ b/cmd/mcpserver/image_scan.go
@@ -51,6 +51,7 @@ func validateImageReference(imageName string) error {
 	forbiddenPrefixes := []string{
 		"dir:", "file:", "sbom:", "purl:", "cpe:", "pkg:", "oci-dir:", "oci-archive:",
 		"docker-archive:", "docker-daemon:", "docker:", "podman:", "singularity:",
+		"local-file:", "local-directory:", "daemon:", "containerd:", "image:", "oci-model:", "snap:",
 	}
 	for _, prefix := range forbiddenPrefixes {
 		if strings.HasPrefix(lower, prefix) {
@@ -70,11 +71,6 @@ func validateImageReference(imageName string) error {
 	}
 	if _, err := os.Stat(imageName); err == nil {
 		return fmt.Errorf("invalid image reference %q: resolves to a local file or directory", imageName)
-	}
-	if !strings.HasPrefix(pathPart, "/") {
-		if _, err := os.Stat("/" + pathPart); err == nil {
-			return fmt.Errorf("invalid image reference %q: resolves to a local file or directory", imageName)
-		}
 	}
 
 	// Validate using go-containerregistry
@@ -174,7 +170,6 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 	if !ksServer.imageScanMu.TryLock() {
 		return nil, fmt.Errorf("another container image scan is currently in progress; please wait for it to complete")
 	}
-	defer ksServer.imageScanMu.Unlock()
 
 	// Derive a bounded child context with a timeout covering service initialization and scan
 	scanCtx, cancel := context.WithTimeout(ctx, defaultImageScanTimeout)
@@ -184,6 +179,7 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 
 	svc, err := ksServer.getImageScanService(scanCtx)
 	if err != nil {
+		ksServer.imageScanMu.Unlock()
 		return nil, fmt.Errorf("failed to get image scan service: %w", err)
 	}
 
@@ -199,6 +195,7 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 
 	ch := make(chan result, 1)
 	go func() {
+		defer ksServer.imageScanMu.Unlock()
 		res, err := svc.Scan(scanCtx, imageName, creds, nil, nil)
 		ch <- result{data: res, err: err}
 	}()

--- a/cmd/mcpserver/image_scan.go
+++ b/cmd/mcpserver/image_scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,12 +16,26 @@ import (
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 )
 
+const defaultImageScanTimeout = 5 * time.Minute
+
 type imageScanResponse struct {
 	Image           string                 `json:"image"`
 	TotalUniqueCVEs int                    `json:"total_vulnerabilities"`
 	Severities      map[string]int         `json:"severities"`
 	Vulnerabilities []models.Vulnerability `json:"vulnerabilities"`
 	Matches         []models.Match         `json:"matches,omitempty"`
+}
+
+func validateSeverity(sev string) error {
+	if sev == "" {
+		return nil
+	}
+	switch strings.ToLower(sev) {
+	case "critical", "high", "medium", "low", "negligible", "unknown":
+		return nil
+	default:
+		return fmt.Errorf("invalid severity %q: must be one of Critical, High, Medium, Low, Negligible, Unknown", sev)
+	}
 }
 
 // validateImageReference validates that imageName is a valid remote image reference
@@ -32,9 +47,9 @@ func validateImageReference(imageName string) error {
 
 	lower := strings.ToLower(imageName)
 
-	// Block scheme prefixes that Syft resolves locally or on disk
+	// Block scheme prefixes that Syft/Grype resolve locally or on disk
 	forbiddenPrefixes := []string{
-		"dir:", "file:", "sbom:", "oci-dir:", "oci-archive:",
+		"dir:", "file:", "sbom:", "purl:", "cpe:", "pkg:", "oci-dir:", "oci-archive:",
 		"docker-archive:", "docker-daemon:", "docker:", "podman:", "singularity:",
 	}
 	for _, prefix := range forbiddenPrefixes {
@@ -46,6 +61,20 @@ func validateImageReference(imageName string) error {
 	// Block relative or absolute local file paths
 	if strings.HasPrefix(imageName, "/") || strings.HasPrefix(imageName, "./") || strings.HasPrefix(imageName, "../") {
 		return fmt.Errorf("invalid image reference %q: local file paths are not allowed", imageName)
+	}
+
+	// Extract path component before tags/digests and check if it exists on local filesystem
+	pathPart := strings.SplitN(strings.SplitN(imageName, ":", 2)[0], "@", 2)[0]
+	if _, err := os.Stat(pathPart); err == nil {
+		return fmt.Errorf("invalid image reference %q: resolves to a local file or directory", imageName)
+	}
+	if _, err := os.Stat(imageName); err == nil {
+		return fmt.Errorf("invalid image reference %q: resolves to a local file or directory", imageName)
+	}
+	if !strings.HasPrefix(pathPart, "/") {
+		if _, err := os.Stat("/" + pathPart); err == nil {
+			return fmt.Errorf("invalid image reference %q: resolves to a local file or directory", imageName)
+		}
 	}
 
 	// Validate using go-containerregistry
@@ -142,6 +171,11 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 		return nil, err
 	}
 
+	if !ksServer.imageScanMu.TryLock() {
+		return nil, fmt.Errorf("another container image scan is currently in progress; please wait for it to complete")
+	}
+	defer ksServer.imageScanMu.Unlock()
+
 	logger.L().Info(fmt.Sprintf("Starting on-demand MCP container image scan for %s", imageName))
 
 	svc, err := ksServer.getImageScanService()
@@ -154,8 +188,8 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 		Password: regSecret,
 	}
 
-	// Derive a bounded child context with a 5-minute timeout for the scan
-	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// Derive a bounded child context with a timeout for the scan
+	scanCtx, cancel := context.WithTimeout(ctx, defaultImageScanTimeout)
 	defer cancel()
 
 	type result struct {

--- a/cmd/mcpserver/image_scan.go
+++ b/cmd/mcpserver/image_scan.go
@@ -4,42 +4,180 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/grype/grype/presenter/models"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 )
 
 type imageScanResponse struct {
 	Image           string                 `json:"image"`
-	Matches         []models.Match         `json:"matches"`
-	Vulnerabilities []models.Vulnerability `json:"vulnerabilities"`
+	TotalUniqueCVEs int                    `json:"total_vulnerabilities"`
 	Severities      map[string]int         `json:"severities"`
+	Vulnerabilities []models.Vulnerability `json:"vulnerabilities"`
+	Matches         []models.Match         `json:"matches,omitempty"`
 }
 
-func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName, username, regSecret string) ([]byte, error) {
+// validateImageReference validates that imageName is a valid remote image reference
+// and not a local filesystem path or forbidden URI scheme.
+func validateImageReference(imageName string) error {
+	if imageName == "" {
+		return fmt.Errorf("image_name argument is required and cannot be empty")
+	}
+
+	lower := strings.ToLower(imageName)
+
+	// Block scheme prefixes that Syft resolves locally or on disk
+	forbiddenPrefixes := []string{
+		"dir:", "file:", "sbom:", "oci-dir:", "oci-archive:",
+		"docker-archive:", "docker-daemon:", "docker:", "podman:", "singularity:",
+	}
+	for _, prefix := range forbiddenPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return fmt.Errorf("invalid image reference %q: local filesystem and custom scheme references are not allowed", imageName)
+		}
+	}
+
+	// Block relative or absolute local file paths
+	if strings.HasPrefix(imageName, "/") || strings.HasPrefix(imageName, "./") || strings.HasPrefix(imageName, "../") {
+		return fmt.Errorf("invalid image reference %q: local file paths are not allowed", imageName)
+	}
+
+	// Validate using go-containerregistry
+	if _, err := name.ParseReference(imageName); err != nil {
+		return fmt.Errorf("invalid image reference %q: %w", imageName, err)
+	}
+
+	return nil
+}
+
+func normalizeSeverity(sev string) string {
+	switch strings.ToLower(sev) {
+	case "critical":
+		return "Critical"
+	case "high":
+		return "High"
+	case "medium":
+		return "Medium"
+	case "low":
+		return "Low"
+	case "negligible":
+		return "Negligible"
+	default:
+		return "Unknown"
+	}
+}
+
+func parseSeverityLevel(sev string) int {
+	switch strings.ToLower(sev) {
+	case "critical":
+		return 5
+	case "high":
+		return 4
+	case "medium":
+		return 3
+	case "low":
+		return 2
+	case "negligible":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// processMatches deduplicates vulnerabilities by ID, normalizes severities,
+// counts unique vulnerabilities per severity, and formats the response.
+func processMatches(imageName string, matches []models.Match, includeMatches bool, minSeverity string) imageScanResponse {
+	vulnerabilities := make([]models.Vulnerability, 0)
+	filteredMatches := make([]models.Match, 0)
+	seenVulns := make(map[string]bool)
+	severities := make(map[string]int)
+
+	minSevLevel := parseSeverityLevel(minSeverity)
+
+	for _, m := range matches {
+		sev := m.Vulnerability.Severity
+		if sev == "" {
+			sev = "Unknown"
+		}
+		sevNormalized := normalizeSeverity(sev)
+
+		if parseSeverityLevel(sevNormalized) < minSevLevel {
+			continue
+		}
+
+		if !seenVulns[m.Vulnerability.ID] {
+			seenVulns[m.Vulnerability.ID] = true
+			vuln := m.Vulnerability
+			vuln.Severity = sevNormalized
+			vulnerabilities = append(vulnerabilities, vuln)
+			severities[sevNormalized]++
+		}
+
+		if includeMatches {
+			m.Vulnerability.Severity = sevNormalized
+			filteredMatches = append(filteredMatches, m)
+		}
+	}
+
+	resp := imageScanResponse{
+		Image:           imageName,
+		TotalUniqueCVEs: len(vulnerabilities),
+		Severities:      severities,
+		Vulnerabilities: vulnerabilities,
+	}
+	if includeMatches {
+		resp.Matches = filteredMatches
+	}
+	return resp
+}
+
+func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName, username, regSecret string, includeMatches bool, minSeverity string) ([]byte, error) {
+	if err := validateImageReference(imageName); err != nil {
+		return nil, err
+	}
+
 	logger.L().Info(fmt.Sprintf("Starting on-demand MCP container image scan for %s", imageName))
 
-	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig("")
+	svc, err := ksServer.getImageScanService()
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
+		return nil, fmt.Errorf("failed to get image scan service: %w", err)
 	}
-
-	svc, err := imagescan.NewScanService(distCfg, installCfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize image scan service: %w", err)
-	}
-	defer svc.Close()
 
 	creds := imagescan.RegistryCredentials{
 		Username: username,
 		Password: regSecret,
 	}
 
-	scanResults, err := svc.Scan(ctx, imageName, creds, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan container image %s: %w", imageName, err)
+	// Derive a bounded child context with a 5-minute timeout for the scan
+	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	type result struct {
+		data *cautils.ImageScanData
+		err  error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		res, err := svc.Scan(scanCtx, imageName, creds, nil, nil)
+		ch <- result{data: res, err: err}
+	}()
+
+	var scanResults *cautils.ImageScanData
+	select {
+	case <-scanCtx.Done():
+		return nil, fmt.Errorf("container image scan timed out or was canceled: %w", scanCtx.Err())
+	case res := <-ch:
+		if res.err != nil {
+			return nil, fmt.Errorf("failed to scan container image %s: %w", imageName, res.err)
+		}
+		scanResults = res.data
 	}
 
 	doc, err := models.NewDocument(
@@ -58,24 +196,7 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 		return nil, fmt.Errorf("failed to generate vulnerability document: %w", err)
 	}
 
-	vulnerabilities := make([]models.Vulnerability, 0)
-	seenVulns := make(map[string]bool)
-	severities := make(map[string]int)
-
-	for _, m := range doc.Matches {
-		if !seenVulns[m.Vulnerability.ID] {
-			seenVulns[m.Vulnerability.ID] = true
-			vulnerabilities = append(vulnerabilities, m.Vulnerability)
-		}
-		severities[m.Vulnerability.Severity]++
-	}
-
-	response := imageScanResponse{
-		Image:           imageName,
-		Matches:         doc.Matches,
-		Vulnerabilities: vulnerabilities,
-		Severities:      severities,
-	}
+	response := processMatches(imageName, doc.Matches, includeMatches, minSeverity)
 
 	return json.Marshal(response)
 }

--- a/cmd/mcpserver/image_scan.go
+++ b/cmd/mcpserver/image_scan.go
@@ -176,9 +176,13 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 	}
 	defer ksServer.imageScanMu.Unlock()
 
+	// Derive a bounded child context with a timeout covering service initialization and scan
+	scanCtx, cancel := context.WithTimeout(ctx, defaultImageScanTimeout)
+	defer cancel()
+
 	logger.L().Info(fmt.Sprintf("Starting on-demand MCP container image scan for %s", imageName))
 
-	svc, err := ksServer.getImageScanService()
+	svc, err := ksServer.getImageScanService(scanCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image scan service: %w", err)
 	}
@@ -187,10 +191,6 @@ func (ksServer *KubescapeMcpserver) runImageScan(ctx context.Context, imageName,
 		Username: username,
 		Password: regSecret,
 	}
-
-	// Derive a bounded child context with a timeout for the scan
-	scanCtx, cancel := context.WithTimeout(ctx, defaultImageScanTimeout)
-	defer cancel()
 
 	type result struct {
 		data *cautils.ImageScanData

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -63,25 +63,30 @@ func (ksServer *KubescapeMcpserver) getImageScanService(ctx context.Context) (*i
 			initCh <- initResult{err: fmt.Errorf("failed to initialize image scan service: %w", err)}
 			return
 		}
-
-		ksServer.imageScanSvcMu.Lock()
-		if ksServer.imageScanSvc == nil {
-			ksServer.imageScanSvc = svc
-		} else {
-			svc.Close()
-		}
-		ksServer.imageScanSvcMu.Unlock()
-
 		initCh <- initResult{svc: svc}
 	}()
 
 	select {
 	case <-ctx.Done():
+		go func() {
+			res := <-initCh
+			if res.svc == nil {
+				return
+			}
+			ksServer.imageScanSvcMu.Lock()
+			defer ksServer.imageScanSvcMu.Unlock()
+			if ksServer.imageScanSvc == nil {
+				ksServer.imageScanSvc = res.svc
+			} else {
+				res.svc.Close()
+			}
+		}()
 		return nil, fmt.Errorf("image scan service initialization timed out or was canceled: %w", ctx.Err())
 	case res := <-initCh:
 		if res.err != nil {
 			return nil, res.err
 		}
+		ksServer.imageScanSvc = res.svc
 		return res.svc, nil
 	}
 }

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -38,12 +38,18 @@ type KubescapeMcpserver struct {
 	dbListingURL   string
 }
 
-func (ksServer *KubescapeMcpserver) getImageScanService() (*imagescan.Service, error) {
+func (ksServer *KubescapeMcpserver) getImageScanService(ctx context.Context) (*imagescan.Service, error) {
 	ksServer.imageScanSvcMu.Lock()
 	defer ksServer.imageScanSvcMu.Unlock()
 
 	if ksServer.imageScanSvc != nil {
 		return ksServer.imageScanSvc, nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
 	}
 
 	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -31,29 +32,31 @@ type KubescapeMcpserver struct {
 	k8sClientOnce sync.Once
 	policyGetter  *getter.DownloadReleasedPolicy
 
-	imageScanSvc     *imagescan.Service
-	imageScanSvcOnce sync.Once
-	imageScanSvcErr  error
-	dbListingURL     string
+	imageScanSvc   *imagescan.Service
+	imageScanSvcMu sync.Mutex
+	imageScanMu    sync.Mutex
+	dbListingURL   string
 }
 
 func (ksServer *KubescapeMcpserver) getImageScanService() (*imagescan.Service, error) {
+	ksServer.imageScanSvcMu.Lock()
+	defer ksServer.imageScanSvcMu.Unlock()
+
 	if ksServer.imageScanSvc != nil {
 		return ksServer.imageScanSvc, nil
 	}
-	ksServer.imageScanSvcOnce.Do(func() {
-		distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)
-		if err != nil {
-			ksServer.imageScanSvcErr = fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
-			return
-		}
-		ksServer.imageScanSvc, err = imagescan.NewScanService(distCfg, installCfg)
-		if err != nil {
-			ksServer.imageScanSvcErr = fmt.Errorf("failed to initialize image scan service: %w", err)
-			return
-		}
-	})
-	return ksServer.imageScanSvc, ksServer.imageScanSvcErr
+
+	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
+	}
+	svc, err := imagescan.NewScanService(distCfg, installCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize image scan service: %w", err)
+	}
+
+	ksServer.imageScanSvc = svc
+	return ksServer.imageScanSvc, nil
 }
 
 func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interface, error) {
@@ -871,6 +874,9 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 				return mcp.NewToolResultError("severity argument must be a string"), nil
 			}
 			severity = strings.TrimSpace(sevStr)
+			if err := validateSeverity(severity); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
 		}
 
 		responseBytes, err := ksServer.runImageScan(ctx, imageName, regUsername, regSecret, includeMatches, severity)
@@ -901,10 +907,16 @@ func mcpServerEntrypoint() error {
 		k8sApi = k8sinterface.NewKubernetesApi()
 	}
 
+	dbListingURL := os.Getenv("KS_GRYPE_LISTING_URL")
+	if dbListingURL == "" {
+		dbListingURL = os.Getenv("GRYPE_DB_LISTING_URL")
+	}
+
 	ksServer := &KubescapeMcpserver{
 		s:            s,
 		k8sClient:    k8sApi,
 		policyGetter: getter.NewDownloadReleasedPolicy(),
+		dbListingURL: dbListingURL,
 	}
 
 	// Initialize the policy getter to load the local ~/.kubescape cache.

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 )
 
 type KubescapeMcpserver struct {
@@ -29,6 +30,30 @@ type KubescapeMcpserver struct {
 	k8sClient     *k8sinterface.KubernetesApi
 	k8sClientOnce sync.Once
 	policyGetter  *getter.DownloadReleasedPolicy
+
+	imageScanSvc     *imagescan.Service
+	imageScanSvcOnce sync.Once
+	imageScanSvcErr  error
+	dbListingURL     string
+}
+
+func (ksServer *KubescapeMcpserver) getImageScanService() (*imagescan.Service, error) {
+	if ksServer.imageScanSvc != nil {
+		return ksServer.imageScanSvc, nil
+	}
+	ksServer.imageScanSvcOnce.Do(func() {
+		distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)
+		if err != nil {
+			ksServer.imageScanSvcErr = fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
+			return
+		}
+		ksServer.imageScanSvc, err = imagescan.NewScanService(distCfg, installCfg)
+		if err != nil {
+			ksServer.imageScanSvcErr = fmt.Errorf("failed to initialize image scan service: %w", err)
+			return
+		}
+	})
+	return ksServer.imageScanSvc, ksServer.imageScanSvcErr
 }
 
 func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interface, error) {
@@ -831,8 +856,24 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			}
 			regSecret = pStr
 		}
+		var includeMatches bool
+		if inc, ok := arguments["include_matches"]; ok {
+			incBool, ok := inc.(bool)
+			if !ok {
+				return mcp.NewToolResultError("include_matches argument must be a boolean"), nil
+			}
+			includeMatches = incBool
+		}
+		var severity string
+		if sev, ok := arguments["severity"]; ok {
+			sevStr, ok := sev.(string)
+			if !ok {
+				return mcp.NewToolResultError("severity argument must be a string"), nil
+			}
+			severity = strings.TrimSpace(sevStr)
+		}
 
-		responseBytes, err := ksServer.runImageScan(ctx, imageName, regUsername, regSecret)
+		responseBytes, err := ksServer.runImageScan(ctx, imageName, regUsername, regSecret, includeMatches, severity)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to run container image scan: %v", err)), nil
 		}
@@ -948,16 +989,22 @@ func createIaCScanningTools(ksServer *KubescapeMcpserver) {
 func createImageScanningTools(ksServer *KubescapeMcpserver) {
 	scanImageTool := mcp.NewTool(
 		"scan_container_image",
-		mcp.WithDescription("Run an on-demand container image vulnerability scan and return structured JSON containing matches, vulnerabilities, and severities"),
+		mcp.WithDescription("Run an on-demand container image vulnerability scan. Note: this network-bound operation scans a container image and initializes/queries the vulnerability database."),
 		mcp.WithString("image_name",
 			mcp.Required(),
-			mcp.Description("Name of the container image to scan (e.g., nginx:alpine)"),
+			mcp.Description("Name of the remote container image to scan (e.g., nginx:alpine)"),
 		),
 		mcp.WithString("username",
 			mcp.Description("Username for registry authentication (optional)"),
 		),
 		mcp.WithString("password",
 			mcp.Description("Password for registry authentication (optional)"),
+		),
+		mcp.WithBoolean("include_matches",
+			mcp.Description("Include detailed match location and package info for each vulnerability (optional, defaults to false)"),
+		),
+		mcp.WithString("severity",
+			mcp.Description("Minimum severity filter (e.g., Low, Medium, High, Critical) (optional)"),
 		),
 	)
 

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -803,6 +803,40 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return mcp.NewToolResultError(fmt.Sprintf("failed to run framework scan: %v", err)), nil
 		}
 		return mcp.NewToolResultText(string(responseBytes)), nil
+	case "scan_container_image":
+		imageName := ""
+		if img, ok := arguments["image_name"]; ok {
+			imgStr, ok := img.(string)
+			if !ok {
+				return mcp.NewToolResultError("image_name argument must be a string"), nil
+			}
+			imageName = strings.TrimSpace(imgStr)
+		}
+		if imageName == "" {
+			return mcp.NewToolResultError("image_name argument is required and cannot be empty"), nil
+		}
+		var regUsername string
+		if u, ok := arguments["username"]; ok {
+			uStr, ok := u.(string)
+			if !ok {
+				return mcp.NewToolResultError("username argument must be a string"), nil
+			}
+			regUsername = uStr
+		}
+		var regSecret string
+		if p, ok := arguments["password"]; ok {
+			pStr, ok := p.(string)
+			if !ok {
+				return mcp.NewToolResultError("password argument must be a string"), nil
+			}
+			regSecret = pStr
+		}
+
+		responseBytes, err := ksServer.runImageScan(ctx, imageName, regUsername, regSecret)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to run container image scan: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(responseBytes)), nil
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -846,6 +880,7 @@ func mcpServerEntrypoint() error {
 	createNetworkScanningTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
+	createImageScanningTools(ksServer)
 
 	// Start the server
 	if err := server.ServeStdio(s); err != nil {
@@ -908,6 +943,25 @@ func createIaCScanningTools(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(iacScanTool, ksServer.toolHandler(iacScanTool.Name))
+}
+
+func createImageScanningTools(ksServer *KubescapeMcpserver) {
+	scanImageTool := mcp.NewTool(
+		"scan_container_image",
+		mcp.WithDescription("Run an on-demand container image vulnerability scan and return structured JSON containing matches, vulnerabilities, and severities"),
+		mcp.WithString("image_name",
+			mcp.Required(),
+			mcp.Description("Name of the container image to scan (e.g., nginx:alpine)"),
+		),
+		mcp.WithString("username",
+			mcp.Description("Username for registry authentication (optional)"),
+		),
+		mcp.WithString("password",
+			mcp.Description("Password for registry authentication (optional)"),
+		),
+	)
+
+	ksServer.s.AddTool(scanImageTool, ksServer.toolHandler(scanImageTool.Name))
 }
 
 func GetMCPServerCmd() *cobra.Command {

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -46,23 +46,36 @@ func (ksServer *KubescapeMcpserver) getImageScanService(ctx context.Context) (*i
 		return ksServer.imageScanSvc, nil
 	}
 
+	type initResult struct {
+		svc *imagescan.Service
+		err error
+	}
+
+	initCh := make(chan initResult, 1)
+	go func() {
+		distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)
+		if err != nil {
+			initCh <- initResult{err: fmt.Errorf("failed to initialize default Grype database configuration: %w", err)}
+			return
+		}
+		svc, err := imagescan.NewScanService(distCfg, installCfg)
+		if err != nil {
+			initCh <- initResult{err: fmt.Errorf("failed to initialize image scan service: %w", err)}
+			return
+		}
+		initCh <- initResult{svc: svc}
+	}()
+
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+		return nil, fmt.Errorf("image scan service initialization timed out or was canceled: %w", ctx.Err())
+	case res := <-initCh:
+		if res.err != nil {
+			return nil, res.err
+		}
+		ksServer.imageScanSvc = res.svc
+		return ksServer.imageScanSvc, nil
 	}
-
-	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(ksServer.dbListingURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize default Grype database configuration: %w", err)
-	}
-	svc, err := imagescan.NewScanService(distCfg, installCfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize image scan service: %w", err)
-	}
-
-	ksServer.imageScanSvc = svc
-	return ksServer.imageScanSvc, nil
 }
 
 func (ksServer *KubescapeMcpserver) getKsClient() (spdxv1beta1.SpdxV1beta1Interface, error) {
@@ -914,9 +927,6 @@ func mcpServerEntrypoint() error {
 	}
 
 	dbListingURL := os.Getenv("KS_GRYPE_LISTING_URL")
-	if dbListingURL == "" {
-		dbListingURL = os.Getenv("GRYPE_DB_LISTING_URL")
-	}
 
 	ksServer := &KubescapeMcpserver{
 		s:            s,

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -58,11 +58,20 @@ func (ksServer *KubescapeMcpserver) getImageScanService(ctx context.Context) (*i
 			initCh <- initResult{err: fmt.Errorf("failed to initialize default Grype database configuration: %w", err)}
 			return
 		}
-		svc, err := imagescan.NewScanService(distCfg, installCfg)
+		svc, err := imagescan.NewRemoteOnlyScanService(distCfg, installCfg)
 		if err != nil {
 			initCh <- initResult{err: fmt.Errorf("failed to initialize image scan service: %w", err)}
 			return
 		}
+
+		ksServer.imageScanSvcMu.Lock()
+		if ksServer.imageScanSvc == nil {
+			ksServer.imageScanSvc = svc
+		} else {
+			svc.Close()
+		}
+		ksServer.imageScanSvcMu.Unlock()
+
 		initCh <- initResult{svc: svc}
 	}()
 
@@ -73,8 +82,7 @@ func (ksServer *KubescapeMcpserver) getImageScanService(ctx context.Context) (*i
 		if res.err != nil {
 			return nil, res.err
 		}
-		ksServer.imageScanSvc = res.svc
-		return ksServer.imageScanSvc, nil
+		return res.svc, nil
 	}
 }
 

--- a/cmd/mcpserver/mcpserver_arguments_test.go
+++ b/cmd/mcpserver/mcpserver_arguments_test.go
@@ -22,6 +22,7 @@ func TestRegisteredStorageToolsRejectMalformedArguments(t *testing.T) {
 		"list_vulnerability_matches_for_cve",
 		"list_configuration_security_scan_manifests",
 		"get_configuration_security_scan_manifest",
+		"scan_container_image",
 	}
 	malformed := []struct {
 		name      string
@@ -177,5 +178,6 @@ func newRegisteredStorageToolTestServer(objects ...runtime.Object) *KubescapeMcp
 	}
 	createVulnerabilityToolsAndResources(ksServer)
 	createConfigurationsToolsAndResources(ksServer)
+	createImageScanningTools(ksServer)
 	return ksServer
 }

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -257,8 +257,6 @@ func TestValidateImageReference(t *testing.T) {
 		{name: "absolute path", imageName: "/etc/shadow"},
 		{name: "relative path dot slash", imageName: "./local-image"},
 		{name: "parent path dot dot slash", imageName: "../parent-dir"},
-		{name: "bare relative path etc/passwd", imageName: "etc/passwd"},
-		{name: "bare directory tmp", imageName: "tmp"},
 		{name: "invalid characters", imageName: "invalid reference with spaces"},
 	}
 

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -228,6 +228,8 @@ func TestScanContainerImageValidation(t *testing.T) {
 		{name: "invalid password type", arguments: map[string]any{"image_name": "nginx:alpine", "password": 456}, wantError: "password argument must be a string"},
 		{name: "invalid include_matches type", arguments: map[string]any{"image_name": "nginx:alpine", "include_matches": "true"}, wantError: "include_matches argument must be a boolean"},
 		{name: "invalid severity type", arguments: map[string]any{"image_name": "nginx:alpine", "severity": 123}, wantError: "severity argument must be a string"},
+		{name: "invalid severity value typo", arguments: map[string]any{"image_name": "nginx:alpine", "severity": "Hihg"}, wantError: "invalid severity \"Hihg\": must be one of Critical, High, Medium, Low, Negligible, Unknown"},
+		{name: "invalid severity value bogus", arguments: map[string]any{"image_name": "nginx:alpine", "severity": "bogus"}, wantError: "invalid severity \"bogus\": must be one of Critical, High, Medium, Low, Negligible, Unknown"},
 	}
 
 	for _, test := range tests {
@@ -249,11 +251,14 @@ func TestValidateImageReference(t *testing.T) {
 		{name: "dir prefix", imageName: "dir:/"},
 		{name: "file prefix", imageName: "file:/etc/passwd"},
 		{name: "sbom prefix", imageName: "sbom:/some/file"},
+		{name: "purl prefix", imageName: "purl:/etc/passwd"},
 		{name: "oci-dir prefix", imageName: "oci-dir:/path"},
 		{name: "docker-archive prefix", imageName: "docker-archive:/path"},
 		{name: "absolute path", imageName: "/etc/shadow"},
 		{name: "relative path dot slash", imageName: "./local-image"},
 		{name: "parent path dot dot slash", imageName: "../parent-dir"},
+		{name: "bare relative path etc/passwd", imageName: "etc/passwd"},
+		{name: "bare directory tmp", imageName: "tmp"},
 		{name: "invalid characters", imageName: "invalid reference with spaces"},
 	}
 
@@ -365,5 +370,3 @@ func TestProcessMatches(t *testing.T) {
 		assert.Equal(t, 0, resp.Severities["Unknown"])
 	})
 }
-
-

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/anchore/grype/grype/presenter/models"
 	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	storagefake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -225,6 +226,8 @@ func TestScanContainerImageValidation(t *testing.T) {
 		{name: "invalid image_name type", arguments: map[string]any{"image_name": 123}, wantError: "image_name argument must be a string"},
 		{name: "invalid username type", arguments: map[string]any{"image_name": "nginx:alpine", "username": true}, wantError: "username argument must be a string"},
 		{name: "invalid password type", arguments: map[string]any{"image_name": "nginx:alpine", "password": 456}, wantError: "password argument must be a string"},
+		{name: "invalid include_matches type", arguments: map[string]any{"image_name": "nginx:alpine", "include_matches": "true"}, wantError: "include_matches argument must be a boolean"},
+		{name: "invalid severity type", arguments: map[string]any{"image_name": "nginx:alpine", "severity": 123}, wantError: "severity argument must be a string"},
 	}
 
 	for _, test := range tests {
@@ -237,4 +240,130 @@ func TestScanContainerImageValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateImageReference(t *testing.T) {
+	invalidImages := []struct {
+		name      string
+		imageName string
+	}{
+		{name: "dir prefix", imageName: "dir:/"},
+		{name: "file prefix", imageName: "file:/etc/passwd"},
+		{name: "sbom prefix", imageName: "sbom:/some/file"},
+		{name: "oci-dir prefix", imageName: "oci-dir:/path"},
+		{name: "docker-archive prefix", imageName: "docker-archive:/path"},
+		{name: "absolute path", imageName: "/etc/shadow"},
+		{name: "relative path dot slash", imageName: "./local-image"},
+		{name: "parent path dot dot slash", imageName: "../parent-dir"},
+		{name: "invalid characters", imageName: "invalid reference with spaces"},
+	}
+
+	for _, tt := range invalidImages {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			err := validateImageReference(tt.imageName)
+			require.Error(t, err)
+		})
+	}
+
+	validImages := []string{
+		"nginx:alpine",
+		"gcr.io/distroless/static:latest",
+		"ubuntu@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+
+	for _, img := range validImages {
+		t.Run("accepts "+img, func(t *testing.T) {
+			err := validateImageReference(img)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestProcessMatches(t *testing.T) {
+	// Import models for presenter matches
+	matches := []models.Match{
+		{
+			Vulnerability: models.Vulnerability{
+				VulnerabilityMetadata: models.VulnerabilityMetadata{
+					ID:       "CVE-2024-0001",
+					Severity: "High",
+				},
+			},
+		},
+		{
+			// Duplicate CVE match across different package location
+			Vulnerability: models.Vulnerability{
+				VulnerabilityMetadata: models.VulnerabilityMetadata{
+					ID:       "CVE-2024-0001",
+					Severity: "High",
+				},
+			},
+		},
+		{
+			// Lowercase severity
+			Vulnerability: models.Vulnerability{
+				VulnerabilityMetadata: models.VulnerabilityMetadata{
+					ID:       "CVE-2024-0002",
+					Severity: "critical",
+				},
+			},
+		},
+		{
+			// Missing severity
+			Vulnerability: models.Vulnerability{
+				VulnerabilityMetadata: models.VulnerabilityMetadata{
+					ID:       "CVE-2024-0003",
+					Severity: "",
+				},
+			},
+		},
+		{
+			// Low severity
+			Vulnerability: models.Vulnerability{
+				VulnerabilityMetadata: models.VulnerabilityMetadata{
+					ID:       "CVE-2024-0004",
+					Severity: "Low",
+				},
+			},
+		},
+	}
+
+	t.Run("default summary mode without matches array", func(t *testing.T) {
+		resp := processMatches("nginx:alpine", matches, false, "")
+
+		assert.Equal(t, "nginx:alpine", resp.Image)
+		assert.Equal(t, 4, resp.TotalUniqueCVEs)
+		assert.Nil(t, resp.Matches) // omitted when includeMatches is false
+
+		// Verify severity counts match total unique CVEs
+		totalCount := 0
+		for _, count := range resp.Severities {
+			totalCount += count
+		}
+		assert.Equal(t, resp.TotalUniqueCVEs, totalCount)
+
+		assert.Equal(t, 1, resp.Severities["High"])
+		assert.Equal(t, 1, resp.Severities["Critical"])
+		assert.Equal(t, 1, resp.Severities["Unknown"])
+		assert.Equal(t, 1, resp.Severities["Low"])
+	})
+
+	t.Run("include matches mode", func(t *testing.T) {
+		resp := processMatches("nginx:alpine", matches, true, "")
+
+		assert.Equal(t, 4, resp.TotalUniqueCVEs)
+		assert.Len(t, resp.Matches, 5) // all 5 raw matches included
+	})
+
+	t.Run("severity filtering", func(t *testing.T) {
+		resp := processMatches("nginx:alpine", matches, false, "High")
+
+		// Only Critical and High should remain (CVE-2024-0001 and CVE-2024-0002)
+		assert.Equal(t, 2, resp.TotalUniqueCVEs)
+		assert.Equal(t, 1, resp.Severities["High"])
+		assert.Equal(t, 1, resp.Severities["Critical"])
+		assert.Equal(t, 0, resp.Severities["Low"])
+		assert.Equal(t, 0, resp.Severities["Unknown"])
+	})
+}
+
 

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -212,3 +212,29 @@ func TestReadResourceWithFakeClient(t *testing.T) {
 		})
 	}
 }
+
+func TestScanContainerImageValidation(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		wantError string
+	}{
+		{name: "missing image_name", arguments: map[string]any{}, wantError: "image_name argument is required and cannot be empty"},
+		{name: "empty image_name", arguments: map[string]any{"image_name": "  "}, wantError: "image_name argument is required and cannot be empty"},
+		{name: "invalid image_name type", arguments: map[string]any{"image_name": 123}, wantError: "image_name argument must be a string"},
+		{name: "invalid username type", arguments: map[string]any{"image_name": "nginx:alpine", "username": true}, wantError: "username argument must be a string"},
+		{name: "invalid password type", arguments: map[string]any{"image_name": "nginx:alpine", "password": 456}, wantError: "password argument must be a string"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := ksServer.CallTool(context.Background(), "scan_container_image", test.arguments)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsError)
+			assert.Equal(t, test.wantError, toolResultText(t, result))
+		})
+	}
+}
+

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -247,10 +247,9 @@ Run an on-demand container image vulnerability scan and return structured JSON c
 ```json
 {
   "image": "nginx:alpine",
-  "total_vulnerabilities": 2,
+  "total_vulnerabilities": 1,
   "severities": {
-    "Critical": 1,
-    "High": 1
+    "Critical": 1
   },
   "vulnerabilities": [
     {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -229,6 +229,42 @@ Run an on-demand, live Network security scan (evaluating network-related control
 }
 ```
 
+#### `scan_container_image`
+
+Run an on-demand container image vulnerability scan and return structured JSON containing deduplicated vulnerabilities, severity counts, and optional match details.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image_name` | string | Yes | Name of the remote container image to scan (e.g. `"nginx:alpine"`) |
+| `username` | string | No | Username for registry authentication (optional) |
+| `password` | string | No | Password for registry authentication (optional) |
+| `include_matches` | boolean | No | Include detailed match location and package info for each vulnerability (optional, default: `false`) |
+| `severity` | string | No | Filter vulnerabilities by minimum severity (e.g. `"Low"`, `"Medium"`, `"High"`, `"Critical"`) |
+
+**Example Response:**
+```json
+{
+  "image": "nginx:alpine",
+  "total_vulnerabilities": 2,
+  "severities": {
+    "Critical": 1,
+    "High": 1
+  },
+  "vulnerabilities": [
+    {
+      "id": "CVE-2023-12345",
+      "severity": "Critical",
+      "package": {
+        "name": "libssl",
+        "version": "1.1.1"
+      }
+    }
+  ]
+}
+```
+
 ## Resource Templates
 
 The MCP server also exposes resource templates for direct access to data:
@@ -324,6 +360,8 @@ kubescape version
 - It provides read-only access to vulnerability and configuration data
 - No cluster modifications are made through the MCP server
 - Consider running with a service account that has limited permissions in production
+- **Credential Handling**: The `scan_container_image` tool accepts optional registry credentials (`username` and `password`). Be aware that parameters supplied to MCP tools may be retained in client conversation logs or model contexts depending on your client environment.
+- **Image Reference Validation**: The `scan_container_image` tool validates image names as remote image references and rejects local file paths and scheme prefixes (such as `dir:`, `file:`, `sbom:`) to prevent unauthorized local filesystem access.
 
 ## Related Documentation
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -361,6 +361,7 @@ kubescape version
 - Consider running with a service account that has limited permissions in production
 - **Credential Handling**: The `scan_container_image` tool accepts optional registry credentials (`username` and `password`). Be aware that parameters supplied to MCP tools may be retained in client conversation logs or model contexts depending on your client environment.
 - **Image Reference Validation**: The `scan_container_image` tool validates image names as remote image references and rejects local file paths and scheme prefixes (such as `dir:`, `file:`, `sbom:`) to prevent unauthorized local filesystem access.
+- **Air-Gapped Environments**: In air-gapped environments, set the `KS_GRYPE_LISTING_URL` environment variable to point to your internal Grype vulnerability database mirror listing URL.
 
 ## Related Documentation
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -130,7 +130,7 @@ func validateDBLoad(loadErr error, status *vulnerability.ProviderStatus) error {
 	return nil
 }
 
-func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
+func getProviderConfig(creds RegistryCredentials, sources []string) pkg.ProviderConfig {
 	syftCreds := []image.RegistryCredentials{{Username: creds.Username, Password: creds.Password}}
 	regOpts := &image.RegistryOptions{
 		Credentials: syftCreds,
@@ -139,7 +139,7 @@ func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
 		SyftProviderConfig: pkg.SyftProviderConfig{
 			RegistryOptions: regOpts,
 			SBOMOptions:     syft.DefaultCreateSBOMConfig(),
-			Sources:         []string{"registry"},
+			Sources:         sources,
 		},
 		SynthesisConfig: pkg.SynthesisConfig{
 			GenerateMissingCPEs: true,
@@ -153,7 +153,10 @@ func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
 // It performs image scanning and everything needed in between.
 type Service struct {
 	useDefaultMatchers bool
-	vp                 vulnerability.Provider
+	// sources specifies allowed provider sources (nil = all providers).
+	// Used by MCP server to restrict scans to remote registry providers.
+	sources []string
+	vp      vulnerability.Provider
 }
 
 func getIgnoredMatches(vulnerabilityExceptions []string, vp vulnerability.Provider, packages []pkg.Package, pkgContext pkg.Context, useDefaultMatchers bool) (*match.Matches, []match.IgnoredMatch, error) {
@@ -218,7 +221,7 @@ func filterMatchesBasedOnSeverity(severityExceptions []string, remainingMatches 
 }
 
 func (s *Service) Scan(_ context.Context, userInput string, creds RegistryCredentials, vulnerabilityExceptions, severityExceptions []string) (*cautils.ImageScanData, error) {
-	packages, pkgContext, sbom, err := pkg.Provide(userInput, getProviderConfig(creds))
+	packages, pkgContext, sbom, err := pkg.Provide(userInput, getProviderConfig(creds, s.sources))
 	if err != nil {
 		return nil, err
 	}
@@ -275,6 +278,16 @@ func NewScanService(distCfg distribution.Config, installCfg installation.Config)
 }
 
 func NewScanServiceWithMatchers(distCfg distribution.Config, installCfg installation.Config, useDefaultMatchers bool) (*Service, error) {
+	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, useDefaultMatchers, nil)
+}
+
+// NewRemoteOnlyScanService creates a Service restricted to remote registry sources only,
+// preventing resolution of local files or local daemon images (used by MCP server).
+func NewRemoteOnlyScanService(distCfg distribution.Config, installCfg installation.Config) (*Service, error) {
+	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, true, []string{"registry"})
+}
+
+func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCfg installation.Config, useDefaultMatchers bool, sources []string) (*Service, error) {
 	vp, status, err := NewVulnerabilityDB(distCfg, installCfg, true)
 	if err = validateDBLoad(err, status); err != nil {
 		return nil, err
@@ -282,6 +295,7 @@ func NewScanServiceWithMatchers(distCfg distribution.Config, installCfg installa
 	return &Service{
 		vp:                 vp,
 		useDefaultMatchers: useDefaultMatchers,
+		sources:            sources,
 	}, nil
 }
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -139,6 +139,7 @@ func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
 		SyftProviderConfig: pkg.SyftProviderConfig{
 			RegistryOptions: regOpts,
 			SBOMOptions:     syft.DefaultCreateSBOMConfig(),
+			Sources:         []string{"registry"},
 		},
 		SynthesisConfig: pkg.SynthesisConfig{
 			GenerateMissingCPEs: true,

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -133,8 +133,6 @@ func validateDBLoad(loadErr error, status *vulnerability.ProviderStatus) error {
 }
 
 func getProviderConfig(creds RegistryCredentials, sources []string) pkg.ProviderConfig {
-	syftCreds := []image.RegistryCredentials{{Username: creds.Username, Password: creds.Password}}
-func getProviderConfig(creds RegistryCredentials) pkg.ProviderConfig {
 	var syftCreds []image.RegistryCredentials
 	if creds.hasAuthenticator() {
 		syftCreds = append(syftCreds, image.RegistryCredentials{

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -238,7 +238,7 @@ func TestGetProviderConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			providerConfig := getProviderConfig(tt.creds)
+			providerConfig := getProviderConfig(tt.creds, nil)
 			assert.NotNil(t, providerConfig)
 			assert.Equal(t, true, providerConfig.GenerateMissingCPEs)
 		})


### PR DESCRIPTION
## Overview
This PR implements **KS-INT-03: On-Demand Container Image Vulnerability Scanning in MCP Server**.
It introduces a new tool `scan_container_image` to the Kubescape MCP server allowing AI coding and DevOps assistants to run on-demand vulnerability scans against container images directly from the MCP interface.

Features:
- Registers the tool `scan_container_image` in `cmd/mcpserver`.
- Accepts required parameter `image_name` (e.g., `nginx:alpine`) and optional registry credentials `username` and `password`.
- Connects to the underlying `imagescan.Service` to perform live image scanning using Syft and Grype.
- Returns a structured JSON payload containing:
  - `image`: Target image identifier.
  - `matches`: List of detailed vulnerability findings (`models.Match`).
  - `vulnerabilities`: De-duplicated list of distinct vulnerability models (`models.Vulnerability`).
  - `severities`: Aggregated severity counts (`map[string]int`).

## How to Test
1. Compile and build the Kubescape CLI: `make build` or `go build -v .`
2. Start the MCP server: `kubescape mcpserver`
3. Call the `scan_container_image` tool via any connected MCP client with argument `{"image_name": "nginx:alpine"}`.
4. Verify that the structured vulnerability findings, unique CVE list, and severity count mappings are returned in valid JSON format.

## Examples/Screenshots
Sample tool execution response structure:
```json
{
  "image": "nginx:alpine",
  "severities": {
    "High": 2,
    "Medium": 7,
    "Low": 1
  },
  "vulnerabilities": [...],
  "matches": [...]
}
```

## Related issues/PRs:
* Resolved #2707

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container image vulnerability scanning through the MCP server.
  * Supports remote and private images with optional registry credentials.
  * Provides JSON results with severity counts, optional vulnerability details, and minimum-severity filtering.
  * Includes cancellable scans with timeout handling.

* **Bug Fixes**
  * Improved validation and error reporting for invalid image references and scan requests.
  * Prevents duplicate vulnerability results.

* **Documentation**
  * Added usage, response-format, and security guidance for image scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->