### PR TITLE
fix(cel): resolve namespaceObject from collected namespaces and honor admission scoping offline

### DIFF
--- a/core/pkg/opaprocessor/cel/dispatch_test.go
+++ b/core/pkg/opaprocessor/cel/dispatch_test.go
@@ -104,3 +104,70 @@ func TestEvaluateControlUnknownControl(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "C-9999")
 }
+
+// capabilitiesPod is a Pod whose single container adds the given capabilities.
+func capabilitiesPod(name string, caps ...any) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": name, "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name":  "c",
+					"image": "nginx",
+					"securityContext": map[string]any{
+						"capabilities": map[string]any{"add": caps},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestEvaluateControlResolvesParamsEndToEnd runs a paramKind control (C-0046)
+// through the whole pipeline: bundle load, params resolution from the embedded
+// control configuration, and evaluation. Its expressions select
+// params.settings.insecureCapabilities with no has() guard, so if params were
+// not actually bound the selection would error and every result would carry
+// Err — the clean verdicts below are only reachable with the configuration
+// resolved for real. TestLoadVAPWithParams covers the loader half in
+// isolation; this is the two halves together, which nothing else exercises
+// (C-0017 above declares no paramKind).
+func TestEvaluateControlResolvesParamsEndToEnd(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	t.Run("capability listed in the embedded params fails the policy", func(t *testing.T) {
+		// SYS_ADMIN is in basic-control-configuration.yaml's insecureCapabilities.
+		eval, err := e.EvaluateControl(context.Background(), "C-0046", capabilitiesPod("privileged", "SYS_ADMIN"), nil)
+		require.NoError(t, err)
+		require.True(t, eval.Applicable)
+		require.NotEmpty(t, eval.Results)
+
+		violated := false
+		for _, res := range eval.Results {
+			require.NoError(t, res.Err, "an eval error here means params did not resolve")
+			if !res.Passed {
+				violated = true
+				assert.NotEmpty(t, res.Message)
+			}
+		}
+		assert.True(t, violated, "a pod adding SYS_ADMIN must violate C-0046")
+	})
+
+	t.Run("capability absent from the embedded params passes", func(t *testing.T) {
+		// NET_BIND_SERVICE is not in the vendored insecureCapabilities list, so a
+		// pass here proves the verdict came from the resolved values rather than
+		// from a short-circuit that never read them.
+		eval, err := e.EvaluateControl(context.Background(), "C-0046", capabilitiesPod("bind", "NET_BIND_SERVICE"), nil)
+		require.NoError(t, err)
+		require.True(t, eval.Applicable)
+		require.NotEmpty(t, eval.Results)
+
+		for _, res := range eval.Results {
+			require.NoError(t, res.Err, "an eval error here means params did not resolve")
+			assert.True(t, res.Passed)
+		}
+	})
+}

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -74,23 +74,31 @@ type VAP struct {
 // scan/admission parity. matchConditions is an admission-time gate we do not
 // evaluate yet; running a gated policy's validations unconditionally would emit
 // violations live admission never would, so we refuse the control instead. The
-// namespaceSelector and objectSelector on matchConstraints are the same kind of
-// gate (they exempt labelled objects at admission) and are refused for the same
-// reason: ignoring one would evaluate objects admission exempts. The error maps
-// to the same errored/skipped status a Rego eval error takes, never a silent
-// pass or a false violation. Removing a guard here is the seam for when the
-// evaluator learns to evaluate that gate.
+// error maps to the same errored/skipped status a Rego eval error takes, never a
+// silent pass or a false violation. Removing a guard here is the seam for when
+// the evaluator learns to evaluate that gate.
+//
+// A namespaceSelector is refused for a subtler reason. Its input is the
+// NAMESPACE's labels, and the scan only has those when some control's match
+// happened to collect Namespaces (the same best-effort behind the
+// namespaceObject binding, see the scanner's celNamespaceObjectFor). Evaluating
+// it against an absent namespace would silently exempt objects admission
+// matches, or match objects admission exempts, depending on the selector's
+// direction — both are silent parity breaks, where refusal is a loud skip. So
+// it stays refused not because the input never exists, but because it is not
+// GUARANTEED to exist; the seam for honoring it is guaranteeing Namespace
+// collection whenever a loaded policy needs it.
+//
+// The other matchConstraints narrowings do not need refusing, because their
+// inputs are on the scanned object itself and appliesTo evaluates them:
+// objectSelector (the object's own labels) and a resource rule's operations
+// and resourceNames (the object's own name).
 func (v *VAP) requireSupported() error {
 	if len(v.matchConditions) > 0 {
 		return fmt.Errorf("control %q uses spec.matchConditions, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
 	}
-	if v.matchConstraints != nil {
-		if selectorNarrows(v.matchConstraints.NamespaceSelector) {
-			return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
-		}
-		if selectorNarrows(v.matchConstraints.ObjectSelector) {
-			return fmt.Errorf("control %q scopes matchConstraints with an objectSelector, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
-		}
+	if v.matchConstraints != nil && selectorNarrows(v.matchConstraints.NamespaceSelector) {
+		return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, whose input (namespace labels) the scan cannot guarantee to have; refusing it to preserve scan/admission parity", v.ControlID)
 	}
 	return nil
 }

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
@@ -73,14 +74,33 @@ type VAP struct {
 // scan/admission parity. matchConditions is an admission-time gate we do not
 // evaluate yet; running a gated policy's validations unconditionally would emit
 // violations live admission never would, so we refuse the control instead. The
-// error maps to the same errored/skipped status a Rego eval error takes, never a
-// silent pass or a false violation. Removing this guard is the seam for when the
-// evaluator learns to evaluate matchConditions.
+// namespaceSelector and objectSelector on matchConstraints are the same kind of
+// gate (they exempt labelled objects at admission) and are refused for the same
+// reason: ignoring one would evaluate objects admission exempts. The error maps
+// to the same errored/skipped status a Rego eval error takes, never a silent
+// pass or a false violation. Removing a guard here is the seam for when the
+// evaluator learns to evaluate that gate.
 func (v *VAP) requireSupported() error {
 	if len(v.matchConditions) > 0 {
 		return fmt.Errorf("control %q uses spec.matchConditions, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
 	}
+	if v.matchConstraints != nil {
+		if selectorNarrows(v.matchConstraints.NamespaceSelector) {
+			return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
+		}
+		if selectorNarrows(v.matchConstraints.ObjectSelector) {
+			return fmt.Errorf("control %q scopes matchConstraints with an objectSelector, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
+		}
+	}
 	return nil
+}
+
+// selectorNarrows reports whether a label selector actually narrows anything.
+// Both nil and the empty selector match every object (the empty selector is
+// what the apiserver defaults an omitted one to), so only a selector carrying
+// requirements makes the policy one the offline engine cannot honor.
+func selectorNarrows(s *metav1.LabelSelector) bool {
+	return s != nil && (len(s.MatchLabels) > 0 || len(s.MatchExpressions) > 0)
 }
 
 // vapCatalog is everything indexed out of the embedded bundle. It is built once

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -180,3 +180,78 @@ spec:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "matchConditions")
 }
+
+// TestLoadVAPRefusesNarrowingSelectors proves a policy that narrows its
+// matchConstraints with a namespaceSelector or objectSelector is refused, the
+// same way a matchConditions gate is: the offline engine does not evaluate
+// selectors, and ignoring one would evaluate objects admission exempts. An
+// empty selector matches everything (it is what the apiserver defaults an
+// omitted one to), so it must NOT trip the refusal.
+func TestLoadVAPRefusesNarrowingSelectors(t *testing.T) {
+	policy := func(selectorYAML string) string {
+		return `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-1002
+  labels:
+    controlId: C-1002
+spec:
+  matchConstraints:
+` + selectorYAML + `    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  validations:
+  - expression: "false"
+`
+	}
+
+	cases := []struct {
+		name         string
+		selectorYAML string
+		refusedFor   string // empty: must be supported
+	}{
+		{
+			name: "namespaceSelector with labels is refused",
+			selectorYAML: `    namespaceSelector:
+      matchLabels:
+        env: prod
+`,
+			refusedFor: "namespaceSelector",
+		},
+		{
+			name: "objectSelector with expressions is refused",
+			selectorYAML: `    objectSelector:
+      matchExpressions:
+      - key: app
+        operator: Exists
+`,
+			refusedFor: "objectSelector",
+		},
+		{
+			name: "empty selectors match everything and are supported",
+			selectorYAML: `    namespaceSelector: {}
+    objectSelector: {}
+`,
+			refusedFor: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog, err := parseVAPBundle([]byte(policy(tc.selectorYAML)))
+			require.NoError(t, err)
+			vap := catalog.byControl["C-1002"]
+			require.NotNil(t, vap)
+
+			err = vap.requireSupported()
+			if tc.refusedFor == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.refusedFor)
+		})
+	}
+}

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -181,12 +181,15 @@ spec:
 	assert.Contains(t, err.Error(), "matchConditions")
 }
 
-// TestLoadVAPRefusesNarrowingSelectors proves a policy that narrows its
-// matchConstraints with a namespaceSelector or objectSelector is refused, the
-// same way a matchConditions gate is: the offline engine does not evaluate
-// selectors, and ignoring one would evaluate objects admission exempts. An
-// empty selector matches everything (it is what the apiserver defaults an
-// omitted one to), so it must NOT trip the refusal.
+// TestLoadVAPRefusesNarrowingSelectors pins which selector is refused and which
+// is not. namespaceSelector reads the NAMESPACE's labels, which the scan only
+// has when some control's match happened to collect Namespaces, so a policy
+// narrowing with it is refused (a loud skip) rather than evaluated against an
+// input that may be absent (a silent parity break). objectSelector reads the
+// scanned object's own labels, which the scan always has, so it is evaluated in
+// appliesTo instead of refused — see TestVAPAppliesToObjectSelector. An empty
+// selector matches everything (it is what the apiserver defaults an omitted one
+// to), so it must not trip the refusal either.
 func TestLoadVAPRefusesNarrowingSelectors(t *testing.T) {
 	policy := func(selectorYAML string) string {
 		return `apiVersion: admissionregistration.k8s.io/v1
@@ -221,13 +224,13 @@ spec:
 			refusedFor: "namespaceSelector",
 		},
 		{
-			name: "objectSelector with expressions is refused",
+			name: "objectSelector with expressions is supported, not refused",
 			selectorYAML: `    objectSelector:
       matchExpressions:
       - key: app
         operator: Exists
 `,
-			refusedFor: "objectSelector",
+			refusedFor: "",
 		},
 		{
 			name: "empty selectors match everything and are supported",

--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -13,11 +13,13 @@ import (
 // non-matching kind, which the scanner would otherwise record as a pass the
 // cluster never made (issue #2001).
 //
-// Matching is by resource rule (apiGroups/apiVersions/resources, honoring "*"
-// and excludeResourceRules). The label selectors and operations on
-// matchConstraints are not applied offline: the vendored bundle uses neither,
-// and ignoring them can only widen scope, which surfaces as an evaluated result
-// rather than a silently dropped one.
+// Matching is by resource rule (apiGroups/apiVersions/resources plus the rule's
+// operations, honoring "*" and excludeResourceRules). The scan models every
+// resource as a fresh CREATE (see stub.go), so a rule that fires only on other
+// operations does not match here either. The label selectors on matchConstraints
+// are not evaluated offline; a policy that narrows with one is refused at load
+// instead (see requireSupported), since ignoring it would evaluate objects
+// admission exempts.
 func (v *VAP) appliesTo(obj map[string]any) bool {
 	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
 		return true // no scoping info: evaluate (a malformed-policy edge)
@@ -64,9 +66,31 @@ func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 }
 
 func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource) bool {
-	return matchesValue(rule.APIGroups, gvr.Group) &&
+	return matchesOperation(rule.Operations) &&
+		matchesValue(rule.APIGroups, gvr.Group) &&
 		matchesValue(rule.APIVersions, gvr.Version) &&
 		matchesResource(rule.Resources, gvr.Resource)
+}
+
+// matchesOperation reports whether the rule fires on CREATE, the one operation
+// the offline scan models (request.operation is stubbed to CREATE, see stub.go).
+// A rule listing only UPDATE or DELETE never sees the CREATE we model, so at
+// admission the policy would not be handed the object and the scan must not
+// evaluate it either. This applies to exclude rules symmetrically: an exclusion
+// scoped to UPDATE does not exempt the CREATE we model. An empty list is invalid
+// on a real policy (the API requires at least one operation); treat it as
+// matching so a malformed rule surfaces as an evaluated result rather than a
+// silently dropped one, the same stance appliesTo takes on missing constraints.
+func matchesOperation(ops []admissionregistrationv1.OperationType) bool {
+	if len(ops) == 0 {
+		return true
+	}
+	for _, op := range ops {
+		if op == admissionregistrationv1.OperationAll || op == admissionregistrationv1.Create {
+			return true
+		}
+	}
+	return false
 }
 
 // matchesValue reports whether want is listed, treating "*" as "any".

--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -3,6 +3,9 @@ package cel
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -13,13 +16,18 @@ import (
 // non-matching kind, which the scanner would otherwise record as a pass the
 // cluster never made (issue #2001).
 //
-// Matching is by resource rule (apiGroups/apiVersions/resources plus the rule's
-// operations, honoring "*" and excludeResourceRules). The scan models every
-// resource as a fresh CREATE (see stub.go), so a rule that fires only on other
-// operations does not match here either. The label selectors on matchConstraints
-// are not evaluated offline; a policy that narrows with one is refused at load
-// instead (see requireSupported), since ignoring it would evaluate objects
-// admission exempts.
+// Matching covers everything on matchConstraints whose input the scanned
+// object itself carries: the resource rules (apiGroups/apiVersions/resources,
+// each rule's operations and resourceNames, honoring "*" and
+// excludeResourceRules) and the objectSelector, which matches the object's own
+// labels. The scan models every resource as a fresh CREATE (see stub.go), so a
+// rule that fires only on other operations does not match here either. The one
+// selector NOT evaluated is namespaceSelector — its input is the namespace's
+// labels, which the scan cannot guarantee to have — so a policy narrowing with
+// it is refused at load instead (see requireSupported). matchPolicy is
+// genuinely irrelevant offline: Equivalent matching only widens a rule across
+// API conversions, and a scan never converts — the object is matched at the
+// exact group/version it was scanned at.
 func (v *VAP) appliesTo(obj map[string]any) bool {
 	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
 		return true // no scoping info: evaluate (a malformed-policy edge)
@@ -28,10 +36,11 @@ func (v *VAP) appliesTo(obj map[string]any) bool {
 	if !ok {
 		return true // kind undeterminable; let evaluation proceed (it will error and skip)
 	}
+	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
 
 	included := false
 	for i := range v.matchConstraints.ResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], gvr) {
+		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], gvr, name) {
 			included = true
 			break
 		}
@@ -40,11 +49,41 @@ func (v *VAP) appliesTo(obj map[string]any) bool {
 		return false
 	}
 	for i := range v.matchConstraints.ExcludeResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], gvr) {
+		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], gvr, name) {
 			return false
 		}
 	}
-	return true
+	return objectSelectorMatches(v.matchConstraints.ObjectSelector, obj)
+}
+
+// objectSelectorMatches evaluates matchConstraints.objectSelector against the
+// object's own labels — fully resolvable offline, since the labels are on the
+// scanned object itself. The nil guard matters: an omitted selector means
+// "match everything" on a policy, but metav1.LabelSelectorAsSelector maps nil
+// to "match nothing", the exact opposite.
+//
+// Both malformed cases (a selector that will not parse, labels that are not a
+// string map) fall back to evaluating, the same stance appliesTo takes on an
+// undeterminable kind: widening surfaces as an evaluated result, while
+// narrowing on something we failed to read would drop the resource silently.
+// An object with no labels at all is not malformed — it is an empty set, which
+// correctly fails a matchLabels selector and satisfies a DoesNotExist one.
+func objectSelectorMatches(selector *metav1.LabelSelector, obj map[string]any) bool {
+	if selector == nil {
+		return true
+	}
+	sel, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return true
+	}
+	objLabels, found, err := unstructured.NestedStringMap(obj, "metadata", "labels")
+	if err != nil {
+		return true // labels present but not a string map
+	}
+	if !found {
+		objLabels = nil
+	}
+	return sel.Matches(labels.Set(objLabels))
 }
 
 // objectGVR guesses an object's GroupVersionResource from its apiVersion and
@@ -65,11 +104,30 @@ func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 	return gvr, true
 }
 
-func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource) bool {
+func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource, name string) bool {
 	return matchesOperation(rule.Operations) &&
 		matchesValue(rule.APIGroups, gvr.Group) &&
 		matchesValue(rule.APIVersions, gvr.Version) &&
-		matchesResource(rule.Resources, gvr.Resource)
+		matchesResource(rule.Resources, gvr.Resource) &&
+		matchesName(rule.ResourceNames, name)
+}
+
+// matchesName reports whether the rule's resourceNames admit the object's
+// metadata.name. An empty list is the common case and matches every name. The
+// empty-NAME edge mirrors admission: a resource created with generateName has
+// no name yet when admission evaluates it, so a named rule does not match it
+// there, and an offline manifest carrying only generateName gets the same
+// no-match here.
+func matchesName(allowed []string, name string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, a := range allowed {
+		if a == name && name != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // matchesOperation reports whether the rule fires on CREATE, the one operation

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func rule(groups, versions, resources []string) admissionregistrationv1.NamedRuleWithOperations {
@@ -192,5 +193,137 @@ func TestVAPAppliesToOperations(t *testing.T) {
 			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{withOps(pods, admissionregistrationv1.Update)},
 		}}
 		assert.True(t, v.appliesTo(obj("v1", "Pod")), "the exclusion only covers UPDATE, so the CREATE we model is still matched")
+	})
+}
+
+// TestBundleControlRulesAllMatchModeledCreate is the safety case for honoring
+// operations, and it is the assertion the kind sweep cannot make: that sweep
+// skips subresources, which is exactly where the bundle's non-CREATE rules
+// live. Every controlId-bearing policy must have rules the modeled CREATE
+// matches, otherwise that control silently loses those resources at scan time
+// (an exclusion is only Debug-logged, so there is no signal in the output). A
+// `make sync-vap` introducing an UPDATE-only control fails here instead.
+func TestBundleControlRulesAllMatchModeledCreate(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+	require.NotEmpty(t, catalog.byControl)
+
+	for id, vap := range catalog.byControl {
+		if vap.matchConstraints == nil {
+			continue
+		}
+		for _, rr := range vap.matchConstraints.ResourceRules {
+			assert.Truef(t, matchesOperation(rr.Operations),
+				"control %q has a rule scoped to %v, which the modeled CREATE will not match; that control silently loses those resources", id, rr.Operations)
+		}
+	}
+}
+
+// TestBundleUsesNoUnevaluatedScoping records the other half of the safety case:
+// the scoping knobs this package evaluates or refuses are all unused by the
+// vendored bundle today, so none of it changes a shipped control's behaviour.
+// When a sync does introduce one, this test is the notice that the handling
+// stopped being theoretical and wants checking against a real policy.
+func TestBundleUsesNoUnevaluatedScoping(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	for name, vap := range catalog.byName {
+		if vap.matchConstraints == nil {
+			continue
+		}
+		assert.Falsef(t, selectorNarrows(vap.matchConstraints.NamespaceSelector),
+			"policy %q now uses a namespaceSelector: loadVAP refuses it, so confirm a control-wide skip is the outcome you want", name)
+		assert.Falsef(t, selectorNarrows(vap.matchConstraints.ObjectSelector),
+			"policy %q now uses an objectSelector: appliesTo evaluates it against the object's labels, so confirm that matches the policy's intent", name)
+
+		rules := append(append([]admissionregistrationv1.NamedRuleWithOperations{}, vap.matchConstraints.ResourceRules...), vap.matchConstraints.ExcludeResourceRules...)
+		for _, rr := range rules {
+			assert.Emptyf(t, rr.ResourceNames,
+				"policy %q now uses resourceNames: appliesTo matches it against metadata.name, so confirm the scanned manifests carry the names it expects", name)
+		}
+	}
+}
+
+func TestVAPAppliesToObjectSelector(t *testing.T) {
+	pods := rule([]string{""}, []string{"v1"}, []string{"pods"})
+	labelled := func(labels map[string]any) map[string]any {
+		o := obj("v1", "Pod")
+		o["metadata"].(map[string]any)["labels"] = labels
+		return o
+	}
+
+	t.Run("matchLabels narrows to the labelled object", func(t *testing.T) {
+		v := vapWithConstraints(pods)
+		v.matchConstraints.ObjectSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+
+		assert.True(t, v.appliesTo(labelled(map[string]any{"app": "web"})))
+		assert.False(t, v.appliesTo(labelled(map[string]any{"app": "db"})), "a non-matching label must put the object out of scope")
+		assert.False(t, v.appliesTo(obj("v1", "Pod")), "an unlabelled object cannot satisfy matchLabels")
+	})
+
+	t.Run("matchExpressions are honored", func(t *testing.T) {
+		v := vapWithConstraints(pods)
+		v.matchConstraints.ObjectSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "skip", Operator: metav1.LabelSelectorOpDoesNotExist}},
+		}
+
+		assert.True(t, v.appliesTo(obj("v1", "Pod")))
+		assert.False(t, v.appliesTo(labelled(map[string]any{"skip": "true"})), "an object carrying the exempting label must be out of scope")
+	})
+
+	t.Run("nil and empty selectors match everything", func(t *testing.T) {
+		// The nil case is the one that bites: LabelSelectorAsSelector maps nil to
+		// "match nothing", the opposite of what an omitted selector means.
+		v := vapWithConstraints(pods)
+		assert.True(t, v.appliesTo(obj("v1", "Pod")), "an omitted objectSelector must not narrow anything")
+
+		v.matchConstraints.ObjectSelector = &metav1.LabelSelector{}
+		assert.True(t, v.appliesTo(obj("v1", "Pod")))
+		assert.True(t, v.appliesTo(labelled(map[string]any{"app": "web"})))
+	})
+}
+
+// TestVAPAppliesToResourceNames covers the third narrowing knob on a resource
+// rule. Ignoring it would evaluate every object of the kind against a policy
+// admission only ever hands one named object, which is a false violation on
+// objects admission exempts.
+func TestVAPAppliesToResourceNames(t *testing.T) {
+	named := func(resourceNames ...string) admissionregistrationv1.NamedRuleWithOperations {
+		r := rule([]string{""}, []string{"v1"}, []string{"pods"})
+		r.ResourceNames = resourceNames
+		return r
+	}
+	podNamed := func(name string) map[string]any {
+		o := obj("v1", "Pod")
+		o["metadata"].(map[string]any)["name"] = name
+		return o
+	}
+
+	t.Run("only the named resource is in scope", func(t *testing.T) {
+		v := vapWithConstraints(named("coredns"))
+		assert.True(t, v.appliesTo(podNamed("coredns")))
+		assert.False(t, v.appliesTo(podNamed("nginx")), "a rule naming one pod must not pull in every pod")
+	})
+
+	t.Run("an empty resourceNames list matches every name", func(t *testing.T) {
+		v := vapWithConstraints(named())
+		assert.True(t, v.appliesTo(podNamed("anything")))
+	})
+
+	t.Run("a named exclusion exempts only that resource", func(t *testing.T) {
+		v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{named()},
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{named("kube-proxy")},
+		}}
+		assert.False(t, v.appliesTo(podNamed("kube-proxy")))
+		assert.True(t, v.appliesTo(podNamed("nginx")))
+	})
+
+	t.Run("a generateName-only manifest does not match a named rule", func(t *testing.T) {
+		// Admission sees no name either at that point, so it would not match.
+		o := obj("v1", "Pod")
+		delete(o["metadata"].(map[string]any), "name")
+		assert.False(t, vapWithConstraints(named("coredns")).appliesTo(o))
 	})
 }

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -153,3 +153,44 @@ func TestVAPAppliesToExcludeRules(t *testing.T) {
 	assert.True(t, v.appliesTo(obj("v1", "Pod")))
 	assert.False(t, v.appliesTo(obj("v1", "ConfigMap")), "excluded resource must not apply")
 }
+
+// withOps returns a copy of the rule constrained to the given operations.
+func withOps(r admissionregistrationv1.NamedRuleWithOperations, ops ...admissionregistrationv1.OperationType) admissionregistrationv1.NamedRuleWithOperations {
+	r.Operations = ops
+	return r
+}
+
+// TestVAPAppliesToOperations pins the operation side of rule matching: the scan
+// models every resource as a CREATE, so a rule that fires only on other
+// operations must not match — at admission that policy would never be handed
+// the object we are scanning.
+func TestVAPAppliesToOperations(t *testing.T) {
+	pods := rule([]string{""}, []string{"v1"}, []string{"pods"})
+
+	cases := []struct {
+		name string
+		ops  []admissionregistrationv1.OperationType
+		want bool
+	}{
+		{"CREATE matches", []admissionregistrationv1.OperationType{admissionregistrationv1.Create}, true},
+		{"CREATE and UPDATE matches (the bundle's shape)", []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}, true},
+		{"wildcard matches", []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll}, true},
+		{"UPDATE-only does not match a modeled CREATE", []admissionregistrationv1.OperationType{admissionregistrationv1.Update}, false},
+		{"DELETE-only does not match a modeled CREATE", []admissionregistrationv1.OperationType{admissionregistrationv1.Delete}, false},
+		{"no operations (malformed) falls back to matching", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := vapWithConstraints(withOps(pods, tc.ops...))
+			assert.Equal(t, tc.want, v.appliesTo(obj("v1", "Pod")))
+		})
+	}
+
+	t.Run("an exclusion scoped to UPDATE does not exempt the modeled CREATE", func(t *testing.T) {
+		v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{withOps(pods, admissionregistrationv1.Create)},
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{withOps(pods, admissionregistrationv1.Update)},
+		}}
+		assert.True(t, v.appliesTo(obj("v1", "Pod")), "the exclusion only covers UPDATE, so the CREATE we model is still matched")
+	})
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage"
 	opaprint "github.com/open-policy-agent/opa/v1/topdown/print"
 	"go.opentelemetry.io/otel"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -74,6 +75,15 @@ type OPAProcessor struct {
 	celEvaluator     *cel.Evaluator
 	celEvaluatorOnce sync.Once
 	celEvaluatorErr  error
+	// celNamespaceIndex maps namespace name -> the scan's Namespace object, so
+	// CEL evaluation can bind namespaceObject the way the apiserver does. Built
+	// once via celNamespaceOnce (see celNamespaceObjects): Namespace objects
+	// come from resource collection, which is complete before processing starts
+	// (see NewOPAProcessor), so a one-time snapshot cannot miss one — the
+	// mid-scan writes into AllResources are aggregator-produced resources,
+	// never Namespaces.
+	celNamespaceIndex map[string]map[string]any
+	celNamespaceOnce  sync.Once
 	// initialResourceCount is the size of AllResources snapshotted once at
 	// construction, so the large-cluster namespace-bucketing decision (see
 	// getNamespaceName) is made once per scan instead of drifting mid-scan as
@@ -590,10 +600,12 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 			return nil, celOutcome{}, err
 		}
 
-		// namespaceObject is not resolved yet: policies referencing it eval-error
-		// and their resources are skipped (parity-safe), never passed. Wiring the
-		// real namespace object is a follow-up.
-		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, nil)
+		// namespaceObject is the resource's Namespace object when the scan
+		// collected it, and nil otherwise — the evaluator then binds null, so a
+		// policy reading namespaceObject.* sees an absent namespace (and a
+		// selection into it eval-errors and skips, never passes). File scans and
+		// scans whose frameworks never matched Namespaces stay on that safe path.
+		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, opap.celNamespaceObjectFor(obj))
 		if err != nil {
 			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 		}
@@ -686,6 +698,41 @@ func (opap *OPAProcessor) getCELEvaluator() (*cel.Evaluator, error) {
 		opap.celEvaluator, opap.celEvaluatorErr = cel.NewEvaluator()
 	})
 	return opap.celEvaluator, opap.celEvaluatorErr
+}
+
+// celNamespaceObjectFor resolves the Namespace object a scanned resource lives
+// in, for the evaluator's namespaceObject binding. It returns nil for a
+// cluster-scoped resource (no namespace to resolve) and for a namespace the
+// scan did not collect; the evaluator binds null in both cases, exactly as the
+// apiserver binds null for cluster-scoped resources.
+func (opap *OPAProcessor) celNamespaceObjectFor(obj map[string]any) map[string]any {
+	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
+	if namespace == "" {
+		return nil
+	}
+	return opap.celNamespaceObjects()[namespace]
+}
+
+// celNamespaceObjects lazily indexes the scan's collected Namespace objects by
+// name (see the celNamespaceIndex field for why once is enough). Scans that
+// carry no session or no Namespaces produce an empty index, never an error: a
+// missing namespace binds null, the same degraded-but-safe behaviour those
+// scans had before namespaceObject was resolved at all.
+func (opap *OPAProcessor) celNamespaceObjects() map[string]map[string]any {
+	opap.celNamespaceOnce.Do(func() {
+		if opap.OPASessionObj == nil {
+			return
+		}
+		index := make(map[string]map[string]any)
+		for _, resource := range opap.AllResources {
+			if resource == nil || resource.GetKind() != "Namespace" || resource.GetApiVersion() != "v1" {
+				continue
+			}
+			index[resource.GetName()] = resource.GetObject()
+		}
+		opap.celNamespaceIndex = index
+	})
+	return opap.celNamespaceIndex
 }
 
 // celRuleResponse builds the RuleResponse for one object that violated a CEL

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -77,13 +77,11 @@ type OPAProcessor struct {
 	celEvaluatorErr  error
 	// celNamespaceIndex maps namespace name -> the scan's Namespace object, so
 	// CEL evaluation can bind namespaceObject the way the apiserver does. Built
-	// once via celNamespaceOnce (see celNamespaceObjects): Namespace objects
-	// come from resource collection, which is complete before processing starts
-	// (see NewOPAProcessor), so a one-time snapshot cannot miss one — the
-	// mid-scan writes into AllResources are aggregator-produced resources,
-	// never Namespaces.
+	// at construction (see indexNamespaces): NewOPAProcessor already requires
+	// AllResources to be fully collected, so indexing there makes the snapshot
+	// structurally independent of whatever rules write into AllResources
+	// mid-scan, instead of depending on when the first CEL rule happens to run.
 	celNamespaceIndex map[string]map[string]any
-	celNamespaceOnce  sync.Once
 	// initialResourceCount is the size of AllResources snapshotted once at
 	// construction, so the large-cluster namespace-bucketing decision (see
 	// getNamespaceName) is made once per scan instead of drifting mid-scan as
@@ -114,7 +112,27 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		compiledModules:        make(map[string]compiledRule),
 		TimedOutControls:       make(map[string]string),
 		initialResourceCount:   initialResourceCount,
+		celNamespaceIndex:      indexNamespaces(sessionObj),
 	}
+}
+
+// indexNamespaces maps namespace name -> Namespace object out of the session's
+// collected resources, for the CEL namespaceObject binding (see
+// celNamespaceObjectFor). Nil-safe by returning an empty index: a nil session
+// or a scan that never collected Namespaces (file scans, frameworks with no
+// Namespace-matching control) just resolves every lookup to nil.
+func indexNamespaces(sessionObj *cautils.OPASessionObj) map[string]map[string]any {
+	if sessionObj == nil {
+		return nil
+	}
+	index := make(map[string]map[string]any)
+	for _, resource := range sessionObj.AllResources {
+		if resource == nil || resource.GetKind() != "Namespace" || resource.GetApiVersion() != "v1" {
+			continue
+		}
+		index[resource.GetName()] = resource.GetObject()
+	}
+	return index
 }
 
 func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressListener IJobProgressNotificationClient) error {
@@ -704,35 +722,15 @@ func (opap *OPAProcessor) getCELEvaluator() (*cel.Evaluator, error) {
 // in, for the evaluator's namespaceObject binding. It returns nil for a
 // cluster-scoped resource (no namespace to resolve) and for a namespace the
 // scan did not collect; the evaluator binds null in both cases, exactly as the
-// apiserver binds null for cluster-scoped resources.
+// apiserver binds null for cluster-scoped resources. The namespaced test is
+// the same one stub.go's isNamespaced applies to the same object a moment
+// later: a non-empty metadata.namespace.
 func (opap *OPAProcessor) celNamespaceObjectFor(obj map[string]any) map[string]any {
 	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
 	if namespace == "" {
 		return nil
 	}
-	return opap.celNamespaceObjects()[namespace]
-}
-
-// celNamespaceObjects lazily indexes the scan's collected Namespace objects by
-// name (see the celNamespaceIndex field for why once is enough). Scans that
-// carry no session or no Namespaces produce an empty index, never an error: a
-// missing namespace binds null, the same degraded-but-safe behaviour those
-// scans had before namespaceObject was resolved at all.
-func (opap *OPAProcessor) celNamespaceObjects() map[string]map[string]any {
-	opap.celNamespaceOnce.Do(func() {
-		if opap.OPASessionObj == nil {
-			return
-		}
-		index := make(map[string]map[string]any)
-		for _, resource := range opap.AllResources {
-			if resource == nil || resource.GetKind() != "Namespace" || resource.GetApiVersion() != "v1" {
-				continue
-			}
-			index[resource.GetName()] = resource.GetObject()
-		}
-		opap.celNamespaceIndex = index
-	})
-	return opap.celNamespaceIndex
+	return opap.celNamespaceIndex[namespace]
 }
 
 // celRuleResponse builds the RuleResponse for one object that violated a CEL

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -962,12 +962,14 @@ func TestCELNamespaceObjectFor(t *testing.T) {
 	})
 	require.NotNil(t, decoy)
 
-	opap := &OPAProcessor{OPASessionObj: &cautils.OPASessionObj{
+	// Built through the constructor on purpose: that is where the index is
+	// snapshotted, so this also pins that NewOPAProcessor wires it.
+	opap := NewOPAProcessor(&cautils.OPASessionObj{
 		AllResources: map[string]workloadinterface.IMetadata{
 			nsMeta.GetID(): nsMeta,
 			decoy.GetID():  decoy,
 		},
-	}}
+	}, &resources.RegoDependenciesData{}, "", "", "", false, nil)
 
 	podIn := func(namespace string) map[string]any {
 		metadata := map[string]any{"name": "p"}
@@ -995,7 +997,9 @@ func TestCELNamespaceObjectFor(t *testing.T) {
 	})
 
 	t.Run("no session resolves to nil without panicking", func(t *testing.T) {
-		bare := &OPAProcessor{}
-		assert.Nil(t, bare.celNamespaceObjectFor(podIn("prod")))
+		// Both the zero value and a constructor call with no session: the second
+		// is the one a caller can actually reach.
+		assert.Nil(t, (&OPAProcessor{}).celNamespaceObjectFor(podIn("prod")))
+		assert.Nil(t, NewOPAProcessor(nil, nil, "", "", "", false, nil).celNamespaceObjectFor(podIn("prod")))
 	})
 }

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -935,3 +935,67 @@ func TestRunCELOnK8s(t *testing.T) {
 		assert.Empty(t, outcome.excluded)
 	})
 }
+
+// TestCELNamespaceObjectFor covers the resolver behind the evaluator's
+// namespaceObject binding: the scanned resource's Namespace object out of the
+// scan's collected resources, and nil on every path where the scan cannot
+// know it (cluster-scoped resource, uncollected namespace, no session at
+// all) — the evaluator then binds null, which is the pre-wiring behaviour.
+func TestCELNamespaceObjectFor(t *testing.T) {
+	nsObject := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "prod",
+			"labels": map[string]any{"pod-security.kubernetes.io/enforce": "restricted"},
+		},
+	}
+	nsMeta := objectsenvelopes.NewObject(nsObject)
+	require.NotNil(t, nsMeta)
+
+	// A namespaced resource whose NAME matches a namespace must not be mistaken
+	// for the Namespace object itself.
+	decoy := objectsenvelopes.NewObject(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "prod", "namespace": "prod"},
+	})
+	require.NotNil(t, decoy)
+
+	opap := &OPAProcessor{OPASessionObj: &cautils.OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			nsMeta.GetID(): nsMeta,
+			decoy.GetID():  decoy,
+		},
+	}}
+
+	podIn := func(namespace string) map[string]any {
+		metadata := map[string]any{"name": "p"}
+		if namespace != "" {
+			metadata["namespace"] = namespace
+		}
+		return map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": metadata, "spec": map[string]any{}}
+	}
+
+	t.Run("resolves the collected Namespace object", func(t *testing.T) {
+		got := opap.celNamespaceObjectFor(podIn("prod"))
+		require.NotNil(t, got)
+		assert.Equal(t, "Namespace", got["kind"])
+		labels := got["metadata"].(map[string]any)["labels"].(map[string]any)
+		assert.Equal(t, "restricted", labels["pod-security.kubernetes.io/enforce"],
+			"the binding must carry the real Namespace object, labels included")
+	})
+
+	t.Run("uncollected namespace resolves to nil", func(t *testing.T) {
+		assert.Nil(t, opap.celNamespaceObjectFor(podIn("staging")))
+	})
+
+	t.Run("cluster-scoped resource resolves to nil", func(t *testing.T) {
+		assert.Nil(t, opap.celNamespaceObjectFor(podIn("")))
+	})
+
+	t.Run("no session resolves to nil without panicking", func(t *testing.T) {
+		bare := &OPAProcessor{}
+		assert.Nil(t, bare.celNamespaceObjectFor(podIn("prod")))
+	})
+}


### PR DESCRIPTION
## Overview

The scan was passing nil for namespaceObject, so a policy reading it would eval error and get skipped. Now the scanner indexes the Namespace objects it collected and hands each resource its own namespace, the same binding the apiserver does. When the scan does not have the namespace (file scans, cluster scoped resources, frameworks that never matched a Namespace) it still binds null, which is the old safe behaviour.

Worth being clear about what this is and is not: no policy in the bundle reads namespaceObject today, so this is forward looking, and nothing in the scan path exercises the non-nil branch outside the new unit test. It is also conditional rather than guaranteed, because Namespace collection is driven by what the frameworks' policies match, not by what a CEL control needs. So the same control can bind a real Namespace under one framework and null under another. A policy that null-guards would then get a clean pass off an absent namespace, which is not the safe direction. Making collection follow the policy is the real fix and it is not in here, so I would rather record namespaceObject in #2001 as a conditional input alongside authorizer and request.userInfo than call it resolved end to end.

While in there I made the matchConstraints handling consistent, on the rule that a knob whose input the scanned object carries gets evaluated, and one whose input the scan cannot guarantee to have gets refused at load:

- objectSelector is evaluated in appliesTo. It matches the object's own labels, which the scan always has. Refusing it would be a control wide blackout (loadVAP errors, the rule errors, every resource for that control is marked skipped) to avoid a handful of labelled objects.
- resourceNames is evaluated the same way, against metadata.name. Ignoring it would evaluate every object of the kind against a policy admission only ever hands one named object.
- operations is evaluated. The scan models every resource as CREATE, so a rule that only fires on other operations does not match offline either.
- namespaceSelector stays refused, and the comment now says why it stays refused even though this PR builds the index that would make it evaluable in the common case: the input is namespace labels, which are only present when Namespaces happened to be collected. A selector silently evaluating against an absent namespace is worse than a loud skip.
- matchPolicy needs nothing. Equivalent matching only widens a rule across API conversions and a scan never converts, so there is a sentence saying so rather than a guard.

Modelling scanned resources as CREATE is a design call worth naming: an UPDATE only control ("you may not change X") is out of scope offline by construction. That seems right for a scanner, but it is a product decision, not just a scoping fix.

The safety argument for the operations change, correctly this time: every controlId bearing policy in the bundle lists [CREATE, UPDATE]. Three rules do not list CREATE (cluster-policy-deny-attach, deny-exec, deny-portforward, all CONNECT on pods subresources), and all three are unlabelled helper policies the scan path cannot reach, on top of which matchesResource already never matches a resource/subresource entry against a bare pods. TestVAPAppliesToCoversEveryBundleKind cannot prove any of this, since it skips subresources outright, so there is a new test over catalog.byControl that does, and a second one asserting the bundle uses no selectors or resourceNames today, so a sync that introduces one is a failure rather than a silent behaviour change.

Also added the missing end to end test for a paramKind control: C-0046 through EvaluateControl, one pod failing on SYS_ADMIN from the embedded config and one passing with NET_BIND_SERVICE. Its expressions read params.settings.insecureCapabilities unguarded, so clean verdicts are only possible with params actually resolved. Until now params were only covered at the loader level.

The namespace index is built in NewOPAProcessor rather than lazily on first CEL evaluation. Lazily meant it snapshotted AllResources after an arbitrary number of earlier rules had written to it, so it depended on an unenforced property of unrelated Rego rules. The constructor already requires AllResources to be fully collected and already snapshots initialResourceCount for the same reason.

Docs-exempt: internal CEL engine change, no documented behavior change

## How to Test

`go test ./core/pkg/opaprocessor/...` covers all of it: the resolver (TestCELNamespaceObjectFor), the params e2e (TestEvaluateControlResolvesParamsEndToEnd), scoping (TestVAPAppliesToOperations, TestVAPAppliesToObjectSelector, TestVAPAppliesToResourceNames), the refusal (TestLoadVAPRefusesNarrowingSelectors) and the two bundle assertions (TestBundleControlRulesAllMatchModeledCreate, TestBundleUsesNoUnevaluatedScoping).

## Related issues/PRs:

* #2001
