### PR TITLE
fix(cautils): resolve git metadata when scanning from a linked worktree

### DIFF
--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -29,7 +29,8 @@ type LocalGitRepository struct {
 var worktreeRoot = (*LocalGitRepository).GetRootDir
 
 func NewLocalGitRepository(path string) (*LocalGitRepository, error) {
-	goGitRepo, err := gitv5.PlainOpenWithOptions(path, &gitv5.PlainOpenOptions{DetectDotGit: true})
+	// EnableDotGitCommonDir is required for linked worktrees, whose .git points at a per-worktree admin dir while the ref HEAD names, the config and the objects stay in the main repository's common dir.
+	goGitRepo, err := gitv5.PlainOpenWithOptions(path, &gitv5.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +153,7 @@ func (g *LocalGitRepository) GetLastCommit() (*apis.Commit, error) {
 // checkouts routinely lack even though the repository every reported path is
 // relative to is right there.
 func GetGitRootDir(path string) (string, error) {
+	// EnableDotGitCommonDir is deliberately omitted here: Worktree() reads no refs, so a linked worktree already resolves, and setting it would fail an orphaned one whose root still resolves fine.
 	goGitRepo, err := gitv5.PlainOpenWithOptions(path, &gitv5.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return "", err

--- a/core/cautils/localgitrepository_test.go
+++ b/core/cautils/localgitrepository_test.go
@@ -396,3 +396,127 @@ func createDetachedRepositoryFixture(t *testing.T, remoteName, remoteURL string)
 
 	return detachedRepositoryFixture{root: root, commit: commit, when: when}
 }
+
+type linkedWorktreeFixture struct {
+	worktreeRoot string
+	branch       string
+	commit       plumbingv5.Hash
+	when         time.Time
+}
+
+// createLinkedWorktreeFixture reproduces the on-disk layout `git worktree add` writes,
+// because go-git can open a linked worktree but cannot create one and the tests must not
+// depend on a git binary. The worktree's own admin directory holds only HEAD, commondir
+// and gitdir; the branch it names, the config and the objects stay in the main
+// repository's common directory, which is exactly what makes this case interesting.
+func createLinkedWorktreeFixture(t *testing.T, branch, remoteURL string) linkedWorktreeFixture {
+	t.Helper()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	mainRoot := filepath.Join(base, "main")
+	require.NoError(t, os.Mkdir(mainRoot, 0o750))
+	repository, err := gitv5.PlainInit(mainRoot, false)
+	require.NoError(t, err)
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(mainRoot, "README.md"), []byte("fixture\n"), 0o600))
+	_, err = worktree.Add("README.md")
+	require.NoError(t, err)
+
+	when := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commit, err := worktree.Commit("fixture commit", &gitv5.CommitOptions{
+		Author: &objectv5.Signature{
+			Name:  "Fixture Author",
+			Email: "author@example.com",
+			When:  when.Add(-time.Minute),
+		},
+		Committer: &objectv5.Signature{
+			Name:  "Fixture Committer",
+			Email: "committer@example.com",
+			When:  when,
+		},
+	})
+	require.NoError(t, err)
+	_, err = repository.CreateRemote(&configv5.RemoteConfig{Name: "origin", URLs: []string{remoteURL}})
+	require.NoError(t, err)
+
+	branchRef := plumbingv5.NewBranchReferenceName(branch)
+	require.NoError(t, repository.Storer.SetReference(plumbingv5.NewHashReference(branchRef, commit)))
+
+	worktreeRoot := filepath.Join(base, "worktree")
+	require.NoError(t, os.Mkdir(worktreeRoot, 0o750))
+	require.NoError(t, os.Mkdir(filepath.Join(worktreeRoot, "nested"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeRoot, "README.md"), []byte("fixture\n"), 0o600))
+
+	adminDir := filepath.Join(mainRoot, gitv5.GitDirName, "worktrees", "worktree")
+	require.NoError(t, os.MkdirAll(adminDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "HEAD"), []byte("ref: "+branchRef.String()+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "commondir"), []byte("../..\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(filepath.Join(worktreeRoot, gitv5.GitDirName)+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeRoot, gitv5.GitDirName), []byte("gitdir: "+adminDir+"\n"), 0o600))
+
+	return linkedWorktreeFixture{worktreeRoot: worktreeRoot, branch: branch, commit: commit, when: when}
+}
+
+// TestLocalGitRepositoryLinkedWorktree verifies that scanning from a linked worktree
+// resolves the repository's metadata instead of failing with "reference not found",
+// which every caller treats as "not a repository" and then scans without any git context.
+func TestLocalGitRepositoryLinkedWorktree(t *testing.T) {
+	fixture := createLinkedWorktreeFixture(t, "feature", "https://github.com/kubescape/worktree-fixture.git")
+
+	repository, err := NewLocalGitRepository(filepath.Join(fixture.worktreeRoot, "nested"))
+	require.NoError(t, err)
+	assert.Equal(t, fixture.branch, repository.GetBranchName())
+
+	remoteURL, err := repository.GetRemoteUrl()
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/kubescape/worktree-fixture.git", remoteURL)
+
+	name, err := repository.GetName()
+	require.NoError(t, err)
+	assert.Equal(t, "worktree-fixture", name)
+
+	root, err := repository.GetRootDir()
+	require.NoError(t, err)
+	assert.Equal(t, fixture.worktreeRoot, root, "reported paths must be anchored to the linked worktree, not to the main repository")
+
+	commit, err := repository.GetLastCommit()
+	require.NoError(t, err)
+	assert.Equal(t, fixture.commit.String(), commit.SHA)
+	assert.Equal(t, "fixture commit", commit.Message)
+	assert.Equal(t, "Fixture Committer", commit.Committer.Name)
+	assert.True(t, fixture.when.Equal(commit.Committer.Date))
+}
+
+// TestGetGitRootDirLinkedWorktree pins the root resolution a linked worktree already had,
+// so the deliberate absence of EnableDotGitCommonDir in GetGitRootDir stays a decision
+// rather than an oversight: the root must be the worktree's, not the main repository's.
+func TestGetGitRootDirLinkedWorktree(t *testing.T) {
+	fixture := createLinkedWorktreeFixture(t, "feature", "https://github.com/kubescape/worktree-fixture.git")
+
+	root, err := GetGitRootDir(filepath.Join(fixture.worktreeRoot, "nested"))
+	if assert.NoError(t, err) {
+		assert.Equal(t, fixture.worktreeRoot, root)
+	}
+	assert.Equal(t, fixture.worktreeRoot, ScanRootPath(filepath.Join(fixture.worktreeRoot, "nested")))
+}
+
+func TestMetadataGitLocalLinkedWorktree(t *testing.T) {
+	fixture := createLinkedWorktreeFixture(t, "feature", "https://github.com/kubescape/worktree-fixture.git")
+
+	metadata, err := metadataGitLocal(filepath.Join(fixture.worktreeRoot, "nested"))
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "github", metadata.Provider)
+	assert.Equal(t, "kubescape", metadata.Owner)
+	assert.Equal(t, "worktree-fixture", metadata.Repo)
+	assert.Equal(t, fixture.branch, metadata.Branch)
+	assert.Empty(t, metadata.DefaultBranch, "a resolved branch clears the default-branch placeholder")
+	assert.Equal(t, "https://github.com/kubescape/worktree-fixture", metadata.RemoteURL)
+	assert.Equal(t, fixture.worktreeRoot, metadata.LocalRootPath)
+	assert.Equal(t, fixture.commit.String(), metadata.LastCommit.Hash)
+	assert.Equal(t, "Fixture Committer", metadata.LastCommit.CommitterName)
+	assert.True(t, fixture.when.Equal(metadata.LastCommit.Date))
+}

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -193,6 +193,18 @@ func TestGetScanningContext(t *testing.T) {
 	}
 }
 
+// TestGetScanningContextLinkedWorktree covers the user-visible half of the linked
+// worktree bug: the metadata loss is silent precisely because the scan still succeeds,
+// having been classified as a plain directory rather than as a local git repository.
+// It is kept out of the TestGetScanningContext table so it stays hermetic — that table
+// clones over the network, and this case needs nothing but a temp directory.
+func TestGetScanningContextLinkedWorktree(t *testing.T) {
+	fixture := createLinkedWorktreeFixture(t, "feature", "https://github.com/kubescape/worktree-fixture.git")
+
+	scanInfo := &ScanInfo{}
+	assert.Equal(t, ContextGitLocal, scanInfo.getScanningContext(fixture.worktreeRoot))
+}
+
 func TestScanInfoFormats(t *testing.T) {
 	testCases := []struct {
 		name  string


### PR DESCRIPTION
## Overview

**Current behavior:** scanning from inside a linked git worktree (`git worktree add`) silently loses all repository metadata. In a linked worktree, `.git` is a *file* pointing at a per-worktree admin directory, but the refs `HEAD` names, the config and the objects all live in the main repository's *common* directory. Without `EnableDotGitCommonDir`, go-git cannot follow them, so `goGitRepo.Head()` in `NewLocalGitRepository` fails with `reference not found`.

Every caller reads that error as "this isn't a repository" and carries on:

| Caller | Effect |
|---|---|
| `scaninfo.go` `getScanningContext` | falls through to `ContextDir` — the scan is typed as a plain directory rather than a local git repo |
| `scaninfo.go` `metadataGitLocal` | logs a warning and returns empty `Provider`/`Owner`/`Repo`/`RemoteURL`/`LastCommit`, with `Branch` left at `"none"` |
| `filesloader.go` `extractGitRepo` | gets a `nil` repository, so per-file commit attribution is dropped |

The scan itself still succeeds, which is exactly what makes this easy to miss.

**Future behavior:** `NewLocalGitRepository` opens with `EnableDotGitCommonDir`, so all three paths resolve normally from within a linked worktree.

Observed on a linked-worktree fixture, before and after:

```
before:  NewLocalGitRepository -> err="reference not found"
         metadataGitLocal      -> Provider:"" Repo:"" RemoteURL:"" LastCommit:{}
after:   NewLocalGitRepository -> ok
         metadataGitLocal      -> Provider:"github" Owner:"…" Repo:"…" Branch:"feature" LastCommit:{…}
```

## Additional Information

**The change is a no-op for ordinary repositories.** go-git returns a nil filesystem when there is no `commondir` file, and `RepositoryFilesystem.mapToRepositoryFsByPath` then short-circuits every path back to the normal `.git` directory. `EnableDotGitCommonDir` has been available since well before the pinned `v5.19.1`, so no dependency change is needed.

**`GetGitRootDir` deliberately keeps its current options.** There are two `PlainOpenWithOptions` call sites in this file and only one is changed. `GetGitRootDir` calls just `Worktree()`, which reads no refs, config or objects — it already returns the correct root inside a linked worktree (covered by a new test). Enabling the flag there would only add a failure mode: for an *orphaned* worktree whose main repository has been deleted, `dotGitCommonDirectory` returns `ErrRepositoryIncomplete`, so `GetGitRootDir` would start erroring where today it correctly returns the root that `ScanRootPath` anchors reported paths to. A comment at that call site records the reasoning so it doesn't read as an oversight. Happy to flip it too if you'd prefer consistency over that trade-off.

**The test fixture doesn't shell out to git.** go-git can *open* a linked worktree but cannot *create* one, so `createLinkedWorktreeFixture` writes the layout `git worktree add` would produce directly: the `.git` file, the admin directory's `HEAD`/`commondir`/`gitdir`, and the branch ref left in the common directory. This keeps the tests hermetic — no git binary, no network — and matches the programmatic style of the existing fixture helpers. All new tests scan from a nested subdirectory so the `DetectDotGit` walk up to the `.git` file is exercised as well.

The new scanning-context test is intentionally a standalone function rather than a case in the existing `TestGetScanningContext` table, because that table performs a live `PlainClone` over the network, while this case needs nothing but a temp directory.

## How to Test

Automated:

```bash
go test ./core/cautils/ -run LinkedWorktree -v
go test ./core/...
```

To confirm the new tests are genuine regression guards, revert the `EnableDotGitCommonDir` option in `NewLocalGitRepository` and re-run — 3 of the 4 fail with `reference not found`. `TestGetGitRootDirLinkedWorktree` passes either way by design: it pins behavior that was never broken, so the omission in `GetGitRootDir` stays a documented decision.

Related issues/PRs:
- Resolves #2709

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for linked Git worktrees, ensuring shared repository references, configuration, and objects are resolved correctly.
  * Repository details, branches, remotes, commits, root paths, and local metadata are now detected reliably in linked worktrees.

* **Tests**
  * Added coverage for linked-worktree repository handling and scanning context detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->