### PR TITLE
test(cautils): use t.Setenv so env vars are restored between runs

### DIFF
--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -292,9 +292,9 @@ func TestGetConfigMapNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.env != "" {
-				t.Setenv("KS_DEFAULT_CONFIGMAP_NAMESPACE", tt.env)
-			}
+			// Set unconditionally, including the empty "no env" case, so the
+			// subtest does not inherit a value from the caller's environment.
+			t.Setenv(defaultConfigMapNamespaceEnvVar, tt.env)
 			assert.Equalf(t, tt.want, GetConfigMapNamespace(), "GetConfigMapNamespace()")
 		})
 	}

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -209,7 +209,7 @@ func TestAdoptClusterName(t *testing.T) {
 func TestUpdateCloudURLs(t *testing.T) {
 	co := mockConfigObj()
 	mockCloudAPIURL := "1-2-3-4.com"
-	os.Setenv("KS_CLOUD_API_URL", mockCloudAPIURL)
+	t.Setenv("KS_CLOUD_API_URL", mockCloudAPIURL)
 
 	assert.NotEqual(t, co.CloudAPIURL, mockCloudAPIURL)
 	updateCloudURLs(co)
@@ -293,7 +293,7 @@ func TestGetConfigMapNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != "" {
-				_ = os.Setenv("KS_DEFAULT_CONFIGMAP_NAMESPACE", tt.env)
+				t.Setenv("KS_DEFAULT_CONFIGMAP_NAMESPACE", tt.env)
 			}
 			assert.Equalf(t, tt.want, GetConfigMapNamespace(), "GetConfigMapNamespace()")
 		})


### PR DESCRIPTION
## Overview

`go test ./core/cautils/ -count=2` fails on master:

```
--- FAIL: TestGetConfigMapNamespace/no_env
    Error: Not equal:
           expected: "kubescape"
           actual  : "my-ns"
```

The subtests in `TestGetConfigMapNamespace` set `KS_DEFAULT_CONFIGMAP_NAMESPACE`
with `os.Setenv` and never restore it. They run in the order `no env`,
`default ns`, `custom ns`, so the last one leaves the variable set to `my-ns`.
On the second iteration `no env` no longer runs with the variable unset and
reads the leftover value instead of the default.

Switching to `t.Setenv` restores the previous value when each subtest ends.
That is already what the sibling test at `customerloader_data_driven_test.go:269`
does, so this just makes the two consistent.

Also changed `TestUpdateCloudURLs` (line 212), which leaks `KS_CLOUD_API_URL`
into the rest of the package run the same way. That one does not break anything
today, so it is included as the same one-word change rather than as a fix for
an observed failure.

No production code is touched.

## How to Test

Before:

```bash
go test ./core/cautils/ -count=2   # FAIL
```

After:

```bash
go test ./core/cautils/ -count=5              # ok
go test -shuffle=on ./core/cautils/ -count=3  # ok
go test -race ./core/cautils/ -count=2        # ok
go test ./core/... -count=2                   # ok
```

## Related issues/PRs

Resolved #2784

Found while working on #2761; @matthyx suggested opening it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test environment handling by automatically restoring environment variables after each test.
  * Ensured empty-value scenarios are isolated from the caller’s environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->