### PR TITLE
fix: enforce image severity threshold on combined scans 

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -61,7 +61,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -76,7 +76,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -79,7 +81,7 @@ func TestGetImageCmd_RunE_FormatFlagEmpty(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", ""))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.Equal(t, "format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml", err.Error())
+	assert.Equal(t, fmt.Sprintf("format cannot be empty, supported formats: %s", strings.Join(shared.ImageScanFormats, ", ")), err.Error())
 }
 
 func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -7,11 +7,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -326,6 +328,11 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifie
 	if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), &scanInfo); err != nil {
 		return err
 	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, &scanInfo); err != nil {
+			return err
+		}
+	}
 	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), &scanInfo); err != nil {
 		return err
 	}
@@ -333,5 +340,31 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifie
 		return err
 	}
 
+	return nil
+}
+
+func enforceImageSeverityThresholds(imageScanData []cautils.ImageScanData, scanInfo *cautils.ScanInfo) error {
+	if scanInfo.FailThresholdSeverity == "" {
+		return nil
+	}
+
+	thresholdSeverity := imagescan.ParseSeverity(scanInfo.FailThresholdSeverity)
+	if thresholdSeverity == vulnerability.UnknownSeverity {
+		return nil
+	}
+
+	for _, data := range imageScanData {
+		for m := range data.Matches.Enumerate() {
+			//nolint:staticcheck // deprecated but replacing it requires refactoring
+			metadata, err := data.VulnerabilityProvider.VulnerabilityMetadata(m.Vulnerability.Reference)
+			if err != nil {
+				continue
+			}
+
+			if imagescan.ParseSeverity(metadata.Severity) >= thresholdSeverity {
+				return fmt.Errorf("image scan result exceeds severity threshold: %s", scanInfo.FailThresholdSeverity)
+			}
+		}
+	}
 	return nil
 }

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/mocks"
@@ -662,6 +665,90 @@ func Test_enforceCoverageThreshold(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantFail, coverageWouldFail(tt.notEvaluated, tt.totalControls, tt.threshold))
+		})
+	}
+}
+
+type mockVulnerabilityProvider struct {
+	severity string
+}
+
+func (m mockVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference) (*vulnerability.Metadata, error) {
+	return &vulnerability.Metadata{Severity: m.severity}, nil
+}
+func (m mockVulnerabilityProvider) PackageSearchNames(grypepkg.Package) []string { return nil }
+func (m mockVulnerabilityProvider) FindVulnerabilities(criteria ...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+func (m mockVulnerabilityProvider) Close() error { return nil }
+
+func TestEnforceImageSeverityThresholds(t *testing.T) {
+	tests := []struct {
+		name          string
+		threshold     string
+		matchSeverity string
+		expectedError bool
+	}{
+		{
+			name:          "no threshold",
+			threshold:     "",
+			matchSeverity: "Critical",
+			expectedError: false,
+		},
+		{
+			name:          "threshold unknown",
+			threshold:     "unknown",
+			matchSeverity: "Critical",
+			expectedError: false,
+		},
+		{
+			name:          "threshold met exactly",
+			threshold:     "high",
+			matchSeverity: "High",
+			expectedError: true,
+		},
+		{
+			name:          "threshold exceeded",
+			threshold:     "high",
+			matchSeverity: "Critical",
+			expectedError: true,
+		},
+		{
+			name:          "below threshold",
+			threshold:     "critical",
+			matchSeverity: "High",
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				FailThresholdSeverity: tt.threshold,
+			}
+
+			matches := match.NewMatches()
+			if tt.matchSeverity != "" {
+				matches.Add(match.Match{
+					Vulnerability: vulnerability.Vulnerability{
+						Reference: vulnerability.Reference{ID: "CVE-TEST"},
+					},
+				})
+			}
+
+			imgData := []cautils.ImageScanData{
+				{
+					Matches:               matches,
+					VulnerabilityProvider: mockVulnerabilityProvider{severity: tt.matchSeverity},
+				},
+			}
+
+			err := enforceImageSeverityThresholds(imgData, scanInfo)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -69,7 +69,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				}
 			}
 			if f := cmd.InheritedFlags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ScanFormats, ", "))
 			}
 			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ScanFormats); err != nil {
 				return err


### PR DESCRIPTION
## Overview

This PR enforces the `--severity-threshold` flag for image vulnerabilities during combined scans (e.g., `kubescape scan workload --scan-images`).

**Current behavior:**

When running combined scans, the exit code is only gated by the compliance scan severity. If the image scanner identifies vulnerabilities that exceed the threshold (e.g., Critical CVEs), the command still exits with code `0`.

**Future behavior:**

The CLI will now correctly evaluate the `ImageScanData` alongside the compliance counters. If any identified image vulnerability exceeds the defined `--severity-threshold`, the command will fail and exit with code `1`, aligning with the behavior of standalone `scan image` commands.

## Additional Information

Introduced `enforceImageSeverityThresholds()` in `cmd/scan/scan.go` to parse and validate image scan results natively during the combined execution path.

A merge conflict in `cmd/scan/image_test.go` from a previous commit was also resolved.

## How to Test

1. Create a `test-workload.yaml` containing a pod with a known vulnerable image (e.g., `nginx:1.14.2`).

2. Run a combined scan:

   `kubescape scan test-workload.yaml --scan-images --severity-threshold=critical`

3. Verify that the output prints an error message:

   `image scan result exceeds severity threshold: critical`

   and that the process exits with code `1`:

   `echo $?`

## Examples/Screenshots

**Test Execution:**

```text
$ go test ./cmd/scan -run TestEnforceImageSeverityThresholds -v
=== RUN   TestEnforceImageSeverityThresholds
=== RUN   TestEnforceImageSeverityThresholds/no_threshold
=== RUN   TestEnforceImageSeverityThresholds/threshold_unknown
--- PASS: TestEnforceImageSeverityThresholds (0.00s)
    --- PASS: TestEnforceImageSeverityThresholds/no_threshold (0.00s)
    --- PASS: TestEnforceImageSeverityThresholds/threshold_unknown (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/cmd/scan	1.469s
```

## Related issues/PRs

- Resolved #2893

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image scans now enforce configured vulnerability severity thresholds, reporting an error when matches meet or exceed the selected level.

- **Bug Fixes**
  - Empty-format validation messages now consistently display the currently supported scan and image formats across scan commands.
  - Severity threshold checks safely continue when vulnerability metadata is unavailable or when no valid threshold is configured.
  - Supported-format messages stay synchronized as available scan formats change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->