### PR TITLE
fix: return values for IKubescape List and Download

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -73,7 +73,8 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 				}
 				downloadInfo.Identifier = args[1]
 			}
-			if err := ks.Download(&downloadInfo); err != nil {
+			_, err := ks.Download(&downloadInfo)
+			if err != nil {
 				return err
 			}
 			return nil

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -56,8 +55,12 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 
 			listPolicies.Target = args[0]
 
-			if err := ks.List(&listPolicies); err != nil {
-				logger.L().Fatal(err.Error())
+			result, err := ks.List(&listPolicies)
+			if err != nil {
+				return err
+			}
+			if err := core.PrintListResult(ks.Context(), result, listPolicies.Target, listPolicies.Format); err != nil {
+				return err
 			}
 			return nil
 		},

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -36,5 +36,5 @@ func TestGetListCmd(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = listCmd.RunE(&cobra.Command{}, []string{"some-value"})
-	assert.Nil(t, err)
+	assert.ErrorContains(t, err, "invalid target")
 }

--- a/core/README.md
+++ b/core/README.md
@@ -87,14 +87,25 @@ results, err := ks.Scan(scanInfo, policyIdentifiers)
 
 ```go
 // List available policies
-err := ks.List(listPolicies)
+listResult, err := ks.List(listPolicies)
+if err != nil {
+    // Handle list error
+}
+
+// Use listResult.Names for frameworks/exceptions
+// Use listResult.Controls for controls
 ```
 
 ### Downloading Artifacts
 
 ```go
 // Download for offline use
-err := ks.Download(downloadInfo)
+downloadResult, err := ks.Download(downloadInfo)
+if err != nil {
+    // Handle download error
+}
+
+// Use downloadResult.Files for the saved artifact paths
 ```
 
 ### Image Scanning

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ const (
 	downloadDirPerm = 0700
 )
 
-var downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{
+var downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){
 	TargetControlsInputs: downloadConfigInputs,
 	TargetExceptions:     downloadExceptions,
 	TargetControl:        downloadControl,
@@ -77,25 +78,27 @@ func DownloadSupportCommands() []string {
 	return commands
 }
 
-func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) error {
+func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) (*metav1.DownloadResult, error) {
 	setPathAndFilename(downloadInfo)
 	if err := os.MkdirAll(downloadInfo.Path, downloadDirPerm); err != nil {
-		return err
+		return nil, err
 	}
-	if err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc); err != nil {
-		return err
+	files, err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return &metav1.DownloadResult{Files: files}, nil
 }
 
-func downloadArtifact(ctx context.Context, downloadInfo *metav1.DownloadInfo, downloadArtifactFunc map[string]func(context.Context, *metav1.DownloadInfo) error) error {
+func downloadArtifact(ctx context.Context, downloadInfo *metav1.DownloadInfo, downloadArtifactFunc map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error)) ([]string, error) {
 	if f, ok := downloadArtifactFunc[downloadInfo.Target]; ok {
-		if err := f(ctx, downloadInfo); err != nil {
-			return err
+		files, err := f(ctx, downloadInfo)
+		if err != nil {
+			return nil, err
 		}
-		return nil
+		return files, nil
 	}
-	return fmt.Errorf("unknown command to download")
+	return nil, fmt.Errorf("unknown command to download")
 }
 
 func setPathAndFilename(downloadInfo *metav1.DownloadInfo) {
@@ -114,114 +117,130 @@ func setPathAndFilename(downloadInfo *metav1.DownloadInfo) {
 	}
 }
 
-func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadArtifacts(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 	downloadInfo.FileName = ""
-	var artifacts = map[string]func(context.Context, *metav1.DownloadInfo) error{
-		"controls-inputs": downloadConfigInputs,
-		"exceptions":      downloadExceptions,
-		"framework":       downloadFramework,
-		"attack-tracks":   downloadAttackTracks,
+	var artifacts = map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){
+		TargetControlsInputs: downloadConfigInputs,
+		TargetExceptions:     downloadExceptions,
+		TargetFramework:      downloadFramework,
+		TargetAttackTracks:   downloadAttackTracks,
 	}
+	var files []string
+	var errs []error
 	for artifact := range artifacts {
-		if err := downloadArtifact(ctx, &metav1.DownloadInfo{Target: artifact, Path: downloadInfo.Path, FileName: fmt.Sprintf("%s.json", artifact)}, artifacts); err != nil {
+		artifactFiles, err := downloadArtifact(ctx, &metav1.DownloadInfo{
+			Target:    artifact,
+			Path:      downloadInfo.Path,
+			FileName:  fmt.Sprintf("%s.json", artifact),
+			AccountID: downloadInfo.AccountID,
+			AccessKey: downloadInfo.AccessKey,
+		}, artifacts)
+		if err != nil {
 			logger.L().Ctx(ctx).Warning("error downloading", helpers.String("artifact", artifact), helpers.Error(err))
+			errs = append(errs, err)
+			continue
 		}
+		files = append(files, artifactFiles...)
 	}
-	return nil
+	return files, errors.Join(errs...)
 }
 
-func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	controlsInputsGetter, _, err := configInputsGetterFunc(ctx, downloadInfo.Identifier, tenant.GetAccountID(), nil, false, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	controlInputs, err := controlsInputsGetter.GetControlsInputs(ctx, tenant.GetContextName())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if downloadInfo.FileName == "" {
 		downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Target)
 	}
 	if controlInputs == nil {
-		return fmt.Errorf("failed to download controlInputs - received empty objects")
+		return nil, fmt.Errorf("failed to download controlInputs - received empty objects")
 	}
 	// save in file
-	err = getter.SaveInFile(controlInputs, filepath.Join(downloadInfo.Path, downloadInfo.FileName))
+	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
+	err = getter.SaveInFile(controlInputs, downloadTo)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("path", filepath.Join(downloadInfo.Path, downloadInfo.FileName)))
-	return nil
+	logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("path", downloadTo))
+	return []string{downloadTo}, nil
 }
 
-func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 	exceptionsGetter, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	exceptions, err := exceptionsGetter.GetExceptions(ctx, tenant.GetContextName())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if downloadInfo.FileName == "" {
 		downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Target)
 	}
 	// save in file
-	err = getter.SaveInFile(exceptions, filepath.Join(downloadInfo.Path, downloadInfo.FileName))
+	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
+	err = getter.SaveInFile(exceptions, downloadTo)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	logger.L().Ctx(ctx).Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("path", filepath.Join(downloadInfo.Path, downloadInfo.FileName)))
-	return nil
+	logger.L().Ctx(ctx).Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("path", downloadTo))
+	return []string{downloadTo}, nil
 }
 
-func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadAttackTracks(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 	var err error
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	attackTracksGetter, err := attackTracksGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	attackTracks, err := attackTracksGetter.GetAttackTracks()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if downloadInfo.FileName == "" {
 		downloadInfo.FileName = fmt.Sprintf("%s.json", downloadInfo.Target)
 	}
 	// save in file
-	err = getter.SaveInFile(attackTracks, filepath.Join(downloadInfo.Path, downloadInfo.FileName))
+	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
+	err = getter.SaveInFile(attackTracks, downloadTo)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	logger.L().Success("Downloaded", helpers.String("attack tracks", downloadInfo.Target), helpers.String("path", filepath.Join(downloadInfo.Path, downloadInfo.FileName)))
-	return nil
+	logger.L().Success("Downloaded", helpers.String("attack tracks", downloadInfo.Target), helpers.String("path", downloadTo))
+	return []string{downloadTo}, nil
 
 }
 
-func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), true, nil, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if downloadInfo.Identifier == "" {
 		// if framework name not specified - download all frameworks
 		frameworks, err := g.GetFrameworks()
 		if err != nil {
-			return err
+			return nil, err
 		}
+		var files []string
 		for _, fw := range frameworks {
 			filename, err := getter.PolicyCacheFilename(fw.Name)
 			if err != nil {
@@ -231,68 +250,69 @@ func downloadFramework(ctx context.Context, downloadInfo *metav1.DownloadInfo) e
 			downloadTo := filepath.Join(downloadInfo.Path, filename)
 			err = getter.SaveInFile(fw, downloadTo)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("name", fw.Name), helpers.String("path", downloadTo))
+			files = append(files, downloadTo)
 		}
-		// return fmt.Errorf("missing framework name")
-	} else {
-		if downloadInfo.FileName == "" {
-			filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)
-			if err != nil {
-				return err
-			}
-			downloadInfo.FileName = filename
-		}
-		framework, err := g.GetFramework(downloadInfo.Identifier)
-		if err != nil {
-			return err
-		}
-		if framework == nil {
-			return fmt.Errorf("failed to download framework - received empty objects")
-		}
-		downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
-		err = getter.SaveInFile(framework, downloadTo)
-		if err != nil {
-			return err
-		}
-		logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("name", framework.Name), helpers.String("path", downloadTo))
+		return files, nil
 	}
-	return nil
+
+	if downloadInfo.FileName == "" {
+		filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)
+		if err != nil {
+			return nil, err
+		}
+		downloadInfo.FileName = filename
+	}
+	framework, err := g.GetFramework(downloadInfo.Identifier)
+	if err != nil {
+		return nil, err
+	}
+	if framework == nil {
+		return nil, fmt.Errorf("failed to download framework - received empty objects")
+	}
+	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
+	err = getter.SaveInFile(framework, downloadTo)
+	if err != nil {
+		return nil, err
+	}
+	logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("name", framework.Name), helpers.String("path", downloadTo))
+	return []string{downloadTo}, nil
 }
 
-func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
+func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
 
 	g, err := policyGetterFunc(ctx, nil, tenant.GetAccountID(), false, nil, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if downloadInfo.Identifier == "" {
 		// TODO - support
-		return fmt.Errorf("missing control ID")
+		return nil, fmt.Errorf("missing control ID")
 	}
 	if downloadInfo.FileName == "" {
 		filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		downloadInfo.FileName = filename
 	}
 	controls, err := g.GetControl(downloadInfo.Identifier)
 	if err != nil {
-		return fmt.Errorf("failed to download control ID '%s': %w", downloadInfo.Identifier, err)
+		return nil, fmt.Errorf("failed to download control ID '%s': %w", downloadInfo.Identifier, err)
 	}
 	if controls == nil {
-		return fmt.Errorf("failed to download control id '%s' - received empty objects", downloadInfo.Identifier)
+		return nil, fmt.Errorf("failed to download control id '%s' - received empty objects", downloadInfo.Identifier)
 	}
 	downloadTo := filepath.Join(downloadInfo.Path, downloadInfo.FileName)
 	err = getter.SaveInFile(controls, downloadTo)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("ID", downloadInfo.Identifier), helpers.String("path", downloadTo))
-	return nil
+	return []string{downloadTo}, nil
 }

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -31,7 +31,7 @@ func TestDownloadSupportCommands_ReturnsListOfAllAvailableDownloadCommands(t *te
 // Returns a non-empty list of download commands when 'DownloadSupportCommands' is called and 'downloadFunc' is not empty.
 func TestDownloadSupportCommands_ReturnsNonEmptyListOfDownloadCommandsWhenDownloadFuncNotEmpty(t *testing.T) {
 	// Arrange
-	downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{
+	downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){
 		"controls-inputs": downloadConfigInputs,
 		"exceptions":      downloadExceptions,
 		"framework":       downloadFramework,
@@ -60,7 +60,7 @@ func TestDownloadSupportCommands_ReturnsListOfStrings(t *testing.T) {
 // Returns an empty list when 'DownloadSupportCommands' is called and 'downloadFunc' is empty.
 func TestDownloadSupportCommands_ReturnsEmptyListWhenDownloadFuncEmpty(t *testing.T) {
 	// Arrange
-	downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) error{}
+	downloadFunc = map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){}
 
 	// Act
 	result := DownloadSupportCommands()
@@ -87,7 +87,8 @@ func TestDownloadArtifact(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		downloadInfo         *metav1.DownloadInfo
-		downloadArtifactFunc map[string]func(context.Context, *metav1.DownloadInfo) error
+		downloadArtifactFunc map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error)
+		files                []string
 		err                  error
 	}{
 		{
@@ -95,27 +96,30 @@ func TestDownloadArtifact(t *testing.T) {
 				Target: "controls-inputs",
 				Path:   filepath.Join("path", "to", "download"),
 			},
-			downloadArtifactFunc: map[string]func(context.Context, *metav1.DownloadInfo) error{
-				"controls-inputs": func(ctx context.Context, downloadInfo *metav1.DownloadInfo) error {
-					return nil
+			downloadArtifactFunc: map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){
+				"controls-inputs": func(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
+					return []string{filepath.Join(downloadInfo.Path, "controls-inputs.json")}, nil
 				},
 			},
-			err: nil,
+			files: []string{filepath.Join("path", "to", "download", "controls-inputs.json")},
+			err:   nil,
 		},
 		{
 			downloadInfo: &metav1.DownloadInfo{
 				Target: "unknown",
 				Path:   filepath.Join("path", "to", "download"),
 			},
-			downloadArtifactFunc: map[string]func(context.Context, *metav1.DownloadInfo) error{},
+			downloadArtifactFunc: map[string]func(context.Context, *metav1.DownloadInfo) ([]string, error){},
+			files:                nil,
 			err:                  fmt.Errorf("unknown command to download"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			err := downloadArtifact(ctx, tt.downloadInfo, tt.downloadArtifactFunc)
+			files, err := downloadArtifact(ctx, tt.downloadInfo, tt.downloadArtifactFunc)
 			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.files, files)
 		})
 	}
 }
@@ -168,7 +172,7 @@ func TestSetPathAndFilename(t *testing.T) {
 // TestDownload_UnknownTargetReturnsError verifies Kubescape.Download surfaces unknown targets.
 func TestDownload_UnknownTargetReturnsError(t *testing.T) {
 	ks := NewKubescape(context.Background())
-	err := ks.Download(&metav1.DownloadInfo{
+	_, err := ks.Download(&metav1.DownloadInfo{
 		Target: "unknown",
 		Path:   t.TempDir(),
 	})
@@ -197,7 +201,7 @@ func TestDownload_CreatesOutputDirectoryWithRestrictivePermissions(t *testing.T)
 	path := filepath.Join(t.TempDir(), "nested", "download-dir")
 
 	ks := NewKubescape(context.Background())
-	err := ks.Download(&metav1.DownloadInfo{
+	_, err := ks.Download(&metav1.DownloadInfo{
 		Target: "unknown",
 		Path:   path,
 	})
@@ -368,7 +372,7 @@ func TestDownloadConfigInputs(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withConfigInputsGetter(t, nil, errors.New("boom"))
 
-		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		_, err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
@@ -376,7 +380,7 @@ func TestDownloadConfigInputs(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withConfigInputsGetter(t, &fakeControlsInputsGetter{err: errors.New("fetch failed")}, nil)
 
-		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		_, err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
@@ -384,7 +388,7 @@ func TestDownloadConfigInputs(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: nil}, nil)
 
-		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
+		_, err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: t.TempDir()})
 		require.EqualError(t, err, "failed to download controlInputs - received empty objects")
 	})
 
@@ -392,7 +396,7 @@ func TestDownloadConfigInputs(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"b"}}}, nil)
 
-		err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: blockedDir(t)})
+		_, err := downloadConfigInputs(context.Background(), &metav1.DownloadInfo{Target: TargetControlsInputs, Path: blockedDir(t)})
 		require.ErrorContains(t, err, "blocker")
 	})
 
@@ -403,7 +407,8 @@ func TestDownloadConfigInputs(t *testing.T) {
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetControlsInputs, Path: dir}
-		require.NoError(t, downloadConfigInputs(context.Background(), info))
+		_, err := downloadConfigInputs(context.Background(), info)
+		require.NoError(t, err)
 		assert.Equal(t, "controls-inputs.json", info.FileName)
 
 		var got map[string][]string
@@ -417,7 +422,7 @@ func TestDownloadExceptions(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withExceptionsGetter(t, nil, errors.New("boom"))
 
-		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
+		_, err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
@@ -425,7 +430,7 @@ func TestDownloadExceptions(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withExceptionsGetter(t, &fakeExceptionsGetter{err: errors.New("fetch failed")}, nil)
 
-		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
+		_, err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
@@ -433,7 +438,7 @@ func TestDownloadExceptions(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withExceptionsGetter(t, &fakeExceptionsGetter{}, nil)
 
-		err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: blockedDir(t)})
+		_, err := downloadExceptions(context.Background(), &metav1.DownloadInfo{Target: TargetExceptions, Path: blockedDir(t)})
 		require.ErrorContains(t, err, "blocker")
 	})
 
@@ -444,7 +449,8 @@ func TestDownloadExceptions(t *testing.T) {
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetExceptions, Path: dir, FileName: "custom-exceptions.json"}
-		require.NoError(t, downloadExceptions(context.Background(), info))
+		_, err := downloadExceptions(context.Background(), info)
+		require.NoError(t, err)
 		assert.Equal(t, "custom-exceptions.json", info.FileName)
 
 		var got []armotypes.PostureExceptionPolicy
@@ -458,7 +464,7 @@ func TestDownloadAttackTracks(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withAttackTracksGetter(t, nil, errors.New("boom"))
 
-		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
+		_, err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
@@ -466,7 +472,7 @@ func TestDownloadAttackTracks(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withAttackTracksGetter(t, &fakeAttackTracksGetter{err: errors.New("fetch failed")}, nil)
 
-		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
+		_, err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
@@ -474,7 +480,7 @@ func TestDownloadAttackTracks(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withAttackTracksGetter(t, &fakeAttackTracksGetter{}, nil)
 
-		err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: blockedDir(t)})
+		_, err := downloadAttackTracks(context.Background(), &metav1.DownloadInfo{Target: TargetAttackTracks, Path: blockedDir(t)})
 		require.ErrorContains(t, err, "blocker")
 	})
 
@@ -485,7 +491,8 @@ func TestDownloadAttackTracks(t *testing.T) {
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetAttackTracks, Path: dir}
-		require.NoError(t, downloadAttackTracks(context.Background(), info))
+		_, err := downloadAttackTracks(context.Background(), info)
+		require.NoError(t, err)
 		assert.Equal(t, "attack-tracks.json", info.FileName)
 
 		var got []v1alpha1.AttackTrack
@@ -499,7 +506,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, nil, errors.New("boom"))
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
 		require.EqualError(t, err, "boom")
 	})
 
@@ -507,7 +514,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{frameworksErr: errors.New("fetch failed")}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir()})
 		require.EqualError(t, err, "fetch failed")
 	})
 
@@ -519,7 +526,7 @@ func TestDownloadFramework(t *testing.T) {
 		}}, nil)
 
 		dir := t.TempDir()
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: dir})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: dir})
 		require.NoError(t, err)
 
 		entries, err := os.ReadDir(dir)
@@ -534,7 +541,7 @@ func TestDownloadFramework(t *testing.T) {
 			{PortalBase: armotypes.PortalBase{Name: "nsa"}},
 		}}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t)})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t)})
 		require.ErrorContains(t, err, "blocker")
 	})
 
@@ -542,7 +549,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "a/b"})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "a/b"})
 		require.ErrorContains(t, err, "path separators")
 	})
 
@@ -550,7 +557,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{frameworkErr: errors.New("fetch failed")}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
 		require.EqualError(t, err, "fetch failed")
 	})
 
@@ -558,7 +565,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{framework: nil}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: t.TempDir(), Identifier: "nsa"})
 		require.EqualError(t, err, "failed to download framework - received empty objects")
 	})
 
@@ -569,7 +576,8 @@ func TestDownloadFramework(t *testing.T) {
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetFramework, Path: dir, Identifier: "nsa"}
-		require.NoError(t, downloadFramework(context.Background(), info))
+		_, err := downloadFramework(context.Background(), info)
+		require.NoError(t, err)
 		assert.Equal(t, "nsa.json", info.FileName)
 
 		var got reporthandling.Framework
@@ -581,7 +589,7 @@ func TestDownloadFramework(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{framework: &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}}, nil)
 
-		err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t), Identifier: "nsa"})
+		_, err := downloadFramework(context.Background(), &metav1.DownloadInfo{Target: TargetFramework, Path: blockedDir(t), Identifier: "nsa"})
 		require.ErrorContains(t, err, "blocker")
 	})
 }
@@ -591,7 +599,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, nil, errors.New("boom"))
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.EqualError(t, err, "boom")
 	})
 
@@ -599,7 +607,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir()})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir()})
 		require.EqualError(t, err, "missing control ID")
 	})
 
@@ -607,7 +615,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{}, nil)
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "a/b"})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "a/b"})
 		require.ErrorContains(t, err, "path separators")
 	})
 
@@ -615,7 +623,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{controlErr: errors.New("fetch failed")}, nil)
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "C-0001")
 		require.ErrorContains(t, err, "fetch failed")
 	})
@@ -624,7 +632,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{control: nil}, nil)
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir(), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "C-0001")
 		require.ErrorContains(t, err, "received empty objects")
 	})
@@ -633,7 +641,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withPolicyGetter(t, &fakePolicyGetter{control: &reporthandling.Control{}}, nil)
 
-		err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: blockedDir(t), Identifier: "C-0001"})
+		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: blockedDir(t), Identifier: "C-0001"})
 		require.ErrorContains(t, err, "blocker")
 	})
 
@@ -644,7 +652,8 @@ func TestDownloadControl(t *testing.T) {
 
 		dir := t.TempDir()
 		info := &metav1.DownloadInfo{Target: TargetControl, Path: dir, Identifier: "C-0001"}
-		require.NoError(t, downloadControl(context.Background(), info))
+		_, err := downloadControl(context.Background(), info)
+		require.NoError(t, err)
 		assert.Equal(t, "c-0001.json", info.FileName)
 
 		var got reporthandling.Control
@@ -662,7 +671,7 @@ func TestDownloadArtifacts(t *testing.T) {
 		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil)
 
 		dir := t.TempDir()
-		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
+		_, err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
 		require.NoError(t, err)
 
 		for _, want := range []string{"controls-inputs.json", "exceptions.json", "nsa.json", "attack-tracks.json"} {
@@ -671,7 +680,7 @@ func TestDownloadArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("continues after one artifact fails", func(t *testing.T) {
+	t.Run("continues after one artifact fails and reports the error", func(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		withConfigInputsGetter(t, &fakeControlsInputsGetter{inputs: map[string][]string{"a": {"1"}}}, nil)
 		withExceptionsGetter(t, nil, errors.New("boom"))
@@ -679,8 +688,9 @@ func TestDownloadArtifacts(t *testing.T) {
 		withPolicyGetter(t, &fakePolicyGetter{frameworks: []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "nsa"}}}}, nil)
 
 		dir := t.TempDir()
-		err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
-		require.NoError(t, err)
+		files, err := downloadArtifacts(context.Background(), &metav1.DownloadInfo{Target: TargetArtifacts, Path: dir})
+		require.Error(t, err)
+		assert.NotEmpty(t, files)
 
 		_, statErr := os.Stat(filepath.Join(dir, "exceptions.json"))
 		assert.True(t, os.IsNotExist(statErr), "exceptions.json should not have been written")

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -17,15 +17,10 @@ import (
 )
 
 // listFunc handles targets whose output is a flat []string (frameworks, exceptions).
-// "controls" is handled separately via listAndFormatControls because it produces typed structs.
+// "controls" is handled separately via listControls because it produces typed structs.
 var listFunc = map[string]func(context.Context, *metav1.ListPolicies) ([]string, error){
 	"frameworks": listFrameworks,
 	"exceptions": listExceptions,
-}
-
-var listFormatFunc = map[string]func(context.Context, string, []string){
-	"pretty-print": prettyPrintListFormat,
-	"json":         jsonListFormat,
 }
 
 func ListSupportActions() []string {
@@ -38,43 +33,55 @@ func ListSupportActions() []string {
 	return commands
 }
 
-func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) error {
+func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) (*metav1.ListResult, error) {
 	if listPolicies.Target == "controls" {
-		return ks.listAndFormatControls(listPolicies)
+		entries, err := listControls(ks.Context(), listPolicies)
+		if err != nil {
+			return nil, err
+		}
+		entries = naturalSortControls(entries)
+		return &metav1.ListResult{Controls: entries}, nil
 	}
 
 	if policyListerFunc, ok := listFunc[listPolicies.Target]; ok {
 		policies, err := policyListerFunc(ks.Context(), listPolicies)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		policies = naturalSortPolicies(policies)
-
-		if listFormatFunction, ok := listFormatFunc[listPolicies.Format]; ok {
-			listFormatFunction(ks.Context(), listPolicies.Target, policies)
-		} else {
-			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json' ", listPolicies.Format)
-		}
-
-		return nil
+		return &metav1.ListResult{Names: policies}, nil
 	}
-	return fmt.Errorf("unknown command to list")
+	return nil, fmt.Errorf("unknown command to list")
 }
 
-func (ks *Kubescape) listAndFormatControls(listPolicies *metav1.ListPolicies) error {
-	entries, err := listControls(ks.Context(), listPolicies)
-	if err != nil {
-		return err
+// PrintListResult writes a ListResult to the configured output using the
+// requested target and format. It is the caller side of Kubescape.List.
+func PrintListResult(ctx context.Context, result *metav1.ListResult, target, format string) error {
+	if result == nil {
+		return nil
 	}
-	entries = naturalSortControls(entries)
 
-	switch listPolicies.Format {
-	case "pretty-print":
-		prettyPrintControls(ks.Context(), entries)
-	case "json":
-		jsonControlsFormat(entries)
+	switch target {
+	case "controls":
+		switch format {
+		case "pretty-print":
+			prettyPrintControls(ctx, result.Controls)
+		case "json":
+			jsonControlsFormat(result.Controls)
+		default:
+			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'", format)
+		}
+	case "frameworks", "exceptions":
+		switch format {
+		case "pretty-print":
+			prettyPrintListFormat(ctx, target, result.Names)
+		case "json":
+			jsonListFormat(ctx, target, result.Names)
+		default:
+			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'", format)
+		}
 	default:
-		return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'", listPolicies.Format)
+		return fmt.Errorf("invalid target %q, supported targets: 'controls'/'frameworks'/'exceptions'", target)
 	}
 	return nil
 }

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Function receives a non-empty list of policies
@@ -522,6 +523,75 @@ func TestNaturalSortPolicies(t *testing.T) {
 
 func TestList_UnknownTargetReturnsError(t *testing.T) {
 	ks := &Kubescape{}
-	err := ks.List(&metav1.ListPolicies{Target: "not-a-valid-target", Format: "json"})
+	_, err := ks.List(&metav1.ListPolicies{Target: "not-a-valid-target", Format: "json"})
 	assert.EqualError(t, err, "unknown command to list")
+}
+
+func TestPrintListResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		format    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "controls pretty-print is valid",
+			target:  "controls",
+			format:  "pretty-print",
+			wantErr: false,
+		},
+		{
+			name:    "controls json is valid",
+			target:  "controls",
+			format:  "json",
+			wantErr: false,
+		},
+		{
+			name:      "controls invalid format returns error",
+			target:    "controls",
+			format:    "yaml",
+			wantErr:   true,
+			errSubstr: "invalid format",
+		},
+		{
+			name:    "frameworks pretty-print is valid",
+			target:  "frameworks",
+			format:  "pretty-print",
+			wantErr: false,
+		},
+		{
+			name:    "frameworks json is valid",
+			target:  "frameworks",
+			format:  "json",
+			wantErr: false,
+		},
+		{
+			name:      "frameworks invalid format returns error",
+			target:    "frameworks",
+			format:    "yaml",
+			wantErr:   true,
+			errSubstr: "invalid format",
+		},
+		{
+			name:      "invalid target returns error",
+			target:    "not-a-target",
+			format:    "json",
+			wantErr:   true,
+			errSubstr: "invalid target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &metav1.ListResult{Names: []string{"nsa"}, Controls: []metav1.ControlListEntry{{ID: "C-0001", Name: "control"}}}
+			err := PrintListResult(context.Background(), result, tt.target, tt.format)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/core/meta/datastructures/v1/download.go
+++ b/core/meta/datastructures/v1/download.go
@@ -8,3 +8,7 @@ type DownloadInfo struct {
 	AccountID  string
 	AccessKey  string
 }
+
+type DownloadResult struct {
+	Files []string // paths of the downloaded artifacts that were saved
+}

--- a/core/meta/datastructures/v1/listpolicies.go
+++ b/core/meta/datastructures/v1/listpolicies.go
@@ -12,6 +12,11 @@ type ListResponse struct {
 	IDs   []string
 }
 
+type ListResult struct {
+	Names    []string
+	Controls []ControlListEntry
+}
+
 // ControlListEntry is a single row emitted by "kubescape list controls --format json".
 type ControlListEntry struct {
 	ID         string   `json:"id"`

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -15,8 +15,8 @@ type IKubescape interface {
 	Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
 
 	// policies
-	List(listPolicies *metav1.ListPolicies) error     // TODO - return list response
-	Download(downloadInfo *metav1.DownloadInfo) error // TODO - return downloaded policies
+	List(listPolicies *metav1.ListPolicies) (*metav1.ListResult, error)
+	Download(downloadInfo *metav1.DownloadInfo) (*metav1.DownloadResult, error)
 
 	// config
 	SetCachedConfig(setConfig *metav1.SetConfig) error

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -20,12 +20,12 @@ func (m *MockIKubescape) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier)
 	return nil, nil
 }
 
-func (m *MockIKubescape) List(_ *metav1.ListPolicies) error {
-	return nil
+func (m *MockIKubescape) List(_ *metav1.ListPolicies) (*metav1.ListResult, error) {
+	return &metav1.ListResult{}, nil
 }
 
-func (m *MockIKubescape) Download(_ *metav1.DownloadInfo) error {
-	return nil
+func (m *MockIKubescape) Download(_ *metav1.DownloadInfo) (*metav1.DownloadResult, error) {
+	return &metav1.DownloadResult{}, nil
 }
 
 func (m *MockIKubescape) SetCachedConfig(_ *metav1.SetConfig) error {

--- a/downloader/main.go
+++ b/downloader/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -17,8 +19,11 @@ func main() {
 		{Target: "framework", Identifier: "security"}, // force add the "security" framework
 	}
 	for _, download := range downloads {
-		if err := ks.Download(&download); err != nil {
+		result, err := ks.Download(&download)
+		if err != nil {
 			logger.L().Error("failed to download artifact", helpers.Error(err), helpers.String("target", download.Target))
+			continue
 		}
+		logger.L().Success("downloaded artifacts", helpers.String("count", fmt.Sprintf("%d", len(result.Files))), helpers.String("files", strings.Join(result.Files, ", ")))
 	}
 }


### PR DESCRIPTION
## Description
close - #2789 
This PR resolves two of the three TODOs on the IKubescape public library interface.

- List now returns a ListResult pointer and an error.
- Download now returns a DownloadResult pointer and an error.

The third TODO for Scan is intentionally left for a follow-up PR because it requires designing a new metav1 ScanInfo type and migrating all Scan callers.

### What changed

- Added metav1 ListResult to core/meta/datastructures/v1/listpolicies.go.
- Added metav1 DownloadResult to core/meta/datastructures/v1/download.go.
- Updated core/meta/ksinterface.go signatures for List and Download.
- Refactored core/core/list.go so Kubescape.List returns results instead of formatting or printing.
- Added core.PrintListResult so CLI callers can still print the list in pretty-print or json format.
- Refactored core/core/download.go so Kubescape.Download returns the saved artifact paths.
- Updated cmd/list/list.go cmd/download/download.go and downloader/main.go to use the new return values.
- Updated core/mocks/cmd_mocks.go and affected tests.
- Updated core/README.md examples.

### Verification

- go build ./... passes in the root module.
- go build ./... passes in the httphandler module.
- go test -run '^$' ./... passes for root.
- go test ./cmd/list ./cmd/download ./core/core passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now report created files, including filenames and download counts.
  * Listing commands return structured results for policies, frameworks, controls, and exceptions.
  * List results support pretty-print and JSON output formats.

* **Bug Fixes**
  * Download operations continue processing remaining artifacts when individual downloads fail.
  * Listing and downloading errors are handled and reported more consistently.

* **Documentation**
  * Updated API examples to show returned listing and download results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->