### PR TITLE
fix(resourcehandler): block Secret reads via single-resource scan

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -530,13 +530,18 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	}
 	apiGroup, apiVersion, resourceName := k8sinterface.StringToResourceGroup(resolved[0].groupVersionResourceTriplet)
 	if apiGroup == "" && resourceName == "secrets" {
-		// This is resolved from cluster discovery (not the client-supplied kind
-		// string), so it can't be bypassed by casing/aliasing tricks. Single
-		// resource scan is reachable from the unauthenticated httphandler
-		// POST /v1/scan endpoint with an attacker-chosen name/namespace; letting
-		// it live-fetch Secret objects would turn it into an unauthenticated
-		// arbitrary-secret-read primitive, since the fetched object's data is
-		// embedded verbatim in the scan report.
+		// Defense in depth: a Secret is not a useful single-resource scan
+		// target, so reject it here instead of fetching it and discarding it
+		// later. Rejecting before pullSingleResource avoids an unnecessary
+		// Kubernetes API call (and the RBAC it requires) and guarantees Secret
+		// objects are never retrieved from the cluster in single-resource scan
+		// mode, rather than relying solely on downstream sanitization
+		// (removeData()/removeSecretData(), which redacts "data" and
+		// "stringData" to "XXXXXX").
+		//
+		// The GVR is resolved from cluster discovery, not from the
+		// client-supplied kind string, so this check cannot be sidestepped with
+		// casing or aliasing tricks.
 		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", getReadableID(resource))
 	}
 	gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resourceName}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -529,6 +529,16 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		return nil, fmt.Errorf("resource not found in Kubernetes discovery: %s", getReadableID(resource))
 	}
 	apiGroup, apiVersion, resourceName := k8sinterface.StringToResourceGroup(resolved[0].groupVersionResourceTriplet)
+	if apiGroup == "" && resourceName == "secrets" {
+		// This is resolved from cluster discovery (not the client-supplied kind
+		// string), so it can't be bypassed by casing/aliasing tricks. Single
+		// resource scan is reachable from the unauthenticated httphandler
+		// POST /v1/scan endpoint with an attacker-chosen name/namespace; letting
+		// it live-fetch Secret objects would turn it into an unauthenticated
+		// arbitrary-secret-read primitive, since the fetched object's data is
+		// embedded verbatim in the scan report.
+		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", getReadableID(resource))
+	}
 	gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resourceName}
 
 	fieldSelectors := getNameFieldSelectorString(resource.GetName(), FieldSelectorsEqualsOperator)

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -97,11 +97,12 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			wantError: "apiVersion is required to resolve non-built-in resource",
 		},
 		{
-			// Regression test: single resource scan is reachable from the
-			// unauthenticated httphandler POST /v1/scan endpoint with an
-			// attacker-chosen name/namespace. It must never live-fetch Secret
-			// objects, since the fetched object (including its data field) is
-			// embedded verbatim in the scan report returned to the caller.
+			// Defense in depth: a Secret is not a useful single-resource scan
+			// target, so it must be rejected before retrieval rather than
+			// fetched and then sanitized downstream. Rejecting early also
+			// avoids an unnecessary Kubernetes API call. The Secret exists in
+			// the fake client here, so the rejection is proven to be a policy
+			// decision and not a lookup miss.
 			name:             "secret is rejected even when it exists",
 			request:          scanObject("v1", "Secret", "shop", "db-creds"),
 			objects:          []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
@@ -126,9 +127,11 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 
 			workload, err := handler.findScanObjectResource(context.Background(), test.request, &EmptySelector{}, resolver)
 			if test.wantNoAPIActions {
-				// The rejection has to happen before the live API pull: if the
-				// object were fetched first and only then refused, the Secret's
-				// data would already have left the cluster.
+				// Defense in depth: the rejection must happen before the live
+				// API pull, so no Kubernetes API/RBAC operation is issued for a
+				// Secret at all. Fetching first and refusing afterwards would
+				// still pass the error assertion below, so the absence of
+				// client actions is what actually pins the ordering.
 				assert.Empty(t, dynamicClient.Actions(), "expected the request to be rejected before any API call")
 			}
 			if test.wantError != "" {

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -89,6 +89,23 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			request:   scanObject("", "UnknownKind", "shop", "object"),
 			wantError: "apiVersion is required to resolve non-built-in resource",
 		},
+		{
+			// Regression test: single resource scan is reachable from the
+			// unauthenticated httphandler POST /v1/scan endpoint with an
+			// attacker-chosen name/namespace. It must never live-fetch Secret
+			// objects, since the fetched object (including its data field) is
+			// embedded verbatim in the scan report returned to the caller.
+			name:      "secret is rejected even when it exists",
+			request:   scanObject("v1", "Secret", "shop", "db-creds"),
+			objects:   []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
+			wantError: "scanning Secret resources via single resource scan is not supported",
+		},
+		{
+			name:      "secret is rejected via the legacy no-apiVersion path",
+			request:   scanObject("", "Secret", "shop", "db-creds"),
+			objects:   []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
+			wantError: "scanning Secret resources via single resource scan is not supported",
+		},
 	}
 
 	for _, test := range tests {

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -46,17 +46,24 @@ func unstructuredResource(apiVersion, kind, namespace, name string) *unstructure
 func TestFindScanObjectResourceDataDriven(t *testing.T) {
 	k8sinterface.InitializeMapResourcesMock()
 	deploymentGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	listKinds := map[schema.GroupVersionResource]string{
 		deploymentGVR: "DeploymentList",
+		// Secrets are registered so the fake client is genuinely able to serve
+		// them. Without this the client cannot list secrets at all and the
+		// "no API calls were issued" assertion below would hold even for an
+		// implementation that fetches the Secret before rejecting it.
+		secretGVR: "SecretList",
 	}
 
 	tests := []struct {
-		name      string
-		request   *objectsenvelopes.ScanObject
-		objects   []runtime.Object
-		wantName  string
-		wantError string
-		wantNil   bool
+		name             string
+		request          *objectsenvelopes.ScanObject
+		objects          []runtime.Object
+		wantName         string
+		wantError        string
+		wantNil          bool
+		wantNoAPIActions bool
 	}{
 		{name: "nil request is not a single-resource scan", request: nil, wantNil: true},
 		{
@@ -95,16 +102,18 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			// attacker-chosen name/namespace. It must never live-fetch Secret
 			// objects, since the fetched object (including its data field) is
 			// embedded verbatim in the scan report returned to the caller.
-			name:      "secret is rejected even when it exists",
-			request:   scanObject("v1", "Secret", "shop", "db-creds"),
-			objects:   []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
-			wantError: "scanning Secret resources via single resource scan is not supported",
+			name:             "secret is rejected even when it exists",
+			request:          scanObject("v1", "Secret", "shop", "db-creds"),
+			objects:          []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
+			wantError:        "scanning Secret resources via single resource scan is not supported",
+			wantNoAPIActions: true,
 		},
 		{
-			name:      "secret is rejected via the legacy no-apiVersion path",
-			request:   scanObject("", "Secret", "shop", "db-creds"),
-			objects:   []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
-			wantError: "scanning Secret resources via single resource scan is not supported",
+			name:             "secret is rejected via the legacy no-apiVersion path",
+			request:          scanObject("", "Secret", "shop", "db-creds"),
+			objects:          []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
+			wantError:        "scanning Secret resources via single resource scan is not supported",
+			wantNoAPIActions: true,
 		},
 	}
 
@@ -116,6 +125,12 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			require.Empty(t, discoveryFailures)
 
 			workload, err := handler.findScanObjectResource(context.Background(), test.request, &EmptySelector{}, resolver)
+			if test.wantNoAPIActions {
+				// The rejection has to happen before the live API pull: if the
+				// object were fetched first and only then refused, the Secret's
+				// data would already have left the cluster.
+				assert.Empty(t, dynamicClient.Actions(), "expected the request to be rejected before any API call")
+			}
 			if test.wantError != "" {
 				require.ErrorContains(t, err, test.wantError)
 				assert.Nil(t, workload)


### PR DESCRIPTION
## Summary
- `findScanObjectResource` accepts a `scanObject` (`apiVersion`/`kind`/`namespace`/`name`)
  to target a single resource, and resolves it to a GVR before pulling it live
  from the cluster.
- A Secret is not a meaningful single-resource scan target: there are no
  workload controls to evaluate against it, so fetching one only costs a
  Kubernetes API call and the RBAC it requires, and produces nothing scannable.
- Fix: reject Secret resources in `findScanObjectResource` before
  `pullSingleResource` / any live API retrieval. The check is made on the GVR
  resolved through cluster discovery rather than on the client-supplied kind
  string, so it cannot be sidestepped with casing or aliasing tricks, and it
  covers both the `apiVersion`-provided path and the legacy no-`apiVersion`
  built-in-kind path.
- This is defense in depth. Downstream sanitization already redacts Secret
  `data` and `stringData` to `"XXXXXX"` via `removeData()` /
  `removeSecretData()`; rejecting before retrieval means single-resource scan
  never fetches a Secret from the cluster in the first place, so the guarantee
  does not depend on that downstream step remaining in place.

Thanks @madhav-sharma0201 for verifying the sanitization path and @matthyx for
the review — the description previously framed this as a secret-disclosure
issue, which was not accurate. Reframed as defense in depth.

## Test plan
- [x] `TestFindScanObjectResourceDataDriven` covers both resolution paths
      (`v1`/`Secret` and legacy no-apiVersion `Secret`), asserting the request
      is rejected even when the Secret exists in the fake client, and that
      `dynamicClient.Actions()` is empty — i.e. the rejection happens before any
      API request is issued.
- [x] `go test ./core/pkg/resourcehandler/...` passes.
- [x] `go build ./...` and `go test ./...` pass in both the root module and the
      `httphandler` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Single-resource scans now clearly reject unsupported Kubernetes Secret resources before retrieving or processing their data.
  - Requests using either explicit or legacy resource version formats receive consistent unsupported-resource errors.
  - Secret data is not fetched or embedded when an unsupported resource is requested.

- **Tests**
  - Added regression coverage for Secret resource rejection, including cases where the requested Secret exists.
  - Verified consistent behavior across supported request formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
