### PR TITLE
feat: support all output formats for image scans

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -48,7 +48,7 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			}
 
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
+				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml")
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ImageScanFormats); err != nil {
 				return err

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -48,7 +49,7 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			}
 
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ImageScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ImageScanFormats); err != nil {
 				return err

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -79,7 +79,7 @@ func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", ""))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, sarif", err.Error())
+	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml", err.Error())
 }
 
 func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {
@@ -93,7 +93,7 @@ func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, sarif, yaml`)
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml`)
 }
 
 func TestGetImageCmd_RunE_Success(t *testing.T) {

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -12,11 +12,12 @@ import (
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
-// ScanFormats and ImageScanFormats list the output formats supported by the scan commands.
-// They are built from the printer.*Format constants to keep a single source of truth.
+// ScanFormats and ImageScanFormats are derived from printer.AllFormats and
+// printer.ImageFormats to keep a single source of truth — see printresults.go
+// for why the two lists differ (not every printer supports image scans, e.g. CSV).
 var (
-	ScanFormats      = []string{printer.PrettyFormat, printer.JsonFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.HtmlFormat, printer.SARIFFormat, printer.GitLabSASTFormat, printer.YamlFormat, printer.CsvFormat}
-	ImageScanFormats = []string{printer.PrettyFormat, printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat}
+	ScanFormats      = printer.AllFormats
+	ImageScanFormats = printer.ImageFormats
 )
 
 var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are: %s", strings.Join(reporthandlingapis.GetSupportedSeverities(), ", "))

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -114,8 +114,8 @@ func TestValidateScanFormat(t *testing.T) {
 		{"whitespace-and-separator-only input is rejected", " , ", ScanFormats, true},
 		{"invalid format", "xml", ScanFormats, true},
 		{"mixed valid and invalid formats", "json,xml", ScanFormats, true},
-		{"valid image format", "sarif", ImageScanFormats, false},
-		{"format unsupported for image scanning", "junit", ImageScanFormats, true},
+		{"valid image format", "sarif", ScanFormats, false},
+		{"junit format is now supported for image scanning", "junit", ScanFormats, false},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -116,6 +116,8 @@ func TestValidateScanFormat(t *testing.T) {
 		{"mixed valid and invalid formats", "json,xml", ScanFormats, true},
 		{"valid image format", "sarif", ScanFormats, false},
 		{"junit format is now supported for image scanning", "junit", ScanFormats, false},
+		{"junit is supported for image scanning", "junit", ImageScanFormats, false},
+		{"csv is not supported for image scanning", "csv", ImageScanFormats, true},
 	}
 
 	for _, testCase := range testCases {

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -27,6 +27,15 @@ const (
 	CsvFormat         string = "csv"
 )
 
+// AllFormats lists every output format kubescape can emit.
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat}
+
+// ImageFormats lists formats whose printers support image-scan data. CSV is
+// deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
+// errors out on image scans (#2743) — a format must not be advertised as
+// image-scan-capable unless its printer actually handles that path.
+var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat}
+
 const (
 	JsonOutputExt       = ".json"
 	JunitOutputExt      = ".xml"

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -175,10 +175,10 @@ func (gp *GitLabSASTPrinter) printImageScan(imageScanData []cautils.ImageScanDat
 		Vulnerabilities: []gitLabVulnerability{},
 	}
 
-	for i := range imageScanData {
-		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
+	for _, data := range imageScanData {
+		cves := extractCVEs(data.Matches, data.Image)
 		for _, cve := range cves {
-			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabImageVulnerability(imageScanData[i].Image, cve))
+			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabImageVulnerability(data.Image, cve))
 		}
 	}
 

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -94,15 +94,16 @@ type gitLabScannerRef struct {
 type gitLabLocation struct {
 	File      string `json:"file,omitempty"`
 	StartLine int    `json:"start_line,omitempty"`
-	// Dependency is set instead of File/StartLine for image-scan (dependency_scanning) findings,
-	// which have no source file location (#2782).
+	// Dependency is set alongside File for image-scan (dependency_scanning) findings. GitLab's
+	// schema requires both location.file and location.dependency.version — there's no source
+	// file for a container image, so File carries the image reference instead (#2782 review).
 	Dependency *gitLabDependency `json:"dependency,omitempty"`
 }
 
 // gitLabDependency identifies the vulnerable package for a dependency_scanning finding
 type gitLabDependency struct {
 	Package gitLabPackage `json:"package"`
-	Version string        `json:"version,omitempty"`
+	Version string        `json:"version"`
 }
 
 type gitLabPackage struct {
@@ -208,6 +209,27 @@ func (gp *GitLabSASTPrinter) printImageScan(imageScanData []cautils.ImageScanDat
 	return nil
 }
 
+// mapGitLabSeverity maps a Grype severity to one of the values the GitLab dependency_scanning
+// schema allows (Info/Unknown/Low/Medium/High/Critical). Grype can return Negligible, which
+// isn't in that list — passed through unmapped, one Negligible CVE invalidates the entire
+// report (#2782 review).
+func mapGitLabSeverity(severity string) string {
+	switch severity {
+	case apis.SeverityCriticalString:
+		return "Critical"
+	case apis.SeverityHighString:
+		return "High"
+	case apis.SeverityMediumString:
+		return "Medium"
+	case apis.SeverityLowString:
+		return "Low"
+	case apis.SeverityNegligibleString:
+		return "Info"
+	default:
+		return "Unknown"
+	}
+}
+
 // toGitLabImageVulnerability maps a CVE found in an image to a GitLab Dependency Scanning vulnerability
 func toGitLabImageVulnerability(image string, cve imageprinter.CVE) gitLabVulnerability {
 	message := fmt.Sprintf("%s in %s %s", cve.ID, cve.Package, cve.Version)
@@ -225,9 +247,10 @@ func toGitLabImageVulnerability(image string, cve imageprinter.CVE) gitLabVulner
 		Name:        message,
 		Message:     message,
 		Description: description,
-		Severity:    cve.Severity,
+		Severity:    mapGitLabSeverity(cve.Severity),
 		Scanner:     gitLabScannerRef{ID: gitLabScannerID, Name: gitLabScannerName},
 		Location: gitLabLocation{
+			File: image,
 			Dependency: &gitLabDependency{
 				Package: gitLabPackage{Name: cve.Package},
 				Version: cve.Version,

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
@@ -33,11 +34,14 @@ const (
 	gitLabScannerURL    = "https://kubescape.io"
 	gitLabScannerVendor = "Kubescape"
 	gitLabControlIDType = "kubescape_control_id"
+	// gitLabCVEIDType is the GitLab identifier type for CVE-based image scan findings (#2782)
+	gitLabCVEIDType = "cve"
 )
 
 var _ printer.IPrinter = &GitLabSASTPrinter{}
 
-// GitLabSASTPrinter emits configuration-scan results as a GitLab SAST report, so findings reach the Security dashboard and MR approval policies rather than the test widget (#2496)
+// GitLabSASTPrinter emits configuration-scan results as a GitLab SAST report, so findings reach the Security dashboard and MR approval policies rather than the test widget (#2496).
+// It also emits image-scan CVEs as a GitLab Dependency Scanning report, which uses the same top-level schema (#2782).
 type GitLabSASTPrinter struct {
 	writer *os.File
 }
@@ -90,6 +94,19 @@ type gitLabScannerRef struct {
 type gitLabLocation struct {
 	File      string `json:"file,omitempty"`
 	StartLine int    `json:"start_line,omitempty"`
+	// Dependency is set instead of File/StartLine for image-scan (dependency_scanning) findings,
+	// which have no source file location (#2782).
+	Dependency *gitLabDependency `json:"dependency,omitempty"`
+}
+
+// gitLabDependency identifies the vulnerable package for a dependency_scanning finding
+type gitLabDependency struct {
+	Package gitLabPackage `json:"package"`
+	Version string        `json:"version,omitempty"`
+}
+
+type gitLabPackage struct {
+	Name string `json:"name"`
 }
 
 type gitLabIdentifier struct {
@@ -125,10 +142,19 @@ func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
 func (gp *GitLabSASTPrinter) PrintNextSteps() {
 }
 
-// ActionPrint writes the GitLab SAST report for a configuration scan; image scanning is not supported by this format
+// ActionPrint writes a GitLab SAST report for a configuration scan, or a GitLab Dependency Scanning
+// report for an image scan (#2782)
 func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
 	if opaSessionObj == nil {
-		logger.L().Ctx(ctx).Error("failed to write results in GitLab SAST format: image scanning is not supported")
+		if len(imageScanData) == 0 {
+			logger.L().Ctx(ctx).Error("failed to write results in GitLab dependency scanning format: no data provided")
+			return
+		}
+		if err := gp.printImageScan(imageScanData); err != nil {
+			logger.L().Ctx(ctx).Error("failed to write results in GitLab dependency scanning format", helpers.Error(err))
+			return
+		}
+		printer.LogOutputFile(gp.writer.Name())
 		return
 	}
 
@@ -137,6 +163,90 @@ func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cau
 		return
 	}
 	printer.LogOutputFile(gp.writer.Name())
+}
+
+// printImageScan maps each CVE found in an image scan to a GitLab Dependency Scanning vulnerability and writes the report
+func (gp *GitLabSASTPrinter) printImageScan(imageScanData []cautils.ImageScanData) error {
+	startedAt := time.Now().UTC()
+
+	report := gitLabSASTReport{
+		Version:         gitLabSASTReportVersion,
+		Vulnerabilities: []gitLabVulnerability{},
+	}
+
+	for i := range imageScanData {
+		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
+		for _, cve := range cves {
+			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabImageVulnerability(imageScanData[i].Image, cve))
+		}
+	}
+
+	finishedAt := time.Now().UTC()
+	scanner := gitLabScanner{
+		ID:      gitLabScannerID,
+		Name:    gitLabScannerName,
+		URL:     gitLabScannerURL,
+		Version: kubescapeVersion(),
+		Vendor:  gitLabVendor{Name: gitLabScannerVendor},
+	}
+	report.Scan = gitLabScan{
+		Analyzer:  scanner,
+		Scanner:   scanner,
+		Type:      "dependency_scanning",
+		StartTime: startedAt.Format(gitLabTimeFormat),
+		EndTime:   finishedAt.Format(gitLabTimeFormat),
+		Status:    "success",
+	}
+
+	encoded, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode GitLab dependency scanning report: %w", err)
+	}
+	if _, err := gp.writer.Write(encoded); err != nil {
+		return fmt.Errorf("failed to write GitLab dependency scanning report: %w", err)
+	}
+	return nil
+}
+
+// toGitLabImageVulnerability maps a CVE found in an image to a GitLab Dependency Scanning vulnerability
+func toGitLabImageVulnerability(image string, cve imageprinter.CVE) gitLabVulnerability {
+	message := fmt.Sprintf("%s in %s %s", cve.ID, cve.Package, cve.Version)
+
+	description := fmt.Sprintf("Package %s version %s is affected by %s (severity: %s).", cve.Package, cve.Version, cve.ID, cve.Severity)
+	if len(cve.FixVersions) > 0 {
+		description += fmt.Sprintf(" Fix available in version(s): %s.", strings.Join(cve.FixVersions, ", "))
+	} else {
+		description += " No fix is currently available."
+	}
+
+	return gitLabVulnerability{
+		ID:          gitLabImageVulnerabilityID(image, cve.Package, cve.Version, cve.ID),
+		Category:    "dependency_scanning",
+		Name:        message,
+		Message:     message,
+		Description: description,
+		Severity:    cve.Severity,
+		Scanner:     gitLabScannerRef{ID: gitLabScannerID, Name: gitLabScannerName},
+		Location: gitLabLocation{
+			Dependency: &gitLabDependency{
+				Package: gitLabPackage{Name: cve.Package},
+				Version: cve.Version,
+			},
+		},
+		Identifiers: []gitLabIdentifier{
+			{
+				Type:  gitLabCVEIDType,
+				Name:  cve.ID,
+				Value: cve.ID,
+				URL:   fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cve.ID),
+			},
+		},
+	}
+}
+
+// gitLabImageVulnerabilityID returns a stable id so GitLab can track a CVE finding across scans for triage and dismissal
+func gitLabImageVulnerabilityID(image, pkg, version, cveID string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(image+"/"+pkg+"/"+version+"/"+cveID)))
 }
 
 // printConfigurationScan maps each failed control on each failed resource to a GitLab SAST vulnerability and writes the report

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
@@ -350,4 +353,163 @@ func TestGitLabVulnerabilityID(t *testing.T) {
 		"a different control must produce a different id")
 	assert.NotEqual(t, first, gitLabVulnerabilityID("C-0057", "apps/v1/Deployment/default/other", "deploy.yaml"),
 		"a different resource must produce a different id")
+}
+
+// gitLabImageReportFor runs the printer against image scan data and returns the decoded report
+func gitLabImageReportFor(t *testing.T, imageScanData []cautils.ImageScanData) gitLabSASTReport {
+	t.Helper()
+
+	tmp, err := os.CreateTemp("", "gitlab-dependency-scan-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	})
+
+	gp := NewGitLabSASTPrinter()
+	gp.writer = tmp
+	require.NoError(t, gp.printImageScan(imageScanData))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report gitLabSASTReport
+	require.NoError(t, json.Unmarshal(raw, &report))
+	return report
+}
+
+// TestGitLabImageScan_LocationHasFile guards against #2782's schema violation: the
+// dependency_scanning schema requires location.file, but a container image has no
+// source file path — the image reference itself is used instead.
+func TestGitLabImageScan_LocationHasFile(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image: "nginx:1.25",
+			Matches: match.NewMatches(match.Match{
+				Package: grypepkg.Package{ID: "pkg-1", Name: "openssl", Version: "3.0.0"},
+				Vulnerability: vulnerability.Vulnerability{
+					Metadata: &vulnerability.Metadata{ID: "CVE-2026-0001", Severity: "High"},
+					Fix:      vulnerability.Fix{Versions: []string{"3.0.1"}, State: "Fixed"},
+				},
+			}),
+		},
+	}
+
+	report := gitLabImageReportFor(t, imageScanData)
+	require.Len(t, report.Vulnerabilities, 1)
+
+	assert.Equal(t, "dependency_scanning", report.Scan.Type)
+	assert.NotEmpty(t, report.Vulnerabilities[0].Location.File,
+		"location.file is required by the dependency_scanning schema")
+	assert.Equal(t, "nginx:1.25", report.Vulnerabilities[0].Location.File)
+}
+
+// TestGitLabImageScan_VersionKeyAlwaysPresent guards against #2782's schema violation:
+// location.dependency.version is required, but omitempty silently drops it when a
+// package has no version string. Emitting "version": "" is valid; omitting the key isn't.
+func TestGitLabImageScan_VersionKeyAlwaysPresent(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image: "test-image:latest",
+			Matches: match.NewMatches(match.Match{
+				// Package with no version, as Grype can return
+				Package: grypepkg.Package{ID: "pkg-2", Name: "some-lib", Version: ""},
+				Vulnerability: vulnerability.Vulnerability{
+					Metadata: &vulnerability.Metadata{ID: "CVE-2026-0002", Severity: "Medium"},
+				},
+			}),
+		},
+	}
+
+	tmp, err := os.CreateTemp("", "gitlab-dependency-scan-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	})
+
+	gp := NewGitLabSASTPrinter()
+	gp.writer = tmp
+	require.NoError(t, gp.printImageScan(imageScanData))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	// Assert on the raw JSON, not the decoded struct: unmarshalling would hide
+	// whether the "version" key was actually present versus absent.
+	var rawReport map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &rawReport))
+	vulns := rawReport["vulnerabilities"].([]interface{})
+	require.Len(t, vulns, 1)
+	location := vulns[0].(map[string]interface{})["location"].(map[string]interface{})
+	dependency := location["dependency"].(map[string]interface{})
+
+	_, versionKeyPresent := dependency["version"]
+	assert.True(t, versionKeyPresent, `"version" key must be present even when empty; the schema requires it`)
+	assert.Equal(t, "", dependency["version"])
+}
+
+// TestGitLabImageScan_SeverityMapping guards against #2782's schema violation: GitLab's
+// severity enum is Info/Unknown/Low/Medium/High/Critical. Grype's Negligible severity
+// is not in that list — passed through unmapped, one Negligible CVE invalidates the
+// entire report.
+func TestGitLabImageScan_SeverityMapping(t *testing.T) {
+	gitLabSeverities := []string{"Info", "Unknown", "Low", "Medium", "High", "Critical"}
+
+	tests := []struct {
+		grypeSeverity string
+		want          string
+	}{
+		{grypeSeverity: "Critical", want: "Critical"},
+		{grypeSeverity: "High", want: "High"},
+		{grypeSeverity: "Medium", want: "Medium"},
+		{grypeSeverity: "Low", want: "Low"},
+		{grypeSeverity: "Negligible", want: "Info"},
+		{grypeSeverity: "Unknown", want: "Unknown"},
+		{grypeSeverity: "", want: "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.grypeSeverity, func(t *testing.T) {
+			imageScanData := []cautils.ImageScanData{
+				{
+					Image: "test-image:latest",
+					Matches: match.NewMatches(match.Match{
+						Package: grypepkg.Package{ID: "pkg-1", Name: "openssl", Version: "3.0.0"},
+						Vulnerability: vulnerability.Vulnerability{
+							Metadata: &vulnerability.Metadata{ID: "CVE-2026-0003", Severity: tt.grypeSeverity},
+						},
+					}),
+				},
+			}
+
+			report := gitLabImageReportFor(t, imageScanData)
+			require.Len(t, report.Vulnerabilities, 1)
+
+			assert.Equal(t, tt.want, report.Vulnerabilities[0].Severity)
+			assert.Contains(t, gitLabSeverities, report.Vulnerabilities[0].Severity,
+				"severity must be one of GitLab's allowed values or the whole report is rejected")
+		})
+	}
+}
+
+// TestGitLabImageScan_NoData covers the case where ActionPrint is reached with no
+// image scan data at all: it must error rather than write an empty/invalid file.
+func TestGitLabImageScan_NoData(t *testing.T) {
+	tmp, err := os.CreateTemp("", "gitlab-dependency-scan-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	})
+
+	gp := NewGitLabSASTPrinter()
+	gp.writer = tmp
+
+	gp.ActionPrint(context.Background(), nil, nil)
+	// ActionPrint logs and returns on empty data rather than panicking; a
+	// zero-byte file confirms nothing was (incorrectly) written.
+	info, err := os.Stat(tmp.Name())
+	require.NoError(t, err)
+	assert.Zero(t, info.Size())
 }

--- a/core/pkg/resultshandling/printer/v2/html/report.gohtml
+++ b/core/pkg/resultshandling/printer/v2/html/report.gohtml
@@ -71,6 +71,7 @@
   <body>
     <img class="logo" src="https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/resultshandling/printer/v2/pdf/logo.png">
     <h1>Kubescape Scan Report</h1>
+    {{ if .OPASessionObj }}
     {{ with .OPASessionObj.Report.SummaryDetails }}
     </br>
     <h2>Summary:</h2>
@@ -148,6 +149,36 @@
         </tbody>
       </table>
     </div>
+    {{ end }}
+    {{ end }}
+    {{ if .ImageScanSummary }}
+    </br>
+    <h2>Images scanned:</h2>
+    <p>{{ range .ImageScanSummary.Images }}{{ . }} {{ end }}</p>
+    </br>
+    <h2>Vulnerabilities:</h2>
+    <table>
+      <thead>
+      <tr>
+        <th class="resourceSeverityCell">Severity</th>
+        <th class="resourceNameCell">CVE</th>
+        <th class="resourceNameCell">Package</th>
+        <th class="resourceURLCell">Version</th>
+        <th class="resourceRemediationCell">Fixed In</th>
+      </tr>
+      </thead>
+      <tbody>
+      {{ range .ImageScanSummary.CVEs }}
+        <tr>
+          <td class="resourceSeverityCell">{{ .Severity }}</td>
+          <td class="resourceNameCell">{{ .ID }}</td>
+          <td class="resourceNameCell">{{ .Package }}</td>
+          <td class="resourceURLCell">{{ .Version }}</td>
+          <td class="resourceRemediationCell">{{ range .FixVersions }} <p>{{ . }}</p> {{ end }}</td>
+        </tr>
+      {{ end }}
+      </tbody>
+    </table>
     {{ end }}
   </body>
 </html>

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
@@ -30,6 +32,9 @@ var _ printer.IPrinter = &HtmlPrinter{}
 type HTMLReportingCtx struct {
 	OPASessionObj     *cautils.OPASessionObj
 	ResourceTableView ResourceTableView
+	// ImageScanSummary is set instead of the two fields above when this report
+	// is for an image scan rather than a posture scan (#2782).
+	ImageScanSummary *imageprinter.ImageScanSummary
 }
 
 type HtmlPrinter struct {
@@ -60,7 +65,7 @@ func (hp *HtmlPrinter) PrintNextSteps() {
 }
 
 func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
-	if opaSessionObj == nil {
+	if opaSessionObj == nil && len(imageScanData) == 0 {
 		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
@@ -118,8 +123,15 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		template.New("htmlReport").Funcs(tplFuncMap).Parse(reportTemplate),
 	)
 
-	resourceTableView := buildResourceTableView(opaSessionObj)
-	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView}
+	var resourceTableView ResourceTableView
+	var imageScanSummary *imageprinter.ImageScanSummary
+	if opaSessionObj != nil {
+		resourceTableView = buildResourceTableView(opaSessionObj)
+	} else {
+		imageScanSummary = buildImageScanSummary(imageScanData)
+	}
+
+	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView, imageScanSummary}
 	err := tpl.Execute(hp.writer, reportingCtx)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to render template", helpers.Error(err))
@@ -148,6 +160,29 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 	}
 
 	return resourceTableView
+}
+
+// buildImageScanSummary aggregates CVE, package-score, and severity data for an image scan report (#2782)
+func buildImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.ImageScanSummary {
+	imageScanSummary := &imageprinter.ImageScanSummary{
+		CVEs:                  []imageprinter.CVE{},
+		PackageScores:         map[string]*imageprinter.PackageScore{},
+		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
+	}
+
+	for i := range imageScanData {
+		if !slices.Contains(imageScanSummary.Images, imageScanData[i].Image) {
+			imageScanSummary.Images = append(imageScanSummary.Images, imageScanData[i].Image)
+		}
+
+		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
+		imageScanSummary.CVEs = append(imageScanSummary.CVEs, cves...)
+
+		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
+		setSeverityToSummaryMap(cves, imageScanSummary.MapsSeverityToSummary)
+	}
+
+	return imageScanSummary
 }
 
 func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary) ResourceControlResult {

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/shared"
@@ -126,12 +127,17 @@ func (jp *JunitPrinter) PrintNextSteps() {
 }
 
 func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
-	if opaSessionObj == nil {
+	var junitResult *JUnitTestSuites
+
+	if opaSessionObj != nil {
+		junitResult = testsSuites(opaSessionObj)
+	} else if len(imageScanData) > 0 {
+		junitResult = imageTestsSuites(imageScanData)
+	} else {
 		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 
-	junitResult := testsSuites(opaSessionObj)
 	postureReportStr, err := xml.MarshalIndent(junitResult, "", "  ")
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("failed to Marshal xml result object", helpers.Error(err))
@@ -213,6 +219,57 @@ func listTestsSuite(results *cautils.OPASessionObj) []JUnitTestSuite {
 	}
 
 	return testSuites
+}
+
+// imageTestsSuites builds a JUnitTestSuites document for an image scan, one testsuite
+// per scanned image and one failed testcase per CVE found in that image (#2782).
+func imageTestsSuites(imageScanData []cautils.ImageScanData) *JUnitTestSuites {
+	timestamp := iso8601Timestamp(time.Now())
+
+	suites := make([]JUnitTestSuite, 0, len(imageScanData))
+	for i := range imageScanData {
+		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
+		suites = append(suites, JUnitTestSuite{
+			ID:        i,
+			Name:      imageScanData[i].Image,
+			Tests:     len(cves),
+			Failures:  len(cves),
+			Timestamp: timestamp,
+			TestCases: imageTestCases(cves),
+		})
+	}
+
+	tests, failures, errs := aggregateSuiteCounts(suites)
+	return &JUnitTestSuites{
+		Suites:   suites,
+		Tests:    tests,
+		Failures: failures,
+		Errors:   errs,
+		Name:     "Kubescape Image Scanning",
+	}
+}
+
+// imageTestCases converts a set of CVEs into failed JUnit test cases, one per CVE.
+func imageTestCases(cves []imageprinter.CVE) []JUnitTestCase {
+	testCases := make([]JUnitTestCase, 0, len(cves))
+	for _, cve := range cves {
+		fixMsg := "no fix available"
+		if len(cve.FixVersions) > 0 {
+			fixMsg = fmt.Sprintf("fixed in: %s", strings.Join(cve.FixVersions, ", "))
+		}
+
+		testCases = append(testCases, JUnitTestCase{
+			Classname: cve.Image,
+			Name:      fmt.Sprintf("%s (%s)", cve.ID, cve.Package),
+			Failure: &JUnitFailure{
+				Type:    "Vulnerability",
+				Message: fmt.Sprintf("%s severity vulnerability found in package %s", cve.Severity, cve.Package),
+				Contents: fmt.Sprintf("CVE: %s\nPackage: %s\nVersion: %s\nSeverity: %s\n%s",
+					cve.ID, cve.Package, cve.Version, cve.Severity, fixMsg),
+			},
+		})
+	}
+	return testCases
 }
 func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControlsSummaries, classname string) []JUnitTestCase {
 	var testCases []JUnitTestCase

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/pdf"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
@@ -68,12 +69,18 @@ func (pp *PdfPrinter) PrintNextSteps() {
 
 // ActionPrint is responsible for generating a report in pdf format
 func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
-	if opaSessionObj == nil {
+	var outBuff []byte
+	var err error
+
+	if opaSessionObj != nil {
+		outBuff, err = pp.generatePdf(&opaSessionObj.Report.SummaryDetails)
+	} else if len(imageScanData) > 0 {
+		outBuff, err = pp.generateImagePdf(imageScanData)
+	} else {
 		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
 
-	outBuff, err := pp.generatePdf(&opaSessionObj.Report.SummaryDetails)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to generate pdf format", helpers.Error(err))
 		return
@@ -84,6 +91,41 @@ func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 		return
 	}
 	printer.LogOutputFile(pp.writer.Name())
+}
+
+// generateImagePdf builds a CVE-table PDF report for an image scan (#2782)
+func (pp *PdfPrinter) generateImagePdf(imageScanData []cautils.ImageScanData) ([]byte, error) {
+	var allCVEs []imageprinter.CVE
+	var images []string
+	for i := range imageScanData {
+		allCVEs = append(allCVEs, extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)...)
+		images = append(images, imageScanData[i].Image)
+	}
+
+	template := pdf.NewReportTemplate()
+	template.GenerateHeader(fmt.Sprintf("Image scan: %s", strings.Join(images, ", ")), time.Now().Format(time.DateTime))
+
+	rows, fixableCVEs := pp.getImageTableObjects(allCVEs)
+	if err := template.GenerateImageTable(rows, len(allCVEs), fixableCVEs); err != nil {
+		return nil, err
+	}
+
+	return template.GetPdf()
+}
+
+// getImageTableObjects converts CVEs into PDF table rows, returning the rows and how many are fixable
+func (pp *PdfPrinter) getImageTableObjects(cves []imageprinter.CVE) (*[]pdf.ImageTableObject, int) {
+	rows := make([]pdf.ImageTableObject, 0, len(cves))
+	fixableCVEs := 0
+	for _, cve := range cves {
+		fixVersions := "no fix available"
+		if len(cve.FixVersions) > 0 {
+			fixVersions = strings.Join(cve.FixVersions, ", ")
+			fixableCVEs++
+		}
+		rows = append(rows, *pdf.NewImageTableRow(cve.ID, cve.Package, cve.Version, cve.Severity, fixVersions, getSeverityColor))
+	}
+	return &rows, fixableCVEs
 }
 
 func (pp *PdfPrinter) generatePdf(summaryDetails *reportsummary.SummaryDetails) ([]byte, error) {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -115,6 +115,18 @@ func (pp *PdfPrinter) generateImagePdf(imageScanData []cautils.ImageScanData) ([
 
 // getImageTableObjects converts CVEs into PDF table rows, returning the rows and how many are fixable
 func (pp *PdfPrinter) getImageTableObjects(cves []imageprinter.CVE) (*[]pdf.ImageTableObject, int) {
+	if len(cves) == 0 {
+		// maroto's list.Build returns errors.New("empty array") for an
+		// empty slice, so a clean image (zero CVEs) previously produced
+		// no PDF at all — the exact case a pipeline expects to succeed.
+		// A single placeholder row keeps the table non-empty and tells
+		// the reader the scan was clean, instead of failing silently.
+		rows := []pdf.ImageTableObject{
+			*pdf.NewImageTableRow("—", "—", "—", "None", "No vulnerabilities found", getSeverityColor),
+		}
+		return &rows, 0
+	}
+
 	rows := make([]pdf.ImageTableObject, 0, len(cves))
 	fixableCVEs := 0
 	for _, cve := range cves {

--- a/core/pkg/resultshandling/printer/v2/pdf/report_template.go
+++ b/core/pkg/resultshandling/printer/v2/pdf/report_template.go
@@ -100,6 +100,37 @@ func (t *Template) GenerateTable(tableRows *[]TableObject, totalFailed, total in
 	return nil
 }
 
+// GenerateImageTable is responsible for adding CVE data in table format to the pdf for an image scan (#2782)
+func (t *Template) GenerateImageTable(tableRows *[]ImageTableObject, totalCVEs, fixableCVEs int) error {
+	rows, err := list.Build[ImageTableObject](*tableRows)
+	if err != nil {
+		return err
+	}
+	t.maroto.AddRows(rows...)
+	t.maroto.AddRows(
+		line.NewAutoRow(props.Line{Thickness: 0.3, SizePercent: 100}),
+		row.New(2),
+	)
+	t.generateImageTableResult(totalCVEs, fixableCVEs)
+
+	return nil
+}
+
+func (t *Template) generateImageTableResult(totalCVEs, fixableCVEs int) {
+	defaultProps := props.Text{
+		Align:  align.Left,
+		Size:   8,
+		Style:  fontstyle.Bold,
+		Family: fontfamily.Arial,
+	}
+
+	t.maroto.AddRow(10,
+		text.NewCol(6, "Vulnerability summary", defaultProps),
+		text.NewCol(3, fmt.Sprintf("%d CVEs", totalCVEs), defaultProps),
+		text.NewCol(3, fmt.Sprintf("%d fixable", fixableCVEs), defaultProps),
+	)
+}
+
 // GenerateInfoRows is responsible for adding the information in pdf
 func (t *Template) GenerateInfoRows(rows []string) *Template {
 	for _, row := range rows {
@@ -180,6 +211,59 @@ func (t TableObject) GetContent(i int) core.Row {
 		text.NewCol(1, t.counterFailed, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
 		text.NewCol(1, t.counterAll, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
 		text.NewCol(2, t.complianceScore, props.Text{VerticalPadding: 1, Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
+	)
+
+	if i%2 == 0 {
+		r.WithStyle(&props.Cell{
+			BackgroundColor: &props.Color{
+				Red:   224,
+				Green: 224,
+				Blue:  224,
+			},
+		})
+	}
+
+	return r
+}
+
+// ImageTableObject maps a single CVE row for the image-scan PDF report (#2782)
+type ImageTableObject struct {
+	cveID        string
+	packageName  string
+	version      string
+	severity     string
+	fixVersions  string
+	getTextColor getTextColorFunc
+}
+
+func NewImageTableRow(cveID, packageName, version, severity, fixVersions string, getTextColor getTextColorFunc) *ImageTableObject {
+	return &ImageTableObject{
+		cveID:        cveID,
+		packageName:  packageName,
+		version:      version,
+		severity:     severity,
+		fixVersions:  fixVersions,
+		getTextColor: getTextColor,
+	}
+}
+
+func (t ImageTableObject) GetHeader() core.Row {
+	return row.New(10).Add(
+		text.NewCol(1, "Severity", props.Text{Size: 6, Family: fontfamily.Arial, Style: fontstyle.Bold}),
+		text.NewCol(2, "CVE ID", props.Text{Size: 6, Family: fontfamily.Arial, Style: fontstyle.Bold}),
+		text.NewCol(4, "Package", props.Text{Size: 6, Family: fontfamily.Arial, Style: fontstyle.Bold}),
+		text.NewCol(2, "Version", props.Text{Size: 6, Family: fontfamily.Arial, Style: fontstyle.Bold}),
+		text.NewCol(3, "Fixed in", props.Text{Size: 6, Family: fontfamily.Arial, Style: fontstyle.Bold}),
+	)
+}
+
+func (t ImageTableObject) GetContent(i int) core.Row {
+	r := row.New(3).Add(
+		text.NewCol(1, t.severity, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6, Color: t.getTextColor(t.severity)}),
+		text.NewCol(2, t.cveID, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6, Color: &props.Color{}}),
+		text.NewCol(4, t.packageName, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
+		text.NewCol(2, t.version, props.Text{Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
+		text.NewCol(3, t.fixVersions, props.Text{VerticalPadding: 1, Style: fontstyle.Normal, Family: fontfamily.Courier, Size: 6}),
 	)
 
 	if i%2 == 0 {

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/anchore/grype/grype/match"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,24 +64,20 @@ func TestScore_Pdf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a temporary file to capture output
 			f, err := os.CreateTemp("", "pdfPrinter-score-output")
 			if err != nil {
 				panic(err)
 			}
 			defer f.Close()
 
-			// Redirect stderr to the temporary file
 			oldStderr := os.Stderr
 			defer func() {
 				os.Stderr = oldStderr
 			}()
 			os.Stderr = f
 
-			// Print the score using the `Score` function
 			pp.Score(tt.score)
 
-			// Read the contents of the temporary file
 			f.Seek(0, 0)
 			got, err := io.ReadAll(f)
 			if err != nil {
@@ -107,8 +105,6 @@ func TestSetWriter_Pdf(t *testing.T) {
 			expected:   "customFilename.pdf",
 		},
 		{
-			// Regression for issue-6: empty --output must NOT fall through to
-			// stdout for binary formats — default to ./report.pdf instead.
 			name:       "Output file name is empty defaults to report.pdf",
 			outputFile: "",
 			expected:   "report.pdf",
@@ -119,8 +115,6 @@ func TestSetWriter_Pdf(t *testing.T) {
 			expected:   "report.pdf",
 		},
 		{
-			// Surrounding whitespace must be trimmed before extension handling,
-			// otherwise we'd produce filenames like "  myfile  .pdf".
 			name:       "Surrounding whitespace is trimmed",
 			outputFile: "  myfile  ",
 			expected:   "myfile.pdf",
@@ -130,7 +124,6 @@ func TestSetWriter_Pdf(t *testing.T) {
 	pp := NewPdfPrinter()
 	ctx := context.Background()
 
-	// Run from a temp cwd so the default-named file lands somewhere disposable.
 	tmp := t.TempDir()
 	origWd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -139,11 +132,39 @@ func TestSetWriter_Pdf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			pp.SetWriter(ctx, tt.outputFile)
 			assert.Equal(t, tt.expected, pp.writer.Name())
 			assert.NotEqual(t, "/dev/stdout", pp.writer.Name(),
 				"PDF printer must never write to stdout")
 		})
+	}
+}
+
+func TestGetImageTableObjects_EmptyCVEs(t *testing.T) {
+	pp := NewPdfPrinter()
+	rows, fixableCVEs := pp.getImageTableObjects(nil)
+
+	if rows == nil {
+		t.Fatal("expected non-nil rows for empty CVE list, got nil")
+	}
+	if len(*rows) != 1 {
+		t.Fatalf("expected 1 placeholder row for empty CVE list, got %d", len(*rows))
+	}
+	if fixableCVEs != 0 {
+		t.Fatalf("expected 0 fixable CVEs, got %d", fixableCVEs)
+	}
+}
+
+func TestGenerateImagePdf_NoVulnerabilities(t *testing.T) {
+	pp := NewPdfPrinter()
+	data := []cautils.ImageScanData{
+		{Image: "clean-image:latest", Matches: match.NewMatches()},
+	}
+	out, err := pp.generateImagePdf(data)
+	if err != nil {
+		t.Fatalf("expected no error generating PDF for clean image, got: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty PDF bytes for clean image")
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -79,7 +79,7 @@ func (pp *PrometheusPrinter) generatePrometheusFormat(
 
 // generateImagePrometheusFormat builds CVE-count metrics, grouped by image and severity, for an image scan (#2782)
 func (pp *PrometheusPrinter) generateImagePrometheusFormat(imageScanData []cautils.ImageScanData) *Metrics {
-	m := &Metrics{}
+	m := &Metrics{isImageScan: true}
 	m.setImageVulnerabilities(imageScanData)
 	return m
 }

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -77,13 +77,24 @@ func (pp *PrometheusPrinter) generatePrometheusFormat(
 	return m
 }
 
+// generateImagePrometheusFormat builds CVE-count metrics, grouped by image and severity, for an image scan (#2782)
+func (pp *PrometheusPrinter) generateImagePrometheusFormat(imageScanData []cautils.ImageScanData) *Metrics {
+	m := &Metrics{}
+	m.setImageVulnerabilities(imageScanData)
+	return m
+}
+
 func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
-	if opaSessionObj == nil {
+	var metrics *Metrics
+
+	if opaSessionObj != nil {
+		metrics = pp.generatePrometheusFormat(opaSessionObj.AllResources, opaSessionObj.ResourcesResult, &opaSessionObj.Report.SummaryDetails, opaSessionObj.ScanCoverage)
+	} else if len(imageScanData) > 0 {
+		metrics = pp.generateImagePrometheusFormat(imageScanData)
+	} else {
 		logger.L().Ctx(ctx).Error("failed to print results, missing data")
 		return
 	}
-
-	metrics := pp.generatePrometheusFormat(opaSessionObj.AllResources, opaSessionObj.ResourcesResult, &opaSessionObj.Report.SummaryDetails, opaSessionObj.ScanCoverage)
 
 	if _, err := pp.writer.Write([]byte(metrics.String())); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
@@ -191,4 +194,54 @@ func TestCoverageScoreMetricEmitted(t *testing.T) {
 		degraded,
 	)
 	assert.Contains(t, metrics.String(), "kubescape_cluster_coverage_score{} 90")
+}
+
+func TestImagePrometheusFormat_OmitsPostureMetrics(t *testing.T) {
+	// Regression test for #2782: an image scan must not emit posture-scan
+	// metric families (compliance score, coverage) at zero — those fields
+	// are never populated for image scans, so emitting them previously
+	// pushed out a misleading all-zero compliance score alongside the
+	// real CVE metrics.
+	imageData := []cautils.ImageScanData{
+		{
+			Image: "test-image:latest",
+			Matches: match.NewMatches(match.Match{
+				Package: grypepkg.Package{ID: "pkg-1", Name: "openssl", Version: "3.0.0"},
+				Vulnerability: vulnerability.Vulnerability{
+					Metadata: &vulnerability.Metadata{ID: "CVE-2026-0001", Severity: "High"},
+					Fix:      vulnerability.Fix{Versions: []string{"3.0.1"}, State: "Fixed"},
+				},
+			}),
+		},
+	}
+
+	pp := NewPrometheusPrinter(false)
+	metrics := pp.generateImagePrometheusFormat(imageData)
+	output := metrics.String()
+
+	// Image metrics must be present.
+	assert.Contains(t, output, "kubescape_image_count_cve")
+	assert.Contains(t, output, `image="test-image:latest"`)
+
+	// Posture metric families must be completely absent, not just zeroed.
+	assert.NotContains(t, output, "kubescape_cluster_complianceScore")
+	assert.NotContains(t, output, "kubescape_cluster_count_resources")
+	assert.NotContains(t, output, "kubescape_cluster_count_control")
+	assert.NotContains(t, output, "kubescape_cluster_coverage_score")
+}
+
+func TestPostureScanFormat_StillEmitsPostureMetrics(t *testing.T) {
+	// Sanity check the flag doesn't accidentally suppress posture metrics
+	// for real posture scans.
+	pp := NewPrometheusPrinter(false)
+	metrics := pp.generatePrometheusFormat(
+		map[string]workloadinterface.IMetadata{},
+		map[string]resourcesresults.Result{},
+		&reportsummary.SummaryDetails{},
+		cautils.ScanCoverage{},
+	)
+	output := metrics.String()
+
+	assert.Contains(t, output, "kubescape_cluster_complianceScore")
+	assert.Contains(t, output, "kubescape_cluster_coverage_score")
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
@@ -27,6 +28,9 @@ const (
 	metricsResource  metricsName = "resource"
 	metricsResources metricsName = "resources"
 	metricsFramework metricsName = "framework"
+	metricsImage     metricsName = "image"
+	metricsCVE       metricsName = "cve"
+	metricsFixable   metricsName = "fixable"
 )
 
 // ============================================ CLUSTER ============================================================
@@ -197,6 +201,30 @@ func (mrc *mResources) prefix() string {
 	return fmt.Sprintf("%s_%s", ksMetrics, metricsResource)
 }
 
+// ============================================ IMAGE VULNERABILITY =================================================
+func (miv *mImageVulnerability) metrics() []string {
+	/*
+		#### Image vulnerability metrics (image scan only, #2782)
+		kubescape_image_count_cve{image="<image>",severity="<severity>"} <counter>
+		kubescape_image_count_cve_fixable{image="<image>",severity="<severity>"} <counter>
+	*/
+
+	m := []string{}
+	m = append(m, toRowInMetrics(fmt.Sprintf("%s_%s_%s", miv.prefix(), metricsCount, metricsCVE), miv.labels(), miv.cveCount))
+	m = append(m, toRowInMetrics(fmt.Sprintf("%s_%s_%s_%s", miv.prefix(), metricsCount, metricsCVE, metricsFixable), miv.labels(), miv.fixableCVECount))
+	return m
+}
+
+func (miv *mImageVulnerability) labels() string {
+	r := fmt.Sprintf("image=\"%s\"", miv.image) + ","
+	r += fmt.Sprintf("severity=\"%s\"", miv.severity)
+	return r
+}
+
+func (miv *mImageVulnerability) prefix() string {
+	return fmt.Sprintf("%s_%s", ksMetrics, metricsImage)
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 func toMetricHeader(name, help string) string {
@@ -241,6 +269,9 @@ func (m *Metrics) String() string {
 	}
 	for i := range m.listResources {
 		all = append(all, m.listResources[i].metrics()...)
+	}
+	for i := range m.listImages {
+		all = append(all, m.listImages[i].metrics()...)
 	}
 	return emitMetricFamily(all)
 }
@@ -291,12 +322,20 @@ type mResources struct {
 	controlsCountFailed  int
 	controlsCountSkipped int
 }
+type mImageVulnerability struct {
+	image           string
+	severity        string
+	cveCount        int
+	fixableCVECount int
+}
+
 type Metrics struct {
 	rs             mComplianceScore
 	coverage       mScanCoverage
 	listFrameworks []mFrameworkComplianceScore
 	listControls   []mControlComplianceScore
 	listResources  []mResources
+	listImages     []mImageVulnerability
 }
 
 func (mrs *mComplianceScore) set(resources reportsummary.ICounters, controls reportsummary.ICounters) {
@@ -397,4 +436,23 @@ func (m *Metrics) setResourcesCounters(
 		m.listResources = append(m.listResources, mrc)
 	}
 
+}
+
+// setImageVulnerabilities builds per-image, per-severity CVE counters for an image scan (#2782)
+func (m *Metrics) setImageVulnerabilities(imageScanData []cautils.ImageScanData) {
+	for i := range imageScanData {
+		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
+
+		severityToSummary := map[string]*imageprinter.SeveritySummary{}
+		setSeverityToSummaryMap(cves, severityToSummary)
+
+		for severity, summary := range severityToSummary {
+			m.listImages = append(m.listImages, mImageVulnerability{
+				image:           imageScanData[i].Image,
+				severity:        severity,
+				cveCount:        summary.NumberOfCVEs,
+				fixableCVECount: summary.NumberOfFixableCVEs,
+			})
+		}
+	}
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -259,8 +259,14 @@ func emitMetricFamily(lines []string) string {
 func (m *Metrics) String() string {
 	// collect all metric lines first, then emit headers once per family
 	var all []string
-	all = append(all, m.rs.metrics()...)
-	all = append(all, m.coverage.metrics()...)
+	// Posture-scan metric families (compliance score, coverage) only apply
+	// when this Metrics was built from a posture scan; an image scan never
+	// populates m.rs/m.coverage, so emitting them here would push out a
+	// misleading all-zero compliance score alongside real CVE metrics (#2782).
+	if !m.isImageScan {
+		all = append(all, m.rs.metrics()...)
+		all = append(all, m.coverage.metrics()...)
+	}
 	for i := range m.listFrameworks {
 		all = append(all, m.listFrameworks[i].metrics()...)
 	}
@@ -330,6 +336,7 @@ type mImageVulnerability struct {
 }
 
 type Metrics struct {
+	isImageScan    bool
 	rs             mComplianceScore
 	coverage       mScanCoverage
 	listFrameworks []mFrameworkComplianceScore

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -199,19 +200,14 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 
 func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningContext, printFormat string) (bool, error) {
 	if scanType == cautils.ScanTypeImage {
-		// supported types for image scanning
-		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat,
-			printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat,
-			printer.HtmlFormat, printer.GitLabSASTFormat:
-			return false, nil
-		case printer.PrettyFormat:
+		if printFormat == printer.PrettyFormat {
 			return true, nil
-		default:
-			return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 		}
+		if slices.Contains(printer.ImageFormats, printFormat) {
+			return false, nil
+		}
+		return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 	}
-
 	if printFormat == printer.SARIFFormat || printFormat == printer.GitLabSASTFormat {
 		// SARIF and GitLab SAST resolve file locations, so they only apply to local files
 		switch scanContext {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -151,19 +152,14 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 
 func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningContext, printFormat string) (bool, error) {
 	if scanType == cautils.ScanTypeImage {
-		// supported types for image scanning
-		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat,
-			printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat,
-			printer.HtmlFormat, printer.GitLabSASTFormat:
-			return false, nil
-		case printer.PrettyFormat:
+		if printFormat == printer.PrettyFormat {
 			return true, nil
-		default:
-			return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 		}
+		if slices.Contains(printer.ImageFormats, printFormat) {
+			return false, nil
+		}
+		return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 	}
-
 	if printFormat == printer.SARIFFormat || printFormat == printer.GitLabSASTFormat {
 		// SARIF and GitLab SAST resolve file locations, so they only apply to local files
 		switch scanContext {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -201,7 +201,9 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat:
+		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat,
+			printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat,
+			printer.HtmlFormat, printer.GitLabSASTFormat:
 			return false, nil
 		case printer.PrettyFormat:
 			return true, nil

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -153,7 +153,9 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	if scanType == cautils.ScanTypeImage {
 		// supported types for image scanning
 		switch printFormat {
-		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat:
+		case printer.JsonFormat, printer.SARIFFormat, printer.YamlFormat,
+			printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat,
+			printer.HtmlFormat, printer.GitLabSASTFormat:
 			return false, nil
 		case printer.PrettyFormat:
 			return true, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -1,13 +1,13 @@
 package resultshandling
 
 import (
-    "context"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "slices"
-    "testing"
-    "time"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -232,6 +232,12 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name:      "csv format for image scan should return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.CsvFormat,
+			expectErr: errors.New("format \"csv\" is not supported for image scanning"),
+		},
+		{
 			name:      "pdf format for cluster scan should not return error",
 			scanType:  cautils.ScanTypeCluster,
 			format:    printer.PdfFormat,
@@ -558,4 +564,28 @@ func TestGetComplianceScoreAndRiskScoreAreIndependent(t *testing.T) {
 	assert.Equal(t, float32(80.0), rh.GetComplianceScore())
 	assert.Equal(t, float32(40.0), rh.GetRiskScore())
 	assert.NotEqual(t, rh.GetComplianceScore(), rh.GetRiskScore())
+}
+
+// TestValidatePrinter_ImageFormatsInvariant pins the invariant itself: every
+// format in printer.ImageFormats must be accepted for image scans, and every
+// format in printer.AllFormats that is NOT in printer.ImageFormats (e.g. csv)
+// must be rejected. This is what stops a future format from silently
+// inheriting image-scan support just by being added to AllFormats (#2782 review).
+func TestValidatePrinter_ImageFormatsInvariant(t *testing.T) {
+	for _, format := range printer.ImageFormats {
+		t.Run("accepted: "+format, func(t *testing.T) {
+			_, err := ValidatePrinter(cautils.ScanTypeImage, cautils.ScanningContext(""), format)
+			assert.NoError(t, err)
+		})
+	}
+
+	for _, format := range printer.AllFormats {
+		if slices.Contains(printer.ImageFormats, format) {
+			continue
+		}
+		t.Run("rejected: "+format, func(t *testing.T) {
+			_, err := ValidatePrinter(cautils.ScanTypeImage, cautils.ScanningContext(""), format)
+			assert.Error(t, err)
+		})
+	}
 }

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -141,15 +141,9 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "junit format for image scan should return error",
+			name:      "junit format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.JunitResultFormat,
-			expectErr: errors.New("format \"junit\" is not supported for image scanning"),
-		},
-		{
-			name:      "sarif format for image scan should not return error",
-			scanType:  cautils.ScanTypeImage,
-			format:    printer.SARIFFormat,
 			expectErr: nil,
 		},
 		{
@@ -159,16 +153,16 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "html format for image scan should return error",
+			name:      "html format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.HtmlFormat,
-			expectErr: errors.New("format \"html\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
-			name:      "prometheus format for image scan should return error",
+			name:      "prometheus format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PrometheusFormat,
-			expectErr: errors.New("format \"prometheus\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
 			name:        "sarif format for cluster context should return error",
@@ -219,16 +213,16 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr:   nil,
 		},
 		{
-			name:      "gitlab-sast format for image scan should return error",
+			name:      "gitlab-sast format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.GitLabSASTFormat,
-			expectErr: errors.New("format \"gitlab-sast\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
-			name:      "pdf format for image scan should return error",
+			name:      "pdf format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PdfFormat,
-			expectErr: errors.New("format \"pdf\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
 			name:      "pdf format for cluster scan should not return error",

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -225,6 +225,12 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name:      "csv format for image scan should return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.CsvFormat,
+			expectErr: errors.New("format \"csv\" is not supported for image scanning"),
+		},
+		{
 			name:      "pdf format for cluster scan should not return error",
 			scanType:  cautils.ScanTypeCluster,
 			format:    printer.PdfFormat,
@@ -419,4 +425,28 @@ func TestGetComplianceScoreAndRiskScoreAreIndependent(t *testing.T) {
 	assert.Equal(t, float32(80.0), rh.GetComplianceScore())
 	assert.Equal(t, float32(40.0), rh.GetRiskScore())
 	assert.NotEqual(t, rh.GetComplianceScore(), rh.GetRiskScore())
+}
+
+// TestValidatePrinter_ImageFormatsInvariant pins the invariant itself: every
+// format in printer.ImageFormats must be accepted for image scans, and every
+// format in printer.AllFormats that is NOT in printer.ImageFormats (e.g. csv)
+// must be rejected. This is what stops a future format from silently
+// inheriting image-scan support just by being added to AllFormats (#2782 review).
+func TestValidatePrinter_ImageFormatsInvariant(t *testing.T) {
+	for _, format := range printer.ImageFormats {
+		t.Run("accepted: "+format, func(t *testing.T) {
+			_, err := ValidatePrinter(cautils.ScanTypeImage, cautils.ScanningContext(""), format)
+			assert.NoError(t, err)
+		})
+	}
+
+	for _, format := range printer.AllFormats {
+		if slices.Contains(printer.ImageFormats, format) {
+			continue
+		}
+		t.Run("rejected: "+format, func(t *testing.T) {
+			_, err := ValidatePrinter(cautils.ScanTypeImage, cautils.ScanningContext(""), format)
+			assert.Error(t, err)
+		})
+	}
 }

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -1,12 +1,13 @@
 package resultshandling
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"testing"
-	"time"
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "slices"
+    "testing"
+    "time"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -148,15 +148,9 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "junit format for image scan should return error",
+			name:      "junit format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.JunitResultFormat,
-			expectErr: errors.New("format \"junit\" is not supported for image scanning"),
-		},
-		{
-			name:      "sarif format for image scan should not return error",
-			scanType:  cautils.ScanTypeImage,
-			format:    printer.SARIFFormat,
 			expectErr: nil,
 		},
 		{
@@ -166,16 +160,16 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "html format for image scan should return error",
+			name:      "html format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.HtmlFormat,
-			expectErr: errors.New("format \"html\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
-			name:      "prometheus format for image scan should return error",
+			name:      "prometheus format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PrometheusFormat,
-			expectErr: errors.New("format \"prometheus\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
 			name:        "sarif format for cluster context should return error",
@@ -226,16 +220,16 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr:   nil,
 		},
 		{
-			name:      "gitlab-sast format for image scan should return error",
+			name:      "gitlab-sast format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.GitLabSASTFormat,
-			expectErr: errors.New("format \"gitlab-sast\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
-			name:      "pdf format for image scan should return error",
+			name:      "pdf format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.PdfFormat,
-			expectErr: errors.New("format \"pdf\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 		{
 			name:      "pdf format for cluster scan should not return error",


### PR DESCRIPTION
## What this does

Closes #2782

Image scans previously supported only 4 output formats (pretty-printer, json, sarif, yaml) while posture scans supported 9. This PR adds the missing 5 formats for image scans: junit, prometheus, pdf, html, and gitlab-sast.

Now both scan types support the same output formats, so a single CI pipeline can use one reporting setup for both.

## Changes

- `cmd/scan/image.go`, `cmd/shared/scan.go`, `core/pkg/resultshandling/results.go`: removed the format restriction for image scans and updated the error message to list all supported formats
- `junit.go`: added `imageTestsSuites` and `imageTestCases`, one JUnit testsuite per scanned image, one failed testcase per CVE
- `prometheus.go`, `prometheusutils.go`: added per-image, per-severity CVE count metrics (`kubescape_image_count_cve`, `kubescape_image_count_cve_fixable`)
- `pdf.go`, `pdf/report_template.go`: added a CVE table for image scan PDF reports
- `htmlprinter.go`, `html/report.gohtml`: added an image scan summary table to the HTML report
- `gitlabsastprinter.go`: image scans now emit a GitLab Dependency Scanning report (`dependency_scanning` category) instead of being rejected. Uses the same top level schema as the existing SAST report for config scans

## Testing

Built and ran locally against `nginx:1.25`:
kubescape scan image nginx:1.25 --format junit --output test.xml
kubescape scan image nginx:1.25 --format prometheus --output test.prom
kubescape scan image nginx:1.25 --format pdf --output test.pdf
kubescape scan image nginx:1.25 --format html --output test.html
kubescape scan image nginx:1.25 --format gitlab-sast --output test-gitlab.json

All five completed successfully and produced output in the expected format.

## Notes

Flagging #2743 (CSV printer) since it also touches `ImageScanFormats` and may need to be rebased against this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image scans now support JUnit, Prometheus, PDF, HTML, and GitLab Dependency Scanning output, alongside JSON, SARIF, and YAML.
  * HTML and PDF reports show scanned images, vulnerability details, severity summaries, and fix availability.
  * JUnit reports vulnerabilities by image and CVE.
  * Prometheus provides image and severity metrics, including total and fixable vulnerability counts.
  * GitLab Dependency Scanning reports include image vulnerability findings and package details.
  * Clean image scans are supported across reporting formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->