### PR TITLE
fix: resolve review feedback for CycloneDX/SPDX SBOM output formats

### DIFF
--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -95,7 +95,7 @@ func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml`)
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, cyclonedx-json, spdx-json`)
 }
 
 func TestGetImageCmd_RunE_Success(t *testing.T) {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -392,7 +392,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv"
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, cyclonedx-json, spdx-json"
 	assert.EqualError(t, err, errMessage)
 }
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -197,6 +197,10 @@ func fileExtForFormat(format string) string {
 		return printer.PrometheusOutputExt
 	case printer.CsvFormat:
 		return printer.CsvOutputExt
+	case printer.CycloneDXFormat:
+		return printer.CycloneDXOutputExt
+	case printer.SPDXFormat:
+		return printer.SPDXOutputExt
 	default:
 		return printer.PrettyOutputExt
 	}

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -25,16 +25,21 @@ const (
 	GitLabSASTFormat  string = "gitlab-sast"
 	YamlFormat        string = "yaml"
 	CsvFormat         string = "csv"
+	CycloneDXFormat   string = "cyclonedx-json"
+	SPDXFormat        string = "spdx-json"
 )
 
 // AllFormats lists every output format kubescape can emit.
-var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat}
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, CycloneDXFormat, SPDXFormat}
 
 // ImageFormats lists formats whose printers support image-scan data. CSV is
 // deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
 // errors out on image scans (#2743) — a format must not be advertised as
 // image-scan-capable unless its printer actually handles that path.
-var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat}
+//
+// CycloneDXFormat and SPDXFormat are the inverse: they encode the SBOM that
+// only exists on image scans, so they are image-scan-only (see ValidatePrinter).
+var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CycloneDXFormat, SPDXFormat}
 
 const (
 	JsonOutputExt       = ".json"
@@ -46,6 +51,8 @@ const (
 	PrettyOutputExt     = ".txt"
 	YamlOutputExt       = ".yaml"
 	CsvOutputExt        = ".csv"
+	CycloneDXOutputExt  = ".cdx.json"
+	SPDXOutputExt       = ".spdx.json"
 )
 
 type IPrinter interface {

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -3,7 +3,6 @@ package printer
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/anchore/syft/syft/format"

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -1,0 +1,84 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/anchore/syft/syft/format"
+	"github.com/anchore/syft/syft/format/cyclonedxjson"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+)
+
+const (
+	cyclonedxOutputFile = "sbom"
+)
+
+var _ printer.IPrinter = &CycloneDXPrinter{}
+
+type CycloneDXPrinter struct {
+	writer *os.File
+}
+
+func NewCycloneDXPrinter() *CycloneDXPrinter {
+	return &CycloneDXPrinter{}
+}
+
+func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = cyclonedxOutputFile
+		}
+		if !strings.HasSuffix(strings.TrimSpace(outputFile), printer.CycloneDXOutputExt) {
+			outputFile = outputFile + printer.CycloneDXOutputExt
+		}
+	}
+	cp.writer = printer.GetWriter(ctx, outputFile)
+}
+
+// Score is a no-op: HandleResults only calls Score when opaSessionObj != nil
+// (core/pkg/resultshandling/results.go), and this printer only ever runs
+// against image scans, so it is never invoked in practice.
+func (cp *CycloneDXPrinter) Score(score float32) {}
+
+func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj != nil || len(imageScanData) == 0 {
+		logger.L().Ctx(ctx).Error("cyclonedx-json output is only supported for image scans")
+		return
+	}
+	if imageScanData[0].SBOM == nil {
+		logger.L().Ctx(ctx).Error("no SBOM data available for cyclonedx-json output")
+		return
+	}
+
+	encoder, err := cyclonedxjson.NewFormatEncoderWithConfig(cyclonedxjson.DefaultEncoderConfig())
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to create cyclonedx-json encoder", helpers.Error(err))
+		return
+	}
+
+	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to encode SBOM as cyclonedx-json", helpers.Error(err))
+		return
+	}
+
+	if _, err := cp.writer.Write(data); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write cyclonedx-json output", helpers.Error(err))
+		return
+	}
+
+	printer.LogOutputFile(cp.writer.Name())
+}
+
+func (cp *CycloneDXPrinter) PrintNextSteps() {}
+
+func (cp *CycloneDXPrinter) CloseWriter() {
+	if cp.writer != nil && cp.writer != os.Stdout {
+		cp.writer.Close()
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
@@ -1,0 +1,69 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCycloneDXPrinter(t *testing.T) {
+	cp := NewCycloneDXPrinter()
+	assert.NotNil(t, cp)
+}
+
+func TestSetWriter_CycloneDX(t *testing.T) {
+	cp := NewCycloneDXPrinter()
+	cp.SetWriter(context.TODO(), "")
+	assert.NotNil(t, cp.writer)
+	cp.CloseWriter()
+}
+
+func TestSetWriter_CycloneDX_AppendsExtension(t *testing.T) {
+	cp := NewCycloneDXPrinter()
+	tmpDir := t.TempDir()
+	cp.SetWriter(context.TODO(), tmpDir+"/report")
+	defer cp.CloseWriter()
+
+	assert.Contains(t, cp.writer.Name(), ".cdx.json")
+}
+
+func TestActionPrint_CycloneDX_ImageScan(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{buildSeverityExceptionImageScanData()}
+
+	tmp, err := os.CreateTemp("", "cyclonedx-imagescan-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	cp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &doc), "output must be valid JSON")
+	assert.Equal(t, "CycloneDX", doc["bomFormat"])
+}
+
+func TestActionPrint_CycloneDX_NonImageScan_NoOutput(t *testing.T) {
+	tmp, err := os.CreateTemp("", "cyclonedx-noimage-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	cp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	assert.Empty(t, raw, "cyclonedx-json must not write anything for a non-image scan")
+}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -1,0 +1,84 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/anchore/syft/syft/format"
+	"github.com/anchore/syft/syft/format/spdxjson"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+)
+
+const (
+	spdxOutputFile = "sbom"
+)
+
+var _ printer.IPrinter = &SPDXPrinter{}
+
+type SPDXPrinter struct {
+	writer *os.File
+}
+
+func NewSPDXPrinter() *SPDXPrinter {
+	return &SPDXPrinter{}
+}
+
+func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = spdxOutputFile
+		}
+		if !strings.HasSuffix(strings.TrimSpace(outputFile), printer.SPDXOutputExt) {
+			outputFile = outputFile + printer.SPDXOutputExt
+		}
+	}
+	sp.writer = printer.GetWriter(ctx, outputFile)
+}
+
+// Score is a no-op: HandleResults only calls Score when opaSessionObj != nil
+// (core/pkg/resultshandling/results.go), and this printer only ever runs
+// against image scans, so it is never invoked in practice.
+func (sp *SPDXPrinter) Score(score float32) {}
+
+func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+	if opaSessionObj != nil || len(imageScanData) == 0 {
+		logger.L().Ctx(ctx).Error("spdx-json output is only supported for image scans")
+		return
+	}
+	if imageScanData[0].SBOM == nil {
+		logger.L().Ctx(ctx).Error("no SBOM data available for spdx-json output")
+		return
+	}
+
+	encoder, err := spdxjson.NewFormatEncoderWithConfig(spdxjson.DefaultEncoderConfig())
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to create spdx-json encoder", helpers.Error(err))
+		return
+	}
+
+	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to encode SBOM as spdx-json", helpers.Error(err))
+		return
+	}
+
+	if _, err := sp.writer.Write(data); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write spdx-json output", helpers.Error(err))
+		return
+	}
+
+	printer.LogOutputFile(sp.writer.Name())
+}
+
+func (sp *SPDXPrinter) PrintNextSteps() {}
+
+func (sp *SPDXPrinter) CloseWriter() {
+	if sp.writer != nil && sp.writer != os.Stdout {
+		sp.writer.Close()
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -3,7 +3,6 @@ package printer
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/anchore/syft/syft/format"

--- a/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
@@ -1,0 +1,72 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSPDXPrinter(t *testing.T) {
+	sp := NewSPDXPrinter()
+	assert.NotNil(t, sp)
+}
+
+func TestSetWriter_SPDX(t *testing.T) {
+	sp := NewSPDXPrinter()
+	sp.SetWriter(context.TODO(), "")
+	assert.NotNil(t, sp.writer)
+	sp.CloseWriter()
+}
+
+func TestSetWriter_SPDX_AppendsExtension(t *testing.T) {
+	sp := NewSPDXPrinter()
+	tmpDir := t.TempDir()
+	sp.SetWriter(context.TODO(), tmpDir+"/report")
+	defer sp.CloseWriter()
+
+	assert.Contains(t, sp.writer.Name(), ".spdx.json")
+}
+
+func TestActionPrint_SPDX_ImageScan(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{buildSeverityExceptionImageScanData()}
+
+	tmp, err := os.CreateTemp("", "spdx-imagescan-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	sp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &doc), "output must be valid JSON")
+	version, ok := doc["spdxVersion"].(string)
+	require.True(t, ok, "expected spdxVersion field")
+	assert.True(t, strings.HasPrefix(version, "SPDX-"))
+}
+
+func TestActionPrint_SPDX_NonImageScan_NoOutput(t *testing.T) {
+	tmp, err := os.CreateTemp("", "spdx-noimage-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	sp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	assert.Empty(t, raw, "spdx-json must not write anything for a non-image scan")
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -190,6 +190,10 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewSARIFPrinter()
 	case printer.GitLabSASTFormat:
 		return printerv2.NewGitLabSASTPrinter()
+	case printer.CycloneDXFormat:
+		return printerv2.NewCycloneDXPrinter()
+	case printer.SPDXFormat:
+		return printerv2.NewSPDXPrinter()
 	default:
 		if printFormat != printer.PrettyFormat {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Invalid format \"%s\", default format \"pretty-printer\" is applied", printFormat))
@@ -216,6 +220,9 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		default:
 			return false, fmt.Errorf("format \"%s\" is only supported when scanning local files", printFormat)
 		}
+	}
+	if printFormat == printer.CycloneDXFormat || printFormat == printer.SPDXFormat {
+		return false, fmt.Errorf("format \"%s\" is only supported for image scanning", printFormat)
 	}
 
 	switch printFormat {

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -244,6 +244,30 @@ func TestValidatePrinter(t *testing.T) {
 			format:    printer.PdfFormat,
 			expectErr: nil,
 		},
+		{
+			name:      "cyclonedx-json format for image scan should not return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.CycloneDXFormat,
+			expectErr: nil,
+		},
+		{
+			name:      "spdx-json format for image scan should not return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.SPDXFormat,
+			expectErr: nil,
+		},
+		{
+			name:      "cyclonedx-json format for cluster scan should return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    printer.CycloneDXFormat,
+			expectErr: errors.New("format \"cyclonedx-json\" is only supported for image scanning"),
+		},
+		{
+			name:      "spdx-json format for cluster scan should return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    printer.SPDXFormat,
+			expectErr: errors.New("format \"spdx-json\" is only supported for image scanning"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -315,6 +339,18 @@ func TestNewPrinter(t *testing.T) {
 		{
 			name:     "GitLab SAST printer",
 			format:   "gitlab-sast",
+			viewType: "resource",
+			version:  defaultVersion,
+		},
+		{
+			name:     "CycloneDX printer",
+			format:   "cyclonedx-json",
+			viewType: "resource",
+			version:  defaultVersion,
+		},
+		{
+			name:     "SPDX printer",
+			format:   "spdx-json",
 			viewType: "resource",
 			version:  defaultVersion,
 		},


### PR DESCRIPTION
## Overview
Addresses @matthyx's review on this PR (adding `cyclonedx-json`/`spdx-json` SBOM output formats for `kubescape scan image`, resolving #2881). No functional/design changes from the original PR — this fixes the three blocking issues raised in review.

## Changes
- **Compilation failure**: removed the unused `path/filepath` import from `cyclonedxprinter.go` and `spdxprinter.go` — leftover from an earlier draft, never actually used by the final `SetWriter` implementation.
- **Failing CLI format-flag tests**: updated the expected error strings in `TestGetImageCmd_RunE_FormatFlagInvalid` (`cmd/scan/image_test.go`) and `TestGetScanCommand_RunE_FormatFlagInvalid` (`cmd/scan/scan_test.go`) to include `cyclonedx-json, spdx-json`, since both formats are now part of the supported-formats list surfaced in that error message.
- **Missing unit tests**:
  - Added `core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go` and `spdxprinter_test.go` — constructor, `SetWriter` (default writer + extension auto-append), and `ActionPrint` for both the image-scan success path (asserts valid `bomFormat`/`spdxVersion` JSON output) and the non-image-scan no-op path.
  - Added 4 new cases to `TestValidatePrinter` and 2 new cases to `TestNewPrinter` in `core/pkg/resultshandling/results_test.go`, covering both formats for image scans (accepted) and cluster scans (rejected with the image-only error).

## How to test
go build ./... && go vet ./...
go test ./core/pkg/resultshandling/... -v
go test ./cmd/scan/... -v

kubescape scan image nginx:latest --format cyclonedx-json --output sbom.cdx.json
kubescape scan image nginx:latest --format spdx-json --output sbom.spdx.json
kubescape scan . --format cyclonedx-json   # expect: error, image-scan only

## Related issues/PRs
* Resolved #2881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CycloneDX JSON and SPDX JSON output formats for image scan results.
  - Automatically uses `.cdx.json` and `.spdx.json` filename extensions.
  - Added format validation and clear supported-format guidance.
  - Prevented these formats from being used with non-image scans.

- **Tests**
  - Added coverage for valid output, filename handling, writer behavior, and unsupported scan types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->