### PR TITLE
fix(core): expand ScanAll frameworks before resolving cache paths

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -315,9 +315,13 @@ func AppendPolicyIdentifiers(existing []PolicyIdentifier, policies []string, kin
 }
 
 // containsIdentifier reports whether the named identifier is already present.
+// The comparison is case-insensitive because the identifier sources disagree on
+// casing - getter.NativeFrameworks is lower case while IPolicyGetter.ListFrameworks
+// returns the framework's declared name ("NSA", "MITRE") - and a duplicate makes
+// downloadScanPolicies fetch and evaluate the same framework twice.
 func containsIdentifier(identifiers []PolicyIdentifier, name string) bool {
 	for _, policy := range identifiers {
-		if policy.Identifier == name {
+		if strings.EqualFold(policy.Identifier, name) {
 			return true
 		}
 	}

--- a/core/cautils/scaninfo_helpers_test.go
+++ b/core/cautils/scaninfo_helpers_test.go
@@ -269,4 +269,10 @@ func TestContainsIdentifier(t *testing.T) {
 	assert.True(t, containsIdentifier(policyIdentifiers, "mitre"))
 	assert.False(t, containsIdentifier(policyIdentifiers, "cis"))
 	assert.False(t, containsIdentifier(policyIdentifiers, ""))
+
+	// ListFrameworks returns the framework's declared name, which is cased
+	// differently from the lower case getter.NativeFrameworks entries.
+	assert.True(t, containsIdentifier(policyIdentifiers, "NSA"))
+	assert.True(t, containsIdentifier(policyIdentifiers, "MITRE"))
+	assert.False(t, containsIdentifier(policyIdentifiers, "CIS"))
 }

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	giturl "github.com/kubescape/go-git-url"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
@@ -302,6 +303,24 @@ func TestAppendPolicyIdentifiers(t *testing.T) {
 			existing: []PolicyIdentifier{{Identifier: "C-0001", Kind: apisv1.KindControl}},
 			want:     []PolicyIdentifier{{Identifier: "C-0001", Kind: apisv1.KindControl}},
 		},
+		{
+			name: "skips existing policy regardless of case",
+			existing: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+			},
+			policies: []string{"NSA", "MITRE"},
+			want: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+				{Identifier: "MITRE", Kind: apisv1.KindFramework},
+			},
+		},
+		{
+			name:     "deduplicates differently cased policies within the same list",
+			policies: []string{"nsa", "NSA"},
+			want: []PolicyIdentifier{
+				{Identifier: "nsa", Kind: apisv1.KindFramework},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -309,6 +328,54 @@ func TestAppendPolicyIdentifiers(t *testing.T) {
 			policyIdentifiers := AppendPolicyIdentifiers(tt.existing, tt.policies, apisv1.KindFramework)
 
 			assert.Equal(t, tt.want, policyIdentifiers)
+		})
+	}
+}
+
+func TestSetUseFrom(t *testing.T) {
+	cachePath := func(identifier string) string {
+		path, err := getter.PolicyCachePath(identifier)
+		require.NoError(t, err)
+		return path
+	}
+
+	tests := []struct {
+		name              string
+		scanInfo          *ScanInfo
+		policyIdentifiers []PolicyIdentifier
+		want              []string
+	}{
+		{
+			name:              "resolves a cache path per identifier",
+			scanInfo:          &ScanInfo{UseDefault: true},
+			policyIdentifiers: BuildPolicyIdentifiers([]string{"nsa", "mitre"}, apisv1.KindFramework),
+			want:              []string{cachePath("nsa"), cachePath("mitre")},
+		},
+		{
+			name:              "resolves every identifier a ScanAll expansion contributed",
+			scanInfo:          &ScanInfo{UseDefault: true, ScanAll: true},
+			policyIdentifiers: BuildPolicyIdentifiers([]string{"allcontrols", "nsa", "mitre"}, apisv1.KindFramework),
+			want:              []string{cachePath("allcontrols"), cachePath("nsa"), cachePath("mitre")},
+		},
+		{
+			name:              "skips identifiers that cannot be turned into a cache path",
+			scanInfo:          &ScanInfo{UseDefault: true},
+			policyIdentifiers: BuildPolicyIdentifiers([]string{"../etc/passwd", "nsa"}, apisv1.KindFramework),
+			want:              []string{cachePath("nsa")},
+		},
+		{
+			name:              "without UseDefault nothing is resolved",
+			scanInfo:          &ScanInfo{},
+			policyIdentifiers: BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework),
+			want:              nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.scanInfo.setUseFrom(tt.policyIdentifiers)
+
+			assert.Equal(t, tt.want, tt.scanInfo.UseFrom)
 		})
 	}
 }

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -16,6 +16,7 @@ import (
 	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter"
 	reporterv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/rbac-utils/rbacscanner"
 	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
@@ -353,6 +354,19 @@ func getDefaultFrameworksPaths() []string {
 		fwPaths = append(fwPaths, getter.GetDefaultPath(getter.NativeFrameworks[i]+".json")) // GetDefaultPath expects a filename, not just the framework name
 	}
 	return fwPaths
+}
+
+// resolveDefaultScanAllPolicies expands a ScanAll framework list before ScanInfo.Init runs.
+// Init's setUseFrom resolves a local cache path per identifier, so the ScanAll expansion that
+// happens later - once the policy getter exists - would add frameworks that carry no cached
+// path, leaving an offline scan with a downloader it cannot reach. --use-default makes the
+// local store the policy source, so the expansion is answered from the default framework set
+// instead of the getter, the same set getDefaultFrameworksPaths serves in air-gapped mode.
+func resolveDefaultScanAllPolicies(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) []cautils.PolicyIdentifier {
+	if !scanInfo.ScanAll || !scanInfo.UseDefault {
+		return policyIdentifiers
+	}
+	return cautils.AppendPolicyIdentifiers(policyIdentifiers, getter.NativeFrameworks, apisv1.KindFramework)
 }
 
 func listFrameworksNames(policyGetter getter.IPolicyGetter) []string {

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,6 +158,78 @@ func TestGettersAirGappedUseCache(t *testing.T) {
 			assert.Equal(t, "*getter.MergedExceptionsGetter", reflect.TypeOf(exceptionsGetter).String())
 		})
 	}
+}
+
+func TestResolveDefaultScanAllPolicies(t *testing.T) {
+	nativeIdentifiers := func() []cautils.PolicyIdentifier {
+		return cautils.BuildPolicyIdentifiers(getter.NativeFrameworks, apisv1.KindFramework)
+	}
+
+	tests := []struct {
+		name              string
+		scanInfo          *cautils.ScanInfo
+		policyIdentifiers []cautils.PolicyIdentifier
+		want              []cautils.PolicyIdentifier
+	}{
+		{
+			name:     "ScanAll with UseDefault expands an empty list to the default frameworks",
+			scanInfo: &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			want:     nativeIdentifiers(),
+		},
+		{
+			name:              "ScanAll with UseDefault keeps the requested frameworks first",
+			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"cis-v1.23-t1.0.1"}, apisv1.KindFramework),
+			want: append(
+				cautils.BuildPolicyIdentifiers([]string{"cis-v1.23-t1.0.1"}, apisv1.KindFramework),
+				nativeIdentifiers()...,
+			),
+		},
+		{
+			name:              "ScanAll with UseDefault does not re-add differently cased frameworks",
+			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"NSA", "MITRE"}, apisv1.KindFramework),
+			want: append(
+				cautils.BuildPolicyIdentifiers([]string{"NSA", "MITRE"}, apisv1.KindFramework),
+				cautils.PolicyIdentifier{Identifier: "allcontrols", Kind: apisv1.KindFramework},
+			),
+		},
+		{
+			name:     "ScanAll without UseDefault is left to the policy getter",
+			scanInfo: &cautils.ScanInfo{ScanAll: true},
+			want:     nil,
+		},
+		{
+			name:              "UseDefault without ScanAll leaves the list untouched",
+			scanInfo:          &cautils.ScanInfo{UseDefault: true},
+			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework),
+			want:              cautils.BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveDefaultScanAllPolicies(tt.scanInfo, tt.policyIdentifiers))
+		})
+	}
+}
+
+// TestScanAllWithUseDefaultResolvesCachePaths is the regression test for the ordering bug:
+// a ScanAll scan combined with --use-default must reach getPolicyGetter with every framework
+// already resolved to a cache path, so the scan loads locally instead of reaching the network.
+func TestScanAllWithUseDefaultResolvesCachePaths(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: true}
+
+	policyIdentifiers := resolveDefaultScanAllPolicies(scanInfo, nil)
+	scanInfo.Init(context.Background(), policyIdentifiers)
+
+	wantPaths := getDefaultFrameworksPaths()
+	assert.ElementsMatch(t, wantPaths, scanInfo.UseFrom)
+	assert.True(t, isAirGappedMode(scanInfo), "cached paths must put the scan in air-gapped mode")
+
+	policyGetter, err := getPolicyGetter(context.Background(), scanInfo.UseFrom, "123456789012", scanInfo.FrameworkScan, nil, isAirGappedMode(scanInfo))
+	require.NoError(t, err)
+	assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(policyGetter).String())
 }
 
 func TestPolicyIdentifierIdentities(t *testing.T) {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -196,7 +196,8 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	logger.L().Start("Kubescape scanner initializing...")
 
 	// ===================== Initialization =====================
-	scanInfo.Init(ctxInit, policyIdentifiers) // initialize scan info
+	policyIdentifiers = resolveDefaultScanAllPolicies(scanInfo, policyIdentifiers) // resolve the ScanAll expansion while Init can still cache its paths
+	scanInfo.Init(ctxInit, policyIdentifiers)                                      // initialize scan info
 	defer scanInfo.Cleanup()
 
 	interfaces, err := getInterfaces(ctxInit, scanInfo, policyIdentifiers)

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -16,7 +16,7 @@ import (
 
 func streamingTestSession(ctx context.Context) (*cautils.ScanInfo, *cautils.OPASessionObj) {
 	scanInfo := &cautils.ScanInfo{InputPatterns: []string{"/not-a-cluster-scan"}}
-	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo)
+	return scanInfo, cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, nil)
 }
 
 func testPodList(name, namespace string) *unstructured.UnstructuredList {


### PR DESCRIPTION
## Overview

`ScanInfo.Init` resolves a local cache path for every policy identifier it is given (`setUseFrom` → `getter.PolicyCachePath`), but a `ScanAll` scan only expands its framework list *after* that, once the policy getter has already been built.

**Current behavior:** frameworks added by the `ScanAll` expansion carry no cache path, because `Init` had already run. `--use-default` therefore never stands on its own for `ScanAll` — it works only where `UseArtifactsFrom` happens to populate `scanInfo.UseFrom` as a side effect. Separately, the expansion appends identifiers that are already in the list under different casing, so the same framework gets fetched and evaluated twice.

**New behavior:** when `--use-default` is set, the `ScanAll` list is expanded from the default framework set *before* `Init`, so every identifier reaches `setUseFrom` in time, `isAirGappedMode` sees the populated `UseFrom`, and `getPolicyGetter` builds a `LoadPolicy` over the local store instead of a downloader. Identifier matching is now case-insensitive, so the later expansion no longer produces duplicates.

Changes:
* `core/core/initutils.go` — new `resolveDefaultScanAllPolicies`, expanding from `getter.NativeFrameworks` (the same set `getDefaultFrameworksPaths` already serves in air-gapped mode).
* `core/core/scan.go` — call it immediately before `scanInfo.Init`.
* `core/cautils/scaninfo.go` — `containsIdentifier` uses `strings.EqualFold`.

## Additional Information

The issue suggests two approaches: resolve the final identifier list before `Init`, or re-resolve cache paths and policy getter after the expansion. This PR takes the first.

It applies it on the `--use-default` branch specifically. The general `ScanAll` expansion can't move ahead of `Init` — it needs `ListFrameworks()` from the policy getter, the getter needs `UseFrom`, and `UseFrom` comes from `Init`, which is circular. Re-resolving afterwards breaks that cycle but only after `getDownloadReleasedPolicy` has already attempted the network fetch, which is the cost an offline scan is trying to avoid. `--use-default` is the one case where the framework set is knowable without a getter, and it is also the only case the bug affects.

The case-folding fix is included rather than split out because it is load-bearing here: `NativeFrameworks` is lower case while `ListFrameworks()` returns the framework's declared name (`NSA`, `MITRE`), so without it this change would widen the existing duplicate-evaluation problem in `downloadScanPolicies`. Happy to break it into its own PR if preferred.

Unrelated, but worth flagging so it isn't misattributed to this PR: `go vet` already fails on `master` in `core/pkg/resourcehandler/k8sresources_streaming_failures_test.go:19`, which still calls `cautils.NewOPASessionObj` with the pre-#2768 four-argument signature. Not touched here.

 Includes an unrelated one-line build fix: core/pkg/resourcehandler/k8sresources_streaming_failures_test.go still called cautils.NewOPASessionObj with the pre-#2768 four-argument signature, so that test package did not compile and CI was red. #2768 updated the other 18 call sites; this one was missed because #2771 added the file concurrently. Happy to split it out if preferred.

## How to Test

```bash
go build ./...
go test ./core/cautils/... ./core/core/...
```

The new coverage:
* `TestScanAllWithUseDefaultResolvesCachePaths` (`core/core/initutils_test.go`) — the `ScanAll` + `--use-default` regression test the issue asks for. Asserts `scanInfo.UseFrom` matches `getDefaultFrameworksPaths()`, that `isAirGappedMode` is true, and that `getPolicyGetter` returns a `*getter.LoadPolicy`.
* `TestResolveDefaultScanAllPolicies` (`core/core/initutils_test.go`) — expansion from the default set, and that differently cased frameworks are not re-added.
* `TestSetUseFrom` (`core/cautils/scaninfo_test.go`) — cache-path resolution per identifier, including identifiers that can't be turned into a path.
* `TestAppendPolicyIdentifiers` / `TestContainsIdentifier` — extended with case-insensitive matching.

## Related issues/PRs

* Resolves #2770

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy identifiers are now matched case-insensitively, preventing duplicate frameworks caused by casing differences.
  * `ScanAll` with default policies now automatically includes all supported native frameworks.
  * Default policy paths are resolved correctly for local policy loading.
  * Existing behavior remains unchanged for non-`ScanAll` scans and explicitly selected policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->