### PR TITLE
fix(cautils): synchronize access to global KSCloudAPIConnector

### DIFF
--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"sync"
 
 	v1 "github.com/kubescape/backend/pkg/client/v1"
 	utils "github.com/kubescape/backend/pkg/utils"
@@ -14,7 +15,8 @@ import (
 var (
 	// globalKSCloudAPIConnector is a static global instance of the KS Cloud client,
 	// to be initialized with SetKSCloudAPIConnector.
-	globalKSCloudAPIConnector *v1.KSCloudAPI
+	globalKSCloudAPIConnector   *v1.KSCloudAPI
+	globalKSCloudAPIConnectorMu sync.Mutex
 
 	_ IPolicyGetter         = &v1.KSCloudAPI{}
 	_ IExceptionsGetter     = &v1.KSCloudAPI{}
@@ -24,7 +26,7 @@ var (
 
 // SetKSCloudAPIConnector registers a global instance of the KS Cloud client.
 //
-// NOTE: cannot be used concurrently.
+// Safe for concurrent use.
 func SetKSCloudAPIConnector(ksCloudAPI *v1.KSCloudAPI) {
 	if ksCloudAPI != nil && ksCloudAPI.GetCloudAPIURL() != "" {
 		logger.L().Debug("setting global KS Cloud API connector",
@@ -32,15 +34,20 @@ func SetKSCloudAPIConnector(ksCloudAPI *v1.KSCloudAPI) {
 			helpers.String("cloudAPIURL", ksCloudAPI.GetCloudAPIURL()),
 			helpers.String("cloudReportURL", ksCloudAPI.GetCloudReportURL()))
 	}
+	globalKSCloudAPIConnectorMu.Lock()
+	defer globalKSCloudAPIConnectorMu.Unlock()
 	globalKSCloudAPIConnector = ksCloudAPI
 }
 
 // GetKSCloudAPIConnector returns a shallow clone of the KS Cloud client registered for this package.
 //
-// NOTE: cannot be used concurrently with SetKSCloudAPIConnector.
+// Safe for concurrent use, including concurrent use with SetKSCloudAPIConnector.
 func GetKSCloudAPIConnector() *v1.KSCloudAPI {
+	globalKSCloudAPIConnectorMu.Lock()
+	defer globalKSCloudAPIConnectorMu.Unlock()
+
 	if globalKSCloudAPIConnector == nil {
-		SetKSCloudAPIConnector(v1.NewEmptyKSCloudAPI())
+		globalKSCloudAPIConnector = v1.NewEmptyKSCloudAPI()
 	}
 
 	// we return a shallow clone that may be freely modified by the caller.

--- a/core/cautils/getter/kscloudapi_test.go
+++ b/core/cautils/getter/kscloudapi_test.go
@@ -49,6 +49,34 @@ func TestGlobalKSCloudAPIConnector(t *testing.T) {
 	})
 }
 
+func TestGlobalKSCloudAPIConnector_Race(t *testing.T) {
+	globalMx.Lock()
+	defer globalMx.Unlock()
+
+	globalKSCloudAPIConnector = nil
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// concurrent writer
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			SetKSCloudAPIConnector(v1.NewEmptyKSCloudAPI())
+		}
+	}()
+
+	// concurrent reader
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = GetKSCloudAPIConnector()
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestHttpPost(t *testing.T) {
 	client := http.DefaultClient
 	hdrs := map[string]string{"key": "value"}

--- a/core/cautils/getter/kscloudapi_test.go
+++ b/core/cautils/getter/kscloudapi_test.go
@@ -53,7 +53,15 @@ func TestGlobalKSCloudAPIConnector_Race(t *testing.T) {
 	globalMx.Lock()
 	defer globalMx.Unlock()
 
+	globalKSCloudAPIConnectorMu.Lock()
+	previous := globalKSCloudAPIConnector
 	globalKSCloudAPIConnector = nil
+	globalKSCloudAPIConnectorMu.Unlock()
+	t.Cleanup(func() {
+		globalKSCloudAPIConnectorMu.Lock()
+		globalKSCloudAPIConnector = previous
+		globalKSCloudAPIConnectorMu.Unlock()
+	})
 
 	var wg sync.WaitGroup
 	wg.Add(2)


### PR DESCRIPTION
## Overview

`globalKSCloudAPIConnector` in `core/cautils/getter/kscloudapi.go` was a package-level variable read and written with no synchronization. `SetKSCloudAPIConnector()` and `GetKSCloudAPIConnector()` were documented as "cannot be used concurrently," but production call paths (tenant config initialization/refresh vs. policy/config/attack-track downloads during a scan) can reach them from different goroutines, e.g. when Kubescape runs as a long-lived service. This is a genuine data race under the Go race detector: concurrent `Set`/`Get` calls, and unsynchronized lazy-initialization inside `Get`, race on the shared pointer.

This PR adds a `sync.Mutex` guarding all reads and writes of `globalKSCloudAPIConnector`, including the lazy-init path, and updates both functions' doc comments to state they are now safe for concurrent use. The shallow-clone behavior returned by `GetKSCloudAPIConnector` is unchanged; the clone is copied while the lock is held so callers still get an independent, freely-mutable copy.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

```
go test -race ./core/cautils/getter/...
```

A new test, `TestGlobalKSCloudAPIConnector_Race` (mirroring the reproduction from the issue), was added to `core/cautils/getter/kscloudapi_test.go`. Verified it fails with the reported data race against the pre-fix code, and passes with the fix applied. Also ran `go build ./...` and `go vet ./core/cautils/getter/...` clean.

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

Report: https://github.com/kubescape/kubescape/issues/2760

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Fixes #2760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when the global cloud API connection is accessed concurrently.
  - Prevented potential data races during connection updates and retrievals.

- **Tests**
  - Added coverage for simultaneous connection reads and writes to help ensure stable concurrent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->