### PR TITLE
fix(printer): keep YAML compliance score below perfect

### DIFF
--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -55,7 +55,7 @@ func (yp *YamlPrinter) Score(score float32) {
 		score = 0
 	}
 
-	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.Float32ToInt(score))
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
 func (yp *YamlPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.ImageScanSummary {

--- a/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
@@ -39,6 +39,11 @@ func TestScore_Yaml(t *testing.T) {
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n",
 		},
 		{
+			name:  "Fractional score below perfect",
+			score: 99.5,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 99\n",
+		},
+		{
 			name:  "Score less than 0",
 			score: -20.0,
 			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 0\n",


### PR DESCRIPTION
## Summary

- use `cautils.ComplianceScoreToInt` for YAML compliance score output
- add a YAML score regression case for `99.5 -> 99`

Fixes #2725

## Testing

```sh
go test ./core/pkg/resultshandling/printer/v2 -run 'TestScore_(Json|Junit|Pdf|Yaml)' -count=1\ngo test ./core/pkg/resultshandling/printer/v2 -count=1\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected YAML output so fractional compliance scores are consistently converted to whole numbers.
  * A score of 99.5 is now displayed as 99.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->