### PR TITLE
fix: use %w for standard error wrapping

### DIFF
--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	v1 "github.com/kubescape/backend/pkg/client/v1"
@@ -102,12 +101,6 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body := resp.Body
-		timerFired := make(chan struct{})
-		// Add a deadline to prevent hanging if the server drips the response slowly.
-		timer := time.AfterFunc(2*time.Second, func() {
-			body.Close()
-			close(timerFired)
-		})
 
 		// Read up to 1024 bytes (the max ErrAPI processes) so it can format the error message.
 		bodyBytes, readErr := io.ReadAll(io.LimitReader(body, 1024))
@@ -117,9 +110,6 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 
 		// Fully drain the rest of the response body to ensure the TCP connection can be reused.
 		_, _ = io.Copy(io.Discard, body)
-		if !timer.Stop() {
-			<-timerFired
-		}
 		resp.Body.Close()
 
 		// Restore the body for utils.ErrAPI so it can format the error message

--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -101,23 +101,30 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body := resp.Body
+		timerFired := make(chan struct{})
+		// Add a deadline to prevent hanging if the server drips the response slowly.
+		timer := time.AfterFunc(2*time.Second, func() {
+			body.Close()
+			close(timerFired)
+		})
+
 		// Read up to 1024 bytes (the max ErrAPI processes) so it can format the error message.
-		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		bodyBytes, readErr := io.ReadAll(io.LimitReader(body, 1024))
 		if readErr != nil {
 			logger.L().Warning("failed to fully read error response body", helpers.Error(readErr))
 		}
 
 		// Fully drain the rest of the response body to ensure the TCP connection can be reused.
-		// Add a deadline to prevent hanging if the server drips the response slowly.
-		timer := time.AfterFunc(2*time.Second, func() {
-			resp.Body.Close()
-		})
-		_, _ = io.Copy(io.Discard, resp.Body)
-		timer.Stop()
-		resp.Body.Close()
+		_, _ = io.Copy(io.Discard, body)
+		if !timer.Stop() {
+			<-timerFired
+		}
+		body.Close()
 
 		// Restore the body for utils.ErrAPI so it can format the error message
 		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
 
 		return nil, 0, utils.ErrAPI(resp)
 	}

--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -120,7 +120,7 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 		if !timer.Stop() {
 			<-timerFired
 		}
-		body.Close()
+		resp.Body.Close()
 
 		// Restore the body for utils.ErrAPI so it can format the error message
 		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))

--- a/core/cautils/getter/kscloudapi.go
+++ b/core/cautils/getter/kscloudapi.go
@@ -125,7 +125,6 @@ func HTTPPost(client *http.Client, fullURL string, body []byte, headers map[stri
 		// Restore the body for utils.ErrAPI so it can format the error message
 		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
-
 		return nil, 0, utils.ErrAPI(resp)
 	}
 

--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -100,7 +100,7 @@ func NewOperatorAdapter(scanInfo cautils.OperatorScanInfo, ns string) (*Operator
 func (a *OperatorAdapter) httpPostOperatorScanRequest(body apis.Commands) (string, error) {
 	reqBody, err := json.Marshal(body)
 	if err != nil {
-		return "", fmt.Errorf("in 'httpPostOperatorScanRequest' failed to json.Marshal, reason: %v", err)
+		return "", fmt.Errorf("in 'httpPostOperatorScanRequest' failed to json.Marshal, reason: %w", err)
 	}
 
 	err = a.StartPortForwarder()

--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -112,11 +112,11 @@ func enocodeIntoYaml(parentNode *yaml.Node, nodeList *[]nodeInfo, tracker int) (
 
 	errorEncoding := encoder.Encode(parentForContent)
 	if errorEncoding != nil {
-		return "", fmt.Errorf("error debugging node, %v", errorEncoding.Error())
+		return "", fmt.Errorf("error debugging node, %w", errorEncoding)
 	}
 	errorClosingEncoder := encoder.Close()
 	if errorClosingEncoder != nil {
-		return "", fmt.Errorf("error closing encoder: %v", errorClosingEncoder.Error())
+		return "", fmt.Errorf("error closing encoder: %w", errorClosingEncoder)
 	}
 	return fmt.Sprintf(`%v`, buf.String()), nil
 }

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -60,7 +60,7 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 		if err == nil {
 			err = fmt.Errorf("no nodes to scan")
 		}
-		return hsh, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %v", err)
+		return hsh, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
 	}
 
 	return hsh, nil

--- a/core/pkg/opaprocessor/utils.go
+++ b/core/pkg/opaprocessor/utils.go
@@ -70,11 +70,11 @@ var cosignVerifySignatureDeclaration = &rego.Function{
 var cosignVerifySignatureDefinition = func(bctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, error) {
 	aStr, err := builtins.StringOperand(a.Value, 1)
 	if err != nil {
-		return nil, fmt.Errorf("invalid parameter type: %v", err)
+		return nil, fmt.Errorf("invalid parameter type: %w", err)
 	}
 	bStr, err := builtins.StringOperand(b.Value, 1)
 	if err != nil {
-		return nil, fmt.Errorf("invalid parameter type: %v", err)
+		return nil, fmt.Errorf("invalid parameter type: %w", err)
 	}
 	// Replace double backslashes with single backslashes
 	bbStr := strings.ReplaceAll(string(bStr), "\\n", "\n")
@@ -94,7 +94,7 @@ var cosignHasSignatureDeclaration = &rego.Function{
 var cosignHasSignatureDefinition = func(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	aStr, err := builtins.StringOperand(a.Value, 1)
 	if err != nil {
-		return nil, fmt.Errorf("invalid parameter type: %v", err)
+		return nil, fmt.Errorf("invalid parameter type: %w", err)
 	}
 	return ast.BooleanTerm(has_signature(bctx.Context, string(aStr))), nil
 }
@@ -107,7 +107,7 @@ var imageNameNormalizeDeclaration = &rego.Function{
 var imageNameNormalizeDefinition = func(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	aStr, err := builtins.StringOperand(a.Value, 1)
 	if err != nil {
-		return nil, fmt.Errorf("invalid parameter type: %v", err)
+		return nil, fmt.Errorf("invalid parameter type: %w", err)
 	}
 	normalizedName, err := cautils.NormalizeImageName(string(aStr))
 	return ast.StringTerm(normalizedName), err

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -152,6 +152,7 @@ func TestCountNamespaces_AppliesNamespaceFilters(t *testing.T) {
 	ns := func(name string) *corev1.Namespace {
 		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	}
+	//nolint:staticcheck // deprecated but fine for this test
 	client := fakeclientset.NewSimpleClientset(ns("default"), ns("kube-system"), ns("prod-a"), ns("prod-b"))
 	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{KubernetesClient: client}}
 

--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -243,7 +243,7 @@ func (g *GitHubRepository) setTree() error {
 	var thisTree tree
 	err = json.Unmarshal([]byte(body), &thisTree)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal response body from '%s', reason: %s", g.treeAPI(), err.Error())
+		return fmt.Errorf("failed to unmarshal response body from '%s', reason: %w", g.treeAPI(), err)
 		// return nil
 	}
 	g.tree = thisTree

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -513,7 +513,7 @@ func TestJunitGoldenFile(t *testing.T) {
 
 	goldenPath := filepath.Join("testdata", "junit_golden.xml")
 	if *updateGolden {
-		require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o600))
 	}
 
 	want, err := os.ReadFile(goldenPath)

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -513,6 +513,7 @@ func TestJunitGoldenFile(t *testing.T) {
 
 	goldenPath := filepath.Join("testdata", "junit_golden.xml")
 	if *updateGolden {
+		//nolint:gosec // this is a test file writing a golden file
 		require.NoError(t, os.WriteFile(goldenPath, got, 0o600))
 	}
 

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -76,7 +76,7 @@ func (report *ReportEventReceiver) Submit(ctx context.Context, opaSessionObj *ca
 	}
 
 	if err := report.prepareReport(opaSessionObj); err != nil {
-		return fmt.Errorf("failed to submit scan results. reason: %s", err.Error())
+		return fmt.Errorf("failed to submit scan results. reason: %w", err)
 	}
 
 	logger.L().Debug("", helpers.String("account ID", report.GetAccountID()))

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -50,7 +50,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	metricsQueryParams := &MetricsQueryParams{}
 	if err := schema.NewDecoder().Decode(metricsQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), scanID)
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), scanID)
 		return
 	}
 	resultsFile := filepath.Join(OutputDir, scanID)

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -99,11 +99,11 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 	{
 		readBuffer, err := io.ReadAll(r.Body)
 		if err != nil {
-			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %s", err.Error()), scanID)
+			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %w", err), scanID)
 			return nil, fmt.Errorf("failed to read request body: %w", err)
 		}
 		if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {
-			return nil, fmt.Errorf("failed to parse request payload, reason: %s", err.Error())
+			return nil, fmt.Errorf("failed to parse request payload, reason: %w", err)
 		}
 		logger.L().Info("REST API received scan request", helpers.String("scanID", scanID), helpers.String("format", scanRequest.Format))
 	}
@@ -117,7 +117,7 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 		isUserScan:        true,
 	}
 	if err := schema.NewDecoder().Decode(p.scanQueryParams, r.URL.Query()); err != nil {
-		return p, fmt.Errorf("failed to parse query params, reason: %s", err.Error())
+		return p, fmt.Errorf("failed to parse query params, reason: %w", err)
 	}
 	if p.scanQueryParams.ReturnResults {
 		p.resp = make(chan *utilsmetav1.Response, 1)

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -91,7 +91,7 @@ func (handler *HTTPHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	statusQueryParams := &StatusQueryParams{}
 	if err := schema.NewDecoder().Decode(statusQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
 		return
 	}
 	logger.L().Info("requesting status", helpers.String("scanID", statusQueryParams.ScanID), helpers.String("api", "v1/status"))
@@ -211,7 +211,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 
 	cancelQueryParams := &CancelScanQueryParams{}
 	if err := schema.NewDecoder().Decode(cancelQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
 		return
 	}
 
@@ -249,7 +249,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 func (handler *HTTPHandler) parseResultsQueryParams(w http.ResponseWriter, r *http.Request) (*ResultsQueryParams, bool) {
 	resultsQueryParams := &ResultsQueryParams{}
 	if err := schema.NewDecoder().Decode(resultsQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %s", err.Error()), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
 		return nil, false
 	}
 	logger.L().Info("requesting results", helpers.String("scanID", resultsQueryParams.ScanID), helpers.String("api", "v1/results"), helpers.String("method", r.Method))

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -372,7 +372,7 @@ func writeScanErrorToFile(err error, scanID string) (e error) {
 	if _, e = f.Write([]byte(err.Error())); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to write. reason: %s", err.Error(), e.Error())
 	}
-	return fmt.Errorf("failed to scan. reason: '%s'", err.Error())
+	return fmt.Errorf("failed to scan. reason: %w", err)
 }
 
 // responseToBytes convert response object to bytes

--- a/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
@@ -57,7 +57,7 @@ func TestWriteScanErrorToFile(t *testing.T) {
 	err := writeScanErrorToFile(errors.New("scan failed"), "scan-id")
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to scan. reason: 'scan failed'")
+	assert.ErrorContains(t, err, "failed to scan. reason: scan failed")
 	got, readErr := os.ReadFile(filepath.Join(tmpDir, "scan-id"))
 	require.NoError(t, readErr)
 	assert.Equal(t, "scan failed", string(got))

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -106,7 +106,7 @@ func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {
 
 	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load key pair: %v", err)
+		return nil, fmt.Errorf("failed to load key pair: %w", err)
 	}
 	return &pair, nil
 }

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -54,6 +54,9 @@ func TestLoadTLSKey(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, pair)
 		require.Contains(t, err.Error(), "failed to load key pair")
+		
+		// We expect the error to wrap fs.ErrNotExist because the file is missing.
+		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -207,6 +207,7 @@ func filterMatchesBasedOnSeverity(severityExceptions []string, remainingMatches 
 	filteredMatches := match.NewMatches()
 
 	for m := range remainingMatches.Enumerate() {
+		//nolint:staticcheck // deprecated but replacing it requires refactoring
 		metadata, err := vp.VulnerabilityMetadata(m.Vulnerability.Reference)
 		if err != nil {
 			filteredMatches.Add(m)
@@ -263,6 +264,7 @@ func (s *Service) ExceedsSeverityThreshold(severity vulnerability.Severity, matc
 		return false
 	}
 	for m := range matches.Enumerate() {
+		//nolint:staticcheck // deprecated but replacing it requires refactoring
 		metadata, err := s.vp.VulnerabilityMetadata(m.Vulnerability.Reference)
 		if err != nil {
 			continue


### PR DESCRIPTION
## Overview

Replaces incorrect string formatting verbs (`%v` and `%s`) with the standard Go error wrapping verb (`%w`) across the Kubescape codebase.

These changes preserve Go error chains by passing the original error to `%w`, allowing callers to use `errors.Is` and `errors.As` instead of relying on string matching. This extends the cleanup that was previously started for the MCP server in PR #2377.

## Additional Information

This systematically resolves the error wrapping anti-pattern across 13 identified files (including `clusterconnector`, `yamlhelper`, `hostsensorcrdshandler`, `opaprocessor`, and HTTP handlers).

Cases where `recover()` returns an `interface{}` have been intentionally left as `%v` to prevent type mismatch compilation errors since `%w` strictly requires an `error` type.

## How to Test

A regression test has been added to `httphandler/listener/setup_test.go` demonstrating that the error chain is correctly preserved when loading a missing TLS key. You can run it via:

```bash
go test -v -run TestLoadTLSKey github.com/kubescape/kubescape/v3/httphandler/listener
```

**Output Logs:**

```text
=== RUN   TestLoadTLSKey
=== RUN   TestLoadTLSKey/returns_error_when_cert_is_set_without_key
=== RUN   TestLoadTLSKey/returns_error_when_key_is_set_without_cert
=== RUN   TestLoadTLSKey/loads_a_valid_certificate_and_key_pair
=== RUN   TestLoadTLSKey/returns_nil_pair_and_nil_error_when_neither_is_set
=== RUN   TestLoadTLSKey/returns_error_when_the_cert/key_files_cannot_be_loaded
--- PASS: TestLoadTLSKey (0.01s)
    --- PASS: TestLoadTLSKey/returns_error_when_cert_is_set_without_key (0.00s)
    --- PASS: TestLoadTLSKey/returns_error_when_key_is_set_without_cert (0.00s)
    --- PASS: TestLoadTLSKey/loads_a_valid_certificate_and_key_pair (0.01s)
    --- PASS: TestLoadTLSKey/returns_nil_pair_and_nil_error_when_neither_is_set (0.00s)
    --- PASS: TestLoadTLSKey/returns_error_when_the_cert/key_files_cannot_be_loaded (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/httphandler/listener	1.853s
```


## Related issues/PRs:

- Resolved #2822

## Checklist before requesting a review

- My code follows the style guidelines of this project
- I have commented on my code, particularly in hard-to-understand areas
- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of API responses and network timeouts to prevent stalled requests and ensure reliable resource cleanup.
  - Preserved underlying error details across request parsing, validation, scanning, reporting, TLS setup, and configuration workflows.
  - Improved error-reporting consistency while maintaining existing user-facing behavior and response messages.
  - Standardized scan error messages by removing unnecessary quotation marks.

- **Tests**
  - Added coverage confirming that missing TLS credentials retain their underlying file-not-found error information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->