### PR TITLE
fix(fixhandler): skip document node when resolving a line to replace

### DIFF
--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -243,6 +243,22 @@ func TestApplyFixToContent_EmptyLeadingDocument(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+// TestApplyFixToContent_TopLevelFlowSequence covers a flow collection that is not nested
+// under a key of its own, so it starts on the first line of the document. Resolving the
+// line to replace picked the document node that shares that line and rendered it against
+// its nil parent, panicking out of `kubescape fix` before anything was written. A nested
+// flow sequence never hit this because the document node sits on an earlier line.
+func TestApplyFixToContent_TopLevelFlowSequence(t *testing.T) {
+	yamlContent := "args: [--foo]\n"
+	expression := FixPathToValidYamlExpression("args[1]", "--bar", 0)
+
+	got, err := ApplyFixToContent(context.Background(), yamlContent, expression)
+
+	require.NoError(t, err)
+	// the flow style of the original line is kept
+	assert.Equal(t, "args: [--foo, --bar]\n", got)
+}
+
 func Test_fixPathToValidYamlExpression(t *testing.T) {
 	type args struct {
 		fixPath             string

--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -343,6 +343,12 @@ func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMeta
 	originalListTracker := getFirstNodeInLine(fixInfoMetadata.originalList, line)
 	fixedListTracker := getFirstNodeInLine(fixInfoMetadata.fixedList, line)
 
+	// getFirstNodeInLine reports -1 when the line holds no renderable node. Indexing the
+	// list with it panics, so skip this fix and let the caller leave the file untouched.
+	if originalListTracker < 0 || fixedListTracker < 0 {
+		return 0, 0, fmt.Errorf("cannot resolve the node to replace at line %d", line)
+	}
+
 	currentDFSNode := (*fixInfoMetadata.fixedList)[fixedListTracker]
 	contentToInsert, err := getContent(ctx, currentDFSNode.parent, fixInfoMetadata.fixedList, fixedListTracker)
 	if err != nil {
@@ -367,11 +373,12 @@ func replaceSingleLineSequence(ctx context.Context, fixInfoMetadata *fixInfoMeta
 	return originalListTracker, fixedListTracker, nil
 }
 
-// Returns the first node in the given line that is not mapping node
+// Returns the first node in the given line that is not a mapping or document node.
+// Both share their line with a child, and a document node has no parent to render against.
 func getFirstNodeInLine(list *[]nodeInfo, line int) int {
 	for tracker := 0; tracker < len(*list); tracker++ {
 		currentNode := (*list)[tracker].node
-		if currentNode.Line == line && currentNode.Kind != yaml.MappingNode {
+		if currentNode.Line == line && currentNode.Kind != yaml.MappingNode && currentNode.Kind != yaml.DocumentNode {
 			return tracker
 		}
 	}

--- a/core/pkg/fixhandler/yamlhelper_test.go
+++ b/core/pkg/fixhandler/yamlhelper_test.go
@@ -1,6 +1,7 @@
 package fixhandler
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -377,6 +378,39 @@ func TestGetFirstNodeInLine_LineNotFound(t *testing.T) {
 	index := getFirstNodeInLine(&list, line)
 
 	assert.Equal(t, -1, index)
+}
+
+// Skips the document node sharing the line and returns the first node that can be encoded
+func TestGetFirstNodeInLine_SkipsDocumentNode(t *testing.T) {
+	list := []nodeInfo{
+		{node: &yaml.Node{Line: 1, Kind: yaml.DocumentNode}},
+		{node: &yaml.Node{Line: 1, Kind: yaml.MappingNode}},
+		{node: &yaml.Node{Line: 1, Kind: yaml.ScalarNode, Value: "a"}},
+		{node: &yaml.Node{Line: 1, Kind: yaml.SequenceNode}},
+	}
+
+	index := getFirstNodeInLine(&list, 1)
+
+	assert.Equal(t, 2, index)
+}
+
+// Returns an error instead of panicking when the line holds no renderable node
+func TestReplaceSingleLineSequence_UnresolvableLine(t *testing.T) {
+	list := []nodeInfo{{node: &yaml.Node{Line: 1, Kind: yaml.ScalarNode}}}
+	contentToAdd := make([]contentToAdd, 0)
+	linesToRemove := make([]linesToRemove, 0)
+	fixInfoMetadata := &fixInfoMetadata{
+		originalList:  &list,
+		fixedList:     &list,
+		contentToAdd:  &contentToAdd,
+		linesToRemove: &linesToRemove,
+	}
+
+	assert.NotPanics(t, func() {
+		_, _, err := replaceSingleLineSequence(context.Background(), fixInfoMetadata, 99)
+
+		assert.Error(t, err)
+	})
 }
 
 // Function removes lines within specified range


### PR DESCRIPTION
## Overview

getFirstNodeInLine picks the node that a single line gets replaced with. It skips mapping nodes, because a mapping reports the position of its first child and shares the line with it, so it has nothing of its own to render. A document node has the same property and was not skipped.

A document node only shares its line with a child on the first line of the file, so this shows up when a flow collection sits at the top level:

```yaml
a: [1, 2, 3]
```

Fixing that resolved to the document node, and getContent then dereferenced its parent, which is nil for the root. The result is a nil pointer dereference, so kubescape fix crashes before writing anything. A nested flow sequence was never affected because the document node sits on an earlier line.

Current behavior: panic.
New behavior: the top level resolves to the same kind of node the nested case already resolves to, and the flow style of the line is kept. `a: [1, 2, 3]` with `a[3]` set to 4 gives `a: [1, 2, 3, 4]`.

This is not limited to one shape. Append, modify, unicode values, CRLF files, a leading `---`, multi document files and anchors all panic on master when the flow collection is on the first line, and all produce correct output after the change.

Alongside that, replaceSingleLineSequence indexed the node list with the -1 that getFirstNodeInLine returns for "not found", which panics with index out of range. It now returns an error, so the file is left untouched and the caller reports it, matching how the encode failure a few lines below is already handled.

Each guard has a regression test that fails when that guard alone is removed. Existing tests in the package are unchanged and still pass.

Out of scope: an edit inside a flow collection that is not on the first line, such as `a: [{b: 1}]` or `a: {}`, still produces invalid YAML. That is a separate problem in how the line splicer renders into flow collections and it behaves the same before and after this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updates to top-level YAML flow sequences while preserving their formatting.
  * Improved handling of YAML document nodes during updates.
  * Replaced potential crashes with clear errors when a target YAML node cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->