### PR TITLE
fix: populate ClusterName in JSON reports

### DIFF
--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -6,6 +6,7 @@ import (
 
 	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/anchore/grype/grype/match"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
@@ -200,6 +201,9 @@ func extractResourceLabels(allResources map[string]workloadinterface.IMetadata, 
 func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureReport {
 	if data.Report.ReportGenerationTime.IsZero() {
 		data.Report.ReportGenerationTime = time.Now().UTC()
+	}
+	if data.Report.ClusterName == "" {
+		data.Report.ClusterName = cautils.AdoptClusterName(k8sinterface.GetContextName())
 	}
 	report := reporthandlingv2.PostureReport{
 		SummaryDetails:       data.Report.SummaryDetails,

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
@@ -968,6 +969,42 @@ func TestFinalizeResults_PreservesExistingGenerationTime(t *testing.T) {
 	require.NotNil(t, report)
 	assert.Equal(t, preset, report.ReportGenerationTime)
 	assert.Equal(t, preset, session.Report.ReportGenerationTime)
+}
+
+// TestFinalizeResults_SetsClusterNameWhenEmpty is the regression test for
+// kubescape/kubescape#2856: JSON reports always had an empty clusterName
+// because nothing on the scan path ever assigned OPASessionObj.Report.ClusterName,
+// even though the context name is known via k8sinterface at scan time.
+func TestFinalizeResults_SetsClusterNameWhenEmpty(t *testing.T) {
+	k8sinterface.SetClusterContextName("test-cluster")
+	defer k8sinterface.SetClusterContextName("")
+
+	session := cautils.NewOPASessionObjMock()
+	require.Empty(t, session.Report.ClusterName,
+		"precondition: mock starts with the empty ClusterName that #2856 reported")
+
+	report := FinalizeResults(session)
+
+	require.NotNil(t, report)
+	assert.Equal(t, "test-cluster", report.ClusterName)
+	assert.Equal(t, "test-cluster", session.Report.ClusterName,
+		"FinalizeResults must also write back to the session so downstream consumers see it")
+}
+
+// TestFinalizeResults_PreservesExistingClusterName ensures we don't clobber a
+// cluster name the caller has already set.
+func TestFinalizeResults_PreservesExistingClusterName(t *testing.T) {
+	k8sinterface.SetClusterContextName("other-cluster")
+	defer k8sinterface.SetClusterContextName("")
+
+	session := cautils.NewOPASessionObjMock()
+	session.Report.ClusterName = "preset-cluster"
+
+	report := FinalizeResults(session)
+
+	require.NotNil(t, report)
+	assert.Equal(t, "preset-cluster", report.ClusterName)
+	assert.Equal(t, "preset-cluster", session.Report.ClusterName)
 }
 
 func TestFinalizeResults_SortsResultsAndResourcesByResourceID(t *testing.T) {


### PR DESCRIPTION
Fixes #2856. clusterName in JSON reports was always empty because nothing ever wrote to it, even though the value is known at scan time. FinalizeResults already has the exact same fix for ReportGenerationTime (from #2325), this follows that same pattern for ClusterName.

Left CustomerGUID out of this one. It comes from the tenant config interface rather than a plain function like k8sinterface.GetContextName, so fixing it would mean changing FinalizeResults's signature and touching every call site. Wanted to check if that's actually wanted before doing something that invasive.

Added two tests mirroring the existing generation-time ones, one for the empty case getting filled in and one for an existing value not getting overwritten.

Feel free to ping me for any issues or questions!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reports now automatically include the Kubernetes cluster name when it was previously missing.
  * Existing cluster names are preserved without being overwritten.

* **Tests**
  * Added regression coverage to verify cluster name assignment and preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->