### PR TITLE
feat: add --only-fixable flag to gate scan image severity threshold on fix availability

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -176,6 +176,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.FailOnDegradedConfig, "fail-on-degraded-config", false, "Fail the scan (exit code 1) if control configurations or exceptions could not be loaded from their configured source and bundled defaults were used instead")
 
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.OnlyFixable, "only-fixable", false, "When used with --severity-threshold on image scans, only count CVEs that have an available fix toward the pass/fail decision")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release. Has no effect when --account is set (cloud backend is used instead)")
 
 	// Tri-state flag bound to the same BoolPtrFlag as the removed --enable-host-scan:

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -138,6 +138,7 @@ type ScanInfo struct {
 	FailThreshold         float32                      // DEPRECATED - Failure score threshold
 	ComplianceThreshold   float32                      // Compliance score threshold
 	FailThresholdSeverity string                       // Severity at and above which the command should fail
+	OnlyFixable           bool                         // Gate the severity threshold to only count CVEs that have an available fix
 	FailCoverageThreshold float32                      // Coverage threshold below which the command fails (0 = disabled)
 	FailOnDegradedConfig  bool                         // Fail the scan if control inputs or exceptions could not be loaded and a fallback was used
 	Submit                BoolPtrFlag                  // Submit results to Kubescape Cloud BE. Get() is nil unless explicitly set by the caller (flag/env/request field)

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -358,7 +358,7 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 
 	resultsHandler.ImageScanData = []cautils.ImageScanData{*imageScanData}
 
-	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), imageScanData.Matches), resultsHandler.HandleResults(ks.Context(), scanInfo)
+	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), imageScanData.Matches, scanInfo.OnlyFixable), resultsHandler.HandleResults(ks.Context(), scanInfo)
 }
 
 // ScanErrorCategory defines distinct vulnerability scan failure categories.

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -159,7 +159,7 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	resultsHandler := resultshandling.NewResultsHandler(nil, outputPrinters, uiPrinter)
 	resultsHandler.ImageScanData = []cautils.ImageScanData{*scanResultsPatched}
 
-	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), scanResultsPatched.Matches), resultsHandler.HandleResults(ks.Context(), scanInfo)
+	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), scanResultsPatched.Matches, scanInfo.OnlyFixable), resultsHandler.HandleResults(ks.Context(), scanInfo)
 }
 
 // buildPatchedImageName returns the canonical "<name>:<tag>" used as the buildkit

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -258,8 +258,9 @@ func (s *Service) Scan(_ context.Context, userInput string, creds RegistryCreden
 
 // ExceedsSeverityThreshold returns true if vulnerabilities in the scan results exceed the severity threshold, false otherwise.
 //
-// Values equal to the threshold are considered failing, too.
-func (s *Service) ExceedsSeverityThreshold(severity vulnerability.Severity, matches match.Matches) bool {
+// Values equal to the threshold are considered failing, too. When onlyFixable is true, a CVE only
+// counts toward the threshold if grype reports a fix state of "fixed" for it.
+func (s *Service) ExceedsSeverityThreshold(severity vulnerability.Severity, matches match.Matches, onlyFixable bool) bool {
 	if severity == vulnerability.UnknownSeverity {
 		return false
 	}
@@ -270,9 +271,15 @@ func (s *Service) ExceedsSeverityThreshold(severity vulnerability.Severity, matc
 			continue
 		}
 
-		if vulnerability.ParseSeverity(metadata.Severity) >= severity {
-			return true
+		if vulnerability.ParseSeverity(metadata.Severity) < severity {
+			continue
 		}
+
+		if onlyFixable && m.Vulnerability.Fix.State != vulnerability.FixStateFixed {
+			continue
+		}
+
+		return true
 	}
 	return false
 }

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -62,6 +62,12 @@ func makeThresholdTestMatch(id string) match.Match {
 	}
 }
 
+func makeThresholdTestMatchWithFixState(id string, state vulnerability.FixState) match.Match {
+	m := makeThresholdTestMatch(id)
+	m.Vulnerability.Fix.State = state
+	return m
+}
+
 type stubVulnerabilityProvider struct {
 	metadataByID map[string]*vulnerability.Metadata
 	errByID      map[string]error
@@ -267,8 +273,10 @@ func TestNewScanServiceWithMatchersIntegration(t *testing.T) {
 func TestExceedsSeverityThreshold(t *testing.T) {
 	provider := thresholdStubVulnerabilityProvider{
 		metadataByID: map[string]*vulnerability.Metadata{
-			"CVE-high": {Severity: vulnerability.HighSeverity.String()},
-			"CVE-low":  {Severity: vulnerability.LowSeverity.String()},
+			"CVE-high":         {Severity: vulnerability.HighSeverity.String()},
+			"CVE-low":          {Severity: vulnerability.LowSeverity.String()},
+			"CVE-high-fixed":   {Severity: vulnerability.HighSeverity.String()},
+			"CVE-high-unfixed": {Severity: vulnerability.HighSeverity.String()},
 		},
 		errByID: map[string]error{
 			"CVE-error": errors.New("lookup failed"),
@@ -276,10 +284,11 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		threshold vulnerability.Severity
-		matches   match.Matches
-		want      bool
+		name        string
+		threshold   vulnerability.Severity
+		matches     match.Matches
+		onlyFixable bool
+		want        bool
 	}{
 		{
 			name:      "unknown threshold never fails the scan",
@@ -287,7 +296,8 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 			matches: match.NewMatches(
 				makeThresholdTestMatch("CVE-high"),
 			),
-			want: false,
+			onlyFixable: false,
+			want:        false,
 		},
 		{
 			name:      "match equal to threshold fails the scan",
@@ -296,7 +306,8 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 				makeThresholdTestMatch("CVE-high"),
 				makeThresholdTestMatch("CVE-low"),
 			),
-			want: true,
+			onlyFixable: false,
+			want:        true,
 		},
 		{
 			name:      "metadata errors are ignored when no remaining match exceeds threshold",
@@ -305,7 +316,26 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 				makeThresholdTestMatch("CVE-error"),
 				makeThresholdTestMatch("CVE-low"),
 			),
-			want: false,
+			onlyFixable: false,
+			want:        false,
+		},
+		{
+			name:      "onlyFixable ignores an unfixable CVE at or above threshold",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithFixState("CVE-high-unfixed", vulnerability.FixStateNotFixed),
+			),
+			onlyFixable: true,
+			want:        false,
+		},
+		{
+			name:      "onlyFixable still fails on a fixable CVE at or above threshold",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithFixState("CVE-high-fixed", vulnerability.FixStateFixed),
+			),
+			onlyFixable: true,
+			want:        true,
 		},
 	}
 
@@ -313,7 +343,7 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, svc.ExceedsSeverityThreshold(tt.threshold, tt.matches))
+			assert.Equal(t, tt.want, svc.ExceedsSeverityThreshold(tt.threshold, tt.matches, tt.onlyFixable))
 		})
 	}
 }


### PR DESCRIPTION
## Overview
--severity-threshold (cmd/scan/scan.go) is currently the only pass/fail gate for scan image, and it counts every matched CVE that meets the severity level regardless of whether a fix exists. Grype's Fix.State is already tracked on each match but never factored into the exit code decision.

This means CI pipelines using --severity-threshold fail on CVEs that have no available patch, which teams cannot act on yet. That produces noise and forces teams to either ignore the gate or maintain manual exception lists.

This PR adds an --only-fixable flag that changes the pass/fail condition to "severity is at or above threshold AND a fix is available" (Fix.State == FixStateFixed), reusing data already present in the scan result. When the flag is not set, behavior is unchanged (severity threshold alone).

## Changes
- cmd/scan/scan.go: register --only-fixable flag
- core/cautils/scaninfo.go: add OnlyFixable field to ScanInfo
- pkg/imagescan/imagescan.go: ExceedsSeverityThreshold now takes an onlyFixable bool and skips CVEs without an available fix when set
- core/core/image_scan.go, core/core/patch.go: pass scanInfo.OnlyFixable through at both call sites
- pkg/imagescan/imagescan_test.go: existing cases updated, plus two new cases covering onlyFixable with a fixed and an unfixed CVE at threshold

## How to Test
kubescape scan image nginx:latest --severity-threshold high --only-fixable

## Additional Information
Ran the full test suite locally. Two failures exist on master independent of this change and are not related to these files:
- TestJunitGoldenFile (core/pkg/resultshandling/printer/v2): fails on line ending (\r\n vs \n) differences, environment-specific (Windows/WSL checkout)
- TestGetFileString / fixhandler tests (core/pkg/fixhandler): fails on a permission-denied error writing to /tmp, also environment-specific (WSL)

pkg/imagescan (the package this PR touches) passes cleanly, including the new onlyFixable test cases.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] New and existing unit tests pass locally with my changes (excluding two pre-existing, environment-specific failures noted above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--only-fixable` scan option for image scans using severity thresholds.
  * Severity-threshold checks can now count only vulnerabilities with available fixes.
  * Existing severity-threshold behavior remains unchanged unless this option is enabled.
* **Bug Fixes**
  * Improved scan pass/fail results by excluding unfixed vulnerabilities when `--only-fixable` is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
close #2887 