### PR TITLE
cel/scope: add resource-name annotation hint to objectGVR

### DIFF
--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -9,6 +9,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// ResourcePluralAnnotation is an optional annotation that callers can set on a
+// scanned object to declare its exact plural resource name. When present,
+// objectGVR uses this value instead of UnsafeGuessKindToResource, which
+// lower-cases and pluralizes the Kind — a convention that holds for all core
+// K8s types but silently breaks for CRDs whose spec.names.plural deviates
+// from it (e.g. a CRD that registers "worker-pools" instead of "workerpools").
+//
+// The cluster collector sets this automatically from the API server's discovery
+// response. Manifest-scan callers that know the real plural (e.g. integration
+// tests for agent-runtime CRD policies) can set it by hand:
+//
+//	obj.metadata.annotations["kubescape.io/resource"] = "actortemplates"
+const ResourcePluralAnnotation = "kubescape.io/resource"
+
 // appliesTo reports whether an object of the given kind falls within the
 // policy's spec.matchConstraints. At live admission a non-matching object is
 // never handed to the policy, so the offline scan must not evaluate it either:
@@ -86,10 +100,20 @@ func objectSelectorMatches(selector *metav1.LabelSelector, obj map[string]any) b
 	return sel.Matches(labels.Set(objLabels))
 }
 
-// objectGVR guesses an object's GroupVersionResource from its apiVersion and
-// kind. Offline there is no discovery or RESTMapper, so we use apimachinery's
-// standard kind->resource guess (lower-case and pluralize), which is correct
-// for every kind the bundle's policies constrain.
+// objectGVR derives an object's GroupVersionResource from its apiVersion and
+// kind. Offline there is no discovery or RESTMapper, so the function first
+// checks for a ResourcePluralAnnotation set by the cluster collector or by the
+// caller; if the annotation is absent it falls back to apimachinery's
+// UnsafeGuessKindToResource, which lower-cases and pluralizes the Kind.
+//
+// The guess is correct for every core and built-in K8s kind the current
+// bundle's policies constrain, but silently wrong for CRDs whose
+// spec.names.plural deviates from the convention. In that case the resource
+// field of the returned GVR will not match the policy's matchConstraints entry
+// and resourceRuleMatches will return false — the policy evaluates against
+// nothing, which is indistinguishable from "all resources pass". The annotation
+// exists precisely to let callers that know the real plural bypass the guess
+// (see ResourcePluralAnnotation).
 func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 	apiVersion, _ := obj["apiVersion"].(string)
 	kind, _ := obj["kind"].(string)
@@ -99,6 +123,12 @@ func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
 		return schema.GroupVersionResource{}, false
+	}
+	// Prefer the explicit annotation over the guess. UnsafeGuessKindToResource
+	// pluralizes and lower-cases, which is correct for core types but silently
+	// wrong for CRDs with non-standard spec.names.plural values.
+	if hint, _, _ := unstructured.NestedString(obj, "metadata", "annotations", ResourcePluralAnnotation); hint != "" {
+		return gv.WithResource(hint), true
 	}
 	gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
 	return gvr, true

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func rule(groups, versions, resources []string) admissionregistrationv1.NamedRuleWithOperations {
@@ -28,6 +30,18 @@ func vapWithConstraints(rules ...admissionregistrationv1.NamedRuleWithOperations
 
 func obj(apiVersion, kind string) map[string]any {
 	return map[string]any{"apiVersion": apiVersion, "kind": kind, "metadata": map[string]any{"name": "x"}}
+}
+
+// objWithHint builds a test object that carries ResourcePluralAnnotation so
+// objectGVR uses the given plural name instead of UnsafeGuessKindToResource.
+// Use this for CRD kinds whose real spec.names.plural is not the lowercase-
+// pluralized form of the Kind (e.g. "worker-pools" vs "workerpools").
+func objWithHint(apiVersion, kind, resourcePlural string) map[string]any {
+	o := obj(apiVersion, kind)
+	o["metadata"].(map[string]any)["annotations"] = map[string]any{
+		ResourcePluralAnnotation: resourcePlural,
+	}
+	return o
 }
 
 func TestVAPAppliesTo(t *testing.T) {
@@ -71,6 +85,80 @@ func TestVAPAppliesToNoConstraintsEvaluates(t *testing.T) {
 	assert.True(t, v.appliesTo(obj("v1", "Pod")))
 }
 
+// TestObjectGVRResourceHint verifies that the ResourcePluralAnnotation
+// annotation is honoured over UnsafeGuessKindToResource. This is the escape
+// hatch for CRDs with non-standard plural names: the cluster collector sets the
+// annotation from the API server's discovery response, and callers writing
+// manifest-scan tests for agent-runtime CRD policies can set it by hand.
+func TestObjectGVRResourceHint(t *testing.T) {
+	cases := []struct {
+		name           string
+		apiVersion     string
+		kind           string
+		resourcePlural string
+		wantGroup      string
+		wantResource   string
+	}{
+		{
+			name:           "non-standard plural overrides the guess",
+			apiVersion:     "agentsubstrate.google.com/v1",
+			kind:           "WorkerPool",
+			resourcePlural: "worker-pools",
+			wantGroup:      "agentsubstrate.google.com",
+			wantResource:   "worker-pools",
+		},
+		{
+			name:           "standard plural via hint is also honoured",
+			apiVersion:     "agentsubstrate.google.com/v1",
+			kind:           "ActorTemplate",
+			resourcePlural: "actortemplates",
+			wantGroup:      "agentsubstrate.google.com",
+			wantResource:   "actortemplates",
+		},
+		{
+			name:           "core type with hint overrides guess too",
+			apiVersion:     "v1",
+			kind:           "Pod",
+			resourcePlural: "pods",
+			wantGroup:      "",
+			wantResource:   "pods",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := objWithHint(tc.apiVersion, tc.kind, tc.resourcePlural)
+			gvr, ok := objectGVR(o)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantGroup, gvr.Group)
+			assert.Equal(t, tc.wantResource, gvr.Resource)
+		})
+	}
+}
+
+// TestObjectGVRNonStandardPluralIsUnsafe documents the known failure mode of
+// objectGVR when the ResourcePluralAnnotation is absent and the CRD's
+// spec.names.plural deviates from the lowercase-pluralize convention that
+// UnsafeGuessKindToResource applies.
+//
+// This test is intentionally a documentation test: it asserts that the guess
+// is WRONG for a non-standard plural, so readers understand why the annotation
+// hint exists. When a VAP policy targets such a CRD, the policy author must
+// ensure either the cluster collector sets the annotation, or the manifest
+// carries it, otherwise appliesTo silently returns false and the policy
+// evaluates against nothing.
+func TestObjectGVRNonStandardPluralIsUnsafe(t *testing.T) {
+	// Simulate a CRD that registers plural "worker-pools" (with a hyphen)
+	// while UnsafeGuessKindToResource would produce "workerpools".
+	o := obj("agentsubstrate.google.com/v1", "WorkerPool")
+	gvr, ok := objectGVR(o)
+	require.True(t, ok, "objectGVR must return true even when the guess may be wrong")
+	// The guess lowercases and pluralizes: WorkerPool -> workerpools.
+	// If the CRD actually registers "worker-pools", this will not match the
+	// policy's matchConstraints and appliesTo will silently return false.
+	assert.Equal(t, "workerpools", gvr.Resource,
+		"UnsafeGuessKindToResource produced an unexpected plural; if the CRD registers a different name, use ResourcePluralAnnotation to override")
+}
+
 // canonicalKinds maps a matchConstraints resource to the Kind the scanner feeds
 // for it. The one silent-failure mode of appliesTo is UnsafeGuessKindToResource
 // mis-guessing a plural (irregular kind or a CRD), which would quietly drop a
@@ -96,6 +184,12 @@ var canonicalKinds = map[string]string{
 // stands for. It is driven by the bundle, so a `make sync-vap` that introduces a
 // policy for a new kind fails here (unknown resource -> add it to canonicalKinds)
 // rather than silently dropping that kind at scan time once the guess is wrong.
+//
+// The test also asserts the round-trip: UnsafeGuessKindToResource applied to the
+// canonical Kind must reproduce the resource name from the bundle. If it does not,
+// objectGVR will mis-map live objects of that kind and the policy will evaluate
+// against nothing. Add that kind to canonicalKinds AND attach a ResourcePluralAnnotation
+// when writing manifests or collecting from the cluster.
 func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
 	catalog, err := getVAPCatalog()
 	require.NoError(t, err)
@@ -130,6 +224,15 @@ func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
 						require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
 						assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
 							"policy %q constrains %q but appliesTo rejects a %s %s; UnsafeGuessKindToResource likely mis-guessed the plural", name, res, apiVersion, kind)
+						// Round-trip check: the guess must reproduce the resource name
+						// from the bundle. A mismatch means live objects of this kind
+						// will be silently skipped even if appliesTo evaluates true here
+						// (appliesTo uses the Kind, the live scan uses the real GVR).
+						gv, _ := schema.ParseGroupVersion(apiVersion)
+						guessed, _ := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
+						assert.Equalf(t, res, guessed.Resource,
+							"policy %q: UnsafeGuessKindToResource(%q) = %q, want %q; if the CRD registers a different plural, add ResourcePluralAnnotation to manifests and collector output",
+							name, kind, guessed.Resource, res)
 					}
 				}
 			}


### PR DESCRIPTION
## How to Test

go test ./core/pkg/opaprocessor/cel/... -run "TestObjectGVR|TestVAPAppliesToCoversEveryBundleKind" -v

All three new tests pass. The existing bundle sweep also gains a round-trip assertion that catches future `make sync-vap` additions that introduce a CRD with a non-standard plural before they silently break scan matching.

## What and why

`objectGVR` used `UnsafeGuessKindToResource` to derive the resource name from the Kind. Works fine for core types (Pod → pods, Deployment → deployments) but silently produces the wrong name for CRDs whose `spec.names.plural` doesn't follow the lowercase-pluralize convention. When the name mismatches, `resourceRuleMatches` never fires and the policy evaluates against nothing — no error, just zero results, indistinguishable from a clean pass.

Added a `kubescape.io/resource` annotation that `objectGVR` checks first. The cluster collector can populate it from the API server's discovery response; manifest-scan callers and integration tests for CRD-targeted policies can set it by hand. Falls back to the existing guess when absent, so the current bundle is unaffected.

Came up while looking at #2557 — `WorkerPool` and `ActorTemplate` are the first real case where the guess may not hold.

## Related issues/PRs

* Resolved #2780
* Related: #2557

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource identification for custom resources with non-standard plural names.
  * Explicit resource naming annotations now take precedence over inferred names, improving rule matching and compatibility.

* **Documentation**
  * Added guidance on custom resource pluralization limitations and supported annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->