### PR TITLE
feat(version): add --output json flag

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,37 +1,56 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"github.com/kubescape/kubescape/v3/core/meta"
-
 	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/kubescape/v3/core/meta"
 	"github.com/spf13/cobra"
 )
 
+type versionInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
 func GetVersionCmd(ks meta.IKubescape, version, commit, date string) *cobra.Command {
+	var outputFormat string
+
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Get current version",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			v := versioncheck.NewIVersionCheckHandler(ks.Context())
-			_ = v.CheckLatestVersion(ks.Context(), versioncheck.NewVersionCheckRequest("", version, "", "", "version", nil))
+			switch outputFormat {
+			case "json":
+				info := versionInfo{
+					Version: version,
+					Commit:  commit,
+					Date:    date,
+				}
+				b, err := json.Marshal(info)
+				if err != nil {
+					return fmt.Errorf("failed to marshal version info: %w", err)
+				}
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(b))
+				return err
+			case "text":
+				v := versioncheck.NewIVersionCheckHandler(ks.Context())
+				_ = v.CheckLatestVersion(ks.Context(), versioncheck.NewVersionCheckRequest("", version, "", "", "version", nil))
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-				"Your current version is: %s\n",
-				version,
-			)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-				"Build commit: %s\n",
-				commit,
-			)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-				"Build date: %s\n",
-				date,
-			)
-			return nil
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Your current version is: %s\n", version)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Build commit: %s\n", commit)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Build date: %s\n", date)
+				return nil
+			default:
+				return fmt.Errorf("unsupported format %q, supported: text, json", outputFormat)
+			}
 		},
 	}
+
+	versionCmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json"`)
+
 	return versionCmd
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -3,29 +3,35 @@ package version
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
-	"github.com/kubescape/kubescape/v3/core/core"
-
 	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGetVersionCmd(t *testing.T) {
+func TestGetVersionCmd_TextOutput(t *testing.T) {
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+
 	tests := []struct {
 		name        string
 		buildNumber string
+		args        []string
 		want        string
 	}{
 		{
-			name:        "Undefined Build Number",
+			name:        "default (no flag)",
 			buildNumber: "unknown",
+			args:        nil,
 			want:        "Your current version is: unknown\nBuild commit: \nBuild date: \n",
 		},
 		{
-			name:        "Defined Build Number: v3.0.1",
+			name:        "explicit --format text",
 			buildNumber: "v3.0.1",
+			args:        []string{"--format", "text"},
 			want:        "Your current version is: v3.0.1\nBuild commit: \nBuild date: \n",
 		},
 	}
@@ -34,16 +40,90 @@ func TestGetVersionCmd(t *testing.T) {
 			versioncheck.BuildNumber = tt.buildNumber
 
 			ks := core.NewKubescape(context.Background())
-			if cmd := GetVersionCmd(ks, tt.buildNumber, "", ""); cmd != nil {
-				buf := bytes.NewBufferString("")
-				cmd.SetOut(buf)
-				cmd.Execute()
-				out, err := io.ReadAll(buf)
-				if err != nil {
-					t.Fatal(err)
-				}
-				assert.Equal(t, tt.want, string(out))
+			cmd := GetVersionCmd(ks, tt.buildNumber, "", "")
+			require.NotNil(t, cmd)
+
+			buf := bytes.NewBufferString("")
+			cmd.SetOut(buf)
+			if tt.args != nil {
+				cmd.SetArgs(tt.args)
 			}
+			require.NoError(t, cmd.Execute())
+
+			out, err := io.ReadAll(buf)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(out))
 		})
 	}
+}
+
+func TestGetVersionCmd_JSONOutput(t *testing.T) {
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+		date    string
+	}{
+		{
+			name:    "all fields populated",
+			version: "v3.0.1",
+			commit:  "abc123",
+			date:    "2024-01-15",
+		},
+		{
+			name:    "empty commit and date",
+			version: "v3.2.0",
+			commit:  "",
+			date:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			versioncheck.BuildNumber = tt.version
+
+			ks := core.NewKubescape(context.Background())
+			cmd := GetVersionCmd(ks, tt.version, tt.commit, tt.date)
+			require.NotNil(t, cmd)
+
+			buf := bytes.NewBufferString("")
+			cmd.SetOut(buf)
+			cmd.SetArgs([]string{"--format", "json"})
+			require.NoError(t, cmd.Execute())
+
+			out, err := io.ReadAll(buf)
+			require.NoError(t, err)
+
+			var got versionInfo
+			require.NoError(t, json.Unmarshal(out, &got))
+			assert.Equal(t, tt.version, got.Version)
+			assert.Equal(t, tt.commit, got.Commit)
+			assert.Equal(t, tt.date, got.Date)
+		})
+	}
+}
+
+func TestGetVersionCmd_FormatFlagRegistered(t *testing.T) {
+	ks := core.NewKubescape(context.Background())
+	cmd := GetVersionCmd(ks, "v3.0.0", "", "")
+	require.NotNil(t, cmd)
+
+	f := cmd.Flags().Lookup("format")
+	require.NotNil(t, f, "--format flag must be registered on the version command")
+	assert.Equal(t, "text", f.DefValue, "--format default must be text")
+}
+
+func TestGetVersionCmd_InvalidFormat(t *testing.T) {
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+
+	ks := core.NewKubescape(context.Background())
+	cmd := GetVersionCmd(ks, "v3.0.0", "", "")
+	require.NotNil(t, cmd)
+
+	cmd.SetArgs([]string{"--format", "yaml"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "yaml")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -711,7 +711,24 @@ Display version information.
 ### Synopsis
 
 ```bash
+kubescape version [--format text|json]
+```
+
+### Flags
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--format` | `-f` | `text` | Output format. Supported: `text`, `json` |
+
+### Examples
+
+```bash
+# Default human-readable output
 kubescape version
+
+# Machine-readable JSON output (safe to pipe to jq)
+kubescape version --format json
+# {"version":"v3.x.x","commit":"abc123","date":"2024-01-15"}
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `kubescape version` only prints human-readable text, making it
  unsuitable for scripts and CI pipelines that need to consume version
  info programmatically.
- Added `--output` flag (shorthand `-o`) with values `text` (default,
  unchanged behavior) and `json`.
- JSON output marshals `version`, `commit`, and `date` into a single
  object: `{"version":"v3.x.x","commit":"abc123","date":"2024-01-15"}`.
- The text path is entirely unchanged - existing users are unaffected.
- Tested: text output (existing cases preserved), JSON unmarshal, flag
  registration and default value.

**Which issue(s) this PR fixes:**
N/A, self-identified gap.

**Special notes for your reviewer:**
Only `cmd/version/version.go` and `cmd/version/version_test.go` change.
The `--output` flag is local to this command (not inherited from a parent)
to keep it isolated from the scan command's `--format` flag.

**Does this PR introduce a user-facing change?**
Yes `kubescape version --output json` now emits a JSON object. The
default text output is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output for version information, including the version, commit, and release date.
  * Added an `--output`/`-o` option supporting `text` and `json` formats.
  * Text output remains the default format.

* **Bug Fixes**
  * Unsupported output formats now return a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->