### PR TITLE
fix: register deprecated flags to prevent unknown flag errors

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -68,7 +68,12 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.Format, "format", "f", "pretty-print", "output format. supported: 'pretty-print'/'json'/'yaml'")
-	listCmd.PersistentFlags().MarkDeprecated("id", "Control ID's are included in list outputs")
+
+	// Deprecated flags
+	var dummyID bool
+	listCmd.PersistentFlags().BoolVar(&dummyID, "id", false, "Control ID's are included in list outputs")
+	_ = listCmd.PersistentFlags().MarkHidden("id")
+	_ = listCmd.PersistentFlags().MarkDeprecated("id", "Control ID's are included in list outputs")
 
 	return listCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,10 +86,13 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 
 	rootCmd.PersistentFlags().StringVar(&rootInfo.DiscoveryServerURL, "server", "", "Backend discovery server URL")
 
-	rootCmd.PersistentFlags().MarkDeprecated("environment", "'environment' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")
-	rootCmd.PersistentFlags().MarkDeprecated("env", "'env' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")
-	rootCmd.PersistentFlags().MarkHidden("environment")
-	rootCmd.PersistentFlags().MarkHidden("env")
+	var dummyEnvironment, dummyEnv string
+	rootCmd.PersistentFlags().StringVar(&dummyEnvironment, "environment", "", "'environment' is no longer supported, Use 'server' instead.")
+	rootCmd.PersistentFlags().StringVar(&dummyEnv, "env", "", "'env' is no longer supported, Use 'server' instead.")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("environment", "'environment' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("env", "'env' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.")
+	_ = rootCmd.PersistentFlags().MarkHidden("environment")
+	_ = rootCmd.PersistentFlags().MarkHidden("env")
 
 	rootCmd.PersistentFlags().StringVar(&rootInfo.LoggerName, "logger-name", "", fmt.Sprintf("Logger name. Supported: %s [$KS_LOGGER_NAME]", strings.Join(logger.ListLoggersNames(), "/")))
 	rootCmd.PersistentFlags().MarkHidden("logger-name")


### PR DESCRIPTION
## Overview

This PR resolves an issue where running commands with deprecated flags (such as `kubescape list controls --id`) would crash the CLI with an `unknown flag` error instead of gracefully printing a deprecation notice.

**Root cause:** `pflag`'s `MarkDeprecated` requires the target flag to be actively registered. Because the backing fields and flag definitions for `--id`, `--environment`, and `--env` were removed in previous refactors, `MarkDeprecated` returned a `NotExistError` which was being silently discarded. Since the flags were never registered, `cobra` halted execution upon encountering them.

**Fix:** Re-registered these vestigial flags as hidden, dummy variables before calling `MarkDeprecated` and `MarkHidden`.

## Additional Information

The `--id` flag in `cmd/list/list.go` was explicitly re-added as a `BoolVar` so that legacy scripts calling `--id` without any argument values don't accidentally trip a `flag needs an argument` error.

 The same fix was applied to the root command in `cmd/root.go` for the `--environment` and `--env` deprecated flags.

## How to Test

 1. Build the binary from this branch: `go build -o kubescape .`
 2. Run: `./kubescape list controls --id`
 3. Run: `./kubescape --environment test`

 Both commands should execute successfully and print a deprecation warning at the top of the logs, rather than crashing with an `unknown flag` error.

## Examples/Screenshots

 **Real Test Output (After Fix):**
>
> **Testing `--id`:**
>
> ```text
> $ ./kubescape list controls --id
> Flag --id has been deprecated, Control ID's are included in list outputs
> ╭────────────┬──────────────────────────────────────────────────────────────────
> │ Control ID │ Control name
> ├────────────┼──────────────────────────────────────────────────────────────────
> │     C-0001 │ Forbidden Container Registries
> │            │
> ├────────────┼──────────────────────────────────────────────────────────────────
> │     C-0002 │ Prevent containers from allowing command execution
> ...
> ```
>
> **Testing `--environment`:**
>
> ```text
> $ ./kubescape --environment test
> Flag --environment has been deprecated, 'environment' is no longer supported, Use 'server' instead. Feel free to contact the Kubescape maintainers for more information.
> Kubescape is a tool for testing Kubernetes security posture. Docs: https://kubescape.io/docs/
>
> Usage:
>   kubescape [command]
> ...
> ```

## Related issues/PRs: Resolves #2867 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan commands now report execution, threshold, coverage, severity, and policy errors cleanly without abruptly terminating the process.
  * Command-line failures now exit with a standard failure status.

* **Compatibility**
  * Preserved support for deprecated `--id`, `environment`, and `env` flags while directing users toward current alternatives.
  * Deprecated flags remain hidden from standard help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->