### PR TITLE
refactor(core): expose cluster connection failure as a sentinel error

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -155,8 +155,9 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 	switch {
 	case k8s == nil:
 		// k8s is nil exactly when this scan never connected to a cluster (a
-		// non-cluster scan, or getKubernetesApi() failing - which exits the
-		// process via logger.Fatal before we'd get here). Re-checking
+		// non-cluster scan, or a cluster scan that failed to connect, which
+		// getInterfaces returns ErrClusterConnection for before reaching this
+		// point). Re-checking
 		// k8sinterface.IsConnectedToCluster() here as well used to read the
 		// same global connection state a second time, at a later point than
 		// when k8s was obtained, with no synchronization between the two

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -32,6 +33,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// ErrClusterConnection is returned when a cluster scan cannot reach the
+// Kubernetes API server. Callers embedding Kubescape.Scan can test for it with
+// errors.Is to distinguish an unreachable cluster from other scan failures.
+var ErrClusterConnection = errors.New("failed connecting to Kubernetes cluster")
+
 type componentInterfaces struct {
 	tenantConfig      cautils.ITenantConfig
 	resourceHandler   resourcehandler.IResourceHandler
@@ -53,7 +59,8 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdenti
 		if k8s == nil {
 			// Return rather than terminate: Scan already propagates this to the
 			// caller, and the command layer still exits non-zero on it.
-			return componentInterfaces{}, fmt.Errorf("failed connecting to Kubernetes cluster")
+			span.RecordError(ErrClusterConnection)
+			return componentInterfaces{}, ErrClusterConnection
 		}
 		k8sClient = k8s.KubernetesClient
 	}

--- a/core/core/scan_interfaces_test.go
+++ b/core/core/scan_interfaces_test.go
@@ -27,7 +27,7 @@ func TestGetInterfaces_ClusterConnectionFailureReturnsError(t *testing.T) {
 	_, err := getInterfaces(context.Background(), scanInfo, nil)
 
 	require.Error(t, err, "an unreachable cluster must be reported to the caller")
-	assert.ErrorContains(t, err, "failed connecting to Kubernetes cluster")
+	assert.ErrorIs(t, err, ErrClusterConnection)
 }
 
 // A caller that survives one unreachable cluster must be able to keep going,


### PR DESCRIPTION
## Overview

The three non-blocking follow-ups @matthyx raised reviewing #2788.

**1. Sentinel error.** `getInterfaces` returned an anonymous `fmt.Errorf` with a
constant string, so an embedder of `Kubescape.Scan` could only tell "cluster
unreachable" apart from any other scan failure by string-matching the message.
That undercuts the point of #2788, which was to make the failure handleable.

```go
// ErrClusterConnection is returned when a cluster scan cannot reach the
// Kubernetes API server.
var ErrClusterConnection = errors.New("failed connecting to Kubernetes cluster")
```

The message is unchanged, so `logger.L().Fatal(err.Error())` at the command
layer prints exactly what it printed before. The regression test now asserts
`errors.Is(err, ErrClusterConnection)` rather than matching on text. This also
lines up with `NewOperatorAdapter` in `clusterconnector.go`, which already uses
`errors.New` for the same class of failure.

**2. Stale comment.** `getHostSensorHandler` in `core/core/initutils.go` still
said `getKubernetesApi()` failing "exits the process via logger.Fatal before
we'd get here". #2788 made that untrue. The logic it guards is still correct —
`getInterfaces` returns before reaching `getHostSensorHandler`, so `k8s == nil`
there still means a non-cluster scan — but the parenthetical would mislead the
next reader, so it now describes the error return instead.

**3. Span association.** The old call was
`logger.L().Ctx(ctx).Fatal(...)`; the command layer's
`logger.L().Fatal(err.Error())` has no `ctx`, so the failure was no longer
attached to the `setup interfaces` span. Added `span.RecordError` before
returning to preserve it.

No behaviour change for any existing caller.

## How to Test

```bash
go test ./core/core/ -run TestGetInterfaces_ClusterConnection -count=1 -v
```

```
--- PASS: TestGetInterfaces_ClusterConnectionFailureReturnsError
--- PASS: TestGetInterfaces_ClusterConnectionFailureIsRecoverable
```

Also ran:

```bash
go build ./...
go vet ./...
go test ./core/core/... -count=1
go test -race ./core/core/... -count=1
```

All clean.

## Related issues/PRs

Follow-up to #2788.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kubernetes cluster connection failures.
  * Connection errors can now be identified consistently, enabling clearer error reporting and handling.
* **Documentation**
  * Clarified initialization guidance for cases where a cluster connection attempt fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->