### PR TITLE
fix(opaprocessor): scrub stringData field in Secret resources

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -294,14 +294,24 @@ func removeConfigMapData(workload workloadinterface.IWorkload) {
 }
 
 func overrideSensitiveData(workload workloadinterface.IWorkload) {
-	dataInterface, ok := workloadinterface.InspectMap(workload.GetObject(), "data")
-	if ok {
-		data, ok := dataInterface.(map[string]any)
-		if ok {
-			for key := range data {
-				workloadinterface.SetInMap(workload.GetObject(), []string{"data"}, key, "XXXXXX")
-			}
-		}
+	overrideMapField(workload, "data")
+}
+
+func overrideStringData(workload workloadinterface.IWorkload) {
+	overrideMapField(workload, "stringData")
+}
+
+func overrideMapField(workload workloadinterface.IWorkload, field string) {
+	dataInterface, ok := workloadinterface.InspectMap(workload.GetObject(), field)
+	if !ok {
+		return
+	}
+	data, ok := dataInterface.(map[string]any)
+	if !ok {
+		return
+	}
+	for key := range data {
+		workloadinterface.SetInMap(workload.GetObject(), []string{field}, key, "XXXXXX")
 	}
 }
 
@@ -309,7 +319,9 @@ func removeSecretData(workload workloadinterface.IWorkload) {
 	workload.RemoveAnnotation("kubectl.kubernetes.io/last-applied-configuration")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "metadata", "managedFields")
 	overrideSensitiveData(workload)
+	overrideStringData(workload)
 }
+
 func removePodData(workload workloadinterface.IWorkload) {
 	workload.RemoveAnnotation("kubectl.kubernetes.io/last-applied-configuration")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "metadata", "managedFields")

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -94,6 +94,12 @@ func TestRemoveData(t *testing.T) {
 			},
 		},
 		{
+			name: "remove secret stringData",
+			args: args{
+				w: `{"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "example-secret", "namespace": "default"}, "type": "Opaque", "stringData": {"token": "supersecret", "apiKey": "abc123"}}`,
+			},
+		},
+		{
 			name: "remove configMap data",
 			args: args{
 				w: `{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "example-configmap", "namespace": "default", "annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{}"}}, "data": {"exampleKey": "exampleValue"}}`,
@@ -124,6 +130,14 @@ func TestRemoveData(t *testing.T) {
 				}
 			}
 
+			if sd, ok := workloadinterface.InspectMap(workload.GetObject(), "stringData"); ok {
+				stringData, ok := sd.(map[string]any)
+				assert.True(t, ok)
+				for key := range stringData {
+					assert.Equalf(t, "XXXXXX", stringData[key], "stringData[%q] was not redacted", key)
+				}
+			}
+
 			if c, _ := workload.GetContainers(); c != nil {
 				for i := range c {
 					for _, e := range c[i].Env {
@@ -149,6 +163,47 @@ func TestRemoveData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoveSecretData(t *testing.T) {
+	t.Run("stringData values are redacted", func(t *testing.T) {
+		raw := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s","namespace":"default"},"type":"Opaque","stringData":{"token":"supersecret","apiKey":"abc123"}}`
+		obj, err := workloadinterface.NewWorkload([]byte(raw))
+		assert.NoError(t, err)
+		removeData(obj)
+		sd, ok := workloadinterface.InspectMap(obj.GetObject(), "stringData")
+		assert.True(t, ok, "stringData key must still be present after redaction")
+		stringData, ok := sd.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "XXXXXX", stringData["token"])
+		assert.Equal(t, "XXXXXX", stringData["apiKey"])
+	})
+
+	t.Run("data and stringData are both redacted", func(t *testing.T) {
+		raw := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s","namespace":"default"},"type":"Opaque","data":{"user":"dXNlcg=="},"stringData":{"pass":"cleartext"}}`
+		obj, err := workloadinterface.NewWorkload([]byte(raw))
+		assert.NoError(t, err)
+		removeData(obj)
+		d, ok := workloadinterface.InspectMap(obj.GetObject(), "data")
+		assert.True(t, ok)
+		data, ok := d.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "XXXXXX", data["user"])
+		sd, ok := workloadinterface.InspectMap(obj.GetObject(), "stringData")
+		assert.True(t, ok)
+		stringData, ok := sd.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "XXXXXX", stringData["pass"])
+	})
+
+	t.Run("absent stringData does not panic", func(t *testing.T) {
+		raw := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s","namespace":"default"},"type":"Opaque","data":{"key":"dmFsdWU="}}`
+		obj, err := workloadinterface.NewWorkload([]byte(raw))
+		assert.NoError(t, err)
+		assert.NotPanics(t, func() { removeData(obj) })
+		_, ok := workloadinterface.InspectMap(obj.GetObject(), "stringData")
+		assert.False(t, ok, "stringData must not appear when it was not present originally")
+	})
 }
 
 func TestRemoveContainersData(t *testing.T) {


### PR DESCRIPTION
## Summary

`removeSecretData` only redacted the `data` field of Secret resources. Kubernetes
Secrets also have a `stringData` field that holds cleartext values such as passwords, API
keys, tokens - written directly by users in YAML manifests. The Kubernetes API server
encodes and merges `stringData` into `data` on write, but kubescape's file-based scan
reads the manifest directly, so `stringData` is preserved verbatim. With
`OmitRawResources` defaulting to false, those cleartext values appeared in scan output.

**Files changed:**

- `core/pkg/opaprocessor/processorhandlerutils.go`: extracted a single
  `overrideMapField(workload, field)` helper (the body shared by the existing
  `overrideSensitiveData`), updated `overrideSensitiveData` to delegate to it, added
  `overrideStringData` which calls the same helper for the `stringData` key, and
  called it from `removeSecretData`.
- `core/pkg/opaprocessor/processorhandlerutils_test.go`: added
  `"remove secret stringData"` table entry to `TestRemoveData`, and a dedicated
  `TestRemoveSecretData` with three subtests: direct key assertions on redacted values,
  a combined `data`+`stringData` case, and a no-panic case when `stringData` is absent.

**What was tested:**

- `TestRemoveData/remove_secret_stringData`
- `TestRemoveSecretData/stringData_values_are_redacted`
- `TestRemoveSecretData/data_and_stringData_are_both_redacted`
- `TestRemoveSecretData/absent_stringData_does_not_panic`

**Does this PR introduce a user-facing change?**
Yes cleartext values in `stringData` fields of Secret manifests are now redacted
to `XXXXXX` in scan output, matching the existing behaviour for the `data` field.

**Special notes for reviewer:**
The `overrideMapField` helper also simplifies the pre-existing `overrideSensitiveData`
(which had nested `if ok` blocks) into a single early-return path. Behaviour is
identical, existing tests confirm it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensitive data masking for Secret `stringData` fields.
  * Safely handles missing or non-string fields without errors.
  * Ensures all sensitive map values are consistently redacted.

* **Tests**
  * Added coverage for Secrets containing `stringData`, both alone and alongside other sensitive fields.
  * Verified safe behavior when `stringData` is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->