### PR TITLE
fix(resourcehandler): discover nested Kustomize directories in broad scans

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -197,6 +197,21 @@ func listHelmChartDirs(basePath string) ([]string, []error) {
 	return helmDirectories, errs
 }
 
+// listKustomizeDirs scans a given path (recursively) and returns the directories holding a
+// Kustomize configuration (a kustomization.yaml/kustomization.yml/Kustomization file). Each
+// carries its own Kustomization file, so an overlay nested below basePath is found on its own
+// even when basePath itself is not a Kustomize directory.
+func listKustomizeDirs(basePath string) ([]string, []error) {
+	directories, errs := listDirs(basePath)
+	kustomizeDirectories := make([]string, 0)
+	for _, dir := range directories {
+		if isKustomizeDirectory(dir) {
+			kustomizeDirectories = append(kustomizeDirectories, dir)
+		}
+	}
+	return kustomizeDirectories, errs
+}
+
 // excludeHelmTemplateFiles drops the files living under the templates/ directory of a helm chart.
 // LoadResourcesFromHelmCharts renders those templates, so passing them to the plain-YAML loader
 // as well duplicates the workloads it already renders, and warns on every raw template whose
@@ -366,6 +381,41 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 
 	maps.Copy(sourceToWorkloads, wls)
 	return sourceToWorkloads, kustomizeDirectoryName, nil
+}
+
+// LoadResourcesFromNestedKustomizeDirectories discovers and renders Kustomize configurations
+// found below basePath, for the case where basePath itself is a broader directory (e.g. a
+// repository root) rather than a Kustomize directory or file — that direct-input case is already
+// handled by LoadResourcesFromKustomizeDirectory. Every discovered directory carries its own
+// Kustomization file, so each is rendered independently; a directory whose render fails is
+// skipped with a warning rather than aborting the scan, leaving its files to the plain-manifest
+// loader as a fallback. The returned directories are exactly those that rendered successfully,
+// for the caller to exclude from the plain-manifest pass.
+func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, []string, error) {
+	if isKustomizeDirectory(basePath) || IsKustomizeFile(basePath) {
+		// The direct-input case is handled by LoadResourcesFromKustomizeDirectory.
+		return nil, nil, nil
+	}
+
+	kustomizeDirs, errs := listKustomizeDirs(basePath)
+	if len(errs) > 0 {
+		return nil, nil, fmt.Errorf("failed to discover Kustomize configurations under %q: %w", basePath, errors.Join(errs...))
+	}
+
+	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
+	renderedDirs := make([]string, 0, len(kustomizeDirs))
+	for _, dir := range kustomizeDirs {
+		wls, _, err := LoadResourcesFromKustomizeDirectory(ctx, dir)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("Skipping Kustomize directory that failed to render; its files remain available to the plain-manifest loader",
+				helpers.String("path", dir), helpers.Error(err))
+			continue
+		}
+		maps.Copy(sourceToWorkloads, wls)
+		renderedDirs = append(renderedDirs, dir)
+	}
+
+	return sourceToWorkloads, renderedDirs, nil
 }
 
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -254,6 +254,29 @@ func resolveHelmRemotePath(clonedRepo string, gitRepo *cautils.LocalGitRepositor
 	return strings.TrimSuffix(url, ".git")
 }
 
+// excludeFilesUnderDirectories drops entries from sourceToWorkloads whose source path falls
+// under any of dirs. Used to keep a nested Kustomize directory's local inputs out of the
+// plain-manifest results once that directory has already been rendered on its own, so the
+// transformed and raw identities of the same resource don't both end up in the scan.
+func excludeFilesUnderDirectories(sourceToWorkloads map[string][]workloadinterface.IMetadata, dirs []string) {
+	if len(dirs) == 0 {
+		return
+	}
+	cleanDirs := make([]string, len(dirs))
+	for i, dir := range dirs {
+		cleanDirs[i] = filepath.Clean(dir) + string(filepath.Separator)
+	}
+	for source := range sourceToWorkloads {
+		cleanSource := filepath.Clean(source)
+		for _, dir := range cleanDirs {
+			if strings.HasPrefix(cleanSource, dir) {
+				delete(sourceToWorkloads, source)
+				break
+			}
+		}
+	}
+}
+
 // getResourcesFromPath loads every scannable resource under path, from plain
 // manifests, helm charts and kustomize directories, and maps each workload to the
 // source file it came from.
@@ -294,9 +317,23 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 
 	// Confirm that the owning Kustomize render succeeds before excluding its chart
 	// templates from the plain-manifest fallback.
-	kustomizeSourceToWorkloads, kustomizeDirectoryName, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
+	kustomizeSourceToWorkloads, _, err := cautils.LoadResourcesFromKustomizeDirectory(ctx, path)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// path itself may not be a Kustomize directory (e.g. a repository root), but a child
+	// directory below it can still hold its own Kustomization. Discover and render those too,
+	// so a broad scan applies their transformations instead of falling through to raw manifests.
+	nestedKustomizeSourceToWorkloads, nestedKustomizeDirs, err := cautils.LoadResourcesFromNestedKustomizeDirectories(ctx, path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(nestedKustomizeSourceToWorkloads) > 0 {
+		if kustomizeSourceToWorkloads == nil {
+			kustomizeSourceToWorkloads = map[string][]workloadinterface.IMetadata{}
+		}
+		maps.Copy(kustomizeSourceToWorkloads, nestedKustomizeSourceToWorkloads)
 	}
 
 	// load resource from local file system
@@ -307,6 +344,9 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	if err != nil {
 		return nil, nil, err
 	}
+	// A nested Kustomization owns the local inputs it rendered; keep them from also being
+	// consumed by the plain-manifest loader as untransformed raw manifests.
+	excludeFilesUnderDirectories(sourceToWorkloads, nestedKustomizeDirs)
 
 	// update workloads and workloadIDToSource
 	var warnIssued bool
@@ -404,6 +444,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// update workloads and workloadIDToSource with workloads from Kustomize Directory
 	for source, ws := range kustomizeSourceToWorkloads {
 		workloads = append(workloads, ws...)
+		// GetWorkloads keys its result by the rendered Kustomize directory's own path, so source
+		// (before it is rewritten to a repo-relative path below) is that directory's name — the
+		// correct owner for each entry even when several Kustomize directories were rendered.
+		kustomizeDirectoryName := source
 		relSource, err := filepath.Rel(repoRoot, source)
 
 		if err == nil {

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -456,3 +456,87 @@ resources:
 	assert.Nil(t, workloads)
 	assert.Contains(t, err.Error(), "failed to render Kustomize resources")
 }
+
+func TestGetResourcesFromPath_RendersNestedKustomizeDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+resources:
+  - deployment.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+
+	_, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+	}
+	assert.Equal(t, 1, counts["Deployment/prod-app"], "the nested Kustomization's transformed output must be scanned")
+	assert.Zero(t, counts["Deployment/app"], "the untransformed raw manifest must not also be scanned")
+	assert.Zero(t, counts["Kustomization/"], "the Kustomization document itself must not enter the scanned set")
+}
+
+func TestGetResourcesFromPath_NestedKustomizeSiblingFilesStillScanned(t *testing.T) {
+	repoRoot := t.TempDir()
+	appDir := filepath.Join(repoRoot, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+resources:
+  - deployment.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "standalone.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone
+`), 0o600))
+
+	_, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	for _, workload := range workloads {
+		counts[workload.GetKind()+"/"+workload.GetName()]++
+	}
+	assert.Equal(t, 1, counts["Deployment/prod-app"])
+	assert.Equal(t, 1, counts["ConfigMap/standalone"], "a manifest outside the Kustomize directory must still be scanned")
+}


### PR DESCRIPTION
## Overview

Kustomize rendering only ever looked at the exact scan input path (`isKustomizeDirectory(path)` / `IsKustomizeFile(path)`). If a broad scan input such as a repository root had no `kustomization.yaml` at its own top level, Kustomize was skipped entirely, and any Kustomize configuration in a child directory was picked up by the recursive plain-YAML loader instead — as raw, untransformed manifests. `namePrefix`, `namespace`, patches, image replacements and other transformations never applied, and the Kustomization document itself could enter the scanned object set.

This PR adds `LoadResourcesFromNestedKustomizeDirectories` (`core/cautils/fileutils.go`), which recursively discovers Kustomize directories below a broader input and renders each one independently, mirroring the existing recursive Helm chart discovery (`listHelmChartDirs`). A directory that fails to render is skipped with a warning rather than aborting the whole scan, leaving its files to the plain-manifest fallback. Directories that rendered successfully have their local input files excluded from the plain-manifest pass, so the transformed and raw identities of the same resource don't both end up in the scan — while manifests elsewhere in the tree that aren't part of any Kustomization are scanned as before.

This change is intentionally scoped to nested-directory *discovery*. A Kustomize configuration's `helmCharts` requiring renderer ownership when reached through a broader (non-Kustomize) scan root is a separate, adjacent problem and is not addressed here.

## How to Test

```
go test ./core/pkg/resourcehandler/... -run TestGetResourcesFromPath_RendersNestedKustomizeDirectory -v
go test ./core/pkg/resourcehandler/... -run TestGetResourcesFromPath_NestedKustomizeSiblingFilesStillScanned -v
```

The first reproduces the reported case (nested `namePrefix` overlay under a repo root: only the transformed `Deployment/prod-app` is scanned, not the raw `Deployment/app` or the Kustomization document itself). The second confirms a standalone manifest outside the Kustomize directory is still scanned normally. Full existing suite for the affected packages passes locally with no regressions.

## Related issues/PRs:

* Resolved #2858

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and rendering Kustomize configurations in nested directories.
  * Combined resources from root and nested configurations while preserving Kustomize source information.
  * Continued processing when an individual nested configuration cannot be rendered.

* **Bug Fixes**
  * Prevented duplicate scanning of raw manifests already processed by nested Kustomize configurations.
  * Preserved scanning of standalone manifests alongside nested configurations.

* **Tests**
  * Added coverage for nested rendering, transformations, filtering, and sibling manifest handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->