### PR TITLE
fix(cautils): stop LocalGitRepository exposing a nil-embedded panic to callers 

### DIFF
--- a/core/cautils/git_native_enabled_test.go
+++ b/core/cautils/git_native_enabled_test.go
@@ -52,7 +52,7 @@ func BenchmarkBuildCommitMap(b *testing.B) {
 	localRepo, err := NewLocalGitRepository("testdata/temp/localrepo")
 	assert.NoError(b, err)
 	for b.Loop() {
-		localRepo.buildCommitMap()
+		localRepo.gitRepository.buildCommitMap()
 	}
 	b.ReportAllocs()
 }

--- a/core/cautils/git_native_enabled_test.go
+++ b/core/cautils/git_native_enabled_test.go
@@ -3,7 +3,7 @@ package cautils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (s *LocalGitRepositoryTestSuite) TestGetLastCommit() {
@@ -50,7 +50,8 @@ func (s *LocalGitRepositoryTestSuite) TestGetFileLastCommit() {
 
 func BenchmarkBuildCommitMap(b *testing.B) {
 	localRepo, err := NewLocalGitRepository("testdata/temp/localrepo")
-	assert.NoError(b, err)
+	// require, not assert: NewLocalGitRepository returns a nil repository on error, so continuing would panic on the nil dereference below and bury the real setup failure.
+	require.NoError(b, err)
 	for b.Loop() {
 		localRepo.gitRepository.buildCommitMap()
 	}

--- a/core/cautils/localgitrepository.go
+++ b/core/cautils/localgitrepository.go
@@ -13,10 +13,11 @@ import (
 )
 
 type LocalGitRepository struct {
-	*gitRepository
-	goGitRepo *gitv5.Repository
-	head      *plumbingv5.Reference
-	config    *configv5.Config
+	// named rather than embedded: embedding promoted GetFileLastCommit, and since this field is unexported no caller outside the package could check it was set before invoking the promoted method.
+	gitRepository *gitRepository
+	goGitRepo     *gitv5.Repository
+	head          *plumbingv5.Reference
+	config        *configv5.Config
 }
 
 // worktreeRoot resolves the repository's worktree root. It is a package-level
@@ -144,6 +145,16 @@ func (g *LocalGitRepository) GetLastCommit() (*apis.Commit, error) {
 		},
 		Files: []apis.Files{},
 	}, nil
+}
+
+// GetFileLastCommit returns the last commit that touched filePath, or an error when the repository carries no git metadata.
+// It replaces the method the embedded *gitRepository used to promote, so an unset metadata reader reports itself instead of panicking on a nil receiver the caller had no way to inspect.
+func (g *LocalGitRepository) GetFileLastCommit(filePath string) (*apis.Commit, error) {
+	if g == nil || g.gitRepository == nil {
+		return nil, fmt.Errorf("no git metadata available for file: %s", filePath)
+	}
+
+	return g.gitRepository.GetFileLastCommit(filePath)
 }
 
 // GetGitRootDir returns the root directory of the git repository containing path.

--- a/core/cautils/localgitrepository_test.go
+++ b/core/cautils/localgitrepository_test.go
@@ -256,6 +256,45 @@ func TestNewLocalGitRepositoryRootDirFailure(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 }
 
+// TestGetFileLastCommitWithoutMetadata covers the reason GetFileLastCommit is declared
+// explicitly instead of being promoted from an embedded *gitRepository. The field is
+// unexported, so callers outside this package can only check the outer pointer; when the
+// metadata reader was left unset, the promoted method dereferenced a nil receiver and
+// panicked. Both shapes must now report the failure through the error they already handle.
+func TestGetFileLastCommitWithoutMetadata(t *testing.T) {
+	t.Run("repository without a metadata reader", func(t *testing.T) {
+		repository := &LocalGitRepository{}
+
+		commit, err := repository.GetFileLastCommit("workloads/deployment.yaml")
+		assert.Nil(t, commit)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workloads/deployment.yaml")
+	})
+
+	t.Run("nil repository", func(t *testing.T) {
+		var repository *LocalGitRepository
+
+		commit, err := repository.GetFileLastCommit("workloads/deployment.yaml")
+		assert.Nil(t, commit)
+		assert.Error(t, err)
+	})
+}
+
+// TestNewLocalGitRepositoryPopulatesMetadataReader pins the invariant the type change is
+// meant to protect: a repository handed out by the constructor always carries its metadata
+// reader, so a caller that got one never has to reason about a half-built value.
+func TestNewLocalGitRepositoryPopulatesMetadataReader(t *testing.T) {
+	fixture := createDetachedRepositoryFixture(t, "origin", "https://example.com/team/project.git")
+
+	repository, err := NewLocalGitRepository(fixture.root)
+	require.NoError(t, err)
+	require.NotNil(t, repository.gitRepository, "the constructor must never hand out a repository without a metadata reader")
+
+	// a file that was never committed still resolves through the reader rather than panicking
+	_, err = repository.GetFileLastCommit("never-committed.yaml")
+	assert.Error(t, err)
+}
+
 func TestLocalGitRepositoryDetachedHead(t *testing.T) {
 	fixture := createDetachedRepositoryFixture(t, "origin", "https://github.com/kubescape/detached-head-fixture.git")
 


### PR DESCRIPTION
## Overview

**Current behavior:** `LocalGitRepository` embeds an unexported `*gitRepository`, which promotes `GetFileLastCommit` onto the outer type. Because the embedded field is unexported, callers outside `cautils` can only check the outer pointer:

```go
if gitRepo != nil {
    commitInfo, _ := gitRepo.GetFileLastCommit(source)
}
```

That guard says nothing about the embedded pointer. When it is nil, the promoted call runs with a nil receiver and immediately dereferences it (`len(g.fileToLastCommit)`, `g.gitLogDisabled` in `git_native_disabled.go`), so the caller gets a panic where the nil check it already wrote should have been sufficient.

Confirmed directly — both shapes panic today:

```
&LocalGitRepository{}     → GetFileLastCommit → panic: invalid memory address or nil pointer dereference
var r *LocalGitRepository → GetFileLastCommit → panic: invalid memory address or nil pointer dereference
```

**Future behavior:** `gitRepository` becomes a named field and `GetFileLastCommit` is declared explicitly on `*LocalGitRepository`, returning an error when no metadata reader is present. Callers get the failure through the error return they already have, instead of a panic they had no exported way to prevent.

This is option 1 of the three in the issue. Option 2 (`HasGitMetadata()`) leaves the hazard in place and pushes the work onto every caller; option 3 is the nil-receiver-safe variant, which hides rather than fixes the problem.

## Additional Information

**Every call site compiles unchanged.** The explicit method has the same signature the promotion exposed, so `filesloader.go:172`, `:270`, `:359` and the commented-out `filesloaderutils.go:142` needed no edits — `go build ./...` passed on the first run after the struct change. The existing `if gitRepo != nil` guards are now redundant but harmless, so I left them as they are rather than churning unrelated lines.

**Scope of reachability, stated honestly.** I could not reach the panic from production code as it stands: `NewLocalGitRepository` returns nil on every error path and `newGitRepository` always returns a non-nil struct, so `extractGitRepo` hands callers either a nil pointer or a fully-formed one. This PR enforces at the type level an invariant currently established at one constructor path, which is how the issue frames it. The hazardous shape is not hypothetical, though — `localgitrepository_test.go` already builds `LocalGitRepository{config: …, head: …}` with the embedded pointer left nil, and any new constructor could do the same without a compiler complaint.

**One consequence worth flagging.** Dropping the embedding also drops promotion of the unexported methods, which `BenchmarkBuildCommitMap` in `git_native_enabled_test.go` relied on via `localRepo.buildCommitMap()`. It now reaches through the field explicitly, which is legal in-package and arguably clearer about what is being measured. Benchmark unchanged: 10 iterations, 217 ms/op, 19.6 MB/op, 93348 allocs/op.

**Not touched:** `extractGitRepo` has a branch that can never fire — in the error path `gitRepo` is always nil, so `if gitRepo != nil { gitRepo.GetRootDir() }` at `filesloader.go:410` is dead. I left it rather than cleaning it up, since it is outside this issue's scope.

## How to Test

```bash
go test ./core/cautils/ -run 'GetFileLastCommit|MetadataReader' -v
go test ./core/...
```

To confirm the new tests are genuine regression guards, restore the embedding on `LocalGitRepository` and delete the explicit method, then re-run: `TestGetFileLastCommitWithoutMetadata` fails with `panic: runtime error: invalid memory address or nil pointer dereference` — exactly the failure mode described in the issue.

Locally: `go build ./...`, `go vet`, `gofmt -l` clean, and tests pass across all 31 packages.

Related issues/PRs:
- Resolves #2710

Follows up on #2651, which closed one constructor path; this enforces the invariant at the type level.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safer handling when repository metadata is unavailable, returning clear errors instead of causing failures.
  * Improved retrieval of the latest commit associated with a file.
* **Tests**
  * Added coverage for missing repository metadata and uncommitted files.
  * Added validation that initialized repositories include the required metadata reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->