### PR TITLE
Refactor: remove Getters and PolicyIdentifier from ScanInfo

### DIFF
--- a/cmd/mcpserver/network_scan_bench_test.go
+++ b/cmd/mcpserver/network_scan_bench_test.go
@@ -26,17 +26,19 @@ func BenchmarkNetworkScan_Isolation(b *testing.B) {
 	policyHandler := policyhandler.NewRequestScopedPolicyHandler("")
 	defer policyHandler.Close()
 
+	getters := cautils.Getters{
+		PolicyGetter:         getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/policy.json"}),
+		ExceptionsGetter:     getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/exceptions.json"}),
+		ControlsInputsGetter: getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/controls-inputs.json"}),
+		AttackTracksGetter:   getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/attack-tracks.json"}),
+	}
+
+	policyIdentifiers := []cautils.PolicyIdentifier{
+		{Kind: apisv1.KindControl, Identifier: "C-0030"},
+	}
+
 	scanInfo := &cautils.ScanInfo{
-		Getters: cautils.Getters{
-			PolicyGetter:         getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/policy.json"}),
-			ExceptionsGetter:     getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/exceptions.json"}),
-			ControlsInputsGetter: getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/controls-inputs.json"}),
-			AttackTracksGetter:   getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/attack-tracks.json"}),
-		},
-		ScanAll: false,
-		PolicyIdentifier: []cautils.PolicyIdentifier{
-			{Kind: apisv1.KindControl, Identifier: "C-0030"},
-		},
+		ScanAll:     false,
 		ScanTimeout: 10 * time.Second,
 	}
 
@@ -96,7 +98,7 @@ func BenchmarkNetworkScan_Isolation(b *testing.B) {
 
 		// Collect a fresh OPASessionObj per iteration so mutations from the previous
 		// run don't bleed into the next one.
-		scanData, err := policyHandler.CollectPolicies(ctx, scanInfo.PolicyIdentifier, scanInfo)
+		scanData, err := policyHandler.CollectPolicies(ctx, policyIdentifiers, scanInfo, &getters)
 		if err != nil {
 			b.Fatalf("failed to collect policies: %v", err)
 		}

--- a/cmd/mcpserver/rbac_scan_bench_test.go
+++ b/cmd/mcpserver/rbac_scan_bench_test.go
@@ -26,18 +26,20 @@ func BenchmarkRBACScan_Isolation(b *testing.B) {
 	policyHandler := policyhandler.NewRequestScopedPolicyHandler("")
 	defer policyHandler.Close()
 
+	getters := cautils.Getters{
+		PolicyGetter:         getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/policy.json"}),
+		ExceptionsGetter:     getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/exceptions.json"}),
+		ControlsInputsGetter: getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/controls-inputs.json"}),
+		AttackTracksGetter:   getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/attack-tracks.json"}),
+	}
+
+	policyIdentifiers := []cautils.PolicyIdentifier{
+		{Kind: apisv1.KindControl, Identifier: "C-0015"},
+		{Kind: apisv1.KindControl, Identifier: "C-0016"},
+	}
+
 	scanInfo := &cautils.ScanInfo{
-		Getters: cautils.Getters{
-			PolicyGetter:         getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/policy.json"}),
-			ExceptionsGetter:     getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/exceptions.json"}),
-			ControlsInputsGetter: getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/controls-inputs.json"}),
-			AttackTracksGetter:   getter.NewLoadPolicy([]string{"../../core/cautils/getter/testdata/attack-tracks.json"}),
-		},
-		ScanAll: false,
-		PolicyIdentifier: []cautils.PolicyIdentifier{
-			{Kind: apisv1.KindControl, Identifier: "C-0015"},
-			{Kind: apisv1.KindControl, Identifier: "C-0016"},
-		},
+		ScanAll:     false,
 		ScanTimeout: 10 * time.Second,
 	}
 
@@ -69,7 +71,7 @@ func BenchmarkRBACScan_Isolation(b *testing.B) {
 
 		// Collect a fresh OPASessionObj per iteration so mutations from the previous
 		// run don't bleed into the next one.
-		scanData, err := policyHandler.CollectPolicies(ctx, scanInfo.PolicyIdentifier, scanInfo)
+		scanData, err := policyHandler.CollectPolicies(ctx, policyIdentifiers, scanInfo, &getters)
 		if err != nil {
 			b.Fatalf("failed to collect policies: %v", err)
 		}

--- a/cmd/mcpserver/scan_helper.go
+++ b/cmd/mcpserver/scan_helper.go
@@ -75,9 +75,7 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 	}
 
 	scanInfo := &cautils.ScanInfo{
-		Getters:           getters,
 		ScanAll:           false,
-		PolicyIdentifier:  policyIdentifiers,
 		IncludeNamespaces: namespace,
 		ScanTimeout:       timeout,
 		InputPatterns:     inputPatterns,
@@ -88,7 +86,7 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 
 	policyHandler := policyhandler.NewRequestScopedPolicyHandler("")
 	defer policyHandler.Close()
-	scanData, err := policyHandler.CollectPolicies(scanCtx, scanInfo.PolicyIdentifier, scanInfo)
+	scanData, err := policyHandler.CollectPolicies(scanCtx, policyIdentifiers, scanInfo, &getters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect %s policies: %w", label, err)
 	}

--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -72,14 +72,14 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			}
 
 			// flagValidationControl(scanInfo)
-			scanInfo.PolicyIdentifier = []cautils.PolicyIdentifier{}
+			var policyIdentifiers []cautils.PolicyIdentifier
 
 			if len(args) == 0 {
 				scanInfo.ScanAll = true
 			} else { // expected control or list of control separated by ","
 
 				// Read controls from input args
-				scanInfo.SetPolicyIdentifiers(strings.Split(args[0], ","), apisv1.KindControl)
+				policyIdentifiers = cautils.BuildPolicyIdentifiers(strings.Split(args[0], ","), apisv1.KindControl)
 
 				if len(args) > 1 {
 					if len(args[1:]) == 0 || args[1] != "-" {
@@ -106,7 +106,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
-			results, err := ks.Scan(scanInfo)
+			results, err := ks.Scan(scanInfo, policyIdentifiers)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -121,9 +121,9 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			}
 			scanInfo.SetScanType(cautils.ScanTypeFramework)
 
-			scanInfo.SetPolicyIdentifiers(frameworks, apisv1.KindFramework)
+			policyIdentifiers := cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
-			results, err := ks.Scan(scanInfo)
+			results, err := ks.Scan(scanInfo, policyIdentifiers)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -126,9 +126,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 			scanInfo.View = requestedView
 
 			if scanInfo.View == string(cautils.SecurityViewType) {
-				setSecurityViewScanInfo(args, &scanInfo)
+				policyIdentifiers := setSecurityViewScanInfo(args, &scanInfo)
 
-				if err := securityScan(scanInfo, ks); err != nil {
+				if err := securityScan(scanInfo, ks, policyIdentifiers); err != nil {
 					logger.L().Fatal(err.Error())
 				}
 			} else if len(args) == 0 ||
@@ -280,15 +280,14 @@ func registryCredentialFlagChanged(cmd *cobra.Command, names ...string) bool {
 	return false
 }
 
-func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) {
+func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) []cautils.PolicyIdentifier {
 	if len(args) > 0 {
 		scanInfo.SetScanType(cautils.ScanTypeRepo)
 		scanInfo.InputPatterns = args
-		scanInfo.SetPolicyIdentifiers([]string{"workloadscan", "allcontrols"}, v1.KindFramework)
-	} else {
-		scanInfo.SetScanType(cautils.ScanTypeCluster)
-		scanInfo.SetPolicyIdentifiers([]string{"clusterscan", "mitre", "nsa"}, v1.KindFramework)
+		return cautils.BuildPolicyIdentifiers([]string{"workloadscan", "allcontrols"}, v1.KindFramework)
 	}
+	scanInfo.SetScanType(cautils.ScanTypeCluster)
+	return cautils.BuildPolicyIdentifiers([]string{"clusterscan", "mitre", "nsa"}, v1.KindFramework)
 }
 
 // applyTimeout wraps ks with a deadline context when ScanTimeout > 0 and
@@ -310,10 +309,10 @@ func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
 	}
 }
 
-func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape) error {
+func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
 	defer applyTimeout(&scanInfo, ks)()
 
-	results, err := ks.Scan(&scanInfo)
+	results, err := ks.Scan(&scanInfo, policyIdentifiers)
 	if err != nil {
 		return err
 	}

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -271,9 +271,10 @@ func Test_terminateOnExceedingSeverity(t *testing.T) {
 
 func TestSetSecurityViewScanInfo(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want *cautils.ScanInfo
+		name         string
+		args         []string
+		want         *cautils.ScanInfo
+		wantPolicies []cautils.PolicyIdentifier
 	}{
 		{
 			name: "no args",
@@ -281,19 +282,19 @@ func TestSetSecurityViewScanInfo(t *testing.T) {
 			want: &cautils.ScanInfo{
 				InputPatterns: []string{},
 				ScanType:      cautils.ScanTypeCluster,
-				PolicyIdentifier: []cautils.PolicyIdentifier{
-					{
-						Kind:       v1.KindFramework,
-						Identifier: "clusterscan",
-					},
-					{
-						Kind:       v1.KindFramework,
-						Identifier: "mitre",
-					},
-					{
-						Kind:       v1.KindFramework,
-						Identifier: "nsa",
-					},
+			},
+			wantPolicies: []cautils.PolicyIdentifier{
+				{
+					Kind:       v1.KindFramework,
+					Identifier: "clusterscan",
+				},
+				{
+					Kind:       v1.KindFramework,
+					Identifier: "mitre",
+				},
+				{
+					Kind:       v1.KindFramework,
+					Identifier: "nsa",
 				},
 			},
 		},
@@ -309,15 +310,15 @@ func TestSetSecurityViewScanInfo(t *testing.T) {
 					"file.yaml",
 					"file2.yaml",
 				},
-				PolicyIdentifier: []cautils.PolicyIdentifier{
-					{
-						Kind:       v1.KindFramework,
-						Identifier: "workloadscan",
-					},
-					{
-						Kind:       v1.KindFramework,
-						Identifier: "allcontrols",
-					},
+			},
+			wantPolicies: []cautils.PolicyIdentifier{
+				{
+					Kind:       v1.KindFramework,
+					Identifier: "workloadscan",
+				},
+				{
+					Kind:       v1.KindFramework,
+					Identifier: "allcontrols",
 				},
 			},
 		},
@@ -328,7 +329,7 @@ func TestSetSecurityViewScanInfo(t *testing.T) {
 			got := &cautils.ScanInfo{
 				View: string(cautils.SecurityViewType),
 			}
-			setSecurityViewScanInfo(tt.args, got)
+			policyIdentifiers := setSecurityViewScanInfo(tt.args, got)
 
 			if len(tt.want.InputPatterns) != len(got.InputPatterns) {
 				t.Errorf("in test: %s, got: %v, want: %v", tt.name, got.InputPatterns, tt.want.InputPatterns)
@@ -351,16 +352,16 @@ func TestSetSecurityViewScanInfo(t *testing.T) {
 				}
 			}
 
-			for i := range tt.want.PolicyIdentifier {
+			for i := range tt.wantPolicies {
 				found := false
-				for j := range got.PolicyIdentifier {
-					if tt.want.PolicyIdentifier[i].Kind == got.PolicyIdentifier[j].Kind && tt.want.PolicyIdentifier[i].Identifier == got.PolicyIdentifier[j].Identifier {
+				for j := range policyIdentifiers {
+					if tt.wantPolicies[i].Kind == policyIdentifiers[j].Kind && tt.wantPolicies[i].Identifier == policyIdentifiers[j].Identifier {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("in test: %s, got: %v, want: %v", tt.name, got.PolicyIdentifier, tt.want.PolicyIdentifier)
+					t.Errorf("in test: %s, got: %v, want: %v", tt.name, policyIdentifiers, tt.wantPolicies)
 				}
 			}
 		})
@@ -572,7 +573,7 @@ type contextTrackingKubescape struct {
 
 func (m *contextTrackingKubescape) Context() context.Context       { return m.ctx }
 func (m *contextTrackingKubescape) SetContext(ctx context.Context) { m.ctx = ctx }
-func (m *contextTrackingKubescape) Scan(_ *cautils.ScanInfo) (*resultshandlingpkg.ResultsHandler, error) {
+func (m *contextTrackingKubescape) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandlingpkg.ResultsHandler, error) {
 	m.scanCalledWith = m.ctx
 	return nil, errors.New("stub: scan not implemented in test")
 }
@@ -581,7 +582,7 @@ func TestSecurityScan_TimeoutDeadlineActiveForScan(t *testing.T) {
 	ks := &contextTrackingKubescape{ctx: context.Background()}
 	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
 
-	_ = securityScan(scanInfo, ks)
+	_ = securityScan(scanInfo, ks, nil)
 
 	_, hasDeadline := ks.scanCalledWith.Deadline()
 	assert.True(t, hasDeadline, "Scan() must receive a context with a deadline when ScanTimeout > 0")
@@ -592,7 +593,7 @@ func TestSecurityScan_TimeoutContextRestoredAfterReturn(t *testing.T) {
 	ks := &contextTrackingKubescape{ctx: originalCtx}
 	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
 
-	_ = securityScan(scanInfo, ks)
+	_ = securityScan(scanInfo, ks, nil)
 
 	_, hasDeadline := ks.Context().Deadline()
 	assert.False(t, hasDeadline, "original context must be restored on ks after securityScan returns")
@@ -602,7 +603,7 @@ func TestSecurityScan_ZeroTimeoutNoDeadline(t *testing.T) {
 	ks := &contextTrackingKubescape{ctx: context.Background()}
 	scanInfo := cautils.ScanInfo{ScanTimeout: 0}
 
-	_ = securityScan(scanInfo, ks)
+	_ = securityScan(scanInfo, ks, nil)
 
 	_, hasDeadline := ks.scanCalledWith.Deadline()
 	assert.False(t, hasDeadline, "Scan() must not receive a deadline when ScanTimeout is 0")

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -84,9 +84,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				scanInfo.Namespace = namespace
 			}
 
-			setWorkloadScanInfo(scanInfo, apiVersion, kind, name)
+			policyIdentifiers := setWorkloadScanInfo(scanInfo, apiVersion, kind, name)
 
-			results, err := ks.Scan(scanInfo)
+			results, err := ks.Scan(scanInfo, policyIdentifiers)
 			if err != nil {
 				logger.L().Fatal(err.Error())
 			}
@@ -109,7 +109,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 	return workloadCmd
 }
 
-func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, apiVersion string, kind string, name string) {
+func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, apiVersion string, kind string, name string) []cautils.PolicyIdentifier {
 	scanInfo.SetScanType(cautils.ScanTypeWorkload)
 	scanInfo.ScanImages = true
 
@@ -121,11 +121,13 @@ func setWorkloadScanInfo(scanInfo *cautils.ScanInfo, apiVersion string, kind str
 	scanInfo.ScanObject.SetKind(kind)
 	scanInfo.ScanObject.SetName(name)
 
-	scanInfo.SetPolicyIdentifiers([]string{"workloadscan", "allcontrols"}, v1.KindFramework)
+	policyIdentifiers := cautils.BuildPolicyIdentifiers([]string{"workloadscan", "allcontrols"}, v1.KindFramework)
 
 	if scanInfo.FilePath != "" {
 		scanInfo.InputPatterns = []string{scanInfo.FilePath}
 	}
+
+	return policyIdentifiers
 }
 
 func validateWorkloadIdentifier(workloadIdentifier string) error {

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -13,29 +13,20 @@ import (
 
 func TestSetWorkloadScanInfo(t *testing.T) {
 	tests := []struct {
-		Description string
-		apiVersion  string
-		kind        string
-		name        string
-		namespace   string
-		filePath    string
-		want        *cautils.ScanInfo
+		Description  string
+		apiVersion   string
+		kind         string
+		name         string
+		namespace    string
+		filePath     string
+		want         *cautils.ScanInfo
+		wantPolicies []cautils.PolicyIdentifier
 	}{
 		{
 			Description: "Set workload scan info",
 			kind:        "Deployment",
 			name:        "test",
 			want: &cautils.ScanInfo{
-				PolicyIdentifier: []cautils.PolicyIdentifier{
-					{
-						Identifier: "workloadscan",
-						Kind:       v1.KindFramework,
-					},
-					{
-						Identifier: "allcontrols",
-						Kind:       v1.KindFramework,
-					},
-				},
 				ScanType:   cautils.ScanTypeWorkload,
 				ScanImages: true,
 				ScanObject: &objectsenvelopes.ScanObject{
@@ -43,6 +34,16 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 					Metadata: objectsenvelopes.ScanObjectMetadata{
 						Name: "test",
 					},
+				},
+			},
+			wantPolicies: []cautils.PolicyIdentifier{
+				{
+					Identifier: "workloadscan",
+					Kind:       v1.KindFramework,
+				},
+				{
+					Identifier: "allcontrols",
+					Kind:       v1.KindFramework,
 				},
 			},
 		},
@@ -53,16 +54,6 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 			namespace:   "default",
 			filePath:    "manifests/pod.yaml",
 			want: &cautils.ScanInfo{
-				PolicyIdentifier: []cautils.PolicyIdentifier{
-					{
-						Identifier: "workloadscan",
-						Kind:       v1.KindFramework,
-					},
-					{
-						Identifier: "allcontrols",
-						Kind:       v1.KindFramework,
-					},
-				},
 				ScanType:   cautils.ScanTypeWorkload,
 				ScanImages: true,
 				ScanObject: &objectsenvelopes.ScanObject{
@@ -74,6 +65,16 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 				},
 				InputPatterns: []string{"manifests/pod.yaml"},
 			},
+			wantPolicies: []cautils.PolicyIdentifier{
+				{
+					Identifier: "workloadscan",
+					Kind:       v1.KindFramework,
+				},
+				{
+					Identifier: "allcontrols",
+					Kind:       v1.KindFramework,
+				},
+			},
 		},
 		{
 			Description: "Set workload scan info with apiVersion",
@@ -83,16 +84,6 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 			namespace:   "default",
 			filePath:    "manifests/deployment.yaml",
 			want: &cautils.ScanInfo{
-				PolicyIdentifier: []cautils.PolicyIdentifier{
-					{
-						Identifier: "workloadscan",
-						Kind:       v1.KindFramework,
-					},
-					{
-						Identifier: "allcontrols",
-						Kind:       v1.KindFramework,
-					},
-				},
 				ScanType:   cautils.ScanTypeWorkload,
 				ScanImages: true,
 				ScanObject: &objectsenvelopes.ScanObject{
@@ -105,6 +96,16 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 				},
 				InputPatterns: []string{"manifests/deployment.yaml"},
 			},
+			wantPolicies: []cautils.PolicyIdentifier{
+				{
+					Identifier: "workloadscan",
+					Kind:       v1.KindFramework,
+				},
+				{
+					Identifier: "allcontrols",
+					Kind:       v1.KindFramework,
+				},
+			},
 		},
 	}
 
@@ -113,7 +114,7 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 			tc.Description,
 			func(t *testing.T) {
 				scanInfo := &cautils.ScanInfo{FilePath: tc.filePath, Namespace: tc.namespace}
-				setWorkloadScanInfo(scanInfo, tc.apiVersion, tc.kind, tc.name)
+				policyIdentifiers := setWorkloadScanInfo(scanInfo, tc.apiVersion, tc.kind, tc.name)
 
 				if scanInfo.ScanType != tc.want.ScanType {
 					t.Errorf("got: %v, want: %v", scanInfo.ScanType, tc.want.ScanType)
@@ -143,17 +144,17 @@ func TestSetWorkloadScanInfo(t *testing.T) {
 					assert.Equal(t, tc.want.InputPatterns, scanInfo.InputPatterns)
 				}
 
-				if len(scanInfo.PolicyIdentifier) != len(tc.want.PolicyIdentifier) {
-					t.Errorf("got: %v policy identifiers, want: %v", len(scanInfo.PolicyIdentifier), len(tc.want.PolicyIdentifier))
+				if len(policyIdentifiers) != len(tc.wantPolicies) {
+					t.Errorf("got: %v policy identifiers, want: %v", len(policyIdentifiers), len(tc.wantPolicies))
 				}
 
-				for i, wantPolicy := range tc.want.PolicyIdentifier {
-					if i < len(scanInfo.PolicyIdentifier) {
-						if scanInfo.PolicyIdentifier[i].Identifier != wantPolicy.Identifier {
-							t.Errorf("got: %v, want: %v", scanInfo.PolicyIdentifier[i].Identifier, wantPolicy.Identifier)
+				for i, wantPolicy := range tc.wantPolicies {
+					if i < len(policyIdentifiers) {
+						if policyIdentifiers[i].Identifier != wantPolicy.Identifier {
+							t.Errorf("got: %v, want: %v", policyIdentifiers[i].Identifier, wantPolicy.Identifier)
 						}
-						if scanInfo.PolicyIdentifier[i].Kind != wantPolicy.Kind {
-							t.Errorf("got: %v, want: %v", scanInfo.PolicyIdentifier[i].Kind, wantPolicy.Kind)
+						if policyIdentifiers[i].Kind != wantPolicy.Kind {
+							t.Errorf("got: %v, want: %v", policyIdentifiers[i].Kind, wantPolicy.Kind)
 						}
 					}
 				}

--- a/core/README.md
+++ b/core/README.md
@@ -46,8 +46,10 @@ func main() {
         ScanAll: true,
     }
 
+    var policyIdentifiers []cautils.PolicyIdentifier
+
     // Run scan
-    results, err := ks.Scan(scanInfo)
+    results, err := ks.Scan(scanInfo, policyIdentifiers)
     if err != nil {
         log.Fatalf("Scan failed: %v", err)
     }
@@ -77,7 +79,8 @@ ks := core.NewKubescape(ctx)
 
 ```go
 // Scan with configuration
-results, err := ks.Scan(scanInfo)
+var policyIdentifiers []cautils.PolicyIdentifier
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 ```
 
 ### Listing Frameworks and Controls
@@ -115,10 +118,15 @@ err := ks.Fix(fixInfo)
 ### Scan a Specific Framework
 
 ```go
-scanInfo := &cautils.ScanInfo{}
-scanInfo.SetPolicyIdentifiers([]string{"nsa"}, "framework")
+import (
+    "github.com/kubescape/kubescape/v3/core/cautils"
+    apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+)
 
-results, err := ks.Scan(scanInfo)
+scanInfo := &cautils.ScanInfo{}
+policyIdentifiers := cautils.BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework)
+
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 ```
 
 ### Scan Specific Namespaces
@@ -127,8 +135,9 @@ results, err := ks.Scan(scanInfo)
 scanInfo := &cautils.ScanInfo{
     IncludeNamespaces: "production,staging",
 }
+var policyIdentifiers []cautils.PolicyIdentifier
 
-results, err := ks.Scan(scanInfo)
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 ```
 
 ### Scan Local YAML Files
@@ -138,14 +147,16 @@ scanInfo := &cautils.ScanInfo{
     InputPatterns: []string{"/path/to/manifests"},
 }
 scanInfo.SetScanType(cautils.ScanTypeRepo)
+var policyIdentifiers []cautils.PolicyIdentifier
 
-results, err := ks.Scan(scanInfo)
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 ```
 
 ### Export Results to Different Formats
 
 ```go
-results, _ := ks.Scan(scanInfo)
+var policyIdentifiers []cautils.PolicyIdentifier
+results, _ := ks.Scan(scanInfo, policyIdentifiers)
 
 // JSON
 jsonData, _ := results.ToJson()
@@ -161,8 +172,9 @@ fmt.Printf("Compliance Score: %.2f%%\n", summary.ComplianceScore)
 scanInfo := &cautils.ScanInfo{
     ComplianceThreshold: 80.0, // Fail if below 80%
 }
+var policyIdentifiers []cautils.PolicyIdentifier
 
-results, err := ks.Scan(scanInfo)
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 if err != nil {
     // Handle scan failure
 }
@@ -201,7 +213,8 @@ if results.GetData().Report.SummaryDetails.ComplianceScore < scanInfo.Compliance
 ## Error Handling
 
 ```go
-results, err := ks.Scan(scanInfo)
+var policyIdentifiers []cautils.PolicyIdentifier
+results, err := ks.Scan(scanInfo, policyIdentifiers)
 if err != nil {
     switch {
     case errors.Is(err, context.DeadlineExceeded):
@@ -231,7 +244,8 @@ for _, ns := range namespaces {
         scanInfo := &cautils.ScanInfo{
             IncludeNamespaces: namespace,
         }
-        results, _ := ks.Scan(scanInfo)
+        var policyIdentifiers []cautils.PolicyIdentifier
+        results, _ := ks.Scan(scanInfo, policyIdentifiers)
         // Process results...
     }(ns)
 }

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -78,7 +78,7 @@ type OPASessionObj struct {
 	VAPBindings           []unstructured.Unstructured // ValidatingAdmissionPolicyBinding resources collected from the cluster
 }
 
-func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo) *OPASessionObj {
+func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {
 	clusterSize := max(estimateClusterSize(k8sResources), 100)
 
 	return &OPASessionObj{
@@ -92,7 +92,7 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		ResourceToControlsMap: make(map[string][]string, clusterSize/2),
 		ResourceSource:        make(map[string]reporthandling.Source, clusterSize),
 		SessionID:             scanInfo.ScanID,
-		Metadata:              scanInfoToScanMetadata(ctx, scanInfo),
+		Metadata:              scanInfoToScanMetadata(ctx, scanInfo, policyIdentifiers),
 		OmitRawResources:      scanInfo.OmitRawResources,
 		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		LabelsToCopy:          scanInfo.LabelsToCopy,

--- a/core/cautils/datastructures_test.go
+++ b/core/cautils/datastructures_test.go
@@ -184,7 +184,7 @@ func TestNewOPASessionObj(t *testing.T) {
 		OmitRawResources: true,
 		TriggeredByCLI:   true,
 	}
-	sessionObj := NewOPASessionObj(ctx, frameworks, k8sResources, scanInfo)
+	sessionObj := NewOPASessionObj(ctx, frameworks, k8sResources, scanInfo, nil)
 	assert.NotNil(t, sessionObj)
 	assert.Equal(t, "test-scan-id", sessionObj.SessionID)
 	assert.Equal(t, true, sessionObj.OmitRawResources)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -113,17 +113,15 @@ type PolicyIdentifier struct {
 }
 
 type ScanInfo struct {
-	Getters                                  // TODO - remove from object
-	PolicyIdentifier      []PolicyIdentifier // TODO - remove from object
-	UseExceptions         string             // Load file with exceptions configuration
-	ControlsInputs        string             // Load file with inputs for controls
-	AttackTracks          string             // Load file with attack tracks
-	UseFrom               []string           // Load framework from local file (instead of download). Use when running offline
-	UseDefault            bool               // Load framework from cached file (instead of download). Use when running offline
-	UseArtifactsFrom      string             // Load artifacts from local path. Use when running offline
-	ControlsVersion       string             // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
-	VerboseMode           bool               // Display all the input resources and not only failed resources
-	Hide                  bool               // Hide sensitive identifiers (names, namespaces, images) in results
+	UseExceptions         string   // Load file with exceptions configuration
+	ControlsInputs        string   // Load file with inputs for controls
+	AttackTracks          string   // Load file with attack tracks
+	UseFrom               []string // Load framework from local file (instead of download). Use when running offline
+	UseDefault            bool     // Load framework from cached file (instead of download). Use when running offline
+	UseArtifactsFrom      string   // Load artifacts from local path. Use when running offline
+	ControlsVersion       string   // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
+	VerboseMode           bool     // Display all the input resources and not only failed resources
+	Hide                  bool     // Hide sensitive identifiers (names, namespaces, images) in results
 	EncryptionEnabled     bool
 	View                  string                       //
 	Format                string                       // Format results (table, json, junit ...)
@@ -187,8 +185,8 @@ type Getters struct {
 	AttackTracksGetter   getter.IAttackTracksGetter
 }
 
-func (scanInfo *ScanInfo) Init(ctx context.Context) {
-	scanInfo.setUseFrom()
+func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyIdentifier) {
+	scanInfo.setUseFrom(policyIdentifiers)
 	scanInfo.setUseArtifactsFrom(ctx)
 	if scanInfo.ScanID == "" {
 		scanInfo.ScanID = uuid.NewString()
@@ -246,9 +244,9 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 	}
 }
 
-func (scanInfo *ScanInfo) setUseFrom() {
+func (scanInfo *ScanInfo) setUseFrom(policyIdentifiers []PolicyIdentifier) {
 	if scanInfo.UseDefault {
-		for _, policy := range scanInfo.PolicyIdentifier {
+		for _, policy := range policyIdentifiers {
 			path, err := getter.PolicyCachePath(policy.Identifier)
 			if err != nil {
 				logger.L().Warning("skipping default cache lookup for policy", helpers.String("identifier", policy.Identifier), helpers.Error(err))
@@ -295,20 +293,31 @@ func (scanInfo *ScanInfo) SetScanType(scanType ScanTypes) {
 	scanInfo.ScanType = scanType
 }
 
-func (scanInfo *ScanInfo) SetPolicyIdentifiers(policies []string, kind apisv1.NotificationPolicyKind) {
-	for _, policy := range policies {
-		if !scanInfo.contains(policy) {
-			newPolicy := PolicyIdentifier{}
-			newPolicy.Kind = kind
-			newPolicy.Identifier = policy
-			scanInfo.PolicyIdentifier = append(scanInfo.PolicyIdentifier, newPolicy)
-		}
-	}
+// BuildPolicyIdentifiers builds a list of policy identifiers from the given
+// string identifiers, adding any new ones that are not already present.
+func BuildPolicyIdentifiers(policies []string, kind apisv1.NotificationPolicyKind) []PolicyIdentifier {
+	return AppendPolicyIdentifiers(nil, policies, kind)
 }
 
-func (scanInfo *ScanInfo) contains(policyName string) bool {
-	for _, policy := range scanInfo.PolicyIdentifier {
-		if policy.Identifier == policyName {
+// AppendPolicyIdentifiers appends the given string identifiers to the existing
+// list, adding any new ones that are not already present.
+func AppendPolicyIdentifiers(existing []PolicyIdentifier, policies []string, kind apisv1.NotificationPolicyKind) []PolicyIdentifier {
+	result := append([]PolicyIdentifier(nil), existing...)
+	for _, policy := range policies {
+		if !containsIdentifier(result, policy) {
+			result = append(result, PolicyIdentifier{
+				Kind:       kind,
+				Identifier: policy,
+			})
+		}
+	}
+	return result
+}
+
+// containsIdentifier reports whether the named identifier is already present.
+func containsIdentifier(identifiers []PolicyIdentifier, name string) bool {
+	for _, policy := range identifiers {
+		if policy.Identifier == name {
 			return true
 		}
 	}
@@ -331,7 +340,7 @@ func splitNamespaceList(s string) []string {
 	return out
 }
 
-func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo) *reporthandlingv2.Metadata {
+func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *reporthandlingv2.Metadata {
 	metadata := &reporthandlingv2.Metadata{}
 
 	metadata.ScanMetadata.Formats = []string{scanInfo.Format}
@@ -346,11 +355,11 @@ func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo) *reporthand
 	}
 
 	// scan type
-	if len(scanInfo.PolicyIdentifier) > 0 {
-		metadata.ScanMetadata.TargetType = string(scanInfo.PolicyIdentifier[0].Kind)
+	if len(policyIdentifiers) > 0 {
+		metadata.ScanMetadata.TargetType = string(policyIdentifiers[0].Kind)
 	}
 	// append frameworks
-	for _, policy := range scanInfo.PolicyIdentifier {
+	for _, policy := range policyIdentifiers {
 		metadata.ScanMetadata.TargetNames = append(metadata.ScanMetadata.TargetNames, policy.Identifier)
 	}
 

--- a/core/cautils/scaninfo_helpers_test.go
+++ b/core/cautils/scaninfo_helpers_test.go
@@ -259,16 +259,14 @@ func TestScanInfo_SetScanType(t *testing.T) {
 // ScanInfo.contains (unexported helper)
 // ---------------------------------------------------------------------------
 
-func TestScanInfo_contains(t *testing.T) {
-	scanInfo := &ScanInfo{
-		PolicyIdentifier: []PolicyIdentifier{
-			{Identifier: "nsa"},
-			{Identifier: "mitre"},
-		},
+func TestContainsIdentifier(t *testing.T) {
+	policyIdentifiers := []PolicyIdentifier{
+		{Identifier: "nsa"},
+		{Identifier: "mitre"},
 	}
 
-	assert.True(t, scanInfo.contains("nsa"))
-	assert.True(t, scanInfo.contains("mitre"))
-	assert.False(t, scanInfo.contains("cis"))
-	assert.False(t, scanInfo.contains(""))
+	assert.True(t, containsIdentifier(policyIdentifiers, "nsa"))
+	assert.True(t, containsIdentifier(policyIdentifiers, "mitre"))
+	assert.False(t, containsIdentifier(policyIdentifiers, "cis"))
+	assert.False(t, containsIdentifier(policyIdentifiers, ""))
 }

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -271,7 +271,7 @@ func TestScanInfoFormatsDeduplicatesInOrder(t *testing.T) {
 	}
 }
 
-func TestScanInfoSetPolicyIdentifiers(t *testing.T) {
+func TestAppendPolicyIdentifiers(t *testing.T) {
 	tests := []struct {
 		name     string
 		existing []PolicyIdentifier
@@ -306,11 +306,9 @@ func TestScanInfoSetPolicyIdentifiers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scanInfo := &ScanInfo{PolicyIdentifier: tt.existing}
+			policyIdentifiers := AppendPolicyIdentifiers(tt.existing, tt.policies, apisv1.KindFramework)
 
-			scanInfo.SetPolicyIdentifiers(tt.policies, apisv1.KindFramework)
-
-			assert.Equal(t, tt.want, scanInfo.PolicyIdentifier)
+			assert.Equal(t, tt.want, policyIdentifiers)
 		})
 	}
 }
@@ -339,21 +337,21 @@ func TestSplitNamespaceList(t *testing.T) {
 func TestScanInfoToScanMetadataNamespaces(t *testing.T) {
 	t.Run("populates excluded namespaces", func(t *testing.T) {
 		scanInfo := &ScanInfo{ExcludedNamespaces: "kube-system,kube-public"}
-		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		md := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
 		assert.Equal(t, []string{"kube-system", "kube-public"}, md.ScanMetadata.ExcludedNamespaces)
 		assert.Empty(t, md.ScanMetadata.IncludeNamespaces)
 	})
 
 	t.Run("populates included namespaces", func(t *testing.T) {
 		scanInfo := &ScanInfo{IncludeNamespaces: "default,prod"}
-		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		md := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
 		assert.Equal(t, []string{"default", "prod"}, md.ScanMetadata.IncludeNamespaces)
 		assert.Empty(t, md.ScanMetadata.ExcludedNamespaces)
 	})
 
 	t.Run("empty when not set", func(t *testing.T) {
 		scanInfo := &ScanInfo{}
-		md := scanInfoToScanMetadata(context.Background(), scanInfo)
+		md := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
 		assert.Empty(t, md.ScanMetadata.ExcludedNamespaces)
 		assert.Empty(t, md.ScanMetadata.IncludeNamespaces)
 	})

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -41,7 +41,7 @@ type componentInterfaces struct {
 	outputPrinters    []printer.IPrinter
 }
 
-func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentInterfaces, error) {
+func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (componentInterfaces, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "setup interfaces")
 	defer span.End()
 
@@ -74,7 +74,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo) (componentIn
 	// Skip version check in air-gapped mode (when keep-local flag is set)
 	if !scanInfo.Local {
 		v := versioncheck.NewIVersionCheckHandler(ctx)
-		_ = v.CheckLatestVersion(ctx, versioncheck.NewVersionCheckRequest(scanInfo.AccountID, versioncheck.BuildNumber, policyIdentifierIdentities(scanInfo.PolicyIdentifier), "", string(scanInfo.GetScanningContext()), k8sClient))
+		_ = v.CheckLatestVersion(ctx, versioncheck.NewVersionCheckRequest(scanInfo.AccountID, versioncheck.BuildNumber, policyIdentifierIdentities(policyIdentifiers), "", string(scanInfo.GetScanningContext()), k8sClient))
 	}
 
 	// ================== setup host scanner object ======================================
@@ -191,15 +191,15 @@ func fileExtForFormat(format string) string {
 	}
 }
 
-func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
+func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
 	ctxInit, spanInit := otel.Tracer("").Start(ks.Context(), "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
 
 	// ===================== Initialization =====================
-	scanInfo.Init(ctxInit) // initialize scan info
+	scanInfo.Init(ctxInit, policyIdentifiers) // initialize scan info
 	defer scanInfo.Cleanup()
 
-	interfaces, err := getInterfaces(ctxInit, scanInfo)
+	interfaces, err := getInterfaces(ctxInit, scanInfo, policyIdentifiers)
 	if err != nil {
 		spanInit.End()
 		return nil, err
@@ -226,23 +226,24 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	}
 
 	// set policy getter only after setting the customerGUID
-	scanInfo.PolicyGetter, err = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
+	var getters cautils.Getters
+	getters.PolicyGetter, err = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
 	}
 	var controlInputsFromCache bool
-	scanInfo.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
+	getters.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
 	}
-	scanInfo.ExceptionsGetter, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	getters.ExceptionsGetter, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
 	}
-	scanInfo.AttackTracksGetter, err = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	getters.AttackTracksGetter, err = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
@@ -250,7 +251,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 
 	// TODO - list supported frameworks/controls
 	if scanInfo.ScanAll {
-		scanInfo.SetPolicyIdentifiers(listFrameworksNames(scanInfo.PolicyGetter), apisv1.KindFramework)
+		policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, listFrameworksNames(getters.PolicyGetter), apisv1.KindFramework)
 	}
 
 	logger.L().StopSuccess("Initialized scanner")
@@ -260,7 +261,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	// ===================== policies =====================
 	ctxPolicies, spanPolicies := otel.Tracer("").Start(ctxInit, "policies")
 	policyHandler := policyhandler.NewPolicyHandler(interfaces.tenantConfig.GetContextName())
-	scanData, err := policyHandler.CollectPolicies(ctxPolicies, scanInfo.PolicyIdentifier, scanInfo)
+	scanData, err := policyHandler.CollectPolicies(ctxPolicies, policyIdentifiers, scanInfo, &getters)
 	if err != nil {
 		spanInit.End()
 		return resultsHandling, err
@@ -327,7 +328,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsH
 	// ======================== prioritization ===================
 	if scanInfo.PrintAttackTree || isPrioritizationScanType(scanInfo.ScanType) {
 		_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
-		if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, scanInfo.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
+		if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, getters.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
 			logger.L().Ctx(ks.Context()).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
 		} else if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
 			return resultsHandling, fmt.Errorf("%w", err)

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -12,7 +12,7 @@ type IKubescape interface {
 	Context() context.Context
 	SetContext(ctx context.Context)
 
-	Scan(scanInfo *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
+	Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
 
 	// policies
 	List(listPolicies *metav1.ListPolicies) error     // TODO - return list response

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -16,7 +16,7 @@ func (m *MockIKubescape) Context() context.Context {
 
 func (m *MockIKubescape) SetContext(_ context.Context) {}
 
-func (m *MockIKubescape) Scan(_ *cautils.ScanInfo) (*resultshandling.ResultsHandler, error) {
+func (m *MockIKubescape) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
 	return nil, nil
 }
 

--- a/core/pkg/opaprocessor/processorhandler_streaming_test.go
+++ b/core/pkg/opaprocessor/processorhandler_streaming_test.go
@@ -133,7 +133,7 @@ func TestProcessWithStreaming_EndToEndParity(t *testing.T) {
 
 	// Eager path: CollectResources → ProcessRulesListener, as scan.go does for
 	// non-streaming scans.
-	eagerSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo)
+	eagerSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
 	eagerSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 	require.NoError(t, resourcehandler.CollectResources(context.Background(), handler, eagerSession, scanInfo))
 
@@ -144,7 +144,7 @@ func TestProcessWithStreaming_EndToEndParity(t *testing.T) {
 	// Streaming path: StreamResourcesBatches → ProcessWithStreaming, as scan.go
 	// does for streaming scans. NewOPAProcessor runs against the live session
 	// the producer goroutine fills — the seam this test exists to cover.
-	streamingSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo)
+	streamingSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
 	streamingSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 
 	batchChan, errChan, expectedBatches, err := handler.StreamResourcesBatches(context.Background(), streamingSession, scanInfo)
@@ -380,7 +380,7 @@ func TestProcessWithStreaming_PopulatesCELNamespaceIndex(t *testing.T) {
 	node := mustWorkload(t, `{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"}}`)
 
 	scanInfo := &cautils.ScanInfo{}
-	session := cautils.NewOPASessionObj(context.Background(), parityFrameworks(true), nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), parityFrameworks(true), nil, scanInfo, nil)
 	session.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
 
 	opap := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -87,10 +87,10 @@ func (policyHandler *PolicyHandler) Close() {
 	}
 }
 
-func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo) (*cautils.OPASessionObj, error) {
-	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (*cautils.OPASessionObj, error) {
+	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier)
 
-	policyHandler.getters = &scanInfo.Getters
+	policyHandler.getters = getters
 
 	// get policies, exceptions and controls inputs
 	policies, exceptions, controlInputs, degradations, err := policyHandler.getPolicies(ctx, policyIdentifier)

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -128,13 +128,13 @@ func TestCollectPolicies(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			tc.policyHandler.getters = &cautils.Getters{
+			getters := &cautils.Getters{
 				PolicyGetter:         &PolicyGetterMock{},
 				ExceptionsGetter:     &ExceptionsGetterMock{},
 				ControlsInputsGetter: &ControlsInputsGetterMock{},
 			}
 
-			opaSessionObj, err := tc.policyHandler.CollectPolicies(ctx, tc.policyIdent, tc.scanInfo, tc.policyHandler.getters)
+			opaSessionObj, err := tc.policyHandler.CollectPolicies(ctx, tc.policyIdent, tc.scanInfo, getters)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.NotNil(t, opaSessionObj)

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -113,26 +113,14 @@ func TestCollectPolicies(t *testing.T) {
 			name:          "Collect Framework policy",
 			policyHandler: NewPolicyHandler("test-cluster"),
 			policyIdent:   []cautils.PolicyIdentifier{{Identifier: FrameworkName, Kind: "Framework"}},
-			scanInfo: &cautils.ScanInfo{
-				Getters: cautils.Getters{
-					PolicyGetter:         &PolicyGetterMock{},
-					ExceptionsGetter:     &ExceptionsGetterMock{},
-					ControlsInputsGetter: &ControlsInputsGetterMock{},
-				},
-			},
+			scanInfo:      &cautils.ScanInfo{},
 			expectedError: nil,
 		},
 		{
 			name:          "Collect Control policy",
 			policyHandler: NewPolicyHandler("test-cluster"),
 			policyIdent:   []cautils.PolicyIdentifier{{Identifier: "", Kind: "Control"}},
-			scanInfo: &cautils.ScanInfo{
-				Getters: cautils.Getters{
-					PolicyGetter:         &PolicyGetterMock{},
-					ExceptionsGetter:     &ExceptionsGetterMock{},
-					ControlsInputsGetter: &ControlsInputsGetterMock{},
-				},
-			},
+			scanInfo:      &cautils.ScanInfo{},
 			expectedError: nil,
 		},
 	}
@@ -146,7 +134,7 @@ func TestCollectPolicies(t *testing.T) {
 				ControlsInputsGetter: &ControlsInputsGetterMock{},
 			}
 
-			opaSessionObj, err := tc.policyHandler.CollectPolicies(ctx, tc.policyIdent, tc.scanInfo)
+			opaSessionObj, err := tc.policyHandler.CollectPolicies(ctx, tc.policyIdent, tc.scanInfo, tc.policyHandler.getters)
 
 			assert.Equal(t, tc.expectedError, err)
 			assert.NotNil(t, opaSessionObj)

--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -274,7 +274,7 @@ metadata:
 	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o600))
 
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
-	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	session.Policies = []reporthandling.Framework{agentRuntimeFramework()}
 
 	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
@@ -316,7 +316,7 @@ metadata:
 				mockControl("offline-custom-resource", []reporthandling.PolicyRule{mockRule("offline-custom-resource", []reporthandling.RuleMatchObjects{match}, "")}),
 			})
 			scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
-			session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+			session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil)
 
 			resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
 			require.NoError(t, err)
@@ -350,7 +350,7 @@ metadata:
 		}),
 	})
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
-	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil)
 
 	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ metadata:
 		InputPatterns: []string{manifestPath},
 		ScanObject:    scanObject("agents.x-k8s.io/v1alpha1", "Sandbox", "agents", "alpha-sandbox"),
 	}
-	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil)
 
 	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
 	require.NoError(t, err)
@@ -497,7 +497,7 @@ metadata:
 		mockControl("current-builtins", []reporthandling.PolicyRule{mockRule("current-builtins", matches, "")}),
 	})
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
-	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil)
 
 	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
 	require.NoError(t, err)
@@ -622,7 +622,7 @@ metadata:
 		}),
 	})
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
-	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo)
+	session := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil)
 
 	resources, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
 	require.NoError(t, err)

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -129,7 +129,7 @@ func TestGetResources_SurfacesMissingGVRFailuresInInfoMap(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
 	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
@@ -158,7 +158,7 @@ func TestGetResources_FailsWhenAllQueriesFail(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
 	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
@@ -196,7 +196,7 @@ func TestGetResources_ScanAbortedOnContextCancellation(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -252,7 +252,7 @@ func TestGetResources_HostSensorInfoMapMerged(t *testing.T) {
 
 	scanInfo := &cautils.ScanInfo{}
 	scanInfo.HostSensorEnabled.SetBool(true)
-	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
 	const preSeededGVR = "/v1/networkpolicies"

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -354,7 +354,7 @@ func TestRecordFailedQueryStatuses_PartialFailureSessionField(t *testing.T) {
 	framework.Controls = append(framework.Controls, control)
 
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	sessionObj.Policies = append(sessionObj.Policies, *framework)
 
 	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
@@ -397,7 +397,7 @@ func TestGetResources_DiscoveryFailureReachesScanCoverage(t *testing.T) {
 	control := mockControl("discovery-coverage", []reporthandling.PolicyRule{rule})
 	framework := mockFramework("discovery-coverage", []reporthandling.Control{control})
 	scanInfo := &cautils.ScanInfo{}
-	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo)
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
 
 	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
 	require.NoError(t, err)

--- a/httphandler/handlerequests/v1/admission_test.go
+++ b/httphandler/handlerequests/v1/admission_test.go
@@ -46,7 +46,7 @@ func TestScanQueueRejectsRequestsWhenCapacityIsExhausted(t *testing.T) {
 	var once sync.Once
 	var releaseOnce sync.Once
 	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		once.Do(func() { close(started) })
 		<-release
 		return nil, nil
@@ -93,7 +93,7 @@ func TestScanQueuePreservesAdmissionOrder(t *testing.T) {
 	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
 	completed := make(chan string, 3)
 	var callCount atomic.Int32
-	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		if callCount.Add(1) == 1 {
 			close(started)
 			<-release
@@ -145,7 +145,7 @@ func TestScanQueuePreservesAdmissionOrder(t *testing.T) {
 func TestScanRejectsOversizedRequestBodyBeforeAdmission(t *testing.T) {
 	defer func(original scanner) { scanImpl = original }(scanImpl)
 	var calls atomic.Int32
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		calls.Add(1)
 		return nil, nil
 	}

--- a/httphandler/handlerequests/v1/callback_test.go
+++ b/httphandler/handlerequests/v1/callback_test.go
@@ -47,7 +47,7 @@ func TestExecuteScan_CallbackOnSuccess(t *testing.T) {
 	// httptest listens on loopback, so the allowlist must explicitly permit it.
 	t.Setenv(callbackAllowlistEnv, "127.0.0.1/32")
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		return nil, nil
 	}
 
@@ -74,7 +74,7 @@ func TestExecuteScan_CallbackOnSuccess(t *testing.T) {
 func TestExecuteScan_CallbackOnFailure(t *testing.T) {
 	t.Setenv(callbackAllowlistEnv, "127.0.0.1/32")
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		return nil, fmt.Errorf("collection boom")
 	}
 

--- a/httphandler/handlerequests/v1/cancel_test.go
+++ b/httphandler/handlerequests/v1/cancel_test.go
@@ -31,7 +31,7 @@ func TestCancelScan_UnblocksBlockedScan_ReturnsErrorType(t *testing.T) {
 
 	scanStarted := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
 		return nil, ctx.Err()
@@ -83,7 +83,7 @@ func TestCancelScan_MarksNotBusy(t *testing.T) {
 	scanStarted := make(chan struct{})
 	releaseScan := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
 		<-releaseScan
@@ -161,7 +161,7 @@ func TestCancelScan_EmptyID_CancelsLatest(t *testing.T) {
 
 	scanStarted := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
 		return nil, ctx.Err()
@@ -221,7 +221,7 @@ func TestCancelScan_SkipsCancelledQueuedRequest_UnblocksWaitingCaller(t *testing
 
 	firstStarted := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(firstStarted)
 		<-ctx.Done()
 		return nil, ctx.Err()
@@ -305,7 +305,7 @@ func TestCancelScan_WaitFalse_NoFailedArtifactLeftBehind(t *testing.T) {
 
 	scanStarted := make(chan struct{})
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		close(scanStarted)
 		<-ctx.Done()
 		return nil, writeScanErrorToFile(ctx.Err(), scanID)

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -16,10 +16,10 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
+func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) (*cautils.ScanInfo, []cautils.PolicyIdentifier) {
 	scanInfo := defaultScanInfo()
 
-	setTargetInScanInfo(scanRequest, scanInfo)
+	policyIdentifiers := setTargetInScanInfo(scanRequest, scanInfo)
 
 	if scanRequest.Account != "" {
 		scanInfo.AccountID = scanRequest.Account
@@ -81,10 +81,10 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) *cautils.ScanInfo {
 		}
 	}
 
-	return scanInfo
+	return scanInfo, policyIdentifiers
 }
 
-func setTargetInScanInfo(scanRequest *utilsmetav1.PostScanRequest, scanInfo *cautils.ScanInfo) {
+func setTargetInScanInfo(scanRequest *utilsmetav1.PostScanRequest, scanInfo *cautils.ScanInfo) []cautils.PolicyIdentifier {
 	if scanRequest.TargetType != "" && len(scanRequest.TargetNames) > 0 {
 		if strings.EqualFold(string(scanRequest.TargetType), string(apisv1.KindFramework)) {
 			scanRequest.TargetType = apisv1.KindFramework
@@ -100,11 +100,11 @@ func setTargetInScanInfo(scanRequest *utilsmetav1.PostScanRequest, scanInfo *cau
 			scanInfo.ScanAll = true
 			scanRequest.TargetNames = []string{}
 		}
-		scanInfo.SetPolicyIdentifiers(scanRequest.TargetNames, scanRequest.TargetType)
-	} else {
-		scanInfo.FrameworkScan = true
-		scanInfo.ScanAll = true
+		return cautils.BuildPolicyIdentifiers(scanRequest.TargetNames, scanRequest.TargetType)
 	}
+	scanInfo.FrameworkScan = true
+	scanInfo.ScanAll = true
+	return nil
 }
 
 func saveExceptions(exceptions []armotypes.PostureExceptionPolicy) (string, error) {

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -17,18 +17,18 @@ import (
 
 func TestToScanInfo_SubmitExplicitlySet(t *testing.T) {
 	// no submit field in the request - not explicitly set
-	s := ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework})
+	s, _ := ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework})
 	assert.Nil(t, s.Submit.Get())
 
 	// submit:false explicitly requested
 	falseVal := false
-	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &falseVal})
+	s, _ = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &falseVal})
 	require.NotNil(t, s.Submit.Get())
 	assert.False(t, s.Submit.GetBool())
 
 	// submit:true explicitly requested
 	trueVal := true
-	s = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &trueVal})
+	s, _ = ToScanInfo(&utilsmetav1.PostScanRequest{TargetType: apisv1.KindFramework, Submit: &trueVal})
 	require.NotNil(t, s.Submit.Get())
 	assert.True(t, s.Submit.GetBool())
 }
@@ -44,11 +44,11 @@ func TestToScanInfo(t *testing.T) {
 			ExcludedNamespaces: []string{"kube-system", "kube-public"},
 			TargetNames:        []string{"nsa", "mitre"},
 		}
-		s := ToScanInfo(req)
+		s, policyIdentifiers := ToScanInfo(req)
 		assert.Equal(t, "abc", s.AccountID)
 		assert.Equal(t, "v2", s.FormatVersion)
 		assert.Equal(t, "pdf", s.Format)
-		assert.Equal(t, 2, len(s.PolicyIdentifier))
+		assert.Equal(t, 2, len(policyIdentifiers))
 		assert.Equal(t, "kube-system,kube-public", s.ExcludedNamespaces)
 
 		assert.False(t, s.HostSensorEnabled.GetBool())
@@ -56,10 +56,10 @@ func TestToScanInfo(t *testing.T) {
 		assert.False(t, s.Submit.GetBool())
 		assert.False(t, s.ScanAll)
 		assert.True(t, s.FrameworkScan)
-		assert.Equal(t, "nsa", s.PolicyIdentifier[0].Identifier)
-		assert.Equal(t, apisv1.KindFramework, s.PolicyIdentifier[0].Kind)
-		assert.Equal(t, "mitre", s.PolicyIdentifier[1].Identifier)
-		assert.Equal(t, apisv1.KindFramework, s.PolicyIdentifier[1].Kind)
+		assert.Equal(t, "nsa", policyIdentifiers[0].Identifier)
+		assert.Equal(t, apisv1.KindFramework, policyIdentifiers[0].Kind)
+		assert.Equal(t, "mitre", policyIdentifiers[1].Identifier)
+		assert.Equal(t, apisv1.KindFramework, policyIdentifiers[1].Kind)
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -67,18 +67,18 @@ func TestToScanInfo(t *testing.T) {
 			TargetNames:       []string{"c-0001"},
 			IncludeNamespaces: []string{"kube-system", "kube-public"},
 		}
-		s := ToScanInfo(req)
+		s, policyIdentifiers := ToScanInfo(req)
 		assert.False(t, s.ScanAll)
 		assert.False(t, s.FrameworkScan)
 		assert.Equal(t, "kube-system,kube-public", s.IncludeNamespaces)
 		assert.Equal(t, "", s.ExcludedNamespaces)
-		assert.Equal(t, 1, len(s.PolicyIdentifier))
-		assert.Equal(t, "c-0001", s.PolicyIdentifier[0].Identifier)
-		assert.Equal(t, apisv1.KindControl, s.PolicyIdentifier[0].Kind)
+		assert.Equal(t, 1, len(policyIdentifiers))
+		assert.Equal(t, "c-0001", policyIdentifiers[0].Identifier)
+		assert.Equal(t, apisv1.KindControl, policyIdentifiers[0].Kind)
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{}
-		s := ToScanInfo(req)
+		s, _ := ToScanInfo(req)
 		assert.True(t, s.ScanAll)
 		assert.True(t, s.FrameworkScan)
 		assert.Nil(t, s.ScanObject)
@@ -94,7 +94,7 @@ func TestToScanInfo(t *testing.T) {
 				},
 			},
 		}
-		s := ToScanInfo(req)
+		s, _ := ToScanInfo(req)
 		assert.NotNil(t, s.ScanObject)
 		assert.Equal(t, "apps/v1", s.ScanObject.GetApiVersion())
 		assert.Equal(t, "Deployment", s.ScanObject.GetKind())
@@ -109,7 +109,7 @@ func TestToScanInfoExceptionsCleanup(t *testing.T) {
 			{PortalBase: armotypes.PortalBase{Name: "ex"}},
 		},
 	}
-	s := ToScanInfo(req)
+	s, _ := ToScanInfo(req)
 	require.NotEmpty(t, s.UseExceptions)
 	_, err := os.Stat(s.UseExceptions)
 	require.NoError(t, err)
@@ -201,10 +201,10 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{""},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll)
-		assert.Equal(t, 0, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 0, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -212,10 +212,10 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{"", "security"},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll)
-		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 1, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -223,10 +223,10 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll)
-		assert.Equal(t, 0, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 0, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -234,10 +234,10 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{"nsa", "mitre"},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.False(t, scanInfo.ScanAll)
-		assert.Equal(t, 2, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 2, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -245,18 +245,18 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{"all"},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll)
-		assert.Equal(t, 0, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 0, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.True(t, scanInfo.FrameworkScan)
 		assert.True(t, scanInfo.ScanAll)
-		assert.Equal(t, 0, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 0, len(policyIdentifiers))
 	}
 	{
 		req := &utilsmetav1.PostScanRequest{
@@ -264,9 +264,9 @@ func TestSetTargetInScanInfo(t *testing.T) {
 			TargetNames: []string{"c-0001"},
 		}
 		scanInfo := &cautils.ScanInfo{}
-		setTargetInScanInfo(req, scanInfo)
+		policyIdentifiers := setTargetInScanInfo(req, scanInfo)
 		assert.False(t, scanInfo.FrameworkScan)
 		assert.False(t, scanInfo.ScanAll)
-		assert.Equal(t, 1, len(scanInfo.PolicyIdentifier))
+		assert.Equal(t, 1, len(policyIdentifiers))
 	}
 }

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -54,7 +54,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resultsFile := filepath.Join(OutputDir, scanID)
-	scanInfo := getPrometheusDefaultScanCommand(scanID, resultsFile, metricsQueryParams.Frameworks)
+	scanInfo, policyIdentifiers := getPrometheusDefaultScanCommand(scanID, resultsFile, metricsQueryParams.Frameworks)
 
 	scanParams := &scanRequestParams{
 		scanQueryParams: &ScanQueryParams{
@@ -62,10 +62,11 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 			KeepResults:     false,
 			SkipPersistence: metricsQueryParams.SkipPersistence,
 		},
-		scanInfo: scanInfo,
-		scanID:   scanID,
-		ctx:      scanCtx,
-		resp:     make(chan *utilsmetav1.Response, 1),
+		scanInfo:          scanInfo,
+		policyIdentifiers: policyIdentifiers,
+		scanID:            scanID,
+		ctx:               scanCtx,
+		resp:              make(chan *utilsmetav1.Response, 1),
 	}
 
 	// send to scan queue
@@ -107,7 +108,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	w.Write(f)
 }
 
-func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string) *cautils.ScanInfo {
+func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string) (*cautils.ScanInfo, []cautils.PolicyIdentifier) {
 	scanInfo := defaultScanInfo()
 	scanInfo.UseArtifactsFrom = getter.DefaultLocalStore // Load files from cache (this will prevent kubescape from downloading the artifacts every time)
 	scanInfo.Submit.SetBool(false)                       // deliberate opt-out, not left at the default - never flipped into submit mode by backend auto-detection
@@ -120,17 +121,19 @@ func getPrometheusDefaultScanCommand(scanID, resultsFile, frameworksParam string
 	scanInfo.Output = resultsFile                            // results output
 	scanInfo.Format = envToString("KS_FORMAT", "prometheus") // default output format is prometheus
 
+	var policyIdentifiers []cautils.PolicyIdentifier
 	// Check if specific frameworks are requested via query parameter
 	frameworks := splitAndTrim(frameworksParam, ",")
 	if len(frameworks) > 0 {
-		scanInfo.SetPolicyIdentifiers(frameworks, utilsapisv1.KindFramework)
+		// Scan specific frameworks (comma-separated list)
+		policyIdentifiers = cautils.BuildPolicyIdentifiers(frameworks, utilsapisv1.KindFramework)
 	} else {
 		// Default: scan all available frameworks (including CIS)
 		scanInfo.ScanAll = true
 		// Framework identifiers will be set dynamically by the scan process when ScanAll is true
 	}
 
-	return scanInfo
+	return scanInfo, policyIdentifiers
 }
 
 // splitAndTrim splits a string by delimiter and trims whitespace from each element

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -52,7 +52,7 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanID := "1234"
 			outputFile := filepath.Join(OutputDir, scanID)
-			scanInfo := getPrometheusDefaultScanCommand(scanID, outputFile, tt.frameworksParam)
+			scanInfo, policyIdentifiers := getPrometheusDefaultScanCommand(scanID, outputFile, tt.frameworksParam)
 
 			assert.Equal(t, scanID, scanInfo.ScanID)
 			assert.Equal(t, outputFile, scanInfo.Output)
@@ -63,10 +63,10 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 			assert.Equal(t, tt.wantScanAll, scanInfo.ScanAll)
 			assert.False(t, scanInfo.HostSensorEnabled.GetBool())
 			assert.Equal(t, getter.DefaultLocalStore, scanInfo.UseArtifactsFrom)
-			assert.Len(t, scanInfo.PolicyIdentifier, len(tt.wantFrameworkIDs))
+			assert.Len(t, policyIdentifiers, len(tt.wantFrameworkIDs))
 
 			for i, wantFrameworkID := range tt.wantFrameworkIDs {
-				assert.Equal(t, wantFrameworkID, scanInfo.PolicyIdentifier[i].Identifier)
+				assert.Equal(t, wantFrameworkID, policyIdentifiers[i].Identifier)
 			}
 		})
 	}
@@ -80,7 +80,7 @@ func TestMetrics_ScanContextDecoupledFromRequest(t *testing.T) {
 	scanCtxErr := make(chan error, 1)
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		cancel() // simulate the scrape connection going away mid-scan
 		scanCtxErr <- ctx.Err()
 		return nil, nil
@@ -131,7 +131,7 @@ func TestMetrics_UsesDecodedSkipPersistenceQueryParam(t *testing.T) {
 
 			defer func(o scanner) { scanImpl = o }(scanImpl)
 			gotSkipPersistence := make(chan bool, 1)
-			scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
+			scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
 				gotSkipPersistence <- skipPersistence
 				require.NoError(t, os.WriteFile(scanInfo.Output, []byte("# metrics\n"), 0o600))
 				return nil, nil
@@ -161,7 +161,7 @@ func TestMetrics_UsesDecodedSkipPersistenceQueryParam(t *testing.T) {
 func TestMetrics_InvalidSkipPersistenceQueryParam(t *testing.T) {
 	defer func(o scanner) { scanImpl = o }(scanImpl)
 	scanCalled := make(chan struct{}, 1)
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		scanCalled <- struct{}{}
 		return nil, nil
 	}
@@ -183,7 +183,7 @@ func TestMetrics_InvalidSkipPersistenceQueryParam(t *testing.T) {
 func TestMetrics_NonGetMethodReturns405WithoutScanning(t *testing.T) {
 	defer func(o scanner) { scanImpl = o }(scanImpl)
 	scanCalled := make(chan struct{}, 1)
-	scanImpl = func(context.Context, *cautils.ScanInfo, string, bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
 		scanCalled <- struct{}{}
 		return nil, nil
 	}
@@ -217,7 +217,7 @@ func TestMetricsQueueRejectsRequestsWhenCapacityIsExhausted(t *testing.T) {
 	var once sync.Once
 	var releaseOnce sync.Once
 	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
-	scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		once.Do(func() { close(started) })
 		<-release
 		require.NoError(t, os.WriteFile(scanInfo.Output, []byte("# metrics\n"), 0o600))

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -74,13 +74,14 @@ type CancelScanQueryParams struct {
 
 // scanRequestParams params passed to channel
 type scanRequestParams struct {
-	scanInfo        *cautils.ScanInfo // request as received from api
-	scanQueryParams *ScanQueryParams  // request as received from api
-	scanID          string            // generated scan ID
-	ctx             context.Context
-	resp            chan *utilsmetav1.Response // Respose chan; nil if not interested.
-	callbackURL     string                     // validated scan-completion callback URL; empty if not requested.
-	isUserScan      bool                       // true when submitted via the Scan handler, not Metrics
+	scanInfo          *cautils.ScanInfo          // request as received from api
+	policyIdentifiers []cautils.PolicyIdentifier // policies to scan
+	scanQueryParams   *ScanQueryParams           // request as received from api
+	scanID            string                     // generated scan ID
+	ctx               context.Context
+	resp              chan *utilsmetav1.Response // Respose chan; nil if not interested.
+	callbackURL       string                     // validated scan-completion callback URL; empty if not requested.
+	isUserScan        bool                       // true when submitted via the Scan handler, not Metrics
 }
 
 // swagger:parameters triggerScan
@@ -107,11 +108,13 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 		logger.L().Info("REST API received scan request", helpers.String("scanID", scanID), helpers.String("format", scanRequest.Format))
 	}
 
+	scanInfo, policyIdentifiers := getScanCommand(scanRequest, scanID)
 	p := &scanRequestParams{
-		scanID:          scanID,
-		scanQueryParams: &ScanQueryParams{},
-		scanInfo:        getScanCommand(scanRequest, scanID),
-		isUserScan:      true,
+		scanID:            scanID,
+		scanQueryParams:   &ScanQueryParams{},
+		scanInfo:          scanInfo,
+		policyIdentifiers: policyIdentifiers,
+		isUserScan:        true,
 	}
 	if err := schema.NewDecoder().Decode(p.scanQueryParams, r.URL.Query()); err != nil {
 		return p, fmt.Errorf("failed to parse query params, reason: %s", err.Error())

--- a/httphandler/handlerequests/v1/requestshandler_test.go
+++ b/httphandler/handlerequests/v1/requestshandler_test.go
@@ -26,7 +26,7 @@ func testBody(t *testing.T) io.Reader {
 	return bytes.NewReader(b)
 }
 
-type scanner func(_ context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error)
+type scanner func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error)
 
 // TestScan tests that the scan handler passes the scan requests correctly to the underlying scan engine.
 func TestScan(t *testing.T) {
@@ -36,7 +36,7 @@ func TestScan(t *testing.T) {
 	withTempOutputDirs(t)
 
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		report := &reporthandlingv2.PostureReport{}
 		b, err := json.Marshal(report)
 		if err != nil {
@@ -98,7 +98,7 @@ func TestScan_SyncResponse(t *testing.T) {
 			withTempOutputDirs(t)
 
 			defer func(o scanner) { scanImpl = o }(scanImpl)
-			scanImpl = func(_ context.Context, _ *cautils.ScanInfo, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
 				if tt.writeResults {
 					b, err := json.Marshal(&reporthandlingv2.PostureReport{})
 					if err != nil {

--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -95,7 +95,7 @@ func TestGetScanCommand(t *testing.T) {
 	req := utilsmetav1.PostScanRequest{
 		TargetType: apisv1.KindFramework,
 	}
-	s := getScanCommand(&req, "abc")
+	s, _ := getScanCommand(&req, "abc")
 	assert.Equal(t, "", s.AccountID)
 	assert.Equal(t, "abc", s.ScanID)
 	assert.Equal(t, "v2", s.FormatVersion)
@@ -113,7 +113,7 @@ func TestGetScanCommandWithAccessKey(t *testing.T) {
 	req := utilsmetav1.PostScanRequest{
 		TargetType: apisv1.KindFramework,
 	}
-	s := getScanCommand(&req, "abc")
+	s, _ := getScanCommand(&req, "abc")
 	assert.Equal(t, "", s.AccountID)
 	assert.Equal(t, "abc", s.ScanID)
 	assert.Equal(t, "v2", s.FormatVersion)

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -62,7 +62,7 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	}()
 
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
-	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
+	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.policyIdentifiers, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {
 		if errors.Is(scanReq.ctx.Err(), context.Canceled) {
 			logger.L().Ctx(scanReq.ctx).Info("scan cancelled", helpers.String("ID", scanReq.scanID))
@@ -155,7 +155,7 @@ func (handler *HTTPHandler) watchForScan() {
 		handler.executeScan(scanReq)
 	}
 }
-func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
+func scan(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier, scanID string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
 	ctx, spanScan := otel.Tracer("").Start(ctx, "kubescape.scan")
 	defer spanScan.End()
 
@@ -172,7 +172,7 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, scanID string, skipPe
 		trace.WithAttributes(attribute.String("hostSensorYamlPath", scanInfo.HostSensorYamlPath)),
 	)
 
-	result, err := ks.Scan(scanInfo)
+	result, err := ks.Scan(scanInfo, policyIdentifiers)
 	if err != nil {
 		return nil, writeScanErrorToFile(err, scanID)
 	}
@@ -283,9 +283,9 @@ func removeResultsFile(fileID string) error {
 	return nil
 }
 
-func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *cautils.ScanInfo {
+func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) (*cautils.ScanInfo, []cautils.PolicyIdentifier) {
 
-	scanInfo := ToScanInfo(scanRequest)
+	scanInfo, policyIdentifiers := ToScanInfo(scanRequest)
 	scanInfo.ScanID = scanID
 
 	// *** start ***
@@ -301,7 +301,7 @@ func getScanCommand(scanRequest *utilsmetav1.PostScanRequest, scanID string) *ca
 	scanInfo.Output = filepath.Join(OutputDir, scanID)
 	// *** end ***
 
-	return scanInfo
+	return scanInfo, policyIdentifiers
 }
 
 func defaultScanInfo() *cautils.ScanInfo {

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -267,7 +267,7 @@ func TestStatus_InvalidQueryParams_Returns400(t *testing.T) {
 
 func TestScan_WhenScanFails_Returns500WithErrorType(t *testing.T) {
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		return nil, fmt.Errorf("rego evaluation failed: module not found")
 	}
 
@@ -300,7 +300,7 @@ func TestScan_WhenScanFails_Returns500WithErrorType(t *testing.T) {
 
 func TestScan_WhenScanPanics_RecoversAndReturns500(t *testing.T) {
 	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+	scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
 		panic("boom")
 	}
 


### PR DESCRIPTION
## Description
 
This PR resolves the TODO in `core/cautils/scaninfo.go` by removing the `Getters` embedded field and `PolicyIdentifier` slice from `cautils.ScanInfo`. These fields were coupling the CLI scan-input object to runtime policy-loading state, so they are now carried explicitly through the scan call path.
 
### What changed
 
- **`core/cautils/scaninfo.go`**
  - Removed `Getters` and `PolicyIdentifier` from the `ScanInfo` struct.
  - `Init` now accepts `policyIdentifiers []PolicyIdentifier`.
  - `scanInfoToScanMetadata` now accepts `policyIdentifiers []PolicyIdentifier`.
  - Added package helpers `BuildPolicyIdentifiers` and `ContainsIdentifier`.
 
- **`core/cautils/datastructures.go`**
  - `NewOPASessionObj` now accepts a `policyIdentifiers` parameter.
 
- **`core/meta/ksinterface.go` & `core/core/scan.go`**
  - `IKubescape.Scan` and `Kubescape.Scan` now take `policyIdentifiers []cautils.PolicyIdentifier`.
  - `getInterfaces` takes `policyIdentifiers` for the version check.
  - `Getters` is built locally in `Scan` and passed explicitly to `CollectPolicies` and `NewResourcesPrioritizationHandler`.
 
- **`core/pkg/policyhandler/handlepullpolicies.go`**
  - `CollectPolicies` now accepts `getters *cautils.Getters` and `policyIdentifiers []cautils.PolicyIdentifier` directly.
 
- **`cmd/scan/*` & `httphandler/handlerequests/v1/*`**
  - Commands and HTTP handlers build the policy identifier list with `cautils.BuildPolicyIdentifiers` and pass it through the call chain.
 
- **Mocks and tests**
  - Updated `core/mocks/cmd_mocks.go` and all affected `_test.go` files to match the new signatures.
 
### Verification
 
- `go build ./...` passes
- `go test -run '^$' ./...` passes (test discovery/compile)
- `go test ./core/pkg/policyhandler/... ./cmd/scan/...` passes
- `go test ./handlerequests/v1` in `httphandler` passes
- `go test -run 'TestScanInfo|TestNewOPASessionObj|...' ./core/cautils` passes
 
> Note: full `go test ./core/cautils` has an unrelated `TestKustomizeDirectoryWithHelmCharts` failure due to missing Helm in the test environment; it is not caused by this refactor.
 
### Related
 
- Resolves the TODO at `core/cautils/scaninfo.go:103-104`
closed - #2765


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Scan requests now preserve selected controls, frameworks, workloads, and cluster targets more consistently.
  * Targeted and framework-based scans apply policy selections reliably across command-line, API, and Prometheus-triggered scans.
  * Prometheus scans continue supporting framework selection and default to full scans when no frameworks are specified.
  * Scan configuration is handled more consistently across supported workflows.

* **Tests**
  * Expanded coverage for scan requests, workload scans, policy selection, and resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->