### PR TITLE
fix(locationresolver): split fix paths on the first '=' rather than the last

### DIFF
--- a/core/pkg/resultshandling/locationresolver/locationresolver.go
+++ b/core/pkg/resultshandling/locationresolver/locationresolver.go
@@ -87,10 +87,18 @@ func (l *FixPathLocationResolver) ResolveLocation(fixPath string, nodeIndex int)
 }
 
 func FixPathToValidYamlExpression(fixPath string) string {
-	// remove everything after the first =
-	yamlExpression := regexp.MustCompile(`(.*)=.*`).ReplaceAllString(fixPath, `${1}`)
+	// Remove everything after the first "=": assisted-remediation strings are built
+	// as "<path>=<value>" by fixPathsToString in printer/v2/resourcetable.go, and
+	// only the path half is a valid yaml expression.
+	//
+	// This must split on the *first* separator. Fix values routinely contain "="
+	// themselves — the CIS control-plane rules emit values such as
+	// "--anonymous-auth=false" and "--authorization-mode=RBAC" — so a greedy match
+	// keeps part of the value in the path and produces an unusable expression.
+	if i := strings.Index(fixPath, "="); i >= 0 {
+		fixPath = fixPath[:i]
+	}
 
 	// add a dot for the root node
-	yamlExpression = "." + yamlExpression
-	return yamlExpression
+	return "." + fixPath
 }

--- a/core/pkg/resultshandling/locationresolver/locationresolver_test.go
+++ b/core/pkg/resultshandling/locationresolver/locationresolver_test.go
@@ -83,6 +83,64 @@ func TestResolveLocation_ZeroCandidateNodesDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestFixPathToValidYamlExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixPath string
+		want    string
+	}{
+		{
+			name:    "path with no value is prefixed only",
+			fixPath: "spec.template.spec.containers[0].image",
+			want:    ".spec.template.spec.containers[0].image",
+		},
+		{
+			name:    "value is stripped",
+			fixPath: "spec.template.spec.containers[0].securityContext.privileged=true",
+			want:    ".spec.template.spec.containers[0].securityContext.privileged",
+		},
+		{
+			name:    "placeholder value is stripped",
+			fixPath: "spec.template.spec.containers[0].resources.limits.cpu=YOUR_VALUE",
+			want:    ".spec.template.spec.containers[0].resources.limits.cpu",
+		},
+		{
+			// The CIS control-plane rules emit flag-style fix values that themselves
+			// contain "=". Splitting on the last "=" leaves "--anonymous-auth" glued
+			// to the path and yields an expression yq cannot evaluate.
+			name:    "flag-style value containing = is fully stripped",
+			fixPath: "spec.containers[0].command[3]=--anonymous-auth=false",
+			want:    ".spec.containers[0].command[3]",
+		},
+		{
+			name:    "value with multiple = is fully stripped",
+			fixPath: "spec.containers[0].command[0]=--enable-admission-plugins=NodeRestriction",
+			want:    ".spec.containers[0].command[0]",
+		},
+		{
+			name:    "value containing = and a path separator is fully stripped",
+			fixPath: "spec.containers[0].command[1]=--encryption-provider-config=/etc/kubernetes/enc.yaml",
+			want:    ".spec.containers[0].command[1]",
+		},
+		{
+			name:    "empty value after separator",
+			fixPath: "metadata.namespace=",
+			want:    ".metadata.namespace",
+		},
+		{
+			name:    "empty input",
+			fixPath: "",
+			want:    ".",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FixPathToValidYamlExpression(tt.fixPath))
+		})
+	}
+}
+
 func TestFixPathLocationResolver_NonExistentYaml(t *testing.T) {
 	yamlFilePath := filepath.Join(onlineBoutiquePath(), "adservice_invalid.yaml")
 	resolver, err := NewFixPathLocationResolver(yamlFilePath)


### PR DESCRIPTION
Fixes #2844

## Overview

`FixPathToValidYamlExpression` splits an assisted-remediation string into path and value before
evaluating the path with yq. The comment says it removes everything after the *first* `=`, but
`regexp.MustCompile("(.*)=.*")` is greedy and splits on the *last* one.

That only matters when a fix value itself contains `=`, which the CIS control-plane rules do,
because their fix values are command-line flags:

```
--anonymous-auth=false
--authorization-mode=RBAC
--enable-admission-plugins=NodeRestriction
--encryption-provider-config=<path/to/encryption-config.yaml>
```

For those, the trailing fragment stays glued to the path:

```
input:    spec.containers[0].command[3]=--anonymous-auth=false
expected: .spec.containers[0].command[3]
actual:   .spec.containers[0].command[3]=--anonymous-auth
```

The `=` survives into the expression handed to yq. If that fails to resolve, the error is
discarded at `sarifprinter.go:286` and `resolveFixLocation` returns the `Line: 1, Column: 1`
default. The corrupted output is pinned by the test below; I haven't measured yq's behaviour on
the malformed expression against a live scan, so the downstream line-number effect follows from
the code path rather than from an observed failure.

## Change

Split on the first `=` with `strings.Index`, which is what the comment already describes.
Behaviour is unchanged for any path without a second `=`, which is nearly all of them. The
existing `TestResolveLocation` cases pass unmodified.

## Tests

Adds `TestFixPathToValidYamlExpression`, table-driven over: path with no value, ordinary value
(`=true`), placeholder value (`=YOUR_VALUE`), **flag-style value containing `=`** (the
regression), value with multiple `=`, value containing `=` and a `/`, empty value after the
separator, and empty input.

## How to test

```bash
go test ./core/pkg/resultshandling/locationresolver/... -run TestFixPathToValidYamlExpression -v
go test ./core/pkg/resultshandling/...
```

## Related

#2393 / #2406, same user-visible symptom (SARIF locations collapsing to line 1), different
root cause.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML path handling when paths include `=` characters.
  * Preserved valid `=` characters within values while removing trailing value content correctly.
  * Added support for empty inputs and paths with separators.

* **Tests**
  * Added coverage for standard paths, values, multiple `=` characters, empty values, and empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->