### PR TITLE
fix(core): stop port-forward when startup fails to avoid goroutine leak

### DIFF
--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -105,6 +105,7 @@ func (a *OperatorAdapter) httpPostOperatorScanRequest(body apis.Commands) (strin
 
 	err = a.StartPortForwarder()
 	if err != nil {
+		a.StopPortForwarder()
 		return "", err
 	}
 	defer a.StopPortForwarder()

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -316,12 +316,10 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 			// StartPortForwarder is always attempted first, regardless of outcome.
 			assert.Equal(t, 1, connector.startCalls, "StartPortForwarder must be attempted exactly once")
 
-			// StopPortForwarder must run even on failure paths that reach past StartPortForwarder.
-			if tc.startErr == nil {
-				assert.Equal(t, 1, connector.stopCalls, "StopPortForwarder must be called after a successful StartPortForwarder")
-			} else {
-				assert.Equal(t, 0, connector.stopCalls, "StopPortForwarder must not run if StartPortForwarder itself failed")
-			}
+			// StopPortForwarder must run on every path that reaches past StartPortForwarder,
+			// including when StartPortForwarder itself fails, so the ForwardPorts goroutine
+			// it spawned cannot outlive the scan attempt.
+			assert.Equal(t, 1, connector.stopCalls, "StopPortForwarder must be called exactly once after StartPortForwarder")
 
 			if tc.expectPost {
 				require.Equal(t, 1, recorder.calls, "httpPostFunc must be invoked exactly once")


### PR DESCRIPTION
## Overview
Fixes a goroutine leak on the operator-scan error path. `StartPortForwarder` spawns a background goroutine running `ForwardPorts()`. When startup fails (e.g. readiness never succeeds), `httpPostOperatorScanRequest` returned the error without calling `StopPortForwarder`, leaving the forward goroutine running until process exit.

Now the stop is issued on the failure path too, so the forward goroutine is torn down alongside the error return.

The secondary issue (GetPortForwardLocalhost re-reading `DEFAULT_PORT_FORWARDER_PORT`) is already resolved on master: `localPort` is resolved once at creation in `CreatePortForwarder` and `GetPortForwardLocalhost` falls back to it, so no change was needed there.

## How to Test
Run the operator adapter tests:

```
go test ./core/core/ -run TestOperatorAdapter -count=1
```

`TestOperatorAdapter_httpPostOperatorScanRequest` now asserts `StopPortForwarder` is called exactly once on every path that reaches `StartPortForwarder`, including when `StartPortForwarder` itself fails.

## Related issues/PRs

* Resolved #2693


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when starting a port-forwarding connection fails.
  * Prevented lingering port-forwarding processes after unsuccessful scan requests.

* **Tests**
  * Updated coverage to verify cleanup occurs when port-forwarding startup encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->