### PR TITLE
fix(diff): sort diff buckets so output is deterministic

### DIFF
--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -1,10 +1,12 @@
 package diff
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -129,7 +131,25 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 		}
 	}
 
+	// The buckets above are filled by ranging over maps, and Go randomizes map
+	// iteration order, so identical inputs would otherwise yield a different
+	// ordering on every run. Sort so the output is reproducible and diffable.
+	sortChanges(cs.New)
+	sortChanges(cs.Resolved)
+	sortChanges(cs.Unchanged)
+
 	return cs, nil
+}
+
+// sortChanges orders a bucket by resource ID, then control ID. The pair is
+// unique per bucket, so the resulting order is total and stable across runs.
+func sortChanges(changes []ControlChange) {
+	slices.SortFunc(changes, func(a, b ControlChange) int {
+		if c := cmp.Compare(a.ResourceID, b.ResourceID); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ControlID, b.ControlID)
+	})
 }
 
 func loadReport(path string) (*scanReport, error) {

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -2,9 +2,11 @@ package diff
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -237,4 +239,48 @@ func TestPrintYAML(t *testing.T) {
 	assert.Contains(t, yamlStr, "resourceID: path-123/api/v1/Pod/demo")
 	assert.Contains(t, yamlStr, "controlID: C-0057")
 	assert.Contains(t, yamlStr, "controlName: Privileged container")
+}
+
+func TestCompute_DeterministicOrdering(t *testing.T) {
+	// Several failing resource+control pairs per bucket, deliberately written out
+	// of order so a correct implementation has to sort rather than preserve input.
+	base := makeReport(
+		makeResult("res3", makeControl("C-003", "Control 3", "failed")),
+		makeResult("res1", makeControl("C-002", "Control 2", "failed")),
+		makeResult("res2", makeControl("C-001", "Control 1", "failed")),
+		makeResult("res1", makeControl("C-001", "Control 1", "failed")),
+	)
+	head := makeReport(
+		makeResult("res2", makeControl("C-004", "Control 4", "failed")),
+		makeResult("res1", makeControl("C-001", "Control 1", "failed")),
+		makeResult("res3", makeControl("C-003", "Control 3", "passed")),
+		makeResult("res1", makeControl("C-005", "Control 5", "failed")),
+	)
+
+	basePath := writeTempReport(t, base)
+	headPath := writeTempReport(t, head)
+
+	first, err := Compute(basePath, headPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.New)
+	require.NotEmpty(t, first.Resolved)
+	require.NotEmpty(t, first.Unchanged)
+
+	// Go randomizes map iteration order per range statement, so repeating the
+	// computation on identical inputs surfaces any unsorted bucket.
+	for i := 0; i < 50; i++ {
+		got, err := Compute(basePath, headPath)
+		require.NoError(t, err)
+		assert.Equal(t, first.New, got.New, "New bucket order changed on run %d", i)
+		assert.Equal(t, first.Resolved, got.Resolved, "Resolved bucket order changed on run %d", i)
+		assert.Equal(t, first.Unchanged, got.Unchanged, "Unchanged bucket order changed on run %d", i)
+	}
+
+	// And the order is the documented one: resource ID, then control ID.
+	assert.True(t, slices.IsSortedFunc(first.New, func(a, b ControlChange) int {
+		if c := cmp.Compare(a.ResourceID, b.ResourceID); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ControlID, b.ControlID)
+	}), "New bucket is not sorted by resource ID then control ID: %+v", first.New)
 }


### PR DESCRIPTION
Fixes #2731

### Problem

`diff.Compute` fills the `New`, `Resolved` and `Unchanged` buckets by ranging over the maps built by `buildMap`:

```go
for k, hc := range headMap { ... cs.New = append(cs.New, change) }
for k, bc := range baseMap { ... cs.Resolved = append(cs.Resolved, ...) }
```

Go deliberately randomizes map iteration order on every range, and nothing sorts the buckets afterwards. So `kubescape diff` emits the same findings in a different order on each run — as the reporter showed, two runs over one pair of reports produce different checksums:

```
kubescape diff base.json head.json --format json --output out-1.json
kubescape diff base.json head.json --format json --output out-2.json
md5sum out-1.json out-2.json    # two different sums, same inputs
```

That defeats diffing two `kubescape diff` outputs, byte-comparison in CI, and caching keyed on output content.

### Fix

Sort each bucket by resource ID, then control ID, before returning. That pair is the map key, so it is unique within a bucket and the resulting order is total and stable across runs.

Uses `slices.SortFunc` with `cmp.Compare` (the repo is on Go 1.26 and already uses `slices` elsewhere). Purely an ordering change — no finding is added, removed or altered.

### Testing

`TestCompute_DeterministicOrdering` builds reports with several failing resource+control pairs per bucket, written deliberately out of order, then computes the same inputs 51 times and asserts every bucket keeps its exact order. It also asserts the order is the documented one rather than merely repeatable.

Verified it is a real regression test: with the three `sortChanges` calls removed it **fails** (`Resolved bucket order changed on run 49`), and passes with them.

```
go test ./core/pkg/resultshandling/diff/...   ok
go vet  ./core/pkg/resultshandling/diff/      clean
gofmt                                         clean
```

All pre-existing tests in the package continue to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of result listings by ensuring changes are displayed in a stable, predictable order.
  * Results are now ordered by resource identifier and then control identifier across new, resolved, and unchanged items.

* **Tests**
  * Added coverage to verify consistent ordering across repeated result calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->