### PR TITLE
test(printer): keep pretty writer outputs in tempdir

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -129,6 +130,9 @@ func TestPrintScanCoverage_AllSectionsRendered(t *testing.T) {
 }
 
 func TestSetWriter_Pretty(t *testing.T) {
+	sourceTreeArtifact := "customFilename.txt"
+	require.NoFileExists(t, sourceTreeArtifact, "test setup requires no leftover output file in the package directory")
+
 	tests := []struct {
 		name       string
 		outputFile string
@@ -160,10 +164,20 @@ func TestSetWriter_Pretty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.outputFile != "" && tt.outputFile != os.DevNull {
+				tmpDir := t.TempDir()
+				tt.outputFile = filepath.Join(tmpDir, tt.outputFile)
+				tt.expected = filepath.Join(tmpDir, tt.expected)
+			}
 			pp := NewPrettyPrinter(false, "v2", false, cautils.ViewTypes("control"), cautils.ScanTypes("cluster"), []string{}, "")
 
 			pp.SetWriter(ctx, tt.outputFile)
+			if tt.outputFile != "" && tt.outputFile != os.DevNull {
+				t.Cleanup(func() { _ = pp.writer.Close() })
+			}
 			assert.Equal(t, tt.expected, pp.writer.Name())
 		})
 	}
+
+	assert.NoFileExists(t, sourceTreeArtifact)
 }


### PR DESCRIPTION
## Overview

Fixes #2717.

`TestSetWriter_Pretty` used bare relative output names like `customFilename`, which caused the test to create `core/pkg/resultshandling/printer/v2/customFilename.txt` in the source tree.

This updates the non-stdout/non-`os.DevNull` test cases to write under `t.TempDir()` and closes those temp-file writers during cleanup.

## Testing

```bash
go test ./core/pkg/resultshandling/printer/v2 -run TestSetWriter_Pretty -count=1
go test ./core/pkg/resultshandling/printer/v2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by writing temporary output to dedicated temporary directories.
  * Ensured temporary output files are properly closed during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->