### PR TITLE
fix(cautils): expand offline Kubernetes list envelopes

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -550,6 +550,7 @@ func expandListEnvelope(obj map[string]any, listKind string) ([]workloadinterfac
 	if !ok {
 		return nil, fmt.Errorf("%s.items must be an array", listKind)
 	}
+	restoreTypedListItemTypeMeta(list, listKind)
 
 	workloads := make([]workloadinterface.IMetadata, 0, len(list.Items))
 	for i := range list.Items {
@@ -565,6 +566,29 @@ func expandListEnvelope(obj map[string]any, listKind string) ([]workloadinterfac
 
 	return workloads, nil
 }
+
+// restoreTypedListItemTypeMeta fills each missing field independently. The
+// Kubernetes unstructured decoder only inherits the parent type metadata when
+// both fields are absent, so an item that supplies just one of kind or
+// apiVersion would otherwise remain only partially identified. Explicit item
+// values remain authoritative.
+func restoreTypedListItemTypeMeta(list *unstructured.UnstructuredList, listKind string) {
+	if listKind == string(workloadinterface.TypeListWorkloads) {
+		return
+	}
+
+	itemKind := strings.TrimSuffix(listKind, string(workloadinterface.TypeListWorkloads))
+	listAPIVersion := list.GetAPIVersion()
+	for i := range list.Items {
+		if list.Items[i].GetKind() == "" {
+			list.Items[i].SetKind(itemKind)
+		}
+		if list.Items[i].GetAPIVersion() == "" {
+			list.Items[i].SetAPIVersion(listAPIVersion)
+		}
+	}
+}
+
 func convertYamlToJson(i any) any {
 	switch x := i.(type) {
 	case map[any]any:

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var (
@@ -389,14 +390,10 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err 
 			continue
 		}
 		if obj, ok := j.(map[string]any); ok {
-			if o := objectsenvelopes.NewObject(obj); o != nil {
-				if o.GetObjectType() == workloadinterface.TypeListWorkloads {
-					if list := workloadinterface.NewListWorkloadsObj(o.GetObject()); list != nil {
-						yamlObjs = append(yamlObjs, list.GetItems()...)
-					}
-				} else {
-					yamlObjs = append(yamlObjs, o)
-				}
+			objects, objectErr := manifestObjectToWorkloads(obj)
+			yamlObjs = append(yamlObjs, objects...)
+			if objectErr != nil {
+				parseErrs = append(parseErrs, fmt.Errorf("document %d: %w", i+1, objectErr))
 			}
 		}
 	}
@@ -457,22 +454,116 @@ func readJsonFile(jsonFile []byte) (workloads []workloadinterface.IMetadata, err
 		return workloads, err
 	}
 
-	convertJsonToWorkload(jsonObj, &workloads)
+	if convertErr := convertJsonToWorkload(jsonObj, &workloads); convertErr != nil {
+		return workloads, convertErr
+	}
 
 	return workloads, nil
 }
-func convertJsonToWorkload(jsonObj any, workloads *[]workloadinterface.IMetadata) {
+
+func convertJsonToWorkload(jsonObj any, workloads *[]workloadinterface.IMetadata) error {
 
 	switch x := jsonObj.(type) {
 	case map[string]any:
-		if o := objectsenvelopes.NewObject(x); o != nil {
-			(*workloads) = append(*workloads, o)
-		}
+		objects, err := manifestObjectToWorkloads(x)
+		*workloads = append(*workloads, objects...)
+		return err
 	case []any:
+		var itemErrs []error
 		for i := range x {
-			convertJsonToWorkload(x[i], workloads)
+			if err := convertJsonToWorkload(x[i], workloads); err != nil {
+				itemErrs = append(itemErrs, fmt.Errorf("array item %d: %w", i, err))
+			}
+		}
+		return errors.Join(itemErrs...)
+	}
+	return nil
+}
+
+// manifestObjectToWorkloads normalizes Kubernetes list envelopes before object
+// envelopes are created. Both YAML and JSON readers use it so the accepted
+// manifest shapes do not depend on the input format.
+func manifestObjectToWorkloads(obj map[string]any) ([]workloadinterface.IMetadata, error) {
+	kind, isList, err := listEnvelopeKind(obj)
+	if err != nil {
+		return nil, err
+	}
+	if isList {
+		return expandListEnvelope(obj, kind)
+	}
+
+	if o := objectsenvelopes.NewObject(obj); o != nil {
+		return []workloadinterface.IMetadata{o}, nil
+	}
+	return nil, nil
+}
+
+// listEnvelopeKind recognizes the canonical List kind and typed list
+// envelopes such as PodList. A typed list has no resource identity of its own;
+// requiring that property prevents a normal named CR such as AllowList from
+// being classified as a list merely because its kind ends in "List".
+func listEnvelopeKind(obj map[string]any) (kind string, isList bool, err error) {
+	kindValue, hasKind := obj["kind"]
+	if !hasKind {
+		return "", false, nil
+	}
+	kind, ok := kindValue.(string)
+	if !ok {
+		return "", false, fmt.Errorf("kind must be a string")
+	}
+	if kind == string(workloadinterface.TypeListWorkloads) {
+		return kind, true, nil
+	}
+	if !strings.HasSuffix(kind, string(workloadinterface.TypeListWorkloads)) || manifestHasIdentity(obj) {
+		return kind, false, nil
+	}
+	return kind, true, nil
+}
+
+func manifestHasIdentity(obj map[string]any) bool {
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, field := range []string{"name", "generateName"} {
+		if value, ok := metadata[field].(string); ok && value != "" {
+			return true
 		}
 	}
+	return false
+}
+
+func expandListEnvelope(obj map[string]any, listKind string) ([]workloadinterface.IMetadata, error) {
+	if _, ok := obj["items"].([]any); !ok {
+		return nil, fmt.Errorf("%s.items must be an array", listKind)
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", listKind, err)
+	}
+	decoded, _, err := unstructured.UnstructuredJSONScheme.Decode(data, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", listKind, err)
+	}
+	list, ok := decoded.(*unstructured.UnstructuredList)
+	if !ok {
+		return nil, fmt.Errorf("%s.items must be an array", listKind)
+	}
+
+	workloads := make([]workloadinterface.IMetadata, 0, len(list.Items))
+	for i := range list.Items {
+		normalized, normalizeErr := manifestObjectToWorkloads(list.Items[i].Object)
+		if normalizeErr != nil {
+			return nil, fmt.Errorf("%s.items[%d]: %w", listKind, i, normalizeErr)
+		}
+		if len(normalized) == 0 {
+			return nil, fmt.Errorf("%s.items[%d] is not a Kubernetes object", listKind, i)
+		}
+		workloads = append(workloads, normalized...)
+	}
+
+	return workloads, nil
 }
 func convertYamlToJson(i any) any {
 	switch x := i.(type) {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -588,6 +589,173 @@ func TestReadJsonFile(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantCount, len(got))
+		})
+	}
+}
+
+func TestReadFileExpandsKubernetesListEnvelopes(t *testing.T) {
+	tests := []struct {
+		name      string
+		read      func([]byte) ([]workloadinterface.IMetadata, error)
+		content   string
+		wantKinds []string
+		wantAPIs  []string
+	}{
+		{
+			name: "JSON generic List",
+			read: readJsonFile,
+			content: `{
+				"apiVersion": "v1",
+				"kind": "List",
+				"items": [
+					{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "pod-in-list", "namespace": "default"}},
+					{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "svc-in-list", "namespace": "default"}}
+				]
+			}`,
+			wantKinds: []string{"Pod", "Service"},
+			wantAPIs:  []string{"v1", "v1"},
+		},
+		{
+			name: "JSON typed list inside an array",
+			read: readJsonFile,
+			content: `[
+				{
+					"apiVersion": "v1",
+					"kind": "PodList",
+					"items": [
+						{"metadata": {"name": "pod-in-list", "namespace": "default"}}
+					]
+				},
+				{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "standalone-service", "namespace": "default"}}
+			]`,
+			wantKinds: []string{"Pod", "Service"},
+			wantAPIs:  []string{"v1", "v1"},
+		},
+		{
+			name: "YAML typed list inside a multi-document manifest",
+			read: readYamlFile,
+			content: `apiVersion: v1
+kind: PodList
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-in-list
+      namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standalone-service
+  namespace: default`,
+			wantKinds: []string{"Pod", "Service"},
+			wantAPIs:  []string{"v1", "v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.read([]byte(tt.content))
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.wantKinds))
+			for i, wantKind := range tt.wantKinds {
+				assert.Equal(t, wantKind, got[i].GetKind())
+				assert.Equal(t, tt.wantAPIs[i], got[i].GetApiVersion())
+			}
+		})
+	}
+}
+
+func TestReadFileDoesNotTreatNamedCustomResourceAsListEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		read          func([]byte) ([]workloadinterface.IMetadata, error)
+		content       string
+		identityField string
+		identityValue string
+	}{
+		{
+			name:          "JSON name",
+			read:          readJsonFile,
+			identityField: "name",
+			identityValue: "production-allow-list",
+			content: `{
+				"apiVersion": "example.com/v1",
+				"kind": "AllowList",
+				"metadata": {"name": "production-allow-list"},
+				"items": ["10.0.0.0/8"]
+			}`,
+		},
+		{
+			name:          "YAML generateName",
+			read:          readYamlFile,
+			identityField: "generateName",
+			identityValue: "production-allow-list-",
+			content: `apiVersion: example.com/v1
+kind: AllowList
+metadata:
+  generateName: production-allow-list-
+items:
+  - 10.0.0.0/8`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.read([]byte(tt.content))
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, "AllowList", got[0].GetKind())
+			metadata, ok := got[0].GetObject()["metadata"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.identityValue, metadata[tt.identityField])
+		})
+	}
+}
+
+func TestReadFileRejectsMalformedListEnvelope(t *testing.T) {
+	tests := []struct {
+		name    string
+		read    func([]byte) ([]workloadinterface.IMetadata, error)
+		content string
+	}{
+		{
+			name:    "JSON generic List",
+			read:    readJsonFile,
+			content: `{"apiVersion":"v1","kind":"List","items":"not-an-array"}`,
+		},
+		{
+			name:    "JSON typed list with null items",
+			read:    readJsonFile,
+			content: `{"apiVersion":"v1","kind":"PodList","items":null}`,
+		},
+		{
+			name: "YAML typed list missing items",
+			read: readYamlFile,
+			content: `apiVersion: v1
+kind: PodList`,
+		},
+		{
+			name:    "JSON typed list with non-object item",
+			read:    readJsonFile,
+			content: `{"apiVersion":"v1","kind":"PodList","items":["not-an-object"]}`,
+		},
+		{
+			name: "YAML generic List with non-Kubernetes item",
+			read: readYamlFile,
+			content: `apiVersion: v1
+kind: List
+items:
+  - metadata:
+      name: missing-kind`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.read([]byte(tt.content))
+			assert.Error(t, err)
+			assert.Empty(t, got)
 		})
 	}
 }

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -651,6 +651,45 @@ metadata:
 			wantKinds: []string{"Pod", "Service"},
 			wantAPIs:  []string{"v1", "v1"},
 		},
+		{
+			name: "typed list fills a missing item kind",
+			read: readJsonFile,
+			content: `{
+				"apiVersion": "v1",
+				"kind": "PodList",
+				"items": [
+					{"apiVersion": "v1", "metadata": {"name": "missing-kind", "namespace": "default"}}
+				]
+			}`,
+			wantKinds: []string{"Pod"},
+			wantAPIs:  []string{"v1"},
+		},
+		{
+			name: "typed list fills a missing item apiVersion",
+			read: readYamlFile,
+			content: `apiVersion: v1
+kind: PodList
+items:
+  - kind: Pod
+    metadata:
+      name: missing-api-version
+      namespace: default`,
+			wantKinds: []string{"Pod"},
+			wantAPIs:  []string{"v1"},
+		},
+		{
+			name: "typed list preserves explicit item type metadata",
+			read: readJsonFile,
+			content: `{
+				"apiVersion": "v1",
+				"kind": "PodList",
+				"items": [
+					{"apiVersion": "example.com/v1", "kind": "Widget", "metadata": {"name": "explicit-type", "namespace": "default"}}
+				]
+			}`,
+			wantKinds: []string{"Widget"},
+			wantAPIs:  []string{"example.com/v1"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -59,7 +59,7 @@ func TestFileResourceHandlerIndexesListEnvelopeItemsForPolicies(t *testing.T) {
   "apiVersion": "v1",
   "kind": "PodList",
   "items": [
-    {"metadata": {"name": "json-typed-pod", "namespace": "default"}}
+    {"apiVersion": "v1", "metadata": {"name": "json-typed-pod", "namespace": "default"}}
   ]
 }`,
 			wantByGVR: map[string]string{"/v1/pods": "Pod"},
@@ -71,7 +71,8 @@ func TestFileResourceHandlerIndexesListEnvelopeItemsForPolicies(t *testing.T) {
 			manifest: `apiVersion: v1
 kind: PodList
 items:
-  - metadata:
+  - kind: Pod
+    metadata:
       name: yaml-typed-pod
       namespace: default
 `,

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -21,6 +21,104 @@ func TestNewFileResourceHandler_InitializesNewInstance(t *testing.T) {
 	assert.NotNil(t, fileHandler)
 }
 
+// This is deliberately a FileResourceHandler test rather than another parser
+// count assertion: list items must survive manifest loading, offline resource
+// resolution, and policy filtering before they become OPA input.
+func TestFileResourceHandlerIndexesListEnvelopeItemsForPolicies(t *testing.T) {
+	tests := []struct {
+		name      string
+		extension string
+		manifest  string
+		wantByGVR map[string]string
+		wantNames map[string]string
+	}{
+		{
+			name:      "JSON generic List",
+			extension: "json",
+			manifest: `{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "listed-pod", "namespace": "default"}},
+    {"apiVersion": "v1", "kind": "Service", "metadata": {"name": "listed-service", "namespace": "default"}}
+  ]
+}`,
+			wantByGVR: map[string]string{
+				"/v1/pods":     "Pod",
+				"/v1/services": "Service",
+			},
+			wantNames: map[string]string{
+				"/v1/pods":     "listed-pod",
+				"/v1/services": "listed-service",
+			},
+		},
+		{
+			name:      "JSON typed list",
+			extension: "json",
+			manifest: `{
+  "apiVersion": "v1",
+  "kind": "PodList",
+  "items": [
+    {"metadata": {"name": "json-typed-pod", "namespace": "default"}}
+  ]
+}`,
+			wantByGVR: map[string]string{"/v1/pods": "Pod"},
+			wantNames: map[string]string{"/v1/pods": "json-typed-pod"},
+		},
+		{
+			name:      "YAML typed list",
+			extension: "yaml",
+			manifest: `apiVersion: v1
+kind: PodList
+items:
+  - metadata:
+      name: yaml-typed-pod
+      namespace: default
+`,
+			wantByGVR: map[string]string{"/v1/pods": "Pod"},
+			wantNames: map[string]string{"/v1/pods": "yaml-typed-pod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifestPath := filepath.Join(t.TempDir(), "resources."+tt.extension)
+			require.NoError(t, os.WriteFile(manifestPath, []byte(tt.manifest), 0o600))
+
+			match := reporthandling.RuleMatchObjects{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"pods", "services"},
+			}
+			framework := *mockFramework("list-envelope-input", []reporthandling.Control{
+				mockControl("list-envelope-input", []reporthandling.PolicyRule{
+					mockRule("list-envelope-input", []reporthandling.RuleMatchObjects{match}, ""),
+				}),
+			})
+			scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
+			session := cautils.NewOPASessionObj(
+				context.Background(), []reporthandling.Framework{framework}, nil, scanInfo, nil,
+			)
+
+			resources, allResources, _, _, err := NewFileResourceHandler().GetResources(
+				context.Background(), session, scanInfo,
+			)
+			require.NoError(t, err)
+			require.Len(t, allResources, len(tt.wantByGVR))
+
+			for gvr, wantKind := range tt.wantByGVR {
+				require.Lenf(t, resources[gvr], 1, "expected %s in policy input %s", wantKind, gvr)
+				resourceID := resources[gvr][0]
+				resource, ok := allResources[resourceID]
+				require.Truef(t, ok, "policy input %s referenced missing resource %s", gvr, resourceID)
+				assert.Equal(t, wantKind, resource.GetKind())
+				assert.Equal(t, "v1", resource.GetApiVersion())
+				assert.Equal(t, tt.wantNames[gvr], resource.GetName())
+			}
+		})
+	}
+}
+
 // A single-file scan must yield a repository-relative RelativePath: the SARIF and GitLab SAST printers build the finding's file location from it, and the GitLab printer drops findings whose path is empty, absolute, or escaping the repo root. See #2496.
 func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *testing.T) {
 	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{})


### PR DESCRIPTION
## Overview

Offline manifest scans now expand Kubernetes list envelopes consistently for YAML and JSON.

Previously, the YAML path expanded only the exact `kind: List`, while the JSON path kept that envelope as a placeholder and both readers dropped typed lists such as `PodList`. This change routes decoded manifest objects through one list-aware normalization path that:

- expands generic and typed list envelopes into their items;
- restores item `apiVersion` and `kind` from typed-list metadata when Kubernetes omits them;
- preserves JSON arrays and YAML multi-document inputs;
- reports malformed list envelopes instead of silently returning no workloads; and
- preserves named custom resources whose Kind merely ends in `List`.

The regression suite also passes these documents through `FileResourceHandler` and verifies that the contained resources reach the policy input maps.

## How to Test

```sh
go test ./core/cautils ./core/pkg/resourcehandler -count=1

go test ./core/cautils \
  -run '^TestReadFile' -count=3

go test ./core/pkg/resourcehandler \
  -run '^TestFileResourceHandlerIndexesListEnvelopeItemsForPolicies$' -count=3

go vet ./core/cautils ./core/pkg/resourcehandler
```

## Related issues/PRs

- Resolves #2811

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the list-detection boundary
- [x] I have performed a self-review of my code
- [x] I have added parser and end-to-end resource-loading regression tests
- [x] New and existing relevant unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Kubernetes list manifests in YAML and JSON formats.
  - List envelopes are expanded so individual resources can be processed and indexed correctly.
  - Supports both generic and typed Kubernetes lists while preserving named resources that contain `items`.

- **Bug Fixes**
  - Improved validation and error reporting for malformed list manifests.
  - Prevented Kubernetes resources with list-like names from being misclassified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->