### PR TITLE
fix(cautils): report the bound port from GetPortForwardLocalhost

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -66,14 +66,18 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{})
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 
-	forwarder, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, []string{fmt.Sprintf("%s:%s", getPortForwardingPort(), forwardingPort)}, stopChan, readyChan, out, errOut)
+	// Resolve the requested port once, so the forwarder and the fallback in
+	// GetPortForwardLocalhost cannot disagree if the environment changes.
+	localPort := getPortForwardingPort()
+
+	forwarder, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, []string{fmt.Sprintf("%s:%s", localPort, forwardingPort)}, stopChan, readyChan, out, errOut)
 	if err != nil {
 		return nil, err
 	}
 
 	return &portForward{
 		PortForwarder: forwarder,
-		localPort:     getPortForwardingPort(),
+		localPort:     localPort,
 		stopChan:      stopChan,
 		readyChan:     readyChan,
 		errChan:       make(chan error, 1),
@@ -94,8 +98,14 @@ func (p *portForward) waitForPortForwardReadiness() error {
 	}
 }
 
+// GetPortForwardLocalhost reports the bound port, which differs from the
+// requested one when DEFAULT_PORT_FORWARDER_PORT is 0. GetPorts() errors out
+// until the listeners are ready, hence the fallback.
 func (p *portForward) GetPortForwardLocalhost() string {
-	return "localhost:" + getPortForwardingPort()
+	if ports, err := p.GetPorts(); err == nil && len(ports) > 0 {
+		return fmt.Sprintf("localhost:%d", ports[0].Local)
+	}
+	return "localhost:" + p.localPort
 }
 
 func (p *portForward) StopPortForwarder() {

--- a/core/cautils/portforwarder_boundport_test.go
+++ b/core/cautils/portforwarder_boundport_test.go
@@ -1,0 +1,154 @@
+package cautils
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/tools/portforward"
+)
+
+// The fakes below mirror the minimal httpstream surface that
+// portforward.PortForwarder.ForwardPorts() needs in order to open its local
+// listeners without talking to an API server. They are modelled on the
+// equivalent helpers in client-go's own portforward tests.
+
+type fakeStream struct {
+	headers http.Header
+}
+
+func (*fakeStream) Read(p []byte) (int, error)  { return 0, nil }
+func (*fakeStream) Write(p []byte) (int, error) { return len(p), nil }
+func (*fakeStream) Close() error                { return nil }
+func (*fakeStream) Reset() error                { return nil }
+func (s *fakeStream) Headers() http.Header      { return s.headers }
+func (*fakeStream) Identifier() uint32          { return 0 }
+
+type fakeConnection struct {
+	closed    bool
+	closeChan chan bool
+}
+
+func newFakeConnection() *fakeConnection {
+	return &fakeConnection{closeChan: make(chan bool)}
+}
+
+func (c *fakeConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	switch headers.Get(v1.StreamType) {
+	case v1.StreamTypeData, v1.StreamTypeError:
+		return &fakeStream{headers: headers}, nil
+	default:
+		return nil, fmt.Errorf("unsupported stream type %q", headers.Get(v1.StreamType))
+	}
+}
+
+func (c *fakeConnection) Close() error {
+	if !c.closed {
+		c.closed = true
+		close(c.closeChan)
+	}
+	return nil
+}
+
+func (c *fakeConnection) CloseChan() <-chan bool             { return c.closeChan }
+func (c *fakeConnection) RemoveStreams(...httpstream.Stream) {}
+func (c *fakeConnection) SetIdleTimeout(time.Duration)       {}
+
+type fakeDialer struct {
+	conn httpstream.Connection
+}
+
+func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	return d.conn, portforward.PortForwardProtocolV1Name, nil
+}
+
+// newStartedPortForward builds a portForward around a real
+// portforward.PortForwarder driven by a fake connection, starts forwarding and
+// waits until the local listeners are actually bound.
+func newStartedPortForward(t *testing.T, remotePort string) *portForward {
+	t.Helper()
+
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{})
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+
+	forwarder, err := portforward.NewOnAddresses(
+		&fakeDialer{conn: newFakeConnection()},
+		[]string{"localhost"},
+		[]string{fmt.Sprintf("%s:%s", getPortForwardingPort(), remotePort)},
+		stopChan, readyChan, out, errOut,
+	)
+	require.NoError(t, err)
+
+	p := &portForward{
+		PortForwarder: forwarder,
+		localPort:     getPortForwardingPort(),
+		stopChan:      stopChan,
+		readyChan:     readyChan,
+		errChan:       make(chan error, 1),
+		out:           out,
+		errOut:        errOut,
+	}
+
+	go func() { p.errChan <- p.ForwardPorts() }()
+	t.Cleanup(p.StopPortForwarder)
+
+	select {
+	case <-p.Ready:
+	case err := <-p.errChan:
+		t.Fatalf("port-forward exited before becoming ready: %v (%s)", err, errOut.String())
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for port-forward readiness")
+	}
+
+	return p
+}
+
+// With DEFAULT_PORT_FORWARDER_PORT=0 the kernel picks the port, so the reported
+// address has to be the bound one. Returning the requested "0" means the
+// operator scan POSTs to localhost:0 and fails.
+func Test_GetPortForwardLocalhost_ReportsBoundPortForEphemeralRequest(t *testing.T) {
+	t.Setenv(DefaultPortForwardPortEnv, "0")
+
+	p := newStartedPortForward(t, "5000")
+
+	ports, err := p.GetPorts()
+	require.NoError(t, err)
+	require.Len(t, ports, 1)
+	require.NotZero(t, ports[0].Local, "client-go should have bound a real ephemeral port")
+
+	got := p.GetPortForwardLocalhost()
+
+	assert.NotEqual(t, "localhost:0", got, "must not report the requested port 0 as the address")
+	assert.Equal(t, fmt.Sprintf("localhost:%d", ports[0].Local), got)
+
+	// The reported address must be dialable.
+	_, portStr, found := strings.Cut(got, ":")
+	require.True(t, found)
+	parsed, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	assert.NotZero(t, parsed)
+}
+
+// The address is fixed once the listeners are bound; mutating the environment
+// afterwards must not change what callers are told to dial.
+func Test_GetPortForwardLocalhost_IgnoresEnvMutationAfterBinding(t *testing.T) {
+	t.Setenv(DefaultPortForwardPortEnv, "0")
+	p := newStartedPortForward(t, "5000")
+
+	ports, err := p.GetPorts()
+	require.NoError(t, err)
+	require.Len(t, ports, 1)
+
+	// Mutating the env after construction must not change the reported address.
+	t.Setenv(DefaultPortForwardPortEnv, "9999")
+
+	assert.Equal(t, fmt.Sprintf("localhost:%d", ports[0].Local), p.GetPortForwardLocalhost())
+}


### PR DESCRIPTION
## Overview

Setting `DEFAULT_PORT_FORWARDER_PORT=0` asks the kernel for a free local port,
which is the usual way to avoid a collision on 4444. That doesn't currently
work for the operator scan.

`GetPortForwardLocalhost()` returns the port that was *requested*, not the one
that got bound, so with `0` it hands back `localhost:0` and
`httpPostOperatorScanRequest` POSTs to `http://localhost:0/v1/triggerAction`.
The scan fails. This isn't a regression, it's been this way for a while.

The reason it returns the wrong value is that it re-reads the env var instead
of asking the forwarder:

```go
func (p *portForward) GetPortForwardLocalhost() string {
	return "localhost:" + getPortForwardingPort()
}
```

`NewOnAddresses` parses `"0:5000"` into a `ForwardedPort` with `Local: 0`. The
real port only gets written back in client-go's `getListener()` while
`ForwardPorts()` is running, so `GetPorts()` is the only thing that knows it.

This PR uses `GetPorts()` when the listeners are up and falls back to the
requested port before that (`GetPorts()` returns "listeners not ready" until
`Ready` is closed, so the pre-start path still works).

Also resolves `getPortForwardingPort()` once in `CreatePortForwarder` rather
than twice. It was already called for both the `NewOnAddresses` port spec and
the struct field, and now that the fallback depends on those two agreeing it
seemed worth tidying.

For a fixed port the bound port and the requested port are the same, so the
returned string is identical to before. The default 4444 case is unchanged.
Only `0` behaves differently, and there the old value was never dialable
anyway.

## How to Test

```bash
go test ./core/cautils/ -run Test_GetPortForwardLocalhost -count=1
```

Both new tests fail on master:

```
--- FAIL: Test_GetPortForwardLocalhost_ReportsBoundPortForEphemeralRequest
    Error:    Not equal:
              expected: "localhost:49427"
              actual  : "localhost:0"
```

They drive a real `PortForwarder` over a fake httpstream connection, so no
cluster or API server is needed. The second one mutates the env var after the
listeners are bound to check the address doesn't move.

I checked the existing `Test_GetPortForwardLocalhost` couldn't have caught
this. It asserts against `getPortForwardingPort()`, which is the same
expression the implementation used, so it agreed with the bug.

Also ran:

```bash
go test ./core/cautils/... -count=1
go test ./core/core/... -count=1
go vet ./core/cautils/...
go build ./...
```

`TestOperatorAdapter_httpPostOperatorScanRequest` still passes.

One thing to flag: `TestGetConfigMapNamespace/no_env` fails under `-count>1`
on unmodified master too, it picks up an env var some other test leaves set.
Unrelated to this change, but it's why I scoped the race run:

```bash
go test -race ./core/cautils/ -count=5 -run 'Test_GetPortForwardLocalhost|Test_CreatePortForwarder|TestStopPortForwarder|Test_getPortForwardingPort|Test_splitHostAndBasePath'
```

Happy to open a separate issue for that one if it's useful.

## Related issues/PRs

The `GetPorts()` approach is the one @matthyx sketched while reviewing #2694.
Credit there and to @CygnusMaximillian for the original report. #2694 was
closed and the port reporting was never picked up, so this is just that piece.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Port forwarding now reports the actual local port assigned by the system when an ephemeral port is requested.
  * Reported port-forward addresses remain consistent even if environment settings change after the connection is established.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->