### PR TITLE
fix: format compliance score without rounding sub-100 to 100.00

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -117,7 +117,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
 			}
 			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance score", fmt.Sprintf("%.2f", results.GetComplianceScore())), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
+				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance score", cautils.ComplianceScoreToString(results.GetComplianceScore(), 2)), helpers.String("compliance-threshold", cautils.ComplianceScoreToString(float32(scanInfo.ComplianceThreshold), 2)))
 			}
 			enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)
 			enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo)

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -133,7 +133,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			}
 
 			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance-score", fmt.Sprintf("%.2f", results.GetComplianceScore())), helpers.String("compliance-threshold", fmt.Sprintf("%.2f", scanInfo.ComplianceThreshold)))
+				logger.L().Fatal("scan compliance-score is below permitted threshold", helpers.String("compliance-score", cautils.ComplianceScoreToString(results.GetComplianceScore(), 2)), helpers.String("compliance-threshold", cautils.ComplianceScoreToString(float32(scanInfo.ComplianceThreshold), 2)))
 			}
 
 			enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo, terminateOnExceedingSeverity)

--- a/core/cautils/floatutils.go
+++ b/core/cautils/floatutils.go
@@ -1,6 +1,9 @@
 package cautils
 
-import "math"
+import (
+	"math"
+	"strconv"
+)
 
 const floorEpsilon = 1e-4
 
@@ -37,4 +40,16 @@ func ComplianceScoreToInt(x float32) int {
 		return 99
 	}
 	return i
+}
+
+// ComplianceScoreToString formats a compliance score for display with the given
+// precision, ensuring a score below 100 never renders as "100.00" (or similar).
+func ComplianceScoreToString(x float32, precision int) string {
+	s := strconv.FormatFloat(float64(x), 'f', precision, 32)
+	if x < 100 {
+		if v, err := strconv.ParseFloat(s, 64); err == nil && v >= 100 {
+			return strconv.FormatFloat(100-math.Pow10(-precision), 'f', precision, 64)
+		}
+	}
+	return s
 }

--- a/core/cautils/floatutils_test.go
+++ b/core/cautils/floatutils_test.go
@@ -96,3 +96,55 @@ func TestFloat32ToIntFloor_Float32Precision(t *testing.T) {
 	assert.Equal(t, 59, Float32ToIntFloor(float32(59)/float32(100)*100))
 	assert.Equal(t, 53, Float32ToIntFloor(float32(106)/float32(200)*100))
 }
+
+func TestComplianceScoreToString(t *testing.T) {
+	tests := []struct {
+		name      string
+		score     float32
+		precision int
+		want      string
+	}{
+		{
+			name:      "normal score",
+			score:     50.0,
+			precision: 2,
+			want:      "50.00",
+		},
+		{
+			name:      "just below boundary",
+			score:     99.99,
+			precision: 2,
+			want:      "99.99",
+		},
+		{
+			name:      "sub-100 rounds to 100 without guard",
+			score:     99.996,
+			precision: 2,
+			want:      "99.99",
+		},
+		{
+			name:      "truly perfect stays 100",
+			score:     100.0,
+			precision: 2,
+			want:      "100.00",
+		},
+		{
+			name:      "zero score",
+			score:     0.0,
+			precision: 2,
+			want:      "0.00",
+		},
+		{
+			name:      "precision 3 boundary",
+			score:     99.9996,
+			precision: 3,
+			want:      "99.999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ComplianceScoreToString(tt.score, tt.precision))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -310,7 +310,7 @@ func properties(complianceScore float32) []JUnitProperty {
 	return []JUnitProperty{
 		{
 			Name:  "complianceScore",
-			Value: fmt.Sprintf("%.2f", complianceScore),
+			Value: cautils.ComplianceScoreToString(complianceScore, 2),
 		},
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/xml"
 	"flag"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -168,7 +167,7 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", 20.7),
+					Value: cautils.ComplianceScoreToString(20.7, 2),
 				},
 			},
 		},
@@ -178,7 +177,7 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", -20.0),
+					Value: cautils.ComplianceScoreToString(-20.0, 2),
 				},
 			},
 		},
@@ -188,7 +187,7 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", 120.0),
+					Value: cautils.ComplianceScoreToString(120.0, 2),
 				},
 			},
 		},
@@ -198,7 +197,7 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", 50.0),
+					Value: cautils.ComplianceScoreToString(50.0, 2),
 				},
 			},
 		},
@@ -208,7 +207,7 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", 0.0),
+					Value: cautils.ComplianceScoreToString(0.0, 2),
 				},
 			},
 		},
@@ -218,7 +217,17 @@ func TestProperties(t *testing.T) {
 			expectedProperty: []JUnitProperty{
 				{
 					Name:  "complianceScore",
-					Value: fmt.Sprintf("%.2f", 100.0),
+					Value: cautils.ComplianceScoreToString(100.0, 2),
+				},
+			},
+		},
+		{
+			name:  "Near-perfect score does not round to 100",
+			score: 99.996,
+			expectedProperty: []JUnitProperty{
+				{
+					Name:  "complianceScore",
+					Value: "99.99",
 				},
 			},
 		},

--- a/core/pkg/resultshandling/printer/v2/pdf/report_template.go
+++ b/core/pkg/resultshandling/printer/v2/pdf/report_template.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/johnfercher/go-tree/node"
 	"github.com/johnfercher/maroto/v2"
 	"github.com/johnfercher/maroto/v2/pkg/components/image"
@@ -21,6 +20,7 @@ import (
 	"github.com/johnfercher/maroto/v2/pkg/consts/pagesize"
 	"github.com/johnfercher/maroto/v2/pkg/core"
 	"github.com/johnfercher/maroto/v2/pkg/props"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 )
 
 var (

--- a/core/pkg/resultshandling/printer/v2/pdf/report_template.go
+++ b/core/pkg/resultshandling/printer/v2/pdf/report_template.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/johnfercher/go-tree/node"
 	"github.com/johnfercher/maroto/v2"
 	"github.com/johnfercher/maroto/v2/pkg/components/image"
@@ -129,7 +130,7 @@ func (t *Template) generateTableTableResult(totalFailed, total int, score float3
 		text.NewCol(5, "Resource summary", defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", totalFailed), defaultProps),
 		text.NewCol(2, fmt.Sprintf("%d", total), defaultProps),
-		text.NewCol(2, fmt.Sprintf("%.2f%s", score, "%"), defaultProps),
+		text.NewCol(2, fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(score, 2), "%"), defaultProps),
 	)
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -99,7 +99,7 @@ func GenerateFooter(summaryDetails *reportsummary.SummaryDetails, short bool) ta
 	var row table.Row
 	if short {
 		row = make(table.Row, 1)
-		row[0] = fmt.Sprintf("Resource Summary"+strings.Repeat(" ", 0)+"\n\nFailed Resources"+strings.Repeat(" ", 1)+": %d\nAll Resources"+strings.Repeat(" ", 4)+": %d\n%% Compliance-Score"+strings.Repeat(" ", 4)+": %.2f%%", summaryDetails.NumberOfResources().Failed(), summaryDetails.NumberOfResources().All(), summaryDetails.ComplianceScore)
+		row[0] = fmt.Sprintf("Resource Summary"+strings.Repeat(" ", 0)+"\n\nFailed Resources"+strings.Repeat(" ", 1)+": %d\nAll Resources"+strings.Repeat(" ", 4)+": %d\n%% Compliance-Score"+strings.Repeat(" ", 4)+": %s%%", summaryDetails.NumberOfResources().Failed(), summaryDetails.NumberOfResources().All(), cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2))
 	} else {
 		// Severity | Control name | failed resources | all resources | % success
 		row = make(table.Row, _summaryRowLen)
@@ -107,7 +107,7 @@ func GenerateFooter(summaryDetails *reportsummary.SummaryDetails, short bool) ta
 		row[summaryColumnCounterFailed] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().Failed())
 		row[summaryColumnCounterAll] = fmt.Sprintf("%d", summaryDetails.NumberOfResources().All())
 		row[summaryColumnSeverity] = " "
-		row[summaryColumnComplianceScore] = fmt.Sprintf("%.2f%s", summaryDetails.ComplianceScore, "%")
+		row[summaryColumnComplianceScore] = fmt.Sprintf("%s%s", cautils.ComplianceScoreToString(summaryDetails.ComplianceScore, 2), "%")
 	}
 
 	return row

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils/utils.go
@@ -100,9 +100,9 @@ func FrameworksScoresToString(frameworks []reportsummary.IFrameworkSummary) stri
 		p.WriteString("Frameworks scanned: ")
 		i := 0
 		for ; i < len(frameworks)-1; i++ {
-			fmt.Fprintf(&p, "%s (compliance score: %.2f), ", frameworks[i].GetName(), frameworks[i].GetComplianceScore())
+			fmt.Fprintf(&p, "%s (compliance score: %s), ", frameworks[i].GetName(), cautils.ComplianceScoreToString(frameworks[i].GetComplianceScore(), 2))
 		}
-		fmt.Fprintf(&p, "%s (compliance score: %.2f)\n", frameworks[i].GetName(), frameworks[i].GetComplianceScore())
+		fmt.Fprintf(&p, "%s (compliance score: %s)\n", frameworks[i].GetName(), cautils.ComplianceScoreToString(frameworks[i].GetComplianceScore(), 2))
 		return p.String()
 	}
 	return ""

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -271,7 +271,7 @@ func printComplianceScore(writer *os.File, frameworks []reportsummary.IFramework
 	cautils.SimpleDisplay(writer, "The compliance score is calculated by multiplying control failures by the number of failures against supported compliance frameworks. Remediate controls, or configure your cluster baseline with exceptions, to improve this score.\n\n")
 
 	for _, fw := range frameworks {
-		cautils.StarDisplay(writer, "%s: %s", fw.GetName(), gchalk.WithBrightYellow().Bold(fmt.Sprintf("%.2f%%\n", fw.GetComplianceScore())))
+		cautils.StarDisplay(writer, "%s: %s", fw.GetName(), gchalk.WithBrightYellow().Bold(fmt.Sprintf("%s%%\n", cautils.ComplianceScoreToString(fw.GetComplianceScore(), 2))))
 	}
 
 	cautils.SimpleDisplay(writer, fmt.Sprintf("\nView a full compliance report by running %s or %s\n", getCallToActionString("'$ kubescape scan framework nsa'"), getCallToActionString("'$ kubescape scan framework mitre'")))


### PR DESCRIPTION

---

Add `ComplianceScoreToString` helper to `floatutils.go` which formats a compliance score with a given precision, but prevents rounding a score under 100 up to 100.00.

Replace `%.2f` formatting of compliance score at all 8 identified sites with the safe helper:
- `prettyprinter/tableprinter/configurationprinter/summarytable.go`
- `prettyprinter/utils.go`
- `prettyprinter/tableprinter/utils/utils.go`
- `pdf/report_template.go`
- `junit.go`
- `cmd/scan/control.go`
- `cmd/scan/framework.go`

Add `TestComplianceScoreToString` in `floatutils_test.go` and update `TestProperties` in `junit_test.go` to cover regression case (`99.996` -> `"99.99"`).

Fixes #2728

## Overview
**Current behavior:** 
Formatting compliance scores using `fmt.Sprintf("%.2f")` rounds float values to the nearest decimal representation. Consequently, any compliance score from `99.995` up to `99.999...` is formatted and printed as `100.00%`. This results in imperfect scans displaying as perfect `100.00%` compliance across HTML, PDF, JUnit properties, CLI summaries, and threshold check error logs.

**Future behavior:** 
A display-safe companion helper function `ComplianceScoreToString` in `core/cautils/floatutils.go` is used to format the score to a specified decimal precision. It ensures that a score strictly below 100 is never rounded up to `100.00` (e.g. `99.996` formats as `"99.99"` with precision 2).

## How to Test
Verify that unit tests pass successfully:
```bash
go test ./core/cautils/... -v -run TestComplianceScoreToString
go test ./core/pkg/resultshandling/printer/v2/... -v -run TestProperties
```

Build the CLI binary to ensure clean compilation:
```bash
go build .
```

## Related issues/PRs:
* Resolved #2728

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compliance-score formatting across scan results, summaries, tables, PDFs, and JUnit reports.
  * Prevented near-perfect scores below 100% from incorrectly displaying as 100%.
  * Ensured consistent precision for compliance scores and thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->