### PR TITLE
feat(context): propagate context through tenant config initialization…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 			k8sinterface.SetClusterContextName(rootInfo.KubeContext)
 			initLogger()
 			initLoggerLevel(cmd)
-			initEnvironment()
+			initEnvironment(ks.Context())
 			initCacheDir(cmd)
 		},
 	}

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -83,7 +84,7 @@ func initCacheDir(cmd *cobra.Command) {
 		logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
 	}
 }
-func initEnvironment() {
+func initEnvironment(ctx context.Context) {
 	if rootInfo.DiscoveryServerURL == "" {
 		return
 	}
@@ -107,7 +108,7 @@ func initEnvironment() {
 
 	logger.L().Debug("configuring service discovery URLs", helpers.String("cloudAPIURL", services.GetApiServerUrl()), helpers.String("cloudReportURL", services.GetReportReceiverHttpUrl()))
 
-	tenant := cautils.GetTenantConfig("", "", "", "", nil)
+	tenant := cautils.GetTenantConfig(ctx, "", "", "", "", nil)
 	if services.GetApiServerUrl() != "" {
 		tenant.GetConfigObj().CloudAPIURL = services.GetApiServerUrl()
 	}

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -197,7 +197,7 @@ type ClusterConfig struct {
 	configMapNamespace string
 }
 
-func NewClusterConfig(k8s *k8sinterface.KubernetesApi, accountID, accessKey, clusterName, customClusterName string) *ClusterConfig {
+func NewClusterConfig(ctx context.Context, k8s *k8sinterface.KubernetesApi, accountID, accessKey, clusterName, customClusterName string) *ClusterConfig {
 	c := &ClusterConfig{
 		k8s:                k8s,
 		configObj:          &ConfigObj{},
@@ -214,13 +214,13 @@ func NewClusterConfig(k8s *k8sinterface.KubernetesApi, accountID, accessKey, clu
 	loadUrlsFromFile(c.configObj)
 
 	// second, load urls from config map
-	if err := c.updateConfigEmptyFieldsFromKubescapeConfigMap(); err != nil {
+	if err := c.updateConfigEmptyFieldsFromKubescapeConfigMap(ctx); err != nil {
 		logger.L().Debug("failed to load config from Kubescape ConfigMap in cluster",
 			helpers.String("namespace", c.configMapNamespace), helpers.Error(err))
 	}
 
 	// third, credentials from secret
-	if err := c.updateConfigEmptyFieldsFromCredentialsSecret(); err != nil {
+	if err := c.updateConfigEmptyFieldsFromCredentialsSecret(ctx); err != nil {
 		logger.L().Debug("failed to load credentials from Kubescape Secret in cluster",
 			helpers.String("namespace", c.configMapNamespace), helpers.Error(err))
 	}
@@ -276,8 +276,8 @@ func (c *ClusterConfig) ToMapString() map[string]any {
 	return m
 }
 
-func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap() error {
-	configMaps, err := c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).List(context.Background(), metav1.ListOptions{
+func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap(ctx context.Context) error {
+	configMaps, err := c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: cloudConfigMapLabelSelector,
 	})
 	if err != nil {
@@ -286,7 +286,7 @@ func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap() error {
 	var ksConfigMap *corev1.ConfigMap
 	if len(configMaps.Items) == 0 {
 		// try to find configmaps by name (for backward compatibility)
-		ksConfigMap, _ = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(context.Background(), kubescapeConfigMapName, metav1.GetOptions{})
+		ksConfigMap, _ = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
 	} else {
 		// use the first configmap with the label
 		ksConfigMap = &configMaps.Items[0]
@@ -305,8 +305,8 @@ func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap() error {
 	return err
 }
 
-func (c *ClusterConfig) updateConfigEmptyFieldsFromCredentialsSecret() error {
-	secrets, err := c.k8s.KubernetesClient.CoreV1().Secrets(c.configMapNamespace).List(context.Background(),
+func (c *ClusterConfig) updateConfigEmptyFieldsFromCredentialsSecret(ctx context.Context) error {
+	secrets, err := c.k8s.KubernetesClient.CoreV1().Secrets(c.configMapNamespace).List(ctx,
 		metav1.ListOptions{LabelSelector: credsLabelSelectors})
 	if err != nil {
 		return err
@@ -590,11 +590,11 @@ func initializeCloudAPI(c ITenantConfig) *v1.KSCloudAPI {
 	return getter.GetKSCloudAPIConnector()
 }
 
-func GetTenantConfig(accountID, accessKey, clusterName, customClusterName string, k8s *k8sinterface.KubernetesApi) ITenantConfig {
+func GetTenantConfig(ctx context.Context, accountID, accessKey, clusterName, customClusterName string, k8s *k8sinterface.KubernetesApi) ITenantConfig {
 	if !k8sinterface.IsConnectedToCluster() || k8s == nil {
 		return NewLocalConfig(accountID, accessKey, clusterName, customClusterName)
 	}
-	return NewClusterConfig(k8s, accountID, accessKey, clusterName, customClusterName)
+	return NewClusterConfig(ctx, k8s, accountID, accessKey, clusterName, customClusterName)
 }
 
 // firstNonEmpty returns the first non-empty string

--- a/core/cautils/customerloader_context_test.go
+++ b/core/cautils/customerloader_context_test.go
@@ -1,0 +1,187 @@
+package cautils
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// The generated fake clientset discards the context before reactors run
+// (see client-go gentype.FakeClient), so context propagation can only be
+// asserted at the REST transport layer, where client-go turns the context
+// into http.Request.Context().
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func jsonResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+		Request:    req,
+	}
+}
+
+// newTestClusterConfig builds a ClusterConfig backed by a clientset whose
+// transport is rt, bypassing NewClusterConfig so the test does not touch the
+// on-disk config file or the global cloud API connector.
+func newTestClusterConfig(t *testing.T, rt http.RoundTripper) *ClusterConfig {
+	t.Helper()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host:      "https://kubernetes.test:6443",
+		Transport: rt,
+	})
+	require.NoError(t, err)
+
+	return &ClusterConfig{
+		k8s:                &k8sinterface.KubernetesApi{KubernetesClient: clientset},
+		configObj:          &ConfigObj{},
+		configMapNamespace: kubescapeNamespace,
+	}
+}
+
+func TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_PropagatesContextValues(t *testing.T) {
+	type ctxKey struct{}
+	const sentinel = "ctx-sentinel"
+
+	var capturedCtx context.Context
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		capturedCtx = req.Context()
+		return jsonResponse(req, `{"apiVersion":"v1","kind":"ConfigMapList","items":[]}`), nil
+	})
+
+	c := newTestClusterConfig(t, rt)
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+	require.NoError(t, c.updateConfigEmptyFieldsFromKubescapeConfigMap(ctx))
+
+	require.NotNil(t, capturedCtx, "no request reached the transport")
+	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}),
+		"caller context was not propagated to the Kubernetes API call")
+}
+
+func TestUpdateConfigEmptyFieldsFromCredentialsSecret_PropagatesContextValues(t *testing.T) {
+	type ctxKey struct{}
+	const sentinel = "ctx-sentinel"
+
+	var capturedCtx context.Context
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		capturedCtx = req.Context()
+		return jsonResponse(req, `{"apiVersion":"v1","kind":"SecretList","items":[]}`), nil
+	})
+
+	c := newTestClusterConfig(t, rt)
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+	require.NoError(t, c.updateConfigEmptyFieldsFromCredentialsSecret(ctx))
+
+	require.NotNil(t, capturedCtx, "no request reached the transport")
+	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}),
+		"caller context was not propagated to the Kubernetes API call")
+}
+
+func TestUpdateConfigEmptyFields_ContextCancellationUnblocksSlowAPIServer(t *testing.T) {
+	// Simulates an unreachable API server: the request hangs until the caller's
+	// context is cancelled. With context.Background() this never returns.
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+
+	testCases := []struct {
+		name string
+		call func(*ClusterConfig, context.Context) error
+	}{
+		{
+			name: "configmap lookup",
+			call: (*ClusterConfig).updateConfigEmptyFieldsFromKubescapeConfigMap,
+		},
+		{
+			name: "credentials secret lookup",
+			call: (*ClusterConfig).updateConfigEmptyFieldsFromCredentialsSecret,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClusterConfig(t, rt)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				cancel()
+			}()
+			defer cancel()
+
+			done := make(chan error, 1)
+			go func() { done <- tc.call(c, ctx) }()
+
+			select {
+			case err := <-done:
+				require.Error(t, err, "expected the cancelled request to fail")
+				assert.True(t,
+					errors.Is(err, context.Canceled) || strings.Contains(err.Error(), context.Canceled.Error()),
+					"expected a context.Canceled error, got: %v", err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("call did not return after context cancellation - context is not propagated")
+			}
+		})
+	}
+}
+
+func TestUpdateConfigEmptyFields_ContextTimeoutIsRespected(t *testing.T) {
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+
+	c := newTestClusterConfig(t, rt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := c.updateConfigEmptyFieldsFromKubescapeConfigMap(ctx)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 3*time.Second,
+		"deadline from the caller's context was not honoured")
+}
+
+// Regression guard: threading the context through must not change how the
+// ConfigMap payload is applied to the config object.
+func TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LoadsClusterData(t *testing.T) {
+	const body = `{
+	  "apiVersion": "v1",
+	  "kind": "ConfigMapList",
+	  "items": [
+	    {
+	      "metadata": {"name": "ks-cloud-config", "namespace": "kubescape"},
+	      "data": {"clusterData": "{\"accountID\":\"acc-123\",\"cloudAPIURL\":\"https://api.example.com\"}"}
+	    }
+	  ]
+	}`
+
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(req, body), nil
+	})
+
+	c := newTestClusterConfig(t, rt)
+
+	require.NoError(t, c.updateConfigEmptyFieldsFromKubescapeConfigMap(context.Background()))
+	assert.Equal(t, "acc-123", c.configObj.AccountID)
+	assert.Equal(t, "https://api.example.com", c.configObj.CloudAPIURL)
+}

--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -174,13 +174,13 @@ func TestClusterConfigLoadsKubernetesSourcesDataDriven(t *testing.T) {
 			k8s.KubernetesClient = fake.NewClientset(test.objects...)
 			config := &ClusterConfig{k8s: k8s, configObj: &ConfigObj{}, configMapNamespace: "security"}
 
-			err := config.updateConfigEmptyFieldsFromKubescapeConfigMap()
+			err := config.updateConfigEmptyFieldsFromKubescapeConfigMap(context.Background())
 			if test.wantError != "" {
 				require.ErrorContains(t, err, test.wantError)
 				return
 			}
 			require.NoError(t, err)
-			require.NoError(t, config.updateConfigEmptyFieldsFromCredentialsSecret())
+			require.NoError(t, config.updateConfigEmptyFieldsFromCredentialsSecret(context.Background()))
 			assert.Equal(t, test.wantConfig, *config.configObj)
 		})
 	}
@@ -280,7 +280,7 @@ func Test_NewClusterConfig(t *testing.T) {
 	k8s := k8sinterface.NewKubernetesApiMock()
 	k8s.KubernetesClient = fake.NewClientset(objects...)
 
-	config := NewClusterConfig(k8s, "", "", "my:cluster", "")
+	config := NewClusterConfig(context.Background(), k8s, "", "", "my:cluster", "")
 
 	assert.Equal(t, "security", config.GetDefaultNS())
 	assert.Equal(t, "tenant-id", config.GetAccountID())
@@ -304,7 +304,7 @@ func Test_GetTenantConfig(t *testing.T) {
 	t.Run("not connected to cluster returns LocalConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(false)
 
-		config := GetTenantConfig("account", "key", "cluster", "", nil)
+		config := GetTenantConfig(context.Background(), "account", "key", "cluster", "", nil)
 		_, ok := config.(*LocalConfig)
 		assert.True(t, ok, "expected *LocalConfig when not connected to a cluster")
 	})
@@ -314,7 +314,7 @@ func Test_GetTenantConfig(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(true)
 
 		k8s := k8sinterface.NewKubernetesApiMock()
-		config := GetTenantConfig("account", "key", "cluster", "", k8s)
+		config := GetTenantConfig(context.Background(), "account", "key", "cluster", "", k8s)
 		_, ok := config.(*ClusterConfig)
 		assert.True(t, ok, "expected *ClusterConfig when connected to a cluster with a k8s client")
 	})
@@ -322,7 +322,7 @@ func Test_GetTenantConfig(t *testing.T) {
 	t.Run("connected to cluster without k8s client falls back to LocalConfig", func(t *testing.T) {
 		k8sinterface.SetConnectedToCluster(true)
 
-		config := GetTenantConfig("account", "key", "cluster", "", nil)
+		config := GetTenantConfig(context.Background(), "account", "key", "cluster", "", nil)
 		_, ok := config.(*LocalConfig)
 		assert.True(t, ok, "expected *LocalConfig when k8s client is nil")
 	})

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ks *Kubescape) SetCachedConfig(setConfig *metav1.SetConfig) error {
-	tenant := cautils.GetTenantConfig("", "", "", "", nil)
+	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", nil)
 
 	if setConfig.Account != "" {
 		tenant.GetConfigObj().AccountID = setConfig.Account
@@ -29,13 +29,13 @@ func (ks *Kubescape) SetCachedConfig(setConfig *metav1.SetConfig) error {
 
 // View cached configurations
 func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
-	tenant := cautils.GetTenantConfig("", "", "", "", getKubernetesApi()) // change k8sinterface
+	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", getKubernetesApi()) // change k8sinterface
 	fmt.Fprintf(viewConfig.Writer, "%s\n", tenant.GetConfigObj().Config())
 	return nil
 }
 
 func (ks *Kubescape) DeleteCachedConfig(deleteConfig *metav1.DeleteConfig) error {
 
-	tenant := cautils.GetTenantConfig("", "", "", "", nil) // change k8sinterface
+	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", nil) // change k8sinterface
 	return tenant.DeleteCachedConfig(ks.Context())
 }

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -131,7 +131,7 @@ func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 }
 
 func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
-	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
+	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	controlsInputsGetter, _, err := configInputsGetterFunc(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	if err != nil {
@@ -157,7 +157,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 }
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
-	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
+	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 	exceptionsGetter, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return err
@@ -182,7 +182,7 @@ func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) 
 
 func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 	var err error
-	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
+	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	attackTracksGetter, err := attackTracksGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
@@ -209,7 +209,7 @@ func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 
-	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
+	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), true, nil, false)
 	if err != nil {
@@ -263,7 +263,7 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 
 func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
 
-	tenant := tenantConfigFunc(downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
+	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	if err != nil {

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -353,7 +353,7 @@ func withPolicyGetter(t *testing.T, g getter.IPolicyGetter, err error) {
 func withTenantConfig(t *testing.T, tc cautils.ITenantConfig) {
 	t.Helper()
 	origTenant := tenantConfigFunc
-	tenantConfigFunc = func(string, string, string, string, *k8sinterface.KubernetesApi) cautils.ITenantConfig {
+	tenantConfigFunc = func(context.Context, string, string, string, string, *k8sinterface.KubernetesApi) cautils.ITenantConfig {
 		return tc
 	}
 	t.Cleanup(func() { tenantConfigFunc = origTenant })

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -94,7 +94,7 @@ func naturalSortControls(entries []metav1.ControlListEntry) []metav1.ControlList
 }
 
 func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
-	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
+	tenant := cautils.GetTenantConfig(ctx, listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
 	policyGetter, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), true, nil, false)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func listFrameworks(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 }
 
 func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]metav1.ControlListEntry, error) {
-	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
+	tenant := cautils.GetTenantConfig(ctx, listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi()) // change k8sinterface
 
 	policyGetter, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	if err != nil {
@@ -156,7 +156,7 @@ func parseControlEntry(pipe string) metav1.ControlListEntry {
 
 func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {
 	// load tenant metav1
-	tenant := cautils.GetTenantConfig(listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi())
+	tenant := cautils.GetTenantConfig(ctx, listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi())
 
 	var exceptionsNames []string
 	ksCloudAPI, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -58,7 +58,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentIn
 	}
 
 	// ================== setup tenant object ======================================
-	tenantConfig := cautils.GetTenantConfig(scanInfo.AccountID, scanInfo.AccessKey, k8sinterface.GetContextName(), scanInfo.CustomClusterName, getKubernetesApi())
+	tenantConfig := cautils.GetTenantConfig(ctx, scanInfo.AccountID, scanInfo.AccessKey, k8sinterface.GetContextName(), scanInfo.CustomClusterName, getKubernetesApi())
 
 	// Set submit behavior AFTER loading tenant config
 	setSubmitBehavior(scanInfo, tenantConfig)


### PR DESCRIPTION
## Summary
closed : #2737
This change propagates the caller's `context.Context` through the tenant
configuration initialization chain instead of creating new detached
`context.Background()` roots inside `core/cautils/customerloader.go`.

## Problem

`ClusterConfig` performs three live Kubernetes API server calls while loading
tenant configuration:

- `ConfigMaps(...).List(...)` with `context.Background()`
- `ConfigMaps(...).Get(...)` with `context.Background()`
- `Secrets(...).List(...)` with `context.Background()`

These calls were unreachable by any cancellation, timeout, or observability
context supplied by the caller. In practice this meant:

- `Ctrl-C` could not abort slow/in-flight config-map lookups
- `context.WithTimeout` budgets did not cover the setup phase
- OpenTelemetry trace spans stored in `ctx` were lost at these network calls

## Changes

- Added `ctx context.Context` as the first parameter to:
  - `GetTenantConfig`
  - `NewClusterConfig`
  - `updateConfigEmptyFieldsFromKubescapeConfigMap`
  - `updateConfigEmptyFieldsFromCredentialsSecret`
- Replaced the three `context.Background()` calls in `customerloader.go` with
  the propagated `ctx`
- Updated all call sites across `core/core/scan.go`, `core/core/list.go`,
  `core/core/download.go`, `core/core/cachedconfig.go`, `cmd/root.go`,
  and `cmd/rootutils.go`
- Added `core/cautils/customerloader_context_test.go` with tests covering:
  - context value propagation to the Kubernetes transport
  - context cancellation unblocking slow API calls
  - context deadline being respected
  - regression check that ConfigMap data is still loaded correctly

## Verification

- `go build ./...` passed
- `go vet ./...` passed
- `go test ./core/cautils -run 'TestUpdateConfigEmptyFields' -v` passed
- Full `go test ./core/... ./cmd/...` passed with the exception of the
  pre-existing, unrelated `TestKustomizeDirectoryWithHelmCharts` (fails due to
  missing `helm` binary / `GITLAB_TOKEN` in the local environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation and deadline handling when loading cluster and tenant configuration.
  * Kubernetes configuration requests now consistently honor the active command context.
  * Updated configuration, listing, scanning, and download operations to use context-aware tenant settings.
* **Tests**
  * Added coverage for context propagation, request cancellation, deadlines, and configuration loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->