### PR TITLE
fix(mcp): graceful error handling for legacy MCP tools

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -429,7 +429,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if ns, ok := arguments["namespace"]; ok {
 			nsStr, ok := ns.(string)
 			if !ok {
-				return nil, fmt.Errorf("namespace must be a string")
+				return mcp.NewToolResultError("namespace must be a string"), nil
 			}
 			if nsStr != "" {
 				namespace = nsStr
@@ -458,13 +458,13 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if labelSelector == "" {
 			client, ksErr := ksServer.getKsClient()
 			if ksErr != nil {
-				return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+				return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 			}
 			manifests, err = client.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{})
 		} else {
 			client, ksErr := ksServer.getKsClient()
 			if ksErr != nil {
-				return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+				return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 			}
 			manifests, err = client.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: labelSelector,
@@ -504,7 +504,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 
 		content, err := json.Marshal(result)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal result: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -521,23 +521,23 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		namespaceStr, ok := namespace.(string)
 		if !ok {
-			return nil, fmt.Errorf("namespace must be a string")
+			return mcp.NewToolResultError("namespace must be a string"), nil
 		}
 		manifestName, ok := arguments["manifest_name"]
 		if !ok {
-			return nil, fmt.Errorf("manifest_name is required")
+			return mcp.NewToolResultError("manifest_name is required"), nil
 		}
 		manifestNameStr, ok := manifestName.(string)
 		if !ok {
-			return nil, fmt.Errorf("manifest_name must be a string")
+			return mcp.NewToolResultError("manifest_name must be a string"), nil
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		manifest, err := client.VulnerabilityManifests(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get vulnerability manifest: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get vulnerability manifest: %v", err)), nil
 		}
 		var cveList []v1beta1.Vulnerability
 		for _, match := range manifest.Spec.Payload.Matches {
@@ -545,7 +545,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		responseJson, err := json.Marshal(cveList)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal cve list: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal cve list: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -562,31 +562,31 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		namespaceStr, ok := namespace.(string)
 		if !ok {
-			return nil, fmt.Errorf("namespace must be a string")
+			return mcp.NewToolResultError("namespace must be a string"), nil
 		}
 		manifestName, ok := arguments["manifest_name"]
 		if !ok {
-			return nil, fmt.Errorf("manifest_name is required")
+			return mcp.NewToolResultError("manifest_name is required"), nil
 		}
 		manifestNameStr, ok := manifestName.(string)
 		if !ok {
-			return nil, fmt.Errorf("manifest_name must be a string")
+			return mcp.NewToolResultError("manifest_name must be a string"), nil
 		}
 		cveID, ok := arguments["cve_id"]
 		if !ok {
-			return nil, fmt.Errorf("cve_id is required")
+			return mcp.NewToolResultError("cve_id is required"), nil
 		}
 		cveIDStr, ok := cveID.(string)
 		if !ok {
-			return nil, fmt.Errorf("cve_id must be a string")
+			return mcp.NewToolResultError("cve_id must be a string"), nil
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		manifest, err := client.VulnerabilityManifests(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get vulnerability manifest: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get vulnerability manifest: %v", err)), nil
 		}
 		var match []v1beta1.Match
 		for _, m := range manifest.Spec.Payload.Matches {
@@ -596,7 +596,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		responseJson, err := json.Marshal(match)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal cve details: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal cve details: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -613,11 +613,11 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		namespaceStr, ok := namespace.(string)
 		if !ok {
-			return nil, fmt.Errorf("namespace must be a string")
+			return mcp.NewToolResultError("namespace must be a string"), nil
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		manifests, err := client.WorkloadConfigurationScans(namespaceStr).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -643,7 +643,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		content, err := json.Marshal(result)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal result: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -660,27 +660,27 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		namespaceStr, ok := namespace.(string)
 		if !ok {
-			return nil, fmt.Errorf("namespace must be a string")
+			return mcp.NewToolResultError("namespace must be a string"), nil
 		}
 		manifestName, ok := arguments["manifest_name"]
 		if !ok {
-			return nil, fmt.Errorf("manifest_name is required")
+			return mcp.NewToolResultError("manifest_name is required"), nil
 		}
 		manifestNameStr, ok := manifestName.(string)
 		if !ok {
-			return nil, fmt.Errorf("manifest_name must be a string")
+			return mcp.NewToolResultError("manifest_name must be a string"), nil
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		manifest, err := client.WorkloadConfigurationScans(namespaceStr).Get(ctx, manifestNameStr, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get configuration manifest: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get configuration manifest: %v", err)), nil
 		}
 		responseJson, err := json.Marshal(manifest)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal configuration manifest: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal configuration manifest: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -695,7 +695,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if ns, ok := arguments["namespace"]; ok {
 			nsStr, ok := ns.(string)
 			if !ok {
-				return nil, fmt.Errorf("namespace must be a string")
+				return mcp.NewToolResultError("namespace must be a string"), nil
 			}
 			if nsStr != "" {
 				namespace = nsStr
@@ -703,7 +703,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		profiles, err := client.ContainerProfiles(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -729,7 +729,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		content, err := json.Marshal(result)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal result: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -746,27 +746,27 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		namespaceStr, ok := namespace.(string)
 		if !ok {
-			return nil, fmt.Errorf("namespace must be a string")
+			return mcp.NewToolResultError("namespace must be a string"), nil
 		}
 		profileName, ok := arguments["profile_name"]
 		if !ok {
-			return nil, fmt.Errorf("profile_name is required")
+			return mcp.NewToolResultError("profile_name is required"), nil
 		}
 		profileNameStr, ok := profileName.(string)
 		if !ok {
-			return nil, fmt.Errorf("profile_name must be a string")
+			return mcp.NewToolResultError("profile_name must be a string"), nil
 		}
 		client, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", ksErr)), nil
 		}
 		profile, err := client.ContainerProfiles(namespaceStr).Get(ctx, profileNameStr, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get container profile: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get container profile: %v", err)), nil
 		}
 		responseJson, err := json.Marshal(profile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal container profile: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal container profile: %v", err)), nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -804,7 +804,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		return mcp.NewToolResultText(string(responseBytes)), nil
 	default:
-		return nil, fmt.Errorf("unknown tool: %s", name)
+		return mcp.NewToolResultError(fmt.Sprintf("unknown tool: %s", name)), nil
 	}
 }
 

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -471,7 +471,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			})
 		}
 		if err != nil {
-			return nil, err
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list vulnerability manifests: %v", err)), nil
 		}
 
 		logger.L().Info(fmt.Sprintf("Found %d manifests", len(manifests.Items)))
@@ -621,7 +621,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		manifests, err := client.WorkloadConfigurationScans(namespaceStr).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list configuration scans: %v", err)), nil
 		}
 		logger.L().Info(fmt.Sprintf("Found %d configuration manifests", len(manifests.Items)))
 		configManifests := []map[string]any{}
@@ -707,7 +707,7 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		profiles, err := client.ContainerProfiles(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list container profiles: %v", err)), nil
 		}
 		logger.L().Info(fmt.Sprintf("Found %d container profiles", len(profiles.Items)))
 		containerProfilesList := []map[string]any{}

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -12,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 func toolResultText(t *testing.T, result *mcp.CallToolResult) string {
@@ -25,30 +28,44 @@ func toolResultText(t *testing.T, result *mcp.CallToolResult) string {
 
 func TestCallToolValidation(t *testing.T) {
 	ksServer := &KubescapeMcpserver{}
+
+	client := storagefake.NewClientset()
+	client.PrependReactor("list", "*", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("simulated list error")
+	})
+	ksErrorServer := &KubescapeMcpserver{ksClient: client.SpdxV1beta1()}
+
 	tests := []struct {
 		name      string
+		server    *KubescapeMcpserver
 		tool      string
 		arguments map[string]any
 		wantError string
 	}{
-		{name: "unknown tool", tool: "missing", arguments: map[string]any{}, wantError: "unknown tool"},
-		{name: "vulnerability namespace type", tool: "list_vulnerability_manifests", arguments: map[string]any{"namespace": 42}, wantError: "namespace must be a string"},
-		{name: "CVE list requires manifest", tool: "list_vulnerabilities_in_manifest", arguments: map[string]any{}, wantError: "manifest_name is required"},
-		{name: "CVE list manifest type", tool: "list_vulnerabilities_in_manifest", arguments: map[string]any{"manifest_name": 42}, wantError: "manifest_name must be a string"},
-		{name: "CVE match requires ID", tool: "list_vulnerability_matches_for_cve", arguments: map[string]any{"manifest_name": "manifest"}, wantError: "cve_id is required"},
-		{name: "CVE match ID type", tool: "list_vulnerability_matches_for_cve", arguments: map[string]any{"manifest_name": "manifest", "cve_id": 42}, wantError: "cve_id must be a string"},
-		{name: "configuration namespace type", tool: "list_configuration_security_scan_manifests", arguments: map[string]any{"namespace": true}, wantError: "namespace must be a string"},
-		{name: "configuration get requires name", tool: "get_configuration_security_scan_manifest", arguments: map[string]any{}, wantError: "manifest_name is required"},
-		{name: "profile namespace type", tool: "list_container_profiles", arguments: map[string]any{"namespace": true}, wantError: "namespace must be a string"},
-		{name: "profile get requires name", tool: "get_container_profile", arguments: map[string]any{}, wantError: "profile_name is required"},
-		{name: "profile name type", tool: "get_container_profile", arguments: map[string]any{"profile_name": 42}, wantError: "profile_name must be a string"},
+		{name: "unknown tool", server: ksServer, tool: "missing", arguments: map[string]any{}, wantError: "unknown tool"},
+		{name: "vulnerability namespace type", server: ksServer, tool: "list_vulnerability_manifests", arguments: map[string]any{"namespace": 42}, wantError: "namespace must be a string"},
+		{name: "CVE list requires manifest", server: ksServer, tool: "list_vulnerabilities_in_manifest", arguments: map[string]any{}, wantError: "manifest_name is required"},
+		{name: "CVE list manifest type", server: ksServer, tool: "list_vulnerabilities_in_manifest", arguments: map[string]any{"manifest_name": 42}, wantError: "manifest_name must be a string"},
+		{name: "CVE match requires ID", server: ksServer, tool: "list_vulnerability_matches_for_cve", arguments: map[string]any{"manifest_name": "manifest"}, wantError: "cve_id is required"},
+		{name: "CVE match ID type", server: ksServer, tool: "list_vulnerability_matches_for_cve", arguments: map[string]any{"manifest_name": "manifest", "cve_id": 42}, wantError: "cve_id must be a string"},
+		{name: "configuration namespace type", server: ksServer, tool: "list_configuration_security_scan_manifests", arguments: map[string]any{"namespace": true}, wantError: "namespace must be a string"},
+		{name: "configuration get requires name", server: ksServer, tool: "get_configuration_security_scan_manifest", arguments: map[string]any{}, wantError: "manifest_name is required"},
+		{name: "profile namespace type", server: ksServer, tool: "list_container_profiles", arguments: map[string]any{"namespace": true}, wantError: "namespace must be a string"},
+		{name: "profile get requires name", server: ksServer, tool: "get_container_profile", arguments: map[string]any{}, wantError: "profile_name is required"},
+		{name: "profile name type", server: ksServer, tool: "get_container_profile", arguments: map[string]any{"profile_name": 42}, wantError: "profile_name must be a string"},
+
+		{name: "vulnerability list kubernetes error", server: ksErrorServer, tool: "list_vulnerability_manifests", arguments: map[string]any{}, wantError: "failed to list vulnerability manifests: simulated list error"},
+		{name: "configuration list kubernetes error", server: ksErrorServer, tool: "list_configuration_security_scan_manifests", arguments: map[string]any{}, wantError: "failed to list configuration scans: simulated list error"},
+		{name: "profile list kubernetes error", server: ksErrorServer, tool: "list_container_profiles", arguments: map[string]any{}, wantError: "failed to list container profiles: simulated list error"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := ksServer.CallTool(context.Background(), test.tool, test.arguments)
-			require.ErrorContains(t, err, test.wantError)
-			assert.Nil(t, result)
+			result, err := test.server.CallTool(context.Background(), test.tool, test.arguments)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsError)
+			assert.Contains(t, toolResultText(t, result), test.wantError)
 		})
 	}
 }


### PR DESCRIPTION
## Overview
Currently, the legacy MCP tools (e.g. `list_vulnerability_manifests`, `list_container_profiles`, etc.) return errors via `return nil, fmt.Errorf(...)`. This violates the MCP protocol, causing the underlying JSON-RPC framework to trigger a hard protocol-level crash and breaking the AI agent's session, instead of allowing it to recover gracefully.

The newer MCP tools (like `run_rbac_security_scan` and `scan_local_iac`) correctly return errors using `return mcp.NewToolResultError(...)`.

## Changes Made
All MCP tools in `CallTool` now consistently return tool-level failures via `mcp.NewToolResultError`, allowing the AI agent to read the error as tool output and try again.

Resolves #2747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool failures now return clear MCP error results for validation, Kubernetes, retrieval, and response-formatting issues.
  * Unknown tools and manifest-listing failures are reported consistently without disrupting the tool response flow.
  * Successful tool responses remain unchanged.

* **Tests**
  * Expanded coverage for Kubernetes list-operation failures across vulnerability, configuration, and container-profile tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->