### PR TITLE
fix(core): make ProgressHandler.Stop() complete the progress bar

### DIFF
--- a/core/cautils/display.go
+++ b/core/cautils/display.go
@@ -113,5 +113,18 @@ func (p *ProgressHandler) ProgressJob(step int, message string) {
 	p.pb.Describe(message)
 }
 
+// Stop completes the progress bar to 100%. It must do this explicitly rather
+// than relying on the caller's ProgressJob calls to have added up to exactly
+// allSteps: callers that estimate allSteps in advance (e.g.
+// OPAProcessor.ProcessWithStreaming sizes it from a namespace count that
+// includes namespaces which turn out to hold no scannable resources, and so
+// never receive a corresponding ProgressJob call) legitimately finish having
+// added fewer steps than allSteps. Before this called Finish(), such a run
+// left the bar visibly stuck below 100% with no further updates, since Stop
+// was a no-op.
 func (p *ProgressHandler) Stop() {
+	if p.pb == nil {
+		return
+	}
+	_ = p.pb.Finish()
 }

--- a/core/cautils/display_test.go
+++ b/core/cautils/display_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStartSpinner(t *testing.T) {
@@ -428,6 +429,32 @@ func TestStarDisplay(t *testing.T) {
 			assert.Equal(t, tt.want, string(got))
 		})
 	}
+}
+
+// TestProgressHandler_StopFinishesBarWhenFewerStepsThanEstimated guards
+// against a regression where Stop() was a no-op. A caller that estimates
+// allSteps in advance (e.g. OPAProcessor.ProcessWithStreaming sizing it from
+// a namespace count that includes namespaces holding no scannable resources,
+// which therefore never get a corresponding ProgressJob call) can legitimately
+// finish having added fewer steps than allSteps. Without Stop completing the
+// bar, that run left it visibly stuck below 100% with no further updates.
+func TestProgressHandler_StopFinishesBarWhenFewerStepsThanEstimated(t *testing.T) {
+	p := NewProgressHandler("")
+	p.Start(10)
+	p.ProgressJob(3, "partial work")
+
+	require.Less(t, p.pb.State().CurrentPercent, 1.0, "sanity check: fewer steps were added than allSteps")
+
+	p.Stop()
+
+	assert.Equal(t, 1.0, p.pb.State().CurrentPercent)
+}
+
+// TestProgressHandler_StopIsNilSafe guards against a panic if Stop is ever
+// called without a preceding Start (pb still nil).
+func TestProgressHandler_StopIsNilSafe(t *testing.T) {
+	p := NewProgressHandler("")
+	assert.NotPanics(t, p.Stop)
 }
 
 // Returns a new instance of ProgressHandler with the given title.


### PR DESCRIPTION
## Summary

`ProgressHandler.Stop()` (`core/cautils/display.go`) was a no-op:

```go
func (p *ProgressHandler) Stop() {
}
```

Both callers of the `IJobProgressNotificationClient` interface (`OPAProcessor.Process` and `OPAProcessor.ProcessWithStreaming`, `core/pkg/opaprocessor/processorhandler.go`) pre-compute a total step count *before* evaluation starts, then call `Start(totalSteps)` followed by a deferred `Stop()` once evaluation finishes — the actual number of `ProgressJob()` calls made in between is not guaranteed to add up to exactly `totalSteps`.

`ProcessWithStreaming` sizes its total from `expectedNamespaceBatches`, which comes from `K8sResourceHandler.countNamespaces` — a count of every namespace matching the `--include-namespaces`/`--exclude-namespaces` filters, computed independently of and *before* actual resource collection. `PartitionResources` only produces a batch for a namespace that ends up holding at least one of the queried GVRs' resources; a namespace that exists but has none (empty namespaces, or namespaces containing only resource kinds kubescape does not scan — both common in real clusters) is counted toward `expectedNamespaceBatches` but never produces a batch, so it never receives a corresponding `ProgressJob` call. On a large cluster (this path only runs when `IsLargeCluster(estimatedClusterSize)` is true) with any such namespaces, the run legitimately finishes having added fewer steps than the pre-computed total.

Because `Stop()` did nothing, that left the progress bar visibly stuck below 100% for the rest of the scan, with no further updates — `schollz/progressbar`'s `ProgressBar.Finish()` (which sets the bar to its configured max and redraws) was never called.

## Fix

`Stop()` now calls `pb.Finish()` (nil-checked, matching how `ProgressJob` already assumes `Start()` ran first without a nil check). This fixes the symptom directly and generally, regardless of which caller's step estimate turns out inexact, rather than trying to make `countNamespaces` predict batch counts exactly — which is a data dependency (which namespaces will contain matching resources) that is not known until collection actually happens.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./core/cautils/...`
- [x] `go test ./core/cautils/...` and `go test ./core/pkg/opaprocessor/...` (full packages, all existing tests pass)
- [x] Added `TestProgressHandler_StopFinishesBarWhenFewerStepsThanEstimated` (asserts `pb.State().CurrentPercent` reaches `1.0` after `Stop()` even though fewer `ProgressJob` steps were added than the `Start()` estimate; mutation-verified it fails against the old no-op `Stop()`) and `TestProgressHandler_StopIsNilSafe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress indicators now complete at 100% when stopped before reaching the estimated total.
  * Stopping an unstarted progress indicator no longer causes an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->