### PR TITLE
fix(resultshandling): make finalized report ordering deterministic

### DIFF
--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"sort"
 	"time"
 
 	v5 "github.com/anchore/grype/grype/db/v5"
@@ -221,15 +222,19 @@ func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureRepor
 	return &report
 }
 func finalizeResults(results []resourcesresults.Result, resourcesResult map[string]resourcesresults.Result, prioritizedResources map[string]prioritization.PrioritizedResource) {
-	index := 0
+	resourceIDs := make([]string, 0, len(resourcesResult))
 	for resourceID := range resourcesResult {
+		resourceIDs = append(resourceIDs, resourceID)
+	}
+	sort.Strings(resourceIDs)
+
+	for index, resourceID := range resourceIDs {
 		results[index] = resourcesResult[resourceID]
 
 		// Add prioritization information to the result
 		if v, exist := prioritizedResources[resourceID]; exist {
 			results[index].PrioritizedResource = &v
 		}
-		index++
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -966,4 +968,49 @@ func TestFinalizeResults_PreservesExistingGenerationTime(t *testing.T) {
 	require.NotNil(t, report)
 	assert.Equal(t, preset, report.ReportGenerationTime)
 	assert.Equal(t, preset, session.Report.ReportGenerationTime)
+}
+
+func TestFinalizeResults_SortsResultsAndResourcesByResourceID(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+
+	resources := []workloadinterface.IMetadata{
+		createWorkloadWithLabels("zeta", "default", nil),
+		createWorkloadWithLabels("alpha", "default", nil),
+		createWorkloadWithLabels("kappa", "default", nil),
+		createWorkloadWithLabels("beta", "default", nil),
+		createWorkloadWithLabels("theta", "default", nil),
+		createWorkloadWithLabels("delta", "default", nil),
+		createWorkloadWithLabels("eta", "default", nil),
+		createWorkloadWithLabels("gamma", "default", nil),
+	}
+	expectedResourceIDs := make([]string, 0, len(resources))
+
+	// Insert resources in a deliberately non-canonical order. FinalizeResults
+	// must define its own stable order instead of exposing Go map iteration.
+	for _, resource := range resources {
+		resourceID := resource.GetID()
+		expectedResourceIDs = append(expectedResourceIDs, resourceID)
+		session.ResourcesResult[resourceID] = resourcesresults.Result{ResourceID: resourceID}
+		session.AllResources[resourceID] = resource
+	}
+	sort.Strings(expectedResourceIDs)
+
+	for i := 0; i < 64; i++ {
+		report := FinalizeResults(session)
+		require.NotNil(t, report)
+		require.Len(t, report.Results, len(expectedResourceIDs))
+		require.Len(t, report.Resources, len(expectedResourceIDs))
+
+		resultResourceIDs := make([]string, 0, len(report.Results))
+		for _, result := range report.Results {
+			resultResourceIDs = append(resultResourceIDs, result.ResourceID)
+		}
+		require.Equalf(t, expectedResourceIDs, resultResourceIDs, "results iteration %d", i)
+
+		resourceIDs := make([]string, 0, len(report.Resources))
+		for _, resource := range report.Resources {
+			resourceIDs = append(resourceIDs, resource.ResourceID)
+		}
+		require.Equalf(t, expectedResourceIDs, resourceIDs, "resources iteration %d", i)
+	}
 }


### PR DESCRIPTION
## Overview

`FinalizeResults` currently fills the report's `results` array by ranging directly over the `ResourcesResult` map. Since Go map iteration order is unspecified, identical session data can produce differently ordered result arrays. The derived raw `resources` array inherits the same ordering.

This change collects and sorts resource IDs before copying results into the report. Raw resources continue to be generated from that ordered result list, so both top-level arrays now follow a stable lexicographic resource-ID order.

Findings, scores, resource contents, omission behavior, and prioritization values are unchanged. The change only stabilizes array ordering for report comparisons and reduces noisy diffs.

## How to Test

```sh
go test -vet=off -p=1 ./core/pkg/resultshandling/printer/v2 -count=1

go test -race -vet=off -p=1 \
  ./core/pkg/resultshandling/printer/v2 \
  -run '^TestFinalizeResults_SortsResultsAndResourcesByResourceID$' \
  -count=1

go vet ./core/pkg/resultshandling/printer/v2
```

The regression test inserts eight resources in non-canonical order, finalizes the same session 64 times, and verifies the exact resource-ID order of both `results` and `resources` on every iteration.

## Related issues/PRs

- Related: #2731 and #2734 made the separate `kubescape diff` output path deterministic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report results and resources are now presented consistently in resource ID order.
  * Prioritization data remains correctly aligned with the sorted resources.

* **Tests**
  * Added regression coverage to verify consistent ordering across repeated executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->