### PR TITLE
fix(cautils): sort copies in StringSlicesAreEqual to avoid mutating caller slices

### DIFF
--- a/core/cautils/strutils.go
+++ b/core/cautils/strutils.go
@@ -12,10 +12,12 @@ func StringSlicesAreEqual(a, b []string) bool {
 		return false
 	}
 
-	sort.Strings(a)
-	sort.Strings(b)
-	for i := range a {
-		if a[i] != b[i] {
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
 			return false
 		}
 	}

--- a/core/cautils/strutils_test.go
+++ b/core/cautils/strutils_test.go
@@ -103,6 +103,16 @@ func TestStringSlicesAreEqual(t *testing.T) {
 	}
 }
 
+func TestStringSlicesAreEqual_NoMutation(t *testing.T) {
+	a := []string{"foo", "bar", "baz"}
+	b := []string{"baz", "foo", "bar"}
+
+	StringSlicesAreEqual(a, b)
+
+	assert.Equal(t, []string{"foo", "bar", "baz"}, a, "StringSlicesAreEqual must not mutate a")
+	assert.Equal(t, []string{"baz", "foo", "bar"}, b, "StringSlicesAreEqual must not mutate b")
+}
+
 func TestParseBoolEnvVar(t *testing.T) {
 	testCases := []struct {
 		expectedErr  string


### PR DESCRIPTION
## Summary

- `StringSlicesAreEqual` called `sort.Strings` directly on its parameters, mutating the caller's backing arrays in-place on every call.
- The policy handler in `getScanPolicies` passes its cached identifier slice as an argument; each cache-hit comparison silently reordered that cached slice, making the next comparison order-dependent and potentially triggering unnecessary policy re-downloads in multi-scan operator runs.
- Fixed by sorting copies of the inputs so the caller's slices are never modified.
- Regression covered by `TestStringSlicesAreEqual_NoMutation` in `core/cautils/strutils_test.go`.

**Which issue(s) this PR fixes:**
None (no prior issue filed)

**Special notes for your reviewer:**
The only two pre-existing test failures in the suite (`TestKustomizeDirectoryWithHelmCharts`, `TestGetScanningContext/git_URL_input`) are environment-specific (Helm v4 removed the `-c` flag; the git-URL test requires a network credential) and are unrelated to this change.

**Does this PR introduce a user-facing change?**
No, internal correctness fix; behaviour is identical for callers that do not rely on the sorted side-effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comparing two string lists no longer changes their original order.

* **Tests**
  * Added coverage to verify that list comparisons preserve the input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->