### PR TITLE
fix(scan): dynamically build supported formats error message

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -61,7 +61,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -76,7 +76,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -79,7 +81,7 @@ func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", ""))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml", err.Error())
+	assert.Equal(t, fmt.Sprintf("format cannot be empty, supported formats: %s", strings.Join(shared.ImageScanFormats, ", ")), err.Error())
 }
 
 func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -69,7 +69,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err


### PR DESCRIPTION
## Overview

Currently, the "format cannot be empty" error in the scan subcommands (`control`, `framework`, `workload`, and `image`) returns a hardcoded string of supported formats. This causes the error output to become stale and incorrectly omit newer formats like `yaml` and `csv`.

This PR fixes the issue by replacing the hardcoded strings and building the error message dynamically using the `shared.ScanFormats` and `shared.ImageScanFormats` arrays, perfectly matching the existing behavior in `cmd/scan/scan.go`.

## Additional Information

- The unit test `TestGetImageCmd_RunE_FormatFlagEmpty` inside `cmd/scan/image_test.go` was updated to assert against the new dynamic string.

## How to Test

1. Build the binary from this branch:

   `go build -o kubescape .`

2. Run any scan subcommand with an empty format flag, for example:

   `./kubescape scan control C0001 --format=""`

3. Verify that the fatal error dynamically prints the full updated list of supported formats, which should now correctly include `yaml` and `csv`.

## Examples/Screenshots

**Before (Missing `yaml` and `csv`):**

```text
{"level":"fatal","ts":"2026-08-09T11:27:06+05:30","msg":"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast"}
```

**After (Dynamically pulling all formats):**

```text
{"level":"fatal","ts":"2026-08-09T11:29:11+05:30","msg":"format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv"}
```

## Related issues/PRs

- Resolved #2869

## Checklist before requesting a review

Put an [x] in the box to get it checked.

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan format validation messages to consistently list the currently supported formats.
  * Updated image scan validation to reflect supported image formats accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->