### PR TITLE
fix(cmd): close temporary file handle after streaming stdin in scan commands

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -92,6 +92,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 						defer os.Remove(tempFile.Name())
 
 						if _, err := io.Copy(tempFile, os.Stdin); err != nil {
+							_ = tempFile.Close()
+							return err
+						}
+						if err := tempFile.Close(); err != nil {
 							return err
 						}
 						scanInfo.InputPatterns = []string{tempFile.Name()}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -113,6 +113,10 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 						defer os.Remove(tempFile.Name())
 
 						if _, err := io.Copy(tempFile, os.Stdin); err != nil {
+							_ = tempFile.Close()
+							return err
+						}
+						if err := tempFile.Close(); err != nil {
 							return err
 						}
 						scanInfo.InputPatterns = []string{tempFile.Name()}


### PR DESCRIPTION
## Description

Closes #2798

This PR fixes an issue where temporary files created while scanning Kubernetes manifests from standard input (`-`) were not explicitly closed before being read by the scanner.

Previously, `os.CreateTemp()` was used to create a temporary file and `io.Copy()` wrote stdin to it, but the file handle remained open until process exit. This could result in:

- Unflushed write buffers before the scanner reads the file.
- File sharing violations on Windows because the file remained open for writing.
- Unnecessary file descriptor leaks.

This change explicitly calls `tempFile.Close()` immediately after `io.Copy()` completes in both:

- `cmd/scan/framework.go`
- `cmd/scan/control.go`

This ensures the temporary file is fully flushed, the write handle is released before scanning, and resources are cleaned up correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

- Ran the scan package tests:
  ```bash
  go test -v ./cmd/scan/...
  ```
- Verified that all tests pass successfully.
- Confirmed the temporary file is closed before its path is assigned to `scanInfo.InputPatterns`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have tested my changes locally.
- [x] All existing tests pass.
- [x] My commit message follows the project's conventions.
- [x] I have signed off my commits (`git commit -s`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when scanning input from standard input encounters an error.
  * Temporary files are now properly closed before scan commands return failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->