### PR TITLE
fix: mark CRD-only controls not evaluated after partial discovery failure

### DIFF
--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
@@ -124,10 +125,11 @@ type NotEvaluatedControl struct {
 // ResourceToControlsMap, timedOutControls, and any partial GVR pull failures
 // on the session.
 //
-// A control is considered NotEvaluated when every GVR listed in
-// ResourceToControlsMap for that control appears in InfoMap as a pull failure,
-// or when it appears in timedOutControls because its evaluation was aborted
-// (e.g. by exceeding --control-timeout).
+// A control is considered NotEvaluated when every dependency listed in
+// ResourceToControlsMap for that control either appears in InfoMap as a pull
+// failure or is a mapped discovery failure in partialPulls, or when it appears
+// in timedOutControls because its evaluation was aborted (e.g. by exceeding
+// --control-timeout).
 // Controls with at least one successfully fetched GVR are not included.
 //
 // InfoMap is mixed-purpose: it holds whole-GVR pull failures (keyed by GVR
@@ -136,7 +138,10 @@ type NotEvaluatedControl struct {
 // entries whose key is also a key in ResourceToControlsMap are considered.
 //
 // partialPulls carries per-selector LIST failures for GVRs that were partially
-// collected; they are included as-is in ScanCoverage.PartialGVRPulls.
+// collected; they are included as-is in ScanCoverage.PartialGVRPulls. A
+// discovery-stage failure that has a synthetic ResourceToControlsMap edge also
+// participates in the all-dependencies-failed check without being duplicated
+// in FailedGVRPulls.
 //
 // policyDegradations carries policy inputs (control configurations,
 // exceptions) that were served from a fallback; they are included as-is in
@@ -148,6 +153,17 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 	}
 
 	notEvaluated := make(map[string]NotEvaluatedControl, len(timedOutControls))
+	discoveryFailureKeys := make(map[string]struct{})
+	failedDependencyKeys := make(map[string]struct{})
+	for _, partialPull := range partialPulls {
+		if partialPull.Selector != "discovery" || !strings.HasPrefix(partialPull.GVR, "discovery:") {
+			continue
+		}
+		discoveryFailureKeys[partialPull.GVR] = struct{}{}
+		if _, mappedToControl := resourceToControlsMap[partialPull.GVR]; mappedToControl {
+			failedDependencyKeys[partialPull.GVR] = struct{}{}
+		}
+	}
 
 	for controlID, reason := range timedOutControls {
 		notEvaluated[controlID] = NotEvaluatedControl{
@@ -156,7 +172,7 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 		}
 	}
 
-	if len(infoMap) == 0 {
+	if len(infoMap) == 0 && len(failedDependencyKeys) == 0 {
 		for _, ne := range notEvaluated {
 			coverage.NotEvaluatedControls = append(coverage.NotEvaluatedControls, ne)
 		}
@@ -168,12 +184,18 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 
 	if len(resourceToControlsMap) > 0 {
 		// collect failed GVR pulls from InfoMap, filtering out resource-level
-		// eval skips by requiring the key to be a known GVR
+		// eval skips by requiring the key to be a known dependency. Discovery
+		// failures are already reported in PartialGVRPulls, so keep them in the
+		// dependency set without duplicating them in FailedGVRPulls.
 		for gvr, statusInfo := range infoMap {
 			if statusInfo.InnerStatus != apis.StatusSkipped {
 				continue
 			}
 			if _, isGVR := resourceToControlsMap[gvr]; !isGVR {
+				continue
+			}
+			failedDependencyKeys[gvr] = struct{}{}
+			if _, isDiscoveryFailure := discoveryFailureKeys[gvr]; isDiscoveryFailure {
 				continue
 			}
 			coverage.FailedGVRPulls = append(coverage.FailedGVRPulls, FailedGVRPull{
@@ -182,13 +204,7 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 			})
 		}
 
-		if len(coverage.FailedGVRPulls) > 0 {
-			// build a set of failed GVRs for fast lookup
-			failedGVRs := make(map[string]struct{}, len(coverage.FailedGVRPulls))
-			for _, f := range coverage.FailedGVRPulls {
-				failedGVRs[f.GVR] = struct{}{}
-			}
-
+		if len(failedDependencyKeys) > 0 {
 			// invert ResourceToControlsMap: controlID -> set of GVRs it depends on
 			controlToGVRs := make(map[string]map[string]struct{})
 			for gvr, controlIDs := range resourceToControlsMap {
@@ -208,7 +224,7 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 				missingGVRs := make([]string, 0, len(gvrSet))
 				allFailed := true
 				for gvr := range gvrSet {
-					if _, failed := failedGVRs[gvr]; failed {
+					if _, failed := failedDependencyKeys[gvr]; failed {
 						missingGVRs = append(missingGVRs, gvr)
 					} else {
 						allFailed = false

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildScanCoverage_EmptyInfoMap(t *testing.T) {
@@ -20,6 +21,57 @@ func TestBuildScanCoverage_NoFailedGVRs(t *testing.T) {
 	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
+}
+
+func TestBuildScanCoverage_MappedDiscoveryFailureIsNotEvaluated(t *testing.T) {
+	const discoveryKey = "discovery:example.com/v1"
+	coverage := BuildScanCoverage(
+		nil,
+		map[string][]string{discoveryKey: {"C-WIDGET"}},
+		nil,
+		[]PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
+		nil,
+	)
+	coverage.ComputeCoverageScore(1)
+
+	assert.Empty(t, coverage.FailedGVRPulls, "the discovery error is already present in PartialGVRPulls")
+	require.Len(t, coverage.PartialGVRPulls, 1)
+	require.Len(t, coverage.NotEvaluatedControls, 1)
+	assert.Equal(t, "C-WIDGET", coverage.NotEvaluatedControls[0].ControlID)
+	assert.Equal(t, []string{discoveryKey}, coverage.NotEvaluatedControls[0].MissingGVRs)
+	assert.Equal(t, 0, coverage.EvaluatedControls)
+	assert.Zero(t, coverage.CoverageScore)
+	assert.True(t, coverage.Degraded)
+}
+
+func TestBuildScanCoverage_DiscoveryFailureWithSuccessfulDependencyRemainsEvaluated(t *testing.T) {
+	const discoveryKey = "discovery:example.com/v1"
+	coverage := BuildScanCoverage(
+		nil,
+		map[string][]string{
+			discoveryKey:           {"C-MIXED"},
+			"other.com/v1/gadgets": {"C-MIXED"},
+		},
+		nil,
+		[]PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
+		nil,
+	)
+
+	assert.Empty(t, coverage.NotEvaluatedControls)
+	assert.Empty(t, coverage.FailedGVRPulls)
+}
+
+func TestBuildScanCoverage_UnmappedDiscoveryFailureDoesNotInventControlDependency(t *testing.T) {
+	coverage := BuildScanCoverage(
+		nil,
+		map[string][]string{"other.com/v1/gadgets": {"C-GADGET"}},
+		nil,
+		[]PartialGVRPull{{GVR: "discovery:example.com/v1", Selector: "discovery", Error: "forbidden"}},
+		nil,
+	)
+
+	assert.Empty(t, coverage.NotEvaluatedControls)
+	assert.Empty(t, coverage.FailedGVRPulls)
 }
 
 func TestBuildScanCoverage_FailedGVRPopulated(t *testing.T) {

--- a/core/pkg/opaprocessor/partial_discovery_test.go
+++ b/core/pkg/opaprocessor/partial_discovery_test.go
@@ -1,0 +1,144 @@
+package opaprocessor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resourcehandler"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestMarkNotEvaluatedControlsSkipped_LeavesPartiallyCollectedControlPassed(t *testing.T) {
+	const discoveryKey = "discovery:example.com/v1"
+	allFailed := reportsummary.ControlSummary{ControlID: "C-ALL-FAILED"}
+	allFailed.SetStatus(&apis.StatusInfo{InnerStatus: apis.StatusPassed})
+	partiallyCollected := reportsummary.ControlSummary{ControlID: "C-PARTIAL"}
+	partiallyCollected.SetStatus(&apis.StatusInfo{InnerStatus: apis.StatusPassed})
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-ALL-FAILED": allFailed,
+		"C-PARTIAL":    partiallyCollected,
+	}
+	session.ScanCoverage = cautils.BuildScanCoverage(
+		nil,
+		map[string][]string{
+			discoveryKey:           {"C-ALL-FAILED", "C-PARTIAL"},
+			"other.com/v1/gadgets": {"C-PARTIAL"},
+		},
+		nil,
+		[]cautils.PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
+		nil,
+	)
+
+	opap := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap.markNotEvaluatedControlsSkipped()
+
+	allFailed = session.Report.SummaryDetails.Controls["C-ALL-FAILED"]
+	assert.Equal(t, apis.StatusSkipped, allFailed.GetStatus().Status())
+	assert.Equal(t, apis.SubStatusNotEvaluated, allFailed.GetSubStatus())
+	partiallyCollected = session.Report.SummaryDetails.Controls["C-PARTIAL"]
+	assert.Equal(t, apis.StatusPassed, partiallyCollected.GetStatus().Status())
+}
+
+func TestProcessWithStreaming_PartialDiscoveryFailureDoesNotPassCRDOnlyControl(t *testing.T) {
+	ctx := context.Background()
+
+	discoveryClient := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	discoveryClient.PrependReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{
+			{Group: "example.com", Version: "v1"}: errors.New("forbidden"),
+		}}
+	})
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingAdmissionPolicyList"},
+		&unstructured.UnstructuredList{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingAdmissionPolicyBindingList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	k8s := &k8sinterface.KubernetesApi{
+		KubernetesClient: kubernetesfake.NewSimpleClientset(),
+		DynamicClient:    dynamicfake.NewSimpleDynamicClient(scheme),
+		DiscoveryClient:  discoveryClient,
+		Context:          ctx,
+	}
+	handler := resourcehandler.NewK8sResourceHandler(ctx, k8s, nil, nil, "test-cluster")
+
+	rule := reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+
+deny[msga] {
+	widget := input[_]
+	widget.kind == "Widget"
+	msga := {
+		"alertMessage": "widget is present",
+		"packagename": "armo_builtins",
+		"alertScore": 5,
+		"fixPaths": [],
+		"failedPaths": ["metadata.name"],
+		"alertObject": {"k8sApiObjects": [widget]},
+	}
+}`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{{
+			APIGroups:   []string{"example.com"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"Widget"},
+		}},
+	}
+	rule.Name = "widget-rule"
+	control := reporthandling.Control{ControlID: "C-WIDGET", Rules: []reporthandling.PolicyRule{rule}}
+	control.Name = "widget control"
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{control}}
+	framework.Name = "widget framework"
+
+	scanInfo := &cautils.ScanInfo{}
+	session := cautils.NewOPASessionObj(ctx, []reporthandling.Framework{framework}, nil, scanInfo, nil)
+	session.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+
+	batchChan, errChan, expectedBatches, err := handler.StreamResourcesBatches(ctx, session, scanInfo)
+	require.NoError(t, err)
+
+	opap := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test-cluster", "", "", false, nil)
+	require.NoError(t, opap.ProcessWithStreaming(ctx, batchChan, errChan, cautils.NewProgressHandler(""), expectedBatches))
+
+	require.Len(t, session.PartialGVRFailures, 1)
+	assert.Equal(t, "discovery:example.com/v1", session.PartialGVRFailures[0].GVR)
+	assert.Equal(t, []string{"C-WIDGET"}, session.ResourceToControlsMap["discovery:example.com/v1"])
+	require.Contains(t, session.Report.SummaryDetails.Controls, "C-WIDGET")
+	widgetSummary := session.Report.SummaryDetails.Controls["C-WIDGET"]
+	assert.Equal(t, apis.StatusSkipped, widgetSummary.GetStatus().Status())
+	assert.Equal(t, apis.SubStatusNotEvaluated, widgetSummary.GetSubStatus())
+	assert.Empty(t, session.ScanCoverage.FailedGVRPulls,
+		"the discovery failure is already represented in partialGVRPulls")
+	require.Len(t, session.ScanCoverage.PartialGVRPulls, 1)
+	require.Len(t, session.ScanCoverage.NotEvaluatedControls, 1)
+	assert.Equal(t, "C-WIDGET", session.ScanCoverage.NotEvaluatedControls[0].ControlID)
+	assert.Equal(t, []string{"discovery:example.com/v1"}, session.ScanCoverage.NotEvaluatedControls[0].MissingGVRs)
+	assert.Equal(t, 0, session.ScanCoverage.EvaluatedControls)
+	assert.Equal(t, 1, session.ScanCoverage.TotalControls)
+	assert.Zero(t, session.ScanCoverage.CoverageScore)
+	assert.True(t, session.ScanCoverage.Degraded)
+}

--- a/core/pkg/opaprocessor/partial_discovery_test.go
+++ b/core/pkg/opaprocessor/partial_discovery_test.go
@@ -79,7 +79,7 @@ func TestProcessWithStreaming_PartialDiscoveryFailureDoesNotPassCRDOnlyControl(t
 	)
 
 	k8s := &k8sinterface.KubernetesApi{
-		KubernetesClient: kubernetesfake.NewSimpleClientset(),
+		KubernetesClient: kubernetesfake.NewClientset(),
 		DynamicClient:    dynamicfake.NewSimpleDynamicClient(scheme),
 		DiscoveryClient:  discoveryClient,
 		Context:          ctx,

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -199,7 +199,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	// edit results
 	opap.updateResults(ctx)
 
-	opap.markTimedOutControlsSkipped()
+	opap.markNotEvaluatedControlsSkipped()
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
@@ -370,7 +370,7 @@ done:
 
 	// Update results
 	opap.updateResults(ctx)
-	opap.markTimedOutControlsSkipped()
+	opap.markNotEvaluatedControlsSkipped()
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
@@ -838,15 +838,38 @@ func (opap *OPAProcessor) markResourcesSkipped(out map[string]*resourcesresults.
 	}
 }
 
+func (opap *OPAProcessor) markNotEvaluatedControlsSkipped() {
+	if len(opap.ScanCoverage.NotEvaluatedControls) == 0 {
+		return
+	}
+	controlIDs := make([]string, 0, len(opap.ScanCoverage.NotEvaluatedControls))
+	for _, notEvaluated := range opap.ScanCoverage.NotEvaluatedControls {
+		controlIDs = append(controlIDs, notEvaluated.ControlID)
+	}
+	opap.markControlsSkipped(controlIDs)
+}
+
+// markTimedOutControlsSkipped is retained for callers and focused tests that
+// operate before ScanCoverage is rebuilt. Normal processing uses
+// markNotEvaluatedControlsSkipped so collection failures and timeouts share the
+// same final-summary behavior.
 func (opap *OPAProcessor) markTimedOutControlsSkipped() {
 	if len(opap.TimedOutControls) == 0 {
 		return
 	}
+	controlIDs := make([]string, 0, len(opap.TimedOutControls))
+	for controlID := range opap.TimedOutControls {
+		controlIDs = append(controlIDs, controlID)
+	}
+	opap.markControlsSkipped(controlIDs)
+}
+
+func (opap *OPAProcessor) markControlsSkipped(controlIDs []string) {
 	status := &apis.StatusInfo{
 		InnerStatus: apis.StatusSkipped,
 		SubStatus:   apis.SubStatusNotEvaluated,
 	}
-	for controlID := range opap.TimedOutControls {
+	for _, controlID := range controlIDs {
 		if ctrl, ok := opap.Report.SummaryDetails.Controls[controlID]; ok {
 			ctrl.SetStatus(status)
 			opap.Report.SummaryDetails.Controls[controlID] = ctrl

--- a/core/pkg/resourcehandler/discovery_failure_dependencies_test.go
+++ b/core/pkg/resourcehandler/discovery_failure_dependencies_test.go
@@ -1,0 +1,98 @@
+package resourcehandler
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordDiscoveryFailureDependencies_GroupSpecificAndWildcardMatches(t *testing.T) {
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{
+		discoveryDependencyControl("C-EXACT", "example.com", "v1", "Widget"),
+		discoveryDependencyControl("C-WILDCARD-GROUP", "*", "v1", "Widget"),
+		discoveryDependencyControl("C-WILDCARD-VERSION", "example.com", "*", "Widget"),
+		discoveryDependencyControl("C-WILDCARD-WITH-SUCCESS", "*", "v1", "Gadget"),
+		discoveryDependencyControl("C-RESOLVED-IN-FAILED-GV", "example.com", "v1", "KnownWidget"),
+		discoveryDependencyControl("C-UNRELATED", "other.com", "v1", "Widget"),
+	}}
+	resolver := func(group, version, resource string) []resolvedResource {
+		switch resource {
+		case "Gadget":
+			return []resolvedResource{{groupVersionResourceTriplet: "other.com/v1/gadgets"}}
+		case "KnownWidget":
+			return []resolvedResource{{groupVersionResourceTriplet: "example.com/v1/knownwidgets"}}
+		default:
+			return nil
+		}
+	}
+	resourceToControls := map[string][]string{
+		"other.com/v1/gadgets":        {"C-WILDCARD-WITH-SUCCESS"},
+		"example.com/v1/knownwidgets": {"C-RESOLVED-IN-FAILED-GV"},
+	}
+
+	recordDiscoveryFailureDependencies(
+		[]reporthandling.Framework{framework}, nil, reporthandling.ScopeCluster, resolver,
+		[]cautils.PartialGVRPull{{GVR: "discovery:example.com/v1", Selector: "discovery", Error: "forbidden"}},
+		resourceToControls, make(map[string]struct{}),
+	)
+
+	assert.ElementsMatch(t, []string{
+		"C-EXACT",
+		"C-WILDCARD-GROUP",
+		"C-WILDCARD-VERSION",
+		"C-WILDCARD-WITH-SUCCESS",
+	}, resourceToControls["discovery:example.com/v1"])
+	assert.NotContains(t, resourceToControls["discovery:example.com/v1"], "C-RESOLVED-IN-FAILED-GV")
+	assert.NotContains(t, resourceToControls["discovery:example.com/v1"], "C-UNRELATED")
+}
+
+func TestRecordDiscoveryFailureDependencies_DoesNotGuessUntypedDiscoveryFailure(t *testing.T) {
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{
+		discoveryDependencyControl("C-WIDGET", "example.com", "v1", "Widget"),
+	}}
+	resourceToControls := make(map[string][]string)
+
+	recordDiscoveryFailureDependencies(
+		[]reporthandling.Framework{framework}, nil, reporthandling.ScopeCluster,
+		func(string, string, string) []resolvedResource { return nil },
+		[]cautils.PartialGVRPull{{GVR: "discovery:*", Selector: "discovery", Error: "discovery unavailable"}},
+		resourceToControls, make(map[string]struct{}),
+	)
+
+	assert.Empty(t, resourceToControls)
+}
+
+func TestRecordDiscoveryFailureDependencies_PreservesBuiltInFallback(t *testing.T) {
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{
+		discoveryDependencyControl("C-POD", "core", "v1", "Pod"),
+	}}
+	resourceToControls := map[string][]string{"core/v1/pods": {"C-POD"}}
+
+	recordDiscoveryFailureDependencies(
+		[]reporthandling.Framework{framework}, nil, reporthandling.ScopeCluster,
+		func(string, string, string) []resolvedResource {
+			return []resolvedResource{{groupVersionResourceTriplet: "core/v1/pods"}}
+		},
+		[]cautils.PartialGVRPull{{GVR: "discovery:v1", Selector: "discovery", Error: "forbidden"}},
+		resourceToControls, make(map[string]struct{}),
+	)
+
+	assert.NotContains(t, resourceToControls, "discovery:v1")
+}
+
+func discoveryDependencyControl(controlID, group, version, resource string) reporthandling.Control {
+	rule := reporthandling.PolicyRule{
+		Match: []reporthandling.RuleMatchObjects{{
+			APIGroups:   []string{group},
+			APIVersions: []string{version},
+			Resources:   []string{resource},
+		}},
+	}
+	rule.Name = controlID + "-rule"
+	return reporthandling.Control{
+		ControlID: controlID,
+		Rules:     []reporthandling.PolicyRule{rule},
+	}
+}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -88,8 +88,10 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	resourceToControl := make(map[string][]string)
 	// build resources map
 	// map resources based on framework required resources: map["/group/version/kind"][]<k8s workloads ids>
-	queryableResources, excludedRulesMap := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
+	policyWarnings := make(map[string]struct{})
+	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
+	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 
 	// map of Kubescape resources to control_ids
 	sessionObj.ResourceToControlsMap = resourceToControl
@@ -243,8 +245,10 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 
 	scanningScope := cautils.GetScanningScope(sessionObj.Metadata.ContextMetadata)
 	resourceToControl := make(map[string][]string)
-	queryableResources, excludedRulesMap := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
+	policyWarnings := make(map[string]struct{})
+	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
+	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 	sessionObj.ResourceToControlsMap = resourceToControl
 	sessionObj.ExcludedRules = excludedRulesMap
 

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -41,10 +41,13 @@ func addSingleResourceToResourceMaps(k8sResources cautils.K8SResources, allResou
 }
 
 func getQueryableResourceMapFromPolicies(frameworks []reporthandling.Framework, resource workloadinterface.IWorkload, scanningScope reporthandling.ScanningScopeType, resolver resourceResolver) (QueryableResources, map[string]bool) {
+	return getQueryableResourceMapFromPoliciesWithWarned(frameworks, resource, scanningScope, resolver, make(map[string]struct{}))
+}
+
+func getQueryableResourceMapFromPoliciesWithWarned(frameworks []reporthandling.Framework, resource workloadinterface.IWorkload, scanningScope reporthandling.ScanningScopeType, resolver resourceResolver, warned map[string]struct{}) (QueryableResources, map[string]bool) {
 	queryableResources := make(QueryableResources)
 	excludedRulesMap := make(map[string]bool)
 	namespace := getScannedResourceNamespace(resource, resolver)
-	warned := make(map[string]struct{})
 
 	for _, framework := range frameworks {
 		for _, control := range framework.Controls {

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -263,6 +265,97 @@ func getDiscoveryFailures(err error) []cautils.PartialGVRPull {
 		})
 	}
 	return failures
+}
+
+// recordDiscoveryFailureDependencies links unresolved policy dependencies to the
+// discovery failure that prevented them from being resolved. Discovery errors
+// remain partial pulls because they describe the discovery stage. The synthetic
+// dependency key lets scan coverage determine whether a control had any other
+// successfully resolved input.
+func recordDiscoveryFailureDependencies(
+	frameworks []reporthandling.Framework,
+	scannedResource workloadinterface.IWorkload,
+	scanningScope reporthandling.ScanningScopeType,
+	resolver resourceResolver,
+	discoveryFailures []cautils.PartialGVRPull,
+	resourceToControls map[string][]string,
+	warned map[string]struct{},
+) {
+	if len(discoveryFailures) == 0 || len(frameworks) == 0 {
+		return
+	}
+
+	for _, framework := range frameworks {
+		for _, control := range framework.Controls {
+			for _, rule := range control.Rules {
+				if cautils.ShouldSkipRuleWithWarned(control, rule, scanningScope, warned) {
+					continue
+				}
+
+				var resourcesFilterMap map[string]bool
+				if scannedResource != nil {
+					resourcesFilterMap = filterRuleMatchesForResource(scannedResource.GetKind(), rule.Match)
+					if resourcesFilterMap == nil {
+						continue
+					}
+				}
+
+				for _, match := range rule.Match {
+					for _, group := range match.APIGroups {
+						for _, version := range match.APIVersions {
+							for _, resource := range match.Resources {
+								if resourcesFilterMap != nil && !resourcesFilterMap[resource] {
+									continue
+								}
+								resolved := resolver(group, version, resource)
+
+								for _, failure := range discoveryFailures {
+									failedGroupVersion, matches := matchingDiscoveryFailureGroupVersion(failure, group, version)
+									if !matches || resolvesGroupVersion(resolved, failedGroupVersion) {
+										continue
+									}
+									if !slices.Contains(resourceToControls[failure.GVR], control.ControlID) {
+										resourceToControls[failure.GVR] = append(resourceToControls[failure.GVR], control.ControlID)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func matchingDiscoveryFailureGroupVersion(failure cautils.PartialGVRPull, group, version string) (schema.GroupVersion, bool) {
+	if failure.Selector != "discovery" || !strings.HasPrefix(failure.GVR, "discovery:") {
+		return schema.GroupVersion{}, false
+	}
+	failedGroupVersion := strings.TrimPrefix(failure.GVR, "discovery:")
+	if failedGroupVersion == "*" {
+		return schema.GroupVersion{}, false
+	}
+
+	groupVersion, err := schema.ParseGroupVersion(failedGroupVersion)
+	if err != nil {
+		return schema.GroupVersion{}, false
+	}
+	groupMatches := group == "*" || group == groupVersion.Group || (group == "core" && groupVersion.Group == "")
+	versionMatches := version == "*" || version == groupVersion.Version
+	return groupVersion, groupMatches && versionMatches
+}
+
+func resolvesGroupVersion(resolved []resolvedResource, groupVersion schema.GroupVersion) bool {
+	for _, candidate := range resolved {
+		group, version, _ := k8sinterface.StringToResourceGroup(candidate.groupVersionResourceTriplet)
+		if group == "core" {
+			group = ""
+		}
+		if group == groupVersion.Group && version == groupVersion.Version {
+			return true
+		}
+	}
+	return false
 }
 
 func collectDiscoveredResources(resourceLists []*metav1.APIResourceList) []discoveredAPIResource {


### PR DESCRIPTION
## Overview

Kubernetes partial discovery failures were recorded globally, but an unresolved custom-resource dependency in the failed group/version was dropped from both the live query map and `ResourceToControlsMap`. A control whose only input was that custom resource could consequently finish as `Passed` / `Irrelevant` instead of `Skipped` / `NotEvaluated`.

This change:

- links a group/version-specific `discovery:<group/version>` failure to in-scope policy matches that could not be resolved in that failed group/version;
- preserves successfully resolved dependencies, including built-in fallback resources;
- handles wildcard group/version matches without treating a success in a different group/version as resolution of the failed one;
- deliberately leaves untyped `discovery:*` failures unassigned rather than guessing affected controls;
- lets mapped discovery failures participate in the existing all-dependencies-failed coverage calculation without duplicating them in `failedGVRPulls`;
- applies every control in `ScanCoverage.NotEvaluatedControls` to the final summary as `Skipped` / `NotEvaluated`.

A control with another successfully resolved dependency remains evaluated. The existing `partialGVRPulls` entry and degraded-coverage signal remain unchanged.

## How to Test

```bash
SIGSTORE_NO_CACHE=true go test -vet=off \
  ./core/cautils \
  ./core/pkg/resourcehandler \
  ./core/pkg/opaprocessor \
  -count=1

go vet \
  ./core/cautils \
  ./core/pkg/resourcehandler \
  ./core/pkg/opaprocessor

go test -vet=off ./core/pkg/opaprocessor \
  -run '^TestProcessWithStreaming_PartialDiscoveryFailureDoesNotPassCRDOnlyControl$' \
  -count=3 -v
```

Locally:

- all three related packages passed their full test suites;
- `go vet` passed for all three packages;
- the streaming regression passed three consecutive runs;
- disabling the new synthetic dependency edge made the regression fail again with `Passed` / `Irrelevant` and an empty `NotEvaluatedControls`, confirming that the test exercises the fix.

The targeted `-race` run was attempted twice, but the fresh race-instrumented dependency graph did not finish compiling within the local time bounds; the test binary was not reached and no race report was produced.

## Additional Information

The new control attribution is intentionally conservative:

- only group/version-specific discovery failures are mapped;
- `discovery:*` remains a global partial-discovery signal;
- if the dependency is resolved in the failed group/version, no synthetic failure edge is added;
- a mapped discovery failure remains in `partialGVRPulls` and is not repeated in `failedGVRPulls`.

## Related issues/PRs

* Resolves #2838

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the non-obvious discovery/coverage integration
- [x] I have performed a self-review of the changes
- [x] I have added unit and streaming regression coverage
- [x] New and existing tests in the affected packages pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of partial discovery failures during scans.
  * Controls affected by failed resource discovery are now correctly marked as skipped and not evaluated.
  * Controls with successfully collected dependencies continue to be evaluated normally.
  * Scan coverage reports now avoid duplicate failure entries and provide more accurate degraded-coverage results.
  * Resource matching is more precise for API groups, versions, wildcards, exclusions, and untyped failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->