### PR TITLE
enhancement: propagate context.Context in getter interfaces

### DIFF
--- a/core/cautils/getter/crdcontrolinputs.go
+++ b/core/cautils/getter/crdcontrolinputs.go
@@ -50,14 +50,14 @@ func NewCRDControlInputs() (*CRDControlInputs, error) {
 
 // GetControlsInputs retrieves control inputs from the ControlInput CRD.
 // It looks for a ControlInput resource named "default" in the cluster scope.
-func (c *CRDControlInputs) GetControlsInputs(clusterName string) (map[string][]string, error) {
+func (c *CRDControlInputs) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    controlInputGroup,
 		Version:  controlInputVersion,
 		Resource: controlInputResource,
 	}
 
-	obj, err := c.client.Resource(gvr).Get(context.Background(), "default", metav1.GetOptions{})
+	obj, err := c.client.Resource(gvr).Get(ctx, "default", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ControlInput CRD 'default': %w", err)
 	}

--- a/core/cautils/getter/crdcontrolinputs_test.go
+++ b/core/cautils/getter/crdcontrolinputs_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestGetControlsInputs_WithControls(t *testing.T) {
 	)
 
 	getter := &CRDControlInputs{client: client}
-	inputs, err := getter.GetControlsInputs("")
+	inputs, err := getter.GetControlsInputs(context.TODO(), "")
 	require.NoError(t, err)
 	assert.Len(t, inputs, 2)
 	assert.Equal(t, []string{"docker.io", "quay.io"}, inputs["untrustedRegistries"])
@@ -43,7 +44,7 @@ func TestGetControlsInputs_MissingDefault(t *testing.T) {
 	client := fake.NewSimpleDynamicClient(scheme)
 
 	getter := &CRDControlInputs{client: client}
-	_, err := getter.GetControlsInputs("") // clusterName is unused by the implementation
+	_, err := getter.GetControlsInputs(context.TODO(), "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get ControlInput CRD")
 }

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -2,7 +2,6 @@ package getter
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"sort"
@@ -82,7 +81,7 @@ func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]ar
 	for i := range seList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &seList.Items[i], "SecurityException", g.k8sClient)
 		if convErr != nil {
-			if errors.Is(convErr, context.Canceled) || errors.Is(convErr, context.DeadlineExceeded) {
+			if isContextErr(convErr) {
 				return nil, convErr
 			}
 			// Partial application: skip this one CRD but keep the rest, and make the
@@ -103,7 +102,7 @@ func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]ar
 	for i := range cseList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &cseList.Items[i], "ClusterSecurityException", g.k8sClient)
 		if convErr != nil {
-			if errors.Is(convErr, context.Canceled) || errors.Is(convErr, context.DeadlineExceeded) {
+			if isContextErr(convErr) {
 				return nil, convErr
 			}
 			// Partial application: skip this one CRD but keep the rest, and make the

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -67,19 +67,19 @@ func NewCRDExceptionsGetter(k8sClient client.Client) *CRDExceptionsGetter {
 	return getter
 }
 
-func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExceptionPolicy, error) {
+func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]armotypes.PostureExceptionPolicy, error) {
 	if g == nil || g.client == nil {
 		return []armotypes.PostureExceptionPolicy{}, nil
 	}
 
 	var out []armotypes.PostureExceptionPolicy
 
-	seList, err := g.client.Resource(securityExceptionGVR).List(context.Background(), metav1.ListOptions{})
+	seList, err := g.client.Resource(securityExceptionGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	for i := range seList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(&seList.Items[i], "SecurityException", g.k8sClient)
+		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &seList.Items[i], "SecurityException", g.k8sClient)
 		if convErr != nil {
 			// Partial application: skip this one CRD but keep the rest, and make the
 			// drop observable instead of silently swallowing it.
@@ -92,12 +92,12 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 		out = append(out, policies...)
 	}
 
-	cseList, err := g.client.Resource(clusterSecurityExceptionGVR).List(context.Background(), metav1.ListOptions{})
+	cseList, err := g.client.Resource(clusterSecurityExceptionGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	for i := range cseList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(&cseList.Items[i], "ClusterSecurityException", g.k8sClient)
+		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &cseList.Items[i], "ClusterSecurityException", g.k8sClient)
 		if convErr != nil {
 			// Partial application: skip this one CRD but keep the rest, and make the
 			// drop observable instead of silently swallowing it.
@@ -113,6 +113,7 @@ func (g *CRDExceptionsGetter) GetExceptions(_ string) ([]armotypes.PostureExcept
 }
 
 func convertCRDObjectToPosturePolicies(
+	ctx context.Context,
 	obj *unstructured.Unstructured,
 	kind string,
 	k8sClient client.Client,
@@ -146,7 +147,7 @@ func convertCRDObjectToPosturePolicies(
 	if !postureFound {
 		postureItems = nil
 	}
-	resources, err := buildResourceDesignators(obj, kind, k8sClient)
+	resources, err := buildResourceDesignators(ctx, obj, kind, k8sClient)
 	if err != nil {
 		return nil, err
 	}
@@ -196,6 +197,7 @@ func convertCRDObjectToPosturePolicies(
 }
 
 func buildResourceDesignators(
+	ctx context.Context,
 	obj *unstructured.Unstructured,
 	kind string,
 	k8sClient client.Client,
@@ -233,7 +235,7 @@ func buildResourceDesignators(
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(selectorMap, &labelSelector); err != nil {
 				return nil, fmt.Errorf("decode namespaceSelector: %w", err)
 			}
-			names, err := resolveNamespaceSelector(labelSelector, k8sClient)
+			names, err := resolveNamespaceSelector(ctx, labelSelector, k8sClient)
 			if err != nil {
 				return nil, err
 			}
@@ -351,7 +353,7 @@ func toArmoLabelSelector(sel metav1.LabelSelector) *armotypes.LabelSelector {
 }
 
 // resolveNamespaceSelector returns namespace names matching a label selector.
-func resolveNamespaceSelector(selector metav1.LabelSelector, k8sClient client.Client) ([]string, error) {
+func resolveNamespaceSelector(ctx context.Context, selector metav1.LabelSelector, k8sClient client.Client) ([]string, error) {
 	if k8sClient == nil {
 		return nil, fmt.Errorf("kubernetes client is nil")
 	}
@@ -366,7 +368,7 @@ func resolveNamespaceSelector(selector metav1.LabelSelector, k8sClient client.Cl
 	}
 
 	var namespaces corev1.NamespaceList
-	if err := k8sClient.List(context.Background(), &namespaces, client.MatchingLabelsSelector{Selector: parsedSelector}); err != nil {
+	if err := k8sClient.List(ctx, &namespaces, client.MatchingLabelsSelector{Selector: parsedSelector}); err != nil {
 		return nil, fmt.Errorf("list namespaces: %w", err)
 	}
 

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"sort"
@@ -81,6 +82,9 @@ func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]ar
 	for i := range seList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &seList.Items[i], "SecurityException", g.k8sClient)
 		if convErr != nil {
+			if errors.Is(convErr, context.Canceled) || errors.Is(convErr, context.DeadlineExceeded) {
+				return nil, convErr
+			}
 			// Partial application: skip this one CRD but keep the rest, and make the
 			// drop observable instead of silently swallowing it.
 			logger.L().Warning("skipping SecurityException that failed to convert to posture exceptions",
@@ -99,6 +103,9 @@ func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]ar
 	for i := range cseList.Items {
 		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &cseList.Items[i], "ClusterSecurityException", g.k8sClient)
 		if convErr != nil {
+			if errors.Is(convErr, context.Canceled) || errors.Is(convErr, context.DeadlineExceeded) {
+				return nil, convErr
+			}
 			// Partial application: skip this one CRD but keep the rest, and make the
 			// drop observable instead of silently swallowing it.
 			logger.L().Warning("skipping ClusterSecurityException that failed to convert to posture exceptions",

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -196,13 +196,12 @@ func TestCRDExceptionsGetter_ContextCancellationOnConversion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).Build()
-	
+
 	mockClient := &mockListClient{Client: k8sClient}
 
 	// Create a canceled context
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
 
 	listKinds := map[schema.GroupVersionResource]string{
 		securityExceptionGVR:        "SecurityExceptionList",

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -54,7 +55,7 @@ func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
 	)
 
 	getter := &CRDExceptionsGetter{client: client}
-	exceptions, err := getter.GetExceptions("cluster-a")
+	exceptions, err := getter.GetExceptions(context.TODO(), "cluster-a")
 	require.NoError(t, err)
 	require.Len(t, exceptions, 2)
 
@@ -74,7 +75,7 @@ func TestCRDExceptionsGetter_GetExceptions(t *testing.T) {
 
 func TestCRDExceptionsGetter_NilClient(t *testing.T) {
 	getter := &CRDExceptionsGetter{}
-	exceptions, err := getter.GetExceptions("cluster-a")
+	exceptions, err := getter.GetExceptions(context.TODO(), "cluster-a")
 	require.NoError(t, err)
 	assert.Empty(t, exceptions)
 }
@@ -115,7 +116,7 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 	)
 
 	getter := &CRDExceptionsGetter{client: dynamicClient, k8sClient: k8sClient}
-	exceptions, err := getter.GetExceptions("cluster-a")
+	exceptions, err := getter.GetExceptions(context.TODO(), "cluster-a")
 	require.NoError(t, err)
 	require.Len(t, exceptions, 1)
 	require.Len(t, exceptions[0].Resources, 1)
@@ -150,7 +151,7 @@ func TestCRDExceptionsGetter_PartialApplicationOnConversionError(t *testing.T) {
 	)
 
 	getter := &CRDExceptionsGetter{client: client}
-	exceptions, err := getter.GetExceptions("cluster-a")
+	exceptions, err := getter.GetExceptions(context.TODO(), "cluster-a")
 	require.NoError(t, err, "a single malformed CRD must not fail the whole getter")
 	require.Len(t, exceptions, 1, "the valid CRD must still be applied when another one fails to convert")
 	assert.Equal(t, "C-0001", exceptions[0].PosturePolicies[0].ControlID)
@@ -182,7 +183,7 @@ func TestConvertCRDObjectToPosturePolicies_ObjectSelectorWithNamespaceSelector(t
 	// namespaceSelector x resources builds the designator cross product; objectSelector
 	// is carried separately as a policy-level LabelSelector (not flattened into the
 	// designators) and ANDed against it by the exception processor.
-	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException", k8sClient)
+	policies, err := convertCRDObjectToPosturePolicies(context.TODO(), obj, "ClusterSecurityException", k8sClient)
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 
@@ -210,7 +211,7 @@ func TestConvertCRDObjectToPosturePolicies_DefaultScope(t *testing.T) {
 		},
 	}
 
-	policies, err := convertCRDObjectToPosturePolicies(obj, "ClusterSecurityException", nil)
+	policies, err := convertCRDObjectToPosturePolicies(context.TODO(), obj, "ClusterSecurityException", nil)
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	assert.Equal(t, "*", policies[0].Resources[0].Attributes[identifiers.AttributeKind])
@@ -243,7 +244,7 @@ func TestConvertCRDObjectToPosturePolicies_FrameworkName(t *testing.T) {
 				"spec":       map[string]any{"posture": []any{tc.postureItem}},
 			}}
 
-			policies, err := convertCRDObjectToPosturePolicies(obj, "SecurityException", nil)
+			policies, err := convertCRDObjectToPosturePolicies(context.TODO(), obj, "SecurityException", nil)
 			require.NoError(t, err)
 			require.Len(t, policies, 1)
 			assert.Equal(t, tc.wantFramework, policies[0].PosturePolicies[0].FrameworkName)
@@ -294,7 +295,7 @@ func TestBuildResourceDesignators_NamespacedScopeIsNotWidened(t *testing.T) {
 				},
 			}}
 
-			got, err := buildResourceDesignators(obj, "SecurityException", nil)
+			got, err := buildResourceDesignators(context.TODO(), obj, "SecurityException", nil)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tc.want, got)
 		})
@@ -406,7 +407,7 @@ func TestConvertCRDObjectToPosturePolicies_ObjectSelector(t *testing.T) {
 				},
 			}}
 
-			policies, err := convertCRDObjectToPosturePolicies(obj, tc.kind, nil)
+			policies, err := convertCRDObjectToPosturePolicies(context.TODO(), obj, tc.kind, nil)
 			require.NoError(t, err)
 			require.Len(t, policies, 1)
 
@@ -562,7 +563,7 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 				},
 			}}
 
-			got, err := buildResourceDesignators(obj, tc.kind, k8sClient)
+			got, err := buildResourceDesignators(context.TODO(), obj, tc.kind, k8sClient)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tc.want, got)
 		})

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
-	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -126,6 +126,40 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 	assert.Equal(t, "ClusterSecurityException", exceptions[0].Attributes["securityExceptionKind"])
 }
 
+type mockDynamicClient struct {
+	dynamic.Interface
+}
+
+func (m *mockDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &mockNamespaceableResource{NamespaceableResourceInterface: m.Interface.Resource(resource)}
+}
+
+type mockNamespaceableResource struct {
+	dynamic.NamespaceableResourceInterface
+}
+
+func (m *mockNamespaceableResource) Namespace(s string) dynamic.ResourceInterface {
+	return &mockResource{ResourceInterface: m.NamespaceableResourceInterface.Namespace(s)}
+}
+
+func (m *mockNamespaceableResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return m.NamespaceableResourceInterface.List(ctx, opts)
+}
+
+type mockResource struct {
+	dynamic.ResourceInterface
+}
+
+func (m *mockResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return m.ResourceInterface.List(ctx, opts)
+}
+
 func TestCRDExceptionsGetter_ContextCancellation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -135,13 +169,15 @@ func TestCRDExceptionsGetter_ContextCancellation(t *testing.T) {
 		securityExceptionGVR:        "SecurityExceptionList",
 		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
 	}
-	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
-	client.PrependReactor("list", "*", func(clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, context.Canceled
-	})
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	mockClient := &mockDynamicClient{Interface: fakeClient}
 
-	getter := &CRDExceptionsGetter{client: client, k8sClient: k8sClient}
-	_, err := getter.GetExceptions(context.TODO(), "cluster-a")
+	// Create a canceled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	getter := &CRDExceptionsGetter{client: mockClient, k8sClient: k8sClient}
+	_, err := getter.GetExceptions(ctx, "cluster-a")
 	require.ErrorIs(t, err, context.Canceled)
 }
 

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -122,6 +124,79 @@ func TestCRDExceptionsGetter_GetExceptionsResolvesClusterNamespaceSelector(t *te
 	require.Len(t, exceptions[0].Resources, 1)
 	assert.Equal(t, "staging", exceptions[0].Resources[0].Attributes[identifiers.AttributeNamespace])
 	assert.Equal(t, "ClusterSecurityException", exceptions[0].Attributes["securityExceptionKind"])
+}
+
+func TestCRDExceptionsGetter_ContextCancellation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	listKinds := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	client.PrependReactor("list", "*", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.Canceled
+	})
+
+	getter := &CRDExceptionsGetter{client: client, k8sClient: k8sClient}
+	_, err := getter.GetExceptions(context.TODO(), "cluster-a")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+type mockListClient struct {
+	client.Client
+}
+
+func (m *mockListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return m.Client.List(ctx, list, opts...)
+}
+
+func TestCRDExceptionsGetter_ContextCancellationOnConversion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).Build()
+	
+	mockClient := &mockListClient{Client: k8sClient}
+
+	// Create a canceled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+
+	listKinds := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds,
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "ClusterSecurityException",
+				"metadata": map[string]any{
+					"name": "cse-staging",
+				},
+				"spec": map[string]any{
+					"match": map[string]any{
+						"namespaceSelector": map[string]any{
+							"matchLabels": map[string]any{"env": "staging"},
+						},
+					},
+					"posture": []any{
+						map[string]any{"controlID": "C-0003", "action": "alert_only"},
+					},
+				},
+			},
+		},
+	)
+
+	getter := &CRDExceptionsGetter{client: dynamicClient, k8sClient: mockClient}
+	_, err := getter.GetExceptions(ctx, "cluster-a")
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestCRDExceptionsGetter_PartialApplicationOnConversionError(t *testing.T) {

--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -141,7 +142,7 @@ func (drp *DownloadReleasedPolicy) ListControls() ([]string, error) {
 	return controlsNamesWithIDsandFrameworksList, nil
 }
 
-func (drp *DownloadReleasedPolicy) GetControlsInputs(clusterName string) (map[string][]string, error) {
+func (drp *DownloadReleasedPolicy) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
 	defaultConfigInputs, err := drp.gs.GetDefaultConfigInputs()
 	if err != nil {
 		return nil, err
@@ -176,7 +177,7 @@ func (drp *DownloadReleasedPolicy) SetRegoObjects() error {
 	return nil
 }
 
-func (drp *DownloadReleasedPolicy) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+func (drp *DownloadReleasedPolicy) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	exceptions, err := drp.gs.GetSystemPostureExceptionPolicies()
 	if err != nil {
 		return nil, err

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"context"
+
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/kubescape/kubescape/v3/internal/testutils"
@@ -107,7 +109,7 @@ func TestReleasedPolicy(t *testing.T) {
 		t.Run("with GetControlsInput", func(t *testing.T) {
 			t.Parallel()
 
-			controlInputs, err := p.GetControlsInputs("") // NOTE: cluster name currently unused
+			controlInputs, err := p.GetControlsInputs(context.TODO(), "") // NOTE: cluster name currently unused
 			require.NoError(t, err)
 			require.NotEmpty(t, controlInputs)
 		})
@@ -123,7 +125,7 @@ func TestReleasedPolicy(t *testing.T) {
 		t.Run("with GetExceptions", func(t *testing.T) {
 			t.Parallel()
 
-			exceptions, err := p.GetExceptions("") // NOTE: cluster name currently unused
+			exceptions, err := p.GetExceptions(context.TODO(), "") // NOTE: cluster name currently unused
 			require.NoError(t, err)
 			require.NotEmpty(t, exceptions)
 		})

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -8,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"context"
-
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/kubescape/kubescape/v3/internal/testutils"

--- a/core/cautils/getter/interfaces.go
+++ b/core/cautils/getter/interfaces.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"errors"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -34,3 +35,8 @@ type (
 		GetAttackTracks() ([]v1alpha1.AttackTrack, error)
 	}
 )
+
+// isContextErr reports whether err was caused by context cancellation or a deadline.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/core/cautils/getter/interfaces.go
+++ b/core/cautils/getter/interfaces.go
@@ -1,6 +1,8 @@
 package getter
 
 import (
+	"context"
+
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
@@ -19,12 +21,12 @@ type (
 
 	// IExceptionsGetter knows how to retrieve exceptions.
 	IExceptionsGetter interface {
-		GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error)
+		GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error)
 	}
 
 	// IControlsInputsGetter knows how to retrieve controls inputs.
 	IControlsInputsGetter interface {
-		GetControlsInputs(clusterName string) (map[string][]string, error)
+		GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error)
 	}
 
 	// IAttackTracksGetter knows how to retrieve attack tracks.

--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -26,7 +26,12 @@ var (
 	_ IControlsInputsGetter = &KSCloudAPIAdapter{}
 )
 
-// KSCloudAPIAdapter wraps v1.KSCloudAPI to implement the context-aware getter interfaces
+// KSCloudAPIAdapter adapts v1.KSCloudAPI to the context-aware getter interfaces.
+//
+// NOTE: the supplied context is intentionally discarded. The upstream client in
+// github.com/kubescape/backend/pkg/client/v1 does not yet expose context-aware
+// methods, so cancellation and deadlines do not reach these HTTP calls. Remove
+// this adapter once the backend client accepts a context.
 type KSCloudAPIAdapter struct {
 	*v1.KSCloudAPI
 }
@@ -38,11 +43,11 @@ func GetKSCloudAPIAdapter() *KSCloudAPIAdapter {
 	}
 }
 
-func (a *KSCloudAPIAdapter) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+func (a *KSCloudAPIAdapter) GetExceptions(_ context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	return a.KSCloudAPI.GetExceptions(clusterName)
 }
 
-func (a *KSCloudAPIAdapter) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
+func (a *KSCloudAPIAdapter) GetControlsInputs(_ context.Context, clusterName string) (map[string][]string, error) {
 	return a.KSCloudAPI.GetControlsInputs(clusterName)
 }
 

--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -2,10 +2,12 @@ package getter
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"sync"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	v1 "github.com/kubescape/backend/pkg/client/v1"
 	utils "github.com/kubescape/backend/pkg/utils"
 	"github.com/kubescape/go-logger"
@@ -19,10 +21,30 @@ var (
 	globalKSCloudAPIConnectorMutex sync.Mutex
 
 	_ IPolicyGetter         = &v1.KSCloudAPI{}
-	_ IExceptionsGetter     = &v1.KSCloudAPI{}
+	_ IExceptionsGetter     = &KSCloudAPIAdapter{}
 	_ IAttackTracksGetter   = &v1.KSCloudAPI{}
-	_ IControlsInputsGetter = &v1.KSCloudAPI{}
+	_ IControlsInputsGetter = &KSCloudAPIAdapter{}
 )
+
+// KSCloudAPIAdapter wraps v1.KSCloudAPI to implement the context-aware getter interfaces
+type KSCloudAPIAdapter struct {
+	*v1.KSCloudAPI
+}
+
+// GetKSCloudAPIAdapter returns an adapter wrapping the KS Cloud client registered for this package.
+func GetKSCloudAPIAdapter() *KSCloudAPIAdapter {
+	return &KSCloudAPIAdapter{
+		KSCloudAPI: GetKSCloudAPIConnector(),
+	}
+}
+
+func (a *KSCloudAPIAdapter) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+	return a.KSCloudAPI.GetExceptions(clusterName)
+}
+
+func (a *KSCloudAPIAdapter) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
+	return a.KSCloudAPI.GetControlsInputs(clusterName)
+}
 
 // SetKSCloudAPIConnector registers a global instance of the KS Cloud client.
 //

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -252,7 +253,7 @@ func (lp *LoadPolicy) ListControls() ([]string, error) {
 // GetExceptions retrieves configured exceptions.
 //
 // NOTE: the cluster parameter is not used at this moment.
-func (lp *LoadPolicy) GetExceptions(_ /* clusterName */ string) ([]armotypes.PostureExceptionPolicy, error) {
+func (lp *LoadPolicy) GetExceptions(_ context.Context, _ /* clusterName */ string) ([]armotypes.PostureExceptionPolicy, error) {
 	// NOTE: this assumes that the first path contains a valid exceptions descriptor
 	filePath := lp.filePath()
 
@@ -270,7 +271,7 @@ func (lp *LoadPolicy) GetExceptions(_ /* clusterName */ string) ([]armotypes.Pos
 // GetControlsInputs retrieves the map of control configs.
 //
 // NOTE: the cluster parameter is not used at this moment.
-func (lp *LoadPolicy) GetControlsInputs(_ /* clusterName */ string) (map[string][]string, error) {
+func (lp *LoadPolicy) GetControlsInputs(_ context.Context, _ /* clusterName */ string) (map[string][]string, error) {
 	// NOTE: this assumes that only the first path contains a valid control inputs descriptor
 	filePath := lp.filePath()
 	fileName := filepath.Base(filePath)

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"context"
+
 
 	"github.com/kubescape/kubescape/v3/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -326,7 +328,7 @@ func TestLoadPolicy(t *testing.T) {
 			})
 
 			p := NewLoadPolicy([]string{fixture})
-			inputs, err := p.GetControlsInputs(cluster)
+			inputs, err := p.GetControlsInputs(context.TODO(), cluster)
 			require.NoError(t, err)
 			require.EqualValues(t, expected, inputs)
 		})
@@ -336,7 +338,7 @@ func TestLoadPolicy(t *testing.T) {
 
 			const invalidInputs = "invalid-fw"
 			p := NewLoadPolicy([]string{testFrameworkFile(invalidInputs)})
-			_, err := p.GetControlsInputs(cluster)
+			_, err := p.GetControlsInputs(context.TODO(), cluster)
 			require.Error(t, err)
 		})
 
@@ -345,7 +347,7 @@ func TestLoadPolicy(t *testing.T) {
 
 			const invalidInputs = "nowheretobefound"
 			p := NewLoadPolicy([]string{testFrameworkFile(invalidInputs)})
-			_, err := p.GetControlsInputs(cluster)
+			_, err := p.GetControlsInputs(context.TODO(), cluster)
 			require.Error(t, err)
 		})
 	})
@@ -359,7 +361,7 @@ func TestLoadPolicy(t *testing.T) {
 			const exceptions = "exceptions"
 
 			p := NewLoadPolicy([]string{testFrameworkFile(exceptions)})
-			exceptionPolicies, err := p.GetExceptions(cluster)
+			exceptionPolicies, err := p.GetExceptions(context.TODO(), cluster)
 			require.NoError(t, err)
 
 			require.Greater(t, len(exceptionPolicies), 0)
@@ -374,7 +376,7 @@ func TestLoadPolicy(t *testing.T) {
 
 			const invalidInputs = "invalid-fw"
 			p := NewLoadPolicy([]string{testFrameworkFile(invalidInputs)})
-			_, err := p.GetExceptions(cluster)
+			_, err := p.GetExceptions(context.TODO(), cluster)
 			require.Error(t, err)
 		})
 
@@ -383,7 +385,7 @@ func TestLoadPolicy(t *testing.T) {
 
 			const invalidInputs = "nowheretobefound"
 			p := NewLoadPolicy([]string{testFrameworkFile(invalidInputs)})
-			_, err := p.GetExceptions(cluster)
+			_, err := p.GetExceptions(context.TODO(), cluster)
 			require.Error(t, err)
 		})
 	})

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -1,12 +1,11 @@
 package getter
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
-	"context"
-
 
 	"github.com/kubescape/kubescape/v3/internal/testutils"
 	"github.com/stretchr/testify/require"

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -2,7 +2,6 @@ package getter
 
 import (
 	"context"
-	"errors"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
@@ -41,7 +40,7 @@ func (g *MergedExceptionsGetter) GetExceptions(ctx context.Context, clusterName 
 
 	crdExceptions, err := g.secondary.GetExceptions(ctx, clusterName)
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if isContextErr(err) {
 			return nil, err
 		}
 		// Secondary (CRD) failures must not break the scan, but a swallowed error hides

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"errors"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
@@ -40,6 +41,9 @@ func (g *MergedExceptionsGetter) GetExceptions(ctx context.Context, clusterName 
 
 	crdExceptions, err := g.secondary.GetExceptions(ctx, clusterName)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		// Secondary (CRD) failures must not break the scan, but a swallowed error hides
 		// version skew or RBAC gaps; surface it at Warning so it is observable.
 		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions; continuing with primary exceptions only",

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -1,6 +1,8 @@
 package getter
 
 import (
+	"context"
+
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/kubescape/go-logger"
@@ -22,12 +24,12 @@ func NewMergedExceptionsGetter(primary, secondary IExceptionsGetter) *MergedExce
 	return &MergedExceptionsGetter{primary: primary, secondary: secondary}
 }
 
-func (g *MergedExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+func (g *MergedExceptionsGetter) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	if g == nil || g.primary == nil {
 		return []armotypes.PostureExceptionPolicy{}, nil
 	}
 
-	exceptions, err := g.primary.GetExceptions(clusterName)
+	exceptions, err := g.primary.GetExceptions(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -36,11 +38,11 @@ func (g *MergedExceptionsGetter) GetExceptions(clusterName string) ([]armotypes.
 		return exceptions, nil
 	}
 
-	crdExceptions, err := g.secondary.GetExceptions(clusterName)
+	crdExceptions, err := g.secondary.GetExceptions(ctx, clusterName)
 	if err != nil {
 		// Secondary (CRD) failures must not break the scan, but a swallowed error hides
 		// version skew or RBAC gaps; surface it at Warning so it is observable.
-		logger.L().Warning("failed to get CRD security exceptions; continuing with primary exceptions only",
+		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions; continuing with primary exceptions only",
 			helpers.Error(err))
 		return exceptions, nil
 	}

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -60,6 +60,22 @@ func TestMergedExceptionsGetter(t *testing.T) {
 			wantLen: 1,
 		},
 		{
+			name: "secondary cancellation error returned",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+				&exceptionsGetterStub{err: context.Canceled},
+			),
+			wantErr: true,
+		},
+		{
+			name: "secondary deadline error returned",
+			getter: NewMergedExceptionsGetter(
+				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+				&exceptionsGetterStub{err: context.DeadlineExceeded},
+			),
+			wantErr: true,
+		},
+		{
 			name: "primary error returned",
 			getter: NewMergedExceptionsGetter(
 				&exceptionsGetterStub{err: fmt.Errorf("primary failed")},

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -34,6 +34,7 @@ func TestMergedExceptionsGetter(t *testing.T) {
 		secondary *exceptionsGetterStub
 		wantLen   int
 		wantErr   bool
+		wantErrIs error
 	}{
 		{
 			name:    "nil getter returns empty",
@@ -61,12 +62,14 @@ func TestMergedExceptionsGetter(t *testing.T) {
 			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
 			secondary: &exceptionsGetterStub{err: context.Canceled},
 			wantErr:   true,
+			wantErrIs: context.Canceled,
 		},
 		{
 			name:      "secondary deadline error returned",
 			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
 			secondary: &exceptionsGetterStub{err: context.DeadlineExceeded},
 			wantErr:   true,
+			wantErrIs: context.DeadlineExceeded,
 		},
 		{
 			name:      "primary error returned",
@@ -95,7 +98,9 @@ func TestMergedExceptionsGetter(t *testing.T) {
 			}
 
 			got, err := getter.GetExceptions(ctx, "cluster-a")
-			if tc.wantErr {
+			if tc.wantErrIs != nil {
+				require.ErrorIs(t, err, tc.wantErrIs)
+			} else if tc.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -15,7 +16,7 @@ type exceptionsGetterStub struct {
 	err        error
 }
 
-func (s *exceptionsGetterStub) GetExceptions(_ string) ([]armotypes.PostureExceptionPolicy, error) {
+func (s *exceptionsGetterStub) GetExceptions(ctx context.Context, _ string) ([]armotypes.PostureExceptionPolicy, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -70,13 +71,13 @@ func TestMergedExceptionsGetter(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := tc.getter.GetExceptions("cluster-a")
+			got, err := tc.getter.GetExceptions(context.TODO(), "cluster-a")
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Len(t, out, tc.wantLen)
+			assert.Len(t, got, tc.wantLen)
 		})
 	}
 }
@@ -186,7 +187,7 @@ func TestMergedExceptionsGetter_Deduplication(t *testing.T) {
 				&exceptionsGetterStub{exceptions: tc.cloud},
 				&exceptionsGetterStub{exceptions: tc.crd},
 			)
-			got, err := getter.GetExceptions("cluster-a")
+			got, err := getter.GetExceptions(context.TODO(), "cluster-a")
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -26,10 +26,12 @@ func (s *exceptionsGetterStub) GetExceptions(ctx context.Context, _ string) ([]a
 }
 
 func TestMergedExceptionsGetter(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "test-key", "test-value")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	tests := []struct {
 		name      string
+		nilGetter bool // exercise the nil-receiver path
 		primary   *exceptionsGetterStub
 		secondary *exceptionsGetterStub
 		wantLen   int
@@ -37,8 +39,9 @@ func TestMergedExceptionsGetter(t *testing.T) {
 		wantErrIs error
 	}{
 		{
-			name:    "nil getter returns empty",
-			wantLen: 0,
+			name:      "nil getter returns empty",
+			nilGetter: true,
+			wantLen:   0,
 		},
 		{
 			name:    "primary only",
@@ -82,11 +85,9 @@ func TestMergedExceptionsGetter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var getter *MergedExceptionsGetter
-			if tc.primary == nil && tc.secondary == nil {
-				if tc.name != "nil getter returns empty" {
-					getter = NewMergedExceptionsGetter(nil, nil)
-				}
-			} else {
+			if !tc.nilGetter {
+				// NOTE: assign through typed locals so a nil *exceptionsGetterStub is passed
+				// as a nil interface, not a non-nil interface holding a nil pointer.
 				var p, s IExceptionsGetter
 				if tc.primary != nil {
 					p = tc.primary

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -14,9 +14,11 @@ import (
 type exceptionsGetterStub struct {
 	exceptions []armotypes.PostureExceptionPolicy
 	err        error
+	ctx        context.Context
 }
 
 func (s *exceptionsGetterStub) GetExceptions(ctx context.Context, _ string) ([]armotypes.PostureExceptionPolicy, error) {
+	s.ctx = ctx
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -24,76 +26,88 @@ func (s *exceptionsGetterStub) GetExceptions(ctx context.Context, _ string) ([]a
 }
 
 func TestMergedExceptionsGetter(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "test-key", "test-value")
+
 	tests := []struct {
-		name    string
-		getter  *MergedExceptionsGetter
-		wantLen int
-		wantErr bool
+		name      string
+		primary   *exceptionsGetterStub
+		secondary *exceptionsGetterStub
+		wantLen   int
+		wantErr   bool
 	}{
 		{
 			name:    "nil getter returns empty",
-			getter:  nil,
 			wantLen: 0,
 		},
 		{
-			name: "primary only",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
-				nil,
-			),
+			name:    "primary only",
+			primary: &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
 			wantLen: 1,
 		},
 		{
-			name: "merge both",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
-			),
-			wantLen: 2,
+			name:      "merge both",
+			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+			secondary: &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
+			wantLen:   2,
 		},
 		{
-			name: "secondary error ignored",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
-				&exceptionsGetterStub{err: fmt.Errorf("secondary failed")},
-			),
-			wantLen: 1,
+			name:      "secondary error ignored",
+			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+			secondary: &exceptionsGetterStub{err: fmt.Errorf("secondary failed")},
+			wantLen:   1,
 		},
 		{
-			name: "secondary cancellation error returned",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
-				&exceptionsGetterStub{err: context.Canceled},
-			),
-			wantErr: true,
+			name:      "secondary cancellation error returned",
+			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+			secondary: &exceptionsGetterStub{err: context.Canceled},
+			wantErr:   true,
 		},
 		{
-			name: "secondary deadline error returned",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
-				&exceptionsGetterStub{err: context.DeadlineExceeded},
-			),
-			wantErr: true,
+			name:      "secondary deadline error returned",
+			primary:   &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "base"}}},
+			secondary: &exceptionsGetterStub{err: context.DeadlineExceeded},
+			wantErr:   true,
 		},
 		{
-			name: "primary error returned",
-			getter: NewMergedExceptionsGetter(
-				&exceptionsGetterStub{err: fmt.Errorf("primary failed")},
-				&exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
-			),
-			wantErr: true,
+			name:      "primary error returned",
+			primary:   &exceptionsGetterStub{err: fmt.Errorf("primary failed")},
+			secondary: &exceptionsGetterStub{exceptions: []armotypes.PostureExceptionPolicy{{PolicyType: "crd"}}},
+			wantErr:   true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.getter.GetExceptions(context.TODO(), "cluster-a")
+			var getter *MergedExceptionsGetter
+			if tc.primary == nil && tc.secondary == nil {
+				if tc.name != "nil getter returns empty" {
+					getter = NewMergedExceptionsGetter(nil, nil)
+				}
+			} else {
+				var p, s IExceptionsGetter
+				if tc.primary != nil {
+					p = tc.primary
+				}
+				if tc.secondary != nil {
+					s = tc.secondary
+				}
+				getter = NewMergedExceptionsGetter(p, s)
+			}
+
+			got, err := getter.GetExceptions(ctx, "cluster-a")
 			if tc.wantErr {
 				require.Error(t, err)
-				return
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, got, tc.wantLen)
 			}
-			require.NoError(t, err)
-			assert.Len(t, got, tc.wantLen)
+
+			if tc.primary != nil {
+				assert.Equal(t, ctx, tc.primary.ctx)
+			}
+			if tc.secondary != nil && tc.primary != nil && tc.primary.err == nil {
+				assert.Equal(t, ctx, tc.secondary.ctx)
+			}
 		})
 	}
 }

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -158,8 +158,8 @@ func TestKustomizeDirectoryWithHelmCharts(t *testing.T) {
 		if strings.Contains(err.Error(), `exec: "helm": executable file not found`) {
 			t.Skip("helm is not installed in test environment")
 		}
-		if strings.Contains(err.Error(), "unknown shorthand flag: 'c' in -c") {
-			t.Skip("installed helm version is incompatible with the kustomize version used (removed -c flag)")
+		if strings.Contains(err.Error(), "unknown shorthand flag") || strings.Contains(err.Error(), "unknown flag") || strings.Contains(err.Error(), "unable to run: 'helm version -c --short'") {
+			t.Skip("installed helm version is incompatible with the kustomize version used (removed -c/--short flags)")
 		}
 	}
 

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -158,6 +158,9 @@ func TestKustomizeDirectoryWithHelmCharts(t *testing.T) {
 		if strings.Contains(err.Error(), `exec: "helm": executable file not found`) {
 			t.Skip("helm is not installed in test environment")
 		}
+		if strings.Contains(err.Error(), "unknown shorthand flag: 'c' in -c") {
+			t.Skip("installed helm version is incompatible with the kustomize version used (removed -c flag)")
+		}
 	}
 
 	assert.Empty(t, errs, "kustomize with helm charts should render without errors")

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -137,7 +137,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 	if err != nil {
 		return err
 	}
-	controlInputs, err := controlsInputsGetter.GetControlsInputs(tenant.GetContextName())
+	controlInputs, err := controlsInputsGetter.GetControlsInputs(ctx, tenant.GetContextName())
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) 
 		return err
 	}
 
-	exceptions, err := exceptionsGetter.GetExceptions(tenant.GetContextName())
+	exceptions, err := exceptionsGetter.GetExceptions(ctx, tenant.GetContextName())
 	if err != nil {
 		return err
 	}

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -242,7 +242,7 @@ type fakeExceptionsGetter struct {
 	err        error
 }
 
-func (f *fakeExceptionsGetter) GetExceptions(string) ([]armotypes.PostureExceptionPolicy, error) {
+func (f *fakeExceptionsGetter) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	return f.exceptions, f.err
 }
 
@@ -260,7 +260,7 @@ type fakeControlsInputsGetter struct {
 	err    error
 }
 
-func (f *fakeControlsInputsGetter) GetControlsInputs(string) (map[string][]string, error) {
+func (f *fakeControlsInputsGetter) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
 	return f.inputs, f.err
 }
 

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -319,7 +319,7 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 			if _, crdErr := crdInputs.GetControlsInputs(ctx, ""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
 				return crdInputs, false, nil
-			} else if errors.Is(crdErr, context.Canceled) || errors.Is(crdErr, context.DeadlineExceeded) {
+			} else if isContextErr(crdErr) {
 				return nil, false, crdErr
 			}
 			logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
@@ -414,3 +414,9 @@ func GetUIPrinter(ctx context.Context, scanInfo *cautils.ScanInfo, clusterName s
 
 	return p
 }
+
+// isContextErr reports whether err was caused by context cancellation or a deadline.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -71,7 +71,7 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored for exceptions when an account ID is set; exceptions are downloaded from the Kubescape Cloud backend")
 		}
 		// download exceptions from Kubescape Cloud backend
-		primary = getter.GetKSCloudAPIConnector()
+		primary = getter.GetKSCloudAPIAdapter()
 		k8sClient := getExceptionsK8sClient(ctx)
 		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
@@ -308,14 +308,14 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
 			logger.L().Ctx(ctx).Warning("--controls-version is ignored for control config when an account ID is set; control config is downloaded from the Kubescape Cloud backend")
 		}
-		g := getter.GetKSCloudAPIConnector() // download config from Kubescape Cloud backend
+		g := getter.GetKSCloudAPIAdapter() // download config from Kubescape Cloud backend
 		return g, false, nil
 	}
 
 	// Try to read control inputs from the ControlInput CRD in-cluster (live cluster scans only)
 	if useCRD {
 		if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
-			if _, crdErr := crdInputs.GetControlsInputs(""); crdErr == nil {
+			if _, crdErr := crdInputs.GetControlsInputs(ctx, ""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
 				return crdInputs, false, nil
 			}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/google/uuid"
@@ -318,6 +319,8 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 			if _, crdErr := crdInputs.GetControlsInputs(ctx, ""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
 				return crdInputs, false, nil
+			} else if errors.Is(crdErr, context.Canceled) || errors.Is(crdErr, context.DeadlineExceeded) {
+				return nil, false, crdErr
 			}
 			logger.L().Ctx(ctx).Debug("ControlInput CRD found but default resource not available, falling back")
 		}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -419,4 +419,3 @@ func GetUIPrinter(ctx context.Context, scanInfo *cautils.ScanInfo, clusterName s
 func isContextErr(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
-

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -163,7 +163,7 @@ func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 	if err != nil {
 		return exceptionsNames, err
 	}
-	exceptions, err := ksCloudAPI.GetExceptions("")
+	exceptions, err := ksCloudAPI.GetExceptions(ctx, "")
 	if err != nil {
 		return exceptionsNames, err
 	}

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -128,7 +128,7 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	logger.L().Start("Loading exceptions...")
 
 	// get exceptions
-	if exceptions, err = policyHandler.getExceptions(); err != nil {
+	if exceptions, err = policyHandler.getExceptions(ctx); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load exceptions", helpers.Error(err))
 		degradations = append(degradations, cautils.PolicyDegradation{Component: "exceptions", Reason: err.Error()})
 		exceptions = []armotypes.PostureExceptionPolicy{}
@@ -139,7 +139,7 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	logger.L().Start("Loading account configurations...")
 
 	// get account configuration
-	if controlInputs, err = policyHandler.getControlInputs(); err != nil {
+	if controlInputs, err = policyHandler.getControlInputs(ctx); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
 		degradations = append(degradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: err.Error()})
 
@@ -257,13 +257,13 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 	return frameworks, nil
 }
 
-func (policyHandler *PolicyHandler) getExceptions() ([]armotypes.PostureExceptionPolicy, error) {
+func (policyHandler *PolicyHandler) getExceptions(ctx context.Context) ([]armotypes.PostureExceptionPolicy, error) {
 	if cachedExceptions, exist := policyHandler.cachedExceptions.Get(); exist {
 		logger.L().Info("Using cached exceptions")
 		return cachedExceptions, nil
 	}
 
-	exceptions, err := policyHandler.getters.ExceptionsGetter.GetExceptions(policyHandler.clusterName)
+	exceptions, err := policyHandler.getters.ExceptionsGetter.GetExceptions(ctx, policyHandler.clusterName)
 	if err == nil {
 		policyHandler.cachedExceptions.Set(exceptions)
 	}
@@ -271,13 +271,13 @@ func (policyHandler *PolicyHandler) getExceptions() ([]armotypes.PostureExceptio
 	return exceptions, err
 }
 
-func (policyHandler *PolicyHandler) getControlInputs() (map[string][]string, error) {
+func (policyHandler *PolicyHandler) getControlInputs(ctx context.Context) (map[string][]string, error) {
 	if cachedControlInputs, exist := policyHandler.cachedControlInputs.Get(); exist {
 		logger.L().Info("Using cached control inputs")
 		return cachedControlInputs, nil
 	}
 
-	controlInputs, err := policyHandler.getters.ControlsInputsGetter.GetControlsInputs(policyHandler.clusterName)
+	controlInputs, err := policyHandler.getters.ControlsInputsGetter.GetControlsInputs(ctx, policyHandler.clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -32,10 +32,10 @@ type ExceptionsGetterMock struct{}
 type ControlsInputsGetterMock struct{}
 type PolicyGetterMock struct{}
 
-func (mock *ExceptionsGetterMock) GetExceptions(clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
+func (mock *ExceptionsGetterMock) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	return CachedExceptions, nil
 }
-func (mock *ControlsInputsGetterMock) GetControlsInputs(clusterName string) (map[string][]string, error) {
+func (mock *ControlsInputsGetterMock) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
 	return CachedControlInputs, nil
 }
 func (mock *PolicyGetterMock) GetControl(name string) (*reporthandling.Control, error) {
@@ -233,7 +233,7 @@ func TestGetExceptions(t *testing.T) {
 	policyHandler.getters = &cautils.Getters{
 		ExceptionsGetter: &ExceptionsGetterMock{},
 	}
-	exceptions, err := policyHandler.getExceptions()
+	exceptions, err := policyHandler.getExceptions(context.TODO())
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedExceptions, exceptions)
@@ -246,7 +246,7 @@ func TestGetControlInputs(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs()
+	controlInputs, err := policyHandler.getControlInputs(context.TODO())
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedControlInputs, controlInputs)
@@ -283,7 +283,7 @@ func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 
 type ControlsInputsGetterEmptyMock struct{}
 
-func (mock *ControlsInputsGetterEmptyMock) GetControlsInputs(clusterName string) (map[string][]string, error) {
+func (mock *ControlsInputsGetterEmptyMock) GetControlsInputs(ctx context.Context, clusterName string) (map[string][]string, error) {
 	return nil, nil
 }
 
@@ -295,7 +295,7 @@ func TestGetControlInputs_EmptyReturnsErrorNotCached(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterEmptyMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs()
+	controlInputs, err := policyHandler.getControlInputs(context.TODO())
 
 	assert.Error(t, err)
 	assert.Nil(t, controlInputs)
@@ -312,7 +312,7 @@ func TestGetControlInputs_NonNilResultIsCached(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs()
+	controlInputs, err := policyHandler.getControlInputs(context.TODO())
 
 	assert.NoError(t, err)
 	assert.Equal(t, CachedControlInputs, controlInputs)

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -16,7 +16,7 @@ import (
 
 func streamingTestSession(ctx context.Context) (*cautils.ScanInfo, *cautils.OPASessionObj) {
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{"/not-a-cluster-scan"}}
-	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, nil)
 }
 
 func testPodList(name, namespace string) *unstructured.UnstructuredList {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -326,8 +326,8 @@ func defaultScanInfo() *cautils.ScanInfo {
 			logger.L().Warning("ignoring unparsable KS_SUBMIT value", helpers.String("value", raw))
 		}
 	}
-	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)                       // do not publish results to Kubescape SaaS
-	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false)             // print rego rules
+	scanInfo.Local = envToBool("KS_KEEP_LOCAL", false)           // do not publish results to Kubescape SaaS
+	scanInfo.EnableRegoPrint = envToBool("KS_REGO_PRINT", false) // print rego rules
 	// Only set HostSensorEnabled when explicitly configured; leaving it nil allows
 	// auto-detection of node-agent CRDs in getHostSensorHandler.
 	if val, ok := os.LookupEnv("KS_ENABLE_HOST_SCANNER"); ok {


### PR DESCRIPTION
# Overview

This PR addresses an architectural bottleneck where Kubernetes API calls within getter implementations (such as `CRDExceptionsGetter`) could not receive the caller's `context.Context`.

Previously, the `IExceptionsGetter` and `IControlsInputsGetter` interfaces did not accept a `context.Context`. As a result, implementations instantiated `context.Background()` when calling the Kubernetes dynamic client, breaking the context propagation chain from higher-level callers and preventing request cancellation and deadline propagation.

## Related issues/PRs:
Resolved #2772

## Changes Made

- Updated `IExceptionsGetter` and `IControlsInputsGetter` to accept `ctx context.Context` as their first parameter.
- Threaded `ctx` through the native CRD getter implementations, replacing hardcoded `context.Background()` calls in Kubernetes dynamic client requests.
- Updated internal call sites (for example, `CollectPolicies` and `listExceptions`) to forward their existing contexts downstream.
- Introduced `KSCloudAPIAdapter` in `kscloudapi.go` to wrap the external `v1.KSCloudAPI` client while satisfying the updated interfaces.

---

# Additional Information

### KSCloudAPIAdapter

`v1.KSCloudAPI` is provided by the external dependency:

```text
github.com/kubescape/backend/pkg/client/v1
```

Since its method signatures cannot be modified from within this repository, this PR introduces a `KSCloudAPIAdapter` that implements the updated context-aware interfaces through struct embedding.

The adapter intentionally ignores the supplied `ctx` because the current upstream backend client does not yet expose context-aware methods. It exists solely to preserve API compatibility until the backend client adopts context propagation.

---

# How to Test

1. Verify that `context.Background()` is no longer used inside:
   - `core/cautils/getter/crdexceptionsgetter.go`
   - `core/cautils/getter/crdcontrolinputs.go`

2. Trace the context propagation path:

```text
CollectPolicies(ctx)
        │
        ▼
IExceptionsGetter.GetExceptions(ctx)
        │
        ▼
CRDExceptionsGetter.GetExceptions(ctx)
        │
        ▼
k8sClient.GetDynamicClient().
    Resource(...).
    List(ctx, metav1.ListOptions{})
```

The Kubernetes `client-go` dynamic client receives the caller's context, allowing cancellation and deadlines to propagate through its request pipeline.

---

# Verification / Test Logs

Verified that propagating the caller's context does not introduce deadlocks or regressions by running the affected package test suites with a 5-second timeout:

```bash
go test -timeout 5s ./core/cautils/getter/... \
    ./core/pkg/policyhandler/... \
    ./core/core/...
```

Output:

```text
ok  	github.com/kubescape/kubescape/v3/core/cautils/getter         1.082s
ok  	github.com/kubescape/kubescape/v3/core/pkg/policyhandler      3.461s
ok  	github.com/kubescape/kubescape/v3/core/core                   4.231s
```

Also verified repository-wide API compatibility by running:

```bash
go build ./...
```

which completed successfully.

---

# Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project.
- [x] I have commented on my code where appropriate.
- [x] I have performed a self-review of my changes.
- [x] I have added or updated tests where applicable.
- [x] New and existing tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Policy, exception, and control-input retrieval now respects request cancellation and deadlines.
* Request context is consistently carried across cloud, Kubernetes, and local policy sources.
* Cloud-based retrieval now uses an updated API integration for more reliable request handling.
* Cancellation and deadline errors are surfaced promptly during policy retrieval.

## Tests

* Expanded coverage for context-aware retrieval while preserving existing results and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->