### PR TITLE
fix(cautils): propagate marshal error in updateConfigFile

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -353,6 +354,23 @@ func existsConfigFile() bool {
 // permission tricks, which don't reliably fail for the owning user.
 var chmod = os.Chmod
 
+// configMarshal is a package-level indirection so tests can simulate a
+// marshal failure without needing a struct whose MarshalJSON returns an error.
+// It mirrors the chmod seam used for directory-permission testing.
+var configMarshal = func(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ") //nolint:gosec,nolintlint // G117: AccessKey is intentionally persisted to the local config file
+}
+
+// marshalConfigObj serializes co for persistence, stripping ClusterName
+// (runtime-only, must not be saved) before marshaling and restoring it after.
+func marshalConfigObj(co *ConfigObj) ([]byte, error) {
+	clusterName := co.ClusterName
+	co.ClusterName = ""
+	b, err := configMarshal(co)
+	co.ClusterName = clusterName
+	return b, err
+}
+
 func updateConfigFile(configObj *ConfigObj) error {
 	fullPath := ConfigFileFullPath()
 	dir := filepath.Dir(fullPath)
@@ -391,7 +409,12 @@ func updateConfigFile(configObj *ConfigObj) error {
 		}
 	}()
 
-	if _, err := tmpFile.Write(configObj.Config()); err != nil {
+	data, err := marshalConfigObj(configObj)
+	if err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if _, err := tmpFile.Write(data); err != nil {
 		tmpFile.Close()
 		return err
 	}

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -439,6 +440,41 @@ func TestUpdateConfigFile_RoundTrip(t *testing.T) {
 	readBack := &ConfigObj{}
 	require.NoError(t, json.Unmarshal(dat, readBack))
 	assert.Equal(t, configObj.AccountID, readBack.AccountID)
+}
+
+func TestUpdateConfigFile_ClusterNameStripped(t *testing.T) {
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	defer func() { getter.DefaultLocalStore = originalStore }()
+
+	configObj := mockConfigObj()
+	require.NoError(t, updateConfigFile(configObj))
+
+	dat, err := os.ReadFile(ConfigFileFullPath())
+	require.NoError(t, err)
+	require.NotEmpty(t, dat, "config file must not be empty after write")
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(dat, &raw))
+	_, present := raw["clusterName"]
+	assert.False(t, present, "clusterName key must be absent from the persisted JSON, not merely empty")
+	assert.Contains(t, raw, "accountID", "accountID must be present in the persisted JSON")
+	assert.Equal(t, "ddd", configObj.ClusterName, "ClusterName must be restored on the in-memory object after write")
+}
+
+func TestUpdateConfigFile_PropagatesMarshalError(t *testing.T) {
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	defer func() { getter.DefaultLocalStore = originalStore }()
+
+	origMarshal := configMarshal
+	sentinel := errors.New("injected marshal failure")
+	configMarshal = func(any) ([]byte, error) { return nil, sentinel }
+	defer func() { configMarshal = origMarshal }()
+
+	err := updateConfigFile(mockConfigObj())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
 }
 
 // TestNewLocalConfig_LogsOnMalformedCachedConfigFile guards against a

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -433,7 +433,7 @@ func TestGetFileFormat(t *testing.T) {
 func TestIsFileAndIsDir(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "test_file.txt")
-	err := os.WriteFile(tempFile, []byte("test"), 0644)
+	err := os.WriteFile(tempFile, []byte("test"), 0o600)
 	require.NoError(t, err)
 
 	assert.True(t, isDir(tempDir))


### PR DESCRIPTION
## Summary

`updateConfigFile` called `configObj.Config()` to obtain the bytes to write.
`Config()` returns `[]byte{}` on `json.MarshalIndent` failure instead of
propagating the error. Writing zero bytes to the temp file succeeds without
an OS error, so the function atomically renamed an empty temp file over the
real config at `~/.kubescape/config.json`, silently wiping the user's saved
`AccountID`, `AccessKey`, and cloud API URLs.

Fix `updateConfigFile` to marshal `configObj` directly with an explicit
error check, applying the same `ClusterName`-stripping that `Config()`
performs. `Config()` is unchanged; its display callers tolerate an empty
result.

Add `TestUpdateConfigFile_ClusterNameStripped` to assert the written file
is non-empty, `ClusterName` is absent on disk, and the in-memory object
is restored after the write.

**Does this PR introduce a user-facing change?**
Yes, a marshal failure now returns an error instead of silently destroying
the user's saved credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now omit the cluster name when saved while preserving it in the active configuration.
  * Improved handling of configuration serialization errors to prevent incomplete temporary files.

* **Tests**
  * Added coverage to verify persisted configuration contents and in-memory cluster name retention.
  * Updated temporary test files to use more secure permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->