### PR TITLE
fix(diff): reject invalid scan reports

### DIFF
--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -162,11 +163,90 @@ func loadReport(path string) (*scanReport, error) {
 		return nil, err
 	}
 
-	var r scanReport
-	if err := json.Unmarshal(data, &r); err != nil {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("invalid report: expected a JSON object")
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
+	if fields == nil {
+		return nil, fmt.Errorf("invalid report: expected a JSON object")
+	}
+
+	resultsJSON, ok := fields["results"]
+	if !ok {
+		return nil, fmt.Errorf("invalid report: missing required results field; provide JSON output from kubescape scan")
+	}
+	if isJSONNull(resultsJSON) {
+		return nil, fmt.Errorf("invalid report: results must be an array, not null")
+	}
+
+	summaryJSON, ok := fields["summaryDetails"]
+	if !ok {
+		return nil, fmt.Errorf("invalid report: missing required summaryDetails field; provide JSON output from kubescape scan")
+	}
+	if isJSONNull(summaryJSON) {
+		return nil, fmt.Errorf("invalid report: summaryDetails must be an object, not null")
+	}
+
+	var r scanReport
+	if err := json.Unmarshal(resultsJSON, &r.Results); err != nil {
+		return nil, fmt.Errorf("invalid report results: %w", err)
+	}
+	if err := validateReport(&r, summaryJSON); err != nil {
+		return nil, err
+	}
 	return &r, nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+func validateReport(r *scanReport, summaryJSON json.RawMessage) error {
+	var summaryFields map[string]json.RawMessage
+	if err := json.Unmarshal(summaryJSON, &summaryFields); err != nil {
+		return fmt.Errorf("invalid report summaryDetails: %w", err)
+	}
+	if summaryFields == nil {
+		return fmt.Errorf("invalid report: summaryDetails must be an object")
+	}
+	controlsJSON, ok := summaryFields["controls"]
+	if !ok {
+		return fmt.Errorf("invalid report: summaryDetails is missing required controls field")
+	}
+	if isJSONNull(controlsJSON) {
+		return fmt.Errorf("invalid report: summaryDetails.controls must be an object, not null")
+	}
+	var controls map[string]controlSummary
+	if err := json.Unmarshal(controlsJSON, &controls); err != nil {
+		return fmt.Errorf("invalid report summaryDetails.controls: %w", err)
+	}
+	r.SummaryDetails.Controls = controls
+
+	seen := make(map[key]struct{})
+	for resultIndex, result := range r.Results {
+		if strings.TrimSpace(result.ResourceID) == "" {
+			return fmt.Errorf("invalid report: results[%d].resourceID is empty", resultIndex)
+		}
+		for controlIndex, control := range result.AssociatedControls {
+			if strings.TrimSpace(control.ControlID) == "" {
+				return fmt.Errorf("invalid report: results[%d].controls[%d].controlID is empty", resultIndex, controlIndex)
+			}
+			if strings.TrimSpace(control.Status.InnerStatus) == "" {
+				return fmt.Errorf("invalid report: results[%d].controls[%d].status.status is empty", resultIndex, controlIndex)
+			}
+			controlKey := key{resourceID: result.ResourceID, controlID: control.ControlID}
+			if _, exists := seen[controlKey]; exists {
+				return fmt.Errorf("invalid report: duplicate resource and control pair %q / %q", result.ResourceID, control.ControlID)
+			}
+			seen[controlKey] = struct{}{}
+		}
+	}
+	return nil
 }
 
 func buildMap(r *scanReport) map[key]controlEntry {

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -14,6 +14,12 @@ import (
 
 func writeTempReport(t *testing.T, r scanReport) string {
 	t.Helper()
+	if r.Results == nil {
+		r.Results = []resultEntry{}
+	}
+	if r.SummaryDetails.Controls == nil {
+		r.SummaryDetails.Controls = map[string]controlSummary{}
+	}
 	data, err := json.Marshal(r)
 	require.NoError(t, err)
 	f, err := os.CreateTemp(t.TempDir(), "report-*.json")
@@ -25,7 +31,12 @@ func writeTempReport(t *testing.T, r scanReport) string {
 }
 
 func makeReport(entries ...resultEntry) scanReport {
-	return scanReport{Results: entries}
+	return scanReport{
+		Results: entries,
+		SummaryDetails: summaryDetails{
+			Controls: map[string]controlSummary{},
+		},
+	}
 }
 
 func makeResult(resourceID string, controls ...controlEntry) resultEntry {
@@ -106,6 +117,126 @@ func TestCompute_RemovedResourceFromBase(t *testing.T) {
 func TestCompute_MissingFile(t *testing.T) {
 	_, err := Compute(filepath.Join(t.TempDir(), "missing.json"), filepath.Join(t.TempDir(), "also-missing.json"))
 	assert.Error(t, err)
+}
+
+func writeRawReport(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestComputeRejectsInvalidReportShapes(t *testing.T) {
+	valid := writeTempReport(t, makeReport())
+	tests := []struct {
+		name    string
+		report  string
+		wantErr string
+	}{
+		{
+			name:    "empty object",
+			report:  `{}`,
+			wantErr: "missing required results field",
+		},
+		{
+			name:    "JSON array",
+			report:  `[]`,
+			wantErr: "expected a JSON object",
+		},
+		{
+			name:    "SARIF document",
+			report:  `{"version":"2.1.0","runs":[]}`,
+			wantErr: "missing required results field",
+		},
+		{
+			name:    "results are null",
+			report:  `{"results":null,"summaryDetails":{"controls":{}}}`,
+			wantErr: "results must be an array",
+		},
+		{
+			name:    "results have wrong type",
+			report:  `{"results":{},"summaryDetails":{"controls":{}}}`,
+			wantErr: "invalid report results",
+		},
+		{
+			name:    "missing summary",
+			report:  `{"results":[]}`,
+			wantErr: "missing required summaryDetails field",
+		},
+		{
+			name:    "summary is null",
+			report:  `{"results":[],"summaryDetails":null}`,
+			wantErr: "summaryDetails must be an object",
+		},
+		{
+			name:    "summary controls are missing",
+			report:  `{"results":[],"summaryDetails":{}}`,
+			wantErr: "missing required controls field",
+		},
+		{
+			name:    "summary controls have wrong type",
+			report:  `{"results":[],"summaryDetails":{"controls":[]}}`,
+			wantErr: "invalid report summaryDetails.controls",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Compute(writeRawReport(t, test.report), valid)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestComputeRejectsAmbiguousResultEntries(t *testing.T) {
+	valid := writeTempReport(t, makeReport())
+	tests := []struct {
+		name    string
+		report  scanReport
+		wantErr string
+	}{
+		{
+			name:    "empty resource ID",
+			report:  makeReport(makeResult("", makeControl("C-001", "Control", "failed"))),
+			wantErr: "resourceID is empty",
+		},
+		{
+			name:    "empty control ID",
+			report:  makeReport(makeResult("resource", makeControl("", "Control", "failed"))),
+			wantErr: "controlID is empty",
+		},
+		{
+			name:    "empty status",
+			report:  makeReport(makeResult("resource", makeControl("C-001", "Control", ""))),
+			wantErr: "status.status is empty",
+		},
+		{
+			name: "duplicate resource control pair",
+			report: makeReport(
+				makeResult("resource", makeControl("C-001", "Control", "passed")),
+				makeResult("resource", makeControl("C-001", "Control", "failed")),
+			),
+			wantErr: "duplicate resource and control pair",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Compute(writeTempReport(t, test.report), valid)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestComputeAcceptsEmptyKubescapeReports(t *testing.T) {
+	base := writeTempReport(t, makeReport())
+	head := writeTempReport(t, makeReport())
+
+	changes, err := Compute(base, head)
+	require.NoError(t, err)
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	assert.Empty(t, changes.Unchanged)
 }
 
 func TestFilterBySeverity(t *testing.T) {


### PR DESCRIPTION
## Summary

The diff command previously accepted any syntactically valid JSON document.

Inputs such as `{}`, a SARIF report, or a report with `results: null` were decoded into empty Go values. Kubescape then reported no new failures instead of explaining that the input was not a valid scan report.

This is especially risky when `kubescape diff --fail-on-new` is used as a CI security gate because an invalid report could produce a successful result.

## What changed

- Require each input report to be a JSON object
- Require `results` to be an array
- Require `summaryDetails` and `summaryDetails.controls` to be objects
- Reject empty resource IDs, control IDs, and control statuses
- Reject duplicate resource and control pairs that would otherwise overwrite each other
- Continue accepting valid reports with an empty results array
- Add regression coverage for malformed reports, SARIF input, null fields, duplicate entries, and valid empty reports

## Why this matters

A diff should only return a clean result after comparing two valid Kubescape reports.

Invalid or ambiguous input now produces a clear error instead of silently weakening CI enforcement.

## Testing

- `go test ./core/pkg/resultshandling/diff ./core/core`
- `go test -race ./core/pkg/resultshandling/diff`
- `golangci-lint run --new-from-rev upstream/master ./core/pkg/resultshandling/diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for scan reports before differences are calculated.
  * Reports with missing, empty, malformed, duplicate, or ambiguous data are now rejected with clearer handling.
  * Empty Kubernetes security reports can now be processed successfully.
  * Added support for surrounding whitespace in report files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->