### PR TITLE
core: shutdown security exception event broadcaster after scan

### DIFF
--- a/core/core/exceptionevents.go
+++ b/core/core/exceptionevents.go
@@ -9,25 +9,27 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-func newSecurityExceptionEventRecorder() record.EventRecorder {
+func newSecurityExceptionEventRecorder() (record.EventRecorder, func()) {
 	if !k8sinterface.IsConnectedToCluster() {
-		return nil
+		return nil, nil
 	}
 
 	k8s := getKubernetesApi()
 	if k8s == nil || k8s.KubernetesClient == nil {
-		return nil
+		return nil, nil
 	}
 
 	return newSecurityExceptionEventRecorderWithClient(k8s.KubernetesClient)
 }
 
-func newSecurityExceptionEventRecorderWithClient(k8sClient kubernetes.Interface) record.EventRecorder {
+func newSecurityExceptionEventRecorderWithClient(k8sClient kubernetes.Interface) (record.EventRecorder, func()) {
 	if k8sClient == nil {
-		return nil
+		return nil, nil
 	}
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
-	return broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kubescape"})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kubescape"})
+
+	return recorder, broadcaster.Shutdown
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -308,7 +308,10 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 		}
 
 		deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), interfaces.tenantConfig.GetContextName())
-		var exceptionRecorder = newSecurityExceptionEventRecorder()
+		exceptionRecorder, shutdown := newSecurityExceptionEventRecorder()
+		if shutdown != nil {
+			defer shutdown()
+		}
 		reportResults := opaprocessor.NewOPAProcessor(scanData, deps, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, exceptionRecorder)
 		reportResults.ControlTimeout = scanInfo.ControlTimeout
 		if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
@@ -513,7 +516,10 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	// producer does later — the invariant is enforced by ordering rather than by
 	// a comment in the resource handler.
 	deps := resources.NewRegoDependenciesData(k8sinterface.GetK8sConfig(), clusterName)
-	var exceptionRecorder = newSecurityExceptionEventRecorder()
+	exceptionRecorder, shutdown := newSecurityExceptionEventRecorder()
+	if shutdown != nil {
+		defer shutdown()
+	}
 	reportResults := opaprocessor.NewOPAProcessor(scanData, deps, clusterName, excludedNamespaces, includeNamespaces, enableRegoPrint, exceptionRecorder)
 	reportResults.ControlTimeout = controlTimeout
 


### PR DESCRIPTION
Fixes : #2751

## Summary

This PR fixes a resource lifecycle issue where the security exception event broadcaster was never shut down after a scan completed.

## Changes

- Return a cleanup function alongside the `EventRecorder` from `newSecurityExceptionEventRecorderWithClient`.
- Defer `broadcaster.Shutdown()` in both the regular and streaming scan paths.
- Preserve the existing behavior while ensuring the broadcaster is properly cleaned up after each scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of security event recording after scan and policy-processing operations.
  * Prevented unnecessary shutdown attempts when event recording is unavailable.
  * Enhanced reliability for both standard and streaming processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->