### PR TITLE
fix(results): preserve enrichment in programmatic and HTTP output

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -13,6 +13,8 @@ import (
 	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter"
 	"github.com/kubescape/kubescape/v3/core/pkg/vapreconcile"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
@@ -67,7 +69,53 @@ func (rh *ResultsHandler) GetReporter() reporter.IReport {
 
 // ToJson returns the results in the JSON format
 func (rh *ResultsHandler) ToJson() ([]byte, error) {
-	return json.Marshal(printerv2.FinalizeResults(rh.ScanData))
+	finalizedReport := printerv2.FinalizeResults(rh.ScanData)
+	enrichedReport := printerv2.ConvertToPostureReportWithSeverityLabelsAndCoverage(
+		finalizedReport,
+		rh.ScanData.LabelsToCopy,
+		rh.ScanData.AllResources,
+		&rh.ScanData.ScanCoverage,
+	)
+
+	// Keep the established programmatic JSON contract and override only the two
+	// control collections for which the output printers derive severity.
+	// Marshaling PostureReportWithSeverity directly would omit legacy top-level
+	// fields, rawResource, and nanoseconds from generationTime.
+	type summaryWithEnrichment struct {
+		reportsummary.SummaryDetails
+		Controls map[string]printerv2.ControlSummaryWithSeverity `json:"controls,omitempty"`
+	}
+	type resultWithEnrichment struct {
+		resourcesresults.Result
+		AssociatedControls []printerv2.ResourceAssociatedControlWithSeverity `json:"controls,omitempty"`
+	}
+
+	results := make([]resultWithEnrichment, len(finalizedReport.Results))
+	for i := range finalizedReport.Results {
+		results[i] = resultWithEnrichment{
+			Result:             finalizedReport.Results[i],
+			AssociatedControls: enrichedReport.Results[i].AssociatedControls,
+		}
+	}
+
+	output := struct {
+		*reporthandlingv2.PostureReport
+		SummaryDetails summaryWithEnrichment        `json:"summaryDetails,omitempty"`
+		Results        []resultWithEnrichment       `json:"results,omitempty"`
+		ResourceLabels map[string]map[string]string `json:"resourceLabels,omitempty"`
+		ScanCoverage   *cautils.ScanCoverage        `json:"scanCoverage,omitempty"`
+	}{
+		PostureReport: finalizedReport,
+		SummaryDetails: summaryWithEnrichment{
+			SummaryDetails: finalizedReport.SummaryDetails,
+			Controls:       enrichedReport.SummaryDetails.Controls,
+		},
+		Results:        results,
+		ResourceLabels: enrichedReport.ResourceLabels,
+		ScanCoverage:   enrichedReport.ScanCoverage,
+	}
+
+	return json.Marshal(&output)
 }
 
 // GetResults returns the results

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DummyReporter struct{}
@@ -418,6 +425,134 @@ func TestToJson(t *testing.T) {
 	// verify it is valid JSON
 	var out map[string]any
 	assert.NoError(t, json.Unmarshal(data, &out))
+}
+
+// requireJSONSubset verifies that every value in the legacy JSON remains at
+// the same path, while allowing the enriched output to add new object fields.
+func requireJSONSubset(t *testing.T, want, got any, path string) {
+	t.Helper()
+	switch want := want.(type) {
+	case map[string]any:
+		gotMap, ok := got.(map[string]any)
+		require.Truef(t, ok, "%s type = %T; want object", path, got)
+		for key, wantValue := range want {
+			gotValue, exists := gotMap[key]
+			require.Truef(t, exists, "legacy JSON path %s.%s disappeared", path, key)
+			requireJSONSubset(t, wantValue, gotValue, path+"."+key)
+		}
+	case []any:
+		gotSlice, ok := got.([]any)
+		require.Truef(t, ok, "%s type = %T; want array", path, got)
+		require.Len(t, gotSlice, len(want), "%s length changed", path)
+		for i := range want {
+			requireJSONSubset(t, want[i], gotSlice[i], fmt.Sprintf("%s[%d]", path, i))
+		}
+	default:
+		assert.Equalf(t, want, got, "legacy JSON value at %s changed", path)
+	}
+}
+
+func TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment(t *testing.T) {
+	const controlID = "C-ENRICHED"
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "app",
+			"namespace": "tenant-a",
+			"labels": map[string]any{
+				"team":    "platform",
+				"ignored": "not-copied",
+			},
+		},
+	})
+	resourceID := resource.GetID()
+	scanData := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			ReportGenerationTime: time.Date(2026, time.August, 9, 1, 2, 3, 456789123, time.UTC),
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{
+					controlID: {ControlID: controlID, Name: "enriched control", ScoreFactor: 7},
+				},
+			},
+		},
+		Metadata: &reporthandlingv2.Metadata{},
+		AllResources: map[string]workloadinterface.IMetadata{
+			resourceID: resource,
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			resourceID: {
+				ResourceID: resourceID,
+				RawResource: &reporthandling.Resource{
+					ResourceID: resourceID,
+					Object:     map[string]any{"compatibilityMarker": "preserved"},
+				},
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{ControlID: controlID, Name: "enriched control"},
+				},
+			},
+		},
+		LabelsToCopy: []string{"team"},
+		ScanCoverage: cautils.ScanCoverage{
+			PartialGVRPulls: []cautils.PartialGVRPull{
+				{GVR: "/v1/pods", Selector: "metadata.namespace=tenant-b", Error: "forbidden"},
+			},
+			CoverageScore: 98,
+			Degraded:      true,
+		},
+		OmitRawResources: true,
+	}
+	rh := NewResultsHandler(&DummyReporter{}, nil, &SpyPrinter{})
+	rh.SetData(scanData)
+
+	legacyData, err := json.Marshal(printerv2.FinalizeResults(scanData))
+	require.NoError(t, err)
+	var legacyOutput map[string]any
+	require.NoError(t, json.Unmarshal(legacyData, &legacyOutput))
+
+	data, err := rh.ToJson()
+	require.NoError(t, err)
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(data, &output))
+	assert.Contains(t, output, "resourceLabels")
+	assert.Contains(t, output, "scanCoverage")
+	summary, ok := output["summaryDetails"].(map[string]any)
+	require.True(t, ok)
+	controls, ok := summary["controls"].(map[string]any)
+	require.True(t, ok)
+	control, ok := controls[controlID].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "High", control["severity"])
+	results, ok := output["results"].([]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	result, ok := results[0].(map[string]any)
+	require.True(t, ok)
+	resultControls, ok := result["controls"].([]any)
+	require.True(t, ok)
+	require.Len(t, resultControls, 1)
+	resultControl, ok := resultControls[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "High", resultControl["severity"])
+	labels, ok := output["resourceLabels"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "platform", labels[resourceID].(map[string]any)["team"])
+	coverage, ok := output["scanCoverage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, coverage["degraded"])
+
+	// ToJson historically marshaled FinalizeResults directly. All of that JSON
+	// must remain intact; the new fields are additive only.
+	for _, key := range []string{"reportGUID", "jobID", "paginationInfo", "customerGUIDGenerated"} {
+		require.Contains(t, legacyOutput, key)
+	}
+	requireJSONSubset(t, legacyOutput, output, "$")
+
+	// The legacy typed accessor remains source-compatible and retains its
+	// established opa-utils return type.
+	var legacy *reporthandlingv2.PostureReport = rh.GetResults()
+	require.NotNil(t, legacy)
+	assert.Equal(t, float32(7), legacy.SummaryDetails.Controls[controlID].ScoreFactor)
 }
 
 func TestGetComplianceScoreAndRiskScoreAreIndependent(t *testing.T) {

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -550,7 +550,8 @@ func TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment(t *testing.T
 
 	// The legacy typed accessor remains source-compatible and retains its
 	// established opa-utils return type.
-	var legacy *reporthandlingv2.PostureReport = rh.GetResults()
+	var legacy *reporthandlingv2.PostureReport
+	legacy = rh.GetResults()
 	require.NotNil(t, legacy)
 	assert.Equal(t, float32(7), legacy.SummaryDetails.Controls[controlID].ScoreFactor)
 }

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -452,6 +452,10 @@ func requireJSONSubset(t *testing.T, want, got any, path string) {
 	}
 }
 
+func asLegacyPostureReport(report *reporthandlingv2.PostureReport) *reporthandlingv2.PostureReport {
+	return report
+}
+
 func TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment(t *testing.T) {
 	const controlID = "C-ENRICHED"
 	resource := workloadinterface.NewWorkloadObj(map[string]any{
@@ -550,8 +554,7 @@ func TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment(t *testing.T
 
 	// The legacy typed accessor remains source-compatible and retains its
 	// established opa-utils return type.
-	var legacy *reporthandlingv2.PostureReport
-	legacy = rh.GetResults()
+	legacy := asLegacyPostureReport(rh.GetResults())
 	require.NotNil(t, legacy)
 	assert.Equal(t, float32(7), legacy.SummaryDetails.Controls[controlID].ScoreFactor)
 }

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -216,7 +216,7 @@ func (e *ScanFailedError) Error() string {
 	return e.Message
 }
 
-func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
+func readResultsFile(fileID string) (json.RawMessage, error) {
 	parsedUUID, err := uuid.Parse(fileID)
 	if err != nil {
 		logger.L().Warning("invalid scan ID requested", helpers.String("ID", fileID), helpers.Error(err))
@@ -242,9 +242,13 @@ func readResultsFile(fileID string) (*reporthandlingv2.PostureReport, error) {
 		path := filepath.Join(OutputDir, cleanID+ext)
 		f, err := os.ReadFile(path)
 		if err == nil {
-			postureReport := &reporthandlingv2.PostureReport{}
-			err = json.Unmarshal(f, postureReport)
-			return postureReport, err
+			// Retain the existing structural validation against PostureReport,
+			// then return the original JSON so additive output fields survive.
+			var postureReport reporthandlingv2.PostureReport
+			if err := json.Unmarshal(f, &postureReport); err != nil {
+				return nil, err
+			}
+			return json.RawMessage(f), nil
 		}
 	}
 

--- a/httphandler/handlerequests/v1/results_handler_test.go
+++ b/httphandler/handlerequests/v1/results_handler_test.go
@@ -10,6 +10,8 @@ import (
 
 	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -158,6 +160,97 @@ func TestResults_GetWhileBusy_ReturnsBusyResponse(t *testing.T) {
 		t.Errorf("GET /results?id=<busy>: response.ID = %q; want %q "+
 			"(callers correlate poll responses by ID)", resp.ID, id)
 	}
+}
+
+func TestResults_GetPreservesEnrichedReportFields(t *testing.T) {
+	const id = "123e4567-e89b-12d3-a456-426614174001"
+	const resourceID = "/v1/tenant-a/Pod/app"
+	out := withTempOutputDirs(t)
+	report := `{
+  "summaryDetails": {
+    "controls": {
+      "C-ENRICHED": {
+        "controlID": "C-ENRICHED",
+        "scoreFactor": 7,
+        "severity": "High"
+      }
+    }
+  },
+  "results": [{
+    "resourceID": "` + resourceID + `",
+    "controls": [{"controlID": "C-ENRICHED", "severity": "High"}]
+  }],
+  "resourceLabels": {
+    "` + resourceID + `": {"team": "platform"}
+  },
+  "scanCoverage": {
+    "partialGVRPulls": [{
+      "gvr": "/v1/pods",
+      "selector": "metadata.namespace=tenant-b",
+      "error": "forbidden"
+    }],
+    "coverageScore": 98,
+    "degraded": true
+  }
+}`
+	if err := os.WriteFile(filepath.Join(out, id), []byte(report), 0o644); err != nil {
+		t.Fatalf("setup: write enriched result: %v", err)
+	}
+
+	h := newResultsHandler(false)
+	rq := httptest.NewRequest(http.MethodGet, "/results?id="+id+"&keep=true", nil)
+	w := httptest.NewRecorder()
+	h.GetResults(w, rq)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("GET enriched result = HTTP %d; want %d (body=%q)", w.Result().StatusCode, http.StatusOK, w.Body.String())
+	}
+	response := decodeResultsResponse(t, w)
+	payload, ok := response.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", response.Response)
+	summary, ok := payload["summaryDetails"].(map[string]any)
+	require.True(t, ok)
+	controls, ok := summary["controls"].(map[string]any)
+	require.True(t, ok)
+	control, ok := controls["C-ENRICHED"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "High", control["severity"])
+	results, ok := payload["results"].([]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	result, ok := results[0].(map[string]any)
+	require.True(t, ok)
+	resultControls, ok := result["controls"].([]any)
+	require.True(t, ok)
+	require.Len(t, resultControls, 1)
+	resultControl, ok := resultControls[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "High", resultControl["severity"])
+	labels, ok := payload["resourceLabels"].(map[string]any)
+	require.True(t, ok)
+	resourceLabels, ok := labels[resourceID].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "platform", resourceLabels["team"])
+	coverage, ok := payload["scanCoverage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, coverage["degraded"])
+	partial, ok := coverage["partialGVRPulls"].([]any)
+	require.True(t, ok)
+	assert.Len(t, partial, 1)
+}
+
+func TestReadResultsFileRetainsPostureReportValidation(t *testing.T) {
+	const id = "123e4567-e89b-12d3-a456-426614174002"
+	out := withTempOutputDirs(t)
+	// This is syntactically valid JSON but is not structurally compatible with
+	// the posture report contract. The old typed unmarshal rejected it, and
+	// preserving unknown fields must not weaken that validation.
+	if err := os.WriteFile(filepath.Join(out, id), []byte(`{"summaryDetails":[]}`), 0o644); err != nil {
+		t.Fatalf("setup: write invalid result: %v", err)
+	}
+
+	_, err := readResultsFile(id)
+	require.ErrorContains(t, err, "cannot unmarshal array")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #2861

## Summary

- make the documented `ResultsHandler.ToJson` path include control severity, selected resource labels, and non-empty scan coverage while retaining its established top-level, summary, and per-result fields plus timestamp precision;
- preserve the existing `GetResults() *reporthandlingv2.PostureReport` API and its storage callers;
- retain typed posture-report validation in the internal HTTP result-file reader, then return the original bytes as `json.RawMessage` so additive output fields survive both synchronous and polled HTTP responses;
- keep the MCP compact response unchanged.

## Why

The JSON/YAML file printers already call `ConvertToPostureReportWithSeverityLabelsAndCoverage`, but `ToJson` marshaled `FinalizeResults` directly. The HTTP server then read an enriched file into the narrower `reporthandlingv2.PostureReport`; `encoding/json` silently discarded fields not represented by that type before the response was marshaled again.

## Compatibility

`GetResults` is an exported method with a concrete return type, so this change does not alter it or add a competing typed accessor. Existing callers and operator-storage persistence continue to receive `*reporthandlingv2.PostureReport`.

`ToJson` keeps the same Go signature. It embeds the finalized legacy report, embeds the original summary and each original result, and overrides only their control collections before adding `resourceLabels` and `scanCoverage`. This preserves existing fields such as `reportGUID`, `jobID`, `paginationInfo`, `customerGUIDGenerated`, per-result `rawResource`, and nanosecond `generationTime` precision. Marshaling the printer's enriched DTO directly would have dropped or changed those values.

`readResultsFile` is unexported. Its callers treat the result only as the HTTP response payload, so using `json.RawMessage` avoids schema narrowing without changing the response envelope. The helper still unmarshals into `PostureReport` first, preserving the prior structural validation and its errors; only the subsequent lossy re-encode is removed. `json.RawMessage` is embedded as JSON, not quoted as a string.

## Tests

- `TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment`
  - derives `High` from a control score factor in both summary and resource results;
  - copies only the requested `team` label;
  - attaches a partial-pull coverage record;
  - verifies `ToJson` contains all three enrichment categories;
  - compile-time pins the legacy `GetResults` return type;
  - compares every pre-existing top-level, summary, result, and control field with the former `FinalizeResults` JSON, including zero-valued legacy keys, `rawResource`, and a nanosecond timestamp; only the new `severity` members may be additive.
- `TestResults_GetPreservesEnrichedReportFields`
  - seeds a valid enriched result artifact;
  - exercises the real `GET /results` response envelope;
  - verifies both severity locations, labels, and coverage survive;
  - proves the payload remains a JSON object rather than double-encoded text.
- `TestReadResultsFileRetainsPostureReportValidation`
  - supplies syntactically valid JSON with a schema-incompatible `summaryDetails` value;
  - verifies the existing typed validation still rejects it.

## Validation

Validation completed:

```text
gofmt: clean
git diff --check: clean
```

```bash
GOMAXPROCS=2 go test -vet=off -p=1 ./core/pkg/resultshandling \
  -run '^(TestToJson|TestGetResults|TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment)$' -count=3
(cd httphandler && GOMAXPROCS=2 go test -vet=off -p=1 ./handlerequests/v1 \
  -run '^(TestResults_GetPreservesEnrichedReportFields|TestReadResultsFileRetainsPostureReportValidation|TestResults_GetWhileBusy_ReturnsBusyResponse|TestReadResultsFile)$' -count=3)
GOMAXPROCS=2 go test -vet=off -p=1 ./core/pkg/resultshandling
(cd httphandler && GOMAXPROCS=2 go test -vet=off -p=1 ./handlerequests/v1)
GOMAXPROCS=2 go vet -p=1 ./core/pkg/resultshandling
(cd httphandler && GOMAXPROCS=2 go vet -p=1 ./handlerequests/v1)
```

All commands pass. As baseline/mutation checks, restoring the old `ToJson` marshal made the new programmatic test fail on both severity locations, labels, and coverage; marshaling the enriched printer DTO directly failed on a missing legacy key and truncated nanoseconds. Restoring the HTTP typed decode/re-encode made the handler test fail on both severity locations and labels. Reapplying the patch returned the targeted three-run tests and both full package suites to green.

Targeted race-enabled tests for both affected modules were attempted with independent five-minute caps. Both reached the cap during race-instrumented compilation without emitting a test result; the commands were terminated with exit 124.

## Scope

This change does not alter scan evaluation, output-file generation, the legacy `GetResults`/operator-storage types, or the compact MCP contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Enriched JSON scan results with severity labels, scan coverage, resource labels, and control details.
  * Preserved existing report fields and compatibility with legacy result formats.
  * Results retrieval now retains additional fields included in valid report files.

* **Bug Fixes**
  * Malformed report files continue to be rejected with appropriate scan failure handling.

* **Tests**
  * Added coverage for enriched result fields, legacy compatibility, and report validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->