### PR TITLE
feat(hostsensor): optimize query with paging, rate limits, and cache

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+	"strings"
+	"time"
 )
 
 var DefaultCacheDir string
@@ -28,18 +30,35 @@ func getCacheDir() (string, error) {
 	return DefaultCacheDir, nil
 }
 
-func getCacheFilePath(resourceName string) (string, error) {
+func getCacheFilePath(clusterName, resourceName string) (string, error) {
 	dir, err := getCacheDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, fmt.Sprintf("%s.json.gz", resourceName)), nil
+	
+	safeClusterName := strings.ReplaceAll(clusterName, "/", "_")
+	safeClusterName = strings.ReplaceAll(safeClusterName, ":", "_")
+	safeClusterName = strings.ReplaceAll(safeClusterName, "\\", "_")
+	if safeClusterName == "" {
+		safeClusterName = "default"
+	}
+
+	return filepath.Join(dir, fmt.Sprintf("%s-%s-v1.json.gz", safeClusterName, resourceName)), nil
 }
 
-func loadFromCache(resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
-	path, err := getCacheFilePath(resourceName)
+func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
+	path, err := getCacheFilePath(clusterName, resourceName)
 	if err != nil {
 		return nil, err
+	}
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if time.Since(stat.ModTime()) > 2*time.Hour {
+		os.Remove(path)
+		return nil, fmt.Errorf("cache expired")
 	}
 
 	f, err := os.Open(path)
@@ -68,18 +87,18 @@ func loadFromCache(resourceName string) ([]hostsensor.HostSensorDataEnvelope, er
 	return envelopes, nil
 }
 
-func saveToCache(resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
-	path, err := getCacheFilePath(resourceName)
+func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
+	path, err := getCacheFilePath(clusterName, resourceName)
 	if err != nil {
 		return err
 	}
 
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -35,7 +35,7 @@ func getCacheFilePath(clusterName, resourceName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	safeClusterName := strings.ReplaceAll(clusterName, "/", "_")
 	safeClusterName = strings.ReplaceAll(safeClusterName, ":", "_")
 	safeClusterName = strings.ReplaceAll(safeClusterName, "\\", "_")
@@ -105,7 +105,7 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 	defer f.Close()
 
 	gw := gzip.NewWriter(f)
-	
+
 	data, err := json.Marshal(envelopes)
 	if err != nil {
 		gw.Close()

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -8,11 +8,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"strings"
+	"time"
+
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
-	"strings"
-	"time"
 )
 
 var DefaultCacheDir string

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -98,11 +98,19 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 		return err
 	}
 
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	tmpPath := path + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
+	cleanup := true
+	defer func() {
+		f.Close()
+		if cleanup {
+			os.Remove(tmpPath)
+		}
+	}()
 
 	gw := gzip.NewWriter(f)
 
@@ -120,6 +128,15 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 	if err := gw.Close(); err != nil {
 		return err
 	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
 
 	logger.L().Debug("Saved host sensor envelopes to cache", helpers.String("resource", resourceName), helpers.Int("count", len(envelopes)))
 	return nil

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -1,0 +1,107 @@
+package hostsensorutils
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+)
+
+var DefaultCacheDir string
+
+func init() {
+	if home, err := os.UserHomeDir(); err == nil {
+		DefaultCacheDir = filepath.Join(home, ".kubescape", "cache", "hostsensor")
+	}
+}
+
+func getCacheDir() (string, error) {
+	if DefaultCacheDir == "" {
+		return "", fmt.Errorf("cache directory not configured")
+	}
+	return DefaultCacheDir, nil
+}
+
+func getCacheFilePath(resourceName string) (string, error) {
+	dir, err := getCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.json.gz", resourceName)), nil
+}
+
+func loadFromCache(resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
+	path, err := getCacheFilePath(resourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+
+	data, err := io.ReadAll(gr)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelopes []hostsensor.HostSensorDataEnvelope
+	if err := json.Unmarshal(data, &envelopes); err != nil {
+		return nil, err
+	}
+
+	logger.L().Debug("Loaded host sensor envelopes from cache", helpers.String("resource", resourceName), helpers.Int("count", len(envelopes)))
+	return envelopes, nil
+}
+
+func saveToCache(resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
+	path, err := getCacheFilePath(resourceName)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	
+	data, err := json.Marshal(envelopes)
+	if err != nil {
+		gw.Close()
+		return err
+	}
+
+	if _, err := gw.Write(data); err != nil {
+		gw.Close()
+		return err
+	}
+
+	if err := gw.Close(); err != nil {
+		return err
+	}
+
+	logger.L().Debug("Saved host sensor envelopes to cache", helpers.String("resource", resourceName), helpers.Int("count", len(envelopes)))
+	return nil
+}

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -46,7 +46,7 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 		}
 		return nil
 	})
-	
+
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to list CRD resources",
 			helpers.String("kind", resourceType.String()),

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdjson "encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -19,6 +20,13 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 	pluralName := k8shostsensor.MapResourceToPlural(resourceType)
 	if pluralName == "" {
 		return nil, fmt.Errorf("unsupported resource type: %s", resourceType)
+	}
+
+	// Try loading from cache first
+	if cachedEnvelopes, err := loadFromCache(resourceType.String()); err == nil {
+		return cachedEnvelopes, nil
+	} else if !os.IsNotExist(err) {
+		logger.L().Warning("Failed to load cache, proceeding to fetch", helpers.Error(err))
 	}
 
 	// List CRD resources
@@ -48,6 +56,11 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 	logger.L().Ctx(ctx).Info("Retrieved resources from CRDs",
 		helpers.String("kind", resourceType.String()),
 		helpers.Int("count", len(result)))
+
+	// Save to cache
+	if err := saveToCache(resourceType.String(), result); err != nil {
+		logger.L().Warning("Failed to save to cache", helpers.Error(err))
+	}
 
 	return result, nil
 }

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -22,15 +22,31 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 		return nil, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
 
+	clusterName := k8sinterface.GetContextName()
 	// Try loading from cache first
-	if cachedEnvelopes, err := loadFromCache(resourceType.String()); err == nil {
+	if cachedEnvelopes, err := loadFromCache(clusterName, resourceType.String()); err == nil {
 		return cachedEnvelopes, nil
 	} else if !os.IsNotExist(err) {
 		logger.L().Warning("Failed to load cache, proceeding to fetch", helpers.Error(err))
 	}
 
-	// List CRD resources
-	items, err := hsh.listCRDResources(ctx, pluralName, resourceType.String())
+	// List CRD resources and process them page by page
+	result := make([]hostsensor.HostSensorDataEnvelope, 0)
+	err := hsh.listCRDResources(ctx, pluralName, resourceType.String(), func(items []unstructured.Unstructured) error {
+		for _, item := range items {
+			envelope, err := hsh.convertCRDToEnvelope(item, resourceType)
+			if err != nil {
+				logger.L().Warning("Failed to convert CRD to envelope",
+					helpers.String("kind", resourceType.String()),
+					helpers.String("name", item.GetName()),
+					helpers.Error(err))
+				continue
+			}
+			result = append(result, envelope)
+		}
+		return nil
+	})
+	
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to list CRD resources",
 			helpers.String("kind", resourceType.String()),
@@ -39,26 +55,12 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 		return nil, err
 	}
 
-	// Convert to HostSensorDataEnvelope format
-	result := make([]hostsensor.HostSensorDataEnvelope, 0, len(items))
-	for _, item := range items {
-		envelope, err := hsh.convertCRDToEnvelope(item, resourceType)
-		if err != nil {
-			logger.L().Warning("Failed to convert CRD to envelope",
-				helpers.String("kind", resourceType.String()),
-				helpers.String("name", item.GetName()),
-				helpers.Error(err))
-			continue
-		}
-		result = append(result, envelope)
-	}
-
 	logger.L().Ctx(ctx).Info("Retrieved resources from CRDs",
 		helpers.String("kind", resourceType.String()),
 		helpers.Int("count", len(result)))
 
 	// Save to cache
-	if err := saveToCache(resourceType.String(), result); err != nil {
+	if err := saveToCache(clusterName, resourceType.String(), result); err != nil {
 		logger.L().Warning("Failed to save to cache", helpers.Error(err))
 	}
 

--- a/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
@@ -116,7 +116,11 @@ func TestListCRDResources(t *testing.T) {
 		dynamicClient: newCRDDynamicClient(t, item),
 	}
 
-	got, err := hsh.listCRDResources(context.Background(), "osreleasefiles", k8shostsensor.OsReleaseFile.String())
+	var got []unstructured.Unstructured
+	err := hsh.listCRDResources(context.Background(), "osreleasefiles", k8shostsensor.OsReleaseFile.String(), func(items []unstructured.Unstructured) error {
+		got = append(got, items...)
+		return nil
+	})
 
 	require.NoError(t, err)
 	require.Len(t, got, 1)

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -7,10 +7,12 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"time"
 )
 
 const (
@@ -113,14 +115,47 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 		helpers.String("resource", resourceName),
 		helpers.String("kind", kind))
 
-	list, err := hsh.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list %s CRDs: %w", kind, err)
+	var items []unstructured.Unstructured
+	limit := int64(50)
+	continueToken := ""
+
+	for {
+		listOptions := metav1.ListOptions{Limit: limit, Continue: continueToken}
+		var list *unstructured.UnstructuredList
+		var err error
+
+		retries := 5
+		backoff := 1 * time.Second
+		for i := 0; i < retries; i++ {
+			list, err = hsh.dynamicClient.Resource(gvr).List(ctx, listOptions)
+			if err != nil {
+				if k8serrors.IsTooManyRequests(err) {
+					logger.L().Warning("Rate limited (429) when listing CRDs, retrying",
+						helpers.String("kind", kind),
+						helpers.Int("retry", i+1))
+					time.Sleep(backoff)
+					backoff *= 2
+					continue
+				}
+				break
+			}
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s CRDs: %w", kind, err)
+		}
+
+		items = append(items, list.Items...)
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
 	}
 
 	logger.L().Debug("Retrieved CRD resources",
 		helpers.String("kind", kind),
-		helpers.Int("count", len(list.Items)))
+		helpers.Int("count", len(items)))
 
-	return list.Items, nil
+	return items, nil
 }

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"time"
+
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"time"
 )
 
 const (

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -133,7 +133,7 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 					logger.L().Warning("Rate limited (429) when listing CRDs, retrying",
 						helpers.String("kind", kind),
 						helpers.Int("retry", i+1))
-					
+
 					timer := time.NewTimer(backoff)
 					select {
 					case <-ctx.Done():

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -104,7 +104,7 @@ func (hsh *HostSensorHandler) TearDown() error {
 }
 
 // listCRDResources is a generic function to list CRD resources and convert them to the expected format.
-func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName, kind string) ([]unstructured.Unstructured, error) {
+func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName, kind string, process func([]unstructured.Unstructured) error) error {
 	gvr := schema.GroupVersionResource{
 		Group:    hostDataGroup,
 		Version:  hostDataVersion,
@@ -115,9 +115,9 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 		helpers.String("resource", resourceName),
 		helpers.String("kind", kind))
 
-	var items []unstructured.Unstructured
 	limit := int64(50)
 	continueToken := ""
+	totalCount := 0
 
 	for {
 		listOptions := metav1.ListOptions{Limit: limit, Continue: continueToken}
@@ -133,9 +133,16 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 					logger.L().Warning("Rate limited (429) when listing CRDs, retrying",
 						helpers.String("kind", kind),
 						helpers.Int("retry", i+1))
-					time.Sleep(backoff)
-					backoff *= 2
-					continue
+					
+					timer := time.NewTimer(backoff)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return ctx.Err()
+					case <-timer.C:
+						backoff *= 2
+						continue
+					}
 				}
 				break
 			}
@@ -143,10 +150,14 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to list %s CRDs: %w", kind, err)
+			return fmt.Errorf("failed to list %s CRDs: %w", kind, err)
 		}
 
-		items = append(items, list.Items...)
+		totalCount += len(list.Items)
+		if err := process(list.Items); err != nil {
+			return fmt.Errorf("failed to process %s CRDs page: %w", kind, err)
+		}
+
 		continueToken = list.GetContinue()
 		if continueToken == "" {
 			break
@@ -155,7 +166,7 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 
 	logger.L().Debug("Retrieved CRD resources",
 		helpers.String("kind", kind),
-		helpers.Int("count", len(items)))
+		helpers.Int("count", totalCount))
 
-	return items, nil
+	return nil
 }

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -134,6 +134,10 @@ func (hsh *HostSensorHandler) listCRDResources(ctx context.Context, resourceName
 						helpers.String("kind", kind),
 						helpers.Int("retry", i+1))
 
+					if i == retries-1 {
+						break
+					}
+
 					timer := time.NewTimer(backoff)
 					select {
 					case <-ctx.Done():

--- a/core/pkg/hostsensorutils/hostsensorpagination_test.go
+++ b/core/pkg/hostsensorutils/hostsensorpagination_test.go
@@ -1,0 +1,146 @@
+package hostsensorutils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type mockDynamicClient struct {
+	resourceFunc func(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface
+}
+
+func (m *mockDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return m.resourceFunc(resource)
+}
+
+type mockNamespaceableResourceInterface struct {
+	listFunc func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+}
+
+func (m *mockNamespaceableResourceInterface) Namespace(string) dynamic.ResourceInterface { return m }
+func (m *mockNamespaceableResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error { return nil }
+func (m *mockNamespaceableResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error { return nil }
+func (m *mockNamespaceableResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) { return m.listFunc(ctx, opts) }
+func (m *mockNamespaceableResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) { return nil, nil }
+
+func TestHostSensorPagination(t *testing.T) {
+	totalItems := 525
+	var allItems []unstructured.Unstructured
+	for i := 0; i < totalItems; i++ {
+		item := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": fmt.Sprintf("%s/%s", hostDataGroup, hostDataVersion),
+				"kind":       "OsReleaseFile",
+				"metadata": map[string]interface{}{
+					"name": fmt.Sprintf("node-%d", i),
+				},
+				"spec": map[string]interface{}{
+					"os": "linux",
+				},
+			},
+		}
+		allItems = append(allItems, item)
+	}
+
+	listCount := 0
+	mockResource := &mockNamespaceableResourceInterface{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			listCount++
+			limit := opts.Limit
+			if limit == 0 {
+				limit = 50
+			}
+			startIndex := 0
+			if opts.Continue != "" {
+				fmt.Sscanf(opts.Continue, "%d", &startIndex)
+			}
+			
+			endIndex := startIndex + int(limit)
+			nextContinue := ""
+			if endIndex < totalItems {
+				nextContinue = fmt.Sprintf("%d", endIndex)
+			} else {
+				endIndex = totalItems
+			}
+
+			list := &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", hostDataGroup, hostDataVersion),
+					"kind":       "OsReleaseFileList",
+				},
+				Items: allItems[startIndex:endIndex],
+			}
+			list.SetContinue(nextContinue)
+
+			return list, nil
+		},
+	}
+
+	hsh := &HostSensorHandler{
+		dynamicClient: &mockDynamicClient{
+			resourceFunc: func(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+				return mockResource
+			},
+		},
+	}
+
+	ctx := context.Background()
+	items, err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile")
+	
+	require.NoError(t, err)
+	assert.Equal(t, totalItems, len(items))
+	assert.Equal(t, 11, listCount)
+}
+
+func TestHostSensorRateLimitRetry(t *testing.T) {
+	listCount := 0
+	mockResource := &mockNamespaceableResourceInterface{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			listCount++
+			if listCount <= 2 {
+				return nil, k8serrors.NewTooManyRequests("Rate limited", 1)
+			}
+			list := &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", hostDataGroup, hostDataVersion),
+					"kind":       "OsReleaseFileList",
+				},
+				Items: []unstructured.Unstructured{},
+			}
+			return list, nil
+		},
+	}
+
+	hsh := &HostSensorHandler{
+		dynamicClient: &mockDynamicClient{
+			resourceFunc: func(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+				return mockResource
+			},
+		},
+	}
+
+	ctx := context.Background()
+	items, err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile")
+	
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(items))
+	assert.Equal(t, 3, listCount)
+}

--- a/core/pkg/hostsensorutils/hostsensorpagination_test.go
+++ b/core/pkg/hostsensorutils/hostsensorpagination_test.go
@@ -65,8 +65,8 @@ func TestHostSensorPagination(t *testing.T) {
 		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 			listCount++
 			limit := opts.Limit
-			if limit == 0 {
-				limit = 50
+			if limit != 50 {
+				panic(fmt.Sprintf("expected limit 50, got %d", limit))
 			}
 			startIndex := 0
 			if opts.Continue != "" {
@@ -103,7 +103,11 @@ func TestHostSensorPagination(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	items, err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile")
+	var items []unstructured.Unstructured
+	err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile", func(page []unstructured.Unstructured) error {
+		items = append(items, page...)
+		return nil
+	})
 	
 	require.NoError(t, err)
 	assert.Equal(t, totalItems, len(items))
@@ -138,7 +142,11 @@ func TestHostSensorRateLimitRetry(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	items, err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile")
+	var items []unstructured.Unstructured
+	err := hsh.listCRDResources(ctx, "osreleasefiles", "OsReleaseFile", func(page []unstructured.Unstructured) error {
+		items = append(items, page...)
+		return nil
+	})
 	
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(items))

--- a/core/pkg/hostsensorutils/hostsensorpagination_test.go
+++ b/core/pkg/hostsensorutils/hostsensorpagination_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type mockDynamicClient struct {
@@ -29,17 +29,39 @@ type mockNamespaceableResourceInterface struct {
 }
 
 func (m *mockNamespaceableResourceInterface) Namespace(string) dynamic.ResourceInterface { return m }
-func (m *mockNamespaceableResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error { return nil }
-func (m *mockNamespaceableResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error { return nil }
-func (m *mockNamespaceableResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) { return m.listFunc(ctx, opts) }
-func (m *mockNamespaceableResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) { return nil, nil }
-func (m *mockNamespaceableResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) { return nil, nil }
+func (m *mockNamespaceableResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return nil
+}
+func (m *mockNamespaceableResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return nil
+}
+func (m *mockNamespaceableResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return m.listFunc(ctx, opts)
+}
+func (m *mockNamespaceableResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockNamespaceableResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
 
 func TestHostSensorPagination(t *testing.T) {
 	totalItems := 525
@@ -72,7 +94,7 @@ func TestHostSensorPagination(t *testing.T) {
 			if opts.Continue != "" {
 				fmt.Sscanf(opts.Continue, "%d", &startIndex)
 			}
-			
+
 			endIndex := startIndex + int(limit)
 			nextContinue := ""
 			if endIndex < totalItems {
@@ -108,7 +130,7 @@ func TestHostSensorPagination(t *testing.T) {
 		items = append(items, page...)
 		return nil
 	})
-	
+
 	require.NoError(t, err)
 	assert.Equal(t, totalItems, len(items))
 	assert.Equal(t, 11, listCount)
@@ -147,7 +169,7 @@ func TestHostSensorRateLimitRetry(t *testing.T) {
 		items = append(items, page...)
 		return nil
 	})
-	
+
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(items))
 	assert.Equal(t, 3, listCount)

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -45,6 +45,9 @@ func TestMain(m *testing.M) {
 	k8sinterface.InitializeMapResources(&fakeHostSensorDiscovery{
 		FakeDiscovery: &fakediscovery.FakeDiscovery{Fake: &k8stesting.Fake{}},
 	})
+
+	DefaultCacheDir = "" // Disable cache by default for tests
+
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Overview
This PR optimizes the host sensor CRD query collection to prevent OOM crashes and rate-limiting on large enterprise clusters. It implements chunked retrieval pagination for `listCRDResources`, adds dynamic retry with exponential backoff for HTTP 429 errors, and introduces disk-backed caching under `~/.kubescape/cache/hostsensor/` to save cluster bandwidth.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

## Related issues/PRs:
* Resolved #2863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local caching for host sensor and CRD data to speed up repeat collections.
  * Added compressed cache storage with automatic expiration.
  * Added paginated CRD retrieval to support complete collection of large datasets.
  * Added automatic retries with exponential backoff for temporary rate limiting.

* **Bug Fixes**
  * Improved reliability when collecting large CRD datasets and handling API throttling.
  * Added safer handling of cache read and write failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->