### PR TITLE
fix(policyhandler): reset the PolicyHandler singleton when clusterName changes

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -34,8 +34,25 @@ type PolicyHandler struct {
 
 // NewPolicyHandler creates and returns an instance of the `PolicyHandler`. The function initializes the `PolicyHandler` only if it hasn't been previously created.
 // The PolicyHandler supports caching of downloaded policies and exceptions by setting the `POLICIES_CACHE_TTL` environment variable (default is no caching).
+//
+// This is a process-wide singleton, reused as long as clusterName does not
+// change, so long-running callers that repeatedly scan the same cluster (the
+// httphandler HTTP service, in particular - see core/core/scan.go) keep the
+// POLICIES_CACHE_TTL caching benefit across requests instead of re-downloading
+// policies/exceptions/control-inputs on every call. When clusterName differs
+// from the cached instance's, exceptions and control-inputs are fetched
+// scoped by clusterName (see getExceptions/getControlInputs below), so
+// blindly reusing an instance built for a different cluster would silently
+// apply the wrong cluster's exception policies to this one; the httphandler
+// service can serve /v1/scan requests for different clusters/accounts across
+// the lifetime of one process, and previously always got the first request's
+// PolicyHandler regardless of what later requests asked for. Close the
+// stale instance first so its background TTL goroutines don't leak.
 func NewPolicyHandler(clusterName string) *PolicyHandler {
-	if policyHandlerInstance == nil {
+	if policyHandlerInstance == nil || policyHandlerInstance.clusterName != clusterName {
+		if policyHandlerInstance != nil {
+			policyHandlerInstance.Close()
+		}
 		policyHandlerInstance = NewRequestScopedPolicyHandler(clusterName)
 	}
 	return policyHandlerInstance

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -67,6 +68,30 @@ func TestNewPolicyHandler_MultiplePoliciesWithSameClusterName(t *testing.T) {
 	policyHandler1 := NewPolicyHandler(clusterName)
 	policyHandler2 := NewPolicyHandler(clusterName)
 	assert.Equal(t, policyHandler1, policyHandler2)
+}
+
+// TestNewPolicyHandler_DifferentClusterNameGetsFreshInstance guards against a
+// regression where the process-wide singleton was reused unconditionally,
+// regardless of the requested clusterName. getExceptions/getControlInputs
+// fetch data scoped by policyHandler.clusterName, so a long-running caller
+// that serves requests for more than one cluster/account in the same process
+// (the httphandler HTTP service, via core/core/scan.go) would silently keep
+// using whichever cluster's exceptions/control-inputs the *first* request
+// happened to warm the cache with, for every later request regardless of
+// what clusterName it actually asked for.
+func TestNewPolicyHandler_DifferentClusterNameGetsFreshInstance(t *testing.T) {
+	first := NewPolicyHandler("cluster-a")
+	require.Equal(t, "cluster-a", first.clusterName)
+
+	second := NewPolicyHandler("cluster-b")
+	assert.Equal(t, "cluster-b", second.clusterName,
+		"a different clusterName must produce an instance scoped to that cluster, not reuse the previous cluster's instance")
+	assert.NotSame(t, first, second, "a different clusterName must not reuse the previous cluster's PolicyHandler")
+
+	// Same clusterName as the most recent call must still reuse the
+	// instance (the caching behavior this singleton exists to provide).
+	third := NewPolicyHandler("cluster-b")
+	assert.Same(t, second, third)
 }
 
 func TestCollectPolicies(t *testing.T) {


### PR DESCRIPTION
## Summary

`NewPolicyHandler` caches a single process-wide `*PolicyHandler` in the package-level `policyHandlerInstance` variable and reuses it **unconditionally** on every call, regardless of the `clusterName` argument passed in:

```go
func NewPolicyHandler(clusterName string) *PolicyHandler {
	if policyHandlerInstance == nil {
		policyHandlerInstance = NewRequestScopedPolicyHandler(clusterName)
	}
	return policyHandlerInstance
}
```

`getExceptions()`/`getControlInputs()` fetch data scoped by `policyHandler.clusterName` (`ExceptionsGetter.GetExceptions(name)`, `ControlsInputsGetter.GetControlsInputs(name)`), so once the singleton is created for one cluster, every later call — even one explicitly asking for a *different* `clusterName` — silently gets back the first cluster's cached instance, and therefore the first cluster's exceptions and control-inputs.

`core/core/scan.go` calls `NewPolicyHandler(tenantConfig.GetContextName())` on every scan. For the one-shot CLI this is harmless (one process, one scan), but the same code path backs the `httphandler` HTTP service's `/v1/scan` handler (`httphandler/handlerequests/v1/requestshandlerutils.go` calls `core.NewKubescape(ctx).Scan(scanInfo)`), which is a **long-running process** that can serve scan requests for different clusters/accounts (`PostScanRequest.Account`) over its lifetime. Every scan after the first silently reused whichever cluster's `PolicyHandler` happened to be built first, applying that cluster's exception policies to every other cluster scanned by the same process — security-relevant since exceptions suppress reported vulnerabilities/misconfigurations, and reusing the wrong ones could either hide real findings or spuriously report ones a target actually excepted.

The singleton exists specifically so a long-running caller keeps the `POLICIES_CACHE_TTL` caching benefit (avoiding a policy/exception re-download on every request) across repeated calls for the *same* cluster — the far more common case for both the CLI and a single-tenant `httphandler` deployment — so switching the call site to `NewRequestScopedPolicyHandler` (already used correctly by `cmd/mcpserver/scan_helper.go` for this same staleness reason) would fix correctness but silently lose that caching benefit, and would leak a `TimedCache`'s background goroutine per request unless every caller remembered to `Close()` it.

## Fix

Keep the singleton, but only when `clusterName` matches the cached instance's. On a mismatch (or the first call), `Close()` the stale instance (stopping its background TTL goroutines before dropping it) and build a fresh one scoped to the new `clusterName` via `NewRequestScopedPolicyHandler`. Repeated calls for the same cluster still hit the same cached instance and keep the caching benefit; calls for a different cluster get correctly isolated state instead of silently inheriting the wrong one's.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./core/pkg/policyhandler/...`
- [x] `go test ./core/pkg/policyhandler/...` (full package — including the existing `TestNewPolicyHandler_ClusterNameNotEmpty` and `TestNewPolicyHandler_MultiplePoliciesWithSameClusterName`, which pin the caching behavior this fix preserves — all pass)
- [x] Added `TestNewPolicyHandler_DifferentClusterNameGetsFreshInstance`, which pins both halves: a different `clusterName` gets its own instance (not the previous cluster's), and the same `clusterName` as the most recent call still reuses the cached instance. Mutation-verified: reverting the fix locally makes the "different clusterName" half of this test fail exactly as described (second call still had `clusterName` `"cluster-a"` and was literally the same object as the first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy handling now refreshes correctly when switching between different clusters.
  * Existing handlers continue to be reused when requesting policies for the same cluster.
  * Stale background cache activity is stopped when a handler is replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->