### PR TITLE
fix(core): preserve non-zero risk score rounding in HTML report (#2727)

### DIFF
--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -49,4 +49,3 @@ func RiskScoreToInt(x float32) int {
 	}
 	return i
 }
-

--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -38,3 +38,15 @@ func ComplianceScoreToInt(x float32) int {
 	}
 	return i
 }
+
+// RiskScoreToInt converts a risk score to a display-safe integer. It preserves
+// the existing rounded display while ensuring a non-zero risk never appears as
+// zero because of rounding.
+func RiskScoreToInt(x float32) int {
+	i := Float32ToInt(x)
+	if i <= 0 && x > 0 {
+		return 1
+	}
+	return i
+}
+

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -126,7 +126,6 @@ func TestRiskScoreToInt(t *testing.T) {
 	}
 }
 
-
 func TestFloat32ToIntFloor(t *testing.T) {
 	assert.Equal(t, 99, Float32ToIntFloor(99.5))
 	assert.Equal(t, 99, Float32ToIntFloor(99.9))

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -76,6 +76,57 @@ func TestComplianceScoreToInt(t *testing.T) {
 	}
 }
 
+func TestRiskScoreToInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  int
+	}{
+		{
+			name:  "ordinary fractional score still rounds",
+			score: 20.4,
+			want:  20,
+		},
+		{
+			name:  "ordinary fractional score rounds up",
+			score: 20.7,
+			want:  21,
+		},
+		{
+			name:  "small non-zero risk score does not round to zero",
+			score: 0.4,
+			want:  1,
+		},
+		{
+			name:  "tiny non-zero risk score does not round to zero",
+			score: 0.01,
+			want:  1,
+		},
+		{
+			name:  "zero risk score remains zero",
+			score: 0.0,
+			want:  0,
+		},
+		{
+			name:  "unscored sentinel remains negative",
+			score: -1.0,
+			want:  -1,
+		},
+		{
+			name:  "high risk score rounds normally",
+			score: 99.6,
+			want:  100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RiskScoreToInt(tt.score))
+		})
+	}
+}
+
+
 func TestFloat32ToIntFloor(t *testing.T) {
 	assert.Equal(t, 99, Float32ToIntFloor(99.5))
 	assert.Equal(t, 99, Float32ToIntFloor(99.9))

--- a/core/pkg/resultshandling/printer/v2/html/report.gohtml
+++ b/core/pkg/resultshandling/printer/v2/html/report.gohtml
@@ -110,7 +110,7 @@
           <td class="controlNameCell">{{ $control.Name }}</td>
           <td class="controlRiskCell numericCell">{{ $control.StatusCounters.FailedResources }}</td>
           <td class="controlRiskCell numericCell">{{ sum $control.StatusCounters.SkippedResources $control.StatusCounters.FailedResources $control.StatusCounters.PassedResources }}</td>
-          <td class="controlRiskCell numericCell">{{ float32ToInt $control.Score }}</td>
+          <td class="controlRiskCell numericCell">{{ riskScoreToInt $control.Score }}</td>
         </tr>
       </tr>
       {{ end }}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -73,7 +73,7 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 			}
 			return total
 		},
-		"float32ToInt": cautils.Float32ToInt,
+		"riskScoreToInt": cautils.RiskScoreToInt,
 		"lower":        strings.ToLower,
 		"sortByNamespace": func(resourceTableView ResourceTableView) ResourceTableView {
 			sortedResourceTableView := make(ResourceTableView, len(resourceTableView))

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -74,7 +74,7 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 			return total
 		},
 		"riskScoreToInt": cautils.RiskScoreToInt,
-		"lower":        strings.ToLower,
+		"lower":          strings.ToLower,
 		"sortByNamespace": func(resourceTableView ResourceTableView) ResourceTableView {
 			sortedResourceTableView := make(ResourceTableView, len(resourceTableView))
 			copy(sortedResourceTableView, resourceTableView)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -112,18 +113,13 @@ func TestBuildResourceTableView_SkipsMissingResource(t *testing.T) {
 
 func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	ctx := context.Background()
-	tmp := t.TempDir()
-	origWd, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(tmp))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	out := filepath.Join(t.TempDir(), "report.html")
 
 	hp := NewHtmlPrinter()
-	hp.SetWriter(ctx, "report.html")
-	t.Cleanup(func() {
-		_ = hp.writer.Close()
-	})
+	hp.SetWriter(ctx, out)
 
+	// Fixture counters (FailedResources: 2, AllResources: 100) are intentionally
+	// distinct from the expected risk score (1) so no other numeric cell renders 0 or 1.
 	session := cautils.NewOPASessionObjMock()
 	session.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
 		"C-0001": reportsummary.ControlSummary{
@@ -132,8 +128,8 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 			Score:       0.4,
 			ScoreFactor: 1.0,
 			StatusCounters: reportsummary.StatusCounters{
-				FailedResources: 1,
-				PassedResources: 99,
+				FailedResources: 2,
+				PassedResources: 98,
 			},
 		},
 	}
@@ -141,7 +137,7 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	hp.ActionPrint(ctx, session, nil)
 	hp.CloseWriter()
 
-	content, err := os.ReadFile(hp.writer.Name())
+	content, err := os.ReadFile(out)
 	assert.NoError(t, err)
 	htmlContent := string(content)
 
@@ -149,4 +145,3 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	assert.Contains(t, htmlContent, `<td class="controlRiskCell numericCell">1</td>`)
 	assert.NotContains(t, htmlContent, `<td class="controlRiskCell numericCell">0</td>`)
 }
-

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -109,3 +109,44 @@ func TestBuildResourceTableView_SkipsMissingResource(t *testing.T) {
 	view := buildResourceTableView(session)
 	assert.Empty(t, view, "missing resource should be skipped, not included with nil")
 }
+
+func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	origWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	hp := NewHtmlPrinter()
+	hp.SetWriter(ctx, "report.html")
+	t.Cleanup(func() {
+		_ = hp.writer.Close()
+	})
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-0001": reportsummary.ControlSummary{
+			ControlID:   "C-0001",
+			Name:        "Test Fractional Risk Control",
+			Score:       0.4,
+			ScoreFactor: 1.0,
+			StatusCounters: reportsummary.StatusCounters{
+				FailedResources: 1,
+				PassedResources: 99,
+			},
+		},
+	}
+
+	hp.ActionPrint(ctx, session, nil)
+	hp.CloseWriter()
+
+	content, err := os.ReadFile(hp.writer.Name())
+	assert.NoError(t, err)
+	htmlContent := string(content)
+
+	// Fractional risk score 0.4% must round to 1% display, not 0%
+	assert.Contains(t, htmlContent, `<td class="controlRiskCell numericCell">1</td>`)
+	assert.NotContains(t, htmlContent, `<td class="controlRiskCell numericCell">0</td>`)
+}
+


### PR DESCRIPTION
Closes #2727

### What this PR does
Prevents small non-zero risk scores (e.g. `0.4%`) from rounding down to `0%` in the HTML report's "Risk Score, %" column. Displays `1%` instead so controls with failing resources never look clean.

### Changes made
- **`core/cautils/floatutils.go`**: Added `RiskScoreToInt(x float32) int` (mirrors `ComplianceScoreToInt`). Clamps any `x > 0` rounding to `<= 0` back to `1`.
- **`core/cautils/floatutils_test.go`**: Added `TestRiskScoreToInt` table-driven tests for edge cases.
- **`core/pkg/resultshandling/printer/v2/htmlprinter.go`**: Registered `riskScoreToInt` in template function map.
- **`core/pkg/resultshandling/printer/v2/html/report.gohtml`**: Updated line 113 to call `riskScoreToInt`.
- **`core/pkg/resultshandling/printer/v2/htmlprinter_test.go`**: Added `TestHtmlPrinter_ActionPrint_RiskScoreRounding` asserting rendered HTML outputs `1` instead of `0`.

### How was this tested?
- `go test -v ./core/cautils/...`
- `go test -v ./core/pkg/resultshandling/printer/v2/...`
- `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved risk score display in HTML reports by rounding fractional scores consistently.
  * Ensured small positive risk scores display as at least 1 instead of 0.
  * Preserved expected handling for zero, negative, and high risk scores.

* **Tests**
  * Added coverage for risk score conversion and HTML report rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->