### PR TITLE
fix(core): limit ScanAll expansion to framework scans and dedupe UseFrom

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -188,6 +188,10 @@ type Getters struct {
 func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyIdentifier) {
 	scanInfo.setUseFrom(policyIdentifiers)
 	scanInfo.setUseArtifactsFrom(ctx)
+	// setUseFrom and setUseArtifactsFrom can resolve to the same file - --use-default and
+	// --use-artifacts-from both point at the local store on the offline HTTP handler path -
+	// and a repeated path costs an extra read and unmarshal per policy load.
+	scanInfo.UseFrom = unique(scanInfo.UseFrom)
 	if scanInfo.ScanID == "" {
 		scanInfo.ScanID = uuid.NewString()
 	}
@@ -315,10 +319,11 @@ func AppendPolicyIdentifiers(existing []PolicyIdentifier, policies []string, kin
 }
 
 // containsIdentifier reports whether the named identifier is already present.
-// The comparison is case-insensitive because the identifier sources disagree on
-// casing - getter.NativeFrameworks is lower case while IPolicyGetter.ListFrameworks
-// returns the framework's declared name ("NSA", "MITRE") - and a duplicate makes
-// downloadScanPolicies fetch and evaluate the same framework twice.
+// The comparison is case-insensitive because a cache round-trip changes the casing:
+// the downloader lists regolibrary's lower case "nsa" and writes a file whose name
+// field is "NSA", so LoadPolicy.ListFrameworks reads back a name that no longer matches
+// the lower case getter.NativeFrameworks entry. Matching exactly would leave both in the
+// list and make downloadScanPolicies fetch and evaluate the same framework twice.
 func containsIdentifier(identifiers []PolicyIdentifier, name string) bool {
 	for _, policy := range identifiers {
 		if strings.EqualFold(policy.Identifier, name) {

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -380,6 +380,23 @@ func TestSetUseFrom(t *testing.T) {
 	}
 }
 
+// TestInitDeduplicatesUseFrom covers the offline HTTP handler configuration, where UseDefault
+// and UseArtifactsFrom both point at the local store, so setUseFrom and setUseArtifactsFrom
+// resolve the same framework files.
+func TestInitDeduplicatesUseFrom(t *testing.T) {
+	artifactsDir := t.TempDir()
+	framework := []byte(`{"name":"nsa","controls":[]}`)
+	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "nsa.json"), framework, 0600))
+
+	scanInfo := &ScanInfo{
+		UseFrom:          []string{filepath.Join(artifactsDir, "nsa.json")},
+		UseArtifactsFrom: artifactsDir,
+	}
+	scanInfo.Init(context.Background(), nil)
+
+	assert.Equal(t, []string{filepath.Join(artifactsDir, "nsa.json")}, scanInfo.UseFrom)
+}
+
 func TestSplitNamespaceList(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -381,18 +381,23 @@ func TestSetUseFrom(t *testing.T) {
 }
 
 // TestInitDeduplicatesUseFrom covers the offline HTTP handler configuration, where UseDefault
-// and UseArtifactsFrom both point at the local store, so setUseFrom and setUseArtifactsFrom
-// resolve the same framework files.
+// and UseArtifactsFrom both point at the local store: setUseFrom resolves a cache path per
+// identifier and setUseArtifactsFrom then discovers the very same file by reading the directory.
+// The local store is redirected at the temporary directory so both sources genuinely collide.
 func TestInitDeduplicatesUseFrom(t *testing.T) {
 	artifactsDir := t.TempDir()
 	framework := []byte(`{"name":"nsa","controls":[]}`)
 	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "nsa.json"), framework, 0600))
 
+	prevStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = artifactsDir
+	t.Cleanup(func() { getter.DefaultLocalStore = prevStore })
+
 	scanInfo := &ScanInfo{
-		UseFrom:          []string{filepath.Join(artifactsDir, "nsa.json")},
+		UseDefault:       true,
 		UseArtifactsFrom: artifactsDir,
 	}
-	scanInfo.Init(context.Background(), nil)
+	scanInfo.Init(context.Background(), BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework))
 
 	assert.Equal(t, []string{filepath.Join(artifactsDir, "nsa.json")}, scanInfo.UseFrom)
 }

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -365,8 +365,13 @@ func getDefaultFrameworksPaths() []string {
 // path, leaving an offline scan with a downloader it cannot reach. --use-default makes the
 // local store the policy source, so the expansion is answered from the default framework set
 // instead of the getter, the same set getDefaultFrameworksPaths serves in air-gapped mode.
+//
+// Only framework scans are expanded. `scan control` with no arguments also sets ScanAll, but
+// it is not a framework scan, and injecting KindFramework identifiers there would populate
+// UseFrom and silently turn the scan air-gapped - dropping the downloader that control inputs,
+// exceptions and attack tracks still fall back to.
 func resolveDefaultScanAllPolicies(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) []cautils.PolicyIdentifier {
-	if !scanInfo.ScanAll || !scanInfo.UseDefault {
+	if !scanInfo.ScanAll || !scanInfo.UseDefault || !scanInfo.FrameworkScan {
 		return policyIdentifiers
 	}
 	return cautils.AppendPolicyIdentifiers(policyIdentifiers, getter.NativeFrameworks, apisv1.KindFramework)

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -173,12 +173,12 @@ func TestResolveDefaultScanAllPolicies(t *testing.T) {
 	}{
 		{
 			name:     "ScanAll with UseDefault expands an empty list to the default frameworks",
-			scanInfo: &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			scanInfo: &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: true},
 			want:     nativeIdentifiers(),
 		},
 		{
 			name:              "ScanAll with UseDefault keeps the requested frameworks first",
-			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: true},
 			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"cis-v1.23-t1.0.1"}, apisv1.KindFramework),
 			want: append(
 				cautils.BuildPolicyIdentifiers([]string{"cis-v1.23-t1.0.1"}, apisv1.KindFramework),
@@ -187,7 +187,7 @@ func TestResolveDefaultScanAllPolicies(t *testing.T) {
 		},
 		{
 			name:              "ScanAll with UseDefault does not re-add differently cased frameworks",
-			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true},
+			scanInfo:          &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: true},
 			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"NSA", "MITRE"}, apisv1.KindFramework),
 			want: append(
 				cautils.BuildPolicyIdentifiers([]string{"NSA", "MITRE"}, apisv1.KindFramework),
@@ -204,6 +204,13 @@ func TestResolveDefaultScanAllPolicies(t *testing.T) {
 			scanInfo:          &cautils.ScanInfo{UseDefault: true},
 			policyIdentifiers: cautils.BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework),
 			want:              cautils.BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework),
+		},
+		{
+			// `scan control` with no arguments sets ScanAll but is not a framework scan;
+			// expanding it would populate UseFrom and turn the scan air-gapped.
+			name:     "control scan is not expanded even with ScanAll and UseDefault",
+			scanInfo: &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: false},
+			want:     nil,
 		},
 	}
 
@@ -230,6 +237,21 @@ func TestScanAllWithUseDefaultResolvesCachePaths(t *testing.T) {
 	policyGetter, err := getPolicyGetter(context.Background(), scanInfo.UseFrom, "123456789012", scanInfo.FrameworkScan, nil, isAirGappedMode(scanInfo))
 	require.NoError(t, err)
 	assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(policyGetter).String())
+}
+
+// TestScanAllControlScanWithUseDefaultStaysOnline guards the FrameworkScan gate: `scan control`
+// with no arguments sets ScanAll, and expanding it would resolve cache paths into UseFrom and
+// flip the scan air-gapped, cutting off the download fallback for control inputs, exceptions
+// and attack tracks on a cold cache.
+func TestScanAllControlScanWithUseDefaultStaysOnline(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: false}
+
+	policyIdentifiers := resolveDefaultScanAllPolicies(scanInfo, nil)
+	scanInfo.Init(context.Background(), policyIdentifiers)
+
+	assert.Empty(t, policyIdentifiers, "a control scan must not gain framework identifiers")
+	assert.Empty(t, scanInfo.UseFrom)
+	assert.False(t, isAirGappedMode(scanInfo), "control scans must keep the download fallback")
 }
 
 func TestPolicyIdentifierIdentities(t *testing.T) {


### PR DESCRIPTION
## Overview

Follow-up to #2792, addressing review feedback that arrived after merge. Two items are regressions introduced by that PR.

**1. `scan control --use-default` (no arguments) became an air-gapped scan.** `cmd/scan/control.go:78` sets `ScanAll = true` while `:102` sets `FrameworkScan = false`, so `resolveDefaultScanAllPolicies` fired on control scans and injected `KindFramework` identifiers into them. That populated `UseFrom`, flipped `isAirGappedMode` to true, and left `downloadReleasedPolicy` nil — so control inputs, exceptions and attack tracks came from `~/.kubescape` with no download and no fallback. On a cold cache the command degraded where it previously worked. Now gated on `scanInfo.FrameworkScan`, which also reads better for a function that emits `KindFramework`.

**2. `--use-default` duplicated paths in `UseFrom` on the offline HTTP handler path.** `requestshandler.go:149` sets both `UseDefault` and `UseArtifactsFrom = getter.DefaultLocalStore`, so `setUseFrom` and `setUseArtifactsFrom` resolved the same framework files and each native framework was read and unmarshalled twice. `ScanInfo.Init` now dedupes `UseFrom` via the existing order-preserving `unique` helper.

**3. Corrected the `containsIdentifier` comment.** It attributed the casing mismatch to `IPolicyGetter.ListFrameworks` generally. That is only true for `LoadPolicy` — `DownloadReleasedPolicy` returns regolibrary's lowercase names, so there is no collision on the download path. The collision is specifically the cache round-trip: the downloader lists `nsa`, writes a file whose `name` field is `NSA`, and `LoadPolicy` reads that back.

Dedupe was chosen over skipping `setUseFrom` when `UseArtifactsFrom` is set, since the latter would make `--use-default` silently inert whenever `--use-artifacts-from` is present.

## How to Test

```bash
go build ./... && go vet ./... && go test ./...
```

New coverage:
* `TestScanAllControlScanWithUseDefaultStaysOnline` — a control scan gains no framework identifiers and keeps the download fallback.
* `TestInitDeduplicatesUseFrom` — reproduces the offline handler config where both flags resolve the same file.
* `TestResolveDefaultScanAllPolicies` — new case for the `FrameworkScan` gate.

## Related issues/PRs:

* Follow-up to #2792 (#2770)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate policy files from being loaded when the same framework is provided through multiple sources.
  * Corrected “scan all” behavior so control scans no longer incorrectly include default framework policies.
  * Control scans remain online and no longer receive unrelated policy identifiers or cache paths.
* **Tests**
  * Added regression coverage for duplicate framework paths and control-scan policy resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->