### PR TITLE
fix(core): return cluster connection failures from Scan instead of terminating

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -51,10 +51,11 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdenti
 	if scanInfo.GetScanningContext() == cautils.ContextCluster {
 		k8s = getKubernetesApi()
 		if k8s == nil {
-			logger.L().Ctx(ctx).Fatal("failed connecting to Kubernetes cluster")
-		} else {
-			k8sClient = k8s.KubernetesClient
+			// Return rather than terminate: Scan already propagates this to the
+			// caller, and the command layer still exits non-zero on it.
+			return componentInterfaces{}, fmt.Errorf("failed connecting to Kubernetes cluster")
 		}
+		k8sClient = k8s.KubernetesClient
 	}
 
 	// ================== setup tenant object ======================================

--- a/core/core/scan_interfaces_test.go
+++ b/core/core/scan_interfaces_test.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getInterfaces returns (componentInterfaces, error) and Kubescape.Scan already
+// propagates that error, but the cluster-connection branch used to call
+// logger.Fatal, which is os.Exit(1). An embedded caller could not recover from
+// an unreachable cluster, and running this test against that version killed the
+// test binary instead of failing.
+func TestGetInterfaces_ClusterConnectionFailureReturnsError(t *testing.T) {
+	originalConnected := k8sinterface.IsConnectedToCluster()
+	t.Cleanup(func() { k8sinterface.SetConnectedToCluster(originalConnected) })
+	k8sinterface.SetConnectedToCluster(false)
+
+	// No input patterns means the scanning context is ContextCluster.
+	scanInfo := &cautils.ScanInfo{}
+	require.Equal(t, cautils.ContextCluster, scanInfo.GetScanningContext())
+
+	_, err := getInterfaces(context.Background(), scanInfo, nil)
+
+	require.Error(t, err, "an unreachable cluster must be reported to the caller")
+	assert.ErrorContains(t, err, "failed connecting to Kubernetes cluster")
+}
+
+// A caller that survives one unreachable cluster must be able to keep going,
+// which is the whole point of returning the error rather than exiting.
+func TestGetInterfaces_ClusterConnectionFailureIsRecoverable(t *testing.T) {
+	originalConnected := k8sinterface.IsConnectedToCluster()
+	t.Cleanup(func() { k8sinterface.SetConnectedToCluster(originalConnected) })
+	k8sinterface.SetConnectedToCluster(false)
+
+	scanInfo := &cautils.ScanInfo{}
+
+	for i := range 3 {
+		_, err := getInterfaces(context.Background(), scanInfo, nil)
+		require.Errorf(t, err, "call %d must return rather than terminate", i)
+	}
+}


### PR DESCRIPTION
## Overview

`getInterfaces` returns `(componentInterfaces, error)` and `Kubescape.Scan`
already propagates that error to its caller. The cluster branch didn't use it:

```go
k8s = getKubernetesApi()
if k8s == nil {
	logger.L().Ctx(ctx).Fatal("failed connecting to Kubernetes cluster")
} else {
	k8sClient = k8s.KubernetesClient
}
```

`logger.Fatal` is `os.Exit(1)`, so an unreachable cluster killed the process
from inside a reusable library function. Anything embedding `Kubescape.Scan`
had no way to handle it. This was the only `logger.Fatal` in non-test
`core/core` code.

This returns the error instead.

**CLI behaviour is unchanged.** Every command already terminates on a `Scan`
error itself, e.g. `cmd/scan/framework.go`:

```go
results, err := ks.Scan(scanInfo, policyIdentifiers)
if err != nil {
	logger.L().Fatal(err.Error())
}
```

Same exit code, same message. Only the point of termination moves out of the
library and into the command layer.

## How to Test

```bash
go test ./core/core/ -run TestGetInterfaces_ClusterConnection -count=1 -v
```

On master the test binary is killed rather than the test failing, which is the
bug itself:

```
=== RUN   TestGetInterfaces_ClusterConnectionFailureReturnsError
[fatal] failed connecting to Kubernetes cluster
FAIL	github.com/kubescape/kubescape/v3/core/core	2.604s
```

No `--- FAIL` line, and the second test never runs. With this change:

```
--- PASS: TestGetInterfaces_ClusterConnectionFailureReturnsError
--- PASS: TestGetInterfaces_ClusterConnectionFailureIsRecoverable
```

The second test calls `getInterfaces` three times in a row to show the caller
actually survives, which is the point of returning rather than exiting. Both
use the existing `SetConnectedToCluster` save/restore pattern from
`clusterconnector_test.go` and restore global state in `t.Cleanup`.

Also ran:

```bash
go build ./...
go vet ./core/core/...
go test ./core/core/... -count=1
go test -race ./core/core/... -count=1
```

All clean.

## Related issues/PRs

Resolved #2787


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster connection failures are now reported as recoverable errors instead of abruptly terminating the application.
  * Repeated attempts after an unreachable cluster are handled consistently.

* **Tests**
  * Added coverage for connection failure messages and repeated failed connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->