### PR TITLE
docs: mention MegaLinter in the CI/CD integrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ helm upgrade --install kubescape kubescape/kubescape-operator \
 | **GitHub Actions** | [kubescape/github-action](https://github.com/marketplace/actions/kubescape) |
 | **GitLab CI** | [Documentation](https://kubescape.io/docs/integrations/gitlab/) |
 | **Jenkins** | [Documentation](https://kubescape.io/docs/integrations/jenkins/) |
+| **MegaLinter** | [Documentation](https://megalinter.io/latest/descriptors/kubernetes_kubescape/) — open-source linters aggregator that runs Kubescape out of the box |
 
 ### IDE Extensions
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ helm upgrade --install kubescape kubescape/kubescape-operator \
 | **GitHub Actions** | [kubescape/github-action](https://github.com/marketplace/actions/kubescape) |
 | **GitLab CI** | [Documentation](https://kubescape.io/docs/integrations/gitlab/) |
 | **Jenkins** | [Documentation](https://kubescape.io/docs/integrations/jenkins/) |
-| **MegaLinter** | [Documentation](https://megalinter.io/latest/descriptors/kubernetes_kubescape/) — open-source linters aggregator that runs Kubescape out of the box |
+| **MegaLinter** | [Documentation](https://megalinter.io/latest/descriptors/kubernetes_kubescape/) — open-source linters aggregator that embeds Kubescape and runs it when Kubernetes files are detected |
 
 ### IDE Extensions
 


### PR DESCRIPTION
## Overview

Small docs addition: adds a row for [MegaLinter](https://megalinter.io/) in the README's CI/CD integrations table.

MegaLinter is an open-source linters aggregator for CI that ships Kubescape out of the box (docs: https://megalinter.io/latest/descriptors/kubernetes_kubescape/), so Kubescape users can get it running in their pipelines with zero install. Figured it was worth a line next to the other CI integrations.

No code changes, README only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added MegaLinter to the CI/CD integrations documentation.
  * Included a link to its documentation and noted that it embeds Kubescape and runs it when Kubernetes files are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->