### PR TITLE
fix(diff): sort ChangeSet buckets so diff output is reproducible.

### DIFF
--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -128,8 +129,25 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 			})
 		}
 	}
+	// Go randomizes map iteration order per run, so kubescape diff returned the
+	// same findings in a different order on every invocation over the same two reports.
+	sortChanges(cs.New)
+	sortChanges(cs.Resolved)
+	sortChanges(cs.Unchanged)
 
 	return cs, nil
+}
+
+func sortChanges(changes []ControlChange) {
+	sort.Slice(changes, func(i, j int) bool {
+		if iRank, jRank := severityRank(changes[i].Severity), severityRank(changes[j].Severity); iRank != jRank {
+			return iRank > jRank
+		}
+		if changes[i].ResourceID != changes[j].ResourceID {
+			return changes[i].ResourceID < changes[j].ResourceID
+		}
+		return changes[i].ControlID < changes[j].ControlID
+	})
 }
 
 func loadReport(path string) (*scanReport, error) {

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -3,6 +3,7 @@ package diff
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -237,4 +238,99 @@ func TestPrintYAML(t *testing.T) {
 	assert.Contains(t, yamlStr, "resourceID: path-123/api/v1/Pod/demo")
 	assert.Contains(t, yamlStr, "controlID: C-0057")
 	assert.Contains(t, yamlStr, "controlName: Privileged container")
+}
+
+func TestCompute_OutputOrderIsDeterministic(t *testing.T) {
+	const controlsPerResource = 13
+	resourceIDs := []string{"path-1/api/v1/Pod/alpha", "path-2/api/v1/Pod/bravo"}
+	scoreFactors := []float32{9.5, 7.0, 5.0, 2.0}
+
+	controlSummaries := make(map[string]controlSummary, controlsPerResource)
+	baseResults := make([]resultEntry, 0, len(resourceIDs))
+	headResults := make([]resultEntry, 0, len(resourceIDs))
+
+	for _, resourceID := range resourceIDs {
+		baseControls := make([]controlEntry, 0, controlsPerResource)
+		headControls := make([]controlEntry, 0, controlsPerResource)
+
+		for i := 0; i < controlsPerResource; i++ {
+			controlID := fmt.Sprintf("C-%03d", i)
+			controlName := "Control " + controlID
+			controlSummaries[controlID] = controlSummary{ScoreFactor: scoreFactors[i%len(scoreFactors)]}
+
+			baseStatus, headStatus := "failed", "failed"
+			switch i % 3 {
+			case 1:
+				baseStatus, headStatus = "passed", "failed"
+			case 2:
+				baseStatus, headStatus = "failed", "passed"
+			}
+
+			baseControls = append(baseControls, makeControl(controlID, controlName, baseStatus))
+			headControls = append(headControls, makeControl(controlID, controlName, headStatus))
+		}
+
+		baseResults = append(baseResults, makeResult(resourceID, baseControls...))
+		headResults = append(headResults, makeResult(resourceID, headControls...))
+	}
+
+	summary := summaryDetails{Controls: controlSummaries}
+	baseFile := writeTempReport(t, scanReport{Results: baseResults, SummaryDetails: summary})
+	headFile := writeTempReport(t, scanReport{Results: headResults, SummaryDetails: summary})
+
+	first, err := Compute(baseFile, headFile)
+	require.NoError(t, err)
+
+	buckets := []struct {
+		name    string
+		changes []ControlChange
+		want    [][3]string
+	}{
+		{"New", first.New, [][3]string{
+			{"Critical", "path-1/api/v1/Pod/alpha", "C-004"},
+			{"Critical", "path-2/api/v1/Pod/bravo", "C-004"},
+			{"High", "path-1/api/v1/Pod/alpha", "C-001"},
+			{"High", "path-2/api/v1/Pod/bravo", "C-001"},
+			{"Medium", "path-1/api/v1/Pod/alpha", "C-010"},
+			{"Medium", "path-2/api/v1/Pod/bravo", "C-010"},
+			{"Low", "path-1/api/v1/Pod/alpha", "C-007"},
+			{"Low", "path-2/api/v1/Pod/bravo", "C-007"},
+		}},
+		{"Resolved", first.Resolved, [][3]string{
+			{"Critical", "path-1/api/v1/Pod/alpha", "C-008"},
+			{"Critical", "path-2/api/v1/Pod/bravo", "C-008"},
+			{"High", "path-1/api/v1/Pod/alpha", "C-005"},
+			{"High", "path-2/api/v1/Pod/bravo", "C-005"},
+			{"Medium", "path-1/api/v1/Pod/alpha", "C-002"},
+			{"Medium", "path-2/api/v1/Pod/bravo", "C-002"},
+			{"Low", "path-1/api/v1/Pod/alpha", "C-011"},
+			{"Low", "path-2/api/v1/Pod/bravo", "C-011"},
+		}},
+		{"Unchanged", first.Unchanged, [][3]string{
+			{"Critical", "path-1/api/v1/Pod/alpha", "C-000"},
+			{"Critical", "path-1/api/v1/Pod/alpha", "C-012"},
+			{"Critical", "path-2/api/v1/Pod/bravo", "C-000"},
+			{"Critical", "path-2/api/v1/Pod/bravo", "C-012"},
+			{"High", "path-1/api/v1/Pod/alpha", "C-009"},
+			{"High", "path-2/api/v1/Pod/bravo", "C-009"},
+			{"Medium", "path-1/api/v1/Pod/alpha", "C-006"},
+			{"Medium", "path-2/api/v1/Pod/bravo", "C-006"},
+			{"Low", "path-1/api/v1/Pod/alpha", "C-003"},
+			{"Low", "path-2/api/v1/Pod/bravo", "C-003"},
+		}},
+	}
+	for _, bucket := range buckets {
+		require.Len(t, bucket.changes, len(bucket.want), bucket.name)
+		for i, want := range bucket.want {
+			require.Equal(t, want, [3]string{bucket.changes[i].Severity, bucket.changes[i].ResourceID, bucket.changes[i].ControlID}, "%s[%d]", bucket.name, i)
+		}
+	}
+
+	for run := 2; run <= 5; run++ {
+		got, err := Compute(baseFile, headFile)
+		require.NoError(t, err)
+		require.Equal(t, first.New, got.New, "New ordered differently on run %d for identical inputs", run)
+		require.Equal(t, first.Resolved, got.Resolved, "Resolved ordered differently on run %d for identical inputs", run)
+		require.Equal(t, first.Unchanged, got.Unchanged, "Unchanged ordered differently on run %d for identical inputs", run)
+	}
 }


### PR DESCRIPTION
## Overview

`Compute` fills `New`/`Resolved`/`Unchanged` by ranging over the maps built by `buildMap`. Go randomizes map iteration order per run, and nothing sorts the buckets afterwards `PrintPretty` walks each slice as it is, `PrintJSON`/`PrintYAML` marshal them as ordered sequences. So `kubescape diff base.json head.json` returns the same findings in a different order on every invocation, and `--format json --output diff.json` writes a byte-different artifact each time.

This PR sorts each bucket before `Compute` returns - severity descending, then `ResourceID`, then `ControlID` this makes the output a deterministic function of the input.

Fixes #2731


## Additional Information
Nothing in the suite asserted ordering: every `Compute` test but one builds a single control (one element has only one possible order), `TestFilterBySeverity_CIGate` compares its four findings with `assert.ElementsMatch` which ignores order by design, and `TestPrintYAML` builds its `ChangeSet` literal by hand and never reaches a map.

## How to Test
Unit test fails without the sort, passes with it.

```bash
kubescape scan --format json --output base.json .
kubescape scan --format json --output head.json .   # after some change

for i in 1 2 3 4 5; do kubescape diff base.json head.json --format json --output out-$i.json; done
md5sum out-*.json     # identical after this PR, five different sums before it
```



<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [X] My code follows the style guidelines of this project
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes

--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured change results are displayed in a consistent, predictable order.
  * Results are now ordered by severity, resource, and control, improving readability and repeatability across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->