### PR TITLE
fix(config): preserve higher-priority tenant settings

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -71,16 +71,23 @@ func (co *ConfigObj) Config() []byte {
 }
 
 func (co *ConfigObj) updateEmptyFields(inCO *ConfigObj) error {
-	if inCO.AccountID != "" {
+	if inCO == nil {
+		return nil
+	}
+
+	// Cluster data is a fallback source. Values already loaded from the local
+	// cache or the in-cluster service discovery file have higher precedence and
+	// must not be replaced merely because the ConfigMap also contains them.
+	if co.AccountID == "" && inCO.AccountID != "" {
 		co.AccountID = inCO.AccountID
 	}
-	if inCO.CloudAPIURL != "" {
+	if co.CloudAPIURL == "" && inCO.CloudAPIURL != "" {
 		co.CloudAPIURL = inCO.CloudAPIURL
 	}
-	if inCO.CloudReportURL != "" {
+	if co.CloudReportURL == "" && inCO.CloudReportURL != "" {
 		co.CloudReportURL = inCO.CloudReportURL
 	}
-	if inCO.ClusterName != "" {
+	if co.ClusterName == "" && inCO.ClusterName != "" {
 		co.ClusterName = inCO.ClusterName
 	}
 

--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -186,6 +186,40 @@ func TestClusterConfigLoadsKubernetesSourcesDataDriven(t *testing.T) {
 	}
 }
 
+func TestClusterConfigMapOnlyFillsMissingValues(t *testing.T) {
+	k8s := k8sinterface.NewKubernetesApiMock()
+	k8s.KubernetesClient = fake.NewClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud",
+			Namespace: "security",
+			Labels:    map[string]string{"kubescape.io/infra": "config"},
+		},
+		Data: map[string]string{
+			"clusterData": `{
+				"accountID":"configmap-account",
+				"clusterName":"configmap-cluster",
+				"cloudAPIURL":"https://configmap-api.example.com",
+				"cloudReportURL":"https://configmap-report.example.com"
+			}`,
+		},
+	})
+
+	config := &ClusterConfig{
+		k8s: k8s,
+		configObj: &ConfigObj{
+			AccountID:   "cached-account",
+			CloudAPIURL: "https://service-discovery-api.example.com",
+		},
+		configMapNamespace: "security",
+	}
+
+	require.NoError(t, config.updateConfigEmptyFieldsFromKubescapeConfigMap(context.Background()))
+	assert.Equal(t, "cached-account", config.GetAccountID(), "cached tenant identity must not be replaced by fallback data")
+	assert.Equal(t, "https://service-discovery-api.example.com", config.GetCloudAPIURL(), "service discovery must keep precedence")
+	assert.Equal(t, "configmap-cluster", config.GetContextName(), "a missing cluster name should be filled")
+	assert.Equal(t, "https://configmap-report.example.com", config.GetCloudReportURL(), "a missing report URL should be filled")
+}
+
 func Test_GetDefaultNS(t *testing.T) {
 	c := &ClusterConfig{configMapNamespace: "my-namespace"}
 	assert.Equal(t, "my-namespace", c.GetDefaultNS())

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -300,92 +300,88 @@ func TestGetConfigMapNamespace(t *testing.T) {
 	}
 }
 
-const (
-	anyString       string = "anyString"
-	shouldNotUpdate string = "shouldNotUpdate"
-	shouldUpdate    string = "shouldUpdate"
-)
-
-func checkIsUpdateCorrectly(t *testing.T, beforeField string, afterField string) {
-	switch beforeField {
-	case anyString:
-		assert.Equal(t, anyString, afterField)
-	case "":
-		assert.Equal(t, shouldUpdate, afterField)
-	}
-}
-
 func TestUpdateEmptyFields(t *testing.T) {
-
 	tests := []struct {
-		inCo  *ConfigObj
-		outCo *ConfigObj
+		name     string
+		current  ConfigObj
+		fallback *ConfigObj
+		want     ConfigObj
 	}{
 		{
-			outCo: &ConfigObj{
-				AccountID:      "",
-				ClusterName:    "",
-				CloudReportURL: "",
-				CloudAPIURL:    "",
+			name: "all empty fields are populated",
+			fallback: &ConfigObj{
+				AccountID:      "fallback-account",
+				ClusterName:    "fallback-cluster",
+				CloudReportURL: "https://fallback-report.example.com",
+				CloudAPIURL:    "https://fallback-api.example.com",
 			},
-			inCo: &ConfigObj{
-				AccountID:      shouldUpdate,
-				ClusterName:    shouldUpdate,
-				CloudReportURL: shouldUpdate,
-				CloudAPIURL:    shouldUpdate,
-			},
-		},
-		{
-			outCo: &ConfigObj{
-				AccountID:      anyString,
-				ClusterName:    "",
-				CloudReportURL: "",
-				CloudAPIURL:    "",
-			},
-			inCo: &ConfigObj{
-				AccountID:      shouldNotUpdate,
-				ClusterName:    shouldUpdate,
-				CloudReportURL: shouldUpdate,
-				CloudAPIURL:    shouldUpdate,
+			want: ConfigObj{
+				AccountID:      "fallback-account",
+				ClusterName:    "fallback-cluster",
+				CloudReportURL: "https://fallback-report.example.com",
+				CloudAPIURL:    "https://fallback-api.example.com",
 			},
 		},
 		{
-			outCo: &ConfigObj{
-				AccountID:      "",
-				ClusterName:    anyString,
-				CloudReportURL: anyString,
-				CloudAPIURL:    anyString,
+			name: "existing values keep precedence",
+			current: ConfigObj{
+				AccountID:      "cached-account",
+				ClusterName:    "cached-cluster",
+				CloudReportURL: "https://cached-report.example.com",
+				CloudAPIURL:    "https://cached-api.example.com",
 			},
-			inCo: &ConfigObj{
-				AccountID:      shouldUpdate,
-				ClusterName:    shouldNotUpdate,
-				CloudReportURL: shouldNotUpdate,
-				CloudAPIURL:    shouldNotUpdate,
+			fallback: &ConfigObj{
+				AccountID:      "fallback-account",
+				ClusterName:    "fallback-cluster",
+				CloudReportURL: "https://fallback-report.example.com",
+				CloudAPIURL:    "https://fallback-api.example.com",
+			},
+			want: ConfigObj{
+				AccountID:      "cached-account",
+				ClusterName:    "cached-cluster",
+				CloudReportURL: "https://cached-report.example.com",
+				CloudAPIURL:    "https://cached-api.example.com",
 			},
 		},
 		{
-			outCo: &ConfigObj{
-				AccountID:      anyString,
-				ClusterName:    anyString,
-				CloudReportURL: "",
-				CloudAPIURL:    anyString,
+			name: "only empty fields are populated",
+			current: ConfigObj{
+				AccountID:   "cached-account",
+				CloudAPIURL: "https://cached-api.example.com",
 			},
-			inCo: &ConfigObj{
-				AccountID:      shouldNotUpdate,
-				ClusterName:    shouldNotUpdate,
-				CloudReportURL: shouldUpdate,
-				CloudAPIURL:    shouldNotUpdate,
+			fallback: &ConfigObj{
+				AccountID:      "fallback-account",
+				ClusterName:    "fallback-cluster",
+				CloudReportURL: "https://fallback-report.example.com",
+				CloudAPIURL:    "https://fallback-api.example.com",
 			},
+			want: ConfigObj{
+				AccountID:      "cached-account",
+				ClusterName:    "fallback-cluster",
+				CloudReportURL: "https://fallback-report.example.com",
+				CloudAPIURL:    "https://cached-api.example.com",
+			},
+		},
+		{
+			name:     "empty fallback leaves current values unchanged",
+			current:  ConfigObj{AccountID: "cached-account", ClusterName: "cached-cluster"},
+			fallback: &ConfigObj{},
+			want:     ConfigObj{AccountID: "cached-account", ClusterName: "cached-cluster"},
+		},
+		{
+			name:     "nil fallback leaves current values unchanged",
+			current:  ConfigObj{AccountID: "cached-account", CloudAPIURL: "https://cached-api.example.com"},
+			fallback: nil,
+			want:     ConfigObj{AccountID: "cached-account", CloudAPIURL: "https://cached-api.example.com"},
 		},
 	}
 
-	for i := range tests {
-		beforeChangesOutCO := tests[i].outCo
-		tests[i].outCo.updateEmptyFields(tests[i].inCo)
-		checkIsUpdateCorrectly(t, beforeChangesOutCO.AccountID, tests[i].outCo.AccountID)
-		checkIsUpdateCorrectly(t, beforeChangesOutCO.CloudAPIURL, tests[i].outCo.CloudAPIURL)
-		checkIsUpdateCorrectly(t, beforeChangesOutCO.CloudReportURL, tests[i].outCo.CloudReportURL)
-		checkIsUpdateCorrectly(t, beforeChangesOutCO.ClusterName, tests[i].outCo.ClusterName)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			current := test.current
+			require.NoError(t, current.updateEmptyFields(test.fallback))
+			assert.Equal(t, test.want, current)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Kubescape loads tenant configuration from several sources, including the local cache, service discovery, and the cluster ConfigMap.

The ConfigMap is intended to provide fallback values. However, the existing `updateEmptyFields` implementation replaced fields that were already populated. This could unexpectedly replace a cached account ID, cluster name, API URL, or report URL with an older ConfigMap value.

## What changed

- Only use ConfigMap values when the corresponding configuration field is empty
- Preserve values already loaded from the local cache or service discovery
- Safely handle a nil fallback configuration
- Replace the existing alias-based test that could not detect overwritten values
- Add an integration test covering mixed cached and ConfigMap configuration

## Why this matters

Using the wrong account ID or cloud endpoint can associate scan results with the wrong tenant or send reports to an unexpected backend.

The loading order now matches the intended precedence rules while still allowing the ConfigMap to fill genuinely missing values.

## Testing

- `go test ./core/cautils`
- `go test -race ./core/cautils`
- `golangci-lint run --new-from-rev upstream/master ./core/cautils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved higher-priority cluster configuration values when applying fallback settings.
  * Ensured fallback configuration only fills fields that are missing.
  * Improved handling of empty or unavailable configuration sources.

* **Tests**
  * Added coverage for configuration precedence, selective field population, and empty fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->