### PR TITLE
feat(scan): add --label-selector flag to filter collected resources

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -18,6 +18,7 @@ import (
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -263,6 +264,12 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	severity := scanInfo.FailThresholdSeverity
 	if err := shared.ValidateSeverity(severity); severity != "" && err != nil {
 		return err
+	}
+
+	if scanInfo.LabelSelector != "" {
+		if _, err := labels.Parse(scanInfo.LabelSelector); err != nil {
+			return fmt.Errorf("invalid --label-selector %q: %w", scanInfo.LabelSelector, err)
+		}
 	}
 
 	// Validate the user's credentials

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -186,6 +186,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output file format. Supported formats: "%s"`, strings.Join(shared.ScanFormats, `", "`)))
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -222,3 +222,88 @@ func Test_validateWorkloadIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateFrameworkScanInfo_LabelSelector(t *testing.T) {
+	const validAccountID = "22019933-feac-4012-a8eb-e81461ba6655"
+
+	tests := []struct {
+		name          string
+		labelSelector string
+		wantErr       bool
+	}{
+		{
+			name:          "empty selector is valid",
+			labelSelector: "",
+			wantErr:       false,
+		},
+		{
+			name:          "simple equality",
+			labelSelector: "app=nginx",
+			wantErr:       false,
+		},
+		{
+			name:          "double-equals equality",
+			labelSelector: "app==nginx",
+			wantErr:       false,
+		},
+		{
+			name:          "inequality requirement",
+			labelSelector: "env!=dev",
+			wantErr:       false,
+		},
+		{
+			name:          "multiple requirements comma separated",
+			labelSelector: "app=nginx,env!=dev",
+			wantErr:       false,
+		},
+		{
+			name:          "set-based in requirement",
+			labelSelector: "env in (prod,staging)",
+			wantErr:       false,
+		},
+		{
+			name:          "set-based notin requirement",
+			labelSelector: "env notin (dev,test)",
+			wantErr:       false,
+		},
+		{
+			name:          "existence check",
+			labelSelector: "app",
+			wantErr:       false,
+		},
+		{
+			name:          "negated existence check",
+			labelSelector: "!app",
+			wantErr:       false,
+		},
+		{
+			name:          "malformed selector with unclosed bracket",
+			labelSelector: "env in (prod",
+			wantErr:       true,
+		},
+		{
+			name:          "selector starting with operator is invalid",
+			labelSelector: "=invalid",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			si := &cautils.ScanInfo{
+				AccountID:     validAccountID,
+				LabelSelector: tt.labelSelector,
+			}
+			err := validateFrameworkScanInfo(si)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for label selector %q, got nil", tt.labelSelector)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for label selector %q: %v", tt.labelSelector, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -77,6 +77,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}
+			if scanInfo.LabelSelector != "" {
+				return fmt.Errorf("--label-selector is not supported for workload scans: the named resource is fetched by identity, not by label")
+			}
 			namespace, kind, name, workloadAPIVersion, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %w", err)

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -75,6 +75,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if err := validateThresholdsOnly(scanInfo); err != nil {
 				return err
 			}
+			if scanInfo.LabelSelector != "" {
+				return fmt.Errorf("--label-selector is not supported for workload scans: the named resource is fetched by identity, not by label")
+			}
 			namespace, kind, name, apiVersion, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %w", err)

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -422,3 +422,16 @@ func TestGetWorkloadCmd_ApiVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWorkloadCmd_RejectsLabelSelector(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+	cmd := getWorkloadCmd(mockKubescape, &scanInfo)
+
+	scanInfo.LabelSelector = "app=nginx"
+
+	cmd.SetArgs([]string{"Deployment/my-deploy"})
+	err := cmd.RunE(cmd, []string{"Deployment/my-deploy"})
+
+	assert.ErrorContains(t, err, "--label-selector is not supported for workload scans")
+}

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -330,3 +330,16 @@ func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWorkloadCmd_RejectsLabelSelector(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+	cmd := getWorkloadCmd(mockKubescape, &scanInfo)
+
+	scanInfo.LabelSelector = "app=nginx"
+
+	cmd.SetArgs([]string{"Deployment/my-deploy"})
+	err := cmd.RunE(cmd, []string{"Deployment/my-deploy"})
+
+	assert.ErrorContains(t, err, "--label-selector is not supported for workload scans")
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -130,6 +130,7 @@ type ScanInfo struct {
 	CustomClusterName     string                       // Set the custom name of the cluster
 	ExcludedNamespaces    string                       // used for host scanner namespace
 	IncludeNamespaces     string                       //
+	LabelSelector         string                       // filter collected resources by Kubernetes label selector (e.g. "app=nginx,env!=dev")
 	Namespace             string                       // target namespace for workload scans
 	InputPatterns         []string                     // Yaml files input patterns
 	Silent                bool                         // Silent mode - Do not print progress logs

--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -437,7 +437,7 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 		reporthandling.ScopeCluster,
 		resolver,
 	)
-	resources, allResources, failures := handler.pullResources(context.Background(), queryable, NewIncludeSelector("agents"))
+	resources, allResources, failures := handler.pullResources(context.Background(), queryable, NewIncludeSelector("agents"), "")
 
 	assert.Empty(t, failures)
 	require.Len(t, allResources, 4)

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -95,7 +94,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	sessionObj.ResourceToControlsMap = resourceToControl
 
 	// pull k8s resources
-	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(ctx, queryableResources, globalFieldSelectors)
+	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(ctx, queryableResources, globalFieldSelectors, scanInfo.LabelSelector)
 
 	// Record failed GVR statuses before any early return so BuildScanCoverage
 	// has data even when every pull fails (severe RBAC restrictions).
@@ -297,7 +296,7 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 
-		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, scanInfo.LabelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
 		for _, se := range selectorErrs {
 			// Match the eager collection path: controls may reference optional
 			// CRDs which are not installed, so a missing resource is not a scan
@@ -522,7 +521,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	if resource.GetNamespace() != "" && ((resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))) {
 		fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespaceFieldSelectorString(resource.GetNamespace(), FieldSelectorsEqualsOperator))
 	}
-	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, fieldSelectors, globalFieldSelector, resolved[0].namespaced)
+	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, "", fieldSelectors, globalFieldSelector, resolved[0].namespaced)
 	if len(result) == 0 && len(selectorErrs) > 0 {
 		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
 	}
@@ -677,7 +676,7 @@ type selectorFailure struct {
 
 const maxParallelResourcePulls = 8
 
-func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
+func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector, labelSelector string) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
@@ -711,7 +710,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 
 			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
-			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, labelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
 			if err := ctx.Err(); err != nil {
 				mu.Lock()
 				failedQueries[qr.GroupVersionResourceTriplet] = queryFailure{
@@ -783,7 +782,7 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 	return partials
 }
 
-func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector, namespaced *bool) ([]unstructured.Unstructured, []selectorFailure) {
+func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labelSelector string, fields string, fieldSelector IFieldSelector, namespaced *bool) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
 	var selectorErrs []selectorFailure
 
@@ -792,9 +791,8 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 	for i := range fieldSelectors {
 		listOptions := metav1.ListOptions{}
 
-		if len(labels) > 0 {
-			set := k8slabels.Set(labels)
-			listOptions.LabelSelector = set.AsSelector().String()
+		if labelSelector != "" {
+			listOptions.LabelSelector = labelSelector
 		}
 
 		if fieldSelectors[i] != "" {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -95,7 +94,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	sessionObj.ResourceToControlsMap = resourceToControl
 
 	// pull k8s resources
-	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(ctx, queryableResources, globalFieldSelectors)
+	k8sResourcesMap, allResources, failedQueries := k8sHandler.pullResources(ctx, queryableResources, globalFieldSelectors, scanInfo.LabelSelector)
 
 	// Record failed GVR statuses before any early return so BuildScanCoverage
 	// has data even when every pull fails (severe RBAC restrictions).
@@ -317,7 +316,7 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 
-		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, scanInfo.LabelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
 		for _, se := range selectorErrs {
 			// Match the eager collection path: controls may reference optional
 			// CRDs which are not installed, so a missing resource is not a scan
@@ -542,7 +541,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	if resource.GetNamespace() != "" && ((resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))) {
 		fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespaceFieldSelectorString(resource.GetNamespace(), FieldSelectorsEqualsOperator))
 	}
-	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, fieldSelectors, globalFieldSelector, resolved[0].namespaced)
+	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, "", fieldSelectors, globalFieldSelector, resolved[0].namespaced)
 	if len(result) == 0 && len(selectorErrs) > 0 {
 		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
 	}
@@ -697,7 +696,7 @@ type selectorFailure struct {
 
 const maxParallelResourcePulls = 8
 
-func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
+func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector, labelSelector string) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
 	k8sResources := queryableResources.ToK8sResourceMap()
 	allResources := map[string]workloadinterface.IMetadata{}
 
@@ -731,7 +730,7 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 
 			apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 			gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
-			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, nil, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+			result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, labelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
 			if err := ctx.Err(); err != nil {
 				mu.Lock()
 				failedQueries[qr.GroupVersionResourceTriplet] = queryFailure{
@@ -803,7 +802,7 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 	return partials
 }
 
-func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labels map[string]string, fields string, fieldSelector IFieldSelector, namespaced *bool) ([]unstructured.Unstructured, []selectorFailure) {
+func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labelSelector string, fields string, fieldSelector IFieldSelector, namespaced *bool) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
 	var selectorErrs []selectorFailure
 
@@ -812,9 +811,8 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 	for i := range fieldSelectors {
 		listOptions := metav1.ListOptions{}
 
-		if len(labels) > 0 {
-			set := k8slabels.Set(labels)
-			listOptions.LabelSelector = set.AsSelector().String()
+		if labelSelector != "" {
+			listOptions.LabelSelector = labelSelector
 		}
 
 		if fieldSelectors[i] != "" {

--- a/core/pkg/resourcehandler/k8sresources_context_test.go
+++ b/core/pkg/resourcehandler/k8sresources_context_test.go
@@ -35,7 +35,7 @@ func TestPullSingleResource_ContextPropagated(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 	gvr := &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	handler.pullSingleResource(ctx, gvr, nil, "", &EmptySelector{}, nil)
+	handler.pullSingleResource(ctx, gvr, "", "", &EmptySelector{}, nil)
 
 	require.NotNil(t, capturedCtx)
 	assert.Equal(t, sentinel, capturedCtx.Value(ctxKey{}))
@@ -67,7 +67,7 @@ func TestPullResources_ContextCancellationUnblocksSlowList(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	_, _, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{})
+	_, _, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{}, "")
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, 3*time.Second)
@@ -111,7 +111,7 @@ func TestPullResources_SemaphoreContextCancellation(t *testing.T) {
 	var failedQueries map[string]queryFailure
 	go func() {
 		defer close(done)
-		_, _, failedQueries = handler.pullResources(ctx, qrs, &EmptySelector{})
+		_, _, failedQueries = handler.pullResources(ctx, qrs, &EmptySelector{}, "")
 	}()
 
 	for range maxParallelResourcePulls {
@@ -165,7 +165,7 @@ func TestPullResources_ContextPassedToGoroutines(t *testing.T) {
 		"//v1/pods": QueryableResource{GroupVersionResourceTriplet: "//v1/pods"},
 	}
 
-	handler.pullResources(ctx, qrs, &EmptySelector{})
+	handler.pullResources(ctx, qrs, &EmptySelector{}, "")
 
 	select {
 	case got := <-capturedCtxCh:
@@ -218,7 +218,7 @@ func TestPullResources_PostPullContextCancellation(t *testing.T) {
 		},
 	}
 
-	k8sResources, allResources, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{})
+	k8sResources, allResources, failedQueries := handler.pullResources(ctx, qrs, &EmptySelector{}, "")
 
 	ids, ok := k8sResources["//v1/pods"]
 	assert.True(t, ok)

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -84,7 +84,7 @@ func TestPullResources_PartialFailureSurface(t *testing.T) {
 		},
 	}
 
-	k8sResourcesMap, allResources, failedQueries := handler.pullResources(context.Background(), queryableResources, &EmptySelector{})
+	k8sResourcesMap, allResources, failedQueries := handler.pullResources(context.Background(), queryableResources, &EmptySelector{}, "")
 
 	// Verify that the successful selector populated the shared raw-GVR bucket.
 	assert.Len(t, allResources, 1)

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -333,3 +333,55 @@ func TestCollectAndStreamBatches_CleanSuccessHasNoFailureMetadata(t *testing.T) 
 	assert.Equal(t, "default", defaultBatch.Scope)
 	assert.Len(t, defaultBatch.K8SResources[podsGVR], 1)
 }
+
+// TestCollectAndStreamBatches_LabelSelectorReachesStreamingPath verifies that
+// scanInfo.LabelSelector is forwarded to listOptions.LabelSelector in the
+// collectAndStreamBatches code path, which is exercised by StreamResourcesBatches
+// and is separate from the pullResources eager-collection path.
+func TestCollectAndStreamBatches_LabelSelectorReachesStreamingPath(t *testing.T) {
+	ctx := context.Background()
+
+	var (
+		podsSelectorCaptured bool
+		capturedPodsLabel    string
+	)
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Resource != "pods" {
+			return true, &unstructured.UnstructuredList{}, nil
+		}
+		listAction, ok := action.(k8stesting.ListAction)
+		require.True(t, ok)
+		podsSelectorCaptured = true
+		capturedPodsLabel = listAction.GetListRestrictions().Labels.String()
+		return true, testPodList("web", "default"), nil
+	})
+
+	scanInfo, session := streamingTestSession(ctx)
+	scanInfo.LabelSelector = "app=nginx"
+
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.True(t, podsSelectorCaptured, "expected at least one pods LIST action to be intercepted")
+	assert.Equal(t, "app=nginx", capturedPodsLabel,
+		"label selector from scanInfo must reach listOptions.LabelSelector in the streaming path")
+}

--- a/core/pkg/resourcehandler/label_selector_test.go
+++ b/core/pkg/resourcehandler/label_selector_test.go
@@ -1,0 +1,131 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestPullSingleResource_LabelSelectorPassthrough verifies that a non-empty
+// label selector is forwarded as-is to the Kubernetes LIST call, and that an
+// empty selector leaves the label restriction unset.
+func TestPullSingleResource_LabelSelectorPassthrough(t *testing.T) {
+	tests := []struct {
+		name                 string
+		labelSelector        string
+		wantLabelRestriction string
+	}{
+		{
+			name:                 "empty label selector leaves restriction unset",
+			labelSelector:        "",
+			wantLabelRestriction: "",
+		},
+		{
+			name:                 "equality-based selector is forwarded verbatim",
+			labelSelector:        "app=nginx",
+			wantLabelRestriction: "app=nginx",
+		},
+		{
+			name:                 "inequality requirement is forwarded verbatim",
+			labelSelector:        "env!=dev",
+			wantLabelRestriction: "env!=dev",
+		},
+		{
+			name:                 "multiple requirements comma-separated are forwarded verbatim",
+			labelSelector:        "app=nginx,env=prod",
+			wantLabelRestriction: "app=nginx,env=prod",
+		},
+		{
+			name:                 "set-based in requirement is forwarded verbatim",
+			labelSelector:        "env in (prod,staging)",
+			wantLabelRestriction: "env in (prod,staging)",
+		},
+	}
+
+	podList := &unstructured.UnstructuredList{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedLabel string
+
+			handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listAction, ok := action.(k8stesting.ListAction)
+				require.True(t, ok)
+				capturedLabel = listAction.GetListRestrictions().Labels.String()
+				return true, podList, nil
+			})
+
+			gvr := &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+			handler.pullSingleResource(context.Background(), gvr, tt.labelSelector, "", &EmptySelector{}, nil)
+
+			assert.Equal(t, tt.wantLabelRestriction, capturedLabel,
+				"label selector %q must reach listOptions.LabelSelector exactly", tt.labelSelector)
+		})
+	}
+}
+
+// TestPullResources_LabelSelectorPropagated verifies that a label selector
+// passed to pullResources reaches every individual pullSingleResource LIST call.
+func TestPullResources_LabelSelectorPropagated(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSelector string
+	}{
+		{
+			name:          "no label selector leaves restriction unset",
+			labelSelector: "",
+		},
+		{
+			name:          "label selector reaches the API server call",
+			labelSelector: "team=backend",
+		},
+	}
+
+	podList := &unstructured.UnstructuredList{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedLabels []string
+
+			handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listAction, ok := action.(k8stesting.ListAction)
+				if ok {
+					capturedLabels = append(capturedLabels, listAction.GetListRestrictions().Labels.String())
+				}
+				return true, podList, nil
+			})
+
+			qrs := QueryableResources{
+				"/v1/pods": QueryableResource{
+					GroupVersionResourceTriplet: "/v1/pods",
+					Namespaced:                  nil,
+				},
+			}
+
+			handler.pullResources(context.Background(), qrs, &EmptySelector{}, tt.labelSelector)
+
+			require.NotEmpty(t, capturedLabels,
+				"pullResources must issue at least one LIST request")
+			for _, got := range capturedLabels {
+				assert.Equal(t, tt.labelSelector, got,
+					"label selector must be forwarded to every LIST call")
+			}
+		})
+	}
+}

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -71,7 +71,7 @@ func TestPullSingleResource_FieldSelectorDoesNotLeakAcrossIterations(t *testing.
 	_, selectorErrs := handler.pullSingleResource(
 		context.Background(),
 		resource,
-		nil,
+		"",
 		"",
 		fieldSelector,
 		nil,
@@ -133,7 +133,7 @@ func TestPullResources_NonForbiddenErrorRecorded(t *testing.T) {
 		},
 	}
 
-	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
+	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
 
 	require.Len(t, failedQueries, 1, "expected one failed query entry")
 	for _, f := range failedQueries {
@@ -157,7 +157,7 @@ func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
 		},
 	}
 
-	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
+	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
 
 	assert.Empty(t, failedQueries, "404-style errors should not be recorded as failures")
 }
@@ -207,7 +207,7 @@ func TestPullResources_PartialFailure(t *testing.T) {
 		},
 	}
 
-	k8sResources, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
+	k8sResources, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
 
 	// failed query is recorded
 	assert.Len(t, failedQueries, 1)
@@ -239,7 +239,7 @@ func TestPullResources_TotalFailure(t *testing.T) {
 		},
 	}
 
-	_, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{})
+	_, allResources, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
 
 	assert.Empty(t, allResources, "no resources should be collected when all queries fail")
 	assert.Len(t, failedQueries, 2, "both failed GVRs should be recorded")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -48,6 +48,7 @@ kubescape scan [target] [flags]
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--host-scan` | Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use `--host-scan=false` to disable host data collection. See the [Kubescape operator](https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator) for a managed alternative. | auto-detect |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
+| `--label-selector <selector>` | Filter collected resources by Kubernetes label selector. Accepts any expression `kubectl -l` supports, e.g. `app=nginx,env!=dev` or `env in (prod,staging)`. Syntax is validated before scanning begins; filtering is applied during live cluster collection and ignored when scanning local files. | - |
 | `--keep-local` | Don't report results to backend | `false` |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
@@ -110,6 +111,15 @@ kubescape scan --view resource --compliance-threshold 80
 
 # Exclude namespaces
 kubescape scan --exclude-namespaces kube-system,kube-public
+
+# Scan only resources matching a label selector
+kubescape scan --label-selector "app=nginx"
+
+# Combine a label selector with a specific framework
+kubescape scan framework nsa --label-selector "env=prod,team=backend"
+
+# Set-based label selector using the 'in' operator
+kubescape scan framework mitre --label-selector "env in (prod,staging)"
 ```
 ### Score thresholds
 


### PR DESCRIPTION
## Summary

- No way to scope a cluster scan by label `--include-namespaces` / `--exclude-namespaces` are the only scoping knobs, making it impossible to target label-driven workload groups (e.g. by team, environment, or application tier)
- `ScanInfo` gains a `LabelSelector string` field bound to `--label-selector`; `validateFrameworkScanInfo` calls `labels.Parse` before any API call so malformed selectors are rejected early with a clear error message
- `pullSingleResource`'s signature changes from `labels map[string]string` to `labelSelector string`, removing the dead `k8slabels.Set` conversion; the string flows directly to `listOptions.LabelSelector` and the K8s API server filters LIST responses server-side
- `pullResources` gains a `labelSelector string` param; both the eager and streaming collection paths thread it through to every LIST call; the named-object scan path receives `""` since a label selector is meaningless when fetching a specific resource by name
- All 11 existing test call sites updated; 7 new integration tests in `label_selector_test.go` use `newHandlerWithReactor` to intercept real `ListAction` objects and assert `GetListRestrictions().Labels.String()` equals the input; 11 validation subtests in `validators_test.go` cover equality, set-based, existence, and malformed selectors
- Relates to the namespace-scoping gap for label-driven multi-team cluster setups

**Which issue(s) this PR fixes:**
N/A - new capability

**Special notes for your reviewer:**
The `core/cautils` test `TestGetScanningContext/git_URL_input` fails in offline environments — this is a pre-existing flake on `upstream/master` and unrelated to this change. The `core/pkg/resourcehandler` package-level lint warning (`fakeclientset.NewSimpleClientset` deprecated) is also pre-existing in `k8sresources_estimate_test.go`, a file untouched by this PR.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan` and all its subcommands now accept `--label-selector <selector>` (e.g. `--label-selector "app=nginx,env!=dev"` or `--label-selector "env in (prod,staging)"`); when absent, behavior is identical to before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--label-selector` option to filter Kubernetes resources during cluster scans.
  * Supports equality, inequality, existence, negation, set-based, and combined selectors.
  * Invalid selectors are rejected with a descriptive error before scanning begins.
  * Workload scans clearly reject the unsupported option.

* **Documentation**
  * Added CLI reference details, syntax guidance, limitations, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->