### PR TITLE
[fix] : streaming collector dropping host-sensor fallback, silently passing controls it never evaluated

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -405,7 +405,16 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 
 	cloudResources := cautils.MapCloudResources(ksResourceMap)
 
-	setMapNamespaceToNumOfResources(ctx, allResources, sessionObj)
+	// allResources is resident.AllResources, which only ever holds
+	// cluster-scoped resources (see the partition loop above); namespaced
+	// resources live in namespaceBatches. Aggregate both before counting, and
+	// do it here, before namespaceBatches are drained into batchChan below.
+	countable := make(map[string]workloadinterface.IMetadata, len(allResources))
+	maps.Copy(countable, allResources)
+	for _, batch := range namespaceBatches {
+		maps.Copy(countable, batch.AllResources)
+	}
+	setMapNamespaceToNumOfResources(ctx, countable, sessionObj)
 	if len(cloudResources) > 0 {
 		if err := k8sHandler.collectCloudResources(ctx, sessionObj, allResources, ksResourceMap, cloudResources); err != nil {
 			cautils.SetInfoMapForResources(err.Error(), cloudResources, sessionObj.InfoMap)

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -378,16 +378,24 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 	}
 
 	hostResources := cautils.MapHostResources(ksResourceMap)
-	if len(hostResources) > 0 && sessionObj.Metadata.ScanMetadata.HostScanner {
-		logger.L().Info("Requesting Host scanner data")
-		infoMap, err := k8sHandler.collectHostResources(ctx, allResources, ksResourceMap)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("failed to collect host scanner resources", helpers.Error(err))
-			cautils.SetInfoMapForResources(err.Error(), hostResources, sessionObj.InfoMap)
-		} else {
-			for k, v := range infoMap {
-				sessionObj.InfoMap[k] = v
+	// check that controls use host sensor resources
+	if len(hostResources) > 0 {
+		if sessionObj.Metadata.ScanMetadata.HostScanner {
+			logger.L().Info("Requesting Host scanner data")
+			infoMap, err := k8sHandler.collectHostResources(ctx, allResources, ksResourceMap)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("failed to collect host scanner resources", helpers.Error(err))
+				cautils.SetInfoMapForResources(err.Error(), hostResources, sessionObj.InfoMap)
+			} else if k8sHandler.hostSensorHandler == nil {
+				// using hostSensor mock
+				cautils.SetInfoMapForResources("failed to init host scanner", hostResources, sessionObj.InfoMap)
+			} else {
+				for k, v := range infoMap {
+					sessionObj.InfoMap[k] = v
+				}
 			}
+		} else {
+			cautils.SetInfoMapForResources("This control is scanned exclusively by the Kubescape operator, not the Kubescape CLI. Install the Kubescape operator:\n     https://kubescape.io/docs/install-operator/.", hostResources, sessionObj.InfoMap)
 		}
 	}
 
@@ -396,6 +404,8 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 	}
 
 	cloudResources := cautils.MapCloudResources(ksResourceMap)
+
+	setMapNamespaceToNumOfResources(ctx, allResources, sessionObj)
 	if len(cloudResources) > 0 {
 		if err := k8sHandler.collectCloudResources(ctx, sessionObj, allResources, ksResourceMap, cloudResources); err != nil {
 			cautils.SetInfoMapForResources(err.Error(), cloudResources, sessionObj.InfoMap)

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -168,6 +168,39 @@ func TestCollectAndStreamBatches_RecordsWholeGVRFailureAlongsideSuccess(t *testi
 	assert.Len(t, defaultBatch.K8SResources[podsGVR], 1)
 }
 
+// TestCollectAndStreamBatches_HostScannerDisabled_MarksControlsSkipped guards
+// against the streaming collector silently dropping host-sensor controls: with
+// HostScanner disabled, GetResources (the non-streaming path) records these
+// controls as skipped with a pointer to the operator. The streaming collector
+// must record the same InfoMap entry, or the control resolves to Passed.
+func TestCollectAndStreamBatches_HostScannerDisabled_MarksControlsSkipped(t *testing.T) {
+	ctx := context.Background()
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("unexpected resource: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	session.Metadata.ScanMetadata.HostScanner = false
+	batches := make(chan *cautils.ResourceBatch, 1)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		QueryableResources{},
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{"KubeletConfiguration": nil},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err)
+	info, ok := session.InfoMap["KubeletConfiguration"]
+	require.True(t, ok, "host-sensor resources must be recorded as skipped when the host scanner is disabled")
+	assert.Equal(t, apis.StatusSkipped, info.InnerStatus)
+	assert.Contains(t, info.InnerInfo, "Install the Kubescape operator")
+}
+
 func TestCollectAndStreamBatches_RecordsPartialSelectorFailure(t *testing.T) {
 	ctx := context.Background()
 	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -201,6 +201,49 @@ func TestCollectAndStreamBatches_HostScannerDisabled_MarksControlsSkipped(t *tes
 	assert.Contains(t, info.InnerInfo, "Install the Kubescape operator")
 }
 
+// TestCollectAndStreamBatches_CountsNamespacedResourcesAcrossBatches guards
+// against setMapNamespaceToNumOfResources being handed only the resident
+// (cluster-scoped) batch: namespaced resources live in namespaceBatches, so
+// counting resident.AllResources alone always yields an empty map.
+func TestCollectAndStreamBatches_CountsNamespacedResourcesAcrossBatches(t *testing.T) {
+	ctx := context.Background()
+	twoPods := &unstructured.UnstructuredList{
+		Object: map[string]any{"apiVersion": "v1", "kind": "PodList"},
+		Items: []unstructured.Unstructured{
+			{Object: map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "a", "namespace": "ns-a"}}},
+			{Object: map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "b", "namespace": "ns-a"}}},
+		},
+	}
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, twoPods, nil
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, session.Metadata.ContextMetadata.ClusterContextMetadata)
+	assert.Equal(t, map[string]int{"ns-a": 2}, session.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
+}
+
 func TestCollectAndStreamBatches_RecordsPartialSelectorFailure(t *testing.T) {
 	ctx := context.Background()
 	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
## Overview

This is the fix for #2796 .

The issue was that `collectAndStreamBatches` (the resource collector auto-enabled above 2500 resources) dropped the host-sensor fallback logic that `GetResources` (the small-cluster path) has. When `HostScanner` is disabled, it silently skipped writing anything to `sessionObj.InfoMap` for host-sensor resources, so those controls resolved to Passed/Irrelevant instead of Skipped -- inflating compliance scores on exactly the clusters where accurate results matter most.

The fix restores the nested `if hostResources > 0 { if HostScanner { ... } else { ... } }` structure to match `GetResources`, re-adding the `else` branch that marks host-sensor resources Skipped with the operator-install message when `HostScanner` is off, and the `hostSensorHandler == nil` mock-fallback branch. Also added the missing `setMapNamespaceToNumOfResources(ctx, allResources, sessionObj)` call, which the streaming path had also dropped, leaving `MapNamespaceToNumberOfResources` empty in every streamed report.

Now the two collectors are actually consistent:

- Small cluster (eager path) -> host-sensor controls Skipped with operator-install message when HostScanner is off
- Large cluster (streaming path) -> same Skipped result, same message (previously silently Passed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming resource collection when host scanning is unavailable or disabled.
  - Host resources are now clearly marked with informational statuses, including guidance for enabling the required host sensor.
  - Successful host data is retained when available, while collection errors continue to be reported.
  - Disabled host scanning no longer triggers unnecessary Kubernetes requests.
  - Namespace resource counts are now captured consistently across all namespace batches and combined with cluster-scoped resources for more accurate totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->