### PR TITLE
fix(resultshandling): handle unscored score sentinel in summary table compliance column

### DIFF
--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -16,7 +16,7 @@ import (
 
 func streamingTestSession(ctx context.Context) (*cautils.ScanInfo, *cautils.OPASessionObj) {
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{"/not-a-cluster-scan"}}
-	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, nil)
 }
 
 func testPodList(name, namespace string) *unstructured.UnstructuredList {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable.go
@@ -83,7 +83,11 @@ func GetComplianceScoreColumn(controlSummary reportsummary.IControlSummary, info
 	if controlSummary.GetStatus().IsSkipped() {
 		return fmt.Sprintf("%s %s", "Action Required", GetInfoColumn(controlSummary, infoToPrintInfo))
 	}
-	return fmt.Sprintf("%d", cautils.ComplianceScoreToInt(controlSummary.GetComplianceScore())) + "%"
+	score := cautils.ComplianceScoreToInt(controlSummary.GetComplianceScore())
+	if score < 0 {
+		return "N/A"
+	}
+	return fmt.Sprintf("%d%%", score)
 }
 
 func GetInfoColumn(controlSummary reportsummary.IControlSummary, infoToPrintInfo []utils.InfoStars) string {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/summarytable_test.go
@@ -245,6 +245,15 @@ func TestGetComplianceScoreColumnDoesNotRoundFractionalScoreToPerfect(t *testing
 	assert.Equal(t, "99%", GetComplianceScoreColumn(controlSummary, nil))
 }
 
+func TestGetComplianceScoreColumnHandlesUnscoredSentinel(t *testing.T) {
+	score := float32(-1.0)
+	controlSummary := &reportsummary.ControlSummary{
+		ComplianceScore: &score,
+	}
+
+	assert.Equal(t, "N/A", GetComplianceScoreColumn(controlSummary, nil))
+}
+
 func TestGenerateFooter_ShortVsFullDiffer(t *testing.T) {
 	sd := reportsummary.SummaryDetails{ComplianceScore: 50}
 	short := GenerateFooter(&sd, true)


### PR DESCRIPTION
## Description

Fixes #2790  where unscored or non-applicable security controls render as `"-1%"` in the console summary table output. 

When a control is unscored, `cautils.ComplianceScoreToInt()` returns `-1` as a sentinel value. `GetComplianceScoreColumn` now checks for negative sentinel values (`score < 0`) and returns `"N/A"` instead of appending `%`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

- Added `TestGetComplianceScoreColumnHandlesUnscoredSentinel` in `summarytable_test.go` verifying that negative score sentinels render as `"N/A"`.
- Ran unit test suite: `go test -v -run TestGetComplianceScoreColumn ./core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter/...` (Passes 100%).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] My commit message follows Conventional Commits specification
- [x] I have signed off my commit (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Compliance scores that cannot be calculated are now displayed as **“N/A”** instead of an invalid percentage.
- Valid compliance scores continue to display with a percent sign.

## Tests
- Added coverage for the unscored compliance scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->