### PR TITLE
feat(printer): surface current field value alongside failed paths in scan output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -1,0 +1,182 @@
+package printer
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+)
+
+type pathSegment struct {
+	key   string
+	index int
+}
+
+func splitPath(path string) []pathSegment {
+	path = strings.TrimPrefix(path, ".")
+	if i := strings.Index(path, "="); i >= 0 {
+		path = path[:i]
+	}
+
+	var segments []pathSegment
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			continue
+		}
+		seg := pathSegment{index: -1}
+		if i := strings.Index(part, "["); i >= 0 {
+			seg.key = part[:i]
+			tail := part[i+1:]
+			if j := strings.Index(tail, "]"); j >= 0 {
+				if n, err := strconv.Atoi(tail[:j]); err == nil {
+					seg.index = n
+				}
+			}
+		} else {
+			seg.key = part
+		}
+		segments = append(segments, seg)
+	}
+	return segments
+}
+
+// anyToString converts a scalar value to its string representation.
+// It handles all numeric types that may appear in JSON-decoded or
+// programmatically-constructed Kubernetes objects.
+// Maps and slices return ("", false).
+func anyToString(v any) (string, bool) {
+	switch val := v.(type) {
+	case nil:
+		return "null", true
+	case bool:
+		return strconv.FormatBool(val), true
+	case string:
+		if val == "" {
+			return `""`, true
+		}
+		return val, true
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10), true
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(val), true
+	case int32:
+		return strconv.FormatInt(int64(val), 10), true
+	case int64:
+		return strconv.FormatInt(val, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint64:
+		return strconv.FormatUint(val, 10), true
+	case json.Number:
+		return val.String(), true
+	default:
+		return "", false
+	}
+}
+
+func extractValueAtPath(obj map[string]any, path string) (string, bool) {
+	if len(obj) == 0 || path == "" {
+		return "", false
+	}
+	segments := splitPath(path)
+	if len(segments) == 0 {
+		return "", false
+	}
+
+	var cur any = obj
+	for _, seg := range segments {
+		switch v := cur.(type) {
+		case map[string]any:
+			next, ok := v[seg.key]
+			if !ok {
+				return "", false
+			}
+			if seg.index >= 0 {
+				arr, ok := next.([]any)
+				if !ok || seg.index >= len(arr) {
+					return "", false
+				}
+				cur = arr[seg.index]
+			} else {
+				cur = next
+			}
+		case []any:
+			if seg.index < 0 || seg.index >= len(v) {
+				return "", false
+			}
+			cur = v[seg.index]
+		default:
+			return "", false
+		}
+	}
+	return anyToString(cur)
+}
+
+// isSensitivePath reports whether a path targets a field whose value must
+// not be surfaced in scan output. Secret data and stringData contain
+// credentials that are base64-encoded (or plaintext) and must never be
+// printed regardless of what the existing redaction in updateResults has done.
+func isSensitivePath(kind, path string) bool {
+	if kind != "Secret" {
+		return false
+	}
+	if i := strings.Index(path, "="); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.TrimLeft(path, ".")
+	return path == "data" || strings.HasPrefix(path, "data.") ||
+		path == "stringData" || strings.HasPrefix(path, "stringData.")
+}
+
+// enrichedPathsForField iterates a control's rule paths, extracts the string
+// field selected by getPath, and appends " (current: <value>)" when the value
+// can be read from the resource object. Paths that are sensitive (e.g., Secret
+// data fields) or whose value is a map, slice, or absent fall back to the bare
+// path string so the output is never degraded or a security risk.
+func enrichedPathsForField(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
+	var paths []string
+	obj := resource.GetObject()
+	kind := resource.GetKind()
+	for j := range control.ResourceAssociatedRules {
+		for k := range control.ResourceAssociatedRules[j].Paths {
+			p := getPath(control.ResourceAssociatedRules[j].Paths[k])
+			if p == "" {
+				continue
+			}
+			if !isSensitivePath(kind, p) {
+				if val, ok := extractValueAtPath(obj, p); ok {
+					paths = append(paths, p+" (current: "+val+")")
+					continue
+				}
+			}
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func failedPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+}
+
+func reviewPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
+}
+
+func AssistedRemediationPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	fixPaths := fixPathsToString(control, false)
+	deletePaths := deletePathsToString(control)
+	enrichedReview := reviewPathsWithCurrentValues(control, resource)
+	enrichedFailed := failedPathsWithCurrentValues(control, resource)
+
+	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
+	return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+}

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -1,0 +1,503 @@
+package printer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []pathSegment
+	}{
+		{
+			name:  "simple key",
+			input: "apiVersion",
+			want:  []pathSegment{{key: "apiVersion", index: -1}},
+		},
+		{
+			name:  "dotted path",
+			input: "spec.securityContext.runAsNonRoot",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "securityContext", index: -1},
+				{key: "runAsNonRoot", index: -1},
+			},
+		},
+		{
+			name:  "array index",
+			input: "spec.containers[0].image",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "containers", index: 0},
+				{key: "image", index: -1},
+			},
+		},
+		{
+			name:  "second array element",
+			input: "spec.containers[2].securityContext.privileged",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "containers", index: 2},
+				{key: "securityContext", index: -1},
+				{key: "privileged", index: -1},
+			},
+		},
+		{
+			name:  "strip leading dot",
+			input: ".spec.nodeName",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "nodeName", index: -1},
+			},
+		},
+		{
+			name:  "strip = suffix (failed path format)",
+			input: "spec.containers[0].securityContext.privileged=true",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "containers", index: 0},
+				{key: "securityContext", index: -1},
+				{key: "privileged", index: -1},
+			},
+		},
+		{
+			name:  "empty path",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "empty segments from double dot",
+			input: "spec..image",
+			want: []pathSegment{
+				{key: "spec", index: -1},
+				{key: "image", index: -1},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitPath(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestAnyToString(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  any
+		want   string
+		wantOK bool
+	}{
+		{name: "nil", input: nil, want: "null", wantOK: true},
+		{name: "true", input: true, want: "true", wantOK: true},
+		{name: "false", input: false, want: "false", wantOK: true},
+		{name: "non-empty string", input: "nginx:latest", want: "nginx:latest", wantOK: true},
+		{name: "empty string", input: "", want: `""`, wantOK: true},
+		{name: "integer float64", input: float64(8080), want: "8080", wantOK: true},
+		{name: "fractional float64", input: float64(3.14), want: "3.14", wantOK: true},
+		{name: "int", input: int(42), want: "42", wantOK: true},
+		{name: "int32", input: int32(1000), want: "1000", wantOK: true},
+		{name: "int64", input: int64(99), want: "99", wantOK: true},
+		{name: "uint", input: uint(7), want: "7", wantOK: true},
+		{name: "uint32", input: uint32(8080), want: "8080", wantOK: true},
+		{name: "uint64", input: uint64(65535), want: "65535", wantOK: true},
+		{name: "json.Number integer", input: json.Number("3"), want: "3", wantOK: true},
+		{name: "json.Number float", input: json.Number("1.5"), want: "1.5", wantOK: true},
+		{name: "map (complex)", input: map[string]any{"k": "v"}, want: "", wantOK: false},
+		{name: "slice (complex)", input: []any{"a"}, want: "", wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := anyToString(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestExtractValueAtPath(t *testing.T) {
+	deploymentObj := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "nginx",
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"securityContext": map[string]any{
+				"runAsNonRoot": true,
+			},
+			"containers": []any{
+				map[string]any{
+					"name":  "main",
+					"image": "nginx:latest",
+					"securityContext": map[string]any{
+						"privileged":               true,
+						"allowPrivilegeEscalation": false,
+					},
+					"resources": map[string]any{
+						"limits": map[string]any{
+							"memory": "128Mi",
+							"cpu":    float64(500),
+						},
+					},
+				},
+				map[string]any{
+					"name":  "sidecar",
+					"image": "envoy:v1",
+					"securityContext": map[string]any{
+						"privileged": false,
+					},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name   string
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "top-level key",
+			path:   "apiVersion",
+			want:   "apps/v1",
+			wantOK: true,
+		},
+		{
+			name:   "nested key",
+			path:   "metadata.name",
+			want:   "nginx",
+			wantOK: true,
+		},
+		{
+			name:   "bool true",
+			path:   "spec.securityContext.runAsNonRoot",
+			want:   "true",
+			wantOK: true,
+		},
+		{
+			name:   "bool false",
+			path:   "spec.containers[1].securityContext.privileged",
+			want:   "false",
+			wantOK: true,
+		},
+		{
+			name:   "array index string",
+			path:   "spec.containers[0].image",
+			want:   "nginx:latest",
+			wantOK: true,
+		},
+		{
+			name:   "second array element",
+			path:   "spec.containers[1].image",
+			want:   "envoy:v1",
+			wantOK: true,
+		},
+		{
+			name:   "deeply nested string",
+			path:   "spec.containers[0].resources.limits.memory",
+			want:   "128Mi",
+			wantOK: true,
+		},
+		{
+			name:   "integer-valued float",
+			path:   "spec.containers[0].resources.limits.cpu",
+			want:   "500",
+			wantOK: true,
+		},
+		{
+			name:   "missing top-level key",
+			path:   "status",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "missing nested key",
+			path:   "spec.containers[0].securityContext.readOnlyRootFilesystem",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "out-of-range array index",
+			path:   "spec.containers[9].image",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "path with = suffix stripped",
+			path:   "spec.containers[0].securityContext.privileged=false",
+			want:   "true",
+			wantOK: true,
+		},
+		{
+			name:   "path with leading dot",
+			path:   ".metadata.namespace",
+			want:   "default",
+			wantOK: true,
+		},
+		{
+			name:   "map value returns false",
+			path:   "spec.securityContext",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "empty path",
+			path:   "",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "empty object",
+			path:   "spec.containers[0].image",
+			want:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := deploymentObj
+			if tc.name == "empty object" {
+				obj = map[string]any{}
+			}
+			got, ok := extractValueAtPath(obj, tc.path)
+			assert.Equal(t, tc.wantOK, ok, "ok mismatch")
+			assert.Equal(t, tc.want, got, "value mismatch")
+		})
+	}
+}
+
+func TestIsSensitivePath(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+		path string
+		want bool
+	}{
+		{name: "Secret data key", kind: "Secret", path: "data.password", want: true},
+		{name: "Secret data root", kind: "Secret", path: "data", want: true},
+		{name: "Secret stringData key", kind: "Secret", path: "stringData.token", want: true},
+		{name: "Secret stringData root", kind: "Secret", path: "stringData", want: true},
+		{name: "Secret data with = suffix", kind: "Secret", path: "data.password=changed", want: true},
+		{name: "Secret data with leading dot", kind: "Secret", path: ".data.password", want: true},
+		{name: "Secret data with two leading dots", kind: "Secret", path: "..data.password", want: true},
+		{name: "Secret stringData with three leading dots", kind: "Secret", path: "...stringData.token", want: true},
+		{name: "Secret non-sensitive field", kind: "Secret", path: "metadata.name", want: false},
+		{name: "Deployment data field", kind: "Deployment", path: "data.key", want: false},
+		{name: "ConfigMap data field", kind: "ConfigMap", path: "data.config", want: false},
+		{name: "empty kind", kind: "", path: "data.key", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSensitivePath(tc.kind, tc.path))
+		})
+	}
+}
+
+func TestEnrichedPathsForField(t *testing.T) {
+	deploymentResource := &mockResource{
+		kind: "Deployment",
+		obj: map[string]any{
+			"spec": map[string]any{
+				"hostIPC": true,
+			},
+		},
+	}
+	ctrl := &resourcesresults.ResourceAssociatedControl{
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Paths: []armotypes.PosturePaths{
+					{FailedPath: "spec.hostIPC"},
+					{ReviewPath: "spec.hostIPC"},
+				},
+			},
+		},
+	}
+
+	t.Run("getPath selects FailedPath", func(t *testing.T) {
+		got := enrichedPathsForField(ctrl, deploymentResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.hostIPC (current: true)", got[0])
+	})
+
+	t.Run("getPath selects ReviewPath", func(t *testing.T) {
+		got := enrichedPathsForField(ctrl, deploymentResource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.hostIPC (current: true)", got[0])
+	})
+
+	t.Run("empty obj produces bare path", func(t *testing.T) {
+		emptyResource := &mockResource{kind: "Deployment", obj: map[string]any{}}
+		got := enrichedPathsForField(ctrl, emptyResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.hostIPC", got[0])
+	})
+
+	t.Run("Secret data path is suppressed", func(t *testing.T) {
+		secretResource := &mockResource{
+			kind: "Secret",
+			obj: map[string]any{
+				"data": map[string]any{
+					"password": "XXXXXX",
+				},
+			},
+		}
+		secretCtrl := &resourcesresults.ResourceAssociatedControl{
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+				{Paths: []armotypes.PosturePaths{{FailedPath: "data.password"}}},
+			},
+		}
+		got := enrichedPathsForField(secretCtrl, secretResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+		require.Len(t, got, 1)
+		assert.Equal(t, "data.password", got[0])
+	})
+}
+
+func makeControlWithPaths(failedPaths, reviewPaths []string) *resourcesresults.ResourceAssociatedControl {
+	var posturePaths []armotypes.PosturePaths
+	for _, fp := range failedPaths {
+		posturePaths = append(posturePaths, armotypes.PosturePaths{FailedPath: fp})
+	}
+	for _, rp := range reviewPaths {
+		posturePaths = append(posturePaths, armotypes.PosturePaths{ReviewPath: rp})
+	}
+	return &resourcesresults.ResourceAssociatedControl{
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{Paths: posturePaths},
+		},
+	}
+}
+
+type mockResource struct {
+	kind string
+	obj  map[string]any
+}
+
+func (m *mockResource) GetObject() map[string]any   { return m.obj }
+func (m *mockResource) GetApiVersion() string       { return "" }
+func (m *mockResource) GetKind() string             { return m.kind }
+func (m *mockResource) GetName() string             { return "" }
+func (m *mockResource) GetNamespace() string        { return "" }
+func (m *mockResource) GetID() string               { return "" }
+func (m *mockResource) GetWorkload() map[string]any { return m.obj }
+func (m *mockResource) GetObjectType() workloadinterface.ObjectType {
+	return workloadinterface.TypeUnknown
+}
+
+func (m *mockResource) SetNamespace(string)                {}
+func (m *mockResource) SetName(string)                     {}
+func (m *mockResource) SetKind(string)                     {}
+func (m *mockResource) SetWorkload(map[string]interface{}) {}
+func (m *mockResource) SetObject(map[string]interface{})   {}
+func (m *mockResource) SetApiVersion(string)               {}
+
+func TestFailedPathsWithCurrentValues(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"hostNetwork": true,
+			"containers": []any{
+				map[string]any{
+					"securityContext": map[string]any{
+						"privileged": true,
+					},
+				},
+			},
+		},
+	}
+	resource := &mockResource{obj: obj}
+
+	t.Run("value extracted", func(t *testing.T) {
+		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
+		got := failedPathsWithCurrentValues(ctrl, resource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[0])
+	})
+
+	t.Run("missing path falls back to bare path", func(t *testing.T) {
+		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.readOnlyRootFilesystem"}, nil)
+		got := failedPathsWithCurrentValues(ctrl, resource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.containers[0].securityContext.readOnlyRootFilesystem", got[0])
+	})
+
+	t.Run("multiple paths", func(t *testing.T) {
+		ctrl := makeControlWithPaths([]string{
+			"spec.hostNetwork",
+			"spec.containers[0].securityContext.privileged",
+		}, nil)
+		got := failedPathsWithCurrentValues(ctrl, resource)
+		require.Len(t, got, 2)
+		assert.Equal(t, "spec.hostNetwork (current: true)", got[0])
+		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[1])
+	})
+
+	t.Run("no failed paths returns nil", func(t *testing.T) {
+		ctrl := makeControlWithPaths(nil, nil)
+		got := failedPathsWithCurrentValues(ctrl, resource)
+		assert.Nil(t, got)
+	})
+}
+
+func TestReviewPathsWithCurrentValues(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"automountServiceAccountToken": true,
+		},
+	}
+	resource := &mockResource{obj: obj}
+
+	t.Run("value extracted", func(t *testing.T) {
+		ctrl := makeControlWithPaths(nil, []string{"spec.automountServiceAccountToken"})
+		got := reviewPathsWithCurrentValues(ctrl, resource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.automountServiceAccountToken (current: true)", got[0])
+	})
+
+	t.Run("missing path falls back", func(t *testing.T) {
+		ctrl := makeControlWithPaths(nil, []string{"spec.serviceAccountName"})
+		got := reviewPathsWithCurrentValues(ctrl, resource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.serviceAccountName", got[0])
+	})
+}
+
+func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"hostPID": true,
+		},
+	}
+	resource := &mockResource{obj: obj}
+
+	t.Run("failed path annotated, fix path unchanged", func(t *testing.T) {
+		ctrl := &resourcesresults.ResourceAssociatedControl{
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.hostPID"},
+						{FixPath: armotypes.FixPath{Path: "spec.hostPID", Value: "false"}},
+					},
+				},
+			},
+		}
+		got := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
+		assert.Contains(t, got, "spec.hostPID=false")
+		assert.Contains(t, got, "spec.hostPID (current: true)")
+		assert.Len(t, got, 2)
+	})
+}

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -84,7 +84,7 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 		}
 
 		row[resourceColumnURL] = cautils.GetControlLink(controls[i].GetID())
-		paths := AssistedRemediationPathsToString(&controls[i])
+		paths := AssistedRemediationPathsWithCurrentValues(&controls[i], resource)
 		addContainerNameToAssistedRemediation(resource, &paths)
 		row[resourceColumnPath] = strings.Join(paths, "\n")
 		row[resourceColumnName] = controls[i].GetName()


### PR DESCRIPTION
## Summary

- When a control fails, the pretty-printer lists the field path that triggered
  the failure (e.g. `spec.containers[0].securityContext.privileged`) but not
  the current value - users must open the manifest manually.
- Added `pathvalue.go` with three internal helpers: `splitPath` (handles `[N]`
  array indices, `.` prefix, `=suffix`), `anyToString` (bool/string/float64/nil),
  and `extractValueAtPath`, together they traverse the in-memory resource object
  to read the scalar value at a dot-notation path.
- Added `enrichedPathsForField` which drives both `failedPathsWithCurrentValues`
  and `reviewPathsWithCurrentValues`; the two differ only in which PosturePaths
  field they read.
- Added `AssistedRemediationPathsWithCurrentValues(control, resource)` - used by
  `generateResourceRows` in `resourcetable.go`. `FixPath` output (`path=target`)
  and the HTML/SARIF printers are unchanged.
- 41 table-driven tests: happy paths, missing keys, out-of-range indices, type
  coercion, `=suffix`/leading-dot stripping, and fallback behavior.

**Does this PR introduce a user-facing change?**
Yes the pretty-printer "Assisted remediation" column now shows:
`spec.containers[0].securityContext.privileged (current: true)` instead of
`spec.containers[0].securityContext.privileged`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remediation results now display current values for relevant resource paths.
  * Supports nested fields, array entries, scalar values, review paths, failed paths, and assisted-remediation details.
  * Duplicate remediation paths are automatically consolidated.
  * Sensitive Secret values remain excluded from displayed enrichment.

* **Bug Fixes**
  * Improved handling of missing, invalid, or empty resource values without disrupting result output.

* **Tests**
  * Added comprehensive coverage for path parsing, value extraction, formatting, and remediation output scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->