### PR TITLE
fix: resolve HTTPPost connection leak on error by draining response body

### DIFF
--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	v1 "github.com/kubescape/backend/pkg/client/v1"
@@ -100,6 +101,24 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Read up to 1024 bytes (the max ErrAPI processes) so it can format the error message.
+		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if readErr != nil {
+			logger.L().Warning("failed to fully read error response body", helpers.Error(readErr))
+		}
+
+		// Fully drain the rest of the response body to ensure the TCP connection can be reused.
+		// Add a deadline to prevent hanging if the server drips the response slowly.
+		timer := time.AfterFunc(2*time.Second, func() {
+			resp.Body.Close()
+		})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		timer.Stop()
+		resp.Body.Close()
+
+		// Restore the body for utils.ErrAPI so it can format the error message
+		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
 		return nil, 0, utils.ErrAPI(resp)
 	}
 

--- a/core/cautils/getter/kscloudapi_test.go
+++ b/core/cautils/getter/kscloudapi_test.go
@@ -3,14 +3,17 @@ package getter
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	v1 "github.com/kubescape/backend/pkg/client/v1"
 	utils "github.com/kubescape/backend/pkg/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,4 +116,33 @@ func mockAPIServer(t testing.TB) *testServer {
 	})
 
 	return server
+}
+
+func TestHTTPPost_ReusesConnectionOnError(t *testing.T) {
+	var activeConns int32
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Return a body larger than 1024 bytes (ErrAPI reads max 1024)
+		io.WriteString(w, strings.Repeat("A", 2048))
+	}))
+	ts.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&activeConns, 1)
+		}
+	}
+	ts.Start()
+	defer ts.Close()
+
+	client := ts.Client()
+
+	// Make 5 requests. If connections are reused, activeConns should be 1.
+	for i := 0; i < 5; i++ {
+		_, _, err := HTTPPost(client, ts.URL, []byte("test"), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500 Internal Server Error")
+		assert.Contains(t, err.Error(), strings.Repeat("A", 1024))
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&activeConns), "Bug: HTTPPost leaks connections on error by not draining the response body")
 }


### PR DESCRIPTION
## Overview

This PR fixes a resource management issue in `HTTPPost` (`core/cautils/getter/kscloudapi.go`) that prevents HTTP connections from being reused when requests fail.

**Current behavior:** When an HTTP request returns a non-success status code, `HTTPPost` delegates error formatting to `utils.ErrAPI`. Since `ErrAPI` reads only a limited portion of the response body before closing it, the remaining unread data prevents Go's `net/http` transport from reusing the underlying TCP connection. Under repeated error responses, this results in unnecessary connection churn and reduced keep-alive efficiency.

**New behavior:** Before delegating to `utils.ErrAPI`, `HTTPPost` now preserves the portion of the response body required for error formatting while fully consuming the remaining response body. It then restores the preserved bytes as a new `io.ReadCloser` before calling `utils.ErrAPI`. This allows the HTTP transport to safely reuse the underlying TCP connection while preserving the existing error messages.

---

## Additional Information

- `utils.ErrAPI` is implemented in the external `kubescape/backend` repository, so the fix is applied within `HTTPPost` without changing external dependencies.
- The existing error formatting behavior is preserved while allowing HTTP keep-alive connections to be reused.

---

## How to Test

A regression test, `TestHTTPPost_ReusesConnectionOnError`, has been added to `core/cautils/getter/kscloudapi_test.go`.

Run:

```bash
go test -v -run TestHTTPPost_ReusesConnectionOnError ./core/cautils/getter
```

The test starts a mock HTTP server that returns a large `500 Internal Server Error` response, performs multiple POST requests using the same HTTP client, and verifies that only a single TCP connection is established.

### Example Output

```text
=== RUN   TestHTTPPost_ReusesConnectionOnError
--- PASS: TestHTTPPost_ReusesConnectionOnError (0.00s)

PASS
ok      github.com/kubescape/kubescape/v3/core/cautils/getter    1.138s
```

---

## Related Issues

- Closes #2806 

---

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my changes.
- [x] I have added tests covering the fix.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server-error responses during API requests.
  * Connections are now reused more reliably after oversized error responses, improving request efficiency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->