### PR TITLE
refactor: remove dead count variable and simplify insertControls

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -109,8 +109,6 @@ func estimateClusterSize(k8sResources K8SResources) int {
 
 // SetTopWorkloads sets the top workloads by score
 func (sessionObj *OPASessionObj) SetTopWorkloads() {
-	count := 0
-
 	topWorkloadsSorted := make([]prioritization.PrioritizedResource, 0)
 
 	// create list in order to sort
@@ -151,7 +149,6 @@ func (sessionObj *OPASessionObj) SetTopWorkloads() {
 		}
 
 		topWorkloads = append(topWorkloads, wlObj)
-		count++
 	}
 
 	sessionObj.TopWorkloadsByScore = topWorkloads

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -128,12 +128,8 @@ func insertControls(resource string, resourceToControl map[string][]string, cont
 	for _, ksResource := range ksResources {
 		group, version := k8sinterface.SplitApiVersion(ksResource)
 		r := k8sinterface.JoinResourceTriplets(group, version, resource)
-		if _, ok := resourceToControl[r]; !ok {
+		if !slices.Contains(resourceToControl[r], control.ControlID) {
 			resourceToControl[r] = append(resourceToControl[r], control.ControlID)
-		} else {
-			if !slices.Contains(resourceToControl[r], control.ControlID) {
-				resourceToControl[r] = append(resourceToControl[r], control.ControlID)
-			}
 		}
 	}
 }

--- a/core/pkg/resourcehandler/k8sresourcesutils_test.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils_test.go
@@ -193,3 +193,50 @@ func Test_getGroupNVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestInsertControls(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	makeControl := func(id string) reporthandling.Control {
+		return reporthandling.Control{
+			PortalBase: *armotypes.MockPortalBase("aaaaaaaa-bbbb-cccc-dddd-000000000001", id, nil),
+			ControlID:  id,
+		}
+	}
+
+	t.Run("first insert creates entry", func(t *testing.T) {
+		m := map[string][]string{}
+		insertControls("KubeletConfiguration", m, makeControl("C-0001"))
+		assert.NotEmpty(t, m, "insertControls must write at least one resource key")
+		for _, ids := range m {
+			assert.Contains(t, ids, "C-0001")
+		}
+	})
+
+	t.Run("duplicate insert is deduped", func(t *testing.T) {
+		m := map[string][]string{}
+		insertControls("KubeletConfiguration", m, makeControl("C-0001"))
+		insertControls("KubeletConfiguration", m, makeControl("C-0001"))
+		assert.NotEmpty(t, m, "insertControls must write at least one resource key")
+		for _, ids := range m {
+			count := 0
+			for _, id := range ids {
+				if id == "C-0001" {
+					count++
+				}
+			}
+			assert.Equal(t, 1, count, "control ID must appear exactly once")
+		}
+	})
+
+	t.Run("distinct controls both appear", func(t *testing.T) {
+		m := map[string][]string{}
+		insertControls("KubeletConfiguration", m, makeControl("C-0001"))
+		insertControls("KubeletConfiguration", m, makeControl("C-0002"))
+		assert.NotEmpty(t, m, "insertControls must write at least one resource key")
+		for _, ids := range m {
+			assert.Contains(t, ids, "C-0001")
+			assert.Contains(t, ids, "C-0002")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two related dead-code / simplification fixes:

**`core/cautils/datastructures.go` - `SetTopWorkloads`**
`count` was declared and incremented but never read. `len(topWorkloads)` already drives the `TopWorkloadsNumber` cap.

**`core/pkg/resourcehandler/k8sresourcesutils.go` - `insertControls`**
The `if !ok / else slices.Contains` split was asymmetric. `slices.Contains` on nil returns false, so both branches reduce to the same single guard. Collapsed into one line. Added `TestInsertControls` with three subtests (first insert, dedup, distinct controls) to directly cover the behaviour.

**Does this PR introduce a user-facing change?**
No internal cleanup only, behaviour is identical.

**Special notes for reviewer:**
`TestKustomizeDirectoryWithHelmCharts` and `TestGetScanningContext/git_URL_input` are pre-existing environment failures (Helm v4 / network credential) unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when assigning controls to resources.
  * Prevented duplicate control IDs while preserving multiple distinct assignments.

* **Tests**
  * Added coverage for creating resource mappings, retaining distinct control IDs, and suppressing repeated entries.
  * Expanded validation to support consistent control-assignment behavior in future updates.

* **Refactor**
  * Simplified internal handling of resource-control assignments without changing expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->