### PR TITLE
fix(cautils): avoid standalone renders of owned Helm dependencies

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -67,13 +68,34 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 	}
 	releaseOpts := valueOpts.ReleaseOptions()
 
+	// A parent chart owns unpacked dependencies below its charts/ directory. Process
+	// parents before their descendants so a successful parent render can suppress a
+	// second, standalone render of the same dependency. listHelmChartDirs currently
+	// inherits filepath.Walk ordering, but keep the ownership rule independent of that
+	// implementation detail.
+	sort.Slice(helmDirectories, func(i, j int) bool {
+		leftDepth := pathDepth(helmDirectories[i])
+		rightDepth := pathDepth(helmDirectories[j])
+		if leftDepth != rightDepth {
+			return leftDepth < rightDepth
+		}
+		return helmDirectories[i] < helmDirectories[j]
+	})
+
 	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
 	sourceToChart := make(map[string]Chart, 0)
-	// renderedCharts holds the chart directories that rendered without errors. Rendering is
-	// best-effort: a chart that fails is dropped whole (see the continue below), so callers must
-	// keep plain-scanning its files rather than assume this loader covered them.
+	// renderedCharts holds chart directories covered by a successful Helm render. It includes
+	// dependencies rendered through a successful parent, even when the dependency intentionally
+	// emitted no resources. Callers use this list to keep those templates out of the plain-YAML
+	// fallback. A chart below a failed parent remains eligible for a standalone fallback render.
 	renderedCharts := make([]string, 0, len(helmDirectories))
+	successfulCharts := make([]*HelmChart, 0, len(helmDirectories))
 	for _, helmDir := range helmDirectories {
+		if helmChartOwnedByAny(helmDir, successfulCharts) {
+			renderedCharts = append(renderedCharts, helmDir)
+			continue
+		}
+
 		chart, err := NewHelmChart(helmDir)
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("Failed to load Helm chart", helpers.String("path", helmDir), helpers.Error(err))
@@ -89,6 +111,7 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 			continue
 		}
 		renderedCharts = append(renderedCharts, helmDir)
+		successfulCharts = append(successfulCharts, chart)
 		chartName := chart.GetName()
 		prov := chart.Provenance()
 		for k, v := range wls {
@@ -101,6 +124,29 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 		}
 	}
 	return sourceToWorkloads, sourceToChart, renderedCharts, nil
+}
+
+// helmChartOwnedByAny reports whether chartDir is inside the unpacked dependency
+// tree of a chart that has already rendered successfully. Merely being nested below
+// another chart is not enough: Helm only owns charts below its charts/ directory.
+func helmChartOwnedByAny(chartDir string, successfulCharts []*HelmChart) bool {
+	for _, chart := range successfulCharts {
+		if chart.ownsUnpackedDependency(chartDir) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathDepth(path string) int {
+	depth := 0
+	for path = filepath.Clean(path); ; path = filepath.Dir(path) {
+		parent := filepath.Dir(path)
+		if parent == path {
+			return depth
+		}
+		depth++
+	}
 }
 
 // listHelmChartDirs scans a given path (recursively) and returns the directories holding a helm chart.
@@ -134,9 +180,9 @@ func listHelmChartDirs(basePath string) ([]string, []error) {
 // "{{ ... }}" actions are not valid YAML. Only templates/ is excluded: helm renders nothing else,
 // so the rest of the chart (crds/ in particular, which helm does apply) stays plainly scanned.
 //
-// renderedCharts must be the chart directories that rendered without errors. A chart that failed
-// to render is dropped whole by LoadResourcesFromHelmCharts, so its templates must NOT be excluded
-// here — otherwise its resources reach neither loader and vanish from the scan silently.
+// renderedCharts must be the chart directories covered by successful renders, including unpacked
+// dependencies covered through a parent. A chart that failed and was not covered by a parent must
+// NOT be included — otherwise its resources reach neither loader and vanish from the scan silently.
 func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	if len(renderedCharts) == 0 {
 		return files

--- a/core/cautils/helm_override_test.go
+++ b/core/cautils/helm_override_test.go
@@ -1,0 +1,245 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/require"
+)
+
+func writeParentWithUnpackedChild(
+	t *testing.T,
+	parentValues string,
+	childValues string,
+	childTemplate string,
+) (parentRoot, childRoot, childTemplatePath string) {
+	t.Helper()
+
+	parentRoot = filepath.Join(t.TempDir(), "parent")
+	childRoot = filepath.Join(parentRoot, "charts", "child")
+	require.NoError(t, os.MkdirAll(filepath.Join(childRoot, "templates"), 0o755))
+
+	writeManifestFixture(t, parentRoot, "Chart.yaml", `apiVersion: v2
+name: parent
+version: 0.1.0
+dependencies:
+  - name: child
+    version: 0.1.0
+`)
+	writeManifestFixture(t, parentRoot, "values.yaml", parentValues)
+	writeManifestFixture(t, childRoot, "Chart.yaml", `apiVersion: v2
+name: child
+version: 0.1.0
+`)
+	writeManifestFixture(t, childRoot, "values.yaml", childValues)
+	childTemplatePath = writeManifestFixture(t, filepath.Join(childRoot, "templates"), "service.yaml", childTemplate)
+	return parentRoot, childRoot, childTemplatePath
+}
+
+func requireServicePort(t *testing.T, workloads map[string][]workloadinterface.IMetadata, sourcePath string, expected int) {
+	t.Helper()
+
+	require.Len(t, workloads[sourcePath], 1)
+	spec, ok := workloads[sourcePath][0].GetObject()["spec"].(map[string]any)
+	require.True(t, ok)
+	ports, ok := spec["ports"].([]any)
+	require.True(t, ok)
+	require.Len(t, ports, 1)
+	port, ok := ports[0].(map[string]any)
+	require.True(t, ok)
+	require.EqualValues(t, expected, port["port"])
+}
+
+func TestLoadResourcesFromHelmCharts_PreservesParentSubchartValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueOpts HelmValueOptions
+		wantPort  int
+	}{
+		{
+			name:     "parent values file",
+			wantPort: 443,
+		},
+		{
+			name:      "nested set override",
+			valueOpts: HelmValueOptions{Values: []string{"child.port=8443"}},
+			wantPort:  8443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parentRoot, childRoot, servicePath := writeParentWithUnpackedChild(
+				t,
+				"child:\n  port: 443\n",
+				"port: 80\n",
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: child
+spec:
+  ports:
+    - port: {{ .Values.port }}
+`,
+			)
+
+			workloads, charts, renderedCharts, err := LoadResourcesFromHelmCharts(
+				context.Background(), parentRoot, tt.valueOpts,
+			)
+			require.NoError(t, err)
+			require.ElementsMatch(t, []string{parentRoot, childRoot}, renderedCharts)
+			requireServicePort(t, workloads, servicePath, tt.wantPort)
+			require.Equal(t, "parent", charts[servicePath].Name,
+				"the parent chart should own its dependency's rendered template")
+			require.Equal(t, parentRoot, charts[servicePath].Path)
+		})
+	}
+}
+
+func TestLoadResourcesFromHelmCharts_DoesNotReintroduceParentSuppressedSubchartOutput(t *testing.T) {
+	parentRoot, childRoot, servicePath := writeParentWithUnpackedChild(
+		t,
+		"child:\n  enabled: false\n",
+		"enabled: true\n",
+		`{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: child
+spec:
+  ports:
+    - port: 80
+{{- end }}
+`,
+	)
+
+	workloads, charts, renderedCharts, err := LoadResourcesFromHelmCharts(
+		context.Background(), parentRoot, HelmValueOptions{},
+	)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{parentRoot, childRoot}, renderedCharts)
+	require.NotContains(t, workloads, servicePath,
+		"a standalone child render must not recreate output suppressed by its parent values")
+	require.NotContains(t, charts, servicePath)
+}
+
+func TestLoadResourcesFromHelmCharts_RendersUnrelatedTopLevelCharts(t *testing.T) {
+	repoRoot := t.TempDir()
+	chartRoots := []string{
+		filepath.Join(repoRoot, "first"),
+		filepath.Join(repoRoot, "nested", "second"),
+	}
+	templatePaths := make([]string, 0, len(chartRoots))
+
+	for i, chartRoot := range chartRoots {
+		require.NoError(t, os.MkdirAll(filepath.Join(chartRoot, "templates"), 0o755))
+		chartName := []string{"first", "second"}[i]
+		writeManifestFixture(t, chartRoot, "Chart.yaml", "apiVersion: v2\nname: "+chartName+"\nversion: 0.1.0\n")
+		templatePaths = append(templatePaths, writeManifestFixture(
+			t,
+			filepath.Join(chartRoot, "templates"),
+			"configmap.yaml",
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+chartName+"\n",
+		))
+	}
+
+	workloads, charts, renderedCharts, err := LoadResourcesFromHelmCharts(
+		context.Background(), repoRoot, HelmValueOptions{},
+	)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, chartRoots, renderedCharts)
+	for i, sourcePath := range templatePaths {
+		require.Len(t, workloads[sourcePath], 1)
+		require.Equal(t, chartRoots[i], charts[sourcePath].Path)
+	}
+}
+
+func TestLoadResourcesFromHelmCharts_RendersChildAfterParentRenderFailure(t *testing.T) {
+	parentRoot, childRoot, servicePath := writeParentWithUnpackedChild(
+		t,
+		"child:\n  port: 443\n",
+		"port: 80\n",
+		`apiVersion: v1
+kind: Service
+metadata:
+  name: child
+spec:
+  ports:
+    - port: {{ .Values.port }}
+`,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Join(parentRoot, "templates"), 0o755))
+	writeManifestFixture(t, filepath.Join(parentRoot, "templates"), "broken.yaml", "{{ if }}\n")
+
+	workloads, charts, renderedCharts, err := LoadResourcesFromHelmCharts(
+		context.Background(), parentRoot, HelmValueOptions{},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{childRoot}, renderedCharts,
+		"a failed parent must not claim ownership of its child fallback")
+	requireServicePort(t, workloads, servicePath, 80)
+	require.Equal(t, "child", charts[servicePath].Name)
+	require.Equal(t, childRoot, charts[servicePath].Path)
+}
+
+func TestLoadResourcesFromHelmCharts_RendersChildExcludedFromParentByHelmignore(t *testing.T) {
+	parentRoot, childRoot, servicePath := writeParentWithUnpackedChild(
+		t,
+		"child:\n  port: 443\n",
+		"port: 80\n",
+		`apiVersion: v1
+kind: Service
+metadata:
+  name: child
+spec:
+  ports:
+    - port: {{ .Values.port }}
+`,
+	)
+	writeManifestFixture(t, parentRoot, ".helmignore", "charts/child\n")
+	parentChart, err := NewHelmChart(parentRoot)
+	require.NoError(t, err)
+	require.Empty(t, parentChart.chart.Dependencies(),
+		"the ignored child must not be present in the parent's loaded dependency graph")
+
+	workloads, charts, renderedCharts, err := LoadResourcesFromHelmCharts(
+		context.Background(), parentRoot, HelmValueOptions{},
+	)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{parentRoot, childRoot}, renderedCharts)
+	requireServicePort(t, workloads, servicePath, 80)
+	require.Equal(t, "child", charts[servicePath].Name,
+		"a child excluded from the parent loader is not owned by that render")
+	require.Equal(t, childRoot, charts[servicePath].Path)
+	_, statErr := os.Stat(filepath.Join(parentRoot, "charts", "child-0.1.0.tgz"))
+	require.ErrorIs(t, statErr, os.ErrNotExist,
+		"the fixture must remain an unpacked-child test without a generated archive")
+}
+
+func TestHelmChartOwnsUnpackedDependency_UsesLoadedGraph(t *testing.T) {
+	parentRoot := filepath.Join(t.TempDir(), "parent")
+	childRoot := filepath.Join(parentRoot, "charts", "vendor-directory")
+	grandchildRoot := filepath.Join(childRoot, "charts", "nested-directory")
+	require.NoError(t, os.MkdirAll(grandchildRoot, 0o755))
+
+	writeManifestFixture(t, parentRoot, "Chart.yaml", "apiVersion: v2\nname: parent\nversion: 0.1.0\n")
+	writeManifestFixture(t, childRoot, "Chart.yaml", "apiVersion: v2\nname: actual-child-name\nversion: 0.1.0\n")
+	writeManifestFixture(t, grandchildRoot, "Chart.yaml", "apiVersion: v2\nname: actual-grandchild-name\nversion: 0.1.0\n")
+
+	parentChart, err := NewHelmChart(parentRoot)
+	require.NoError(t, err)
+	require.Len(t, parentChart.chart.Dependencies(), 1)
+	require.Len(t, parentChart.chart.Dependencies()[0].Dependencies(), 1)
+	require.True(t, parentChart.ownsUnpackedDependency(childRoot),
+		"ownership must use the loaded file graph instead of assuming directory name equals chart name")
+	require.True(t, parentChart.ownsUnpackedDependency(grandchildRoot),
+		"ownership must follow more than one loaded dependency edge")
+	require.False(t, parentChart.ownsUnpackedDependency(filepath.Join(childRoot, "examples", "chart")))
+}

--- a/core/cautils/helmchart.go
+++ b/core/cautils/helmchart.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -133,6 +134,66 @@ func buildDependencies(chartPath string) error {
 
 func (hc *HelmChart) GetName() string {
 	return hc.chart.Name()
+}
+
+// ownsUnpackedDependency reports whether candidate is a chart directory loaded
+// through hc's on-disk charts/ dependency tree. It follows the loaded chart graph
+// instead of relying on the path alone: a directory excluded by .helmignore is not
+// owned by the parent and remains eligible for a standalone fallback render.
+func (hc *HelmChart) ownsUnpackedDependency(candidate string) bool {
+	rel, err := filepath.Rel(hc.path, candidate)
+	if err != nil {
+		return false
+	}
+	parts := strings.Split(filepath.Clean(rel), string(filepath.Separator))
+	current := hc.chart
+	for len(parts) > 0 {
+		if len(parts) < 2 || parts[0] != "charts" {
+			return false
+		}
+
+		current = loadedUnpackedDependency(current, parts[1])
+		if current == nil {
+			return false
+		}
+		parts = parts[2:]
+	}
+	return true
+}
+
+// loadedUnpackedDependency matches a direct charts/<directory> tree from the
+// parent's raw, post-.helmignore file set to the dependency object Helm loaded
+// from those same files. Comparing the complete file set avoids assuming that
+// the directory name equals Chart.yaml's name or that chart names are unique.
+func loadedUnpackedDependency(parent *helmchart.Chart, directory string) *helmchart.Chart {
+	prefix := filepath.ToSlash(filepath.Join("charts", directory)) + "/"
+	files := make(map[string][]byte)
+	for _, file := range parent.Raw {
+		if strings.HasPrefix(file.Name, prefix) {
+			files[strings.TrimPrefix(file.Name, prefix)] = file.Data
+		}
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	for _, dependency := range parent.Dependencies() {
+		if len(dependency.Raw) != len(files) {
+			continue
+		}
+		matches := true
+		for _, file := range dependency.Raw {
+			data, ok := files[file.Name]
+			if !ok || !bytes.Equal(data, file.Data) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return dependency
+		}
+	}
+	return nil
 }
 
 func (hc *HelmChart) GetDefaultValues() map[string]any {


### PR DESCRIPTION
## Overview

Recursive chart discovery currently renders an unpacked chart below a parent's `charts/` directory twice. The second standalone render can overwrite the parent's correctly scoped dependency values or recreate output that the parent values intentionally suppressed.

This change makes the render loop ownership-aware:

- chart candidates are processed parent-first.
- after a parent renders successfully, chart directories present in its loaded unpacked dependency graph are treated as covered and are not rendered independently.
- a dependency remains in `renderedCharts`, so its raw templates are not reprocessed as plain YAML.
- a dependency is still rendered as a fallback when its parent fails.
- a directory excluded from the parent by `.helmignore` is not claimed by that parent.
- charts outside another chart's `charts/` tree remain independent.

The merge behavior itself is unchanged. This does not use first-write-wins: when parent-scoped values make a dependency template emit nothing, there is no parent map entry to preserve, so the duplicate render has to be prevented at the ownership boundary.

## How to Test

```bash
go test ./core/cautils \
  -run '^(TestLoadResourcesFromHelmCharts_(PreservesParentSubchartValues|DoesNotReintroduceParentSuppressedSubchartOutput|RendersUnrelatedTopLevelCharts|RendersChildAfterParentRenderFailure|RendersChildExcludedFromParentByHelmignore)|TestHelmChartOwnsUnpackedDependency_UsesLoadedGraph)$' \
  -count=3
```

Regression coverage checks the parent's own values, a nested `--set` equivalent, parent-suppressed dependency output, unrelated top-level charts, the failed-parent fallback, a child excluded from its parent by `.helmignore`, non-matching directory/chart names, and a nested dependency edge.

Local validation:

- the corrected baseline failed three consecutive runs with parent values `443 -> 80` and the parent-suppressed Service reintroduced;
- the fixed targeted suite passed three consecutive runs;
- the complete `core/cautils` and `core/pkg/resourcehandler` package suites passed;
- `go vet ./core/cautils` and `git diff --check` passed; and
- disabling only the ownership check restored the value overwrite and suppressed-resource regressions, confirming that the tests exercise the fix.

A targeted `-race` run was attempted but did not finish compiling/linking the race-instrumented dependencies within the local time bound, so there is no local race result to claim.

## Related issues/PRs

Resolves #2848

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the ownership and fallback behavior
- [x] I have performed a self-review of the code and tests
- [x] I have added targeted regression tests
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Helm chart processing to preserve parent and subchart values.
  * Prevented duplicate output when parent charts successfully render their dependencies.
  * Added fallback rendering for child charts when parent rendering fails.
  * Improved discovery of unrelated top-level charts and `.helmignore` behavior.

* **Bug Fixes**
  * Improved dependency ownership detection for unpacked Helm charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->