### PR TITLE
fix(resourcehandler): let Kustomize own referenced Helm charts

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -68,9 +68,10 @@ func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
 	}
 	if len(excludedChartDirectories) > 0 {
+		normalizedExcludedDirectories := normalizePaths(excludedChartDirectories)
 		remaining := make([]string, 0, len(helmDirectories))
 		for _, directory := range helmDirectories {
-			if !isUnderAnyDir(directory, excludedChartDirectories) {
+			if !isUnderAnyNormalizedDir(normalizePath(directory), normalizedExcludedDirectories) {
 				remaining = append(remaining, directory)
 			}
 		}
@@ -167,19 +168,24 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	for _, helmDir := range renderedCharts {
 		templateDirs = append(templateDirs, filepath.Join(helmDir, "templates"))
 	}
+	templateDirs = pathAliasesForPaths(templateDirs)
 
 	remaining := make([]string, 0, len(files))
 	for _, file := range files {
-		if !isUnderAnyDir(file, templateDirs) {
+		if !isAnyPathAliasUnderAnyDir(file, templateDirs) {
 			remaining = append(remaining, file)
 		}
 	}
 	return remaining
 }
 
-// isUnderAnyDir reports whether path is inside one of dirs. Both are expected to be absolute,
-// as returned by listFiles and listDirs.
+// isUnderAnyDir reports whether path is inside one of dirs after normalizing
+// relative paths and resolving symlinks where the path already exists.
 func isUnderAnyDir(path string, dirs []string) bool {
+	return isUnderAnyNormalizedDir(normalizePath(path), normalizePaths(dirs))
+}
+
+func isUnderAnyNormalizedDir(path string, dirs []string) bool {
 	for _, dir := range dirs {
 		rel, err := filepath.Rel(dir, path)
 		if err != nil {
@@ -191,6 +197,75 @@ func isUnderAnyDir(path string, dirs []string) bool {
 		}
 	}
 	return false
+}
+
+func normalizePaths(paths []string) []string {
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		normalized = append(normalized, normalizePath(path))
+	}
+	return normalized
+}
+
+func pathAliasesForPaths(paths []string) []string {
+	aliases := make([]string, 0, len(paths)*2)
+	for _, path := range paths {
+		aliases = append(aliases, pathAliases(path)...)
+	}
+	return aliases
+}
+
+func isAnyPathAliasUnderAnyDir(path string, dirs []string) bool {
+	for _, alias := range pathAliases(path) {
+		if isUnderAnyNormalizedDir(alias, dirs) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathAliases returns both the absolute lexical path and, when different, its
+// physical path. Keeping both matters for a symlinked template file: Helm owns
+// it by its lexical location below templates/, even if the link target is outside
+// the chart. The physical form still matches scans reached through a symlinked
+// parent directory.
+func pathAliases(path string) []string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return []string{filepath.Clean(path)}
+	}
+	absPath = filepath.Clean(absPath)
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil || resolvedPath == absPath {
+		return []string{absPath}
+	}
+	return []string{absPath, resolvedPath}
+}
+
+func normalizePath(path string) string {
+	normalized, err := canonicalPath(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return normalized
+}
+
+func canonicalPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	// Missing paths are valid for remote charts that Kustomize has not pulled yet.
+	// The absolute lexical form is still sufficient because generic discovery cannot
+	// return a matching path until it exists.
+	if errors.Is(err, os.ErrNotExist) {
+		return filepath.Clean(absPath), nil
+	}
+	return "", err
 }
 
 // mergeMaps performs a deep merge of override into a copy of base, with override winning on conflicts.

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -51,9 +51,30 @@ type Chart struct {
 // --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
 // fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
 func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, nil)
+}
+
+// LoadResourcesFromHelmChartsExcludingDirectories behaves like LoadResourcesFromHelmCharts,
+// but leaves charts at or below excludedChartDirectories to another renderer that owns them.
+// The caller is responsible for including those directories in its plain-file exclusions once
+// that renderer succeeds.
+func LoadResourcesFromHelmChartsExcludingDirectories(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, excludedChartDirectories)
+}
+
+func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
 	helmDirectories, discoveryErrs := listHelmChartDirs(basePath)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
+	}
+	if len(excludedChartDirectories) > 0 {
+		remaining := make([]string, 0, len(helmDirectories))
+		for _, directory := range helmDirectories {
+			if !isUnderAnyDir(directory, excludedChartDirectories) {
+				remaining = append(remaining, directory)
+			}
+		}
+		helmDirectories = remaining
 	}
 
 	// Parse user-supplied value overrides once; reuse for every chart we render.

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -224,6 +224,63 @@ func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	}
 }
 
+func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testing.T) {
+	root := t.TempDir()
+	chartHome := filepath.Join(root, "charts")
+	base := filepath.Join(root, "base")
+	ownedChart := filepath.Join(base, "charts", "app")
+	ownedSubchart := filepath.Join(ownedChart, "charts", "dependency")
+	standaloneChart := filepath.Join(chartHome, "standalone")
+
+	writeChart := func(directory, name string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+		writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
+		writeManifestFixture(t, directory, "values.yaml", "{}\n")
+		writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
+	}
+	writeChart(ownedChart, "app")
+	writeChart(ownedSubchart, "dependency")
+	writeChart(standaloneChart, "standalone")
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+`)
+	writeManifestFixture(t, base, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: app
+    releaseName: app
+`)
+
+	ownedDirectories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	require.Equal(t, []string{ownedChart, ownedSubchart}, ownedDirectories)
+
+	standaloneTemplate := filepath.Join(standaloneChart, "templates", "configmap.yaml")
+	remainingFiles := excludeHelmTemplateFiles([]string{
+		filepath.Join(ownedChart, "templates", "configmap.yaml"),
+		filepath.Join(ownedSubchart, "templates", "configmap.yaml"),
+		standaloneTemplate,
+	}, ownedDirectories)
+	require.Equal(t, []string{standaloneTemplate}, remainingFiles)
+
+	workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+		context.Background(), root, HelmValueOptions{}, ownedDirectories,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{standaloneChart}, renderedDirectories)
+	require.Len(t, workloads, 1)
+	require.Len(t, charts, 1)
+	for source, sourceWorkloads := range workloads {
+		require.Len(t, sourceWorkloads, 1)
+		assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
+		assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
+		assert.Equal(t, standaloneChart, charts[source].Path)
+	}
+}
+
 func TestLoadFiles(t *testing.T) {
 	files, _ := listFiles(onlineBoutiquePath())
 	_, errs := loadFiles("", files)

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -224,6 +224,14 @@ func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	}
 }
 
+func writeHelmChartFixture(t *testing.T, directory, name string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+	writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
+	writeManifestFixture(t, directory, "values.yaml", "{}\n")
+	writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
+}
+
 func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testing.T) {
 	root := t.TempDir()
 	chartHome := filepath.Join(root, "charts")
@@ -232,16 +240,9 @@ func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testin
 	ownedSubchart := filepath.Join(ownedChart, "charts", "dependency")
 	standaloneChart := filepath.Join(chartHome, "standalone")
 
-	writeChart := func(directory, name string) {
-		t.Helper()
-		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
-		writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
-		writeManifestFixture(t, directory, "values.yaml", "{}\n")
-		writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
-	}
-	writeChart(ownedChart, "app")
-	writeChart(ownedSubchart, "dependency")
-	writeChart(standaloneChart, "standalone")
+	writeHelmChartFixture(t, ownedChart, "app")
+	writeHelmChartFixture(t, ownedSubchart, "dependency")
+	writeHelmChartFixture(t, standaloneChart, "standalone")
 	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -254,7 +255,7 @@ helmCharts:
     releaseName: app
 `)
 
-	ownedDirectories, err := KustomizeHelmChartDirectories(root)
+	ownedDirectories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	require.Equal(t, []string{ownedChart, ownedSubchart}, ownedDirectories)
 
@@ -266,19 +267,86 @@ helmCharts:
 	}, ownedDirectories)
 	require.Equal(t, []string{standaloneTemplate}, remainingFiles)
 
-	workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
-		context.Background(), root, HelmValueOptions{}, ownedDirectories,
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	relativeRoot, err := filepath.Rel(cwd, root)
+	require.NoError(t, err)
+	for _, tt := range []struct {
+		name     string
+		scanPath string
+	}{
+		{name: "absolute scan path", scanPath: root},
+		{name: "relative scan path", scanPath: relativeRoot},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+				context.Background(), tt.scanPath, HelmValueOptions{}, ownedDirectories,
+			)
+			require.NoError(t, err)
+			require.Equal(t, []string{standaloneChart}, renderedDirectories)
+			require.Len(t, workloads, 1)
+			require.Len(t, charts, 1)
+			for source, sourceWorkloads := range workloads {
+				require.Len(t, sourceWorkloads, 1)
+				assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
+				assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
+				assert.Equal(t, standaloneChart, charts[source].Path)
+			}
+		})
+	}
+}
+
+func TestLoadResourcesFromHelmChartsExcludingDirectories_CanonicalizesSymlinkedScanPath(t *testing.T) {
+	realParent := t.TempDir()
+	root := filepath.Join(realParent, "project")
+	ownedChart := filepath.Join(root, "charts", "app")
+	standaloneChart := filepath.Join(root, "charts", "standalone")
+	writeHelmChartFixture(t, ownedChart, "app")
+	writeHelmChartFixture(t, standaloneChart, "standalone")
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: app
+    releaseName: app
+`)
+
+	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	linkedRoot := filepath.Join(linkedParent, "project")
+	ownedDirectories, err := KustomizeHelmChartDirectories(context.Background(), linkedRoot)
+	require.NoError(t, err)
+	require.Equal(t, []string{ownedChart}, ownedDirectories)
+
+	workloads, _, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+		context.Background(), linkedRoot, HelmValueOptions{}, ownedDirectories,
 	)
 	require.NoError(t, err)
-	require.Equal(t, []string{standaloneChart}, renderedDirectories)
+	require.Equal(t, []string{filepath.Join(linkedRoot, "charts", "standalone")}, renderedDirectories)
 	require.Len(t, workloads, 1)
-	require.Len(t, charts, 1)
-	for source, sourceWorkloads := range workloads {
+	for _, sourceWorkloads := range workloads {
 		require.Len(t, sourceWorkloads, 1)
-		assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
 		assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
-		assert.Equal(t, standaloneChart, charts[source].Path)
 	}
+}
+
+func TestExcludeHelmTemplateFiles_PreservesLexicalOwnershipOfSymlinkedTemplate(t *testing.T) {
+	root := t.TempDir()
+	templateDir := filepath.Join(root, "chart", "templates")
+	require.NoError(t, os.MkdirAll(templateDir, 0o750))
+
+	externalTemplate := filepath.Join(t.TempDir(), "configmap.yaml")
+	require.NoError(t, os.WriteFile(externalTemplate, []byte("apiVersion: v1\nkind: ConfigMap\n"), 0o600))
+	linkedTemplate := filepath.Join(templateDir, "configmap.yaml")
+	if err := os.Symlink(externalTemplate, linkedTemplate); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	assert.Empty(t, excludeHelmTemplateFiles(
+		[]string{linkedTemplate},
+		[]string{filepath.Dir(templateDir)},
+	), "Helm renders a template symlink by its lexical path below templates")
 }
 
 func TestLoadFiles(t *testing.T) {

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -1,6 +1,8 @@
 package cautils
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -68,6 +70,159 @@ func getKustomizeDirectoryName(path string) string {
 	}
 
 	return path
+}
+
+// KustomizeHelmChartDirectories returns the local chart directories owned by the
+// Kustomize configuration selected by path. Returning only explicitly referenced
+// charts keeps unrelated charts under the same tree available to the generic Helm
+// loader. Nested chart directories are owned by the referenced parent chart too.
+func KustomizeHelmChartDirectories(path string) ([]string, error) {
+	kustomizationPath := selectedKustomizationFile(path)
+	if kustomizationPath == "" {
+		return nil, nil
+	}
+	var chartDirectories []string
+	seenKustomizations := map[string]struct{}{}
+	seenChartDirectories := map[string]struct{}{}
+	if err := collectKustomizeHelmChartDirectories(
+		kustomizationPath,
+		seenKustomizations,
+		seenChartDirectories,
+		&chartDirectories,
+	); err != nil {
+		return nil, err
+	}
+	return chartDirectories, nil
+}
+
+func collectKustomizeHelmChartDirectories(
+	kustomizationPath string,
+	seenKustomizations map[string]struct{},
+	seenChartDirectories map[string]struct{},
+	chartDirectories *[]string,
+) error {
+	absKustomizationPath, err := filepath.Abs(kustomizationPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Kustomization path %q: %w", kustomizationPath, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absKustomizationPath); err == nil {
+		absKustomizationPath = resolved
+	}
+	if _, ok := seenKustomizations[absKustomizationPath]; ok {
+		return nil
+	}
+	seenKustomizations[absKustomizationPath] = struct{}{}
+
+	contents, err := os.ReadFile(absKustomizationPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Kustomization %q: %w", absKustomizationPath, err)
+	}
+	var kustomization types.Kustomization
+	if err := kustomization.Unmarshal(contents); err != nil {
+		return fmt.Errorf("failed to parse Kustomization %q: %w", absKustomizationPath, err)
+	}
+	kustomization.FixKustomization()
+
+	chartHome := types.HelmDefaultHome
+	if kustomization.HelmGlobals != nil && kustomization.HelmGlobals.ChartHome != "" {
+		chartHome = kustomization.HelmGlobals.ChartHome
+	}
+	if !filepath.IsAbs(chartHome) {
+		chartHome = filepath.Join(filepath.Dir(absKustomizationPath), chartHome)
+	}
+
+	for _, chart := range kustomization.HelmCharts {
+		if chart.Name == "" {
+			continue
+		}
+		chartRoot := chartHome
+		// Kustomize isolates a versioned chart fetched from a repository below
+		// <name>-<version> before untarring it. Mirror absChartHome in the Helm
+		// inflator so a chart left there from an earlier build has the same owner.
+		if chart.Repo != "" && chart.Version != "" {
+			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
+		}
+		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
+		if err := appendOwnedHelmChartTree(directory, seenChartDirectories, chartDirectories); err != nil {
+			return err
+		}
+	}
+
+	// A selected Kustomize build can compose local bases and components that carry
+	// their own helmCharts. Follow only those explicit local graph edges; do not
+	// discover unrelated Kustomizations elsewhere below the scan root.
+	references := make([]string, 0, len(kustomization.Resources)+len(kustomization.Components))
+	references = append(references, kustomization.Resources...)
+	references = append(references, kustomization.Components...)
+	for _, reference := range references {
+		candidate := reference
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(filepath.Dir(absKustomizationPath), candidate)
+		}
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		childKustomization := selectedKustomizationFile(candidate)
+		if childKustomization == "" {
+			continue
+		}
+		if err := collectKustomizeHelmChartDirectories(
+			childKustomization,
+			seenKustomizations,
+			seenChartDirectories,
+			chartDirectories,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, directories *[]string) error {
+	if _, ok := seen[directory]; !ok {
+		seen[directory] = struct{}{}
+		*directories = append(*directories, directory)
+	}
+
+	info, err := os.Stat(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	nestedDirectories, discoveryErrs := listHelmChartDirs(directory)
+	if len(discoveryErrs) > 0 {
+		return fmt.Errorf("failed to discover Kustomize-owned Helm chart dependencies below %q: %w", directory, errors.Join(discoveryErrs...))
+	}
+	for _, nestedDirectory := range nestedDirectories {
+		if _, ok := seen[nestedDirectory]; ok {
+			continue
+		}
+		seen[nestedDirectory] = struct{}{}
+		*directories = append(*directories, nestedDirectory)
+	}
+	return nil
+}
+
+func selectedKustomizationFile(path string) string {
+	if IsKustomizeFile(path) {
+		return path
+	}
+	if !isKustomizeDirectory(path) {
+		return ""
+	}
+	for _, matcher := range kustomizationFileMatchers {
+		candidate := filepath.Join(path, matcher)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // Get Workloads, creates the yaml files(K8s resources) using Kustomize and

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -1,12 +1,14 @@
 package cautils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -76,7 +78,7 @@ func getKustomizeDirectoryName(path string) string {
 // Kustomize configuration selected by path. Returning only explicitly referenced
 // charts keeps unrelated charts under the same tree available to the generic Helm
 // loader. Nested chart directories are owned by the referenced parent chart too.
-func KustomizeHelmChartDirectories(path string) ([]string, error) {
+func KustomizeHelmChartDirectories(ctx context.Context, path string) ([]string, error) {
 	kustomizationPath := selectedKustomizationFile(path)
 	if kustomizationPath == "" {
 		return nil, nil
@@ -85,6 +87,7 @@ func KustomizeHelmChartDirectories(path string) ([]string, error) {
 	seenKustomizations := map[string]struct{}{}
 	seenChartDirectories := map[string]struct{}{}
 	if err := collectKustomizeHelmChartDirectories(
+		ctx,
 		kustomizationPath,
 		seenKustomizations,
 		seenChartDirectories,
@@ -96,17 +99,15 @@ func KustomizeHelmChartDirectories(path string) ([]string, error) {
 }
 
 func collectKustomizeHelmChartDirectories(
+	ctx context.Context,
 	kustomizationPath string,
 	seenKustomizations map[string]struct{},
 	seenChartDirectories map[string]struct{},
 	chartDirectories *[]string,
 ) error {
-	absKustomizationPath, err := filepath.Abs(kustomizationPath)
+	absKustomizationPath, err := canonicalPath(kustomizationPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve Kustomization path %q: %w", kustomizationPath, err)
-	}
-	if resolved, err := filepath.EvalSymlinks(absKustomizationPath); err == nil {
-		absKustomizationPath = resolved
 	}
 	if _, ok := seenKustomizations[absKustomizationPath]; ok {
 		return nil
@@ -143,9 +144,7 @@ func collectKustomizeHelmChartDirectories(
 			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
 		}
 		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
-		if err := appendOwnedHelmChartTree(directory, seenChartDirectories, chartDirectories); err != nil {
-			return err
-		}
+		appendOwnedHelmChartTree(ctx, directory, seenChartDirectories, chartDirectories)
 	}
 
 	// A selected Kustomize build can compose local bases and components that carry
@@ -167,6 +166,7 @@ func collectKustomizeHelmChartDirectories(
 			continue
 		}
 		if err := collectKustomizeHelmChartDirectories(
+			ctx,
 			childKustomization,
 			seenKustomizations,
 			seenChartDirectories,
@@ -178,7 +178,19 @@ func collectKustomizeHelmChartDirectories(
 	return nil
 }
 
-func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, directories *[]string) error {
+type helmChartDirectoryLister func(string) ([]string, []error)
+
+func appendOwnedHelmChartTree(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string) {
+	appendOwnedHelmChartTreeWithLister(ctx, directory, seen, directories, listHelmChartDirs)
+}
+
+func appendOwnedHelmChartTreeWithLister(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string, discover helmChartDirectoryLister) {
+	normalizedDirectory, err := canonicalPath(directory)
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
+		normalizedDirectory = filepath.Clean(directory)
+	}
+	directory = normalizedDirectory
 	if _, ok := seen[directory]; !ok {
 		seen[directory] = struct{}{}
 		*directories = append(*directories, directory)
@@ -186,27 +198,30 @@ func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, direct
 
 	info, err := os.Stat(directory)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return
 	}
 	if err != nil {
-		return fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err)
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(
+			fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err),
+		))
+		return
 	}
 	if !info.IsDir() {
-		return nil
+		return
 	}
 
-	nestedDirectories, discoveryErrs := listHelmChartDirs(directory)
-	if len(discoveryErrs) > 0 {
-		return fmt.Errorf("failed to discover Kustomize-owned Helm chart dependencies below %q: %w", directory, errors.Join(discoveryErrs...))
+	nestedDirectories, discoveryErrs := discover(directory)
+	for _, discoveryErr := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(discoveryErr))
 	}
 	for _, nestedDirectory := range nestedDirectories {
+		nestedDirectory = normalizePath(nestedDirectory)
 		if _, ok := seen[nestedDirectory]; ok {
 			continue
 		}
 		seen[nestedDirectory] = struct{}{}
 		*directories = append(*directories, nestedDirectory)
 	}
-	return nil
 }
 
 func selectedKustomizationFile(path string) string {

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -1,6 +1,8 @@
 package cautils
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +87,7 @@ helmCharts:
     releaseName: second
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.Equal(t, []string{filepath.Join(root, "vendor", "charts", "app")}, directories)
 }
@@ -103,7 +105,7 @@ helmCharts:
     releaseName: app
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		filepath.Join(root, "vendor", "charts", "app-1.2.3", "app"),
@@ -112,27 +114,27 @@ helmCharts:
 
 func TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout(t *testing.T) {
 	tests := []struct {
-		name          string
-		chartHome     func(string) string
-		chartFields   string
-		expectedParts []string
+		name        string
+		chartHome   func(string) string
+		chartFields string
+		expected    func(string) string
 	}{
 		{
-			name:          "absolute chart home",
-			chartHome:     func(root string) string { return filepath.Join(root, "absolute-charts") },
-			expectedParts: []string{"absolute-charts", "app"},
+			name:      "absolute chart home",
+			chartHome: func(root string) string { return filepath.Join(root, "absolute-charts") },
+			expected:  func(root string) string { return filepath.Join(root, "absolute-charts", "app") },
 		},
 		{
-			name:          "repository without version uses regular chart home",
-			chartHome:     func(string) string { return "charts" },
-			chartFields:   "    repo: https://charts.example.com\n",
-			expectedParts: []string{"charts", "app"},
+			name:        "repository without version uses regular chart home",
+			chartHome:   func(string) string { return "charts" },
+			chartFields: "    repo: https://charts.example.com\n",
+			expected:    func(root string) string { return filepath.Join(root, "charts", "app") },
 		},
 		{
-			name:          "version without repository uses regular chart home",
-			chartHome:     func(string) string { return "charts" },
-			chartFields:   "    version: 1.2.3\n",
-			expectedParts: []string{"charts", "app"},
+			name:        "version without repository uses regular chart home",
+			chartHome:   func(string) string { return "charts" },
+			chartFields: "    version: 1.2.3\n",
+			expected:    func(root string) string { return filepath.Join(root, "charts", "app") },
 		},
 	}
 
@@ -149,15 +151,31 @@ helmCharts:
 %s    releaseName: app
 `, chartHome, tt.chartFields))
 
-			directories, err := KustomizeHelmChartDirectories(root)
+			directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 			require.NoError(t, err)
-			expected := filepath.Join(append([]string{root}, tt.expectedParts...)...)
-			if filepath.IsAbs(chartHome) {
-				expected = filepath.Join(chartHome, "app")
-			}
-			assert.Equal(t, []string{expected}, directories)
+			assert.Equal(t, []string{tt.expected(root)}, directories)
 		})
 	}
+}
+
+func TestAppendOwnedHelmChartTree_PreservesPartialDiscovery(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "charts", "dependency")
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+
+	seen := map[string]struct{}{}
+	var directories []string
+	appendOwnedHelmChartTreeWithLister(
+		context.Background(),
+		root,
+		seen,
+		&directories,
+		func(string) ([]string, []error) {
+			return []string{nested}, []error{errors.New("synthetic partial walk failure")}
+		},
+	)
+
+	assert.Equal(t, []string{root, nested}, directories)
 }
 
 func TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph(t *testing.T) {
@@ -189,7 +207,7 @@ helmCharts:
     releaseName: component-app
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		filepath.Join(base, "charts", "base-app"),

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -1,12 +1,14 @@
 package cautils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetKustomizeDirectoryName(t *testing.T) {
@@ -68,6 +70,131 @@ func TestGetKustomizeDirectoryName(t *testing.T) {
 func kustomizeTestdataPath() string {
 	o, _ := os.Getwd()
 	return filepath.Join(o, "testdata", "kustomize")
+}
+
+func TestKustomizeHelmChartDirectories_CustomHomeDeduplicatesPhysicalChart(t *testing.T) {
+	root := t.TempDir()
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    releaseName: first
+  - name: app
+    releaseName: second
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(root, "vendor", "charts", "app")}, directories)
+}
+
+func TestKustomizeHelmChartDirectories_VersionedRepositoryChart(t *testing.T) {
+	root := t.TempDir()
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    version: 1.2.3
+    repo: https://charts.example.com
+    releaseName: app
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join(root, "vendor", "charts", "app-1.2.3", "app"),
+	}, directories)
+}
+
+func TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout(t *testing.T) {
+	tests := []struct {
+		name          string
+		chartHome     func(string) string
+		chartFields   string
+		expectedParts []string
+	}{
+		{
+			name:          "absolute chart home",
+			chartHome:     func(root string) string { return filepath.Join(root, "absolute-charts") },
+			expectedParts: []string{"absolute-charts", "app"},
+		},
+		{
+			name:          "repository without version uses regular chart home",
+			chartHome:     func(string) string { return "charts" },
+			chartFields:   "    repo: https://charts.example.com\n",
+			expectedParts: []string{"charts", "app"},
+		},
+		{
+			name:          "version without repository uses regular chart home",
+			chartHome:     func(string) string { return "charts" },
+			chartFields:   "    version: 1.2.3\n",
+			expectedParts: []string{"charts", "app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			chartHome := tt.chartHome(root)
+			writeManifestFixture(t, root, "kustomization.yaml", fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: %q
+helmCharts:
+  - name: app
+%s    releaseName: app
+`, chartHome, tt.chartFields))
+
+			directories, err := KustomizeHelmChartDirectories(root)
+			require.NoError(t, err)
+			expected := filepath.Join(append([]string{root}, tt.expectedParts...)...)
+			if filepath.IsAbs(chartHome) {
+				expected = filepath.Join(chartHome, "app")
+			}
+			assert.Equal(t, []string{expected}, directories)
+		})
+	}
+}
+
+func TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	component := filepath.Join(root, "component")
+	require.NoError(t, os.MkdirAll(base, 0o750))
+	require.NoError(t, os.MkdirAll(component, 0o750))
+
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+components:
+  - component
+`)
+	writeManifestFixture(t, base, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: base-app
+    releaseName: base-app
+`)
+	writeManifestFixture(t, component, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: component-app
+    releaseName: component-app
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		filepath.Join(base, "charts", "base-app"),
+		filepath.Join(component, "vendor", "charts", "component-app"),
+	}, directories)
 }
 
 // TestKustomizeOverlayWithBase tests that kustomize overlays can properly load

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -279,7 +279,7 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
 	// the generic recursive Helm loader as well would add a standalone release beside the transformed
 	// Kustomize output.
-	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(path)
+	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,6 +288,13 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
 	// its templates must stay plainly scanned rather than vanish from the scan.
 	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Confirm that the owning Kustomize render succeeds before excluding its chart
+	// templates from the plain-manifest fallback.
+	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,13 +399,6 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 
 	if len(helmSourceToWorkloads) > 0 { // && len(helmSourceToNodes) > 0
 		logger.L().Debug("helm templates found in local storage", helpers.Int("helmTemplates", len(helmSourceToWorkloads)), helpers.Int("workloads", len(workloads)))
-	}
-
-	//patch, get value from env
-	// Load resources from Kustomize directory
-	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
-	if err != nil {
-		return nil, nil, err
 	}
 
 	// update workloads and workloadIDToSource with workloads from Kustomize Directory

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -276,16 +276,27 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		repoRoot = filepath.Dir(repoRoot)
 	}
 
+	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
+	// the generic recursive Helm loader as well would add a standalone release beside the transformed
+	// Kustomize output.
+	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// render helm charts first, so the plain-YAML loader knows which charts' templates the render
 	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
 	// its templates must stay plainly scanned rather than vanish from the scan.
-	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmCharts(ctx, path, helmValueOpts)
+	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// load resource from local file system
-	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, renderedCharts)
+	// Kustomize-owned charts are excluded here too: their templates are covered by the Kustomize
+	// render even though the generic Helm renderer deliberately left them alone.
+	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeHelmChartDirectories...)
+	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -251,6 +251,65 @@ func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) 
 	assert.Equal(t, "prod-test-app", deployment.GetName())
 }
 
+func TestGetResourcesFromPath_KustomizeOwnsReferencedHelmChart(t *testing.T) {
+	root := t.TempDir()
+	chartDir := filepath.Join(root, "vendor", "charts", "app")
+	templateDir := filepath.Join(chartDir, "templates")
+	require.NoError(t, os.MkdirAll(templateDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    releaseName: first
+  - name: app
+    releaseName: second
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: app\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "configmap.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
+	if err != nil && kustomizeHelmUnavailable(err) {
+		t.Skipf("Kustomize Helm integration is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var configMaps int
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "ConfigMap" {
+			configMaps++
+			assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, sources[workload.GetID()].FileType)
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/prod-first"], "the first Kustomize inflation must survive")
+	assert.Equal(t, 1, counts["ConfigMap/prod-second"], "the second Kustomize inflation must survive")
+	assert.Equal(t, 2, configMaps, "the chart must not also be rendered as a standalone Helm release")
+}
+
+func kustomizeHelmUnavailable(err error) bool {
+	message := err.Error()
+	for _, fragment := range []string{
+		`exec: "helm": executable file not found`,
+		"unknown shorthand flag",
+		"unknown flag",
+		"unable to run: 'helm version -c --short'",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("replicas: 3\n"), 0o600))

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -252,6 +252,8 @@ func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) 
 }
 
 func TestGetResourcesFromPath_KustomizeOwnsReferencedHelmChart(t *testing.T) {
+	installFakeHelm(t)
+
 	root := t.TempDir()
 	chartDir := filepath.Join(root, "vendor", "charts", "app")
 	templateDir := filepath.Join(chartDir, "templates")
@@ -276,9 +278,6 @@ metadata:
 `), 0o600))
 
 	sources, workloads, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
-	if err != nil && kustomizeHelmUnavailable(err) {
-		t.Skipf("Kustomize Helm integration is unavailable: %v", err)
-	}
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -295,19 +294,39 @@ metadata:
 	assert.Equal(t, 2, configMaps, "the chart must not also be rendered as a standalone Helm release")
 }
 
-func kustomizeHelmUnavailable(err error) bool {
-	message := err.Error()
-	for _, fragment := range []string{
-		`exec: "helm": executable file not found`,
-		"unknown shorthand flag",
-		"unknown flag",
-		"unable to run: 'helm version -c --short'",
-	} {
-		if strings.Contains(message, fragment) {
-			return true
-		}
+func installFakeHelm(t *testing.T) {
+	t.Helper()
+	if os.PathSeparator == '\\' {
+		t.Skip("the deterministic Helm test double requires a POSIX shell")
 	}
-	return false
+
+	binDir := t.TempDir()
+	helmPath := filepath.Join(binDir, "helm")
+	//nolint:gosec // The test-owned Helm double must be executable by Kustomize.
+	require.NoError(t, os.WriteFile(helmPath, []byte(`#!/bin/sh
+set -eu
+die() {
+    printf '%s\n' "$*" >&2
+    exit 2
+}
+case "${1:-}" in
+version)
+    [ "$#" -eq 3 ] && [ "$2" = "-c" ] && [ "$3" = "--short" ] || die "unexpected version args: $*"
+    printf '%s\n' 'v3.14.0+gtest'
+    ;;
+template)
+	[ "$#" -ge 3 ] || die "missing template args"
+	release_name=$2
+	chart_path=$3
+	[ -f "$chart_path/Chart.yaml" ] && [ -f "$chart_path/templates/configmap.yaml" ] || die "unexpected chart: $chart_path"
+	printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: %s\n' "$release_name"
+    ;;
+*)
+	die "unsupported helm command: ${1:-}"
+    ;;
+esac
+`), 0o750))
+	t.Setenv("PATH", binDir)
 }
 
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {


### PR DESCRIPTION
Resolves #2853

## Summary

- resolve the physical chart directories explicitly referenced by the selected Kustomization and its local resource/component graph;
- leave those charts and their nested subcharts out of the generic recursive Helm renderer;
- keep their raw templates out of the plain-manifest pass because the Kustomize render owns them;
- preserve generic Helm rendering for unrelated sibling charts.

## Root cause

The local path loader independently ran a recursive Helm render and a Kustomize build. A local chart referenced through `helmCharts` was therefore rendered once as a standalone Helm release and once inside Kustomize.

The existing final deduplication cannot repair this reliably. Kustomize transformations can change the resource identity, and same-rank rendered-provider duplicates are retained intentionally.

## Implementation

`KustomizeHelmChartDirectories` parses the selected Kustomization with `types.Kustomization.Unmarshal`, applies `FixKustomization` for deprecated fields, and follows only explicit, existing local `resources` and `components`. A cycle-safe visited set keeps this traversal bounded to the selected build graph; it does not search the repository for other Kustomizations.

For each configuration it resolves the default or configured chart home and the physical roots explicitly named by `helmCharts`. Existing chart roots are expanded through their nested `Chart.yaml` directories so both generic Helm discovery and the raw-template exclusion account for subcharts.

For charts that specify both `repo` and `version`, it mirrors Kustomize's own downloaded-chart layout, `<chartHome>/<name>-<version>/<name>`, so a previously pulled chart is assigned to the same renderer that consumes it.

`LoadResourcesFromHelmChartsExcludingDirectories` filters those roots before constructing or rendering generic Helm charts. Directory containment compares absolute canonical paths for existing directories, while retaining an absolute lexical fallback for remote charts that have not been pulled yet. Template-file exclusion accepts either lexical or canonical containment so a symlinked template whose target is outside the chart is still owned by Helm/Kustomize.

Nested chart discovery remains best effort: successfully discovered chart roots are retained, while per-path `stat` and walk failures are logged with the same warning contract as generic Helm discovery instead of aborting the whole scan.

The plain-file loader receives both successfully generic-rendered chart roots and Kustomize-owned chart roots.

## Tests

Provider-level coverage creates a selected root that references a local base:

```text
root/
├── kustomization.yaml       # resources: [base]
├── base/
│   ├── kustomization.yaml   # helmCharts: [app]
│   └── charts/app/
│       └── charts/dependency/
└── charts/standalone/       # not referenced
```

It asserts that only `standalone` reaches the generic Helm result and that both the referenced parent and nested chart templates are excluded from the raw-manifest pass.

Parser-level cases cover a custom and absolute chart home, an explicit local resource/component graph, repository-only and version-only path semantics, two release entries that reference the same physical chart, and Kustomize's versioned repository-chart storage path.

The end-to-end file-loader regression installs a strict test-local Helm executable, inflates one physical chart twice (`releaseName: first` and `second`) under `namePrefix: prod-`, and asserts:

- `ConfigMap/prod-first` and `ConfigMap/prod-second` each occur exactly once;
- there is no third standalone ConfigMap;
- both surviving objects have Kustomize source attribution.

Additional regressions cover a symlinked scan root, a symlinked template leaf, cwd-relative scan input, and partial nested-chart discovery errors.

## Verification

A clean `10e16a2a` baseline with the issue reproducer failed deterministically on all three runs because `ConfigMap/app` remained. The same deterministic Helm contract was used for the fixed tests.

```bash
go test ./core/cautils \
  -run '^(TestKustomizeHelmChartDirectories.*|TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories)$' \
  -count=3
go test ./core/pkg/resourcehandler \
  -run '^TestGetResourcesFromPath_KustomizeOwnsReferencedHelmChart$' \
  -count=3
go test ./core/cautils ./core/pkg/resourcehandler
go vet ./core/cautils ./core/pkg/resourcehandler
```

All four fixed commands passed. Removing the ownership lookup made the integration test fail with three ConfigMaps instead of two and attributed the extra object to the Helm provider; disabling canonical path comparison made the symlink regression fail. Restoring both changes returned the focused suite to green.

Both a full affected-package race run and a targeted ownership race run were capped after 300 seconds of compilation in this constrained environment. Neither produced a race diagnostic before timeout; remote race CI remains required. The integration test no longer has an availability-based skip path: its test-local Helm double accepts only the exact commands used by this fixture and fails on command drift.

## Scope

This assigns ownership only for charts explicitly listed by the Kustomization selected directly by the scan input and configurations reached through that build's local `resources`/`components`. It does not discover unrelated nested Kustomizations, suppress the whole chart home, reinterpret unrelated charts, or change Helm-versus-plain behavior from #2509.

When composed with recursive nested-Kustomize discovery, discovery must run first and the union of referenced chart roots from every configuration being rendered must be supplied to the Helm exclusion. This PR keeps that boundary explicit rather than independently choosing which nested Kustomizations represent target environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Helm charts referenced by Kustomize.
  * Prevented Kustomize-managed charts from being rendered or loaded again as standalone Helm releases.
  * Preserved multiple Kustomize inflations of the same Helm chart with correct source attribution.
  * Added support for excluding specified chart directories during Helm resource loading.
  * Improved chart discovery across symlinked, nested, and versioned paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->