### PR TITLE
fix(sarif): guard delta walk against out-of-range line and segment indexes

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -325,13 +325,19 @@ func calculateMove(str string, file []string, endColumn int, endLine int) (int, 
 		logger.L().Debug(fmt.Sprintf("failed to get move from string %s", str), helpers.Error(err))
 		return 0, 0, false
 	}
-	if endLine > len(file) {
+	// endLine is 1-indexed, so 0 is as out of range as len(file)+1
+	if endLine < 1 || endLine > len(file) {
 		return 0, 0, false
 	}
 	for num+endColumn-1 > utf8.RuneCountInString(file[endLine-1]) {
 		num -= utf8.RuneCountInString(file[endLine-1]) - endColumn + 2
 		endLine++
 		endColumn = 1
+		// the delta can claim more characters than the file holds, so the
+		// bound needs re-checking on every step of the walk
+		if endLine > len(file) {
+			return 0, 0, false
+		}
 	}
 	endColumn += num
 	return endLine, endColumn, true
@@ -347,6 +353,11 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 
 	delta := strings.Split(dmp.DiffToDelta(diffs), "\t")
 	for index, seg := range delta {
+		// DiffToDelta returns "" for an empty diff set, which Split turns into
+		// a single empty segment carrying no operation byte
+		if seg == "" {
+			continue
+		}
 		switch seg[0] {
 		case '+':
 			var err error
@@ -355,29 +366,41 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 				logger.L().Debug("failed to unescape string", helpers.Error(err))
 				continue
 			}
-			if index >= len(delta)-1 || delta[index+1][0] == '=' {
+			if closesFixRegion(delta, index) {
 				addFix(result, filepath, startLine, startColumn, endLine, endColumn, text)
 			}
 		case '-':
-			var ok bool
-			endLine, endColumn, ok = calculateMove(seg[1:], file, endColumn, endLine)
+			// commit the position only on success: the (0, 0) failure return
+			// is not a valid SARIF location and breaks the next move
+			newLine, newColumn, ok := calculateMove(seg[1:], file, endColumn, endLine)
 			if !ok {
 				continue
 			}
-			if index >= len(delta)-1 || delta[index+1][0] == '=' {
+			endLine, endColumn = newLine, newColumn
+			if closesFixRegion(delta, index) {
 				addFix(result, filepath, startLine, startColumn, endLine, endColumn, text)
 			}
 		case '=':
-			var ok bool
-			endLine, endColumn, ok = calculateMove(seg[1:], file, endColumn, endLine)
+			newLine, newColumn, ok := calculateMove(seg[1:], file, endColumn, endLine)
 			if !ok {
 				continue
 			}
+			endLine, endColumn = newLine, newColumn
 			startLine = endLine
 			startColumn = endColumn
 			text = ""
 		}
 	}
+}
+
+// closesFixRegion reports whether the segment at index ends the replacement region:
+// it is either the last segment, or the next one resumes unchanged content
+func closesFixRegion(delta []string, index int) bool {
+	if index >= len(delta)-1 {
+		return true
+	}
+	next := delta[index+1]
+	return next != "" && next[0] == '='
 }
 
 func collectFixes(ctx context.Context, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string) {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -394,13 +394,17 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 }
 
 // closesFixRegion reports whether the segment at index ends the replacement region:
-// it is either the last segment, or the next one resumes unchanged content
+// the next operation segment resumes unchanged content, or there is none left
 func closesFixRegion(delta []string, index int) bool {
-	if index >= len(delta)-1 {
-		return true
+	for i := index + 1; i < len(delta); i++ {
+		// empty segments carry no operation and are skipped by the walk too,
+		// so they cannot hold the region open
+		if delta[i] == "" {
+			continue
+		}
+		return delta[i][0] == '='
 	}
-	next := delta[index+1]
-	return next != "" && next[0] == '='
+	return true
 }
 
 func collectFixes(ctx context.Context, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string) {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -312,7 +312,9 @@ func TestClosesFixRegion(t *testing.T) {
 		{"last segment closes the region", []string{"+abc", "=5"}, 1, true},
 		{"next segment resumes unchanged content", []string{"+abc", "=5"}, 0, true},
 		{"next segment continues the edit", []string{"+abc", "-5"}, 0, false},
-		{"empty next segment carries no operation", []string{"+abc", ""}, 0, false},
+		{"trailing empty segment leaves no operation to resume", []string{"+abc", ""}, 0, true},
+		{"empty segments skipped before an equality run", []string{"+abc", "", "", "=5"}, 0, true},
+		{"empty segments skipped before a further edit", []string{"+abc", "", "-5"}, 0, false},
 		{"index past the end of the delta", []string{"+abc"}, 5, true},
 	}
 

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -214,6 +215,114 @@ func TestCalculateMove_MultiByteRunes(t *testing.T) {
 	assert.True(t, success)
 	assert.Equal(t, 2, newLine)
 	assert.Equal(t, 3, newColumn)
+}
+
+// The end line is 1-indexed, so values below 1 are as out of range as values past the end of the file and both return false.
+func TestCalculateMove_EndLineOutOfRange(t *testing.T) {
+	file := []string{"line 1", "line 2", "line 3"}
+
+	tc := []struct {
+		name      string
+		file      []string
+		endLine   int
+		endColumn int
+	}{
+		{"zero end line, as left behind by a failed move", file, 0, 0},
+		{"negative end line", file, -1, 1},
+		{"end line one past the last line", file, 4, 1},
+		{"any end line into an empty file", []string{}, 1, 1},
+	}
+
+	for _, testCase := range tc {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				newLine, newColumn, success := calculateMove("5", testCase.file, testCase.endColumn, testCase.endLine)
+
+				assert.False(t, success)
+				assert.Equal(t, 0, newLine)
+				assert.Equal(t, 0, newColumn)
+			})
+		})
+	}
+}
+
+// A move that claims more characters than the file holds walks past the last line and returns false.
+func TestCalculateMove_WalkPastLastLine(t *testing.T) {
+	file := []string{"line 1", "line 2", "line 3"}
+
+	assert.NotPanics(t, func() {
+		newLine, newColumn, success := calculateMove("50", file, 1, 3)
+
+		assert.False(t, success)
+		assert.Equal(t, 0, newLine)
+		assert.Equal(t, 0, newColumn)
+	})
+}
+
+// A move that fails mid-delta leaves the position untouched, so later fixes keep 1-indexed regions instead of landing on line 0.
+func TestCollectDiffs_FailedMoveKeepsRegionOneIndexed(t *testing.T) {
+	// the equality run claims more content than the file holds, so the first move fails
+	diffs := []diffmatchpatch.Diff{
+		{Type: diffmatchpatch.DiffEqual, Text: strings.Repeat("a", 44)},
+		{Type: diffmatchpatch.DiffInsert, Text: "x"},
+	}
+
+	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+	result := run.CreateResultForRule("0")
+
+	assert.NotPanics(t, func() {
+		collectDiffs(diffmatchpatch.New(), diffs, result, "", "short")
+	})
+
+	require.Len(t, result.Fixes, 1)
+	replacements := result.Fixes[0].ArtifactChanges[0].Replacements
+	require.Len(t, replacements, 1)
+
+	region := replacements[0].DeletedRegion
+	assert.Equal(t, 1, *region.StartLine)
+	assert.Equal(t, 1, *region.StartColumn)
+	assert.Equal(t, 1, *region.EndLine)
+	assert.Equal(t, 1, *region.EndColumn)
+}
+
+// An empty diff set yields a single empty delta segment and collects no fixes.
+func TestCollectDiffs_EmptyDelta(t *testing.T) {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain("", "", false)
+	require.Empty(t, diffs)
+
+	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+	result := run.CreateResultForRule("0")
+
+	assert.NotPanics(t, func() {
+		collectDiffs(dmp, diffs, result, "", "")
+	})
+
+	assert.Empty(t, result.Fixes)
+}
+
+// The region lookahead reports the last segment and an equality run as closing, and tolerates an empty neighbor.
+func TestClosesFixRegion(t *testing.T) {
+	tc := []struct {
+		name     string
+		delta    []string
+		index    int
+		expected bool
+	}{
+		{"last segment closes the region", []string{"+abc", "=5"}, 1, true},
+		{"next segment resumes unchanged content", []string{"+abc", "=5"}, 0, true},
+		{"next segment continues the edit", []string{"+abc", "-5"}, 0, false},
+		{"empty next segment carries no operation", []string{"+abc", ""}, 0, false},
+		{"index past the end of the delta", []string{"+abc"}, 5, true},
+	}
+
+	for _, testCase := range tc {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.Equal(t, testCase.expected, closesFixRegion(testCase.delta, testCase.index))
+			})
+		})
+	}
 }
 
 // Adds a new fix to the result with the given filepath, start and end positions, and text.


### PR DESCRIPTION
## Overview

The SARIF printer walks the diff delta to compute fix regions, and that walk indexes into slices and strings without bounds checks. A scan that emits fixes can panic instead of producing a report.

Three panic sites in collectDiffs and calculateMove:

1. calculateMove checked only the upper bound of endLine, so a zero or negative value read file[-1].
2. The walk loop incremented endLine without re-checking it against len(file), so it ran past the last line.
3. collectDiffs read seg[0] and delta[index+1][0] on segments that can be empty. DiffToDelta returns an empty string for an empty diff set, and strings.Split turns that into a single empty segment.

Alongside those, collectDiffs assigned calculateMove's (0, 0) failure return to its position before checking the ok flag. After a failed move the walk sat on line 0, which is not a valid location in a 1-indexed format and fed an out of range endLine into the next move.

Current behavior: panic, or fix regions anchored to line 0.
New behavior: out of range moves are rejected and the segment is skipped, matching how the function already handled an endLine past the end of the file.

The duplicated lookahead that decides when a replacement region closes is now a single helper, since it was also one of the panic sites.

Each guard has a regression test that fails when that guard alone is removed. Existing tests in the package are unchanged and still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SARIF fix processing for multiline changes that extend beyond file boundaries.
  * Prevented invalid source locations from being recorded after failed changes.
  * Safely handles empty diff segments and terminal replacement regions.

* **Tests**
  * Added regression coverage for invalid line positions, empty diffs, failed moves, and fix-region handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->