### PR TITLE
fix(resourcehandler): propagate streaming LIST failures

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -287,6 +287,9 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo, ksResourceMap cautils.ExternalResources, batchChan chan<- *cautils.ResourceBatch, resolver resourceResolver) error {
 	resident := cautils.NewResourceBatch(cautils.ClusterScope)
 	namespaceBatches := make(map[string]*cautils.ResourceBatch)
+	collectedK8sResources := queryableResources.ToK8sResourceMap()
+	failedQueries := make(map[string]queryFailure)
+	collectedAnyResource := false
 
 	// Single pass: pull each GVR once, partition by scope.
 	for key := range queryableResources {
@@ -295,11 +298,32 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 
 		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+		for _, se := range selectorErrs {
+			// Match the eager collection path: controls may reference optional
+			// CRDs which are not installed, so a missing resource is not a scan
+			// coverage failure.
+			if strings.Contains(se.err.Error(), "the server could not find the requested resource") {
+				continue
+			}
+			qualifiedKey := qr.GroupVersionResourceTriplet + "/" + se.selector
+			failedQueries[qualifiedKey] = queryFailure{
+				gvr:      qr.GroupVersionResourceTriplet,
+				selector: se.selector,
+				err:      se.err,
+			}
+		}
 		if len(result) == 0 && len(selectorErrs) > 0 {
 			continue
 		}
 
 		metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
+		if len(metaObjs) > 0 {
+			// recordFailedQueryStatuses only distinguishes an empty GVR from a
+			// non-empty one. Keep one representative ID instead of duplicating
+			// every ID already retained in the streaming batches.
+			collectedK8sResources[qr.GroupVersionResourceTriplet] = []string{metaObjs[0].GetID()}
+			collectedAnyResource = true
+		}
 
 		for _, metaObj := range metaObjs {
 			scope := cautils.ResourceScope(metaObj)
@@ -316,6 +340,34 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 				batch.AllResources[metaObj.GetID()] = metaObj
 			}
 		}
+	}
+
+	// Preserve the eager collector's failure contract. Whole-GVR failures feed
+	// InfoMap, while selector failures for a GVR that returned some resources
+	// remain non-fatal and are surfaced as partial coverage.
+	partialFailures := recordFailedQueryStatuses(failedQueries, collectedK8sResources, sessionObj.InfoMap)
+	if len(partialFailures) > 0 {
+		sessionObj.PartialGVRFailures = append(sessionObj.PartialGVRFailures, partialFailures...)
+		for _, p := range partialFailures {
+			logger.L().Ctx(ctx).Warning("partial resource collection: some resources may be missing from scan results",
+				helpers.String("gvr", p.GVR),
+				helpers.String("selector", p.Selector),
+				helpers.String("error", p.Error))
+		}
+	}
+	if !collectedAnyResource && len(failedQueries) > 0 {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("scan aborted: %w", ctxErr)
+		}
+		var combined []string
+		for _, f := range failedQueries {
+			combined = append(combined, fmt.Sprintf("%s: %s", f.gvr, f.err.Error()))
+		}
+		return fmt.Errorf("failed to pull any Kubernetes resources: %s", strings.Join(combined, "; "))
+	}
+	for _, f := range failedQueries {
+		logger.L().Ctx(ctx).Warning("failed to pull resource type",
+			helpers.String("gvr", f.gvr), helpers.Error(f.err))
 	}
 
 	// Collect external resources (host, cloud, RBAC, VAP) into the resident batch.

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -1,0 +1,259 @@
+package resourcehandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func streamingTestSession(ctx context.Context) (*cautils.ScanInfo, *cautils.OPASessionObj) {
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{"/not-a-cluster-scan"}}
+	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+}
+
+func testPodList(name, namespace string) *unstructured.UnstructuredList {
+	return &unstructured.UnstructuredList{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+		Items: []unstructured.Unstructured{{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		}}},
+	}
+}
+
+func TestCollectAndStreamBatches_FailsWhenAllQueriesFail(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden: cannot list %s", action.GetResource().Resource)
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 2)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.ErrorContains(t, err, "failed to pull any Kubernetes resources")
+	assert.ErrorContains(t, err, "forbidden")
+	assert.Empty(t, batches, "an all-failed collection must not emit an empty resident batch")
+
+	info, ok := session.InfoMap[podsGVR]
+	require.True(t, ok, "the failed GVR must be available to scan coverage")
+	assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
+	assert.Equal(t, apis.SubStatusNotEvaluated, info.SubStatus)
+}
+
+func TestCollectAndStreamBatches_IgnoresMissingOptionalResource(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("the server could not find the requested resource")
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const optionalGVR = "/v1/somecrd"
+	queryable := QueryableResources{
+		optionalGVR: {
+			GroupVersionResourceTriplet: optionalGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 2)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err, "an optional CRD that is not installed must not abort the scan")
+	assert.Empty(t, session.InfoMap)
+	assert.Empty(t, session.PartialGVRFailures)
+
+	require.Len(t, batches, 1)
+	resident := <-batches
+	assert.Equal(t, cautils.ClusterScope, resident.Scope)
+	assert.Empty(t, resident.AllResources)
+}
+
+func TestCollectAndStreamBatches_RecordsWholeGVRFailureAlongsideSuccess(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		switch action.GetResource().Resource {
+		case "pods":
+			return true, testPodList("survives", "default"), nil
+		case "clusterrolebindings":
+			return true, nil, fmt.Errorf("forbidden: cannot list clusterrolebindings")
+		default:
+			t.Fatalf("unexpected resource: %s", action.GetResource().Resource)
+			return true, nil, nil
+		}
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	clusterScoped := false
+	const (
+		podsGVR                = "/v1/pods"
+		clusterRoleBindingsGVR = "rbac.authorization.k8s.io/v1/clusterrolebindings"
+	)
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+		clusterRoleBindingsGVR: {
+			GroupVersionResourceTriplet: clusterRoleBindingsGVR,
+			Namespaced:                  &clusterScoped,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err, "a whole-GVR failure must not discard resources from another GVR")
+	info, ok := session.InfoMap[clusterRoleBindingsGVR]
+	require.True(t, ok, "the failed GVR must remain visible in scan coverage")
+	assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
+	assert.Equal(t, apis.SubStatusNotEvaluated, info.SubStatus)
+	assert.Empty(t, session.PartialGVRFailures)
+
+	require.Len(t, batches, 2)
+	resident := <-batches
+	defaultBatch := <-batches
+	assert.Equal(t, cautils.ClusterScope, resident.Scope)
+	assert.Equal(t, "default", defaultBatch.Scope)
+	assert.Len(t, defaultBatch.K8SResources[podsGVR], 1)
+}
+
+func TestCollectAndStreamBatches_RecordsPartialSelectorFailure(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListAction)
+		require.True(t, ok)
+		if listAction.GetListRestrictions().Fields.String() == "metadata.namespace=denied" {
+			return true, nil, fmt.Errorf("forbidden: cannot list pods in denied")
+		}
+		return true, testPodList("survives", "allowed"), nil
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	selectors := &staticFieldSelector{selectors: []string{
+		"metadata.namespace=allowed",
+		"metadata.namespace=denied",
+	}}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		selectors,
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err, "a partial selector failure must not abort a usable scan")
+	assert.NotContains(t, session.InfoMap, podsGVR, "a partially collected GVR is not wholly skipped")
+	require.Len(t, session.PartialGVRFailures, 1)
+	assert.Equal(t, podsGVR, session.PartialGVRFailures[0].GVR)
+	assert.Equal(t, "metadata.namespace=denied", session.PartialGVRFailures[0].Selector)
+	assert.Contains(t, session.PartialGVRFailures[0].Error, "forbidden")
+
+	require.Len(t, batches, 2)
+	resident := <-batches
+	allowed := <-batches
+	assert.Equal(t, cautils.ClusterScope, resident.Scope)
+	assert.Equal(t, "allowed", allowed.Scope)
+	assert.Len(t, allowed.AllResources, 1, "resources from successful selectors must survive")
+}
+
+func TestCollectAndStreamBatches_CleanSuccessHasNoFailureMetadata(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, testPodList("clean", "default"), nil
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, session.InfoMap)
+	assert.Empty(t, session.PartialGVRFailures)
+
+	require.Len(t, batches, 2)
+	resident := <-batches
+	defaultBatch := <-batches
+	assert.Equal(t, cautils.ClusterScope, resident.Scope)
+	assert.Equal(t, "default", defaultBatch.Scope)
+	assert.Len(t, defaultBatch.K8SResources[podsGVR], 1)
+}


### PR DESCRIPTION
## Overview

Bring streaming Kubernetes resource collection into parity with the eager
collector when LIST requests fail.

The streaming path previously discarded `selectorErrs`, so a collection with
no usable Kubernetes resources could emit an empty resident batch and return
success. This change:

- retains non-404 selector-level failures while collecting batches;
- reuses `recordFailedQueryStatuses` to populate `InfoMap` and
  `PartialGVRFailures`;
- preserves successfully collected resources when another selector or GVR
  fails;
- returns an error before emitting a batch when no Kubernetes resources were
  collected and at least one non-ignored LIST failed;
- preserves the existing optional-CRD behavior; and
- keeps only one representative ID per successful GVR for failure
  classification instead of retaining a second full copy of streamed resource
  IDs.

## How to Test

```sh
go test ./core/pkg/resourcehandler \
  -run '^TestCollectAndStreamBatches_' -count=1

go test ./core/pkg/resourcehandler -count=1

go test -race ./core/pkg/resourcehandler \
  -run '^TestCollectAndStreamBatches_' -count=1

go vet ./core/pkg/resourcehandler
```

The regression matrix covers:

- every LIST request failing;
- an optional CRD not being installed;
- one GVR failing completely while another returns usable resources;
- one selector failing while another returns a usable resource; and
- a clean successful collection.

## Related issues/PRs

- Resolves #2769
- Related: #2170
- Related: #2645

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added regression tests for the changed behavior
- [x] New and existing package tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan handling when Kubernetes resource collection encounters errors.
  * Missing optional resources are now ignored, while partial and complete failures are reported accurately.
  * Scans now return clear errors when collection fails entirely or is cancelled.
  * Successfully collected resources and scan status are preserved even when some collection operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->