### PR TITLE
refactor(cautils): use slices and assert result in non-mutation test

### DIFF
--- a/core/cautils/strutils.go
+++ b/core/cautils/strutils.go
@@ -3,25 +3,21 @@ package cautils
 import (
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 )
 
+// StringSlicesAreEqual reports whether a and b contain the same elements,
+// ignoring order. It sorts copies rather than the arguments: callers pass
+// slices they do not exclusively own (e.g. the policy handler's cached
+// identifiers), and sorting those in place would mutate shared state outside
+// the owner's lock.
 func StringSlicesAreEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	ac := append([]string(nil), a...)
-	bc := append([]string(nil), b...)
-	sort.Strings(ac)
-	sort.Strings(bc)
-	for i := range ac {
-		if ac[i] != bc[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
 }
 
 func ParseIntEnvVar(varName string, defaultValue int) (int, error) {

--- a/core/cautils/strutils_test.go
+++ b/core/cautils/strutils_test.go
@@ -107,7 +107,7 @@ func TestStringSlicesAreEqual_NoMutation(t *testing.T) {
 	a := []string{"foo", "bar", "baz"}
 	b := []string{"baz", "foo", "bar"}
 
-	StringSlicesAreEqual(a, b)
+	assert.True(t, StringSlicesAreEqual(a, b), "slices with the same elements must compare equal")
 
 	assert.Equal(t, []string{"foo", "bar", "baz"}, a, "StringSlicesAreEqual must not mutate a")
 	assert.Equal(t, []string{"baz", "foo", "bar"}, b, "StringSlicesAreEqual must not mutate b")


### PR DESCRIPTION
## Summary

Follow-up to #2750. That PR landed the correctness fix but was merged past two review comments; the author agreed to both, only after the merge, so neither could be applied there. This rewrites `StringSlicesAreEqual` using `slices`, asserts the return value in the non-mutation test, and documents why the defensive copies exist.

## Ticket

None (no Jira ticket for this repo).

## Changes

- `core/cautils/strutils.go` — replace the hand-rolled `append([]string(nil), ...)` + `sort.Strings` + index loop with `slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))`. Identical semantics — sorted copies, caller slices untouched — with 12 fewer lines and one fewer import. `go.mod` is on `go 1.26.0` and the repo already imports `slices` in a dozen places. The `len` fast path stays, so unequal-length inputs still return without allocating.
- `core/cautils/strutils.go` — add a doc comment recording why the copies are required (see below).
- `core/cautils/strutils_test.go` — `TestStringSlicesAreEqual_NoMutation` called `StringSlicesAreEqual(a, b)` and discarded the result, so it only verified that the inputs survived. A rewrite that preserved the inputs but broke equality would have passed it. It now asserts `true` as well.

## Why the doc comment

The rationale in #2750's commit message is not correct, and it is permanent history now:

> each cache-hit comparison silently reordered that cached slice, making the next comparison order-dependent and potentially causing unnecessary policy re-downloads

That does not hold for the only call site (`core/pkg/policyhandler/handlepullpolicies.go:148`). Sorting is idempotent: once `cachedIdentifiers` is sorted it stays sorted, and `policyIdentifiersSlice` is rebuilt fresh by `policyIdentifierToSlice` and sorted inside the function on every call — so comparisons kept returning the right answer. There was never a false cache miss or a spurious re-download.

The actual defect was a **data race**. `TimedCache.Get()` returns the slice header under `RLock` and then releases the lock; `sort.Strings(cachedIdentifiers)` went on to mutate the cache's shared backing array with no lock held. `NewPolicyHandler` hands out a process-wide singleton, and `NewRequestScopedPolicyHandler` exists precisely because concurrent callers do too — so two goroutines could sort and read the same array simultaneously.

Worth having in the source, so the copies are not "optimized" away later by someone who reads the old commit message and concludes they were pointless.

## Testing

```
go build ./...                                                → pass
go test -race ./core/cautils/... ./core/pkg/policyhandler/...  → pass
go vet ./core/cautils/                                         → clean
gofmt -l core/cautils/                                         → clean
```

## Docs

Docs-exempt: pure refactor plus a test assertion, no behavioral or API change; no doc under `docs/` describes `StringSlicesAreEqual`.

## AI Context

| Category | Used |
|----------|------|
| Skills | None |
| MCP Servers | None |
| Rules/Commands | armosec-shared-rules (docs-gate, pr-structure) |

<!-- armosec-pr: v=1 via=manual -->

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison of string lists regardless of item order.
  * Ensured input lists remain unchanged during comparison.

* **Tests**
  * Updated coverage to verify equivalent lists are recognized before confirming inputs are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->