### PR TITLE
fix(cautils): stop ReportV2ToV1 from mutating the caller's shared resources

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -1,6 +1,8 @@
 package cautils
 
 import (
+	"maps"
+
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
@@ -91,7 +93,7 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 						}
 
 						if fullResource, ok := opaSessionObj.AllResources[resourceID]; ok {
-							tmp := fullResource.GetObject()
+							tmp := maps.Clone(fullResource.GetObject())
 							workloadinterface.RemoveFromMap(tmp, "spec")
 							ruleResponse.AlertObject.K8SApiObjects = append(ruleResponse.AlertObject.K8SApiObjects, tmp)
 						}

--- a/core/cautils/reportv2tov1_test.go
+++ b/core/cautils/reportv2tov1_test.go
@@ -3,7 +3,12 @@ package cautils
 import (
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,4 +72,60 @@ func TestReportV2ToV1(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReportV2ToV1_DoesNotMutateAllResources(t *testing.T) {
+	resourceID := "apps/v1/ns/Deployment/demo"
+	controlID := "C-001"
+
+	controlSummary := reportsummary.ControlSummary{ControlID: controlID, Name: "control demo", ScoreFactor: 5}
+	controlSummary.Append(helpersv1.NewStatus(apis.StatusFailed), resourceID)
+
+	session := &OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			resourceID: workloadinterface.NewWorkloadObj(map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": "demo", "namespace": "ns"},
+				"spec":       map[string]any{"replicas": float64(2)},
+			}),
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			resourceID: {
+				ResourceID: resourceID,
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: controlID,
+						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+							{
+								Name:   "rule-demo",
+								Status: apis.StatusFailed,
+								Paths: []armotypes.PosturePaths{
+									{FailedPath: "spec.replicas", FixPath: armotypes.FixPath{Path: "spec.replicas", Value: "3"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{controlID: controlSummary},
+			},
+		},
+	}
+
+	got := ReportV2ToV1(session)
+
+	// The conversion must not mutate the caller's shared resource.
+	assert.Contains(t, session.AllResources[resourceID].GetObject(), "spec")
+
+	// The v1 alert object must still be trimmed, proving the failed-rule branch ran.
+	require.Len(t, got.FrameworkReports, 1)
+	require.Len(t, got.FrameworkReports[0].ControlReports, 1)
+	require.Len(t, got.FrameworkReports[0].ControlReports[0].RuleReports, 1)
+	alertObjects := got.FrameworkReports[0].ControlReports[0].RuleReports[0].RuleResponses[0].AlertObject.K8SApiObjects
+	require.Len(t, alertObjects, 1)
+	assert.NotContains(t, alertObjects[0], "spec")
 }


### PR DESCRIPTION
## Overview

**Current behavior:** `ReportV2ToV1` (`core/cautils/reportv2tov1.go`) deletes the `spec` key from every **failed** resource in the caller's shared `AllResources` map while building the v1 posture report. `GetObject()` returns the *shared* map reference, so `RemoveFromMap(tmp, "spec")` mutates the scan session rather than a copy. Because printers run before `--submit`, later output formats and the submitted report receive `spec`-less resources in `--format-version v1` runs (issue #2836).

**Future behavior:** the conversion clones the object before trimming — the v1 alert objects stay `spec`-trimmed, and the caller's session is left untouched.

## Additional Information

- **Root cause:** `reportv2tov1.go:93-96` — `tmp := fullResource.GetObject()` returns the shared map reference (`k8s-interface` `workloadinterface/basicobjectmethods.go:56-58`), and `workloadinterface.RemoveFromMap(tmp, "spec")` performs a top-level `delete(m, "spec")` (`interfaceutils.go:35-42`). Runs once per failed rule, mutating the same shared map every time.
- **Why a shallow clone suffices:** `RemoveFromMap` only performs a top-level delete, and report marshaling never mutates the objects — so `maps.Clone` fully isolates the caller's state. No behavior change to the v1 report output itself.
- **Why the mutation matters:** the default v2 path deliberately trims only fields nothing reads after evaluation (`status`/`metadata.managedFields`), whereas `spec` is consumed by later printers (container tables) and the submitted posture report — that asymmetry is the defect.
- **Regression test:** `TestReportV2ToV1_DoesNotMutateAllResources` asserts **both** directions — the shared resource still contains `spec` after conversion **and** the generated v1 alert object does not (proving the failed-rule branch fired). It fails on `master` (spec is deleted) and passes with this fix.
- **Note for reviewers:** this is the deprecated v1 report path; if that format is slated for removal, closing as wontfix was already offered on #2836. The fix is a two-line change and version-independent hygiene.

## How to Test

```bash
go test ./core/cautils/ -run TestReportV2ToV1 -count=1
go test ./core/cautils/ -count=1
go test -race ./core/cautils/ -count=1
go build .
go vet ./core/cautils/
```

## Examples/Screenshots

Deterministic repro (unit level, no cluster/network) — the shared resource after conversion:

**Before (on `master`):**
```text
ReportV2ToV1(session)
session.AllResources["apps/v1/ns/Deployment/demo"].GetObject()["spec"]
→ missing — the conversion deleted spec from the shared resource
```

**After (this fix):**
```text
ReportV2ToV1(session)
session.AllResources["apps/v1/ns/Deployment/demo"].GetObject()["spec"]
→ present — the caller's session is untouched
while the v1 alert object still excludes spec (trim preserved on the copy)
```

## Related issues/PRs:

- Resolved #2836

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed report conversion to preserve original resource data when generating a version 1 report.
  * Prevented shared resource information from being unintentionally modified while trimming report details.

* **Tests**
  * Added regression coverage to verify that source resources remain unchanged after report conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->