### PR TITLE
fix(core): shut down the exception event broadcaster after each scan

### DIFF
--- a/core/core/exceptionevents.go
+++ b/core/core/exceptionevents.go
@@ -9,25 +9,25 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-func newSecurityExceptionEventRecorder() record.EventRecorder {
+func newSecurityExceptionEventRecorder() (record.EventRecorder, func()) {
 	if !k8sinterface.IsConnectedToCluster() {
-		return nil
+		return nil, nil
 	}
 
 	k8s := getKubernetesApi()
 	if k8s == nil || k8s.KubernetesClient == nil {
-		return nil
+		return nil, nil
 	}
 
 	return newSecurityExceptionEventRecorderWithClient(k8s.KubernetesClient)
 }
 
-func newSecurityExceptionEventRecorderWithClient(k8sClient kubernetes.Interface) record.EventRecorder {
+func newSecurityExceptionEventRecorderWithClient(k8sClient kubernetes.Interface) (record.EventRecorder, func()) {
 	if k8sClient == nil {
-		return nil
+		return nil, nil
 	}
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
-	return broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kubescape"})
+	return broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kubescape"}), broadcaster.Shutdown
 }

--- a/core/core/exceptionevents_test.go
+++ b/core/core/exceptionevents_test.go
@@ -34,7 +34,7 @@ func pollGoroutineCount(timeout time.Duration, cond func() bool) bool {
 func TestSecurityExceptionEventRecorderShutdownStopsWatcher(t *testing.T) {
 	baseline := runtime.NumGoroutine()
 
-	recorder, shutdown := newSecurityExceptionEventRecorderWithClient(fake.NewSimpleClientset())
+	recorder, shutdown := newSecurityExceptionEventRecorderWithClient(fake.NewClientset())
 	require.NotNil(t, recorder, "a recorder must be returned for a valid client")
 	require.NotNil(t, shutdown, "a shutdown closure must be returned for a valid client")
 

--- a/core/core/exceptionevents_test.go
+++ b/core/core/exceptionevents_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// pollGoroutineCount waits until cond returns true, giving the scheduler and
+// background goroutines time to settle. A plain poll loop is used instead of
+// require.Eventually because the latter's internal timer goroutines perturb the
+// goroutine count this test asserts on.
+func pollGoroutineCount(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestSecurityExceptionEventRecorderShutdownStopsWatcher verifies that the
+// event broadcaster created by newSecurityExceptionEventRecorderWithClient is
+// shut down when the caller invokes the returned shutdown closure. Before the
+// shutdown closure existed, the broadcaster's StartEventWatcher goroutine was
+// leaked on every scan against a live cluster, growing unbounded in
+// long-running modes like httphandler.
+func TestSecurityExceptionEventRecorderShutdownStopsWatcher(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	recorder, shutdown := newSecurityExceptionEventRecorderWithClient(fake.NewSimpleClientset())
+	require.NotNil(t, recorder, "a recorder must be returned for a valid client")
+	require.NotNil(t, shutdown, "a shutdown closure must be returned for a valid client")
+
+	recorder.Eventf(&corev1.ObjectReference{}, corev1.EventTypeWarning, "TestReason", "a test event")
+
+	// The broadcaster runs a distribution loop and a StartEventWatcher
+	// goroutine, so the count must rise above the baseline.
+	require.True(t, pollGoroutineCount(2*time.Second, func() bool {
+		return runtime.NumGoroutine() > baseline
+	}), "the event watcher goroutine must be running")
+
+	shutdown()
+
+	// Both goroutines must terminate after Shutdown, restoring the baseline.
+	require.True(t, pollGoroutineCount(2*time.Second, func() bool {
+		return runtime.NumGoroutine() <= baseline
+	}), "the event watcher goroutine must stop after shutdown")
+}
+
+func TestSecurityExceptionEventRecorderWithNilClient(t *testing.T) {
+	recorder, shutdown := newSecurityExceptionEventRecorderWithClient(nil)
+	require.Nil(t, recorder)
+	require.Nil(t, shutdown)
+}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -308,7 +308,10 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 		}
 
 		deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
-		var exceptionRecorder = newSecurityExceptionEventRecorder()
+		var exceptionRecorder, shutdownRecorder = newSecurityExceptionEventRecorder()
+		if shutdownRecorder != nil {
+			defer shutdownRecorder()
+		}
 		reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, exceptionRecorder)
 		reportResults.ControlTimeout = scanInfo.ControlTimeout
 		if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
@@ -513,7 +516,10 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	// producer does later — the invariant is enforced by ordering rather than by
 	// a comment in the resource handler.
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), clusterName)
-	var exceptionRecorder = newSecurityExceptionEventRecorder()
+	var exceptionRecorder, shutdownRecorder = newSecurityExceptionEventRecorder()
+	if shutdownRecorder != nil {
+		defer shutdownRecorder()
+	}
 	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, clusterName, excludedNamespaces, includeNamespaces, enableRegoPrint, exceptionRecorder)
 	reportResults.ControlTimeout = controlTimeout
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -308,7 +308,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 		}
 
 		deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
-		var exceptionRecorder, shutdownRecorder = newSecurityExceptionEventRecorder()
+		exceptionRecorder, shutdownRecorder := newSecurityExceptionEventRecorder()
 		if shutdownRecorder != nil {
 			defer shutdownRecorder()
 		}
@@ -516,7 +516,7 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	// producer does later — the invariant is enforced by ordering rather than by
 	// a comment in the resource handler.
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), clusterName)
-	var exceptionRecorder, shutdownRecorder = newSecurityExceptionEventRecorder()
+	exceptionRecorder, shutdownRecorder := newSecurityExceptionEventRecorder()
 	if shutdownRecorder != nil {
 		defer shutdownRecorder()
 	}


### PR DESCRIPTION
## Overview
`newSecurityExceptionEventRecorderWithClient` initialized a Kubernetes event broadcaster via `record.NewBroadcaster()` + `StartRecordingToSink()`, which spawns a background `StartEventWatcher` goroutine, and then discarded the broadcaster pointer. Since `broadcaster.Shutdown()` was never called anywhere, every scan against a live cluster leaked one goroutine and one open API-server watch connection — unbounded in long-running modes like `httphandler`.

Now `newSecurityExceptionEventRecorder` and `newSecurityExceptionEventRecorderWithClient` return a shutdown closure alongside the recorder, and `Scan` / `collectAndProcessResourcesWithStreaming` `defer` it so the watcher goroutine and its connection are torn down when the scan completes.

## Additional Information
The shutdown closure is nil when no cluster is connected or the client is nil, and the callers only invoke it when non-nil, so the CLI one-shot and disconnected paths are unchanged.

## How to Test
```go
recorder, shutdown := newSecurityExceptionEventRecorderWithClient(fake.NewSimpleClientset())
// goroutine count rises above baseline
shutdown()
// goroutine count returns to baseline
```

`go test ./core/core/ -run TestSecurityExceptionEventRecorder -race` passes, including the new goroutine-leak regression test.

## Related issues/PRs
* Resolved #2751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of security exception event recording during standard and streaming scans.
  - Prevented recorder initialization when the required client or cluster is unavailable.
  - Ensured background event watchers shut down after scan processing completes, reducing resource usage.

- **Tests**
  - Added coverage for recorder lifecycle cleanup.
  - Added validation for behavior when the required client is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->