### PR TITLE
fix(fixhandler): quote NaN and Inf fix values so yq expressions parse

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -929,7 +930,7 @@ func FixPathToValidYamlExpression(fixPath, value string, documentIndexInYaml int
 	isStringValue := true
 	if _, err := strconv.ParseBool(value); err == nil {
 		isStringValue = false
-	} else if _, err := strconv.ParseFloat(value, 64); err == nil {
+	} else if f, err := strconv.ParseFloat(value, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
 		isStringValue = false
 	} else if _, err := strconv.Atoi(value); err == nil {
 		isStringValue = false

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -317,6 +317,33 @@ func Test_fixPathToValidYamlExpression(t *testing.T) {
 			},
 			want: "select(di==0).xxx.yyy |= 123",
 		},
+		{
+			name: "fix path with NaN string value",
+			args: args{
+				fixPath:             "xxx.yyy",
+				value:               "NaN",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).xxx.yyy |= \"NaN\"",
+		},
+		{
+			name: "fix path with Inf string value",
+			args: args{
+				fixPath:             "xxx.yyy",
+				value:               "Inf",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).xxx.yyy |= \"Inf\"",
+		},
+		{
+			name: "fix path with -Inf string value",
+			args: args{
+				fixPath:             "xxx.yyy",
+				value:               "-Inf",
+				documentIndexInYaml: 0,
+			},
+			want: "select(di==0).xxx.yyy |= \"-Inf\"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Overview

`FixPathToValidYamlExpression` uses `strconv.ParseFloat` to decide whether a remediation value is a number that should stay unquoted in the generated `yq` expression. `ParseFloat` also accepts the special strings `"NaN"`, `"Inf"`, and `"-Inf"`, so those values are emitted unquoted:

```
select(di==0).path |= NaN
```

The `yq` expression lexer rejects unquoted `NaN`/`Inf` with an `invalid input text` error, aborting the entire remediation run for the file.

This change treats `NaN` and `Inf` as strings, so they are quoted in the generated expression and parse correctly.

## How to Test

```go
expression := FixPathToValidYamlExpression("path", "NaN", 0)
// Before: select(di==0).path |= NaN
// After:  select(di==0).path |= "NaN"
```

`go test ./core/pkg/fixhandler/...` passes, including new cases for `NaN`, `Inf`, and `-Inf`.

## Related issues/PRs

* Resolved #2704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed YAML value handling for non-finite numbers such as `NaN`, `Inf`, and `-Inf`.
  - These values are now safely treated as quoted strings instead of invalid numeric values.

- **Tests**
  - Added coverage to verify correct handling of non-finite numeric values in generated YAML expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->