### PR TITLE
feat(resourcesprioritization): support configurable workload kinds and dynamic pod template spec detection

### DIFF
--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -24,7 +24,7 @@ type ResourcesPrioritizationHandler struct {
 	buildResourcesMap      bool
 }
 
-var DefaultSupportedKinds = []string{
+var defaultSupportedKinds = []string{
 	"Deployment",
 	"Pod",
 	"ReplicaSet",
@@ -33,6 +33,10 @@ var DefaultSupportedKinds = []string{
 	"StatefulSet",
 	"Job",
 	"CronJob",
+}
+
+func DefaultSupportedKinds() []string {
+	return slices.Clone(defaultSupportedKinds)
 }
 
 func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter getter.IAttackTracksGetter, buildResourcesMap bool) (*ResourcesPrioritizationHandler, error) {
@@ -80,7 +84,7 @@ func (handler *ResourcesPrioritizationHandler) SetSupportedKinds(kinds []string)
 
 func (handler *ResourcesPrioritizationHandler) AddSupportedKinds(kinds ...string) {
 	if handler.supportedKinds == nil {
-		handler.supportedKinds = append([]string(nil), DefaultSupportedKinds...)
+		handler.supportedKinds = append([]string(nil), defaultSupportedKinds...)
 	}
 	for _, kind := range kinds {
 		if !slices.Contains(handler.supportedKinds, kind) {
@@ -91,7 +95,7 @@ func (handler *ResourcesPrioritizationHandler) AddSupportedKinds(kinds ...string
 
 func (handler *ResourcesPrioritizationHandler) GetSupportedKinds() []string {
 	if handler.supportedKinds == nil {
-		return slices.Clone(DefaultSupportedKinds)
+		return slices.Clone(defaultSupportedKinds)
 	}
 	return slices.Clone(handler.supportedKinds)
 }
@@ -200,7 +204,7 @@ func (handler *ResourcesPrioritizationHandler) isSupportedKind(obj workloadinter
 	}
 	kinds := handler.supportedKinds
 	if kinds == nil {
-		kinds = DefaultSupportedKinds
+		kinds = defaultSupportedKinds
 	}
 	if slices.Contains(kinds, obj.GetKind()) {
 		return true

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -19,10 +19,11 @@ import (
 type ResourcesPrioritizationHandler struct {
 	resourceToAttackTracks map[string]v1alpha1.IAttackTrack
 	attackTracks           []v1alpha1.IAttackTrack
+	supportedKinds         []string
 	buildResourcesMap      bool
 }
 
-var supportedKinds = []string{
+var DefaultSupportedKinds = []string{
 	"Deployment",
 	"Pod",
 	"ReplicaSet",
@@ -33,10 +34,14 @@ var supportedKinds = []string{
 	"CronJob",
 }
 
+// Keep supportedKinds package variable for backwards compatibility
+var supportedKinds = DefaultSupportedKinds
+
 func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter getter.IAttackTracksGetter, buildResourcesMap bool) (*ResourcesPrioritizationHandler, error) {
 	handler := &ResourcesPrioritizationHandler{
 		attackTracks:           make([]v1alpha1.IAttackTrack, 0),
 		resourceToAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		supportedKinds:         append([]string(nil), DefaultSupportedKinds...),
 		buildResourcesMap:      buildResourcesMap,
 	}
 
@@ -65,6 +70,22 @@ func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter g
 	}
 
 	return handler, nil
+}
+
+func (handler *ResourcesPrioritizationHandler) SetSupportedKinds(kinds []string) {
+	handler.supportedKinds = append([]string(nil), kinds...)
+}
+
+func (handler *ResourcesPrioritizationHandler) AddSupportedKinds(kinds ...string) {
+	for _, kind := range kinds {
+		if !slices.Contains(handler.supportedKinds, kind) {
+			handler.supportedKinds = append(handler.supportedKinds, kind)
+		}
+	}
+}
+
+func (handler *ResourcesPrioritizationHandler) GetSupportedKinds() []string {
+	return handler.supportedKinds
 }
 
 func (handler *ResourcesPrioritizationHandler) PrioritizeResources(sessionObj *cautils.OPASessionObj) error {
@@ -158,12 +179,42 @@ func (handler *ResourcesPrioritizationHandler) PrioritizeResources(sessionObj *c
 }
 
 func (handler *ResourcesPrioritizationHandler) isSupportedKind(obj workloadinterface.IMetadata) bool {
-	if obj != nil {
-		if slices.Contains(supportedKinds, obj.GetKind()) {
-			return true
-		}
+	if obj == nil {
+		return false
 	}
-	return false
+	kinds := handler.supportedKinds
+	if len(kinds) == 0 {
+		kinds = DefaultSupportedKinds
+	}
+	if slices.Contains(kinds, obj.GetKind()) {
+		return true
+	}
+	// Dynamic fallback detector: check if the Kubernetes resource contains a Pod template spec (spec.template.spec.containers)
+	return hasPodTemplateSpec(obj.GetObject())
+}
+
+// hasPodTemplateSpec checks if the Kubernetes resource contains a Pod template spec (spec.template.spec.containers) or spec.containers
+func hasPodTemplateSpec(object map[string]any) bool {
+	if object == nil {
+		return false
+	}
+	spec, ok := object["spec"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if containers, ok := spec["containers"].([]any); ok && len(containers) > 0 {
+		return true
+	}
+	template, ok := spec["template"].(map[string]any)
+	if !ok {
+		return false
+	}
+	templateSpec, ok := template["spec"].(map[string]any)
+	if !ok {
+		return false
+	}
+	containers, ok := templateSpec["containers"].([]any)
+	return ok && len(containers) > 0
 }
 
 func (handler *ResourcesPrioritizationHandler) copyAttackTrack(attackTrack v1alpha1.IAttackTrack, lookup v1alpha1.IAttackTrackControlsLookup) v1alpha1.IAttackTrack {

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -20,6 +20,7 @@ type ResourcesPrioritizationHandler struct {
 	resourceToAttackTracks map[string]v1alpha1.IAttackTrack
 	attackTracks           []v1alpha1.IAttackTrack
 	supportedKinds         []string
+	podTemplateFallback    bool
 	buildResourcesMap      bool
 }
 
@@ -34,14 +35,11 @@ var DefaultSupportedKinds = []string{
 	"CronJob",
 }
 
-// Keep supportedKinds package variable for backwards compatibility
-var supportedKinds = DefaultSupportedKinds
-
 func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter getter.IAttackTracksGetter, buildResourcesMap bool) (*ResourcesPrioritizationHandler, error) {
 	handler := &ResourcesPrioritizationHandler{
 		attackTracks:           make([]v1alpha1.IAttackTrack, 0),
 		resourceToAttackTracks: make(map[string]v1alpha1.IAttackTrack),
-		supportedKinds:         append([]string(nil), DefaultSupportedKinds...),
+		podTemplateFallback:    true,
 		buildResourcesMap:      buildResourcesMap,
 	}
 
@@ -73,10 +71,17 @@ func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter g
 }
 
 func (handler *ResourcesPrioritizationHandler) SetSupportedKinds(kinds []string) {
-	handler.supportedKinds = append([]string(nil), kinds...)
+	if kinds == nil {
+		handler.supportedKinds = nil
+	} else {
+		handler.supportedKinds = append([]string{}, kinds...)
+	}
 }
 
 func (handler *ResourcesPrioritizationHandler) AddSupportedKinds(kinds ...string) {
+	if handler.supportedKinds == nil {
+		handler.supportedKinds = append([]string(nil), DefaultSupportedKinds...)
+	}
 	for _, kind := range kinds {
 		if !slices.Contains(handler.supportedKinds, kind) {
 			handler.supportedKinds = append(handler.supportedKinds, kind)
@@ -85,7 +90,18 @@ func (handler *ResourcesPrioritizationHandler) AddSupportedKinds(kinds ...string
 }
 
 func (handler *ResourcesPrioritizationHandler) GetSupportedKinds() []string {
-	return handler.supportedKinds
+	if handler.supportedKinds == nil {
+		return slices.Clone(DefaultSupportedKinds)
+	}
+	return slices.Clone(handler.supportedKinds)
+}
+
+func (handler *ResourcesPrioritizationHandler) SetPodTemplateFallback(fallback bool) {
+	handler.podTemplateFallback = fallback
+}
+
+func (handler *ResourcesPrioritizationHandler) GetPodTemplateFallback() bool {
+	return handler.podTemplateFallback
 }
 
 func (handler *ResourcesPrioritizationHandler) PrioritizeResources(sessionObj *cautils.OPASessionObj) error {
@@ -183,14 +199,17 @@ func (handler *ResourcesPrioritizationHandler) isSupportedKind(obj workloadinter
 		return false
 	}
 	kinds := handler.supportedKinds
-	if len(kinds) == 0 {
+	if kinds == nil {
 		kinds = DefaultSupportedKinds
 	}
 	if slices.Contains(kinds, obj.GetKind()) {
 		return true
 	}
 	// Dynamic fallback detector: check if the Kubernetes resource contains a Pod template spec (spec.template.spec.containers)
-	return hasPodTemplateSpec(obj.GetObject())
+	if handler.podTemplateFallback {
+		return hasPodTemplateSpec(obj.GetObject())
+	}
+	return false
 }
 
 // hasPodTemplateSpec checks if the Kubernetes resource contains a Pod template spec (spec.template.spec.containers) or spec.containers

--- a/core/pkg/resourcesprioritization/prioritizationhandler_test.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler_test.go
@@ -82,13 +82,19 @@ func OPASessionObjMock(allPoliciesControls map[string]reporthandling.Control, mo
 
 func WorkloadMockWithKind(kind string) workloadinterface.IMetadata {
 	raw := fmt.Sprintf(`{"apiVersion":"v1","kind":"%s","metadata":{"name":"mock-%s"}}`, kind, kind)
-	w, _ := workloadinterface.NewWorkload([]byte(raw))
+	w, err := workloadinterface.NewWorkload([]byte(raw))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create workload mock: %v", err))
+	}
 	return w
 }
 
 func DeploymentWorkloadMock(replicas int) workloadinterface.IMetadata {
 	var deploymentMock = fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"privileged-deployment","labels":{"app":"nginx"}},"spec":{"replicas":%v,"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"name":"nginx","image":"nginx:1.18.0","ports":[{"containerPort":80}],"securityContext":{"privileged":true}}]}}}}`, replicas)
-	w, _ := workloadinterface.NewWorkload([]byte(deploymentMock))
+	w, err := workloadinterface.NewWorkload([]byte(deploymentMock))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create deployment workload mock: %v", err))
+	}
 	return w
 }
 
@@ -110,6 +116,8 @@ func TestNewResourcesPrioritizationHandler(t *testing.T) {
 	assert.Equal(t, handler.attackTracks[0].GetName(), "TestAttackTrack")
 	assert.Equal(t, handler.attackTracks[1].GetName(), "TestAttackTrack_2")
 	assert.Equal(t, handler.attackTracks[2].GetName(), "TestAttackTrack_3")
+	assert.True(t, handler.GetPodTemplateFallback())
+	assert.Equal(t, DefaultSupportedKinds, handler.GetSupportedKinds())
 }
 
 func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
@@ -212,14 +220,15 @@ func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
 
 func RolloutWorkloadMock(replicas int) workloadinterface.IMetadata {
 	var rolloutMock = fmt.Sprintf(`{"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"name":"vulnerable-rollout","namespace":"default"},"spec":{"replicas":%v,"template":{"spec":{"containers":[{"name":"web","image":"nginx:1.18.0","securityContext":{"privileged":true}}]}}}}`, replicas)
-	w, _ := workloadinterface.NewWorkload([]byte(rolloutMock))
+	w, err := workloadinterface.NewWorkload([]byte(rolloutMock))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create rollout workload mock: %v", err))
+	}
 	return w
 }
 
 func TestResourcesPrioritizationHandler_isSupportedKind(t *testing.T) {
-	handler := &ResourcesPrioritizationHandler{
-		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
-	}
+	handler := &ResourcesPrioritizationHandler{}
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")))
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Pod")))
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Node")))
@@ -233,37 +242,79 @@ func TestResourcesPrioritizationHandler_isSupportedKind(t *testing.T) {
 }
 
 func TestResourcesPrioritizationHandler_ConfigurableSupportedKinds(t *testing.T) {
-	handler := &ResourcesPrioritizationHandler{
-		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
-	}
+	handler := &ResourcesPrioritizationHandler{}
 
-	// Default supported kinds check
+	// Default supported kinds check (unset slice)
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")))
 	assert.False(t, handler.isSupportedKind(WorkloadMockWithKind("MyCustomKind")))
 
-	// Add supported kind
+	// Add supported kind onto zero-value handler seeds DefaultSupportedKinds
 	handler.AddSupportedKinds("MyCustomKind")
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("MyCustomKind")))
+	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")), "Deployment should remain supported after AddSupportedKinds on zero-value handler")
 
 	// Override supported kinds
 	handler.SetSupportedKinds([]string{"Rollout"})
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Rollout")))
 	assert.Contains(t, handler.GetSupportedKinds(), "Rollout")
+
+	// Defensive copy verification on GetSupportedKinds
+	kinds := handler.GetSupportedKinds()
+	kinds[0] = "MODIFIED"
+	assert.NotEqual(t, "MODIFIED", handler.GetSupportedKinds()[0])
 }
 
 func TestResourcesPrioritizationHandler_DynamicPodTemplateSpecFallback(t *testing.T) {
 	handler := &ResourcesPrioritizationHandler{
-		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
+		podTemplateFallback: true,
 	}
 
 	// ArgoCD Rollout with spec.template.spec.containers (not in supportedKinds list)
 	rolloutWorkload := RolloutWorkloadMock(2)
 	assert.True(t, handler.isSupportedKind(rolloutWorkload), "ArgoCD Rollout manifest with pod template spec should be dynamically detected")
 
+	// Direct spec.containers branch for Pod-shaped custom workload
+	podSpecRaw := `{"apiVersion":"v1","kind":"CustomPod","metadata":{"name":"custom-pod"},"spec":{"containers":[{"name":"app","image":"nginx"}]}}`
+	customPod, err := workloadinterface.NewWorkload([]byte(podSpecRaw))
+	assert.NoError(t, err)
+	assert.True(t, handler.isSupportedKind(customPod), "Custom workload with direct spec.containers should be dynamically detected")
+
 	// ConfigMap workload without pod template spec
 	configMapYAML := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-cm"},"data":{"key":"val"}}`
-	cmWorkload, _ := workloadinterface.NewWorkload([]byte(configMapYAML))
+	cmWorkload, err := workloadinterface.NewWorkload([]byte(configMapYAML))
+	assert.NoError(t, err)
 	assert.False(t, handler.isSupportedKind(cmWorkload), "ConfigMap should not be detected as supported workload")
+}
+
+func TestResourcesPrioritizationHandler_PodTemplateFallbackKnobAndScope(t *testing.T) {
+	handler := &ResourcesPrioritizationHandler{
+		podTemplateFallback: true,
+	}
+
+	// Dynamic fallback runs when fallback is enabled
+	rolloutWorkload := RolloutWorkloadMock(1)
+	assert.True(t, handler.isSupportedKind(rolloutWorkload))
+
+	// Narrow scope with SetSupportedKinds to only "Deployment"
+	handler.SetSupportedKinds([]string{"Deployment"})
+
+	// While fallback is true, Rollout is still prioritized due to pod template spec
+	assert.True(t, handler.isSupportedKind(rolloutWorkload))
+
+	// Turn fallback off
+	handler.SetPodTemplateFallback(false)
+	assert.False(t, handler.GetPodTemplateFallback())
+	assert.False(t, handler.isSupportedKind(rolloutWorkload), "Rollout should be rejected when fallback is false and not in configured kinds")
+	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")), "Deployment should still be supported")
+
+	// Explicitly empty supportedKinds with fallback off
+	handler.SetSupportedKinds([]string{})
+	assert.False(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")), "explicitly empty supported kinds should match no kind")
+	assert.Empty(t, handler.GetSupportedKinds())
+
+	// Reset to nil (unset -> default kinds)
+	handler.SetSupportedKinds(nil)
+	assert.Equal(t, DefaultSupportedKinds, handler.GetSupportedKinds())
 }
 
 func TestResourcesPrioritizationHandler_PrioritizeCustomWorkload(t *testing.T) {

--- a/core/pkg/resourcesprioritization/prioritizationhandler_test.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler_test.go
@@ -81,9 +81,9 @@ func OPASessionObjMock(allPoliciesControls map[string]reporthandling.Control, mo
 }
 
 func WorkloadMockWithKind(kind string) workloadinterface.IMetadata {
-	mock := workloadinterface.NewWorkloadMock(nil)
-	mock.SetKind(kind)
-	return mock
+	raw := fmt.Sprintf(`{"apiVersion":"v1","kind":"%s","metadata":{"name":"mock-%s"}}`, kind, kind)
+	w, _ := workloadinterface.NewWorkload([]byte(raw))
+	return w
 }
 
 func DeploymentWorkloadMock(replicas int) workloadinterface.IMetadata {
@@ -210,8 +210,16 @@ func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
 	}
 }
 
+func RolloutWorkloadMock(replicas int) workloadinterface.IMetadata {
+	var rolloutMock = fmt.Sprintf(`{"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"name":"vulnerable-rollout","namespace":"default"},"spec":{"replicas":%v,"template":{"spec":{"containers":[{"name":"web","image":"nginx:1.18.0","securityContext":{"privileged":true}}]}}}}`, replicas)
+	w, _ := workloadinterface.NewWorkload([]byte(rolloutMock))
+	return w
+}
+
 func TestResourcesPrioritizationHandler_isSupportedKind(t *testing.T) {
-	handler := &ResourcesPrioritizationHandler{}
+	handler := &ResourcesPrioritizationHandler{
+		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
+	}
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")))
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Pod")))
 	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Node")))
@@ -222,6 +230,70 @@ func TestResourcesPrioritizationHandler_isSupportedKind(t *testing.T) {
 	assert.False(t, handler.isSupportedKind(nil))
 	assert.False(t, handler.isSupportedKind(WorkloadMockWithKind("ConfigMap")))
 	assert.False(t, handler.isSupportedKind(WorkloadMockWithKind("ServiceAccount")))
+}
+
+func TestResourcesPrioritizationHandler_ConfigurableSupportedKinds(t *testing.T) {
+	handler := &ResourcesPrioritizationHandler{
+		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
+	}
+
+	// Default supported kinds check
+	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Deployment")))
+	assert.False(t, handler.isSupportedKind(WorkloadMockWithKind("MyCustomKind")))
+
+	// Add supported kind
+	handler.AddSupportedKinds("MyCustomKind")
+	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("MyCustomKind")))
+
+	// Override supported kinds
+	handler.SetSupportedKinds([]string{"Rollout"})
+	assert.True(t, handler.isSupportedKind(WorkloadMockWithKind("Rollout")))
+	assert.Contains(t, handler.GetSupportedKinds(), "Rollout")
+}
+
+func TestResourcesPrioritizationHandler_DynamicPodTemplateSpecFallback(t *testing.T) {
+	handler := &ResourcesPrioritizationHandler{
+		supportedKinds: append([]string(nil), DefaultSupportedKinds...),
+	}
+
+	// ArgoCD Rollout with spec.template.spec.containers (not in supportedKinds list)
+	rolloutWorkload := RolloutWorkloadMock(2)
+	assert.True(t, handler.isSupportedKind(rolloutWorkload), "ArgoCD Rollout manifest with pod template spec should be dynamically detected")
+
+	// ConfigMap workload without pod template spec
+	configMapYAML := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-cm"},"data":{"key":"val"}}`
+	cmWorkload, _ := workloadinterface.NewWorkload([]byte(configMapYAML))
+	assert.False(t, handler.isSupportedKind(cmWorkload), "ConfigMap should not be detected as supported workload")
+}
+
+func TestResourcesPrioritizationHandler_PrioritizeCustomWorkload(t *testing.T) {
+	handler, _ := NewResourcesPrioritizationHandler(context.Background(), &AttackTracksGetterMock{}, false)
+
+	allPoliciesControls := map[string]reporthandling.Control{
+		"C-001": ControlMock("C-001", 3, []string{"security"}, []string{"D"}),
+		"C-002": ControlMock("C-002", 4, []string{"security"}, []string{"B", "C"}),
+	}
+	results := map[string]resourcesresults.Result{
+		"rollout1": {
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedControlMock("C-001", apis.StatusFailed),
+				ResourceAssociatedControlMock("C-002", apis.StatusFailed),
+			},
+		},
+	}
+	controls := map[string]reportsummary.ControlSummary{
+		"C-001": {ControlID: "C-001", ScoreFactor: 3},
+		"C-002": {ControlID: "C-002", ScoreFactor: 4},
+	}
+	resources := map[string]workloadinterface.IMetadata{
+		"rollout1": RolloutWorkloadMock(1),
+	}
+
+	sessionObj := OPASessionObjMock(allPoliciesControls, results, controls, resources)
+	err := handler.PrioritizeResources(sessionObj)
+	assert.NoError(t, err)
+	assert.Len(t, sessionObj.ResourcesPrioritized, 1, "custom rollout workload should be prioritized")
+	assert.Contains(t, sessionObj.ResourcesPrioritized, "rollout1")
 }
 
 type AttackTrackControlsLookupMock struct {

--- a/core/pkg/resourcesprioritization/prioritizationhandler_test.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler_test.go
@@ -117,7 +117,7 @@ func TestNewResourcesPrioritizationHandler(t *testing.T) {
 	assert.Equal(t, handler.attackTracks[1].GetName(), "TestAttackTrack_2")
 	assert.Equal(t, handler.attackTracks[2].GetName(), "TestAttackTrack_3")
 	assert.True(t, handler.GetPodTemplateFallback())
-	assert.Equal(t, DefaultSupportedKinds, handler.GetSupportedKinds())
+	assert.Equal(t, DefaultSupportedKinds(), handler.GetSupportedKinds())
 }
 
 func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
@@ -262,6 +262,10 @@ func TestResourcesPrioritizationHandler_ConfigurableSupportedKinds(t *testing.T)
 	kinds := handler.GetSupportedKinds()
 	kinds[0] = "MODIFIED"
 	assert.NotEqual(t, "MODIFIED", handler.GetSupportedKinds()[0])
+
+	defaultKinds := DefaultSupportedKinds()
+	defaultKinds[0] = "MODIFIED"
+	assert.NotEqual(t, "MODIFIED", DefaultSupportedKinds()[0])
 }
 
 func TestResourcesPrioritizationHandler_DynamicPodTemplateSpecFallback(t *testing.T) {
@@ -314,7 +318,7 @@ func TestResourcesPrioritizationHandler_PodTemplateFallbackKnobAndScope(t *testi
 
 	// Reset to nil (unset -> default kinds)
 	handler.SetSupportedKinds(nil)
-	assert.Equal(t, DefaultSupportedKinds, handler.GetSupportedKinds())
+	assert.Equal(t, DefaultSupportedKinds(), handler.GetSupportedKinds())
 }
 
 func TestResourcesPrioritizationHandler_PrioritizeCustomWorkload(t *testing.T) {


### PR DESCRIPTION
## Description
This PR refactors the resource prioritization engine in core/pkg/resourcesprioritization to support configurable workload kinds and dynamic pod template spec detection for issue KS-INT-02.

Previously, ResourcesPrioritizationHandler only prioritized a hardcoded set of standard Kubernetes workload kinds. Custom workload controllers like ArgoCD Rollout or OpenShift DeploymentConfig were skipped during attack track calculations.

## Summary of Changes
- Added SetSupportedKinds and AddSupportedKinds methods to customize supported workload kinds.
- Updated GetSupportedKinds to return cloned slices to prevent external state mutation.
- Added hasPodTemplateSpec to check resources for spec.template.spec.containers or spec.containers.
- Added SetPodTemplateFallback knob to enable or disable dynamic fallback detection.
- Added unit tests for custom workload registration, fallback toggles, and end-to-end prioritization of ArgoCD Rollout manifests.

## Testing & Verification
- go test -v ./core/pkg/resourcesprioritization/...
- cd httphandler && go test -v ./...

All unit tests pass.

## DCO Sign-off
All commits are signed off with git commit -s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable supported resource kinds for prioritization.
  * Added support for custom workload types, including Argo Rollouts.
  * Added optional fallback detection for resources using pod-template specifications.
  * Improved recognition of workloads with containers defined directly under their specification.

* **Bug Fixes**
  * Improved workload detection and prioritization for custom resource formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->