### PR TITLE
fix(core): skip image scanner initialization when no images

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -414,23 +414,23 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 	imagesToScan := mapset.NewSet[string]()
 
 	if scanType == cautils.ScanTypeWorkload {
-		containers, err := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject()).GetContainers()
+		workload := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject())
+		images, err := containerImages(workload)
+		imagesToScan.Append(images...)
 		if err != nil {
-			logger.L().Error("failed to get containers", helpers.Error(err))
-			return
-		}
-		for _, container := range containers {
-			imagesToScan.Add(container.Image)
+			logger.L().Error("failed to get container images", helpers.Error(err))
+			if imagesToScan.IsEmpty() {
+				return
+			}
 		}
 	} else {
-		for _, workload := range scanData.AllResources {
-			containers, err := workloadinterface.NewWorkloadObj(workload.GetObject()).GetContainers()
+		for _, resource := range scanData.AllResources {
+			workload := workloadinterface.NewWorkloadObj(resource.GetObject())
+			images, err := containerImages(workload)
+			imagesToScan.Append(images...)
 			if err != nil {
-				logger.L().Error(fmt.Sprintf("failed to get containers for kind: %s, name: %s, namespace: %s", workload.GetKind(), workload.GetName(), workload.GetNamespace()), helpers.Error(err))
+				logger.L().Error(fmt.Sprintf("failed to get container images for kind: %s, name: %s, namespace: %s", resource.GetKind(), resource.GetName(), resource.GetNamespace()), helpers.Error(err))
 				continue
-			}
-			for _, container := range containers {
-				imagesToScan.Add(container.Image)
 			}
 		}
 	}
@@ -478,6 +478,40 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 	if agg := orchestrator.GetErrorAggregator(); agg != nil && agg.HasErrors() {
 		logger.L().Warning(agg.Error())
 	}
+}
+
+func containerImages(workload workloadinterface.IWorkload) ([]string, error) {
+	var images []string
+	var collectionErr error
+
+	containers, err := workload.GetContainers()
+	if err != nil {
+		collectionErr = errors.Join(collectionErr, fmt.Errorf("failed to get regular containers: %w", err))
+	} else {
+		for _, container := range containers {
+			images = append(images, container.Image)
+		}
+	}
+
+	initContainers, err := workload.GetInitContainers()
+	if err != nil {
+		collectionErr = errors.Join(collectionErr, fmt.Errorf("failed to get init containers: %w", err))
+	} else {
+		for _, container := range initContainers {
+			images = append(images, container.Image)
+		}
+	}
+
+	ephemeralContainers, err := workload.GetEphemeralContainers()
+	if err != nil {
+		collectionErr = errors.Join(collectionErr, fmt.Errorf("failed to get ephemeral containers: %w", err))
+	} else {
+		for _, container := range ephemeralContainers {
+			images = append(images, container.Image)
+		}
+	}
+
+	return images, collectionErr
 }
 
 func registryCredentialsFromScanInfo(scanInfo *cautils.ScanInfo) imagescan.RegistryCredentials {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -433,7 +433,14 @@ func resolveClusterContext(scanInfo *cautils.ScanInfo) error {
 }
 
 func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo, k8sApi *k8sinterface.KubernetesApi) {
-	imagesToScan, imageToCreds := collectImageScanTargets(scanType, scanData, ctx, scanInfo.GetScanningContext(), k8sApi)
+	var scanningContext cautils.ScanningContext
+	if scanInfo != nil {
+		scanningContext = scanInfo.GetScanningContext()
+	}
+	imagesToScan, imageToCreds := collectImageScanTargets(scanType, scanData, ctx, scanningContext, k8sApi)
+	if imagesToScan.IsEmpty() {
+		return
+	}
 
 	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
 	if err != nil {

--- a/core/core/scan_images_test.go
+++ b/core/core/scan_images_test.go
@@ -1,0 +1,115 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerImagesIncludesAllContainerTypes(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "all-container-types", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"name": "app", "image": "regular:v1"},
+				map[string]any{"name": "sidecar", "image": "shared:v1"},
+			},
+			"initContainers": []any{
+				map[string]any{"name": "setup", "image": "init:v1"},
+				map[string]any{"name": "shared-init", "image": "shared:v1"},
+			},
+			"ephemeralContainers": []any{
+				map[string]any{"name": "debugger", "image": "debug:v1"},
+				map[string]any{"name": "shared-debugger", "image": "shared:v1"},
+			},
+		},
+	})
+
+	images, err := containerImages(pod)
+
+	assert.NoError(t, err)
+	assert.Equal(t,
+		[]string{"regular:v1", "shared:v1", "init:v1", "shared:v1", "debug:v1", "shared:v1"},
+		images,
+	)
+}
+
+func TestContainerImagesSupportsPodTemplates(t *testing.T) {
+	deployment := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "deployment", "namespace": "default"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers":     []any{map[string]any{"name": "app", "image": "deployment:v1"}},
+					"initContainers": []any{map[string]any{"name": "setup", "image": "deployment-init:v1"}},
+				},
+			},
+		},
+	})
+
+	images, err := containerImages(deployment)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"deployment:v1", "deployment-init:v1"}, images)
+}
+
+func TestContainerImagesCollectsOtherCategoriesAfterOneFails(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      map[string]any
+		want      []string
+		wantError string
+	}{
+		{
+			name: "regular containers fail",
+			spec: map[string]any{
+				"containers":          "not-a-list",
+				"initContainers":      []any{map[string]any{"name": "setup", "image": "init:v1"}},
+				"ephemeralContainers": []any{map[string]any{"name": "debugger", "image": "debug:v1"}},
+			},
+			want:      []string{"init:v1", "debug:v1"},
+			wantError: "failed to get regular containers",
+		},
+		{
+			name: "init containers fail",
+			spec: map[string]any{
+				"containers":          []any{map[string]any{"name": "app", "image": "regular:v1"}},
+				"initContainers":      "not-a-list",
+				"ephemeralContainers": []any{map[string]any{"name": "debugger", "image": "debug:v1"}},
+			},
+			want:      []string{"regular:v1", "debug:v1"},
+			wantError: "failed to get init containers",
+		},
+		{
+			name: "ephemeral containers fail",
+			spec: map[string]any{
+				"containers":          []any{map[string]any{"name": "app", "image": "regular:v1"}},
+				"initContainers":      []any{map[string]any{"name": "setup", "image": "init:v1"}},
+				"ephemeralContainers": "not-a-list",
+			},
+			want:      []string{"regular:v1", "init:v1"},
+			wantError: "failed to get ephemeral containers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := workloadinterface.NewWorkloadObj(map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata":   map[string]any{"name": "partial", "namespace": "default"},
+				"spec":       tt.spec,
+			})
+
+			images, err := containerImages(pod)
+
+			assert.ErrorContains(t, err, tt.wantError)
+			assert.ElementsMatch(t, tt.want, images)
+		})
+	}
+}

--- a/core/core/scan_images_test.go
+++ b/core/core/scan_images_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanImagesSkipsInitializationWhenNoImagesFound(t *testing.T) {
+	emptyPod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "empty", "namespace": "default"},
+		"spec": map[string]any{
+			"containers":          []any{},
+			"initContainers":      []any{},
+			"ephemeralContainers": []any{},
+		},
+	})
+	images := getAllWorkloadImages(emptyPod)
+	assert.Empty(t, images)
+
+	tests := []struct {
+		name     string
+		scanType cautils.ScanTypes
+		scanData *cautils.OPASessionObj
+	}{
+		{
+			name:     "single workload",
+			scanType: cautils.ScanTypeWorkload,
+			scanData: &cautils.OPASessionObj{SingleResourceScan: emptyPod},
+		},
+		{
+			name:     "all resources",
+			scanType: cautils.ScanTypeFramework,
+			scanData: &cautils.OPASessionObj{
+				AllResources: map[string]workloadinterface.IMetadata{"empty": emptyPod},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				scanImages(tt.scanType, tt.scanData, context.Background(), nil, nil, nil)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Skip Grype database and image-scanner initialization when a posture scan discovers no container images.

The original init/ephemeral image-discovery change is now present on `master` through #2980, and workload-scoped registry credentials are present through #2832. After rebasing, this early-return fix is the remaining distinct change in this PR.

## Changes

- return before database/scanner initialization when the collected image set is empty;
- cover both a single-workload scan and an all-resources scan;
- retain the current regular, init, and ephemeral image discovery and per-image credential behavior from `master`.

The previous review request about retaining workload-specific credentials is therefore obsolete: current `master` already deduplicates per-image credential lists and applies deterministic ordering before creating scan jobs.

Container getter decoding errors are intentionally propagated by #2965; that error-handling change is kept separate instead of being duplicated in this focused early-return PR.

## Validation

```bash
go test ./core/core -run 'TestScanImagesSkipsInitializationWhenNoImagesFound|TestGetAllWorkloadImages|TestCollectImageScanTargetsScopesPullSecretsToLiveCluster' -count=1
```

`gofmt` and `git diff --check` also pass.

## Related

- #2843
- #2980
- #2832
- #2965
