### PR TITLE
fix(resourcehandler): repair NewOPASessionObj call broken by merge

### DIFF
--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -16,7 +16,7 @@ import (
 
 func streamingTestSession(ctx context.Context) (*cautils.ScanInfo, *cautils.OPASessionObj) {
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{"/not-a-cluster-scan"}}
-	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, nil)
 }
 
 func testPodList(name, namespace string) *unstructured.UnstructuredList {


### PR DESCRIPTION
## Overview

`master` doesn't currently compile its tests. On `95a70f29`:

```
$ go vet ./core/pkg/resourcehandler/
vet: core/pkg/resourcehandler/k8sresources_streaming_failures_test.go:19:67:
     not enough arguments in call to cautils.NewOPASessionObj
	have (context.Context, nil, nil, *cautils.ScanInfo)
	want (context.Context, []reporthandling.Framework, cautils.K8SResources, *cautils.ScanInfo, []cautils.PolicyIdentifier)
```

This looks like a semantic merge conflict rather than anyone's mistake. #2768
added the `policyIdentifiers` parameter and updated every call site that
existed at the time. #2771 added `k8sresources_streaming_failures_test.go`,
which calls the old four-argument form. Both were green on their own branches,
but the merged result isn't.

Every other call site in the tree already passes five arguments, so this just
brings the one straggler in line by passing `nil` for `policyIdentifiers`, the
same as the other tests do.

## How to Test

Before:

```bash
go vet ./core/pkg/resourcehandler/   # fails to build
```

After:

```bash
go vet ./...                                    # clean
go test ./core/pkg/resourcehandler/ -count=1    # ok
```

The five tests in that file could not run at all before this. They all pass now:

```
--- PASS: TestCollectAndStreamBatches_FailsWhenAllQueriesFail
--- PASS: TestCollectAndStreamBatches_IgnoresMissingOptionalResource
--- PASS: TestCollectAndStreamBatches_RecordsWholeGVRFailureAlongsideSuccess
--- PASS: TestCollectAndStreamBatches_RecordsPartialSelectorFailure
--- PASS: TestCollectAndStreamBatches_CleanSuccessHasNoFailureMetadata
```

Also ran `go test -race ./core/pkg/resourcehandler/ -count=2`, clean.

## Related issues/PRs

Fallout from #2768 and #2771 interacting, no fault of either on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated streaming failure test setup to remain compatible with the current session initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->