### PR TITLE
fix(resourcehandler): render nested Kustomize configurations

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -388,42 +388,117 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 	return sourceToWorkloads, kustomizeDirectoryName, nil
 }
 
-// LoadResourcesFromNestedKustomizeDirectories discovers and renders Kustomize configurations
-// found below basePath, for the case where basePath itself is a broader directory (e.g. a
-// repository root) rather than a Kustomize directory or file — that direct-input case is already
-// handled by LoadResourcesFromKustomizeDirectory. Every discovered directory carries its own
-// Kustomization file, so each is rendered independently; a directory whose render fails is
-// skipped with a warning rather than aborting the scan, leaving its files to the plain-manifest
-// loader as a fallback. Directory discovery errors (e.g. an unreadable subdirectory hit during the
-// tree walk) are likewise logged as warnings rather than aborting the scan, matching
-// loadResourcesFromHelmCharts: a permission error on one subtree should not cost the whole scan
-// the Kustomize directories that were discovered successfully. The returned directories are
-// exactly those that rendered successfully, for the caller to exclude from the plain-manifest pass.
-func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, []string) {
-	if isKustomizeDirectory(basePath) || IsKustomizeFile(basePath) {
-		// The direct-input case is handled by LoadResourcesFromKustomizeDirectory.
+// KustomizeRenderResult records the successful Kustomize renders and the input
+// paths they own. Ownership is claimed only after a build succeeds, so a broken
+// nested configuration remains available to the plain-manifest fallback.
+type KustomizeRenderResult struct {
+	SourceToWorkloads         map[string][]workloadinterface.IMetadata
+	OwnedSourcePaths          []string
+	OwnedHelmChartDirectories []string
+	OwnedHelmCRDDirectories   []string
+	ownedSourcePathAliases    []string
+	ownedHelmChartAliases     []string
+	ownedHelmCRDAliases       []string
+}
+
+// OwnsPlainFile reports whether a successfully rendered Kustomize input already
+// covers path. Chart trees are handled specially: templates are removed by the
+// Helm-template exclusion, while raw CRDs are removed here only when the owning
+// helmCharts entry requested includeCRDs.
+func (result KustomizeRenderResult) OwnsPlainFile(path string) bool {
+	if IsAnyPathAliasUnderAnyDir(path, result.ownedHelmChartAliases) {
+		return IsAnyPathAliasUnderAnyDir(path, result.ownedHelmCRDAliases) ||
+			IsAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+	}
+	return IsAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+}
+
+// LoadResourcesFromKustomizeDirectories renders the Kustomize configuration at
+// basePath, or discovers and renders Kustomize configurations below basePath when
+// the input itself is not one. A broad scan treats invalid nested configurations
+// as best-effort misses; an explicitly selected Kustomize input remains a hard
+// error, preserving its existing behavior.
+func LoadResourcesFromKustomizeDirectories(ctx context.Context, basePath string) (KustomizeRenderResult, error) {
+	kustomizeInputs, discoveryErrs := listKustomizeInputs(basePath)
+	explicitKustomizeInput := IsKustomizeFile(basePath) || isKustomizeDirectory(basePath)
+	for _, err := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize configurations", helpers.Error(err))
+	}
+
+	result := KustomizeRenderResult{SourceToWorkloads: map[string][]workloadinterface.IMetadata{}}
+	seenOwnedSourcePaths := map[string]struct{}{}
+	seenOwnedCharts := map[string]struct{}{}
+	seenOwnedCRDs := map[string]struct{}{}
+	for _, input := range kustomizeInputs {
+		directory := input
+		if IsKustomizeFile(input) {
+			directory = filepath.Dir(input)
+		}
+
+		workloads, _, err := LoadResourcesFromKustomizeDirectory(ctx, input)
+		if err != nil {
+			if explicitKustomizeInput {
+				return KustomizeRenderResult{}, err
+			}
+			logger.L().Ctx(ctx).Warning("Skipping nested Kustomize configuration that failed to render", helpers.String("path", directory), helpers.Error(err))
+			continue
+		}
+
+		// Inspect ownership after the build so a remotely pulled chart and its
+		// nested chart tree are present before generic Helm discovery begins.
+		ownership, err := KustomizeInputOwnershipForPath(ctx, input)
+		if err != nil {
+			if explicitKustomizeInput {
+				return KustomizeRenderResult{}, err
+			}
+			logger.L().Ctx(ctx).Warning("Skipping nested Kustomize configuration with unresolved inputs", helpers.String("path", directory), helpers.Error(err))
+			continue
+		}
+
+		maps.Copy(result.SourceToWorkloads, workloads)
+		appendUniquePaths(&result.OwnedSourcePaths, seenOwnedSourcePaths, ownership.SourcePaths...)
+		appendUniquePaths(&result.OwnedHelmChartDirectories, seenOwnedCharts, ownership.HelmChartDirectories...)
+		appendUniquePaths(&result.OwnedHelmCRDDirectories, seenOwnedCRDs, ownership.HelmCRDDirectories...)
+	}
+	result.ownedSourcePathAliases = pathAliasesForPaths(result.OwnedSourcePaths)
+	result.ownedHelmChartAliases = pathAliasesForPaths(result.OwnedHelmChartDirectories)
+	result.ownedHelmCRDAliases = pathAliasesForPaths(result.OwnedHelmCRDDirectories)
+
+	return result, nil
+}
+
+func appendUniquePaths(destination *[]string, seen map[string]struct{}, paths ...string) {
+	for _, path := range paths {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		*destination = append(*destination, path)
+	}
+}
+
+// listKustomizeInputs preserves exact selection for a Kustomize file or
+// directory. For a broader input it discovers child configurations recursively,
+// matching repository-wide Helm and manifest discovery.
+func listKustomizeInputs(basePath string) ([]string, []error) {
+	if IsKustomizeFile(basePath) || isKustomizeDirectory(basePath) {
+		return []string{basePath}, nil
+	}
+	// A concrete non-Kustomize file is an exact scan target. listDirs interprets
+	// a file path as a parent-directory pattern, which could otherwise discover
+	// an unrelated Kustomize directory sharing the file's basename.
+	if isFile(basePath) {
 		return nil, nil
 	}
 
-	kustomizeDirs, discoveryErrs := listKustomizeDirs(basePath)
-	for _, err := range discoveryErrs {
-		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize directories", helpers.Error(err))
-	}
-
-	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
-	renderedDirs := make([]string, 0, len(kustomizeDirs))
-	for _, dir := range kustomizeDirs {
-		wls, _, err := LoadResourcesFromKustomizeDirectory(ctx, dir)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("Skipping Kustomize directory that failed to render; its files remain available to the plain-manifest loader",
-				helpers.String("path", dir), helpers.Error(err))
-			continue
+	directories, errs := listDirs(basePath)
+	kustomizeDirectories := make([]string, 0)
+	for _, directory := range directories {
+		if isKustomizeDirectory(directory) {
+			kustomizeDirectories = append(kustomizeDirectories, directory)
 		}
-		maps.Copy(sourceToWorkloads, wls)
-		renderedDirs = append(renderedDirs, dir)
 	}
-
-	return sourceToWorkloads, renderedDirs
+	return kustomizeDirectories, errs
 }
 
 func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, error) {

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -68,9 +68,10 @@ func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
 	}
 	if len(excludedChartDirectories) > 0 {
+		normalizedExcludedDirectories := normalizePaths(excludedChartDirectories)
 		remaining := make([]string, 0, len(helmDirectories))
 		for _, directory := range helmDirectories {
-			if !isUnderAnyDir(directory, excludedChartDirectories) {
+			if !isUnderAnyNormalizedDir(normalizePath(directory), normalizedExcludedDirectories) {
 				remaining = append(remaining, directory)
 			}
 		}
@@ -167,19 +168,24 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	for _, helmDir := range renderedCharts {
 		templateDirs = append(templateDirs, filepath.Join(helmDir, "templates"))
 	}
+	templateDirs = pathAliasesForPaths(templateDirs)
 
 	remaining := make([]string, 0, len(files))
 	for _, file := range files {
-		if !isUnderAnyDir(file, templateDirs) {
+		if !isAnyPathAliasUnderAnyDir(file, templateDirs) {
 			remaining = append(remaining, file)
 		}
 	}
 	return remaining
 }
 
-// isUnderAnyDir reports whether path is inside one of dirs. Both are expected to be absolute,
-// as returned by listFiles and listDirs.
+// isUnderAnyDir reports whether path is inside one of dirs after normalizing
+// relative paths and resolving symlinks where the path already exists.
 func isUnderAnyDir(path string, dirs []string) bool {
+	return isUnderAnyNormalizedDir(normalizePath(path), normalizePaths(dirs))
+}
+
+func isUnderAnyNormalizedDir(path string, dirs []string) bool {
 	for _, dir := range dirs {
 		rel, err := filepath.Rel(dir, path)
 		if err != nil {
@@ -191,6 +197,75 @@ func isUnderAnyDir(path string, dirs []string) bool {
 		}
 	}
 	return false
+}
+
+func normalizePaths(paths []string) []string {
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		normalized = append(normalized, normalizePath(path))
+	}
+	return normalized
+}
+
+func pathAliasesForPaths(paths []string) []string {
+	aliases := make([]string, 0, len(paths)*2)
+	for _, path := range paths {
+		aliases = append(aliases, pathAliases(path)...)
+	}
+	return aliases
+}
+
+func isAnyPathAliasUnderAnyDir(path string, dirs []string) bool {
+	for _, alias := range pathAliases(path) {
+		if isUnderAnyNormalizedDir(alias, dirs) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathAliases returns both the absolute lexical path and, when different, its
+// physical path. Keeping both matters for a symlinked template file: Helm owns
+// it by its lexical location below templates/, even if the link target is outside
+// the chart. The physical form still matches scans reached through a symlinked
+// parent directory.
+func pathAliases(path string) []string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return []string{filepath.Clean(path)}
+	}
+	absPath = filepath.Clean(absPath)
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil || resolvedPath == absPath {
+		return []string{absPath}
+	}
+	return []string{absPath, resolvedPath}
+}
+
+func normalizePath(path string) string {
+	normalized, err := canonicalPath(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return normalized
+}
+
+func canonicalPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	// Missing paths are valid for remote charts that Kustomize has not pulled yet.
+	// The absolute lexical form is still sufficient because generic discovery cannot
+	// return a matching path until it exists.
+	if errors.Is(err, os.ErrNotExist) {
+		return filepath.Clean(absPath), nil
+	}
+	return "", err
 }
 
 // mergeMaps performs a deep merge of override into a copy of base, with override winning on conflicts.

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -312,6 +312,9 @@ func pathAliases(path string) []string {
 func normalizePath(path string) string {
 	normalized, err := canonicalPath(path)
 	if err != nil {
+		if absPath, absErr := filepath.Abs(path); absErr == nil {
+			return filepath.Clean(absPath)
+		}
 		return filepath.Clean(path)
 	}
 	return normalized
@@ -499,6 +502,35 @@ func listKustomizeInputs(basePath string) ([]string, []error) {
 		}
 	}
 	return kustomizeDirectories, errs
+}
+
+// LoadResourcesFromNestedKustomizeDirectories preserves the existing nested-rendering API.
+// New callers that also need precise source and Helm ownership should use
+// LoadResourcesFromKustomizeDirectories.
+func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, []string) {
+	if isKustomizeDirectory(basePath) || IsKustomizeFile(basePath) {
+		return nil, nil
+	}
+
+	kustomizeDirs, discoveryErrs := listKustomizeDirs(basePath)
+	for _, err := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize directories", helpers.Error(err))
+	}
+
+	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
+	renderedDirs := make([]string, 0, len(kustomizeDirs))
+	for _, dir := range kustomizeDirs {
+		wls, _, err := LoadResourcesFromKustomizeDirectory(ctx, dir)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("Skipping Kustomize directory that failed to render; its files remain available to the plain-manifest loader",
+				helpers.String("path", dir), helpers.Error(err))
+			continue
+		}
+		maps.Copy(sourceToWorkloads, wls)
+		renderedDirs = append(renderedDirs, dir)
+	}
+
+	return sourceToWorkloads, renderedDirs
 }
 
 func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, error) {

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -321,6 +321,122 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 	return sourceToWorkloads, kustomizeDirectoryName, nil
 }
 
+// KustomizeRenderResult records the successful Kustomize renders and the input
+// paths they own. Ownership is claimed only after a build succeeds, so a broken
+// nested configuration remains available to the plain-manifest fallback.
+type KustomizeRenderResult struct {
+	SourceToWorkloads         map[string][]workloadinterface.IMetadata
+	OwnedSourcePaths          []string
+	OwnedHelmChartDirectories []string
+	OwnedHelmCRDDirectories   []string
+	ownedSourcePathAliases    []string
+	ownedHelmChartAliases     []string
+	ownedHelmCRDAliases       []string
+}
+
+// OwnsPlainFile reports whether a successfully rendered Kustomize input already
+// covers path. Chart trees are handled specially: templates are removed by the
+// Helm-template exclusion, while raw CRDs are removed here only when the owning
+// helmCharts entry requested includeCRDs.
+func (result KustomizeRenderResult) OwnsPlainFile(path string) bool {
+	if isAnyPathAliasUnderAnyDir(path, result.ownedHelmChartAliases) {
+		return isAnyPathAliasUnderAnyDir(path, result.ownedHelmCRDAliases) ||
+			isAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+	}
+	return isAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+}
+
+// LoadResourcesFromKustomizeDirectories renders the Kustomize configuration at
+// basePath, or discovers and renders Kustomize configurations below basePath when
+// the input itself is not one. A broad scan treats invalid nested configurations
+// as best-effort misses; an explicitly selected Kustomize input remains a hard
+// error, preserving its existing behavior.
+func LoadResourcesFromKustomizeDirectories(ctx context.Context, basePath string) (KustomizeRenderResult, error) {
+	kustomizeInputs, discoveryErrs := listKustomizeInputs(basePath)
+	explicitKustomizeInput := IsKustomizeFile(basePath) || isKustomizeDirectory(basePath)
+	if explicitKustomizeInput && len(discoveryErrs) > 0 {
+		return KustomizeRenderResult{}, fmt.Errorf("failed to inspect Kustomize input %q: %w", basePath, errors.Join(discoveryErrs...))
+	}
+	for _, err := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize configurations", helpers.Error(err))
+	}
+
+	result := KustomizeRenderResult{SourceToWorkloads: map[string][]workloadinterface.IMetadata{}}
+	seenOwnedSourcePaths := map[string]struct{}{}
+	seenOwnedCharts := map[string]struct{}{}
+	seenOwnedCRDs := map[string]struct{}{}
+	for _, input := range kustomizeInputs {
+		directory := input
+		if IsKustomizeFile(input) {
+			directory = filepath.Dir(input)
+		}
+
+		workloads, _, err := LoadResourcesFromKustomizeDirectory(ctx, input)
+		if err != nil {
+			if explicitKustomizeInput {
+				return KustomizeRenderResult{}, err
+			}
+			logger.L().Ctx(ctx).Warning("Skipping nested Kustomize configuration that failed to render", helpers.String("path", directory), helpers.Error(err))
+			continue
+		}
+
+		// Inspect ownership after the build so a remotely pulled chart and its
+		// nested chart tree are present before generic Helm discovery begins.
+		ownership, err := KustomizeInputOwnershipForPath(ctx, input)
+		if err != nil {
+			if explicitKustomizeInput {
+				return KustomizeRenderResult{}, err
+			}
+			logger.L().Ctx(ctx).Warning("Skipping nested Kustomize configuration with unresolved inputs", helpers.String("path", directory), helpers.Error(err))
+			continue
+		}
+
+		maps.Copy(result.SourceToWorkloads, workloads)
+		appendUniquePaths(&result.OwnedSourcePaths, seenOwnedSourcePaths, ownership.SourcePaths...)
+		appendUniquePaths(&result.OwnedHelmChartDirectories, seenOwnedCharts, ownership.HelmChartDirectories...)
+		appendUniquePaths(&result.OwnedHelmCRDDirectories, seenOwnedCRDs, ownership.HelmCRDDirectories...)
+	}
+	result.ownedSourcePathAliases = pathAliasesForPaths(result.OwnedSourcePaths)
+	result.ownedHelmChartAliases = pathAliasesForPaths(result.OwnedHelmChartDirectories)
+	result.ownedHelmCRDAliases = pathAliasesForPaths(result.OwnedHelmCRDDirectories)
+
+	return result, nil
+}
+
+func appendUniquePaths(destination *[]string, seen map[string]struct{}, paths ...string) {
+	for _, path := range paths {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		*destination = append(*destination, path)
+	}
+}
+
+// listKustomizeInputs preserves exact selection for a Kustomize file or
+// directory. For a broader input it discovers child configurations recursively,
+// matching repository-wide Helm and manifest discovery.
+func listKustomizeInputs(basePath string) ([]string, []error) {
+	if IsKustomizeFile(basePath) || isKustomizeDirectory(basePath) {
+		return []string{basePath}, nil
+	}
+	// A concrete non-Kustomize file is an exact scan target. listDirs interprets
+	// a file path as a parent-directory pattern, which could otherwise discover
+	// an unrelated Kustomize directory sharing the file's basename.
+	if isFile(basePath) {
+		return nil, nil
+	}
+
+	directories, errs := listDirs(basePath)
+	kustomizeDirectories := make([]string, 0)
+	for _, directory := range directories {
+		if isKustomizeDirectory(directory) {
+			kustomizeDirectories = append(kustomizeDirectories, directory)
+		}
+	}
+	return kustomizeDirectories, errs
+}
+
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts
 // are the chart directories LoadResourcesFromHelmCharts already rendered; their templates are left
 // to that render and skipped here. Pass nil to scan everything (e.g. when no charts were rendered).

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -51,9 +51,30 @@ type Chart struct {
 // --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
 // fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
 func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, nil)
+}
+
+// LoadResourcesFromHelmChartsExcludingDirectories behaves like LoadResourcesFromHelmCharts,
+// but leaves charts at or below excludedChartDirectories to another renderer that owns them.
+// The caller is responsible for including those directories in its plain-file exclusions once
+// that renderer succeeds.
+func LoadResourcesFromHelmChartsExcludingDirectories(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, excludedChartDirectories)
+}
+
+func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
 	helmDirectories, discoveryErrs := listHelmChartDirs(basePath)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
+	}
+	if len(excludedChartDirectories) > 0 {
+		remaining := make([]string, 0, len(helmDirectories))
+		for _, directory := range helmDirectories {
+			if !isUnderAnyDir(directory, excludedChartDirectories) {
+				remaining = append(remaining, directory)
+			}
+		}
+		helmDirectories = remaining
 	}
 
 	// Parse user-supplied value overrides once; reuse for every chart we render.

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -224,6 +224,63 @@ func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	}
 }
 
+func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testing.T) {
+	root := t.TempDir()
+	chartHome := filepath.Join(root, "charts")
+	base := filepath.Join(root, "base")
+	ownedChart := filepath.Join(base, "charts", "app")
+	ownedSubchart := filepath.Join(ownedChart, "charts", "dependency")
+	standaloneChart := filepath.Join(chartHome, "standalone")
+
+	writeChart := func(directory, name string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+		writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
+		writeManifestFixture(t, directory, "values.yaml", "{}\n")
+		writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
+	}
+	writeChart(ownedChart, "app")
+	writeChart(ownedSubchart, "dependency")
+	writeChart(standaloneChart, "standalone")
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+`)
+	writeManifestFixture(t, base, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: app
+    releaseName: app
+`)
+
+	ownedDirectories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	require.Equal(t, []string{ownedChart, ownedSubchart}, ownedDirectories)
+
+	standaloneTemplate := filepath.Join(standaloneChart, "templates", "configmap.yaml")
+	remainingFiles := excludeHelmTemplateFiles([]string{
+		filepath.Join(ownedChart, "templates", "configmap.yaml"),
+		filepath.Join(ownedSubchart, "templates", "configmap.yaml"),
+		standaloneTemplate,
+	}, ownedDirectories)
+	require.Equal(t, []string{standaloneTemplate}, remainingFiles)
+
+	workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+		context.Background(), root, HelmValueOptions{}, ownedDirectories,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{standaloneChart}, renderedDirectories)
+	require.Len(t, workloads, 1)
+	require.Len(t, charts, 1)
+	for source, sourceWorkloads := range workloads {
+		require.Len(t, sourceWorkloads, 1)
+		assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
+		assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
+		assert.Equal(t, standaloneChart, charts[source].Path)
+	}
+}
+
 func TestLoadFiles(t *testing.T) {
 	files, _ := listFiles(onlineBoutiquePath())
 	_, errs := loadFiles("", files)

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -224,6 +224,14 @@ func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	}
 }
 
+func writeHelmChartFixture(t *testing.T, directory, name string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+	writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
+	writeManifestFixture(t, directory, "values.yaml", "{}\n")
+	writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
+}
+
 func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testing.T) {
 	root := t.TempDir()
 	chartHome := filepath.Join(root, "charts")
@@ -232,16 +240,9 @@ func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testin
 	ownedSubchart := filepath.Join(ownedChart, "charts", "dependency")
 	standaloneChart := filepath.Join(chartHome, "standalone")
 
-	writeChart := func(directory, name string) {
-		t.Helper()
-		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
-		writeManifestFixture(t, directory, "Chart.yaml", "apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n")
-		writeManifestFixture(t, directory, "values.yaml", "{}\n")
-		writeManifestFixture(t, filepath.Join(directory, "templates"), "configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n")
-	}
-	writeChart(ownedChart, "app")
-	writeChart(ownedSubchart, "dependency")
-	writeChart(standaloneChart, "standalone")
+	writeHelmChartFixture(t, ownedChart, "app")
+	writeHelmChartFixture(t, ownedSubchart, "dependency")
+	writeHelmChartFixture(t, standaloneChart, "standalone")
 	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -254,7 +255,7 @@ helmCharts:
     releaseName: app
 `)
 
-	ownedDirectories, err := KustomizeHelmChartDirectories(root)
+	ownedDirectories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	require.Equal(t, []string{ownedChart, ownedSubchart}, ownedDirectories)
 
@@ -266,19 +267,86 @@ helmCharts:
 	}, ownedDirectories)
 	require.Equal(t, []string{standaloneTemplate}, remainingFiles)
 
-	workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
-		context.Background(), root, HelmValueOptions{}, ownedDirectories,
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	relativeRoot, err := filepath.Rel(cwd, root)
+	require.NoError(t, err)
+	for _, tt := range []struct {
+		name     string
+		scanPath string
+	}{
+		{name: "absolute scan path", scanPath: root},
+		{name: "relative scan path", scanPath: relativeRoot},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workloads, charts, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+				context.Background(), tt.scanPath, HelmValueOptions{}, ownedDirectories,
+			)
+			require.NoError(t, err)
+			require.Equal(t, []string{standaloneChart}, renderedDirectories)
+			require.Len(t, workloads, 1)
+			require.Len(t, charts, 1)
+			for source, sourceWorkloads := range workloads {
+				require.Len(t, sourceWorkloads, 1)
+				assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
+				assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
+				assert.Equal(t, standaloneChart, charts[source].Path)
+			}
+		})
+	}
+}
+
+func TestLoadResourcesFromHelmChartsExcludingDirectories_CanonicalizesSymlinkedScanPath(t *testing.T) {
+	realParent := t.TempDir()
+	root := filepath.Join(realParent, "project")
+	ownedChart := filepath.Join(root, "charts", "app")
+	standaloneChart := filepath.Join(root, "charts", "standalone")
+	writeHelmChartFixture(t, ownedChart, "app")
+	writeHelmChartFixture(t, standaloneChart, "standalone")
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: app
+    releaseName: app
+`)
+
+	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	linkedRoot := filepath.Join(linkedParent, "project")
+	ownedDirectories, err := KustomizeHelmChartDirectories(context.Background(), linkedRoot)
+	require.NoError(t, err)
+	require.Equal(t, []string{ownedChart}, ownedDirectories)
+
+	workloads, _, renderedDirectories, err := LoadResourcesFromHelmChartsExcludingDirectories(
+		context.Background(), linkedRoot, HelmValueOptions{}, ownedDirectories,
 	)
 	require.NoError(t, err)
-	require.Equal(t, []string{standaloneChart}, renderedDirectories)
+	require.Equal(t, []string{filepath.Join(linkedRoot, "charts", "standalone")}, renderedDirectories)
 	require.Len(t, workloads, 1)
-	require.Len(t, charts, 1)
-	for source, sourceWorkloads := range workloads {
+	for _, sourceWorkloads := range workloads {
 		require.Len(t, sourceWorkloads, 1)
-		assert.Equal(t, "ConfigMap", sourceWorkloads[0].GetKind())
 		assert.Equal(t, "standalone", sourceWorkloads[0].GetName())
-		assert.Equal(t, standaloneChart, charts[source].Path)
 	}
+}
+
+func TestExcludeHelmTemplateFiles_PreservesLexicalOwnershipOfSymlinkedTemplate(t *testing.T) {
+	root := t.TempDir()
+	templateDir := filepath.Join(root, "chart", "templates")
+	require.NoError(t, os.MkdirAll(templateDir, 0o750))
+
+	externalTemplate := filepath.Join(t.TempDir(), "configmap.yaml")
+	require.NoError(t, os.WriteFile(externalTemplate, []byte("apiVersion: v1\nkind: ConfigMap\n"), 0o600))
+	linkedTemplate := filepath.Join(templateDir, "configmap.yaml")
+	if err := os.Symlink(externalTemplate, linkedTemplate); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	assert.Empty(t, excludeHelmTemplateFiles(
+		[]string{linkedTemplate},
+		[]string{filepath.Dir(templateDir)},
+	), "Helm renders a template symlink by its lexical path below templates")
 }
 
 func TestLoadFiles(t *testing.T) {

--- a/core/cautils/kustomize_discovery_test.go
+++ b/core/cautils/kustomize_discovery_test.go
@@ -1,0 +1,76 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListKustomizeInputsDiscoversNestedHelmOwnership(t *testing.T) {
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	writeManifestFixture(t, appDir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    releaseName: app
+`)
+
+	inputs, errs := listKustomizeInputs(repoRoot)
+	require.Empty(t, errs)
+	require.Equal(t, []string{appDir}, inputs)
+
+	ownedCharts, err := KustomizeHelmChartDirectories(context.Background(), inputs[0])
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.Join(appDir, "vendor", "charts", "app")}, ownedCharts)
+}
+
+func TestKustomizeInputOwnershipIncludesCRDAndHelmValuesInputs(t *testing.T) {
+	root := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(root, "charts", "explicit"),
+		filepath.Join(root, "charts", "defaulted"),
+		filepath.Join(root, "values"),
+	} {
+		require.NoError(t, os.MkdirAll(directory, 0o750))
+	}
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+crds:
+  - schema.yaml
+helmGlobals:
+  chartHome: charts
+helmCharts:
+  - name: explicit
+    releaseName: explicit
+    valuesFile: values/override.yaml
+    additionalValuesFiles:
+      - values/additional.yaml
+  - name: defaulted
+    releaseName: defaulted
+`)
+	writeManifestFixture(t, root, "schema.yaml", "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: widgets.example.com\n")
+	writeManifestFixture(t, filepath.Join(root, "values"), "override.yaml", "replicas: 2\n")
+	writeManifestFixture(t, filepath.Join(root, "values"), "additional.yaml", "image: nginx:1.27\n")
+	for _, chart := range []string{"explicit", "defaulted"} {
+		chartDirectory := filepath.Join(root, "charts", chart)
+		writeManifestFixture(t, chartDirectory, "Chart.yaml", "apiVersion: v2\nname: "+chart+"\nversion: 0.1.0\n")
+		writeManifestFixture(t, chartDirectory, "values.yaml", "{}\n")
+	}
+
+	ownership, err := KustomizeInputOwnershipForPath(context.Background(), root)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "kustomization.yaml"),
+		filepath.Join(root, "schema.yaml"),
+		filepath.Join(root, "values", "override.yaml"),
+		filepath.Join(root, "values", "additional.yaml"),
+		filepath.Join(root, "charts", "defaulted", "values.yaml"),
+	}, ownership.SourcePaths)
+}

--- a/core/cautils/kustomize_discovery_test.go
+++ b/core/cautils/kustomize_discovery_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestListKustomizeInputsDiscoversNestedHelmOwnership(t *testing.T) {
-	repoRoot := t.TempDir()
+	repoRoot := resolvedTempDir(t)
 	appDir := filepath.Join(repoRoot, "app")
 	require.NoError(t, os.MkdirAll(appDir, 0o750))
 	writeManifestFixture(t, appDir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
@@ -32,7 +32,7 @@ helmCharts:
 }
 
 func TestKustomizeInputOwnershipIncludesCRDAndHelmValuesInputs(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	for _, directory := range []string{
 		filepath.Join(root, "charts", "explicit"),
 		filepath.Join(root, "charts", "defaulted"),

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -249,8 +249,7 @@ func collectKustomizeInputOwnership(
 	inputReferences := make([]string, 0,
 		len(kustomization.Crds)+len(kustomization.Configurations)+len(kustomization.Generators)+
 			len(kustomization.Transformers)+len(kustomization.Validators)+
-			len(kustomization.Patches)+len(kustomization.PatchesJson6902)+
-			len(kustomization.PatchesStrategicMerge)+len(kustomization.Replacements),
+			len(kustomization.Patches)+len(kustomization.Replacements),
 	)
 	inputReferences = append(inputReferences, kustomization.Crds...)
 	inputReferences = append(inputReferences, kustomization.Configurations...)
@@ -260,10 +259,14 @@ func collectKustomizeInputOwnership(
 	for _, patch := range kustomization.Patches {
 		inputReferences = append(inputReferences, patch.Path)
 	}
-	for _, patch := range kustomization.PatchesJson6902 {
+	// FixKustomization intentionally leaves the deprecated patch fields intact;
+	// only FixKustomizationPreMarshalling migrates them, and that requires a
+	// Kustomize filesystem. Track their local files here so legacy builds get the
+	// same ownership behavior as the normalized Patches field.
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Required for legacy Kustomization input ownership.
 		inputReferences = append(inputReferences, patch.Path)
 	}
-	for _, patch := range kustomization.PatchesStrategicMerge {
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Required for legacy Kustomization input ownership.
 		inputReferences = append(inputReferences, string(patch))
 	}
 	for _, replacement := range kustomization.Replacements {

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -1,6 +1,8 @@
 package cautils
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -68,6 +70,159 @@ func getKustomizeDirectoryName(path string) string {
 	}
 
 	return path
+}
+
+// KustomizeHelmChartDirectories returns the local chart directories owned by the
+// Kustomize configuration selected by path. Returning only explicitly referenced
+// charts keeps unrelated charts under the same tree available to the generic Helm
+// loader. Nested chart directories are owned by the referenced parent chart too.
+func KustomizeHelmChartDirectories(path string) ([]string, error) {
+	kustomizationPath := selectedKustomizationFile(path)
+	if kustomizationPath == "" {
+		return nil, nil
+	}
+	var chartDirectories []string
+	seenKustomizations := map[string]struct{}{}
+	seenChartDirectories := map[string]struct{}{}
+	if err := collectKustomizeHelmChartDirectories(
+		kustomizationPath,
+		seenKustomizations,
+		seenChartDirectories,
+		&chartDirectories,
+	); err != nil {
+		return nil, err
+	}
+	return chartDirectories, nil
+}
+
+func collectKustomizeHelmChartDirectories(
+	kustomizationPath string,
+	seenKustomizations map[string]struct{},
+	seenChartDirectories map[string]struct{},
+	chartDirectories *[]string,
+) error {
+	absKustomizationPath, err := filepath.Abs(kustomizationPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Kustomization path %q: %w", kustomizationPath, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absKustomizationPath); err == nil {
+		absKustomizationPath = resolved
+	}
+	if _, ok := seenKustomizations[absKustomizationPath]; ok {
+		return nil
+	}
+	seenKustomizations[absKustomizationPath] = struct{}{}
+
+	contents, err := os.ReadFile(absKustomizationPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Kustomization %q: %w", absKustomizationPath, err)
+	}
+	var kustomization types.Kustomization
+	if err := kustomization.Unmarshal(contents); err != nil {
+		return fmt.Errorf("failed to parse Kustomization %q: %w", absKustomizationPath, err)
+	}
+	kustomization.FixKustomization()
+
+	chartHome := types.HelmDefaultHome
+	if kustomization.HelmGlobals != nil && kustomization.HelmGlobals.ChartHome != "" {
+		chartHome = kustomization.HelmGlobals.ChartHome
+	}
+	if !filepath.IsAbs(chartHome) {
+		chartHome = filepath.Join(filepath.Dir(absKustomizationPath), chartHome)
+	}
+
+	for _, chart := range kustomization.HelmCharts {
+		if chart.Name == "" {
+			continue
+		}
+		chartRoot := chartHome
+		// Kustomize isolates a versioned chart fetched from a repository below
+		// <name>-<version> before untarring it. Mirror absChartHome in the Helm
+		// inflator so a chart left there from an earlier build has the same owner.
+		if chart.Repo != "" && chart.Version != "" {
+			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
+		}
+		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
+		if err := appendOwnedHelmChartTree(directory, seenChartDirectories, chartDirectories); err != nil {
+			return err
+		}
+	}
+
+	// A selected Kustomize build can compose local bases and components that carry
+	// their own helmCharts. Follow only those explicit local graph edges; do not
+	// discover unrelated Kustomizations elsewhere below the scan root.
+	references := make([]string, 0, len(kustomization.Resources)+len(kustomization.Components))
+	references = append(references, kustomization.Resources...)
+	references = append(references, kustomization.Components...)
+	for _, reference := range references {
+		candidate := reference
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(filepath.Dir(absKustomizationPath), candidate)
+		}
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		childKustomization := selectedKustomizationFile(candidate)
+		if childKustomization == "" {
+			continue
+		}
+		if err := collectKustomizeHelmChartDirectories(
+			childKustomization,
+			seenKustomizations,
+			seenChartDirectories,
+			chartDirectories,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, directories *[]string) error {
+	if _, ok := seen[directory]; !ok {
+		seen[directory] = struct{}{}
+		*directories = append(*directories, directory)
+	}
+
+	info, err := os.Stat(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	nestedDirectories, discoveryErrs := listHelmChartDirs(directory)
+	if len(discoveryErrs) > 0 {
+		return fmt.Errorf("failed to discover Kustomize-owned Helm chart dependencies below %q: %w", directory, errors.Join(discoveryErrs...))
+	}
+	for _, nestedDirectory := range nestedDirectories {
+		if _, ok := seen[nestedDirectory]; ok {
+			continue
+		}
+		seen[nestedDirectory] = struct{}{}
+		*directories = append(*directories, nestedDirectory)
+	}
+	return nil
+}
+
+func selectedKustomizationFile(path string) string {
+	if IsKustomizeFile(path) {
+		return path
+	}
+	if !isKustomizeDirectory(path) {
+		return ""
+	}
+	for _, matcher := range kustomizationFileMatchers {
+		candidate := filepath.Join(path, matcher)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // Get Workloads, creates the yaml files(K8s resources) using Kustomize and

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -244,8 +244,7 @@ func collectKustomizeInputOwnership(
 	inputReferences := make([]string, 0,
 		len(kustomization.Crds)+len(kustomization.Configurations)+len(kustomization.Generators)+
 			len(kustomization.Transformers)+len(kustomization.Validators)+
-			len(kustomization.Patches)+len(kustomization.PatchesJson6902)+
-			len(kustomization.PatchesStrategicMerge)+len(kustomization.Replacements),
+			len(kustomization.Patches)+len(kustomization.Replacements),
 	)
 	inputReferences = append(inputReferences, kustomization.Crds...)
 	inputReferences = append(inputReferences, kustomization.Configurations...)
@@ -255,10 +254,14 @@ func collectKustomizeInputOwnership(
 	for _, patch := range kustomization.Patches {
 		inputReferences = append(inputReferences, patch.Path)
 	}
-	for _, patch := range kustomization.PatchesJson6902 {
+	// FixKustomization intentionally leaves the deprecated patch fields intact;
+	// only FixKustomizationPreMarshalling migrates them, and that requires a
+	// Kustomize filesystem. Track their local files here so legacy builds get the
+	// same ownership behavior as the normalized Patches field.
+	for _, patch := range kustomization.PatchesJson6902 { //nolint:staticcheck // Required for legacy Kustomization input ownership.
 		inputReferences = append(inputReferences, patch.Path)
 	}
-	for _, patch := range kustomization.PatchesStrategicMerge {
+	for _, patch := range kustomization.PatchesStrategicMerge { //nolint:staticcheck // Required for legacy Kustomization input ownership.
 		inputReferences = append(inputReferences, string(patch))
 	}
 	for _, replacement := range kustomization.Replacements {

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -44,7 +44,7 @@ func isKustomizeDirectory(path string) bool {
 	case 1:
 		return true
 	default:
-		logger.L().Info("Multiple kustomize files found while checking the Kustomize Directory")
+		logger.L().Debug("Multiple kustomize files found while checking the Kustomize Directory")
 		return false
 	}
 }
@@ -375,7 +375,7 @@ func appendOwnedHelmChartTreeWithLister(ctx context.Context, directory string, s
 }
 
 func selectedKustomizationFile(path string) string {
-	if IsKustomizeFile(path) {
+	if IsKustomizeFile(path) && isFile(path) {
 		return path
 	}
 	if !isKustomizeDirectory(path) {
@@ -383,7 +383,7 @@ func selectedKustomizationFile(path string) string {
 	}
 	for _, matcher := range kustomizationFileMatchers {
 		candidate := filepath.Join(path, matcher)
-		if _, err := os.Stat(candidate); err == nil {
+		if isFile(candidate) {
 			return candidate
 		}
 	}

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -1,12 +1,14 @@
 package cautils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"sigs.k8s.io/kustomize/api/krusty"
@@ -76,7 +78,7 @@ func getKustomizeDirectoryName(path string) string {
 // Kustomize configuration selected by path. Returning only explicitly referenced
 // charts keeps unrelated charts under the same tree available to the generic Helm
 // loader. Nested chart directories are owned by the referenced parent chart too.
-func KustomizeHelmChartDirectories(path string) ([]string, error) {
+func KustomizeHelmChartDirectories(ctx context.Context, path string) ([]string, error) {
 	kustomizationPath := selectedKustomizationFile(path)
 	if kustomizationPath == "" {
 		return nil, nil
@@ -85,6 +87,7 @@ func KustomizeHelmChartDirectories(path string) ([]string, error) {
 	seenKustomizations := map[string]struct{}{}
 	seenChartDirectories := map[string]struct{}{}
 	if err := collectKustomizeHelmChartDirectories(
+		ctx,
 		kustomizationPath,
 		seenKustomizations,
 		seenChartDirectories,
@@ -96,17 +99,15 @@ func KustomizeHelmChartDirectories(path string) ([]string, error) {
 }
 
 func collectKustomizeHelmChartDirectories(
+	ctx context.Context,
 	kustomizationPath string,
 	seenKustomizations map[string]struct{},
 	seenChartDirectories map[string]struct{},
 	chartDirectories *[]string,
 ) error {
-	absKustomizationPath, err := filepath.Abs(kustomizationPath)
+	absKustomizationPath, err := canonicalPath(kustomizationPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve Kustomization path %q: %w", kustomizationPath, err)
-	}
-	if resolved, err := filepath.EvalSymlinks(absKustomizationPath); err == nil {
-		absKustomizationPath = resolved
 	}
 	if _, ok := seenKustomizations[absKustomizationPath]; ok {
 		return nil
@@ -143,9 +144,7 @@ func collectKustomizeHelmChartDirectories(
 			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
 		}
 		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
-		if err := appendOwnedHelmChartTree(directory, seenChartDirectories, chartDirectories); err != nil {
-			return err
-		}
+		appendOwnedHelmChartTree(ctx, directory, seenChartDirectories, chartDirectories)
 	}
 
 	// A selected Kustomize build can compose local bases and components that carry
@@ -167,6 +166,7 @@ func collectKustomizeHelmChartDirectories(
 			continue
 		}
 		if err := collectKustomizeHelmChartDirectories(
+			ctx,
 			childKustomization,
 			seenKustomizations,
 			seenChartDirectories,
@@ -178,7 +178,19 @@ func collectKustomizeHelmChartDirectories(
 	return nil
 }
 
-func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, directories *[]string) error {
+type helmChartDirectoryLister func(string) ([]string, []error)
+
+func appendOwnedHelmChartTree(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string) {
+	appendOwnedHelmChartTreeWithLister(ctx, directory, seen, directories, listHelmChartDirs)
+}
+
+func appendOwnedHelmChartTreeWithLister(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string, discover helmChartDirectoryLister) {
+	normalizedDirectory, err := canonicalPath(directory)
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
+		normalizedDirectory = filepath.Clean(directory)
+	}
+	directory = normalizedDirectory
 	if _, ok := seen[directory]; !ok {
 		seen[directory] = struct{}{}
 		*directories = append(*directories, directory)
@@ -186,27 +198,30 @@ func appendOwnedHelmChartTree(directory string, seen map[string]struct{}, direct
 
 	info, err := os.Stat(directory)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return
 	}
 	if err != nil {
-		return fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err)
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(
+			fmt.Errorf("failed to inspect Kustomize-owned Helm chart %q: %w", directory, err),
+		))
+		return
 	}
 	if !info.IsDir() {
-		return nil
+		return
 	}
 
-	nestedDirectories, discoveryErrs := listHelmChartDirs(directory)
-	if len(discoveryErrs) > 0 {
-		return fmt.Errorf("failed to discover Kustomize-owned Helm chart dependencies below %q: %w", directory, errors.Join(discoveryErrs...))
+	nestedDirectories, discoveryErrs := discover(directory)
+	for _, discoveryErr := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(discoveryErr))
 	}
 	for _, nestedDirectory := range nestedDirectories {
+		nestedDirectory = normalizePath(nestedDirectory)
 		if _, ok := seen[nestedDirectory]; ok {
 			continue
 		}
 		seen[nestedDirectory] = struct{}{}
 		*directories = append(*directories, nestedDirectory)
 	}
-	return nil
 }
 
 func selectedKustomizationFile(path string) string {

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -79,36 +80,63 @@ func getKustomizeDirectoryName(path string) string {
 	return path
 }
 
+// KustomizeInputOwnership describes the local inputs selected by a Kustomize
+// build. HelmCRDDirectories contains only crds/ directories whose chart is
+// rendered with includeCRDs, so callers can retain raw CRDs when Kustomize omits
+// them. SourcePaths contains exact local build inputs rather than the whole
+// Kustomization directory, preserving unrelated manifests beside a build.
+type KustomizeInputOwnership struct {
+	SourcePaths          []string
+	HelmChartDirectories []string
+	HelmCRDDirectories   []string
+}
+
 // KustomizeHelmChartDirectories returns the local chart directories owned by the
 // Kustomize configuration selected by path. Returning only explicitly referenced
 // charts keeps unrelated charts under the same tree available to the generic Helm
 // loader. Nested chart directories are owned by the referenced parent chart too.
 func KustomizeHelmChartDirectories(ctx context.Context, path string) ([]string, error) {
+	ownership, err := KustomizeInputOwnershipForPath(ctx, path)
+	return ownership.HelmChartDirectories, err
+}
+
+// KustomizeInputOwnershipForPath returns the local source and chart inputs owned
+// by the selected Kustomize build.
+func KustomizeInputOwnershipForPath(ctx context.Context, path string) (KustomizeInputOwnership, error) {
 	kustomizationPath := selectedKustomizationFile(path)
 	if kustomizationPath == "" {
-		return nil, nil
+		return KustomizeInputOwnership{}, nil
 	}
-	var chartDirectories []string
+	ownership := KustomizeInputOwnership{}
 	seenKustomizations := map[string]struct{}{}
+	seenSourcePaths := map[string]struct{}{}
 	seenChartDirectories := map[string]struct{}{}
-	if err := collectKustomizeHelmChartDirectories(
+	seenCRDDirectories := map[string]struct{}{}
+	chartTrees := map[string][]string{}
+	if err := collectKustomizeInputOwnership(
 		ctx,
 		kustomizationPath,
 		seenKustomizations,
+		seenSourcePaths,
 		seenChartDirectories,
-		&chartDirectories,
+		seenCRDDirectories,
+		chartTrees,
+		&ownership,
 	); err != nil {
-		return nil, err
+		return KustomizeInputOwnership{}, err
 	}
-	return chartDirectories, nil
+	return ownership, nil
 }
 
-func collectKustomizeHelmChartDirectories(
+func collectKustomizeInputOwnership(
 	ctx context.Context,
 	kustomizationPath string,
 	seenKustomizations map[string]struct{},
+	seenSourcePaths map[string]struct{},
 	seenChartDirectories map[string]struct{},
-	chartDirectories *[]string,
+	seenCRDDirectories map[string]struct{},
+	chartTrees map[string][]string,
+	ownership *KustomizeInputOwnership,
 ) error {
 	absKustomizationPath, err := canonicalPath(kustomizationPath)
 	if err != nil {
@@ -118,6 +146,7 @@ func collectKustomizeHelmChartDirectories(
 		return nil
 	}
 	seenKustomizations[absKustomizationPath] = struct{}{}
+	appendUniquePath(absKustomizationPath, seenSourcePaths, &ownership.SourcePaths)
 
 	contents, err := os.ReadFile(absKustomizationPath)
 	if err != nil {
@@ -149,7 +178,42 @@ func collectKustomizeHelmChartDirectories(
 			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
 		}
 		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
-		appendOwnedHelmChartTree(ctx, directory, seenChartDirectories, chartDirectories)
+		chartKey := normalizePath(directory)
+		chartTree, ok := chartTrees[chartKey]
+		if !ok {
+			chartTree = make([]string, 0, 1)
+			appendOwnedHelmChartTree(ctx, directory, map[string]struct{}{}, &chartTree)
+			chartTrees[chartKey] = chartTree
+		}
+		for _, chartDirectory := range chartTree {
+			if _, ok := seenChartDirectories[chartDirectory]; !ok {
+				seenChartDirectories[chartDirectory] = struct{}{}
+				ownership.HelmChartDirectories = append(ownership.HelmChartDirectories, chartDirectory)
+			}
+			if !chart.IncludeCRDs {
+				continue
+			}
+			crdDirectory := normalizePath(filepath.Join(chartDirectory, "crds"))
+			if _, ok := seenCRDDirectories[crdDirectory]; ok {
+				continue
+			}
+			seenCRDDirectories[crdDirectory] = struct{}{}
+			ownership.HelmCRDDirectories = append(ownership.HelmCRDDirectories, crdDirectory)
+		}
+
+		valuesFiles := append([]string{}, chart.AdditionalValuesFiles...)
+		if chart.ValuesFile != "" {
+			valuesFiles = append(valuesFiles, chart.ValuesFile)
+		} else {
+			valuesFiles = append(valuesFiles, filepath.Join(directory, "values.yaml"))
+		}
+		for _, valuesFile := range valuesFiles {
+			candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), valuesFile)
+			if !ok {
+				continue
+			}
+			appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
+		}
 	}
 
 	// A selected Kustomize build can compose local bases and components that carry
@@ -159,28 +223,106 @@ func collectKustomizeHelmChartDirectories(
 	references = append(references, kustomization.Resources...)
 	references = append(references, kustomization.Components...)
 	for _, reference := range references {
-		candidate := reference
-		if !filepath.IsAbs(candidate) {
-			candidate = filepath.Join(filepath.Dir(absKustomizationPath), candidate)
-		}
-		if _, err := os.Stat(candidate); err != nil {
+		candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), reference)
+		if !ok {
 			continue
 		}
 		childKustomization := selectedKustomizationFile(candidate)
 		if childKustomization == "" {
+			appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
 			continue
 		}
-		if err := collectKustomizeHelmChartDirectories(
+		if err := collectKustomizeInputOwnership(
 			ctx,
 			childKustomization,
 			seenKustomizations,
+			seenSourcePaths,
 			seenChartDirectories,
-			chartDirectories,
+			seenCRDDirectories,
+			chartTrees,
+			ownership,
 		); err != nil {
 			return err
 		}
 	}
+
+	inputReferences := make([]string, 0,
+		len(kustomization.Crds)+len(kustomization.Configurations)+len(kustomization.Generators)+
+			len(kustomization.Transformers)+len(kustomization.Validators)+
+			len(kustomization.Patches)+len(kustomization.PatchesJson6902)+
+			len(kustomization.PatchesStrategicMerge)+len(kustomization.Replacements),
+	)
+	inputReferences = append(inputReferences, kustomization.Crds...)
+	inputReferences = append(inputReferences, kustomization.Configurations...)
+	inputReferences = append(inputReferences, kustomization.Generators...)
+	inputReferences = append(inputReferences, kustomization.Transformers...)
+	inputReferences = append(inputReferences, kustomization.Validators...)
+	for _, patch := range kustomization.Patches {
+		inputReferences = append(inputReferences, patch.Path)
+	}
+	for _, patch := range kustomization.PatchesJson6902 {
+		inputReferences = append(inputReferences, patch.Path)
+	}
+	for _, patch := range kustomization.PatchesStrategicMerge {
+		inputReferences = append(inputReferences, string(patch))
+	}
+	for _, replacement := range kustomization.Replacements {
+		inputReferences = append(inputReferences, replacement.Path)
+	}
+	if openAPIPath := kustomization.OpenAPI["path"]; openAPIPath != "" {
+		inputReferences = append(inputReferences, openAPIPath)
+	}
+	for _, generator := range kustomization.ConfigMapGenerator {
+		inputReferences = append(inputReferences, generatorInputPaths(generator.FileSources, generator.EnvSources, generator.EnvSource)...)
+	}
+	for _, generator := range kustomization.SecretGenerator {
+		inputReferences = append(inputReferences, generatorInputPaths(generator.FileSources, generator.EnvSources, generator.EnvSource)...)
+	}
+	for _, reference := range inputReferences {
+		candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), reference)
+		if !ok {
+			continue
+		}
+		appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
+	}
 	return nil
+}
+
+func localKustomizeReference(baseDirectory, reference string) (string, bool) {
+	if reference == "" {
+		return "", false
+	}
+	candidate := reference
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(baseDirectory, candidate)
+	}
+	if _, err := os.Stat(candidate); err != nil {
+		return "", false
+	}
+	return candidate, true
+}
+
+func generatorInputPaths(files, envs []string, env string) []string {
+	paths := make([]string, 0, len(files)+len(envs)+1)
+	for _, file := range files {
+		if _, value, ok := strings.Cut(file, "="); ok {
+			file = value
+		}
+		paths = append(paths, file)
+	}
+	paths = append(paths, envs...)
+	if env != "" {
+		paths = append(paths, env)
+	}
+	return paths
+}
+
+func appendUniquePath(path string, seen map[string]struct{}, paths *[]string) {
+	if _, ok := seen[path]; ok {
+		return
+	}
+	seen[path] = struct{}{}
+	*paths = append(*paths, path)
 }
 
 type helmChartDirectoryLister func(string) ([]string, []error)

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -74,36 +75,63 @@ func getKustomizeDirectoryName(path string) string {
 	return path
 }
 
+// KustomizeInputOwnership describes the local inputs selected by a Kustomize
+// build. HelmCRDDirectories contains only crds/ directories whose chart is
+// rendered with includeCRDs, so callers can retain raw CRDs when Kustomize omits
+// them. SourcePaths contains exact local build inputs rather than the whole
+// Kustomization directory, preserving unrelated manifests beside a build.
+type KustomizeInputOwnership struct {
+	SourcePaths          []string
+	HelmChartDirectories []string
+	HelmCRDDirectories   []string
+}
+
 // KustomizeHelmChartDirectories returns the local chart directories owned by the
 // Kustomize configuration selected by path. Returning only explicitly referenced
 // charts keeps unrelated charts under the same tree available to the generic Helm
 // loader. Nested chart directories are owned by the referenced parent chart too.
 func KustomizeHelmChartDirectories(ctx context.Context, path string) ([]string, error) {
+	ownership, err := KustomizeInputOwnershipForPath(ctx, path)
+	return ownership.HelmChartDirectories, err
+}
+
+// KustomizeInputOwnershipForPath returns the local source and chart inputs owned
+// by the selected Kustomize build.
+func KustomizeInputOwnershipForPath(ctx context.Context, path string) (KustomizeInputOwnership, error) {
 	kustomizationPath := selectedKustomizationFile(path)
 	if kustomizationPath == "" {
-		return nil, nil
+		return KustomizeInputOwnership{}, nil
 	}
-	var chartDirectories []string
+	ownership := KustomizeInputOwnership{}
 	seenKustomizations := map[string]struct{}{}
+	seenSourcePaths := map[string]struct{}{}
 	seenChartDirectories := map[string]struct{}{}
-	if err := collectKustomizeHelmChartDirectories(
+	seenCRDDirectories := map[string]struct{}{}
+	chartTrees := map[string][]string{}
+	if err := collectKustomizeInputOwnership(
 		ctx,
 		kustomizationPath,
 		seenKustomizations,
+		seenSourcePaths,
 		seenChartDirectories,
-		&chartDirectories,
+		seenCRDDirectories,
+		chartTrees,
+		&ownership,
 	); err != nil {
-		return nil, err
+		return KustomizeInputOwnership{}, err
 	}
-	return chartDirectories, nil
+	return ownership, nil
 }
 
-func collectKustomizeHelmChartDirectories(
+func collectKustomizeInputOwnership(
 	ctx context.Context,
 	kustomizationPath string,
 	seenKustomizations map[string]struct{},
+	seenSourcePaths map[string]struct{},
 	seenChartDirectories map[string]struct{},
-	chartDirectories *[]string,
+	seenCRDDirectories map[string]struct{},
+	chartTrees map[string][]string,
+	ownership *KustomizeInputOwnership,
 ) error {
 	absKustomizationPath, err := canonicalPath(kustomizationPath)
 	if err != nil {
@@ -113,6 +141,7 @@ func collectKustomizeHelmChartDirectories(
 		return nil
 	}
 	seenKustomizations[absKustomizationPath] = struct{}{}
+	appendUniquePath(absKustomizationPath, seenSourcePaths, &ownership.SourcePaths)
 
 	contents, err := os.ReadFile(absKustomizationPath)
 	if err != nil {
@@ -144,7 +173,42 @@ func collectKustomizeHelmChartDirectories(
 			chartRoot = filepath.Join(chartRoot, fmt.Sprintf("%s-%s", chart.Name, chart.Version))
 		}
 		directory := filepath.Clean(filepath.Join(chartRoot, chart.Name))
-		appendOwnedHelmChartTree(ctx, directory, seenChartDirectories, chartDirectories)
+		chartKey := normalizePath(directory)
+		chartTree, ok := chartTrees[chartKey]
+		if !ok {
+			chartTree = make([]string, 0, 1)
+			appendOwnedHelmChartTree(ctx, directory, map[string]struct{}{}, &chartTree)
+			chartTrees[chartKey] = chartTree
+		}
+		for _, chartDirectory := range chartTree {
+			if _, ok := seenChartDirectories[chartDirectory]; !ok {
+				seenChartDirectories[chartDirectory] = struct{}{}
+				ownership.HelmChartDirectories = append(ownership.HelmChartDirectories, chartDirectory)
+			}
+			if !chart.IncludeCRDs {
+				continue
+			}
+			crdDirectory := normalizePath(filepath.Join(chartDirectory, "crds"))
+			if _, ok := seenCRDDirectories[crdDirectory]; ok {
+				continue
+			}
+			seenCRDDirectories[crdDirectory] = struct{}{}
+			ownership.HelmCRDDirectories = append(ownership.HelmCRDDirectories, crdDirectory)
+		}
+
+		valuesFiles := append([]string{}, chart.AdditionalValuesFiles...)
+		if chart.ValuesFile != "" {
+			valuesFiles = append(valuesFiles, chart.ValuesFile)
+		} else {
+			valuesFiles = append(valuesFiles, filepath.Join(directory, "values.yaml"))
+		}
+		for _, valuesFile := range valuesFiles {
+			candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), valuesFile)
+			if !ok {
+				continue
+			}
+			appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
+		}
 	}
 
 	// A selected Kustomize build can compose local bases and components that carry
@@ -154,28 +218,106 @@ func collectKustomizeHelmChartDirectories(
 	references = append(references, kustomization.Resources...)
 	references = append(references, kustomization.Components...)
 	for _, reference := range references {
-		candidate := reference
-		if !filepath.IsAbs(candidate) {
-			candidate = filepath.Join(filepath.Dir(absKustomizationPath), candidate)
-		}
-		if _, err := os.Stat(candidate); err != nil {
+		candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), reference)
+		if !ok {
 			continue
 		}
 		childKustomization := selectedKustomizationFile(candidate)
 		if childKustomization == "" {
+			appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
 			continue
 		}
-		if err := collectKustomizeHelmChartDirectories(
+		if err := collectKustomizeInputOwnership(
 			ctx,
 			childKustomization,
 			seenKustomizations,
+			seenSourcePaths,
 			seenChartDirectories,
-			chartDirectories,
+			seenCRDDirectories,
+			chartTrees,
+			ownership,
 		); err != nil {
 			return err
 		}
 	}
+
+	inputReferences := make([]string, 0,
+		len(kustomization.Crds)+len(kustomization.Configurations)+len(kustomization.Generators)+
+			len(kustomization.Transformers)+len(kustomization.Validators)+
+			len(kustomization.Patches)+len(kustomization.PatchesJson6902)+
+			len(kustomization.PatchesStrategicMerge)+len(kustomization.Replacements),
+	)
+	inputReferences = append(inputReferences, kustomization.Crds...)
+	inputReferences = append(inputReferences, kustomization.Configurations...)
+	inputReferences = append(inputReferences, kustomization.Generators...)
+	inputReferences = append(inputReferences, kustomization.Transformers...)
+	inputReferences = append(inputReferences, kustomization.Validators...)
+	for _, patch := range kustomization.Patches {
+		inputReferences = append(inputReferences, patch.Path)
+	}
+	for _, patch := range kustomization.PatchesJson6902 {
+		inputReferences = append(inputReferences, patch.Path)
+	}
+	for _, patch := range kustomization.PatchesStrategicMerge {
+		inputReferences = append(inputReferences, string(patch))
+	}
+	for _, replacement := range kustomization.Replacements {
+		inputReferences = append(inputReferences, replacement.Path)
+	}
+	if openAPIPath := kustomization.OpenAPI["path"]; openAPIPath != "" {
+		inputReferences = append(inputReferences, openAPIPath)
+	}
+	for _, generator := range kustomization.ConfigMapGenerator {
+		inputReferences = append(inputReferences, generatorInputPaths(generator.FileSources, generator.EnvSources, generator.EnvSource)...)
+	}
+	for _, generator := range kustomization.SecretGenerator {
+		inputReferences = append(inputReferences, generatorInputPaths(generator.FileSources, generator.EnvSources, generator.EnvSource)...)
+	}
+	for _, reference := range inputReferences {
+		candidate, ok := localKustomizeReference(filepath.Dir(absKustomizationPath), reference)
+		if !ok {
+			continue
+		}
+		appendUniquePath(normalizePath(candidate), seenSourcePaths, &ownership.SourcePaths)
+	}
 	return nil
+}
+
+func localKustomizeReference(baseDirectory, reference string) (string, bool) {
+	if reference == "" {
+		return "", false
+	}
+	candidate := reference
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(baseDirectory, candidate)
+	}
+	if _, err := os.Stat(candidate); err != nil {
+		return "", false
+	}
+	return candidate, true
+}
+
+func generatorInputPaths(files, envs []string, env string) []string {
+	paths := make([]string, 0, len(files)+len(envs)+1)
+	for _, file := range files {
+		if _, value, ok := strings.Cut(file, "="); ok {
+			file = value
+		}
+		paths = append(paths, file)
+	}
+	paths = append(paths, envs...)
+	if env != "" {
+		paths = append(paths, env)
+	}
+	return paths
+}
+
+func appendUniquePath(path string, seen map[string]struct{}, paths *[]string) {
+	if _, ok := seen[path]; ok {
+		return
+	}
+	seen[path] = struct{}{}
+	*paths = append(*paths, path)
 }
 
 type helmChartDirectoryLister func(string) ([]string, []error)

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -75,6 +75,25 @@ func kustomizeTestdataPath() string {
 	return filepath.Join(o, "testdata", "kustomize")
 }
 
+func TestSelectedKustomizationFileRequiresRegularFile(t *testing.T) {
+	for _, basename := range kustomizationFileMatchers {
+		t.Run(basename, func(t *testing.T) {
+			root := resolvedTempDir(t)
+			fileParent := filepath.Join(root, "file")
+			directoryParent := filepath.Join(root, "directory")
+			require.NoError(t, os.MkdirAll(fileParent, 0o750))
+			require.NoError(t, os.MkdirAll(filepath.Join(directoryParent, basename), 0o750))
+
+			filePath := filepath.Join(fileParent, basename)
+			require.NoError(t, os.WriteFile(filePath, []byte("kind: Kustomization\n"), 0o600))
+
+			assert.Equal(t, filePath, selectedKustomizationFile(filePath))
+			assert.Empty(t, selectedKustomizationFile(filepath.Join(directoryParent, basename)))
+			assert.Empty(t, selectedKustomizationFile(directoryParent))
+		})
+	}
+}
+
 func TestKustomizeHelmChartDirectories_CustomHomeDeduplicatesPhysicalChart(t *testing.T) {
 	root := resolvedTempDir(t)
 	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -1,6 +1,8 @@
 package cautils
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +87,7 @@ helmCharts:
     releaseName: second
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.Equal(t, []string{filepath.Join(root, "vendor", "charts", "app")}, directories)
 }
@@ -103,7 +105,7 @@ helmCharts:
     releaseName: app
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		filepath.Join(root, "vendor", "charts", "app-1.2.3", "app"),
@@ -112,27 +114,27 @@ helmCharts:
 
 func TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout(t *testing.T) {
 	tests := []struct {
-		name          string
-		chartHome     func(string) string
-		chartFields   string
-		expectedParts []string
+		name        string
+		chartHome   func(string) string
+		chartFields string
+		expected    func(string) string
 	}{
 		{
-			name:          "absolute chart home",
-			chartHome:     func(root string) string { return filepath.Join(root, "absolute-charts") },
-			expectedParts: []string{"absolute-charts", "app"},
+			name:      "absolute chart home",
+			chartHome: func(root string) string { return filepath.Join(root, "absolute-charts") },
+			expected:  func(root string) string { return filepath.Join(root, "absolute-charts", "app") },
 		},
 		{
-			name:          "repository without version uses regular chart home",
-			chartHome:     func(string) string { return "charts" },
-			chartFields:   "    repo: https://charts.example.com\n",
-			expectedParts: []string{"charts", "app"},
+			name:        "repository without version uses regular chart home",
+			chartHome:   func(string) string { return "charts" },
+			chartFields: "    repo: https://charts.example.com\n",
+			expected:    func(root string) string { return filepath.Join(root, "charts", "app") },
 		},
 		{
-			name:          "version without repository uses regular chart home",
-			chartHome:     func(string) string { return "charts" },
-			chartFields:   "    version: 1.2.3\n",
-			expectedParts: []string{"charts", "app"},
+			name:        "version without repository uses regular chart home",
+			chartHome:   func(string) string { return "charts" },
+			chartFields: "    version: 1.2.3\n",
+			expected:    func(root string) string { return filepath.Join(root, "charts", "app") },
 		},
 	}
 
@@ -149,15 +151,31 @@ helmCharts:
 %s    releaseName: app
 `, chartHome, tt.chartFields))
 
-			directories, err := KustomizeHelmChartDirectories(root)
+			directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 			require.NoError(t, err)
-			expected := filepath.Join(append([]string{root}, tt.expectedParts...)...)
-			if filepath.IsAbs(chartHome) {
-				expected = filepath.Join(chartHome, "app")
-			}
-			assert.Equal(t, []string{expected}, directories)
+			assert.Equal(t, []string{tt.expected(root)}, directories)
 		})
 	}
+}
+
+func TestAppendOwnedHelmChartTree_PreservesPartialDiscovery(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "charts", "dependency")
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+
+	seen := map[string]struct{}{}
+	var directories []string
+	appendOwnedHelmChartTreeWithLister(
+		context.Background(),
+		root,
+		seen,
+		&directories,
+		func(string) ([]string, []error) {
+			return []string{nested}, []error{errors.New("synthetic partial walk failure")}
+		},
+	)
+
+	assert.Equal(t, []string{root, nested}, directories)
 }
 
 func TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph(t *testing.T) {
@@ -189,7 +207,7 @@ helmCharts:
     releaseName: component-app
 `)
 
-	directories, err := KustomizeHelmChartDirectories(root)
+	directories, err := KustomizeHelmChartDirectories(context.Background(), root)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		filepath.Join(base, "charts", "base-app"),

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -1,12 +1,14 @@
 package cautils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetKustomizeDirectoryName(t *testing.T) {
@@ -68,6 +70,131 @@ func TestGetKustomizeDirectoryName(t *testing.T) {
 func kustomizeTestdataPath() string {
 	o, _ := os.Getwd()
 	return filepath.Join(o, "testdata", "kustomize")
+}
+
+func TestKustomizeHelmChartDirectories_CustomHomeDeduplicatesPhysicalChart(t *testing.T) {
+	root := t.TempDir()
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    releaseName: first
+  - name: app
+    releaseName: second
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(root, "vendor", "charts", "app")}, directories)
+}
+
+func TestKustomizeHelmChartDirectories_VersionedRepositoryChart(t *testing.T) {
+	root := t.TempDir()
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    version: 1.2.3
+    repo: https://charts.example.com
+    releaseName: app
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join(root, "vendor", "charts", "app-1.2.3", "app"),
+	}, directories)
+}
+
+func TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout(t *testing.T) {
+	tests := []struct {
+		name          string
+		chartHome     func(string) string
+		chartFields   string
+		expectedParts []string
+	}{
+		{
+			name:          "absolute chart home",
+			chartHome:     func(root string) string { return filepath.Join(root, "absolute-charts") },
+			expectedParts: []string{"absolute-charts", "app"},
+		},
+		{
+			name:          "repository without version uses regular chart home",
+			chartHome:     func(string) string { return "charts" },
+			chartFields:   "    repo: https://charts.example.com\n",
+			expectedParts: []string{"charts", "app"},
+		},
+		{
+			name:          "version without repository uses regular chart home",
+			chartHome:     func(string) string { return "charts" },
+			chartFields:   "    version: 1.2.3\n",
+			expectedParts: []string{"charts", "app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			chartHome := tt.chartHome(root)
+			writeManifestFixture(t, root, "kustomization.yaml", fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: %q
+helmCharts:
+  - name: app
+%s    releaseName: app
+`, chartHome, tt.chartFields))
+
+			directories, err := KustomizeHelmChartDirectories(root)
+			require.NoError(t, err)
+			expected := filepath.Join(append([]string{root}, tt.expectedParts...)...)
+			if filepath.IsAbs(chartHome) {
+				expected = filepath.Join(chartHome, "app")
+			}
+			assert.Equal(t, []string{expected}, directories)
+		})
+	}
+}
+
+func TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	component := filepath.Join(root, "component")
+	require.NoError(t, os.MkdirAll(base, 0o750))
+	require.NoError(t, os.MkdirAll(component, 0o750))
+
+	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+components:
+  - component
+`)
+	writeManifestFixture(t, base, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: base-app
+    releaseName: base-app
+`)
+	writeManifestFixture(t, component, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: component-app
+    releaseName: component-app
+`)
+
+	directories, err := KustomizeHelmChartDirectories(root)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		filepath.Join(base, "charts", "base-app"),
+		filepath.Join(component, "vendor", "charts", "component-app"),
+	}, directories)
 }
 
 // TestKustomizeOverlayWithBase tests that kustomize overlays can properly load

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -276,33 +276,26 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		repoRoot = filepath.Dir(repoRoot)
 	}
 
-	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
-	// the generic recursive Helm loader as well would add a standalone release beside the transformed
-	// Kustomize output.
-	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(ctx, path)
+	// A broad directory input may contain Kustomize configurations below its root.
+	// Render them first so the generic Helm and plain-manifest passes can respect
+	// only the configurations whose builds actually succeeded.
+	kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// render helm charts first, so the plain-YAML loader knows which charts' templates the render
-	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
-	// its templates must stay plainly scanned rather than vanish from the scan.
-	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Confirm that the owning Kustomize render succeeds before excluding its chart
-	// templates from the plain-manifest fallback.
-	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
+	// Charts owned by a successful Kustomize build must not also be rendered as
+	// standalone Helm releases. Unreferenced charts remain in generic discovery.
+	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeResult.OwnedHelmChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// load resource from local file system
-	// Kustomize-owned charts are excluded here too: their templates are covered by the Kustomize
-	// render even though the generic Helm renderer deliberately left them alone.
-	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeHelmChartDirectories...)
+	// Kustomize-owned chart templates are covered by that build even though the
+	// generic Helm renderer left them alone. CRDs are filtered separately according
+	// to includeCRDs, so an omitted CRD remains available to the raw-file pass.
+	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeResult.OwnedHelmChartDirectories...)
 	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
 	if err != nil {
 		return nil, nil, err
@@ -311,6 +304,12 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// update workloads and workloadIDToSource
 	var warnIssued bool
 	for source, ws := range sourceToWorkloads {
+		// Kustomize can transform identity fields, so identity deduplication cannot
+		// reliably remove the corresponding raw input. Exclude only paths covered by
+		// successful builds; broken nested configurations retain their raw fallback.
+		if kustomizeResult.OwnsPlainFile(source) {
+			continue
+		}
 		workloads = append(workloads, ws...)
 
 		relSource, err := filepath.Rel(repoRoot, source)
@@ -401,9 +400,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		logger.L().Debug("helm templates found in local storage", helpers.Int("helmTemplates", len(helmSourceToWorkloads)), helpers.Int("workloads", len(workloads)))
 	}
 
-	// update workloads and workloadIDToSource with workloads from Kustomize Directory
-	for source, ws := range kustomizeSourceToWorkloads {
+	// update workloads and workloadIDToSource with workloads from Kustomize directories
+	for source, ws := range kustomizeResult.SourceToWorkloads {
 		workloads = append(workloads, ws...)
+		kustomizeDirectoryName := source
 		relSource, err := filepath.Rel(repoRoot, source)
 
 		if err == nil {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -279,7 +279,7 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
 	// the generic recursive Helm loader as well would add a standalone release beside the transformed
 	// Kustomize output.
-	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(path)
+	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,6 +288,13 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
 	// its templates must stay plainly scanned rather than vanish from the scan.
 	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Confirm that the owning Kustomize render succeeds before excluding its chart
+	// templates from the plain-manifest fallback.
+	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,13 +399,6 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 
 	if len(helmSourceToWorkloads) > 0 { // && len(helmSourceToNodes) > 0
 		logger.L().Debug("helm templates found in local storage", helpers.Int("helmTemplates", len(helmSourceToWorkloads)), helpers.Int("workloads", len(workloads)))
-	}
-
-	//patch, get value from env
-	// Load resources from Kustomize directory
-	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
-	if err != nil {
-		return nil, nil, err
 	}
 
 	// update workloads and workloadIDToSource with workloads from Kustomize Directory

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -276,16 +276,27 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		repoRoot = filepath.Dir(repoRoot)
 	}
 
+	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
+	// the generic recursive Helm loader as well would add a standalone release beside the transformed
+	// Kustomize output.
+	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// render helm charts first, so the plain-YAML loader knows which charts' templates the render
 	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
 	// its templates must stay plainly scanned rather than vanish from the scan.
-	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmCharts(ctx, path, helmValueOpts)
+	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// load resource from local file system
-	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, renderedCharts)
+	// Kustomize-owned charts are excluded here too: their templates are covered by the Kustomize
+	// render even though the generic Helm renderer deliberately left them alone.
+	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeHelmChartDirectories...)
+	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -307,52 +307,30 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		repoRoot = filepath.Dir(repoRoot)
 	}
 
-	// A chart referenced by this Kustomization belongs to the Kustomize render. Rendering it through
-	// the generic recursive Helm loader as well would add a standalone release beside the transformed
-	// Kustomize output.
-	kustomizeHelmChartDirectories, err := cautils.KustomizeHelmChartDirectories(ctx, path)
+	// A broad directory input may contain Kustomize configurations below its root.
+	// Render them first so the generic Helm and plain-manifest passes can respect
+	// only the configurations whose builds actually succeeded.
+	kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// render helm charts first, so the plain-YAML loader knows which charts' templates the render
-	// already covered and can skip only those. A chart whose render failed is dropped whole here, so
-	// its templates must stay plainly scanned rather than vanish from the scan.
-	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeHelmChartDirectories)
+	// Charts owned by a successful Kustomize build must not also be rendered as
+	// standalone Helm releases. Unreferenced charts remain in generic discovery.
+	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeResult.OwnedHelmChartDirectories)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// Confirm that the owning Kustomize render succeeds before excluding its chart
-	// templates from the plain-manifest fallback.
-	kustomizeSourceToWorkloads, _, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// path itself may not be a Kustomize directory (e.g. a repository root), but a child
-	// directory below it can still hold its own Kustomization. Discover and render those too,
-	// so a broad scan applies their transformations instead of falling through to raw manifests.
-	nestedKustomizeSourceToWorkloads, nestedKustomizeDirs := cautils.LoadResourcesFromNestedKustomizeDirectories(ctx, path)
-	if len(nestedKustomizeSourceToWorkloads) > 0 {
-		if kustomizeSourceToWorkloads == nil {
-			kustomizeSourceToWorkloads = map[string][]workloadinterface.IMetadata{}
-		}
-		maps.Copy(kustomizeSourceToWorkloads, nestedKustomizeSourceToWorkloads)
 	}
 
 	// load resource from local file system
-	// Kustomize-owned charts are excluded here too: their templates are covered by the Kustomize
-	// render even though the generic Helm renderer deliberately left them alone.
-	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeHelmChartDirectories...)
+	// Kustomize-owned chart templates are covered by that build even though the
+	// generic Helm renderer left them alone. CRDs are filtered separately according
+	// to includeCRDs, so an omitted CRD remains available to the raw-file pass.
+	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeResult.OwnedHelmChartDirectories...)
 	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
 	if err != nil {
 		return nil, nil, err
 	}
-	// A nested Kustomization owns the local inputs it rendered; keep them from also being
-	// consumed by the plain-manifest loader as untransformed raw manifests.
-	excludeFilesUnderDirectories(sourceToWorkloads, nestedKustomizeDirs)
-
 	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraform(ctx, path)
 	if err != nil {
 		return nil, nil, err
@@ -404,6 +382,12 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// update workloads and workloadIDToSource
 	var warnIssued bool
 	for source, ws := range sourceToWorkloads {
+		// Kustomize can transform identity fields, so identity deduplication cannot
+		// reliably remove the corresponding raw input. Exclude only paths covered by
+		// successful builds; broken nested configurations retain their raw fallback.
+		if kustomizeResult.OwnsPlainFile(source) {
+			continue
+		}
 		workloads = append(workloads, ws...)
 
 		relSource, err := filepath.Rel(repoRoot, source)
@@ -494,8 +478,8 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 		logger.L().Debug("helm templates found in local storage", helpers.Int("helmTemplates", len(helmSourceToWorkloads)), helpers.Int("workloads", len(workloads)))
 	}
 
-	// update workloads and workloadIDToSource with workloads from Kustomize Directory
-	for source, ws := range kustomizeSourceToWorkloads {
+	// update workloads and workloadIDToSource with workloads from Kustomize directories
+	for source, ws := range kustomizeResult.SourceToWorkloads {
 		workloads = append(workloads, ws...)
 		// GetWorkloads keys its result by the rendered Kustomize directory's own path, so source
 		// (before it is rewritten to a repo-relative path below) is that directory's name — the

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -3,6 +3,7 @@ package resourcehandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -236,6 +237,51 @@ func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *test
 			"RelativePath must not escape the repository root: %q", rel)
 		assert.Equal(t, "pod.yaml", filepath.Base(rel))
 	}
+}
+
+func TestGetResourcesFromPath_SingleManifestDoesNotRenderUnrelatedKustomizeDirectory(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: requested
+`), 0o600))
+
+	// listDirs treats a file path as a basename pattern below its parent. A
+	// Kustomize directory with that basename makes the unintended traversal
+	// observable instead of relying on implementation details alone.
+	unrelatedDirectory := filepath.Join(root, "unrelated", "manifest.yaml")
+	require.NoError(t, os.MkdirAll(unrelatedDirectory, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(unrelatedDirectory, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: unrelated-
+resources:
+  - deployment.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(unrelatedDirectory, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+
+	_, workloads, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+	require.Len(t, workloads, 1, "an exact file scan must not add resources from its parent tree")
+	assert.Equal(t, "ConfigMap", workloads[0].GetKind())
+	assert.Equal(t, "requested", workloads[0].GetName())
 }
 
 // newRepoWithUnusableGitMetadata builds a repository that go-git can locate but
@@ -517,13 +563,278 @@ template)
 	chart_path=$3
 	[ -f "$chart_path/Chart.yaml" ] && [ -f "$chart_path/templates/configmap.yaml" ] || die "unexpected chart: $chart_path"
 	printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: %s\n' "$release_name"
+	include_crds=false
+	for arg in "$@"; do
+		if [ "$arg" = "--include-crds" ]; then
+			include_crds=true
+		fi
+	done
+	if [ "$include_crds" = true ] && [ -f "$chart_path/crds/test.yaml" ]; then
+		printf '%s\n' '---'
+		while IFS= read -r line || [ -n "$line" ]; do
+			printf '%s\n' "$line"
+		done < "$chart_path/crds/test.yaml"
+	fi
     ;;
 *)
 	die "unsupported helm command: ${1:-}"
     ;;
 esac
 `), 0o750))
-	t.Setenv("PATH", binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestGetResourcesFromPath_RendersNestedKustomizeDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+resources:
+  - deployment.yaml
+  - ../shared.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "shared.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "unreferenced.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unreferenced
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "standalone.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var renderedDeployment workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "Deployment" && workload.GetName() == "prod-app" {
+			renderedDeployment = workload
+		}
+	}
+
+	assert.Equal(t, 1, counts["Deployment/prod-app"], "the nested Kustomize output must be scanned")
+	assert.Zero(t, counts["Deployment/app"], "the untransformed source manifest must not also be scanned")
+	assert.Equal(t, 1, counts["ConfigMap/prod-shared"], "a referenced source outside the Kustomize directory must be owned by the render")
+	assert.Zero(t, counts["ConfigMap/shared"], "the external source must not also be scanned raw")
+	assert.Zero(t, counts["Kustomization/"], "the Kustomization file is build input, not a workload")
+	assert.Equal(t, 1, counts["ConfigMap/unreferenced"], "an unreferenced manifest beside the Kustomization must remain")
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "plain manifests outside the Kustomize tree must remain")
+
+	require.NotNil(t, renderedDeployment)
+	source, ok := sources[renderedDeployment.GetID()]
+	require.True(t, ok)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, source.FileType)
+	assert.Equal(t, "app", filepath.ToSlash(source.RelativePath))
+	assert.Equal(t, appDir, source.KustomizeDirectoryName)
+}
+
+func TestGetResourcesFromPath_NestedKustomizeOwnsReferencedHelmChart(t *testing.T) {
+	installFakeHelm(t)
+
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	ownedChart := filepath.Join(appDir, "charts", "app")
+	standaloneChart := filepath.Join(repoRoot, "standalone-chart")
+
+	writeChart := func(directory, name string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "Chart.yaml"), []byte("apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "values.yaml"), []byte("{}\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "templates", "configmap.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n"), 0o600))
+	}
+	writeChart(ownedChart, "app")
+	writeChart(standaloneChart, "standalone")
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+helmCharts:
+  - name: app
+    releaseName: app
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var transformed workloadinterface.IMetadata
+	var standalone workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		switch workload.GetName() {
+		case "prod-app":
+			transformed = workload
+		case "standalone":
+			standalone = workload
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/prod-app"], "the nested Kustomize Helm output must be scanned exactly once")
+	assert.Zero(t, counts["ConfigMap/app"], "the Kustomize-owned chart must not also be rendered as a standalone release")
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "an unreferenced sibling chart must remain in generic Helm discovery")
+	require.NotNil(t, transformed)
+	require.NotNil(t, standalone)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, sources[transformed.GetID()].FileType)
+	assert.Equal(t, reporthandling.SourceTypeHelmChart, sources[standalone.GetID()].FileType)
+}
+
+func TestGetResourcesFromPath_NestedKustomizeHelmCRDOwnershipFollowsIncludeCRDs(t *testing.T) {
+	for _, includeCRDs := range []bool{false, true} {
+		t.Run(fmt.Sprintf("includeCRDs=%t", includeCRDs), func(t *testing.T) {
+			installFakeHelm(t)
+
+			repoRoot := t.TempDir()
+			appDir := filepath.Join(repoRoot, "app")
+			chartDir := filepath.Join(repoRoot, "vendor", "charts", "app")
+			require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "templates"), 0o750))
+			require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "crds"), 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: app\nversion: 0.1.0\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("{}\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "templates", "configmap.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "crds", "test.yaml"), []byte(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`), 0o600))
+			require.NoError(t, os.MkdirAll(appDir, 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: ../vendor/charts
+helmCharts:
+  - name: app
+    releaseName: app
+    includeCRDs: %t
+`, includeCRDs)), 0o600))
+
+			ctx := context.Background()
+			kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, repoRoot)
+			require.NoError(t, err)
+			var renderedCRDs int
+			for _, renderedWorkloads := range kustomizeResult.SourceToWorkloads {
+				for _, workload := range renderedWorkloads {
+					if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+						renderedCRDs++
+					}
+				}
+			}
+
+			rawSources, err := cautils.LoadResourcesFromFiles(ctx, repoRoot, repoRoot, kustomizeResult.OwnedHelmChartDirectories)
+			require.NoError(t, err)
+			var rawCRDs int
+			for source, rawWorkloads := range rawSources {
+				if kustomizeResult.OwnsPlainFile(source) {
+					continue
+				}
+				for _, workload := range rawWorkloads {
+					if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+						rawCRDs++
+					}
+				}
+			}
+			if includeCRDs {
+				assert.Equal(t, 1, renderedCRDs, "Kustomize must emit the CRD when includeCRDs is true")
+				assert.Zero(t, rawCRDs, "the raw pass must exclude the CRD before identity deduplication")
+			} else {
+				assert.Zero(t, renderedCRDs, "Kustomize must omit the CRD when includeCRDs is false")
+				assert.Equal(t, 1, rawCRDs, "the raw pass must retain the omitted CRD")
+			}
+
+			sources, workloads, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{})
+			require.NoError(t, err)
+
+			var crds []workloadinterface.IMetadata
+			for _, workload := range workloads {
+				if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+					crds = append(crds, workload)
+				}
+			}
+			require.Len(t, crds, 1, "the final CRD must be present exactly once")
+			expectedSourceType := reporthandling.SourceTypeYaml
+			if includeCRDs {
+				expectedSourceType = reporthandling.SourceTypeKustomizeDirectory
+			}
+			assert.Equal(t, expectedSourceType, sources[crds[0].GetID()].FileType)
+		})
+	}
+}
+
+func TestGetResourcesFromPath_BrokenNestedKustomizeDoesNotAbortBroadScan(t *testing.T) {
+	repoRoot := t.TempDir()
+	brokenDir := filepath.Join(repoRoot, "broken")
+	require.NoError(t, os.MkdirAll(brokenDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(brokenDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - valid.yaml
+  - missing.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(brokenDir, "valid.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inside-broken
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "standalone.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var insideBroken workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "ConfigMap" && workload.GetName() == "inside-broken" {
+			insideBroken = workload
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "an invalid child configuration must not hide valid sibling resources")
+	assert.Equal(t, 1, counts["ConfigMap/inside-broken"], "a valid input in the failed build must remain in the raw fallback")
+	require.NotNil(t, insideBroken)
+	assert.Equal(t, reporthandling.SourceTypeYaml, sources[insideBroken.GetID()].FileType)
 }
 
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -251,6 +251,65 @@ func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) 
 	assert.Equal(t, "prod-test-app", deployment.GetName())
 }
 
+func TestGetResourcesFromPath_KustomizeOwnsReferencedHelmChart(t *testing.T) {
+	root := t.TempDir()
+	chartDir := filepath.Join(root, "vendor", "charts", "app")
+	templateDir := filepath.Join(chartDir, "templates")
+	require.NoError(t, os.MkdirAll(templateDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+helmGlobals:
+  chartHome: vendor/charts
+helmCharts:
+  - name: app
+    releaseName: first
+  - name: app
+    releaseName: second
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: app\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "configmap.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
+	if err != nil && kustomizeHelmUnavailable(err) {
+		t.Skipf("Kustomize Helm integration is unavailable: %v", err)
+	}
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var configMaps int
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "ConfigMap" {
+			configMaps++
+			assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, sources[workload.GetID()].FileType)
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/prod-first"], "the first Kustomize inflation must survive")
+	assert.Equal(t, 1, counts["ConfigMap/prod-second"], "the second Kustomize inflation must survive")
+	assert.Equal(t, 2, configMaps, "the chart must not also be rendered as a standalone Helm release")
+}
+
+func kustomizeHelmUnavailable(err error) bool {
+	message := err.Error()
+	for _, fragment := range []string{
+		`exec: "helm": executable file not found`,
+		"unknown shorthand flag",
+		"unknown flag",
+		"unable to run: 'helm version -c --short'",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("replicas: 3\n"), 0o600))

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,51 @@ func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *test
 			"RelativePath must not escape the repository root: %q", rel)
 		assert.Equal(t, "pod.yaml", filepath.Base(rel))
 	}
+}
+
+func TestGetResourcesFromPath_SingleManifestDoesNotRenderUnrelatedKustomizeDirectory(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: requested
+`), 0o600))
+
+	// listDirs treats a file path as a basename pattern below its parent. A
+	// Kustomize directory with that basename makes the unintended traversal
+	// observable instead of relying on implementation details alone.
+	unrelatedDirectory := filepath.Join(root, "unrelated", "manifest.yaml")
+	require.NoError(t, os.MkdirAll(unrelatedDirectory, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(unrelatedDirectory, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: unrelated-
+resources:
+  - deployment.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(unrelatedDirectory, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+
+	_, workloads, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+	require.Len(t, workloads, 1, "an exact file scan must not add resources from its parent tree")
+	assert.Equal(t, "ConfigMap", workloads[0].GetKind())
+	assert.Equal(t, "requested", workloads[0].GetName())
 }
 
 // newRepoWithUnusableGitMetadata builds a repository that go-git can locate but
@@ -320,6 +366,18 @@ template)
 	chart_path=$3
 	[ -f "$chart_path/Chart.yaml" ] && [ -f "$chart_path/templates/configmap.yaml" ] || die "unexpected chart: $chart_path"
 	printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: %s\n' "$release_name"
+	include_crds=false
+	for arg in "$@"; do
+		if [ "$arg" = "--include-crds" ]; then
+			include_crds=true
+		fi
+	done
+	if [ "$include_crds" = true ] && [ -f "$chart_path/crds/test.yaml" ]; then
+		printf '%s\n' '---'
+		while IFS= read -r line || [ -n "$line" ]; do
+			printf '%s\n' "$line"
+		done < "$chart_path/crds/test.yaml"
+	fi
     ;;
 *)
 	die "unsupported helm command: ${1:-}"
@@ -327,6 +385,259 @@ template)
 esac
 `), 0o750))
 	t.Setenv("PATH", binDir)
+}
+
+func TestGetResourcesFromPath_RendersNestedKustomizeDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+resources:
+  - deployment.yaml
+  - ../shared.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "shared.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "unreferenced.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unreferenced
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "standalone.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var renderedDeployment workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "Deployment" && workload.GetName() == "prod-app" {
+			renderedDeployment = workload
+		}
+	}
+
+	assert.Equal(t, 1, counts["Deployment/prod-app"], "the nested Kustomize output must be scanned")
+	assert.Zero(t, counts["Deployment/app"], "the untransformed source manifest must not also be scanned")
+	assert.Equal(t, 1, counts["ConfigMap/prod-shared"], "a referenced source outside the Kustomize directory must be owned by the render")
+	assert.Zero(t, counts["ConfigMap/shared"], "the external source must not also be scanned raw")
+	assert.Zero(t, counts["Kustomization/"], "the Kustomization file is build input, not a workload")
+	assert.Equal(t, 1, counts["ConfigMap/unreferenced"], "an unreferenced manifest beside the Kustomization must remain")
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "plain manifests outside the Kustomize tree must remain")
+
+	require.NotNil(t, renderedDeployment)
+	source, ok := sources[renderedDeployment.GetID()]
+	require.True(t, ok)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, source.FileType)
+	assert.Equal(t, "app", filepath.ToSlash(source.RelativePath))
+	assert.Equal(t, appDir, source.KustomizeDirectoryName)
+}
+
+func TestGetResourcesFromPath_NestedKustomizeOwnsReferencedHelmChart(t *testing.T) {
+	installFakeHelm(t)
+
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	ownedChart := filepath.Join(appDir, "charts", "app")
+	standaloneChart := filepath.Join(repoRoot, "standalone-chart")
+
+	writeChart := func(directory, name string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Join(directory, "templates"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "Chart.yaml"), []byte("apiVersion: v2\nname: "+name+"\nversion: 0.1.0\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "values.yaml"), []byte("{}\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "templates", "configmap.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+name+"\n"), 0o600))
+	}
+	writeChart(ownedChart, "app")
+	writeChart(standaloneChart, "standalone")
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+helmCharts:
+  - name: app
+    releaseName: app
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var transformed workloadinterface.IMetadata
+	var standalone workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		switch workload.GetName() {
+		case "prod-app":
+			transformed = workload
+		case "standalone":
+			standalone = workload
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/prod-app"], "the nested Kustomize Helm output must be scanned exactly once")
+	assert.Zero(t, counts["ConfigMap/app"], "the Kustomize-owned chart must not also be rendered as a standalone release")
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "an unreferenced sibling chart must remain in generic Helm discovery")
+	require.NotNil(t, transformed)
+	require.NotNil(t, standalone)
+	assert.Equal(t, reporthandling.SourceTypeKustomizeDirectory, sources[transformed.GetID()].FileType)
+	assert.Equal(t, reporthandling.SourceTypeHelmChart, sources[standalone.GetID()].FileType)
+}
+
+func TestGetResourcesFromPath_NestedKustomizeHelmCRDOwnershipFollowsIncludeCRDs(t *testing.T) {
+	for _, includeCRDs := range []bool{false, true} {
+		t.Run(fmt.Sprintf("includeCRDs=%t", includeCRDs), func(t *testing.T) {
+			installFakeHelm(t)
+
+			repoRoot := t.TempDir()
+			appDir := filepath.Join(repoRoot, "app")
+			chartDir := filepath.Join(repoRoot, "vendor", "charts", "app")
+			require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "templates"), 0o750))
+			require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "crds"), 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: app\nversion: 0.1.0\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("{}\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "templates", "configmap.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app\n"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(chartDir, "crds", "test.yaml"), []byte(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`), 0o600))
+			require.NoError(t, os.MkdirAll(appDir, 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: ../vendor/charts
+helmCharts:
+  - name: app
+    releaseName: app
+    includeCRDs: %t
+`, includeCRDs)), 0o600))
+
+			ctx := context.Background()
+			kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, repoRoot)
+			require.NoError(t, err)
+			var renderedCRDs int
+			for _, renderedWorkloads := range kustomizeResult.SourceToWorkloads {
+				for _, workload := range renderedWorkloads {
+					if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+						renderedCRDs++
+					}
+				}
+			}
+
+			rawSources, err := cautils.LoadResourcesFromFiles(ctx, repoRoot, repoRoot, kustomizeResult.OwnedHelmChartDirectories)
+			require.NoError(t, err)
+			var rawCRDs int
+			for source, rawWorkloads := range rawSources {
+				if kustomizeResult.OwnsPlainFile(source) {
+					continue
+				}
+				for _, workload := range rawWorkloads {
+					if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+						rawCRDs++
+					}
+				}
+			}
+			if includeCRDs {
+				assert.Equal(t, 1, renderedCRDs, "Kustomize must emit the CRD when includeCRDs is true")
+				assert.Zero(t, rawCRDs, "the raw pass must exclude the CRD before identity deduplication")
+			} else {
+				assert.Zero(t, renderedCRDs, "Kustomize must omit the CRD when includeCRDs is false")
+				assert.Equal(t, 1, rawCRDs, "the raw pass must retain the omitted CRD")
+			}
+
+			sources, workloads, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{})
+			require.NoError(t, err)
+
+			var crds []workloadinterface.IMetadata
+			for _, workload := range workloads {
+				if workload.GetKind() == "CustomResourceDefinition" && workload.GetName() == "widgets.example.com" {
+					crds = append(crds, workload)
+				}
+			}
+			require.Len(t, crds, 1, "the final CRD must be present exactly once")
+			expectedSourceType := reporthandling.SourceTypeYaml
+			if includeCRDs {
+				expectedSourceType = reporthandling.SourceTypeKustomizeDirectory
+			}
+			assert.Equal(t, expectedSourceType, sources[crds[0].GetID()].FileType)
+		})
+	}
+}
+
+func TestGetResourcesFromPath_BrokenNestedKustomizeDoesNotAbortBroadScan(t *testing.T) {
+	repoRoot := t.TempDir()
+	brokenDir := filepath.Join(repoRoot, "broken")
+	require.NoError(t, os.MkdirAll(brokenDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(brokenDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - valid.yaml
+  - missing.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(brokenDir, "valid.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inside-broken
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "standalone.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone
+`), 0o600))
+
+	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	var insideBroken workloadinterface.IMetadata
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+		if workload.GetKind() == "ConfigMap" && workload.GetName() == "inside-broken" {
+			insideBroken = workload
+		}
+	}
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "an invalid child configuration must not hide valid sibling resources")
+	assert.Equal(t, 1, counts["ConfigMap/inside-broken"], "a valid input in the failed build must remain in the raw fallback")
+	require.NotNil(t, insideBroken)
+	assert.Equal(t, reporthandling.SourceTypeYaml, sources[insideBroken.GetID()].FileType)
 }
 
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -584,7 +584,7 @@ esac
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-func TestGetResourcesFromPath_RendersNestedKustomizeDirectory(t *testing.T) {
+func TestGetResourcesFromPath_RendersNestedKustomizeDirectoryWithPreciseOwnership(t *testing.T) {
 	repoRoot := t.TempDir()
 	appDir := filepath.Join(repoRoot, "app")
 	require.NoError(t, os.MkdirAll(appDir, 0o750))

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -252,6 +252,8 @@ func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) 
 }
 
 func TestGetResourcesFromPath_KustomizeOwnsReferencedHelmChart(t *testing.T) {
+	installFakeHelm(t)
+
 	root := t.TempDir()
 	chartDir := filepath.Join(root, "vendor", "charts", "app")
 	templateDir := filepath.Join(chartDir, "templates")
@@ -276,9 +278,6 @@ metadata:
 `), 0o600))
 
 	sources, workloads, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
-	if err != nil && kustomizeHelmUnavailable(err) {
-		t.Skipf("Kustomize Helm integration is unavailable: %v", err)
-	}
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -295,19 +294,39 @@ metadata:
 	assert.Equal(t, 2, configMaps, "the chart must not also be rendered as a standalone Helm release")
 }
 
-func kustomizeHelmUnavailable(err error) bool {
-	message := err.Error()
-	for _, fragment := range []string{
-		`exec: "helm": executable file not found`,
-		"unknown shorthand flag",
-		"unknown flag",
-		"unable to run: 'helm version -c --short'",
-	} {
-		if strings.Contains(message, fragment) {
-			return true
-		}
+func installFakeHelm(t *testing.T) {
+	t.Helper()
+	if os.PathSeparator == '\\' {
+		t.Skip("the deterministic Helm test double requires a POSIX shell")
 	}
-	return false
+
+	binDir := t.TempDir()
+	helmPath := filepath.Join(binDir, "helm")
+	//nolint:gosec // The test-owned Helm double must be executable by Kustomize.
+	require.NoError(t, os.WriteFile(helmPath, []byte(`#!/bin/sh
+set -eu
+die() {
+    printf '%s\n' "$*" >&2
+    exit 2
+}
+case "${1:-}" in
+version)
+    [ "$#" -eq 3 ] && [ "$2" = "-c" ] && [ "$3" = "--short" ] || die "unexpected version args: $*"
+    printf '%s\n' 'v3.14.0+gtest'
+    ;;
+template)
+	[ "$#" -ge 3 ] || die "missing template args"
+	release_name=$2
+	chart_path=$3
+	[ -f "$chart_path/Chart.yaml" ] && [ -f "$chart_path/templates/configmap.yaml" ] || die "unexpected chart: $chart_path"
+	printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: %s\n' "$release_name"
+    ;;
+*)
+	die "unsupported helm command: ${1:-}"
+    ;;
+esac
+`), 0o750))
+	t.Setenv("PATH", binDir)
 }
 
 func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testing.T) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,6 +231,9 @@ kubescape scan /path/to/kustomize/directory
 > **Note**  
 > Kubescape will generate Kubernetes YAML objects using the 
 > `kustomization.yaml` file and scan them for security.
+> A broader directory scan also builds nested Kustomizations. Kustomize may
+> follow references outside the scan root, and a nested `helmCharts.repo` may
+> fetch remote chart content, so scan only source you trust to build.
 > If a directory contains both `Chart.yaml` and 
 > `kustomization.yaml`, Kubescape will treat it as a Helm chart.
 


### PR DESCRIPTION
Resolves #2858

Rebased onto current `master`; prerequisite #2855 is already merged.

## Summary

- discover Kustomize configurations below a broad directory input that is not itself an explicit Kustomize input;
- render each configuration with the existing Kustomize build path;
- omit the exact local inputs owned by successful builds from the raw YAML pass, which prevents transformed resources from coexisting with their untransformed inputs without hiding unrelated YAML beside a Kustomization;
- keep a failed child configuration in the existing raw-file fallback so it cannot abort or hide valid sibling resources;
- preserve unreferenced plain manifests and the existing direct-file/direct-directory behavior;
- compose with #2855 so referenced charts stay with Kustomize, including the `includeCRDs` true/false boundary.

## Root cause

Helm and plain-manifest loading recurse below the scan input, but the Kustomize loader was called only with the input path itself. A repository root without its own Kustomization therefore skipped every child configuration and parsed those children as plain YAML.

Identity deduplication is insufficient here because Kustomize can change identity fields. For example, `namePrefix: prod-` makes the raw `Deployment/app` and rendered `Deployment/prod-app` different identities.

The prerequisite PR assigns a Kustomization's referenced local charts to the Kustomize renderer. This PR applies that ownership planning to every successfully rendered nested configuration before generic Helm discovery. Ownership is inspected after the build so remotely pulled charts and their nested chart tree are visible. A nested `helmCharts` entry therefore cannot introduce both Kustomize-transformed and standalone Helm output, while an unreferenced sibling chart remains eligible for generic Helm discovery.

Only successful Kustomize renders claim their local source and chart inputs. Source ownership follows the selected Kustomization graph (including local resources, components, CRD schemas, patches, generators, transformers, validators, and Helm values files) instead of claiming the whole containing directory. A build or parse failure found under a broad input is logged and its inputs stay in the existing plain-file path. An explicitly selected Kustomization retains the existing hard-failure behavior.

Ownership uses the prerequisite's lexical/physical path alias rules, so symlinked paths and relative direct inputs match the absolute paths returned by recursive discovery. The original input is still passed unchanged to the existing renderer and attribution code.

Kustomize-owned chart templates are excluded after the build succeeds. Chart `crds/` directories are excluded from the raw pass only when the corresponding `helmCharts` entry sets `includeCRDs: true`; with the default `false`, the raw CRD remains because Kustomize did not emit it. This avoids both duplicate transformed CRDs and silent CRD loss.

## Tests

The integration regression builds this layout under a temporary repository root:

```text
repo/
├── shared.yaml             # referenced from app/
├── standalone.yaml         # unrelated
└── app/
    ├── kustomization.yaml  # namePrefix: prod-
    ├── deployment.yaml     # referenced Deployment/app
    └── unreferenced.yaml   # unrelated, must remain raw
```

It asserts that:

- `Deployment/prod-app` is loaded exactly once;
- raw `Deployment/app` and the Kustomization document are absent;
- the transformed external `ConfigMap/prod-shared` replaces raw `ConfigMap/shared`;
- both unrelated ConfigMaps, including the one beside the Kustomization, remain;
- the rendered Deployment retains Kustomize source attribution to `app/`.

Additional regressions assert that:

- recursive discovery resolves a nested Kustomization's custom `chartHome` to the local chart directory without invoking Helm;
- an explicit ordinary manifest does not traverse its parent or render an unrelated Kustomize directory with the same basename;
- ownership includes `crds`, explicit/additional Helm values files, and the implicit chart `values.yaml` when used;
- a local chart referenced by a nested `helmCharts` block is present only as Kustomize-transformed output;
- an unreferenced sibling chart is still rendered by the generic Helm path;
- before final identity dedup, `includeCRDs: true` leaves the CRD only in Kustomize output, while `false` leaves it only in raw YAML;
- a broken child Kustomization does not abort or hide either a valid sibling manifest or a valid referenced file inside the failed build.

Verified with `go1.26.5 linux/amd64`; the Helm composition test used a deterministic test-only `helm` shim on `PATH` so the Kustomize Helm generator executed instead of being skipped:

```bash
go test -p=2 ./core/cautils ./core/pkg/resourcehandler \
  -run '^(TestListKustomizeInputsDiscoversNestedHelmOwnership|TestKustomizeInputOwnershipIncludesCRDAndHelmValuesInputs|TestGetResourcesFromPath_(SingleManifestDoesNotRenderUnrelatedKustomizeDirectory|RendersNestedKustomizeDirectory|NestedKustomizeOwnsReferencedHelmChart|NestedKustomizeHelmCRDOwnershipFollowsIncludeCRDs|BrokenNestedKustomizeDoesNotAbortBroadScan))$' \
  -count=3
go test -p=2 ./core/cautils ./core/pkg/resourcehandler -count=1
go vet -p=2 ./core/cautils ./core/pkg/resourcehandler
```

The focused command, the full `core/cautils` and `core/pkg/resourcehandler` package tests, and `go vet` all pass on the final rebased tree. The focused repository-root regression also fails identically on all three runs against prerequisite head `6fa0fcd` alone (`prod-app: 0`, raw `app: 1`). As a mutation check, disabling only the new nested-directory selection makes the fixed regression fail with the same missing/rendered and unexpected/raw objects; restoring it returns the targeted suite to green.

A bounded race attempt did not reach the tests in this environment: even the isolated `core/cautils` discovery test timed out after three minutes of race-instrumented compilation with no diagnostic output. This is recorded as uncompleted, not as a passing race run or a detected race.

## Scope

This does not change Kustomize build options or the parent-relative base behavior fixed by #1914. It changes how a broader input that is not itself a Kustomize file or directory discovers child entry points, and how inputs covered by a successful build are kept out of the plain-manifest pass. Selecting a Kustomization directly still renders only that selected build graph; it does not recursively add unrelated descendants.

A successfully rendered Kustomization owns its selected local input graph, not every YAML file in its directory. Referenced source files outside the directory are excluded from the raw pass, while unreferenced YAML beside the Kustomization remains eligible. A repository containing multiple bases or overlays gets each discovered Kustomization rendered—this PR does not infer which environment the user intended.

#2855 is already present on `master`; this PR builds on it with recursive discovery and nested composition handling, including precise CRD ownership once the nested render succeeds.

## Review follow-ups

- require an existing regular Kustomization file instead of accepting a directory with a matching basename;
- resolve temporary test roots before path comparisons so macOS `/var` symlinks do not break assertions;
- preserve the caller's `PATH` when installing the deterministic Helm test shim;
- document that broad directory scans render nested Kustomizations, may follow parent-relative inputs, and may fetch repositories declared by `helmCharts.repo`.

The trust-boundary behavior itself is unchanged: broad nested rendering is already the default on `master`, and changing `LoadRestrictionsNone` or disabling Helm would regress established parent-relative and Helm behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Kustomize scanning to discover nested configurations, referenced resources, Helm charts, values files, and CRDs.
  * Added more accurate tracking of rendered workloads and their source files.
* **Bug Fixes**
  * Prevented duplicate processing of Kustomize-owned resources and Helm charts.
  * Improved fallback behavior when nested Kustomize rendering fails.
  * Improved path handling when canonicalization is unavailable.
* **Documentation**
  * Added security guidance about scanning trusted directories and remote content referenced by nested configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->