### PR TITLE
fix: count returned items in cluster-size estimates

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1001,8 +1001,8 @@ var namespacedResourcesToEstimate = []schema.GroupVersionResource{
 }
 
 // EstimateClusterSize estimates the number of namespaced resources in the
-// cluster by issuing metadata-only LIST requests (limit=1) to the API server
-// and summing the remainingItemCount from each response. A per-GVR failure
+// cluster by issuing LIST requests (limit=1) to the API server and summing the
+// returned items and remainingItemCount from each response. A per-GVR failure
 // (type unavailable, or the service account lacking read access) is tolerated,
 // but if no representative type can be listed at all the estimate is useless —
 // returning (0, nil) would be indistinguishable from a genuinely small cluster
@@ -1021,6 +1021,7 @@ func (k8sHandler *K8sResourceHandler) EstimateClusterSize(ctx context.Context, s
 			continue
 		}
 		ok++
+		total += len(result.Items)
 		if rc := result.GetRemainingItemCount(); rc != nil {
 			total += int(*rc)
 		}

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -56,14 +56,59 @@ func TestEstimateClusterSize_NilDynamicClient(t *testing.T) {
 	assert.Equal(t, 0, size)
 }
 
-func newListWithRemaining(n int64) *unstructured.UnstructuredList {
+func newLimitOneList() *unstructured.UnstructuredList {
 	return &unstructured.UnstructuredList{
-		Object: map[string]any{
-			"metadata": map[string]any{
-				"remainingItemCount": n,
-			},
+		Items: []unstructured.Unstructured{{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Example",
+			"metadata":   map[string]any{"name": "first"},
+		}}},
+	}
+}
+
+func newLimitOneListWithRemaining(n int64) *unstructured.UnstructuredList {
+	list := newLimitOneList()
+	list.Object = map[string]any{
+		"metadata": map[string]any{
+			"remainingItemCount": n,
 		},
 	}
+	return list
+}
+
+func TestEstimateClusterSize_CountsReturnedItems(t *testing.T) {
+	mockClient := &gvrAwareDynamicClient{
+		listFunc: func(_ schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			assert.Equal(t, int64(1), opts.Limit)
+			return newLimitOneList(), nil
+		},
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient},
+	}
+
+	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
+	require.NoError(t, err)
+	assert.Equal(t, len(namespacedResourcesToEstimate), size,
+		"a returned page item must be counted even when remainingItemCount is absent")
+}
+
+func TestEstimateClusterSize_SuccessfulEmptyLists(t *testing.T) {
+	mockClient := &gvrAwareDynamicClient{
+		listFunc: func(_ schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			assert.Equal(t, int64(1), opts.Limit)
+			return &unstructured.UnstructuredList{}, nil
+		},
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient},
+	}
+
+	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
+	require.NoError(t, err)
+	assert.Zero(t, size, "successfully listed empty resource types form a valid zero-size estimate")
 }
 
 func TestEstimateClusterSize_SmallCluster(t *testing.T) {
@@ -81,7 +126,7 @@ func TestEstimateClusterSize_SmallCluster(t *testing.T) {
 			case "configmaps":
 				n = 20
 			}
-			return newListWithRemaining(n), nil
+			return newLimitOneListWithRemaining(n), nil
 		},
 	}
 
@@ -91,14 +136,14 @@ func TestEstimateClusterSize_SmallCluster(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 50+10+5+20 + (12 other GVRs * 10 each) = 85 + 120 = 205
-	assert.Equal(t, 205, size)
+	// 50+10+5+20 + (12 other GVRs * 10 each) + 16 returned items = 221
+	assert.Equal(t, 221, size)
 }
 
 func TestEstimateClusterSize_LargeCluster(t *testing.T) {
 	mockClient := &gvrAwareDynamicClient{
 		listFunc: func(gvr schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-			return newListWithRemaining(500), nil
+			return newLimitOneListWithRemaining(500), nil
 		},
 	}
 
@@ -108,8 +153,8 @@ func TestEstimateClusterSize_LargeCluster(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 16 GVRs * 500 each = 8000
-	assert.Equal(t, 8000, size)
+	// 16 GVRs * (500 remaining + 1 returned) = 8016
+	assert.Equal(t, 8016, size)
 }
 
 func TestEstimateClusterSize_ListErrors(t *testing.T) {
@@ -118,7 +163,7 @@ func TestEstimateClusterSize_ListErrors(t *testing.T) {
 			if gvr.Resource == "pods" {
 				return nil, errors.New("API server error")
 			}
-			return newListWithRemaining(100), nil
+			return newLimitOneListWithRemaining(100), nil
 		},
 	}
 
@@ -128,8 +173,8 @@ func TestEstimateClusterSize_ListErrors(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 15 GVRs * 100 = 1500 (pods error is skipped)
-	assert.Equal(t, 1500, size)
+	// 15 GVRs * (100 remaining + 1 returned) = 1515 (pods error is skipped)
+	assert.Equal(t, 1515, size)
 }
 
 func TestEstimateClusterSize_AllListErrors(t *testing.T) {
@@ -176,10 +221,10 @@ func TestEstimateClusterSize_NilRemainingItemCount(t *testing.T) {
 	mockClient := &gvrAwareDynamicClient{
 		listFunc: func(gvr schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 			if gvr.Resource == "pods" {
-				// No metadata at all — GetRemainingItemCount returns nil
-				return &unstructured.UnstructuredList{}, nil
+				// A complete one-item page has no remainingItemCount.
+				return newLimitOneList(), nil
 			}
-			return newListWithRemaining(200), nil
+			return newLimitOneListWithRemaining(200), nil
 		},
 	}
 
@@ -189,6 +234,6 @@ func TestEstimateClusterSize_NilRemainingItemCount(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 15 GVRs * 200 = 3000 (pods with nil remainingItemCount is skipped)
-	assert.Equal(t, 3000, size)
+	// 15 GVRs * (200 remaining + 1 returned) + 1 returned pod = 3016.
+	assert.Equal(t, 3016, size)
 }


### PR DESCRIPTION
## Overview

`EstimateClusterSize` currently sums only `remainingItemCount` from each `limit=1` LIST response. That field excludes the items in the returned page, so every successful, non-empty response makes the estimate one too small.

This change:

- adds `len(result.Items)` for each successful representative LIST;
- continues adding `remainingItemCount` when the API server supplies it;
- updates the method comment to describe both parts of the estimate;
- updates the estimate fixtures to model a limit-one response with one returned item;
- covers returned items with both positive and absent `remainingItemCount` values;
- verifies that successful empty LISTs remain a valid zero-size estimate;
- preserves partial-LIST-error tolerance and the existing all-LISTs-failed error.

The change is limited to the arithmetic of the existing representative estimate. It does not change the GVR set, request count, pagination limit, namespace filtering, or streaming threshold.

## How to Test

```bash
go test ./core/pkg/resourcehandler \
  -run '^TestEstimateClusterSize_(CountsReturnedItems|SuccessfulEmptyLists)$' \
  -count=3

go test ./core/pkg/resourcehandler
go vet ./core/pkg/resourcehandler
go test -race ./core/pkg/resourcehandler \
  -run '^TestEstimateClusterSize_' \
  -count=1
```

Local results with Go 1.26.1:

- baseline/mutation (remove `total += len(result.Items)`): `TestEstimateClusterSize_CountsReturnedItems` failed 3/3 with expected 16 and actual 0;
- fixed returned-item and successful-empty-list tests: passed 3/3 each;
- full `core/pkg/resourcehandler` package: passed;
- `go vet ./core/pkg/resourcehandler`: passed;
- `git diff --check`: passed;
- targeted `-race`: stopped after five minutes while race-instrumented dependencies were still compiling; the test binary did not run, so there is no race result to claim.

## Additional Information

Kubernetes `remainingItemCount` represents items after the current page. With the estimator's `limit=1` request, a successful non-empty response represents `len(result.Items) + remainingItemCount` items.

The current representative list has 16 GVRs, so this corrects at most one omitted item per successful GVR. Existing per-GVR error behavior is unchanged.

## Related issues/PRs

- Resolves #2846
- The estimator was introduced in [#2645](https://github.com/kubescape/kubescape/pull/2645).

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster-size estimates by counting both returned resources and any additional remaining resources.
  * Corrected estimates for empty lists, paginated results, and responses without remaining-count information.
  * Preserved existing error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->