### PR TITLE
fix(core): cancel streaming producer context on early evaluation error (#2814)

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -527,7 +527,10 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	reportResults.ControlTimeout = controlTimeout
 
 	// Stream resources in batches
-	batchChan, errChan, expectedNamespaceBatches, err := resourceHandler.StreamResourcesBatches(ctx, scanData, scanInfo)
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	batchChan, errChan, expectedNamespaceBatches, err := resourceHandler.StreamResourcesBatches(streamCtx, scanData, scanInfo)
 	if err != nil {
 		return fmt.Errorf("failed to start resource streaming: %w", err)
 	}
@@ -537,7 +540,7 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	reportResults.SetInitialResourceCount(estimatedClusterSize)
 
 	// Process batches with streaming
-	if err := reportResults.ProcessWithStreaming(ctx, batchChan, errChan, cautils.NewProgressHandler(""), expectedNamespaceBatches); err != nil {
+	if err := reportResults.ProcessWithStreaming(streamCtx, batchChan, errChan, cautils.NewProgressHandler(""), expectedNamespaceBatches); err != nil {
 		return fmt.Errorf("failed to process rules with streaming: %w", err)
 	}
 

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -400,4 +401,32 @@ func TestKubescape_SetContextRestoresOriginal(t *testing.T) {
 	ks.SetContext(originalCtx)
 	_, hasDeadline = ks.Context().Deadline()
 	assert.False(t, hasDeadline)
+}
+
+type streamingCancelMock struct {
+	estimateClusterSizeMock
+	passedCtx context.Context
+}
+
+func (m *streamingCancelMock) StreamResourcesBatches(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (<-chan *cautils.ResourceBatch, <-chan error, int, error) {
+	m.passedCtx = ctx
+	batchChan := make(chan *cautils.ResourceBatch, 1)
+	errChan := make(chan error, 1)
+	close(batchChan)
+	close(errChan)
+	return batchChan, errChan, 0, nil
+}
+
+func TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext(t *testing.T) {
+	mockHandler := &streamingCancelMock{}
+	sessionObj := cautils.NewOPASessionObjMock()
+	scanInfo := &cautils.ScanInfo{}
+
+	parentCtx := context.Background()
+
+	_ = collectAndProcessResourcesWithStreaming(parentCtx, mockHandler, sessionObj, scanInfo, "cluster", "", "", false, time.Second, 10)
+
+	require.NotNil(t, mockHandler.passedCtx)
+	assert.NoError(t, parentCtx.Err(), "parent context must remain uncanceled")
+	assert.Equal(t, context.Canceled, mockHandler.passedCtx.Err(), "derived producer context must be canceled when function returns")
 }


### PR DESCRIPTION


## Overview
This PR fixes a goroutine leak in `collectAndProcessResourcesWithStreaming` (`core/core/scan.go`) when streaming policy evaluation returns an error or fails early.

**Current behavior**: 
`collectAndProcessResourcesWithStreaming` starts a background producer goroutine via `resourceHandler.StreamResourcesBatches(ctx, ...)` and passes `batchChan` to `reportResults.ProcessWithStreaming(ctx, ...)`. If `ProcessWithStreaming` returns an error early (e.g. OPA evaluation failure, progress notification error, or rule timeout), `collectAndProcessResourcesWithStreaming` exits immediately, but `ctx` is not cancelled. Because `ProcessWithStreaming` stopped reading from `batchChan`, once `batchChan` fills its 2-slot buffer, the producer goroutine blocks indefinitely on `batchChan <- batch`, leaking the goroutine and retaining all collected Kubernetes objects in memory.

**Future behavior**: 
- `collectAndProcessResourcesWithStreaming` manages the producer context lifecycle via `streamCtx, cancel := context.WithCancel(ctx)` with `defer cancel()`.
- If `ProcessWithStreaming` exits early for any reason, `defer cancel()` cancels `streamCtx`, triggering `<-ctx.Done()` in `collectAndStreamBatches` and unblocking the producer goroutine immediately.
- Added unit test `TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext` in `core/core/scan_test.go` to verify producer context cancellation.

## Additional Information
This prevents memory and goroutine leaks during streaming scans on large clusters when evaluation encounters errors or terminates prematurely.

## How to Test
Run unit tests in `core/core`:
```bash
go test -v -run TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext ./core/core/...
```

## Related issues/PRs:
* Resolved #2814

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during streaming resource collection.
  * Ensured processing stops cleanly when an operation times out or is canceled.

* **Tests**
  * Added coverage verifying that streaming operations cancel their producer context while preserving the caller’s context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->