### PR TITLE
[fix] : HostSensorEnabled left true when explicit --host-scan=true handler construction fails

### DIFF
--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -170,6 +170,7 @@ func getHostSensorHandler(ctx context.Context, scanInfo *cautils.ScanInfo, k8s *
 		hostSensorHandler, err := hostsensorutils.NewHostSensorHandler(k8s, scanInfo.HostSensorYamlPath)
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("failed to create host scanner", helpers.Error(err))
+			scanInfo.HostSensorEnabled.SetBool(false)
 			return hostsensorutils.NewHostSensorHandlerMock()
 		}
 

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -15,6 +15,8 @@ import (
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
 )
 
 type TenantConfigMock struct {
@@ -463,6 +465,31 @@ func TestGetSensorHandler(t *testing.T) {
 
 		_, isMock := sensor.(*hostsensorutils.HostSensorHandlerMock)
 		require.True(t, isMock)
+	})
+
+	t.Run("should disable HostSensorEnabled if explicitly enabled but construction fails", func(t *testing.T) {
+		originalK8SConfig := k8sinterface.K8SConfig
+		t.Cleanup(func() { k8sinterface.K8SConfig = originalK8SConfig })
+		k8sinterface.K8SConfig = &restclient.Config{}
+
+		trueFlag := cautils.NewBoolPtr(nil)
+		trueFlag.SetBool(true)
+		scanInfo := &cautils.ScanInfo{
+			HostSensorEnabled: trueFlag,
+		}
+		// A client with no nodes makes NewHostSensorHandler fail its liveness check.
+		k8s := &k8sinterface.KubernetesApi{
+			KubernetesClient: fakeclientset.NewClientset(),
+			Context:          ctx,
+		}
+
+		sensor := getHostSensorHandler(ctx, scanInfo, k8s)
+		require.NotNil(t, sensor)
+
+		_, isMock := sensor.(*hostsensorutils.HostSensorHandlerMock)
+		require.True(t, isMock)
+		assert.False(t, scanInfo.HostSensorEnabled.GetBool(),
+			"a failed explicit host-scan request must not leave HostSensorEnabled true, or the collector will treat the mock's empty result as a clean scan")
 	})
 
 	// TODO(fredbi): need to share the k8s client mock to test a happy path / deployment failure path


### PR DESCRIPTION
## Overview

This is the fix for #2816 .

The issue was that `getHostSensorHandler` falls back to the no-op `HostSensorHandlerMock` when a user explicitly passes `--host-scan=true` but `NewHostSensorHandler` fails to construct (e.g. RBAC denies `list` on nodes) -- but leaves `scanInfo.HostSensorEnabled` at true. Downstream, that flag is read as "host scanning is active," so the mock's empty, error-free result is treated as a clean scan: host-sensor controls (kubelet auth, TLS, CNI, control-plane config) silently resolve to Passed instead of Skipped.

The fix is one line, matching the pattern the sibling auto-detect branch already uses -- `scanInfo.HostSensorEnabled.SetBool(false)` right before returning the mock in the explicit-enable branch:

```go
// before -- mock returned without clearing the flag
case hostSensorVal != nil && *hostSensorVal:
    hostSensorHandler, err := hostsensorutils.NewHostSensorHandler(k8s, scanInfo.HostSensorYamlPath)
    if err != nil {
        logger.L().Ctx(ctx).Warning("failed to create host scanner", helpers.Error(err))
        return hostsensorutils.NewHostSensorHandlerMock()
    }
    return hostSensorHandler

// after -- flag cleared, matching the auto-detect branch
case hostSensorVal != nil && *hostSensorVal:
    hostSensorHandler, err := hostsensorutils.NewHostSensorHandler(k8s, scanInfo.HostSensorYamlPath)
    if err != nil {
        logger.L().Ctx(ctx).Warning("failed to create host scanner", helpers.Error(err))
        scanInfo.HostSensorEnabled.SetBool(false)
        return hostsensorutils.NewHostSensorHandlerMock()
    }
    return hostSensorHandler
```

This makes the existing, correct fallback in `k8sresources.go` (`GetResources`/`collectAndStreamBatches`) take over -- it already reports `StatusSkipped` with an operator-install message when `HostScanner` is false.

Now the two cases are actually consistent:

- Host scanning never requested -> Skipped with operator-install message (unchanged)
- Host scanning requested but construction fails -> Skipped with operator-install message (previously silently Passed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host sensor initialization failures so the feature is correctly marked as disabled when a fallback mock sensor is used.
  * Improved reliability when host sensor setup fails after being explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->