### PR TITLE
fix(core): log swallowed errors when loading cached/cluster config

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -121,7 +121,9 @@ func NewLocalConfig(accountID, accessKey, clusterName, customClusterName string)
 	}
 	// get from configMap
 	if existsConfigFile() { // get from file
-		loadConfigFromFile(lc.configObj)
+		if err := loadConfigFromFile(lc.configObj); err != nil {
+			logger.L().Debug("failed to load cached config file", helpers.Error(err))
+		}
 	}
 
 	updateCredentials(lc.configObj, accountID, accessKey)
@@ -204,16 +206,24 @@ func NewClusterConfig(k8s *k8sinterface.KubernetesApi, accountID, accessKey, clu
 
 	// first, load from file
 	if existsConfigFile() { // get from file
-		loadConfigFromFile(c.configObj)
+		if err := loadConfigFromFile(c.configObj); err != nil {
+			logger.L().Debug("failed to load cached config file", helpers.Error(err))
+		}
 	}
 
 	loadUrlsFromFile(c.configObj)
 
 	// second, load urls from config map
-	c.updateConfigEmptyFieldsFromKubescapeConfigMap()
+	if err := c.updateConfigEmptyFieldsFromKubescapeConfigMap(); err != nil {
+		logger.L().Debug("failed to load config from Kubescape ConfigMap in cluster",
+			helpers.String("namespace", c.configMapNamespace), helpers.Error(err))
+	}
 
 	// third, credentials from secret
-	c.updateConfigEmptyFieldsFromCredentialsSecret()
+	if err := c.updateConfigEmptyFieldsFromCredentialsSecret(); err != nil {
+		logger.L().Debug("failed to load credentials from Kubescape Secret in cluster",
+			helpers.String("namespace", c.configMapNamespace), helpers.Error(err))
+	}
 
 	updateCredentials(c.configObj, accountID, accessKey)
 	updateCloudURLs(c.configObj)

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -2,10 +2,13 @@ package cautils
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"testing"
 
 	v1 "github.com/kubescape/backend/pkg/client/v1"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -436,6 +439,39 @@ func TestUpdateConfigFile_RoundTrip(t *testing.T) {
 	readBack := &ConfigObj{}
 	require.NoError(t, json.Unmarshal(dat, readBack))
 	assert.Equal(t, configObj.AccountID, readBack.AccountID)
+}
+
+// TestNewLocalConfig_LogsOnMalformedCachedConfigFile guards against a
+// regression where a malformed cached config file (~/.kubescape/config.json)
+// caused loadConfigFromFile to return an error that NewLocalConfig discarded
+// completely - config loading silently fell back to defaults with no trace
+// anywhere that the cache was broken, which is confusing to debug ("why
+// isn't my configured account being picked up?").
+func TestNewLocalConfig_LogsOnMalformedCachedConfigFile(t *testing.T) {
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	defer func() { getter.DefaultLocalStore = originalStore }()
+
+	require.NoError(t, os.MkdirAll(getter.DefaultLocalStore, 0o700))
+	require.NoError(t, os.WriteFile(ConfigFileFullPath(), []byte("not valid json"), 0o600))
+
+	originalLevel := logger.L().GetLevel()
+	require.NoError(t, logger.L().SetLevel(helpers.DebugLevel.String()))
+	defer func() { _ = logger.L().SetLevel(originalLevel) }()
+
+	originalWriter := logger.L().GetWriter()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	logger.L().SetWriter(w)
+
+	NewLocalConfig("", "", "", "")
+
+	require.NoError(t, w.Close())
+	logger.L().SetWriter(originalWriter)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "failed to load cached config file")
 }
 
 func TestUpdateConfigFile_ToleratesDirectoryChmodFailure(t *testing.T) {


### PR DESCRIPTION
## Summary

`NewLocalConfig`, `NewClusterConfig`, and the two `updateConfigEmptyFieldsFrom*` helpers in `core/cautils/customerloader.go` all call `loadConfigFromFile` / read cluster ConfigMaps and Secrets and discard the returned error entirely, with no logging anywhere in the call chain:

- `loadConfigFromFile` returns an error when the cached config file (`~/.kubescape/config.json`) exists but fails to parse as JSON. Both call sites (`NewLocalConfig`, `NewClusterConfig`) silently fell back to an empty `ConfigObj` on a corrupted cache file, with zero trace that anything went wrong — confusing to debug ("why isn't my configured account being picked up?").
- `updateConfigEmptyFieldsFromKubescapeConfigMap` and `updateConfigEmptyFieldsFromCredentialsSecret` return an error when the Kubernetes API call to list the ConfigMap/Secret fails (e.g. insufficient RBAC to read Secrets in the configured namespace — a common cluster configuration) or when the ConfigMap's embedded JSON fails to unmarshal. `NewClusterConfig` discarded both errors unconditionally, so a user relying on cluster-stored credentials gets no indication the load failed; the scan just silently proceeds without an account ID/access key.

## Fix

Log each failure at debug level (matching this file's existing logging conventions) instead of discarding it, giving these failures a trace to find with `KS_LOG_LEVEL=debug` rather than none at all.

## Test plan
- [x] `go build ./core/cautils/...`
- [x] `go vet ./core/cautils/...`
- [x] `go test ./core/cautils/...` (full package, all existing tests pass)
- [x] Added `TestNewLocalConfig_LogsOnMalformedCachedConfigFile`: writes an invalid JSON cache file, redirects the logger's writer to a pipe, and asserts the failure is logged. Mutation-verified: reverting the `NewLocalConfig` fix locally makes this test fail (empty log output)
- [x] Confirmed via `golangci-lint` (`errcheck`) that these four call sites are no longer flagged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now reports errors from cached files, Kubernetes ConfigMaps, and credential Secrets instead of silently ignoring them.
  * Processing continues after individual configuration errors, improving resilience.
  * Malformed cached configuration files now produce a clear logged error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->