### PR TITLE
feat: add CSV output format printer for scan results

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -48,15 +48,24 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json || true
-          jq -r 'select(.Action=="fail") | .Package' test-output.json | sort -u > failed_packages.txt || true
-          if [ -s failed_packages.txt ]; then
+          test_status=0
+          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json 2>&1 || test_status=$?
+          
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          
+          if grep -q '"Action":"fail"' test-output.json; then
+            jq -r 'select(.Action=="fail") | .Package' test-output.json | sort -u > failed_packages.txt
             echo "Failing packages:"
-            cat failed_packages.txt
+            cat failed_packages.txt || true
             echo ""
             echo "Tail of test-output.json:"
-            tail -n 500 test-output.json
-            exit 1
+            tail -n 500 test-output.json || true
+          fi
+          
+          if [ $test_status -ne 0 ]; then
+            exit $test_status
           fi
 
       - name: Upload test output
@@ -64,7 +73,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: go-test-output
-          path: test-output.json
+          path: |
+            test-output.json
+            failed_packages.txt
+          retention-days: 7
 
       - name: Test httphandler pkg
         run: ${{ env.DOCKER_CMD }} sh -c 'cd httphandler && go test -v ./...'

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -61,8 +61,8 @@ jobs:
             echo "Failing packages:"
             cat failed_packages.txt || true
             echo ""
-            echo "Tail of test-output.json:"
-            tail -n 500 test-output.json || true
+            echo "Tail of failing JSON events:"
+            tail -n 100 test-output.json || true
           fi
           
           if [ $parse_status -ne 0 ]; then
@@ -71,6 +71,9 @@ jobs:
           fi
           
           if [ $test_status -ne 0 ]; then
+            echo "go test failed with exit code $test_status."
+            echo "Tail of test-output.json:"
+            tail -n 100 test-output.json || true
             exit $test_status
           fi
 

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -55,13 +55,19 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
           
+          parse_status=0
           if grep -q '"Action":"fail"' test-output.json; then
-            grep '"Action":"fail"' test-output.json | jq -r '.Package' | sort -u > failed_packages.txt
+            grep '"Action":"fail"' test-output.json | jq -r '.Package' | sort -u > failed_packages.txt || parse_status=$?
             echo "Failing packages:"
             cat failed_packages.txt || true
             echo ""
             echo "Tail of test-output.json:"
             tail -n 500 test-output.json || true
+          fi
+          
+          if [ $parse_status -ne 0 ]; then
+            echo "Parsing test output failed with exit code $parse_status"
+            exit $parse_status
           fi
           
           if [ $test_status -ne 0 ]; then

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -45,7 +45,26 @@ jobs:
           go-version-file: go.mod
 
       - name: Test core pkg
-        run: ${{ env.DOCKER_CMD }} go test -v ./...
+        shell: bash
+        run: |
+          set -o pipefail
+          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json || true
+          jq -r 'select(.Action=="fail") | .Package' test-output.json | sort -u > failed_packages.txt || true
+          if [ -s failed_packages.txt ]; then
+            echo "Failing packages:"
+            cat failed_packages.txt
+            echo ""
+            echo "Tail of test-output.json:"
+            tail -n 500 test-output.json
+            exit 1
+          fi
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-test-output
+          path: test-output.json
 
       - name: Test httphandler pkg
         run: ${{ env.DOCKER_CMD }} sh -c 'cd httphandler && go test -v ./...'

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -49,14 +49,14 @@ jobs:
         run: |
           set -o pipefail
           test_status=0
-          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json 2>&1 || test_status=$?
+          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json || test_status=$?
           
           if ! command -v jq >/dev/null 2>&1; then
             sudo apt-get update && sudo apt-get install -y jq
           fi
           
           if grep -q '"Action":"fail"' test-output.json; then
-            jq -r 'select(.Action=="fail") | .Package' test-output.json | sort -u > failed_packages.txt
+            grep '"Action":"fail"' test-output.json | jq -r '.Package' | sort -u > failed_packages.txt
             echo "Failing packages:"
             cat failed_packages.txt || true
             echo ""

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -45,47 +45,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test core pkg
-        shell: bash
-        run: |
-          set -o pipefail
-          test_status=0
-          ${{ env.DOCKER_CMD }} go test ./... -count=1 -json -p=1 > test-output.json || test_status=$?
-          
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y jq
-          fi
-          
-          parse_status=0
-          if grep -q '"Action":"fail"' test-output.json; then
-            grep '"Action":"fail"' test-output.json | jq -r '.Package' | sort -u > failed_packages.txt || parse_status=$?
-            echo "Failing packages:"
-            cat failed_packages.txt || true
-            echo ""
-            echo "Tail of failing JSON events:"
-            tail -n 100 test-output.json || true
-          fi
-          
-          if [ $parse_status -ne 0 ]; then
-            echo "Parsing test output failed with exit code $parse_status"
-            exit $parse_status
-          fi
-          
-          if [ $test_status -ne 0 ]; then
-            echo "go test failed with exit code $test_status."
-            echo "Tail of test-output.json:"
-            tail -n 100 test-output.json || true
-            exit $test_status
-          fi
-
-      - name: Upload test output
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-test-output
-          path: |
-            test-output.json
-            failed_packages.txt
-          retention-days: 7
+        run: ${{ env.DOCKER_CMD }} go test -v ./...
 
       - name: Test httphandler pkg
         run: ${{ env.DOCKER_CMD }} sh -c 'cd httphandler && go test -v ./...'

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ kubescape scan --format html --output report.html
 
 # PDF report
 kubescape scan --format pdf --output report.pdf
+
+# CSV report
+kubescape scan --format csv --output results.csv
 ```
 
 ### Image Scanning

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -86,7 +86,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 				scanInfo.Format == "" {
 
 				return fmt.Errorf(
-					"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml",
+					"format cannot be empty, supported formats: %s",
+					strings.Join(shared.ScanFormats, ", "),
 				)
 			}
 
@@ -183,7 +184,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "host-scan", "", "Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use --host-scan=false to disable host data collection. See https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator for the operator-based alternative")
 	hostF.NoOptDefVal = "true"
 
-	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output file format. Supported formats: "pretty-printer", "json", "junit", "prometheus", "pdf", "html", "sarif", "gitlab-sast", "yaml"`)
+	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output file format. Supported formats: "%s"`, strings.Join(shared.ScanFormats, `", "`)))
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -485,7 +485,8 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml`)
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv"
+	assert.EqualError(t, err, errMessage)
 }
 
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -16,7 +16,7 @@ import (
 // They are built from the printer.*Format constants to keep a single source of truth.
 var (
 	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat, printer.GitLabSASTFormat, printer.YamlFormat, printer.CsvFormat}
-	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat, printer.CsvFormat}
+	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat}
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -15,8 +15,8 @@ import (
 // ScanFormats and ImageScanFormats list the output formats supported by the scan commands.
 // They are built from the printer.*Format constants to keep a single source of truth.
 var (
-	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat, printer.GitLabSASTFormat, printer.YamlFormat}
-	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat}
+	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat, printer.GitLabSASTFormat, printer.YamlFormat, printer.CsvFormat}
+	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat, printer.CsvFormat}
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -186,6 +186,8 @@ func fileExtForFormat(format string) string {
 		return printer.PdfOutputExt
 	case printer.PrometheusFormat:
 		return printer.PrometheusOutputExt
+	case printer.CsvFormat:
+		return printer.CsvOutputExt
 	default:
 		return printer.PrettyOutputExt
 	}

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -24,6 +24,7 @@ const (
 	SARIFFormat       string = "sarif"
 	GitLabSASTFormat  string = "gitlab-sast"
 	YamlFormat        string = "yaml"
+	CsvFormat         string = "csv"
 )
 
 const (
@@ -35,6 +36,7 @@ const (
 	PrometheusOutputExt = ".txt"
 	PrettyOutputExt     = ".txt"
 	YamlOutputExt       = ".yaml"
+	CsvOutputExt        = ".csv"
 )
 
 type IPrinter interface {

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -63,7 +63,7 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 
 	csvWriter := csv.NewWriter(cp.writer)
-	
+
 	// Write Header
 	header := []string{
 		"Control Name",
@@ -96,7 +96,7 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 		for _, assocCtrl := range result.AssociatedControls {
 			ctrlID := assocCtrl.GetID()
 			ctrlName := assocCtrl.GetName()
-			
+
 			// Find severity from SummaryDetails if available
 			severity := "Unknown"
 			if ctrlData, ok := reportWithSeverity.SummaryDetails.Controls[ctrlID]; ok {
@@ -139,6 +139,6 @@ func (cp *CsvPrinter) PrintNextSteps() {
 
 func (cp *CsvPrinter) CloseWriter() {
 	if cp.writer != nil && cp.writer != os.Stdout {
-		cp.writer.Close()
+		_ = cp.writer.Close()
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
-	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
 const (
@@ -97,10 +96,10 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 			ctrlID := assocCtrl.GetID()
 			ctrlName := assocCtrl.GetName()
 
-			// Find severity from SummaryDetails if available
-			severity := "Unknown"
-			if ctrlData, ok := reportWithSeverity.SummaryDetails.Controls[ctrlID]; ok {
-				severity = apis.ControlSeverityToString(ctrlData.GetScoreFactor())
+			// Severity is already populated
+			severity := assocCtrl.Severity
+			if severity == "" {
+				severity = "Unknown"
 			}
 
 			status := string(assocCtrl.GetStatus(nil).Status())

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -1,0 +1,144 @@
+package printer
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+)
+
+const (
+	csvOutputFile = "report"
+)
+
+var _ printer.IPrinter = &CsvPrinter{}
+
+type CsvPrinter struct {
+	writer *os.File
+}
+
+func NewCsvPrinter() *CsvPrinter {
+	return &CsvPrinter{}
+}
+
+func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = csvOutputFile
+		}
+		ext := filepath.Ext(strings.TrimSpace(outputFile))
+		if ext != printer.CsvOutputExt {
+			outputFile = outputFile + printer.CsvOutputExt
+		}
+	}
+	cp.writer = printer.GetWriter(ctx, outputFile)
+}
+
+func (cp *CsvPrinter) Score(score float32) {
+	// Handle invalid scores
+	if score > 100 {
+		score = 100
+	} else if score < 0 {
+		score = 0
+	}
+
+	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
+}
+
+func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj == nil {
+		logger.L().Ctx(ctx).Error("no data provided for CSV output")
+		return
+	}
+
+	finalizedReport := FinalizeResults(opaSessionObj)
+	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
+
+	csvWriter := csv.NewWriter(cp.writer)
+	
+	// Write Header
+	header := []string{
+		"Control Name",
+		"Control ID",
+		"Severity",
+		"Status",
+		"Resource Name",
+		"Resource Kind",
+		"Resource Namespace",
+		"API Version",
+	}
+	if err := csvWriter.Write(header); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write CSV header", helpers.Error(err))
+		return
+	}
+
+	for _, result := range reportWithSeverity.Results {
+		resID := result.ResourceID
+		var resName, resKind, resNamespace, resApiVersion string
+
+		// Try to find the resource object to extract metadata
+		if resourceData, ok := opaSessionObj.AllResources[resID]; ok {
+			resName = resourceData.GetName()
+			resKind = resourceData.GetKind()
+			resNamespace = resourceData.GetNamespace()
+			resApiVersion = resourceData.GetApiVersion()
+		}
+
+		// Write each control association
+		for _, assocCtrl := range result.AssociatedControls {
+			ctrlID := assocCtrl.GetID()
+			ctrlName := assocCtrl.GetName()
+			
+			// Find severity from SummaryDetails if available
+			severity := "Unknown"
+			if ctrlData, ok := reportWithSeverity.SummaryDetails.Controls[ctrlID]; ok {
+				severity = apis.ControlSeverityToString(ctrlData.GetScoreFactor())
+			}
+
+			status := string(assocCtrl.GetStatus(nil).Status())
+			if status == "" {
+				status = "unknown"
+			}
+
+			row := []string{
+				ctrlName,
+				ctrlID,
+				severity,
+				status,
+				resName,
+				resKind,
+				resNamespace,
+				resApiVersion,
+			}
+			if err := csvWriter.Write(row); err != nil {
+				logger.L().Ctx(ctx).Error("failed to write CSV row", helpers.Error(err))
+				return
+			}
+		}
+	}
+
+	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		logger.L().Ctx(ctx).Error("failed to flush CSV writer", helpers.Error(err))
+		return
+	}
+
+	printer.LogOutputFile(cp.writer.Name())
+}
+
+func (cp *CsvPrinter) PrintNextSteps() {
+}
+
+func (cp *CsvPrinter) CloseWriter() {
+	if cp.writer != nil && cp.writer != os.Stdout {
+		cp.writer.Close()
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -8,8 +8,73 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 )
+
+func csvSessionFixture() *cautils.OPASessionObj {
+	controlID1 := "C-0057"
+	controlID2 := "C-0058"
+	resourceID1 := "apps/v1/Deployment/default/demo"
+	resourceID2 := "apps/v1/Deployment/default/absent"
+
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+
+	ac1 := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID1,
+		Name:      "Privileged container",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+
+	ac2 := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID2,
+		Name:      "Run as root",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.ResourcesResult[resourceID1] = resourcesresults.Result{
+		ResourceID:         resourceID1,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac1, ac2},
+	}
+	session.ResourcesResult[resourceID2] = resourcesresults.Result{
+		ResourceID:         resourceID2,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac1},
+	}
+	session.AllResources[resourceID1] = lw
+
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				controlID1: reportsummary.ControlSummary{
+					ControlID:   controlID1,
+					Name:        "Privileged container",
+					ScoreFactor: 9.0, // Critical severity
+				},
+				controlID2: reportsummary.ControlSummary{
+					ControlID:   controlID2,
+					Name:        "Run as root",
+					ScoreFactor: 5.0, // Medium severity
+				},
+			},
+		},
+	}
+
+	return session
+}
 
 func TestNewCsvPrinter(t *testing.T) {
 	cp := NewCsvPrinter()
@@ -74,7 +139,7 @@ func TestScore_Csv(t *testing.T) {
 }
 
 func TestActionPrint_Csv(t *testing.T) {
-	session := cautils.NewOPASessionObjMock()
+	session := csvSessionFixture()
 
 	tmpCsv, err := os.CreateTemp("", "csv-regression-*.csv")
 	assert.NoError(t, err)
@@ -84,10 +149,9 @@ func TestActionPrint_Csv(t *testing.T) {
 
 	cp := NewCsvPrinter()
 	cp.writer = tmpCsv
-	cp.ActionPrint(context.Background(), session, nil)
-	assert.NoError(t, tmpCsv.Close())
+	cp.ActionPrint(context.TODO(), session, nil)
+	cp.CloseWriter()
 
-	// Read CSV and verify header
 	f, err := os.Open(tmpCsv.Name())
 	assert.NoError(t, err)
 	defer f.Close()
@@ -96,7 +160,8 @@ func TestActionPrint_Csv(t *testing.T) {
 	records, err := r.ReadAll()
 	assert.NoError(t, err)
 
-	assert.GreaterOrEqual(t, len(records), 1, "Should have at least the header")
+	// We expect 1 header row + 3 data rows (2 for resourceID1, 1 for resourceID2)
+	assert.Equal(t, 4, len(records))
 
 	expectedHeader := []string{
 		"Control Name",
@@ -108,6 +173,25 @@ func TestActionPrint_Csv(t *testing.T) {
 		"Resource Namespace",
 		"API Version",
 	}
-
 	assert.Equal(t, expectedHeader, records[0], "Header should match expected")
+
+	// The order of results isn't strictly guaranteed by a map iteration, but we can verify the rows exist.
+	var failedDemo, passedDemo, failedAbsent bool
+	for _, row := range records[1:] {
+		if row[0] == "Privileged container" && row[1] == "C-0057" && row[2] == "Critical" && row[3] == "failed" {
+			if row[4] == "demo" && row[5] == "Deployment" && row[6] == "default" && row[7] == "apps/v1" {
+				failedDemo = true
+			} else if row[4] == "" && row[5] == "" && row[6] == "" && row[7] == "" {
+				failedAbsent = true
+			}
+		} else if row[0] == "Run as root" && row[1] == "C-0058" && row[2] == "Medium" && row[3] == "passed" {
+			if row[4] == "demo" && row[5] == "Deployment" && row[6] == "default" && row[7] == "apps/v1" {
+				passedDemo = true
+			}
+		}
+	}
+
+	assert.True(t, failedDemo, "expected failed control row for demo resource")
+	assert.True(t, passedDemo, "expected passed control row for demo resource")
+	assert.True(t, failedAbsent, "expected failed control row for absent resource (with empty columns)")
 }

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -1,0 +1,113 @@
+package printer
+
+import (
+	"context"
+	"encoding/csv"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCsvPrinter(t *testing.T) {
+	cp := NewCsvPrinter()
+	assert.NotNil(t, cp)
+}
+
+func TestSetWriter_Csv(t *testing.T) {
+	cp := NewCsvPrinter()
+	assert.NotNil(t, cp)
+
+	// Test without outputFile (should use stdout)
+	cp.SetWriter(context.TODO(), "")
+	assert.NotNil(t, cp.writer)
+	cp.CloseWriter()
+}
+
+func TestScore_Csv(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float32
+		want  string
+	}{
+		{
+			name:  "Score not an integer",
+			score: 20.7,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 21\n",
+		},
+		{
+			name:  "Perfect Score",
+			score: 100,
+			want:  "\nOverall compliance-score (100- Excellent, 0- All failed): 100\n",
+		},
+	}
+
+	cp := NewCsvPrinter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "csvPrinter-score-output")
+			if err != nil {
+				panic(err)
+			}
+			defer func() {
+				_ = f.Close()
+			}()
+
+			oldStderr := os.Stderr
+			defer func() {
+				os.Stderr = oldStderr
+			}()
+			os.Stderr = f
+
+			cp.Score(tt.score)
+
+			f.Seek(0, 0)
+			got, err := io.ReadAll(f)
+			if err != nil {
+				panic(err)
+			}
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestActionPrint_Csv(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+
+	tmpCsv, err := os.CreateTemp("", "csv-regression-*.csv")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpCsv.Name())
+	}()
+
+	cp := NewCsvPrinter()
+	cp.writer = tmpCsv
+	cp.ActionPrint(context.Background(), session, nil)
+	assert.NoError(t, tmpCsv.Close())
+
+	// Read CSV and verify header
+	f, err := os.Open(tmpCsv.Name())
+	assert.NoError(t, err)
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	records, err := r.ReadAll()
+	assert.NoError(t, err)
+
+	assert.GreaterOrEqual(t, len(records), 1, "Should have at least the header")
+
+	expectedHeader := []string{
+		"Control Name",
+		"Control ID",
+		"Severity",
+		"Status",
+		"Resource Name",
+		"Resource Kind",
+		"Resource Namespace",
+		"API Version",
+	}
+
+	assert.Equal(t, expectedHeader, records[0], "Header should match expected")
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -127,6 +127,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 			logger.L().Ctx(ctx).Warning("Deprecated format version", helpers.String("run", "--format-version=v2"))
 		}
 		return printerv2.NewYamlPrinter()
+	case printer.CsvFormat:
+		return printerv2.NewCsvPrinter()
 	case printer.JunitResultFormat:
 		return printerv2.NewJunitPrinter(scanInfo.VerboseMode)
 	case printer.PrometheusFormat:
@@ -151,7 +153,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat:
+		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat, printer.CsvFormat:
 			return false, nil
 		case printer.PrettyFormat:
 			return true, nil
@@ -171,7 +173,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	}
 
 	switch printFormat {
-	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat:
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat:
 		return false, nil
 	default:
 		return true, nil

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -153,7 +153,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat, printer.CsvFormat:
+		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat:
 			return false, nil
 		case printer.PrettyFormat:
 			return true, nil

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,7 +44,7 @@ kubescape scan [target] [flags]
 | `--encrypt` | Encrypt sensitive report metadata using the master key provided through the `KUBESCAPE_MASTER_KEY` environment variable. Requires `--format json` for reports that will later be decrypted with `kubescape decrypt`. If both `--encrypt` and `--hide` are specified, `--encrypt` takes precedence. | `false` |
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
-| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `sarif`, `html`, `pdf`, `prometheus` | `pretty-printer` |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `csv` | `pretty-printer` |
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--host-scan` | Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use `--host-scan=false` to disable host data collection. See the [Kubescape operator](https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator) for a managed alternative. | auto-detect |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |


### PR DESCRIPTION
## Overview
Added a new output format `csv` that allows users to export Kubescape scan results into a spreadsheet-friendly CSV format. This is highly useful for reporting, auditing, and integrating with external tracking tools. The CSV printer flattens the nested posture report into clear, tabular rows including Control Name, Control ID, Severity, Status, Resource Name, Resource Kind, Resource Namespace, and API Version.

## Additional Information

> Implemented `CsvPrinter` in `core/pkg/resultshandling/printer/v2/csvprinter.go`. It leverages the `FinalizeResults` structure similar to the YAML and JSON printers to accurately parse and output control evaluations.

## How to Test

> 1. Build the Kubescape binary with the changes.
> 2. Run a scan targeting a file or a cluster and specify the CSV format:
>    `kubescape scan framework nsa <path-to-yaml> --format csv --output results.csv`
> 3. Verify that `results.csv` is created.
> 4. Open `results.csv` in a text editor or spreadsheet application and ensure the columns (Control Name, Severity, Resource Kind, etc.) are correctly populated for failed and passed controls.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV output support for standard scans.
  * CSV reports include scan results, severity labels, compliance scores, and control or resource metadata.
  * CSV output can be saved with the `.csv` file extension.

* **Bug Fixes**
  * Improved handling of CSV output writers, including flushing, closing, and reporting write errors.
  * Image scan output formats remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->