### PR TITLE
fix(core): align scan attribution with explicit kubeconfig

### DIFF
--- a/cmd/scan/kubeconfig_context.go
+++ b/cmd/scan/kubeconfig_context.go
@@ -1,0 +1,29 @@
+package scan
+
+import (
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// captureKubeconfigSelection snapshots the two CLI flags that select a
+// kubeconfig context. It deliberately performs no file I/O here: persistent
+// pre-run hooks also execute for offline and image-only scans.
+func captureKubeconfigSelection(cmd *cobra.Command, scanInfo *cautils.ScanInfo) {
+	scanInfo.SetKubeconfigSelection(
+		commandStringFlag(cmd, "kubeconfig"),
+		commandStringFlag(cmd, "kube-context"),
+	)
+}
+
+func commandStringFlag(cmd *cobra.Command, name string) string {
+	if cmd == nil {
+		return ""
+	}
+	for _, flags := range []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.InheritedFlags()} {
+		if flag := flags.Lookup(name); flag != nil {
+			return flag.Value.String()
+		}
+	}
+	return ""
+}

--- a/cmd/scan/kubeconfig_context_test.go
+++ b/cmd/scan/kubeconfig_context_test.go
@@ -62,6 +62,27 @@ func TestGetScanCommand_CapturesKubeContextOverride(t *testing.T) {
 	assert.Equal(t, "context-selected", mockKubescape.scanInfo.GetClusterContextName())
 }
 
+func TestGetScanCommand_CapturesKubeContextOverrideWithDefaultKubeconfig(t *testing.T) {
+	defaultPath := writeScanMultiContextKubeconfig(t)
+	t.Setenv("KUBECONFIG", defaultPath)
+	restoreKubeconfigFlag(t)
+
+	mockKubescape := &imageScanCaptureKubescape{}
+	rootCmd := &cobra.Command{Use: "kubescape"}
+	rootCmd.PersistentFlags().String("kube-context", "", "")
+	rootCmd.AddCommand(GetScanCommand(mockKubescape))
+	rootCmd.SetArgs([]string{
+		"scan", "image",
+		"--kube-context", "context-selected",
+		"nginx:latest",
+	})
+	require.NoError(t, rootCmd.Execute())
+	require.NotNil(t, mockKubescape.scanInfo)
+
+	require.NoError(t, mockKubescape.scanInfo.ResolveClusterContextName())
+	assert.Equal(t, "context-selected", mockKubescape.scanInfo.GetClusterContextName())
+}
+
 func restoreKubeconfigFlag(t *testing.T) {
 	t.Helper()
 	kubeconfigFlag := flag.Lookup(controllerconfig.KubeconfigFlagName)

--- a/cmd/scan/kubeconfig_context_test.go
+++ b/cmd/scan/kubeconfig_context_test.go
@@ -1,0 +1,128 @@
+package scan
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func TestGetScanCommand_CapturesExplicitKubeconfigSelection(t *testing.T) {
+	explicitPath := writeScanKubeconfig(t, "context-a")
+	restoreKubeconfigFlag(t)
+
+	mockKubescape := &imageScanCaptureKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	cmd.SetArgs([]string{"image", "--kubeconfig", explicitPath, "nginx:latest"})
+	require.NoError(t, cmd.Execute())
+	require.NotNil(t, mockKubescape.scanInfo)
+
+	require.NoError(t, mockKubescape.scanInfo.ResolveClusterContextName())
+	assert.Equal(t, "context-a", mockKubescape.scanInfo.GetClusterContextName())
+}
+
+func TestGetScanCommand_ImageScanDoesNotLoadIrrelevantKubeconfig(t *testing.T) {
+	restoreKubeconfigFlag(t)
+
+	mockKubescape := &imageScanCaptureKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	cmd.SetArgs([]string{
+		"image",
+		"--kubeconfig", filepath.Join(t.TempDir(), "missing"),
+		"nginx:latest",
+	})
+
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestGetScanCommand_CapturesKubeContextOverride(t *testing.T) {
+	explicitPath := writeScanMultiContextKubeconfig(t)
+	restoreKubeconfigFlag(t)
+
+	mockKubescape := &imageScanCaptureKubescape{}
+	rootCmd := &cobra.Command{Use: "kubescape"}
+	rootCmd.PersistentFlags().String("kube-context", "", "")
+	rootCmd.AddCommand(GetScanCommand(mockKubescape))
+	rootCmd.SetArgs([]string{
+		"scan", "image",
+		"--kubeconfig", explicitPath,
+		"--kube-context", "context-selected",
+		"nginx:latest",
+	})
+	require.NoError(t, rootCmd.Execute())
+	require.NotNil(t, mockKubescape.scanInfo)
+
+	require.NoError(t, mockKubescape.scanInfo.ResolveClusterContextName())
+	assert.Equal(t, "context-selected", mockKubescape.scanInfo.GetClusterContextName())
+}
+
+func restoreKubeconfigFlag(t *testing.T) {
+	t.Helper()
+	kubeconfigFlag := flag.Lookup(controllerconfig.KubeconfigFlagName)
+	require.NotNil(t, kubeconfigFlag)
+	original := kubeconfigFlag.Value.String()
+	t.Cleanup(func() {
+		require.NoError(t, flag.Set(controllerconfig.KubeconfigFlagName, original))
+	})
+}
+
+func writeScanKubeconfig(t *testing.T, contextName string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: %[1]s
+clusters:
+- name: cluster
+  cluster:
+    server: https://a.example
+contexts:
+- name: %[1]s
+  context:
+    cluster: cluster
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`, contextName)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func writeScanMultiContextKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := `apiVersion: v1
+kind: Config
+current-context: context-current
+clusters:
+- name: cluster-current
+  cluster:
+    server: https://current.example
+- name: cluster-selected
+  cluster:
+    server: https://selected.example
+contexts:
+- name: context-current
+  context:
+    cluster: cluster-current
+    user: user
+- name: context-selected
+  context:
+    cluster: cluster-selected
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -69,6 +69,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					scanInfo.ControlsVersion,
 				)
 			}
+			captureKubeconfigSelection(cmd, &scanInfo)
 			applyRegistryCredentialsFromEnv(cmd, &scanInfo)
 			return nil
 		},

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -435,18 +435,26 @@ func (scanInfo *ScanInfo) SetKubeconfigSelection(path, contextName string) {
 	scanInfo.contextResolved = false
 }
 
-// ResolveClusterContextName resolves the context from the same explicit
-// kubeconfig selected for the Kubernetes REST client. When no explicit path is
-// configured, the existing k8s-interface loading and in-cluster behavior is
-// retained.
+// ResolveClusterContextName resolves the context from the same kubeconfig
+// loading rules selected for the Kubernetes REST client. When neither an
+// explicit path nor a context override is configured, the existing
+// k8s-interface loading and in-cluster behavior is retained.
 func (scanInfo *ScanInfo) ResolveClusterContextName() error {
-	if scanInfo.kubeconfigPath == "" {
+	if scanInfo.kubeconfigPath == "" && scanInfo.kubeContextOverride == "" {
 		return nil
 	}
 
-	kubeconfig, err := clientcmd.LoadFromFile(scanInfo.kubeconfigPath)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if scanInfo.kubeconfigPath != "" {
+		loadingRules.ExplicitPath = scanInfo.kubeconfigPath
+	}
+
+	kubeconfig, err := loadingRules.Load()
 	if err != nil {
-		return fmt.Errorf("failed to load kubeconfig %q: %w", scanInfo.kubeconfigPath, err)
+		if scanInfo.kubeconfigPath != "" {
+			return fmt.Errorf("failed to load kubeconfig %q: %w", scanInfo.kubeconfigPath, err)
+		}
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
 	contextName := kubeconfig.CurrentContext
@@ -454,7 +462,10 @@ func (scanInfo *ScanInfo) ResolveClusterContextName() error {
 		contextName = scanInfo.kubeContextOverride
 	}
 	if _, ok := kubeconfig.Contexts[contextName]; !ok {
-		return fmt.Errorf("context %q does not exist in kubeconfig %q", contextName, scanInfo.kubeconfigPath)
+		if scanInfo.kubeconfigPath != "" {
+			return fmt.Errorf("context %q does not exist in kubeconfig %q", contextName, scanInfo.kubeconfigPath)
+		}
+		return fmt.Errorf("context %q does not exist in kubeconfig", contextName)
 	}
 
 	scanInfo.clusterContextName = contextName
@@ -462,9 +473,9 @@ func (scanInfo *ScanInfo) ResolveClusterContextName() error {
 	return nil
 }
 
-// GetClusterContextName returns the context resolved from an explicit CLI
-// kubeconfig, falling back to k8s-interface for KUBECONFIG, default-file, and
-// in-cluster callers.
+// GetClusterContextName returns the context resolved from the CLI kubeconfig
+// and context selection, falling back to k8s-interface when neither was
+// resolved by this scan.
 func (scanInfo *ScanInfo) GetClusterContextName() string {
 	if scanInfo.contextResolved {
 		return scanInfo.clusterContextName

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ScanningContext string
@@ -169,6 +170,10 @@ type ScanInfo struct {
 	HelmReleaseNamespace  string   // --release-namespace: Helm release namespace made available as .Release.Namespace
 	LabelsToCopy          []string // Labels to copy from workloads to scan reports
 	scanningContext       *ScanningContext
+	kubeconfigPath        string
+	kubeContextOverride   string
+	clusterContextName    string
+	contextResolved       bool
 	cleanups              []func()
 	ListingURL            string            //Grype vulnerability database URL
 	RegistryMapping       map[string]string // Map internal registry URLs to external ones
@@ -420,6 +425,53 @@ func (scanInfo *ScanInfo) GetScanningContext() ScanningContext {
 	return *scanInfo.scanningContext
 }
 
+// SetKubeconfigSelection records the CLI kubeconfig selection without loading
+// it. Loading is deferred until Kubescape knows that the target is a live
+// cluster, so an irrelevant kubeconfig cannot break an offline manifest scan.
+func (scanInfo *ScanInfo) SetKubeconfigSelection(path, contextName string) {
+	scanInfo.kubeconfigPath = path
+	scanInfo.kubeContextOverride = contextName
+	scanInfo.clusterContextName = ""
+	scanInfo.contextResolved = false
+}
+
+// ResolveClusterContextName resolves the context from the same explicit
+// kubeconfig selected for the Kubernetes REST client. When no explicit path is
+// configured, the existing k8s-interface loading and in-cluster behavior is
+// retained.
+func (scanInfo *ScanInfo) ResolveClusterContextName() error {
+	if scanInfo.kubeconfigPath == "" {
+		return nil
+	}
+
+	kubeconfig, err := clientcmd.LoadFromFile(scanInfo.kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig %q: %w", scanInfo.kubeconfigPath, err)
+	}
+
+	contextName := kubeconfig.CurrentContext
+	if scanInfo.kubeContextOverride != "" {
+		contextName = scanInfo.kubeContextOverride
+	}
+	if _, ok := kubeconfig.Contexts[contextName]; !ok {
+		return fmt.Errorf("context %q does not exist in kubeconfig %q", contextName, scanInfo.kubeconfigPath)
+	}
+
+	scanInfo.clusterContextName = contextName
+	scanInfo.contextResolved = true
+	return nil
+}
+
+// GetClusterContextName returns the context resolved from an explicit CLI
+// kubeconfig, falling back to k8s-interface for KUBECONFIG, default-file, and
+// in-cluster callers.
+func (scanInfo *ScanInfo) GetClusterContextName() string {
+	if scanInfo.contextResolved {
+		return scanInfo.clusterContextName
+	}
+	return k8sinterface.GetContextName()
+}
+
 // getScanningContext get scanning context from the input param
 // this function should be called only once. Call GetScanningContext() to get the scanning context
 func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
@@ -512,7 +564,7 @@ func (scanInfo *ScanInfo) setContextMetadata(ctx context.Context, contextMetadat
 	switch scanInfo.GetScanningContext() {
 	case ContextCluster:
 		contextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{
-			ContextName: k8sinterface.GetContextName(),
+			ContextName: scanInfo.GetClusterContextName(),
 		}
 	case ContextDir:
 		// the base path must be the root the file loader anchored the resources'

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,14 +13,39 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	giturl "github.com/kubescape/go-git-url"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestSetContextMetadata(t *testing.T) {
+	t.Run("explicit kubeconfig context", func(t *testing.T) {
+		defaultPath := writeScanInfoKubeconfig(t, "context-b")
+		explicitPath := writeScanInfoKubeconfig(t, "context-a")
+		defaultConfig, err := clientcmd.LoadFromFile(defaultPath)
+		require.NoError(t, err)
+		k8sinterface.SetClusterContextName("")
+		k8sinterface.SetClientConfigAPI(defaultConfig)
+		t.Cleanup(func() {
+			k8sinterface.SetClientConfigAPI(nil)
+			k8sinterface.SetClusterContextName("")
+		})
+
+		scanInfo := &ScanInfo{}
+		scanInfo.SetKubeconfigSelection(explicitPath, "")
+		scanInfo.Init(context.Background(), nil)
+		require.NoError(t, scanInfo.ResolveClusterContextName())
+		metadata := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
+		ctx := metadata.ContextMetadata
+
+		require.NotNil(t, ctx.ClusterContextMetadata)
+		assert.Equal(t, "context-a", ctx.ClusterContextMetadata.ContextName)
+	})
+
 	t.Run("empty input cluster context", func(t *testing.T) {
 		ctx := reporthandlingv2.ContextMetadata{}
 		scanInfo := &ScanInfo{}
@@ -70,6 +96,60 @@ func TestSetContextMetadata(t *testing.T) {
 		assert.Nil(t, ctx.HelmContextMetadata)
 		assertRepoContextMetadata(t, ctx.RepoContextMetadata, remoteURL, dir)
 	})
+}
+
+func TestResolveClusterContextNameRejectsInvalidSelection(t *testing.T) {
+	t.Run("missing override", func(t *testing.T) {
+		scanInfo := &ScanInfo{}
+		scanInfo.SetKubeconfigSelection(writeScanInfoKubeconfig(t, "context-a"), "context-missing")
+
+		err := scanInfo.ResolveClusterContextName()
+		require.ErrorContains(t, err, `context "context-missing" does not exist`)
+	})
+
+	t.Run("missing current context", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config")
+		require.NoError(t, os.WriteFile(path, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: cluster
+  cluster:
+    server: https://example.invalid
+contexts:
+- name: context-a
+  context:
+    cluster: cluster
+`), 0o600))
+		scanInfo := &ScanInfo{}
+		scanInfo.SetKubeconfigSelection(path, "")
+
+		err := scanInfo.ResolveClusterContextName()
+		require.ErrorContains(t, err, `context "" does not exist`)
+	})
+}
+
+func writeScanInfoKubeconfig(t *testing.T, contextName string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: %[1]s
+clusters:
+- name: cluster
+  cluster:
+    server: https://example.invalid
+contexts:
+- name: %[1]s
+  context:
+    cluster: cluster
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`, contextName)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
 }
 
 // assertRepoContextMetadata verifies every field metadataGitLocal is expected

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -107,6 +107,16 @@ func TestResolveClusterContextNameRejectsInvalidSelection(t *testing.T) {
 		require.ErrorContains(t, err, `context "context-missing" does not exist`)
 	})
 
+	t.Run("missing override in default kubeconfig", func(t *testing.T) {
+		defaultPath := writeScanInfoKubeconfig(t, "context-a")
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, defaultPath)
+		scanInfo := &ScanInfo{}
+		scanInfo.SetKubeconfigSelection("", "context-missing")
+
+		err := scanInfo.ResolveClusterContextName()
+		require.EqualError(t, err, `context "context-missing" does not exist in kubeconfig`)
+	})
+
 	t.Run("missing current context", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "config")
 		require.NoError(t, os.WriteFile(path, []byte(`apiVersion: v1
@@ -126,6 +136,28 @@ contexts:
 		err := scanInfo.ResolveClusterContextName()
 		require.ErrorContains(t, err, `context "" does not exist`)
 	})
+}
+
+func TestResolveClusterContextNameUsesDefaultLoadingRulesForOverride(t *testing.T) {
+	defaultPath := writeScanInfoMultiContextKubeconfig(t)
+	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, defaultPath)
+	scanInfo := &ScanInfo{}
+	scanInfo.SetKubeconfigSelection("", "context-selected")
+
+	require.NoError(t, scanInfo.ResolveClusterContextName())
+	assert.True(t, scanInfo.contextResolved)
+	assert.Equal(t, "context-selected", scanInfo.GetClusterContextName())
+}
+
+func TestResolveClusterContextNameSkipsDefaultLoadingWithoutSelection(t *testing.T) {
+	invalidPath := filepath.Join(t.TempDir(), "invalid-config")
+	require.NoError(t, os.WriteFile(invalidPath, []byte("not: [valid"), 0o600))
+	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, invalidPath)
+	scanInfo := &ScanInfo{}
+	scanInfo.SetKubeconfigSelection("", "")
+
+	require.NoError(t, scanInfo.ResolveClusterContextName())
+	assert.False(t, scanInfo.contextResolved)
 }
 
 func writeScanInfoKubeconfig(t *testing.T, contextName string) string {
@@ -148,6 +180,37 @@ users:
   user:
     token: test
 `, contextName)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func writeScanInfoMultiContextKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := `apiVersion: v1
+kind: Config
+current-context: context-current
+clusters:
+- name: cluster-current
+  cluster:
+    server: https://current.example
+- name: cluster-selected
+  cluster:
+    server: https://selected.example
+contexts:
+- name: context-current
+  context:
+    cluster: cluster-current
+    user: user
+- name: context-selected
+  context:
+    cluster: cluster-selected
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`
 	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
 	return path
 }

--- a/core/core/kubeconfig_context_test.go
+++ b/core/core/kubeconfig_context_test.go
@@ -1,0 +1,203 @@
+package core
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func TestResolveClusterContext_ExplicitKubeconfigMatchesRESTTarget(t *testing.T) {
+	defaultPath := writeContextKubeconfig(t, "context-b", "https://b.example")
+	explicitPath := writeContextKubeconfig(t, "context-a", "https://a.example")
+	t.Setenv("KUBECONFIG", defaultPath)
+	defaultConfig, err := clientcmd.LoadFromFile(defaultPath)
+	require.NoError(t, err)
+	k8sinterface.SetClusterContextName("")
+	k8sinterface.SetClientConfigAPI(defaultConfig)
+	t.Cleanup(func() {
+		k8sinterface.SetClientConfigAPI(nil)
+		k8sinterface.SetClusterContextName("")
+	})
+
+	kubeconfigFlag := flag.Lookup(controllerconfig.KubeconfigFlagName)
+	require.NotNil(t, kubeconfigFlag)
+	originalFlagValue := kubeconfigFlag.Value.String()
+	require.NoError(t, flag.Set(controllerconfig.KubeconfigFlagName, explicitPath))
+	t.Cleanup(func() {
+		require.NoError(t, flag.Set(controllerconfig.KubeconfigFlagName, originalFlagValue))
+	})
+
+	restConfig, err := controllerconfig.GetConfigWithContext("")
+	require.NoError(t, err)
+	require.Equal(t, "https://a.example", restConfig.Host)
+
+	scanInfo := &cautils.ScanInfo{CustomClusterName: "friendly-name"}
+	scanInfo.SetKubeconfigSelection(explicitPath, "")
+	require.NoError(t, resolveClusterContext(scanInfo))
+	assert.Equal(t, "context-a", scanInfo.GetClusterContextName())
+	assert.Equal(t, "friendly-name", scanInfo.CustomClusterName,
+		"resolving the kube context must not replace --cluster-name")
+}
+
+func TestResolveClusterContext_OfflineScanDoesNotLoadKubeconfig(t *testing.T) {
+	manifest := filepath.Join(t.TempDir(), "pod.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: p\n"), 0o600))
+
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifest}}
+	scanInfo.SetKubeconfigSelection(filepath.Join(t.TempDir(), "missing"), "")
+
+	assert.NoError(t, resolveClusterContext(scanInfo),
+		"an irrelevant kubeconfig must not break an offline manifest scan")
+}
+
+func TestResolveClusterContext_KubeContextOverrideMatchesRESTTarget(t *testing.T) {
+	explicitPath := writeMultiContextKubeconfig(t)
+	kubeconfigFlag := flag.Lookup(controllerconfig.KubeconfigFlagName)
+	require.NotNil(t, kubeconfigFlag)
+	originalFlagValue := kubeconfigFlag.Value.String()
+	require.NoError(t, flag.Set(controllerconfig.KubeconfigFlagName, explicitPath))
+	t.Cleanup(func() {
+		require.NoError(t, flag.Set(controllerconfig.KubeconfigFlagName, originalFlagValue))
+	})
+
+	restConfig, err := controllerconfig.GetConfigWithContext("context-selected")
+	require.NoError(t, err)
+	require.Equal(t, "https://selected.example", restConfig.Host)
+
+	scanInfo := &cautils.ScanInfo{}
+	scanInfo.SetKubeconfigSelection(explicitPath, "context-selected")
+	require.NoError(t, resolveClusterContext(scanInfo))
+	assert.Equal(t, "context-selected", scanInfo.GetClusterContextName())
+}
+
+func TestGetInterfacesUsesResolvedContextForTenantConfig(t *testing.T) {
+	var clusterConfigRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api":
+			_, _ = fmt.Fprint(w, `{"kind":"APIVersions","apiVersion":"v1","versions":["v1"]}`)
+		case "/apis":
+			_, _ = fmt.Fprint(w, `{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`)
+		case "/api/v1":
+			_, _ = fmt.Fprint(w, `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[{"name":"configmaps","namespaced":true,"kind":"ConfigMap","verbs":["get","list"]},{"name":"secrets","namespaced":true,"kind":"Secret","verbs":["get","list"]}]}`)
+		case "/api/v1/namespaces/kubescape/configmaps":
+			clusterConfigRequests.Add(1)
+			_, _ = fmt.Fprint(w, `{"kind":"ConfigMapList","apiVersion":"v1","items":[{"metadata":{"name":"cloud","namespace":"kubescape"},"data":{"clusterData":"{\"cloudAPIURL\":\"https://cluster-api.example\"}"}}]}`)
+		case "/api/v1/namespaces/kubescape/secrets":
+			clusterConfigRequests.Add(1)
+			_, _ = fmt.Fprint(w, `{"kind":"SecretList","apiVersion":"v1","items":[{"metadata":{"name":"credentials","namespace":"kubescape"},"data":{"account":"YQ=="}}]}`)
+		default:
+			http.Error(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	defaultPath := writeContextKubeconfig(t, "context-b", "https://b.example")
+	explicitPath := writeContextKubeconfig(t, "context-a", "https://a.example")
+	defaultConfig, err := clientcmd.LoadFromFile(defaultPath)
+	require.NoError(t, err)
+	k8sinterface.SetClusterContextName("")
+	k8sinterface.SetClientConfigAPI(defaultConfig)
+	originalK8SConfig := k8sinterface.K8SConfig
+	originalConnected := k8sinterface.IsConnectedToCluster()
+	k8sinterface.K8SConfig = &rest.Config{Host: server.URL}
+	k8sinterface.SetConnectedToCluster(true)
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	originalCloudAPI := getter.GetKSCloudAPIConnector()
+	getter.SetKSCloudAPIConnector(nil)
+	t.Cleanup(func() {
+		getter.SetKSCloudAPIConnector(originalCloudAPI)
+		getter.DefaultLocalStore = originalStore
+		k8sinterface.K8SConfig = originalK8SConfig
+		k8sinterface.SetConnectedToCluster(originalConnected)
+		k8sinterface.SetClientConfigAPI(nil)
+		k8sinterface.SetClusterContextName("")
+	})
+
+	manifest := filepath.Join(t.TempDir(), "pod.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: p\n"), 0o600))
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifest}, Local: true}
+	scanInfo.SetKubeconfigSelection(explicitPath, "")
+	require.NoError(t, scanInfo.ResolveClusterContextName())
+	interfaces, err := getInterfaces(context.Background(), scanInfo, nil)
+	require.NoError(t, err)
+
+	assert.IsType(t, &cautils.ClusterConfig{}, interfaces.tenantConfig,
+		"offline scans must preserve cluster-backed tenant configuration when a cluster connection is available")
+	assert.Equal(t, int32(2), clusterConfigRequests.Load(),
+		"the offline path must retain both cluster-backed tenant configuration reads")
+	assert.Equal(t, "a", interfaces.tenantConfig.GetAccountID())
+	assert.Equal(t, "context-a", interfaces.tenantConfig.GetContextName())
+}
+
+func writeContextKubeconfig(t *testing.T, contextName, server string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: %[1]s
+clusters:
+- name: cluster
+  cluster:
+    server: %[2]s
+contexts:
+- name: %[1]s
+  context:
+    cluster: cluster
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`, contextName, server)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func writeMultiContextKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := `apiVersion: v1
+kind: Config
+current-context: context-current
+clusters:
+- name: cluster-current
+  cluster:
+    server: https://current.example
+- name: cluster-selected
+  cluster:
+    server: https://selected.example
+contexts:
+- name: context-current
+  context:
+    cluster: cluster-current
+    user: user
+- name: context-selected
+  context:
+    cluster: cluster-selected
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -66,7 +66,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdenti
 	}
 
 	// ================== setup tenant object ======================================
-	tenantConfig := cautils.GetTenantConfig(ctx, scanInfo.AccountID, scanInfo.AccessKey, k8sinterface.GetContextName(), scanInfo.CustomClusterName, getKubernetesApi())
+	tenantConfig := cautils.GetTenantConfig(ctx, scanInfo.AccountID, scanInfo.AccessKey, scanInfo.GetClusterContextName(), scanInfo.CustomClusterName, getKubernetesApi())
 
 	// Set submit behavior AFTER loading tenant config
 	setSubmitBehavior(scanInfo, tenantConfig)
@@ -209,6 +209,10 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	policyIdentifiers = resolveDefaultScanAllPolicies(scanInfo, policyIdentifiers) // resolve the ScanAll expansion while Init can still cache its paths
 	scanInfo.Init(ctxInit, policyIdentifiers)                                      // initialize scan info
 	defer scanInfo.Cleanup()
+	if err := resolveClusterContext(scanInfo); err != nil {
+		spanInit.End()
+		return nil, err
+	}
 
 	interfaces, err := getInterfaces(ctxInit, scanInfo, policyIdentifiers)
 	if err != nil {
@@ -408,6 +412,16 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 
 	return resultsHandling, nil
+}
+
+func resolveClusterContext(scanInfo *cautils.ScanInfo) error {
+	if scanInfo.GetScanningContext() != cautils.ContextCluster {
+		return nil
+	}
+	if err := scanInfo.ResolveClusterContextName(); err != nil {
+		return fmt.Errorf("failed to resolve Kubernetes context: %w", err)
+	}
+	return nil
 }
 
 func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo) {

--- a/core/pkg/resourcehandler/handlepullresources_test.go
+++ b/core/pkg/resourcehandler/handlepullresources_test.go
@@ -11,6 +11,7 @@ import (
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	reportv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,7 +47,7 @@ func Test_getCloudMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			got := newCloudMetadata(tt.provider)
+			got := newCloudMetadata(tt.provider, "")
 			if got == nil {
 				t.Errorf("getCloudMetadata() = %v, want %v", got, tt.want.Provider())
 				return
@@ -56,6 +57,22 @@ func Test_getCloudMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetCloudMetadataUsesSessionContext(t *testing.T) {
+	k8sinterface.SetClusterContextName("context-b")
+	t.Cleanup(func() { k8sinterface.SetClusterContextName("") })
+	session := &cautils.OPASessionObj{
+		Metadata: &reportv2.Metadata{ContextMetadata: reportv2.ContextMetadata{
+			ClusterContextMetadata: &reportv2.ClusterMetadata{ContextName: "context-a"},
+		}},
+		Report: &reportv2.PostureReport{},
+	}
+
+	setCloudMetadata(session, "aks")
+
+	require.NotNil(t, session.Metadata.ContextMetadata.ClusterContextMetadata.CloudMetadata)
+	assert.Equal(t, "context-a", session.Metadata.ContextMetadata.ClusterContextMetadata.CloudMetadata.GetFullName())
 }
 
 // vapTestScheme returns a runtime.Scheme with VAP and VAPBinding list types

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -49,7 +49,14 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 }
 
 func setCloudMetadata(opaSessionObj *cautils.OPASessionObj, provider string) {
-	iCloudMetadata := newCloudMetadata(provider)
+	var contextName string
+	if clusterMetadata := opaSessionObj.Metadata.ContextMetadata.ClusterContextMetadata; clusterMetadata != nil && clusterMetadata.ContextName != "" {
+		contextName = clusterMetadata.ContextName
+	}
+	if contextName == "" {
+		contextName = k8sinterface.GetContextName()
+	}
+	iCloudMetadata := newCloudMetadata(provider, contextName)
 	if iCloudMetadata == nil {
 		return
 	}
@@ -69,14 +76,14 @@ func setCloudMetadata(opaSessionObj *cautils.OPASessionObj, provider string) {
 // 1. Get cloud provider from API server git version (EKS, GKE)
 // 2. Get cloud provider from kubeconfig by parsing the cluster context (EKS, GKE)
 // 3. Get cloud provider from kubeconfig by parsing the server URL (AKS)
-func newCloudMetadata(provider string) apis.ICloudParser {
+func newCloudMetadata(provider, contextName string) apis.ICloudParser {
 	switch provider {
 	case cloudsupportv1.AKS:
-		return helpersv1.NewAKSMetadata(k8sinterface.GetContextName())
+		return helpersv1.NewAKSMetadata(contextName)
 	case cloudsupportv1.EKS:
-		return helpersv1.NewEKSMetadata(k8sinterface.GetContextName())
+		return helpersv1.NewEKSMetadata(contextName)
 	case cloudsupportv1.GKE:
-		return helpersv1.NewGKEMetadata(k8sinterface.GetContextName())
+		return helpersv1.NewGKEMetadata(contextName)
 	default:
 		return nil
 	}


### PR DESCRIPTION
Resolves #2840

## Summary

Keep live CLI scan attribution aligned with the kubeconfig and context selected by `--kubeconfig` and `--kube-context`.

- capture `--kubeconfig` and the inherited `--kube-context` override in the scan's own state;
- defer loading that file until the target is known to be a live cluster;
- resolve and validate the selected context with the same override precedence as the REST client;
- use the resolved name for tenant configuration, report context metadata, and session-backed cloud metadata;
- retain the current k8s-interface fallback when neither an explicit kubeconfig nor a context override is supplied.

The change does not mutate k8s-interface globals. It also preserves `--cluster-name`, in-cluster/default-kubeconfig behavior, and the existing cluster-backed tenant configuration path for offline scans when a connection is already available.

## Why

The REST setup honors controller-runtime's explicit `--kubeconfig` flag, but `k8sinterface.GetContextName()` can separately load `KUBECONFIG` or the default file. With explicit A and default B, the client connects to A while scan metadata can say B.

## Tests

- explicit kubeconfig A + default config B produces REST target A and metadata/tenant context A;
- inherited `--kube-context` follows the REST selection precedence;
- `--kube-context` without `--kubeconfig` is resolved and validated through the default kubeconfig loading rules;
- the production order `ScanInfo.Init -> ResolveClusterContextName -> scanInfoToScanMetadata` retains context A;
- offline and image-only scans do not load an irrelevant missing kubeconfig;
- offline scans that have an existing cluster connection still use cluster-backed tenant configuration;
- session cloud metadata uses the already-resolved context rather than re-reading the default context;
- invalid current-context and missing override selections return errors.

Validation:

~~~bash
go test -p=2 ./cmd/scan ./core/cautils ./core/core ./core/pkg/resourcehandler \
  -run 'Kubeconfig|KubeContext|ResolveClusterContext|GetInterfacesUsesResolved|CloudMetadata|TestSetContextMetadata' \
  -count=3

go test -vet=off -p=2 \
  ./cmd/scan ./core/cautils ./core/core ./core/pkg/resourcehandler

go vet -p=2 \
  ./cmd/scan ./core/cautils ./core/core ./core/pkg/resourcehandler
~~~

Not run locally: the race-enabled targeted variant was skipped to avoid another cold instrumented build; the non-race targeted suite, complete affected-package suites, and explicit vet all passed.

## Scope

This PR aligns CLI scan identity at the tenant/report/session metadata seams. It does not claim to replace every cloud-provider lookup that may exist inside k8s-interface, and it does not make the kubeconfig an immutable single-read snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly selecting a Kubernetes configuration file and context for scans.
  - Scan results and cloud metadata now reflect the selected cluster context.

- **Bug Fixes**
  - Prevented image scans from loading irrelevant or missing Kubernetes configuration files.
  - Added clear validation errors for missing configuration files, contexts, or invalid context overrides.
  - Ensured offline scans and tenant metadata use the correct selected context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->