### PR TITLE
fix(core): recurse convertYamlToJson into map[string]any to drop nested map[interface{}]interface{}

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -484,6 +484,16 @@ func convertYamlToJson(i any) any {
 			}
 		}
 		return m2
+	case map[string]any:
+		// Recurse into values: yaml.v3 decodes a nested mapping with a
+		// non-string key (e.g. `1:` or an unquoted YAML 1.1 `on:`) as
+		// map[interface{}]interface{} even under a string-keyed parent; it
+		// would otherwise survive and break json.Marshal when OPA builds its
+		// input (issue #2833).
+		for k, v := range x {
+			x[k] = convertYamlToJson(v)
+		}
+		return x
 	case []any:
 		for i, v := range x {
 			x[i] = convertYamlToJson(v)

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -281,6 +282,38 @@ func TestConvertYamlToJson(t *testing.T) {
 			assert.Equal(t, tt.jsonObj, convertYamlToJson(tt.yamlObj))
 		})
 	}
+}
+
+// TestConvertYamlToJson_NestedNonStringKey guards against a nested mapping
+// with a non-string key surviving conversion: yaml.v3 decodes such a mapping
+// as map[interface{}]interface{} even under a string-keyed parent, and
+// convertYamlToJson must recurse into map[string]any values so the result
+// stays json.Marshal-able (issue #2833).
+func TestConvertYamlToJson_NestedNonStringKey(t *testing.T) {
+	input := map[string]any{"spec": map[any]any{"1": "enabled"}}
+
+	got := convertYamlToJson(input)
+	_, err := json.Marshal(got)
+	require.NoError(t, err)
+
+	spec, ok := got.(map[string]any)["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "enabled", spec["1"])
+}
+
+// TestReadYamlFile_NestedNonStringKeyIsJSONMarshalable exercises the same bug
+// through readYamlFile: a manifest with a nested non-string key must produce a
+// workload whose object is JSON-serializable (OPA marshals these to build its
+// input, so an unconverted map[interface{}]interface{} breaks evaluation).
+func TestReadYamlFile_NestedNonStringKeyIsJSONMarshalable(t *testing.T) {
+	manifest := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\ndata:\n  1: enabled\n")
+
+	workloads, err := readYamlFile(manifest)
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+
+	_, err = json.Marshal(workloads[0].GetObject())
+	assert.NoError(t, err)
 }
 
 func TestIsYaml(t *testing.T) {


### PR DESCRIPTION
Resolved #2833

## Overview

- **Current behavior:** `convertYamlToJson` (`core/cautils/fileutils.go`) recurses into `map[any]any` and `[]any` but has no `case map[string]any:`. `yaml.v3` decodes a nested mapping with a non-string key (e.g., `1:` or an unquoted YAML 1.1 `on:`) as `map[interface{}]interface{}` even under a string-keyed parent, so it survives conversion. When the resource reaches OPA, `rego.Input`/`rego.Eval` serializes it to JSON and the scan fatal-errors with `json: unsupported type: map[interface {}]interface {}`.
- **Future behavior:** `convertYamlToJson` recurses into `map[string]any` values, so nested non-string-keyed mappings are converted (non-string keys dropped, consistent with the existing `map[any]any` handling) and the object stays JSON-serializable. Such manifests scan normally.

---

## Additional Information

- **Fix:** Adds a 6-line `case map[string]any:` that recurses into values (in-place, matching the existing `[]any` case; safe because the input is a fresh `yaml.Unmarshal` decode). No behavior change for valid manifests — the conversion is idempotent on already-JSON-safe structures, and non-string keys in nested `map[any]any` remain dropped per the existing contract.
- **Failure chain (verified):** `readYamlFile` → `objectsenvelopes.NewObject` → `AllResources` → `getKubernetesObjects` → `rego.Input` / `rego.Eval` (`core/pkg/opaprocessor/processorhandler.go`).
- **Regression tests:** `TestConvertYamlToJson_NestedNonStringKey` (unit) and `TestReadYamlFile_NestedNonStringKeyIsJSONMarshalable` (through the real parse path). Both fail on `master` and pass with the fix.
- **Note for reviewers:** The only `golangci-lint` warning in `./core/cautils/...` is a pre-existing `gosec` issue in `customerloader_test.go` (unmodified by this PR) — left untouched to keep the change scoped.

---

## How to Test

```bash
go test ./core/cautils/ -run 'TestConvertYamlToJson|TestReadYamlFile_NestedNonStringKey' -v
go test ./core/cautils/ -count=1
go test -race ./core/cautils/ -count=1
go build .
```

---

## Examples/Screenshots

**Manifest (`bad.yaml`):** A `ConfigMap` with a nested non-string key.
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
data:
  1: enabled
```

**Before (on `master`) — the scan fatals:**
```text
$ kubescape scan framework nsa bad.yaml
{"level":"warn","msg":"control \"C-0012\": rule \"rule-credentials-configmap\": rego eval failed ...: json: unsupported type: map[interface {}]interface {}"}
{"level":"error","msg":"failed to process rules","error":"... json: unsupported type: map[interface {}]interface {}"}
{"level":"fatal","msg":"control \"C-0012\": rule \"rule-credentials-configmap\": rego eval failed ...: json: unsupported type: map[interface {}]interface {}"}
```

**After (this branch) — scan completes normally:**
```text
$ kubescape scan framework nsa bad.yaml
... resource summary: 0 failed / 1 all ... 100.00%
Scan results saved
Overall compliance-score (100- Excellent, 0- All failed): 100
```

---

## Related Issues/PRs

- Resolved #2833

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML-to-JSON conversion for nested mappings with non-string keys.
  * Prevented errors when processing complex YAML structures for JSON serialization.

* **Tests**
  * Added coverage for nested YAML conversion through direct processing and file loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->