### PR TITLE
fix(resourcehandler): count returned items in cluster size estimate

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1043,6 +1043,7 @@ func (k8sHandler *K8sResourceHandler) EstimateClusterSize(ctx context.Context, s
 			continue
 		}
 		ok++
+		total += len(result.Items)
 		if rc := result.GetRemainingItemCount(); rc != nil {
 			total += int(*rc)
 		}

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -193,3 +193,50 @@ func TestEstimateClusterSize_NilRemainingItemCount(t *testing.T) {
 	// 15 GVRs * 200 = 3000 (pods with nil remainingItemCount is skipped)
 	assert.Equal(t, 3000, size)
 }
+
+func newListWithItem(gvr schema.GroupVersionResource) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Example",
+		"metadata":   map[string]any{"name": gvr.Resource + "-1"},
+	}}
+}
+
+func TestEstimateClusterSize_CountsReturnedItems(t *testing.T) {
+	mockClient := &gvrAwareDynamicClient{
+		listFunc: func(gvr schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			assert.Equal(t, int64(1), opts.Limit)
+			// No remainingItemCount at all: a cluster with exactly one object of
+			// this type still returns that one object in Items.
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{newListWithItem(gvr)}}, nil
+		},
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient},
+	}
+
+	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
+	require.NoError(t, err)
+	assert.Equal(t, len(namespacedResourcesToEstimate), size,
+		"a returned page item must be counted even when remainingItemCount is absent")
+}
+
+func TestEstimateClusterSize_CountsReturnedItemPlusRemaining(t *testing.T) {
+	mockClient := &gvrAwareDynamicClient{
+		listFunc: func(gvr schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			list := newListWithRemaining(9)
+			list.Items = []unstructured.Unstructured{newListWithItem(gvr)}
+			return list, nil
+		},
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient},
+	}
+
+	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
+	require.NoError(t, err)
+	// each successful GVR contributes 1 returned item + 9 remaining = 10
+	assert.Equal(t, len(namespacedResourcesToEstimate)*10, size)
+}


### PR DESCRIPTION
## Overview

`EstimateClusterSize` issues a `limit=1` LIST per representative GVR and sums `remainingItemCount` from each response to approximate cluster size. Per the Kubernetes API, `remainingItemCount` only reports items *after* the current page — it never includes the item(s) already returned in `Items`. The estimator was therefore undercounting every successful, non-empty LIST by exactly one.

With 16 representative GVRs, the estimate could be low by up to 16. This matters most right around the streaming auto-enable threshold (`LARGE_CLUSTER_SIZE`, default 2500): a cluster whose correctly-computed estimate exceeds the threshold could stay on the non-streaming path because of this undercount.

## How to Test

Added `TestEstimateClusterSize_CountsReturnedItems` (one item, no `remainingItemCount` — previously counted as 0, now correctly counted) and `TestEstimateClusterSize_CountsReturnedItemPlusRemaining` (item + positive `remainingItemCount`, both summed). Existing estimator tests are unaffected since their fixtures never populated `Items`.

```
go test ./core/pkg/resourcehandler/... -run TestEstimateClusterSize -v
```

## Related issues/PRs:

* Resolved #2846

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster-size estimates by counting items returned from limited resource-list requests.
  * Estimates now remain accurate both when remaining-item counts are unavailable and when they are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->