### PR TITLE
fix(resourcehandler): resolve offline resources from manifests

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -2,6 +2,8 @@ package opaprocessor
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -203,18 +205,49 @@ func isEmptyResources(counters reportsummary.ICounters) bool {
 }
 
 func getKubernetesObjectsFromExternalResources(externalResources cautils.ExternalResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
+	return getKubernetesObjects(cautils.K8SResources(externalResources), allResources, match)
+}
+
+// getKubernetesObjects returns the objects of a single scope that the rule
+// matches, in match-declaration order. Callers evaluate one scope at a time,
+// so no per-namespace bucketing happens here: the caller's batch already is
+// the bucket (see cautils.PartitionResources).
+func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
 	k8sObjects := []workloadinterface.IMetadata{}
+	seenResourceIDs := make(map[string]struct{})
+	// Match the collected GVR keys directly. Re-resolving policy matches through
+	// k8s-interface here would make file scans depend on its discovery snapshot
+	// again and would lose manifest versions that the snapshot does not contain.
+	resourceGroups := make([]string, 0, len(k8sResources))
+	for resourceGroup := range k8sResources {
+		resourceGroups = append(resourceGroups, resourceGroup)
+	}
+	sort.Strings(resourceGroups)
 
 	for m := range match {
 		for _, groups := range match[m].APIGroups {
 			for _, version := range match[m].APIVersions {
 				for _, resource := range match[m].Resources {
-					groupResources := k8sinterface.ResourceGroupToString(groups, version, resource)
-					for _, groupResource := range groupResources {
-						if k8sObj, ok := externalResources[groupResource]; ok {
-							for i := range k8sObj {
-								k8sObjects = append(k8sObjects, allResources[k8sObj[i]])
+					for _, resourceGroup := range resourceGroups {
+						objectGroup, objectVersion, objectResource := k8sinterface.StringToResourceGroup(resourceGroup)
+						if !matchesKubernetesObjectValue(groups, objectGroup) || !matchesKubernetesObjectValue(version, objectVersion) {
+							continue
+						}
+
+						directResourceMatch := resource == "*" || strings.EqualFold(resource, objectResource)
+						for _, id := range k8sResources[resourceGroup] {
+							if _, seen := seenResourceIDs[id]; seen {
+								continue
 							}
+							object, ok := allResources[id]
+							if !ok || object == nil {
+								continue
+							}
+							if !directResourceMatch && !strings.EqualFold(resource, object.GetKind()) {
+								continue
+							}
+							k8sObjects = append(k8sObjects, object)
+							seenResourceIDs[id] = struct{}{}
 						}
 					}
 				}
@@ -225,31 +258,11 @@ func getKubernetesObjectsFromExternalResources(externalResources cautils.Externa
 	return k8sObjects
 }
 
-// getKubernetesObjects returns the objects of a single scope that the rule
-// matches, in match-declaration order. Callers evaluate one scope at a time,
-// so no per-namespace bucketing happens here: the caller's batch already is
-// the bucket (see cautils.PartitionResources).
-func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
-	k8sObjects := []workloadinterface.IMetadata{}
-
-	for m := range match {
-		for _, groups := range match[m].APIGroups {
-			for _, version := range match[m].APIVersions {
-				for _, resource := range match[m].Resources {
-					groupResources := k8sinterface.ResourceGroupToString(groups, version, resource)
-					for _, groupResource := range groupResources {
-						for _, id := range k8sResources[groupResource] {
-							if obj, ok := allResources[id]; ok {
-								k8sObjects = append(k8sObjects, obj)
-							}
-						}
-					}
-				}
-			}
-		}
+func matchesKubernetesObjectValue(policyValue, objectValue string) bool {
+	if policyValue == "*" || policyValue == objectValue {
+		return true
 	}
-
-	return k8sObjects
+	return policyValue == "core" && objectValue == ""
 }
 func getRuleDependencies(ctx context.Context) (map[string]string, error) {
 	modules := resources.LoadRegoModules()

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,6 +40,31 @@ func TestGetKubernetesObjectsDeduplicatesResourceAliases(t *testing.T) {
 
 	objects := getKubernetesObjects(resources, allResources, match)
 	assert.Equal(t, 1, len(objects))
+}
+
+func TestGetKubernetesObjectsMatchesFutureAPIVersionWithWildcards(t *testing.T) {
+	workload := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "autoscaling/v99",
+		"kind":       "HorizontalPodAutoscaler",
+		"metadata": map[string]any{
+			"name":      "future-hpa",
+			"namespace": "default",
+		},
+	})
+	resourceID := workload.GetID()
+	resources := cautils.K8SResources{
+		"autoscaling/v99/horizontalpodautoscaler": {resourceID},
+	}
+	allResources := map[string]workloadinterface.IMetadata{resourceID: workload}
+	match := []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"HorizontalPodAutoscaler"},
+	}}
+
+	objects := getKubernetesObjects(resources, allResources, match)
+	require.Len(t, objects, 1)
+	assert.Same(t, workload, objects[0])
 }
 
 func TestRemoveData(t *testing.T) {

--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -185,6 +185,47 @@ func TestDiscoveredScopeAppliesIncludeAndExcludeSelectors(t *testing.T) {
 	)
 }
 
+func TestOfflineResolverUsesKindScopeWhenNamespaceIsOmitted(t *testing.T) {
+	tests := []struct {
+		apiVersion     string
+		group          string
+		version        string
+		kind           string
+		resource       string
+		wantNamespaced bool
+		wantSelector   string
+	}{
+		{apiVersion: "v1", version: "v1", kind: "Pod", resource: "pods", wantNamespaced: true, wantSelector: "metadata.namespace!=kube-system"},
+		{apiVersion: "apps/v1", group: "apps", version: "v1", kind: "Deployment", resource: "deployments", wantNamespaced: true, wantSelector: "metadata.namespace!=kube-system"},
+		{apiVersion: "rbac.authorization.k8s.io/v1", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole", resource: "clusterroles", wantNamespaced: false, wantSelector: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			workload := workloadinterface.NewWorkloadObj(map[string]any{
+				"apiVersion": test.apiVersion,
+				"kind":       test.kind,
+				"metadata":   map[string]any{"name": "without-namespace"},
+			})
+			mapped := map[string][]workloadinterface.IMetadata{
+				k8sinterface.JoinResourceTriplets(test.group, test.version, test.resource): {workload},
+			}
+			resolver := newOfflineManifestResourceResolver(mapped)
+
+			resolved := resolver(test.group, test.version, test.kind)
+			require.Len(t, resolved, 1)
+			require.NotNil(t, resolved[0].namespaced)
+			assert.Equal(t, test.wantNamespaced, *resolved[0].namespaced)
+
+			gvr := &schema.GroupVersionResource{Group: test.group, Version: test.version, Resource: test.resource}
+			assert.Equal(t,
+				[]string{test.wantSelector},
+				NewExcludeSelector("kube-system").GetNamespacesSelectors(gvr, resolved[0].namespaced),
+			)
+		})
+	}
+}
+
 func TestAgentRuntimeCRDResourceToControlKeysMatchQueries(t *testing.T) {
 	framework := agentRuntimeFramework()
 	resolver, failures := newDiscoveryResourceResolver(agentRuntimeDiscovery())
@@ -425,21 +466,73 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 	}
 }
 
-func TestAddWorkloadsToResourcesMapPreservesGroupVersionMismatchGuard(t *testing.T) {
-	k8sinterface.InitializeMapResourcesMock()
+func TestFileResourceHandlerUsesManifestAPIVersionsForBuiltIns(t *testing.T) {
+	manifest := `apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web
+  namespace: default
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web
+  namespace: default
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: web
+  namespace: default
+`
+	manifestPath := filepath.Join(t.TempDir(), "current-builtins.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o600))
+
+	matches := []reporthandling.RuleMatchObjects{
+		{APIGroups: []string{"autoscaling"}, APIVersions: []string{"v2"}, Resources: []string{"HorizontalPodAutoscaler"}},
+		{APIGroups: []string{"policy"}, APIVersions: []string{"v1"}, Resources: []string{"PodDisruptionBudget"}},
+		{APIGroups: []string{"discovery.k8s.io"}, APIVersions: []string{"v1"}, Resources: []string{"EndpointSlice"}},
+	}
+	framework := *mockFramework("current-builtins", []reporthandling.Control{
+		mockControl("current-builtins", []reporthandling.PolicyRule{mockRule("current-builtins", matches, "")}),
+	})
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+
+	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
+	require.NoError(t, err)
+	require.Len(t, allResources, 3)
+
+	expected := map[string]string{
+		"autoscaling/v2/horizontalpodautoscaler": "HorizontalPodAutoscaler",
+		"policy/v1/poddisruptionbudget":          "PodDisruptionBudget",
+		"discovery.k8s.io/v1/endpointslice":      "EndpointSlice",
+	}
+	for resourceGroup, kind := range expected {
+		require.Lenf(t, resources[resourceGroup], 1, "expected one %s under %s", kind, resourceGroup)
+		assert.Equal(t, kind, allResources[resources[resourceGroup][0]].GetKind())
+	}
+}
+
+func TestAddWorkloadsToResourcesMapUsesManifestGroupVersionForBuiltIns(t *testing.T) {
 	tests := []struct {
+		name       string
 		apiVersion string
 		kind       string
+		want       string
 	}{
-		{apiVersion: "extensions/v1beta1", kind: "Deployment"},
-		{apiVersion: "rbac.authorization.k8s.io/v1beta1", kind: "Role"},
-		{apiVersion: "batch/v1beta1", kind: "CronJob"},
-		{apiVersion: "autoscaling/v2beta2", kind: "HorizontalPodAutoscaler"},
-		{apiVersion: "networking.k8s.io/v1beta1", kind: "Ingress"},
+		{name: "current HPA", apiVersion: "autoscaling/v2", kind: "HorizontalPodAutoscaler", want: "autoscaling/v2/horizontalpodautoscalers"},
+		{name: "current PDB", apiVersion: "policy/v1", kind: "PodDisruptionBudget", want: "policy/v1/poddisruptionbudgets"},
+		{name: "current EndpointSlice", apiVersion: "discovery.k8s.io/v1", kind: "EndpointSlice", want: "discovery.k8s.io/v1/endpointslices"},
+		{name: "legacy Deployment", apiVersion: "extensions/v1beta1", kind: "Deployment", want: "extensions/v1beta1/deployments"},
+		{name: "legacy Role", apiVersion: "rbac.authorization.k8s.io/v1beta1", kind: "Role", want: "rbac.authorization.k8s.io/v1beta1/roles"},
+		{name: "legacy CronJob", apiVersion: "batch/v1beta1", kind: "CronJob", want: "batch/v1beta1/cronjobs"},
+		{name: "legacy HPA", apiVersion: "autoscaling/v2beta2", kind: "HorizontalPodAutoscaler", want: "autoscaling/v2beta2/horizontalpodautoscalers"},
+		{name: "legacy Ingress", apiVersion: "networking.k8s.io/v1beta1", kind: "Ingress", want: "networking.k8s.io/v1beta1/ingresses"},
 	}
 
 	for _, test := range tests {
-		t.Run(test.kind, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			workload := workloadinterface.NewWorkloadObj(map[string]any{
 				"apiVersion": test.apiVersion,
 				"kind":       test.kind,
@@ -452,13 +545,13 @@ func TestAddWorkloadsToResourcesMapPreservesGroupVersionMismatchGuard(t *testing
 
 			addWorkloadsToResourcesMap(mapped, []workloadinterface.IMetadata{workload})
 
-			assert.Empty(t, mapped, "known resources with a non-canonical GroupVersion must remain skipped")
+			require.Len(t, mapped[test.want], 1)
+			assert.Same(t, workload, mapped[test.want][0])
 		})
 	}
 }
 
 func TestAddWorkloadsToResourcesMapKeepsCustomKindCollisions(t *testing.T) {
-	k8sinterface.InitializeMapResourcesMock()
 	workload := workloadinterface.NewWorkloadObj(map[string]any{
 		"apiVersion": "serving.knative.dev/v1",
 		"kind":       "Service",
@@ -496,13 +589,47 @@ func TestOfflineManifestResourceAliases(t *testing.T) {
 	}
 }
 
-func TestCanonicalAPIGroupMatchingDoesNotRequireAnAllowlist(t *testing.T) {
-	assert.True(t, matchesCanonicalAPIGroup("imagepolicy.k8s.io", "imagepolicy.k8s.io"))
-	assert.True(t, matchesCanonicalAPIGroup("settings.k8s.io", "settings.k8s.io"))
-	assert.True(t, matchesCanonicalAPIGroup("extensions", "apps"))
-	assert.True(t, matchesCanonicalAPIGroup("extensions", "networking.k8s.io"))
-	assert.False(t, matchesCanonicalAPIGroup("serving.knative.dev", ""))
-	assert.False(t, matchesCanonicalAPIGroup("migration.k8s.io", "apps"))
+func TestFileResourceHandlerBuildsWildcardMatchesFromManifestCatalog(t *testing.T) {
+	manifest := `apiVersion: autoscaling/v99
+kind: HorizontalPodAutoscaler
+metadata:
+  name: future-hpa
+  namespace: default
+---
+apiVersion: future.example.io/v7
+kind: Widget
+metadata:
+  name: future-widget
+  namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: core-pod
+  namespace: default
+`
+	manifestPath := filepath.Join(t.TempDir(), "future-resources.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o600))
+
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"HorizontalPodAutoscaler", "Widget", "Pod"},
+	}
+	framework := *mockFramework("future-resources", []reporthandling.Control{
+		mockControl("future-resources", []reporthandling.PolicyRule{
+			mockRule("future-resources", []reporthandling.RuleMatchObjects{match}, ""),
+		}),
+	})
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+
+	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
+	require.NoError(t, err)
+	require.Len(t, allResources, 3)
+	assert.Len(t, resources["autoscaling/v99/horizontalpodautoscaler"], 1)
+	assert.Len(t, resources["future.example.io/v7/widget"], 1)
+	assert.Len(t, resources["/v1/pod"], 1)
 }
 
 func TestAddSingleResourceToResourceMapsIndexesOfflineAliases(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -20,7 +20,6 @@ import (
 type FileResourceHandler struct{}
 
 func NewFileResourceHandler() *FileResourceHandler {
-	k8sinterface.InitializeMapResourcesMock() // initialize the resource map
 	return &FileResourceHandler{}
 }
 
@@ -74,7 +73,8 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 
 	// build a resources map, based on the policies
 	// map resources based on framework required resources: map["/group/version/kind"][]<k8s workloads ids>
-	resourceToQuery, excludedRulesMap := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, defaultResourceResolver)
+	offlineResolver := newOfflineManifestResourceResolver(mappedResources)
+	resourceToQuery, excludedRulesMap := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, offlineResolver)
 	k8sResources := resourceToQuery.ToK8sResourceMap()
 
 	// save only relevant resources
@@ -91,7 +91,7 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 
 	logger.L().StopSuccess("Done accessing local objects")
 	// save input resource in resource maps
-	addSingleResourceToResourceMaps(k8sResources, allResources, sessionObj.SingleResourceScan, defaultResourceResolver)
+	addSingleResourceToResourceMaps(k8sResources, allResources, sessionObj.SingleResourceScan, offlineResolver)
 
 	return k8sResources, allResources, externalResources, excludedRulesMap, nil
 }

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -58,23 +58,10 @@ func addWorkloadsToResourcesMap(allResources map[string][]workloadinterface.IMet
 	for i := range workloads {
 		workload := workloads[i]
 		group, version := k8sinterface.SplitApiVersion(workload.GetApiVersion())
-		canonical, canonicalErr := k8sinterface.GetGroupVersionResource(workload.GetKind())
-
-		var resourceTriplets []string
-		if canonicalErr == nil && matchesCanonicalAPIGroup(group, canonical.Group) {
-			if canonical.Group != group || canonical.Version != version {
-				logger.L().Warning("workload GroupVersion mismatch", helpers.String("id", workload.GetID()), helpers.String("kind", workload.GetKind()), helpers.String("expectedGroup", canonical.Group), helpers.String("actualGroup", group), helpers.String("expectedVersion", canonical.Version), helpers.String("actualVersion", version))
-				continue
-			}
-			resourceTriplets = []string{k8sinterface.JoinResourceTriplets(canonical.Group, canonical.Version, canonical.Resource)}
-		} else {
-			resourceTriplets = offlineManifestResourceTriplets(group, version, workload.GetKind())
-			if len(resourceTriplets) == 0 {
-				logger.L().Warning("unable to resolve object resource", helpers.String("kind", workload.GetKind()), helpers.String("id", workload.GetID()))
-				continue
-			}
-			logger.L().Debug("using manifest identity for custom resource unavailable in discovery",
-				helpers.String("kind", workload.GetKind()), helpers.String("id", workload.GetID()))
+		resourceTriplets := offlineManifestResourceTriplets(group, version, workload.GetKind())
+		if len(resourceTriplets) == 0 {
+			logger.L().Warning("unable to resolve object resource", helpers.String("kind", workload.GetKind()), helpers.String("id", workload.GetID()))
+			continue
 		}
 
 		for _, resourceTriplet := range resourceTriplets {
@@ -84,7 +71,7 @@ func addWorkloadsToResourcesMap(allResources map[string][]workloadinterface.IMet
 }
 
 func offlineManifestResourceTriplets(group, version, kind string) []string {
-	if group == "" || version == "" || kind == "" {
+	if version == "" || kind == "" {
 		return nil
 	}
 
@@ -117,18 +104,6 @@ func offlineManifestResourceAliases(kind string) []string {
 		aliases = append(aliases, singular[:n-1]+"ies")
 	}
 	return aliases
-}
-
-// matchesCanonicalAPIGroup distinguishes a stale built-in API version from a
-// custom resource whose Kind happens to collide with a built-in Kind. Most
-// built-ins retain their canonical group; extensions is the narrow legacy
-// exception for resources that moved to apps or networking.k8s.io.
-func matchesCanonicalAPIGroup(manifestGroup, canonicalGroup string) bool {
-	if manifestGroup == canonicalGroup {
-		return true
-	}
-	return manifestGroup == "extensions" &&
-		(canonicalGroup == "apps" || canonicalGroup == "networking.k8s.io")
 }
 
 /* unused for now

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,6 +23,119 @@ type resolvedResource struct {
 }
 
 type resourceResolver func(group, version, resource string) []resolvedResource
+
+type offlineManifestResource struct {
+	group      string
+	version    string
+	kind       string
+	namespaced bool
+}
+
+// newOfflineManifestResourceResolver builds the only discovery information a
+// file scan can trust: the identities declared by the manifests being scanned.
+// It deliberately does not consult the k8s-interface discovery snapshot.
+func newOfflineManifestResourceResolver(mappedResources map[string][]workloadinterface.IMetadata) resourceResolver {
+	resourcesByGVK := make(map[string]offlineManifestResource)
+	seenWorkloads := make(map[string]struct{})
+	for _, workloads := range mappedResources {
+		for _, workload := range workloads {
+			if workload == nil {
+				continue
+			}
+			if _, seen := seenWorkloads[workload.GetID()]; seen {
+				continue
+			}
+			seenWorkloads[workload.GetID()] = struct{}{}
+
+			group, version := k8sinterface.SplitApiVersion(workload.GetApiVersion())
+			kind := workload.GetKind()
+			if version == "" || kind == "" {
+				continue
+			}
+
+			key := k8sinterface.JoinResourceTriplets(group, version, strings.ToLower(kind))
+			entry := resourcesByGVK[key]
+			entry.group = group
+			entry.version = version
+			entry.kind = kind
+			entry.namespaced = entry.namespaced ||
+				workload.GetNamespace() != "" ||
+				k8sinterface.IsResourceInNamespaceScope(kind)
+			resourcesByGVK[key] = entry
+		}
+	}
+
+	resources := make([]offlineManifestResource, 0, len(resourcesByGVK))
+	for _, resource := range resourcesByGVK {
+		resources = append(resources, resource)
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		left := k8sinterface.JoinResourceTriplets(resources[i].group, resources[i].version, resources[i].kind)
+		right := k8sinterface.JoinResourceTriplets(resources[j].group, resources[j].version, resources[j].kind)
+		return left < right
+	})
+
+	return func(group, version, resource string) []resolvedResource {
+		if version == "" || resource == "" {
+			return nil
+		}
+
+		var resolved []resolvedResource
+		for _, manifestResource := range resources {
+			if !matchesOfflineManifestValue(group, manifestResource.group) ||
+				!matchesOfflineManifestValue(version, manifestResource.version) ||
+				!matchesOfflineManifestResource(resource, manifestResource.kind) {
+				continue
+			}
+
+			aliases := offlineManifestResourceTriplets(manifestResource.group, manifestResource.version, manifestResource.kind)
+			primary := aliases[0]
+			if resource != "*" && !strings.EqualFold(resource, manifestResource.kind) {
+				requested := k8sinterface.JoinResourceTriplets(manifestResource.group, manifestResource.version, strings.ToLower(resource))
+				for _, alias := range aliases {
+					if alias == requested {
+						primary = alias
+						break
+					}
+				}
+			}
+
+			comparisons := make([]string, 0, len(aliases)-1)
+			for _, alias := range aliases {
+				if alias != primary {
+					comparisons = append(comparisons, alias)
+				}
+			}
+			namespaced := manifestResource.namespaced
+			resolved = append(resolved, resolvedResource{
+				groupVersionResourceTriplet: primary,
+				comparisonTriplets:          comparisons,
+				namespaced:                  &namespaced,
+			})
+		}
+		return resolved
+	}
+}
+
+func matchesOfflineManifestValue(policyValue, manifestValue string) bool {
+	if policyValue == "*" || policyValue == manifestValue {
+		return true
+	}
+	return policyValue == "core" && manifestValue == ""
+}
+
+func matchesOfflineManifestResource(policyResource, manifestKind string) bool {
+	if policyResource == "*" || strings.EqualFold(policyResource, manifestKind) {
+		return true
+	}
+	policyResource = strings.ToLower(policyResource)
+	for _, alias := range offlineManifestResourceAliases(manifestKind) {
+		if policyResource == alias {
+			return true
+		}
+	}
+	return false
+}
 
 func defaultResourceResolver(group, version, resource string) []resolvedResource {
 	if version == "" || resource == "" {


### PR DESCRIPTION
## Overview

Offline manifest scans no longer treat the hardcoded Kubernetes discovery snapshot as the authority for resource identity.

Previously, file scans resolved built-in Kinds through that snapshot and dropped a manifest when its declared group/version differed from the captured value. As a result, valid resources such as `autoscaling/v2` HorizontalPodAutoscalers, `policy/v1` PodDisruptionBudgets, and `discovery.k8s.io/v1` EndpointSlices never reached policy evaluation.

This change:

- builds the offline resource catalog from the manifests that were actually loaded
- preserves each manifest's declared group, version, and Kind
- resolves exact and wildcard policy matches from that catalog
- keeps live cluster scans discovery-backed
- distinguishes same-Kind custom resources by API group
- deduplicates resource aliases before policy evaluation

This also allows future API versions and CRDs that are absent from the snapshot to be evaluated without refreshing a captured cluster resource list.

## How to Test

```bash
go test ./core/pkg/resourcehandler \
  -run 'Test(FileResourceHandlerUsesManifestAPIVersionsForBuiltIns|AddWorkloadsToResourcesMapUsesManifestGroupVersionForBuiltIns|AddWorkloadsToResourcesMapKeepsCustomKindCollisions|OfflineManifestResourceAliases|FileResourceHandlerBuildsWildcardMatchesFromManifestCatalog|AddSingleResourceToResourceMapsIndexesOfflineAliases|AddSingleResourceToResourceMapsGuardsUnresolvedIdentity)$' \
  -count=1

go test ./core/pkg/opaprocessor \
  -run 'TestGetKubernetesObjects(DeduplicatesResourceAliases|MatchesFutureAPIVersionWithWildcards)$' \
  -count=1

go vet ./core/pkg/resourcehandler ./core/pkg/opaprocessor
```

## Related issues/PRs

- Resolved #2715

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing relevant unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes resource matching across wildcard, core, and version-specific policies, including deterministic selection and kind-aware filtering.
  * Prevented duplicate results and safely skip missing or nil objects during offline evaluation.
  * Enhanced offline manifest resolution to preserve manifest API versions, support resource aliases, and better handle unknown/legacy versions.
* **Tests**
  * Added coverage for namespace omission scope handling, offline resolver behavior, wildcard manifest-catalog matching, and deduplication. Removed an obsolete allowlist-related test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->