### PR TITLE
fix(cache): publish policy files atomically

### DIFF
--- a/core/cautils/getter/getpoliciesutils.go
+++ b/core/cautils/getter/getpoliciesutils.go
@@ -1,6 +1,7 @@
 package getter
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,6 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 )
+
+const savedJSONFileMode os.FileMode = 0o644
+
+var renameSavedFile = os.Rename
 
 // GetDefaultPath returns a location under the local dot files for kubescape.
 //
@@ -43,24 +48,69 @@ func SaveInFile(object any, targetFile string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(targetFile, encodedData, 0644) //nolint:gosec
-	if err != nil {
-		if os.IsNotExist(err) {
-			pathDir := filepath.Dir(targetFile)
-			// pathDir could contain subdirectories
-			if erm := os.MkdirAll(pathDir, 0755); erm != nil {
-				return erm
-			}
-		} else {
-			return err
-
-		}
-		err = os.WriteFile(targetFile, encodedData, 0644) //nolint:gosec
-		if err != nil {
-			return err
-		}
+	if targetFile == "" {
+		return fmt.Errorf("target file is empty")
 	}
+
+	targetDir := filepath.Dir(targetFile)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("create target directory: %w", err)
+	}
+
+	mode, err := savedFileMode(targetFile)
+	if err != nil {
+		return err
+	}
+
+	tempFile, err := os.CreateTemp(targetDir, ".kubescape-json-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary JSON file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := tempFile.Chmod(mode); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("set temporary JSON file permissions: %w", err)
+	}
+	if _, err := tempFile.Write(encodedData); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write temporary JSON file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("sync temporary JSON file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temporary JSON file: %w", err)
+	}
+	if err := renameSavedFile(tempPath, targetFile); err != nil {
+		return fmt.Errorf("replace target JSON file: %w", err)
+	}
+	committed = true
 	return nil
+}
+
+func savedFileMode(targetFile string) (os.FileMode, error) {
+	info, err := os.Lstat(targetFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return savedJSONFileMode, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("inspect target JSON file: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return 0, fmt.Errorf("target JSON file %q is a symbolic link", targetFile)
+	}
+	if !info.Mode().IsRegular() {
+		return 0, fmt.Errorf("target JSON file %q is not a regular file", targetFile)
+	}
+	return info.Mode().Perm(), nil
 }
 
 // HttpDelete provides a low-level capability to send a HTTP DELETE request and serialize the response as a string.

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -1,11 +1,14 @@
 package getter
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	beClient "github.com/kubescape/backend/pkg/client/v1"
@@ -176,13 +179,7 @@ func TestPolicyCachePath(t *testing.T) {
 }
 
 func TestSaveInFile(t *testing.T) {
-	t.Parallel()
-
-	dir, err := os.MkdirTemp(".", "test")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 
 	policy := map[string]any{
 		"key":    "value",
@@ -199,6 +196,10 @@ func TestSaveInFile(t *testing.T) {
 		require.NoError(t, json.Unmarshal(buf, &retrieved))
 
 		require.EqualValues(t, policy, retrieved)
+
+		info, err := os.Stat(target)
+		require.NoError(t, err)
+		require.Equal(t, savedJSONFileMode, info.Mode().Perm())
 	})
 
 	t.Run("should save data as JSON (new target folder)", func(t *testing.T) {
@@ -221,7 +222,114 @@ func TestSaveInFile(t *testing.T) {
 		}
 		target := filepath.Join(dir, "error.json")
 		require.Error(t, SaveInFile(badPolicy, target))
+		_, err := os.Stat(target)
+		require.ErrorIs(t, err, os.ErrNotExist)
 	})
+}
+
+func TestSaveInFilePreservesExistingFileWhenCommitFails(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "framework.json")
+	original := []byte(`{"name":"known-good"}`)
+	require.NoError(t, os.WriteFile(target, original, 0o600))
+
+	originalRename := renameSavedFile
+	renameSavedFile = func(_, _ string) error {
+		return errors.New("simulated rename failure")
+	}
+	t.Cleanup(func() { renameSavedFile = originalRename })
+
+	err := SaveInFile(map[string]string{"name": "replacement"}, target)
+	require.ErrorContains(t, err, "simulated rename failure")
+
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, original, contents, "a failed commit must leave the last valid cache entry intact")
+
+	temps, err := filepath.Glob(filepath.Join(filepath.Dir(target), ".kubescape-json-*.tmp"))
+	require.NoError(t, err)
+	require.Empty(t, temps, "failed writes must not leak temporary files")
+}
+
+func TestSaveInFilePreservesExistingPermissions(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "controls.json")
+	require.NoError(t, os.WriteFile(target, []byte(`{"old":true}`), 0o600))
+
+	require.NoError(t, SaveInFile(map[string]bool{"new": true}, target))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestSaveInFileRejectsNonRegularTargets(t *testing.T) {
+	t.Run("empty target", func(t *testing.T) {
+		require.ErrorContains(t, SaveInFile(map[string]string{"key": "value"}, ""), "target file is empty")
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "target.json")
+		require.NoError(t, os.Mkdir(target, 0o755))
+		require.ErrorContains(t, SaveInFile(map[string]string{"key": "value"}, target), "not a regular file")
+	})
+
+	t.Run("symbolic link", func(t *testing.T) {
+		dir := t.TempDir()
+		destination := filepath.Join(dir, "destination.json")
+		link := filepath.Join(dir, "target.json")
+		require.NoError(t, os.WriteFile(destination, []byte(`{"safe":true}`), 0o600))
+		if err := os.Symlink(destination, link); err != nil {
+			t.Skipf("symbolic links are unavailable: %v", err)
+		}
+
+		require.ErrorContains(t, SaveInFile(map[string]bool{"safe": false}, link), "symbolic link")
+		contents, err := os.ReadFile(destination)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"safe":true}`, string(contents))
+	})
+}
+
+func TestSaveInFileConcurrentWritersAlwaysPublishCompleteJSON(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "policy.json")
+	require.NoError(t, SaveInFile(map[string]any{"writer": -1, "payload": strings.Repeat("initial", 1000)}, target))
+
+	const writers = 12
+	start := make(chan struct{})
+	errorsByWriter := make(chan error, writers)
+	var writersWG sync.WaitGroup
+	for writer := 0; writer < writers; writer++ {
+		writersWG.Add(1)
+		go func(writer int) {
+			defer writersWG.Done()
+			<-start
+			errorsByWriter <- SaveInFile(map[string]any{
+				"writer":  writer,
+				"payload": strings.Repeat(strconv.Itoa(writer), 20000),
+			}, target)
+		}(writer)
+	}
+
+	close(start)
+	readDone := make(chan struct{})
+	go func() {
+		writersWG.Wait()
+		close(readDone)
+	}()
+
+	for {
+		contents, err := os.ReadFile(target)
+		require.NoError(t, err)
+		var published map[string]any
+		require.NoError(t, json.Unmarshal(contents, &published), "readers must never observe a partially written cache entry")
+
+		select {
+		case <-readDone:
+			for writer := 0; writer < writers; writer++ {
+				require.NoError(t, <-errorsByWriter)
+			}
+			return
+		default:
+		}
+	}
 }
 
 func TestHttpMethods(t *testing.T) {


### PR DESCRIPTION
## Summary

Policy, framework, exception, and control-input files were written directly to their final paths using `os.WriteFile`.

That operation truncates an existing file before the replacement is completely written. If Kubescape exits unexpectedly, the disk becomes full, or another process reads the file concurrently, the cache can contain incomplete JSON. Later scans may then fail until the damaged cache file is removed or downloaded again.

## What changed

- Serialize the complete JSON document before touching the destination
- Write the replacement into a temporary file in the same directory
- Sync and close the temporary file before publishing it
- Atomically rename the completed file over the destination
- Preserve permissions from an existing cache file
- Remove temporary files when a write or rename fails
- Reject symbolic links and other non-regular destination files
- Add concurrent writer and reader coverage to ensure readers only observe complete JSON
- Add failure tests confirming the last valid cache entry remains available

## Why this matters

Policy cache files are used by later scans and may be accessed by multiple Kubescape processes.

Atomic publication prevents interrupted downloads and concurrent updates from leaving corrupted policy data behind.

## Testing

- `go test ./core/cautils/getter`
- `go test -race ./core/cautils/getter`
- `golangci-lint run --new-from-rev upstream/master ./core/cautils/getter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON file saving reliability by preventing partial or corrupted files during interruptions and concurrent updates.
  * Existing file permissions are now preserved when files are replaced.
  * Invalid destinations, including directories, symbolic links, and empty paths, are rejected with clear errors.
  * Failed saves no longer leave behind incomplete files or temporary artifacts.

* **Improvements**
  * Required parent directories are created automatically when saving files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->