### PR TITLE
fix(core): treat closed/non-interactive stdin as refusal in userConfirmed to prevent CPU spin

### DIFF
--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -4,19 +4,32 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/pkg/fixhandler"
+	"github.com/mattn/go-isatty"
 )
 
 const (
 	noChangesApplied     = "No changes were applied."
 	noResourcesToFix     = "No issues to fix."
 	confirmationQuestion = "Would you like to apply the changes to the files above? [y|n]: "
+
+	// maxConfirmRetries bounds retries on a read error we don't recognize as
+	// permanent, so any stdin state the isTerminal check doesn't catch still
+	// can't turn into the unbounded hot loop from #2711.
+	maxConfirmRetries = 100
+
+	nonInteractiveWarning = "stdin is not interactive; treating the fix confirmation as declined and applying no changes (pass --no-confirm to apply without a prompt)"
+	stdinClosedWarning    = "stdin was closed before a confirmation was given; treating the fix confirmation as declined and applying no changes (pass --no-confirm to apply without a prompt)"
 )
+
+// isTerminal is a var (not a direct isatty.IsTerminal call) so tests can stub it.
+var isTerminal = isatty.IsTerminal
 
 func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	logger.L().Info("Reading report file...")
@@ -94,25 +107,41 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 }
 
 func userConfirmed() bool {
+	if !isTerminal(os.Stdin.Fd()) {
+		// Non-interactive stdin (closed, /dev/null, a redirected file, a pipe
+		// whose reads fail outright, ...) will never produce an answer: no
+		// amount of retrying fmt.Scanln fixes that. Treat it as a decline up
+		// front instead of ever entering the retry loop.
+		logger.L().Warning(nonInteractiveWarning)
+		return false
+	}
+	return confirm(os.Stdin)
+}
+
+// confirm reads y/n answers from in, reprompting on unparseable input (e.g. a
+// bare Enter). It is bounded and treats EOF as a decline so a read that can
+// never succeed can't turn into an unbounded retry loop (#2711).
+func confirm(in io.Reader) bool {
 	var input string
 
-	for {
+	for attempt := 0; attempt < maxConfirmRetries; attempt++ {
 		fmt.Println(confirmationQuestion)
-		if _, err := fmt.Scanln(&input); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				// stdin is closed or non-interactive: no answer will ever come,
-				// so treat it as a refusal instead of retrying forever.
+		if _, err := fmt.Fscanln(in, &input); err != nil {
+			if errors.Is(err, io.EOF) {
+				logger.L().Warning(stdinClosedWarning)
 				return false
 			}
 			continue
 		}
 
-		input = strings.ToLower(input)
-		switch input {
+		switch strings.ToLower(input) {
 		case "y", "yes":
 			return true
 		case "n", "no":
 			return false
 		}
 	}
+
+	logger.L().Warning("no valid confirmation received after repeated attempts; treating as declined and applying no changes")
+	return false
 }

--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -28,8 +28,15 @@ const (
 	stdinClosedWarning    = "stdin was closed before a confirmation was given; treating the fix confirmation as declined and applying no changes (pass --no-confirm to apply without a prompt)"
 )
 
-// isTerminal is a var (not a direct isatty.IsTerminal call) so tests can stub it.
-var isTerminal = isatty.IsTerminal
+// isTerminal and isCygwinTerminal are vars (not direct isatty calls) so tests
+// can stub them. Both must be checked: on Windows under mintty (Git Bash,
+// MSYS2), stdin is a named pipe rather than a console, so IsTerminal alone
+// returns false for a real interactive session — IsCygwinTerminal is the
+// isatty-recommended way to detect that case.
+var (
+	isTerminal       = isatty.IsTerminal
+	isCygwinTerminal = isatty.IsCygwinTerminal
+)
 
 func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	logger.L().Info("Reading report file...")
@@ -107,7 +114,8 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 }
 
 func userConfirmed() bool {
-	if !isTerminal(os.Stdin.Fd()) {
+	fd := os.Stdin.Fd()
+	if !isTerminal(fd) && !isCygwinTerminal(fd) {
 		// Non-interactive stdin (closed, /dev/null, a redirected file, a pipe
 		// whose reads fail outright, ...) will never produce an answer: no
 		// amount of retrying fmt.Scanln fixes that. Treat it as a decline up

--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -97,6 +99,11 @@ func userConfirmed() bool {
 	for {
 		fmt.Println(confirmationQuestion)
 		if _, err := fmt.Scanln(&input); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				// stdin is closed or non-interactive: no answer will ever come,
+				// so treat it as a refusal instead of retrying forever.
+				return false
+			}
 			continue
 		}
 

--- a/core/core/fix_test.go
+++ b/core/core/fix_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -59,6 +60,33 @@ func TestUserConfirmed(t *testing.T) {
 
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestUserConfirmed_ClosedStdinReturnsFalse guards against a hang: if stdin is
+// closed or non-interactive (e.g. `kubescape fix < /dev/null`), fmt.Scanln
+// fails with io.EOF on every call. userConfirmed must treat that as a refusal
+// instead of busy-looping forever retrying a read that can never succeed.
+func TestUserConfirmed_ClosedStdinReturnsFalse(t *testing.T) {
+	originalStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, w.Close()) // close the write end so reads see EOF immediately
+	os.Stdin = r
+	defer func() {
+		os.Stdin = originalStdin
+	}()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- userConfirmed()
+	}()
+
+	select {
+	case got := <-done:
+		assert.False(t, got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("userConfirmed did not return after stdin EOF; it is hanging/spinning")
 	}
 }
 

--- a/core/core/fix_test.go
+++ b/core/core/fix_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -20,74 +20,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserConfirmed(t *testing.T) {
+func TestConfirm(t *testing.T) {
 	tests := []struct {
+		name  string
 		input string
 		want  bool
 	}{
-		{
-			input: "yes",
-			want:  true,
-		},
-		{
-			input: "y",
-			want:  true,
-		},
-		{
-			input: "no",
-			want:  false,
-		},
-		{
-			input: "n",
-			want:  false,
-		},
+		{name: "yes", input: "yes\n", want: true},
+		{name: "y", input: "y\n", want: true},
+		{name: "no", input: "no\n", want: false},
+		{name: "n", input: "n\n", want: false},
+		{name: "retries past blank lines then accepts", input: "\n\n  \ny\n", want: true},
+		{name: "EOF before any answer is a decline", input: "", want: false},
 	}
 
 	for _, tt := range tests {
-		t.Run(string(tt.input), func(t *testing.T) {
-			originalStdin := os.Stdin
-			r, w, _ := os.Pipe()
-			os.Stdin = r
-			defer func() {
-				os.Stdin = originalStdin
-			}()
-
-			go func() {
-				fmt.Fprintln(w, tt.input)
-			}()
-
-			got := userConfirmed()
-
+		t.Run(tt.name, func(t *testing.T) {
+			got := confirm(strings.NewReader(tt.input))
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-// TestUserConfirmed_ClosedStdinReturnsFalse guards against a hang: if stdin is
-// closed or non-interactive (e.g. `kubescape fix < /dev/null`), fmt.Scanln
-// fails with io.EOF on every call. userConfirmed must treat that as a refusal
-// instead of busy-looping forever retrying a read that can never succeed.
-func TestUserConfirmed_ClosedStdinReturnsFalse(t *testing.T) {
+// TestUserConfirmed_NonInteractiveStdinDeclines guards against #2711: on
+// non-interactive stdin (closed, /dev/null, a redirected file, a pipe whose
+// reads fail outright, ...) no answer can ever arrive, so userConfirmed must
+// decline up front instead of ever entering the retry loop.
+func TestUserConfirmed_NonInteractiveStdinDeclines(t *testing.T) {
+	prevIsTerminal := isTerminal
+	t.Cleanup(func() { isTerminal = prevIsTerminal })
+	isTerminal = func(uintptr) bool { return false }
+
+	assert.False(t, userConfirmed())
+}
+
+// TestUserConfirmed_InteractiveReadsStdin checks the (small) wiring in
+// userConfirmed itself — that it reads from os.Stdin once isTerminal says
+// stdin is interactive — since TestConfirm exercises the retry/parsing logic
+// directly and wouldn't catch a wiring mistake here.
+func TestUserConfirmed_InteractiveReadsStdin(t *testing.T) {
+	prevIsTerminal := isTerminal
+	t.Cleanup(func() { isTerminal = prevIsTerminal })
+	isTerminal = func(uintptr) bool { return true }
+
 	originalStdin := os.Stdin
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
-	require.NoError(t, w.Close()) // close the write end so reads see EOF immediately
+	t.Cleanup(func() { os.Stdin = originalStdin })
 	os.Stdin = r
-	defer func() {
-		os.Stdin = originalStdin
-	}()
 
-	done := make(chan bool, 1)
-	go func() {
-		done <- userConfirmed()
-	}()
+	_, err = w.WriteString("y\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
 
-	select {
-	case got := <-done:
-		assert.False(t, got)
-	case <-time.After(5 * time.Second):
-		t.Fatal("userConfirmed did not return after stdin EOF; it is hanging/spinning")
-	}
+	assert.True(t, userConfirmed())
 }
 
 // --- Fix() orchestration -----------------------------------------------
@@ -184,8 +170,17 @@ func manifestContent(t *testing.T, dir string) string {
 	return string(b)
 }
 
+// withStdin simulates an interactive user typing input at the confirmation
+// prompt: it stubs isTerminal to true (userConfirmed's non-interactive
+// short-circuit would otherwise decline before ever reading from the pipe)
+// and feeds input through os.Stdin.
 func withStdin(t *testing.T, input string, fn func()) {
 	t.Helper()
+
+	prevIsTerminal := isTerminal
+	isTerminal = func(uintptr) bool { return true }
+	t.Cleanup(func() { isTerminal = prevIsTerminal })
+
 	originalStdin := os.Stdin
 	r, w, err := os.Pipe()
 	require.NoError(t, err)

--- a/core/core/fix_test.go
+++ b/core/core/fix_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,16 +43,70 @@ func TestConfirm(t *testing.T) {
 	}
 }
 
+// errReader always fails with a non-EOF error, simulating a persistent I/O
+// failure that confirm's error branch doesn't recognize as permanent (unlike
+// io.EOF). It exists to pin the maxConfirmRetries backstop without waiting
+// on 100 real reads' worth of wall-clock time.
+type errReader struct {
+	err   error
+	calls int
+}
+
+func (r *errReader) Read([]byte) (int, error) {
+	r.calls++
+	return 0, r.err
+}
+
+// TestConfirm_ExhaustsRetriesOnPersistentNonEOFError locks in the
+// maxConfirmRetries backstop: a read error that never resolves to EOF still
+// isn't treated as retryable forever, so no future non-EOF, non-recoverable
+// stdin state can reintroduce #2711's unbounded loop.
+func TestConfirm_ExhaustsRetriesOnPersistentNonEOFError(t *testing.T) {
+	r := &errReader{err: errors.New("simulated persistent read failure")}
+
+	got := confirm(r)
+
+	assert.False(t, got)
+	assert.Equal(t, maxConfirmRetries, r.calls,
+		"confirm must give up after exactly maxConfirmRetries reads, not loop forever")
+}
+
 // TestUserConfirmed_NonInteractiveStdinDeclines guards against #2711: on
 // non-interactive stdin (closed, /dev/null, a redirected file, a pipe whose
 // reads fail outright, ...) no answer can ever arrive, so userConfirmed must
 // decline up front instead of ever entering the retry loop.
 func TestUserConfirmed_NonInteractiveStdinDeclines(t *testing.T) {
-	prevIsTerminal := isTerminal
-	t.Cleanup(func() { isTerminal = prevIsTerminal })
+	prevIsTerminal, prevIsCygwinTerminal := isTerminal, isCygwinTerminal
+	t.Cleanup(func() { isTerminal, isCygwinTerminal = prevIsTerminal, prevIsCygwinTerminal })
 	isTerminal = func(uintptr) bool { return false }
+	isCygwinTerminal = func(uintptr) bool { return false }
 
 	assert.False(t, userConfirmed())
+}
+
+// TestUserConfirmed_MinttyStdinPrompts guards against a regression on the
+// isTerminal fix itself: on Windows under mintty (Git Bash, MSYS2), stdin is
+// a named pipe, so isatty.IsTerminal returns false even at a real
+// interactive session — only IsCygwinTerminal reports true there. If
+// userConfirmed only checked isTerminal, a real mintty user would be
+// silently declined on every `kubescape fix` regardless of what they typed.
+func TestUserConfirmed_MinttyStdinPrompts(t *testing.T) {
+	prevIsTerminal, prevIsCygwinTerminal := isTerminal, isCygwinTerminal
+	t.Cleanup(func() { isTerminal, isCygwinTerminal = prevIsTerminal, prevIsCygwinTerminal })
+	isTerminal = func(uintptr) bool { return false }
+	isCygwinTerminal = func(uintptr) bool { return true }
+
+	originalStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Stdin = originalStdin })
+	os.Stdin = r
+
+	_, err = w.WriteString("y\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.True(t, userConfirmed())
 }
 
 // TestUserConfirmed_InteractiveReadsStdin checks the (small) wiring in

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -291,6 +291,12 @@ kubescape fix results.json --dry-run
 kubescape fix results.json --no-confirm
 ```
 
+> **Note:** The confirmation prompt requires a real interactive terminal. If
+> stdin isn't a TTY — `kubescape fix results.json < /dev/null`, a piped
+> answer like `echo y | kubescape fix results.json`, or any CI/script
+> context — the prompt is skipped and no changes are applied. Use
+> `--no-confirm` to apply fixes in non-interactive contexts.
+
 ---
 
 ## kubescape patch


### PR DESCRIPTION
## Overview

- **Current Behavior:** `userConfirmed()` retried indefinitely on `fmt.Scanln` errors, causing a 100% CPU spin on non-interactive or unreadable stdin (`/dev/null`, `EISDIR`, `EBADF`).
- **Future Behavior:** Checks for a TTY via `isatty` before prompting. Non-interactive stdin declines immediately with a warning suggesting `--no-confirm`. `confirm()` is also bounded to 100 retries as a safety net.

> **Note:** Piped input (e.g., `echo y | kubescape fix`) is now treated as non-interactive and declined; use `--no-confirm` instead.

## Key Changes

- Added `isatty` checks (`IsTerminal` / `IsCygwinTerminal`) before entering prompt loop.
- Extracted bounded retry logic into `confirm()` for isolated `io.Reader` unit testing.
- Added warning logs on decline paths so CI pipeline failures aren't silent.
- Updated unit tests and CLI documentation.

## How to Test

```bash
# Run unit & race tests
go test -v ./core/core/... -run 'TestConfirm|TestUserConfirmed' -race -count=1

# Verify non-interactive stdin exits immediately
kubescape fix results.json < /dev/null
```

## Related issues/PRs

* Resolves #2711

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation handling for interactive commands.
  * Non-interactive or closed input now declines safely instead of retrying indefinitely.
  * Confirmation prompts stop after a maximum of 100 unsuccessful attempts.
  * Terminal detection now works more reliably across supported environments.

* **Documentation**
  * Clarified behavior for non-interactive `kubescape fix` usage and recommended CI option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->