### PR TITLE
fix(core): add timeout to HTTP client in OperatorAdapter to prevent connection hang

### DIFF
--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/armosec/armoapi-go/apis"
 	"github.com/armosec/utils-go/httputils"
@@ -115,7 +116,10 @@ func (a *OperatorAdapter) httpPostOperatorScanRequest(body apis.Commands) (strin
 		Path:   operatorTriggerPath,
 	}
 
-	resp, err := a.httpPostFunc(http.DefaultClient, urlQuery.String(), map[string]string{"Content-Type": "application/json"}, reqBody)
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := a.httpPostFunc(client, urlQuery.String(), map[string]string{"Content-Type": "application/json"}, reqBody)
 	if err != nil {
 		return "", err
 	}

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -230,14 +230,16 @@ type httpPostRecorder struct {
 	url     string
 	headers map[string]string
 	body    []byte
+	client  httputils.IHttpClient
 }
 
 func (r *httpPostRecorder) fakeHTTPPost(statusCode int, postErr error) func(httputils.IHttpClient, string, map[string]string, []byte) (*http.Response, error) {
-	return func(_ httputils.IHttpClient, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	return func(client httputils.IHttpClient, url string, headers map[string]string, body []byte) (*http.Response, error) {
 		r.calls++
 		r.url = url
 		r.headers = headers
 		r.body = body
+		r.client = client
 
 		if postErr != nil {
 			return nil, postErr
@@ -382,6 +384,11 @@ func TestOperatorAdapter_OperatorScan(t *testing.T) {
 		assert.Equal(t, expectedOperatorURL, recorder.url)
 		assert.Equal(t, "application/json", recorder.headers["Content-Type"])
 		assert.JSONEq(t, string(wantBody), string(recorder.body), "the exact GetRequestPayload() value must reach the HTTP call as JSON")
+
+		// Verify that a sensible timeout is set to prevent connection hangs
+		httpClient, ok := recorder.client.(*http.Client)
+		require.True(t, ok, "expected client to be of type *http.Client")
+		assert.Equal(t, 30*time.Second, httpClient.Timeout, "the HTTP client must have a 30 second timeout to prevent hanging")
 	})
 }
 


### PR DESCRIPTION
## Overview

Currently, `core/core/clusterconnector.go` uses Go's `http.DefaultClient` when executing an HTTP POST request to register a cluster via `httpPostFunc`. Because `http.DefaultClient` has no configured timeout, an unresponsive API server that accepts the TCP connection but never responds will cause the cluster connection process to hang indefinitely. This stalls the application and leaks Goroutines.

This PR fixes the vulnerability by replacing `http.DefaultClient` with a properly configured `&http.Client{Timeout: 30 * time.Second}`.

## Additional Information

This follows the exact precedent set in PR #1822 (commit `2e90143d`), which fixed an identical `http.DefaultClient` bug inside `repositoryscanner.go`. I've also updated the `httpPostRecorder` mock test harness to properly intercept and assert the underlying `http.Client`'s timeout duration.

## How to Test

 1. Spin up a dummy HTTP server using Go's `httptest` that deliberately calls `time.Sleep()` indefinitely.
 2. Trigger the `httpPostFunc` in `clusterconnector.go` to fire a request against the mock server.
 3. Observe that the client now properly aborts and returns a timeout error after 30 seconds instead of blocking forever.

## Examples/Screenshots

> Here is the exact output of my local reproduction script proving that the unpatched `http.DefaultClient` blocks indefinitely when the API server hangs:
>
> ```text
> Server started at: http://127.0.0.1:51834
>
> Making request with http.DefaultClient...
>
> BUG CONFIRMED: http.DefaultClient blocked for >3 seconds without timing out!
>
> 2026/08/08 13:07:41 httptest.Server blocked in Close after 5 seconds, waiting for connections:
>
>   *net.TCPConn 0x365f75c08008 127.0.0.1:51835 in state active
> ```

## Related issues/PRs:

- Resolved #2826

## Checklist before requesting a review

- My code follows the style guidelines of this project
- I have commented on my code, particularly in hard-to-understand areas
- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of operator scan requests by applying a 30-second timeout.
  * Prevented requests from waiting indefinitely when a scan endpoint is unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->