### PR TITLE
fix(core): prevent sub-100 compliance scores formatting as 100.00 (#2728)

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -117,7 +117,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
 			}
 			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance score", fmt.Sprintf("%.2f", results.GetComplianceScore())), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
+				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance score", cautils.ComplianceScoreToString(results.GetComplianceScore(), 2)), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
 			}
 			enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
 			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo)

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -133,7 +133,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			}
 
 			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance-score", fmt.Sprintf("%.2f", results.GetComplianceScore())), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
+				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance-score", cautils.ComplianceScoreToString(results.GetComplianceScore(), 2)), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
 			}
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)

--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -1,6 +1,9 @@
 package cautils
 
-import "math"
+import (
+	"math"
+	"strconv"
+)
 
 const floorEpsilon = 1e-4
 
@@ -37,6 +40,18 @@ func ComplianceScoreToInt(x float32) int {
 		return 99
 	}
 	return i
+}
+
+// ComplianceScoreToString formats a compliance score for display with the given
+// precision, ensuring a score below 100 never renders as perfect.
+func ComplianceScoreToString(x float32, precision int) string {
+	s := strconv.FormatFloat(float64(x), 'f', precision, 32)
+	if x < 100 {
+		if v, err := strconv.ParseFloat(s, 64); err == nil && v >= 100 {
+			return strconv.FormatFloat(100-math.Pow10(-precision), 'f', precision, 64)
+		}
+	}
+	return s
 }
 
 // RiskScoreToInt converts a risk score to a display-safe integer. It preserves

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -76,6 +76,58 @@ func TestComplianceScoreToInt(t *testing.T) {
 	}
 }
 
+func TestComplianceScoreToString(t *testing.T) {
+	tests := []struct {
+		name      string
+		score     float32
+		precision int
+		want      string
+	}{
+		{
+			name:      "ordinary score formats with requested precision",
+			score:     95.4321,
+			precision: 2,
+			want:      "95.43",
+		},
+		{
+			name:      "score above 99.995 does not round to 100.00",
+			score:     99.996,
+			precision: 2,
+			want:      "99.99",
+		},
+		{
+			name:      "score exactly 99.99 stays 99.99",
+			score:     99.99,
+			precision: 2,
+			want:      "99.99",
+		},
+		{
+			name:      "perfect score 100 remains 100.00",
+			score:     100.0,
+			precision: 2,
+			want:      "100.00",
+		},
+		{
+			name:      "score near 100 with precision 1 does not round to 100.0",
+			score:     99.96,
+			precision: 1,
+			want:      "99.9",
+		},
+		{
+			name:      "zero score formats properly",
+			score:     0.0,
+			precision: 2,
+			want:      "0.00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ComplianceScoreToString(tt.score, tt.precision))
+		})
+	}
+}
+
 func TestRiskScoreToInt(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -310,7 +310,7 @@ func properties(complianceScore float32) []JUnitProperty {
 	return []JUnitProperty{
 		{
 			Name:  "complianceScore",
-			Value: fmt.Sprintf("%.2f", complianceScore),
+			Value: cautils.ComplianceScoreToString(complianceScore, 2),
 		},
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_compliance_score_test.go
@@ -38,6 +38,14 @@ func TestListTestsSuiteUsesComplianceScores(t *testing.T) {
 				"MITRE": "20.00",
 			},
 		},
+		{
+			name: "framework scan with near 100 compliance score does not round to 100",
+			summary: reportsummary.SummaryDetails{
+				Score:           0.004,
+				ComplianceScore: 99.996,
+			},
+			want: map[string]string{"kubescape": "99.99"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -222,6 +222,16 @@ func TestProperties(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Score near 100 does not round to 100.00",
+			score: 99.996,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: "99.99",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/resultshandling/printer/v2/pdf/report_template.go
+++ b/core/pkg/resultshandling/printer/v2/pdf/report_template.go
@@ -20,6 +20,7 @@ import (
 	"github.com/johnfercher/maroto/v2/pkg/consts/pagesize"
 	"github.com/johnfercher/maroto/v2/pkg/core"
 	"github.com/johnfercher/maroto/v2/pkg/props"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 )
 
 var (
@@ -129,7 +130,7 @@ func (t *Template) generateTableTableResult(totalFailed, total int, score float3
 		text.NewCol(5, "Resource summary", defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", totalFailed), defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", total), defaultProps),
-		text.NewCol(2, fmt.Sprintf("%.2f%s", score, "%"), defaultProps),
+		text.NewCol(2, fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(score, 2), "%"), defaultProps),
 	)
 }
 

--- a/core/pkg/resultshandling/printer/v2/pdf/report_template.go
+++ b/core/pkg/resultshandling/printer/v2/pdf/report_template.go
@@ -130,7 +130,7 @@ func (t *Template) generateTableTableResult(totalFailed, total int, score float3
 		text.NewCol(5, "Resource summary", defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", totalFailed), defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", total), defaultProps),
-		text.NewCol(2, fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(score, 2), "%"), defaultProps),
+		text.NewCol(2, cautils.ComplianceScoreToString(score, 2)+"%", defaultProps),
 	)
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -99,7 +99,7 @@ func GenerateFooter(summaryDetails *reportsummary.SummaryDetails, short bool) ta
 	var row table.Row
 	if short {
 		row = make(table.Row, 1)
-		row[0] = fmt.Sprintf("Resource Summary"+strings.Repeat(" ", 0)+"\n\nFailed Resources"+strings.Repeat(" ", 1)+": %d\nAll Resources"+strings.Repeat(" ", 4)+": %d\n%% Compliance-Score"+strings.Repeat(" ", 4)+": %.2f%%", summaryDetails.NumberOfResources().Failed(), summaryDetails.NumberOfResources().All(), summaryDetails.ComplianceScore)
+		row[0] = fmt.Sprintf("Resource Summary"+strings.Repeat(" ", 0)+"\n\nFailed Resources"+strings.Repeat(" ", 1)+": %d\nAll Resources"+strings.Repeat(" ", 4)+": %d\n%% Compliance-Score"+strings.Repeat(" ", 4)+": %s%%", summaryDetails.NumberOfResources().Failed(), summaryDetails.NumberOfResources().All(), cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2))
 	} else {
 		// Severity | Control name | failed resources | all resources | % success
 		row = make(table.Row, _summaryRowLen)
@@ -107,7 +107,7 @@ func GenerateFooter(summaryDetails *reportsummary.SummaryDetails, short bool) ta
 		row[summaryColumnCounterFailed] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().Failed())
 		row[summaryColumnCounterAll] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().All())
 		row[summaryColumnSeverity] = " "
-		row[summaryColumnComplianceScore] = fmt.Sprintf("%.2f%s", summaryDetails.ComplianceScore, "%")
+		row[summaryColumnComplianceScore] = fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2), "%")
 	}
 
 	return row

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -107,7 +107,7 @@ func GenerateFooter(summaryDetails *reportsummary.SummaryDetails, short bool) ta
 		row[summaryColumnCounterFailed] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().Failed())
 		row[summaryColumnCounterAll] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().All())
 		row[summaryColumnSeverity] = " "
-		row[summaryColumnComplianceScore] = fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2), "%")
+		row[summaryColumnComplianceScore] = cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2) + "%"
 	}
 
 	return row

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
@@ -174,6 +174,11 @@ func TestGenerateFooter_Short(t *testing.T) {
 			wantContains:    []string{"Compliance-Score", "67.50%"},
 		},
 		{
+			name:            "sub-100 score near 100 does not round to 100.00%",
+			complianceScore: 99.996,
+			wantContains:    []string{"Compliance-Score", "99.99%"},
+		},
+		{
 			name:            "contains resource summary label",
 			complianceScore: 50,
 			wantContains:    []string{"Resource Summary", "Failed Resources", "All Resources"},
@@ -212,6 +217,11 @@ func TestGenerateFooter_Full(t *testing.T) {
 			name:                "partial",
 			complianceScore:     75.25,
 			wantComplianceScore: "75.25%",
+		},
+		{
+			name:                "sub-100 score near 100 does not round to 100.00%",
+			complianceScore:     99.996,
+			wantComplianceScore: "99.99%",
 		},
 	}
 	for _, tt := range tests {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
@@ -100,9 +100,9 @@ func FrameworksScoresToString(frameworks []reportsummary.IFrameworkSummary) stri
 		p.WriteString("Frameworks scanned: ")
 		i := 0
 		for ; i < len(frameworks)-1; i++ {
-			fmt.Fprintf(&p, "%s (compliance score: %.2f), ", frameworks[i].GetName(), frameworks[i].GetComplianceScore())
+			fmt.Fprintf(&p, "%s (compliance score: %s), ", frameworks[i].GetName(), cautils.ComplianceScoreToString(frameworks[i].GetComplianceScore(), 2))
 		}
-		fmt.Fprintf(&p, "%s (compliance score: %.2f)\n", frameworks[i].GetName(), frameworks[i].GetComplianceScore())
+		fmt.Fprintf(&p, "%s (compliance score: %s)\n", frameworks[i].GetName(), cautils.ComplianceScoreToString(frameworks[i].GetComplianceScore(), 2))
 		return p.String()
 	}
 	return ""

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -271,7 +271,7 @@ func printComplianceScore(writer *os.File, frameworks []reportsummary.IFramework
 	cautils.SimpleDisplay(writer, "The compliance score is calculated by multiplying control failures by the number of failures against supported compliance frameworks. Remediate controls, or configure your cluster baseline with exceptions, to improve this score.\n\n")
 
 	for _, fw := range frameworks {
-		cautils.StarDisplay(writer, "%s: %s", fw.GetName(), gchalk.WithBrightYellow().Bold(fmt.Sprintf("%.2f%%\n", fw.GetComplianceScore())))
+		cautils.StarDisplay(writer, "%s: %s", fw.GetName(), gchalk.WithBrightYellow().Bold(fmt.Sprintf("%s%%\n", cautils.ComplianceScoreToString(fw.GetComplianceScore(), 2))))
 	}
 
 	cautils.SimpleDisplay(writer, fmt.Sprintf("\nView a full compliance report by running %s or %s\n", getCallToActionString("'$ kubescape scan framework nsa'"), getCallToActionString("'$ kubescape scan framework mitre'")))


### PR DESCRIPTION
Closes #2728

### What this PR does
Prevents compliance scores between `99.995` and `100` from rounding up to `100.00` when formatted with floating-point precision in PDF reports, JUnit XML, CLI summary tables, and threshold log messages.

### Changes made
- **`core/cautils/floatutils.go`**: Added `ComplianceScoreToString(x float32, precision int) string` to clamp any `x < 100` that rounds to `>= 100` back to `99.99` (for precision 2).
- **Printers & CLI**: Replaced unguarded `%.2f` formatting with `ComplianceScoreToString` in PDF (`report_template.go`), JUnit (`junit.go`), summary table (`summarytable.go`), pretty printer (`prettyprinter/utils.go`, `tableprinter/utils/utils.go`), and scan CLI threshold logs (`cmd/scan/control.go`, `cmd/scan/framework.go`).
- **Tests**: Added regression test cases in `floatutils_test.go`, `junit_test.go`, and `junit_compliance_score_test.go`.

### How was this tested?
- `go test -v ./core/cautils/...`
- `go test -v ./core/pkg/resultshandling/printer/v2/...`
- `go test -v ./cmd/scan/...`
- `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compliance score display consistency across scan results, reports, summaries, and JUnit output.
  - Prevented scores slightly below 100% from being incorrectly displayed as 100.00%.
  - Standardized threshold failure and framework score formatting.
  - Preserved accurate two-decimal precision across all compliance score displays.

- **Tests**
  - Added coverage for score precision, perfect scores, zero values, and scores near 100%.
  - Added regression checks for scores that could previously round up incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->