### PR TITLE
fix(printer): label the report with the context the scan actually used

### DIFF
--- a/core/core/report_clustername_test.go
+++ b/core/core/report_clustername_test.go
@@ -9,35 +9,34 @@ import (
 	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-// #2841 made scan attribution follow the kubeconfig the scan actually selected,
-// via ScanInfo.GetClusterContextName(). #2866 then populated the report's
-// clusterName from the process-global k8sinterface.GetContextName() instead.
+// setAmbientContext pins the process-global context name so these tests do not
+// depend on the machine having a kubeconfig. k8sinterface.GetContextName()
+// returns clusterContextName when it is set, and only falls back to loading a
+// kubeconfig otherwise — which yields "" on a CI runner.
+func setAmbientContext(t *testing.T, name string) {
+	t.Helper()
+	original := k8sinterface.GetContextName()
+	t.Cleanup(func() { k8sinterface.SetClusterContextName(original) })
+	k8sinterface.SetClusterContextName(name)
+	require.Equal(t, name, k8sinterface.GetContextName())
+}
+
+// #2841 made scan attribution follow the kubeconfig the scan selected, via
+// ScanInfo.GetClusterContextName(), and records it on the session metadata.
+// #2866 merged 22 minutes later and populated the report's clusterName from
+// the process-global k8sinterface.GetContextName() instead.
 //
-// When --kubeconfig selects a file whose current-context differs from the
-// ambient kubeconfig, those two disagree: the tenant config attributes the scan
-// to the selected context while the emitted report is labelled with the ambient
-// one. A report labelled with the wrong cluster is worse than the empty field
-// #2866 replaced, because it looks authoritative.
+// When --kubeconfig or --kube-context selects a context other than the ambient
+// one, those disagree: the tenant config attributes the scan to the selected
+// context while the emitted report is labelled with the ambient one. A report
+// labelled with the wrong cluster is worse than the empty field #2866
+// replaced, because it looks authoritative.
 func TestFinalizeResults_ClusterNameFollowsScanSelectedContext(t *testing.T) {
-	ambientPath := writeContextKubeconfig(t, "context-b", "https://b.example")
+	setAmbientContext(t, "context-b")
+
 	explicitPath := writeContextKubeconfig(t, "context-a", "https://a.example")
-
-	t.Setenv("KUBECONFIG", ambientPath)
-	ambientConfig, err := clientcmd.LoadFromFile(ambientPath)
-	require.NoError(t, err)
-	k8sinterface.SetClusterContextName("")
-	k8sinterface.SetClientConfigAPI(ambientConfig)
-	t.Cleanup(func() {
-		k8sinterface.SetClientConfigAPI(nil)
-		k8sinterface.SetClusterContextName("")
-	})
-
-	// Sanity: the ambient global really does resolve to the other context.
-	require.Equal(t, "context-b", k8sinterface.GetContextName())
-
 	scanInfo := &cautils.ScanInfo{}
 	scanInfo.SetKubeconfigSelection(explicitPath, "")
 	require.NoError(t, scanInfo.ResolveClusterContextName())
@@ -51,19 +50,25 @@ func TestFinalizeResults_ClusterNameFollowsScanSelectedContext(t *testing.T) {
 		"the report must be labelled with the context the scan actually used, not the ambient one")
 }
 
-// A scan that made no explicit kubeconfig selection must keep the existing
-// behaviour introduced by #2866: fall back to the ambient context name.
+// The same holds for an explicit --kube-context override.
+func TestFinalizeResults_ClusterNameFollowsContextOverride(t *testing.T) {
+	setAmbientContext(t, "context-b")
+
+	multiPath := writeContextKubeconfig(t, "context-a", "https://a.example")
+	scanInfo := &cautils.ScanInfo{}
+	scanInfo.SetKubeconfigSelection(multiPath, "context-a")
+	require.NoError(t, scanInfo.ResolveClusterContextName())
+
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	report := printerv2.FinalizeResults(session)
+
+	assert.Equal(t, "context-a", report.ClusterName)
+}
+
+// A scan that made no explicit kubeconfig selection must keep the behaviour
+// #2866 introduced: fall back to the ambient context name.
 func TestFinalizeResults_ClusterNameFallsBackToAmbientContext(t *testing.T) {
-	ambientPath := writeContextKubeconfig(t, "context-b", "https://b.example")
-	t.Setenv("KUBECONFIG", ambientPath)
-	ambientConfig, err := clientcmd.LoadFromFile(ambientPath)
-	require.NoError(t, err)
-	k8sinterface.SetClusterContextName("")
-	k8sinterface.SetClientConfigAPI(ambientConfig)
-	t.Cleanup(func() {
-		k8sinterface.SetClientConfigAPI(nil)
-		k8sinterface.SetClusterContextName("")
-	})
+	setAmbientContext(t, "context-b")
 
 	scanInfo := &cautils.ScanInfo{}
 	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
@@ -72,8 +77,10 @@ func TestFinalizeResults_ClusterNameFallsBackToAmbientContext(t *testing.T) {
 	assert.Equal(t, "context-b", report.ClusterName)
 }
 
-// An explicitly supplied cluster name must still win, as before.
+// An already-populated cluster name must still win, as #2866 established.
 func TestFinalizeResults_ClusterNameDoesNotOverwriteExisting(t *testing.T) {
+	setAmbientContext(t, "context-b")
+
 	scanInfo := &cautils.ScanInfo{}
 	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
 	session.Report.ClusterName = "already-set"

--- a/core/core/report_clustername_test.go
+++ b/core/core/report_clustername_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	printerv2 "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// #2841 made scan attribution follow the kubeconfig the scan actually selected,
+// via ScanInfo.GetClusterContextName(). #2866 then populated the report's
+// clusterName from the process-global k8sinterface.GetContextName() instead.
+//
+// When --kubeconfig selects a file whose current-context differs from the
+// ambient kubeconfig, those two disagree: the tenant config attributes the scan
+// to the selected context while the emitted report is labelled with the ambient
+// one. A report labelled with the wrong cluster is worse than the empty field
+// #2866 replaced, because it looks authoritative.
+func TestFinalizeResults_ClusterNameFollowsScanSelectedContext(t *testing.T) {
+	ambientPath := writeContextKubeconfig(t, "context-b", "https://b.example")
+	explicitPath := writeContextKubeconfig(t, "context-a", "https://a.example")
+
+	t.Setenv("KUBECONFIG", ambientPath)
+	ambientConfig, err := clientcmd.LoadFromFile(ambientPath)
+	require.NoError(t, err)
+	k8sinterface.SetClusterContextName("")
+	k8sinterface.SetClientConfigAPI(ambientConfig)
+	t.Cleanup(func() {
+		k8sinterface.SetClientConfigAPI(nil)
+		k8sinterface.SetClusterContextName("")
+	})
+
+	// Sanity: the ambient global really does resolve to the other context.
+	require.Equal(t, "context-b", k8sinterface.GetContextName())
+
+	scanInfo := &cautils.ScanInfo{}
+	scanInfo.SetKubeconfigSelection(explicitPath, "")
+	require.NoError(t, scanInfo.ResolveClusterContextName())
+	require.Equal(t, "context-a", scanInfo.GetClusterContextName(),
+		"the scan selected context-a via --kubeconfig")
+
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	report := printerv2.FinalizeResults(session)
+
+	assert.Equal(t, "context-a", report.ClusterName,
+		"the report must be labelled with the context the scan actually used, not the ambient one")
+}
+
+// A scan that made no explicit kubeconfig selection must keep the existing
+// behaviour introduced by #2866: fall back to the ambient context name.
+func TestFinalizeResults_ClusterNameFallsBackToAmbientContext(t *testing.T) {
+	ambientPath := writeContextKubeconfig(t, "context-b", "https://b.example")
+	t.Setenv("KUBECONFIG", ambientPath)
+	ambientConfig, err := clientcmd.LoadFromFile(ambientPath)
+	require.NoError(t, err)
+	k8sinterface.SetClusterContextName("")
+	k8sinterface.SetClientConfigAPI(ambientConfig)
+	t.Cleanup(func() {
+		k8sinterface.SetClientConfigAPI(nil)
+		k8sinterface.SetClusterContextName("")
+	})
+
+	scanInfo := &cautils.ScanInfo{}
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	report := printerv2.FinalizeResults(session)
+
+	assert.Equal(t, "context-b", report.ClusterName)
+}
+
+// An explicitly supplied cluster name must still win, as before.
+func TestFinalizeResults_ClusterNameDoesNotOverwriteExisting(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{}
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	session.Report.ClusterName = "already-set"
+
+	report := printerv2.FinalizeResults(session)
+
+	assert.Equal(t, "already-set", report.ClusterName)
+}

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -197,13 +197,30 @@ func extractResourceLabels(allResources map[string]workloadinterface.IMetadata, 
 	return resourceLabels
 }
 
+// scanContextName returns the kube context this scan actually ran against.
+//
+// ScanInfo.GetClusterContextName() resolves the context from the kubeconfig the
+// scan selected, and that value is recorded on the session metadata. Reading the
+// process-global k8sinterface.GetContextName() instead would label the report
+// with the ambient context, which differs whenever --kubeconfig or
+// --kube-context points somewhere else. The global remains the fallback for
+// sessions that carry no cluster context metadata.
+func scanContextName(data *cautils.OPASessionObj) string {
+	if data.Metadata != nil {
+		if cluster := data.Metadata.ContextMetadata.ClusterContextMetadata; cluster != nil && cluster.ContextName != "" {
+			return cluster.ContextName
+		}
+	}
+	return k8sinterface.GetContextName()
+}
+
 // FinalizeResults finalize the results objects by copying data from map to lists
 func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureReport {
 	if data.Report.ReportGenerationTime.IsZero() {
 		data.Report.ReportGenerationTime = time.Now().UTC()
 	}
 	if data.Report.ClusterName == "" {
-		data.Report.ClusterName = cautils.AdoptClusterName(k8sinterface.GetContextName())
+		data.Report.ClusterName = cautils.AdoptClusterName(scanContextName(data))
 	}
 	report := reporthandlingv2.PostureReport{
 		SummaryDetails:       data.Report.SummaryDetails,


### PR DESCRIPTION
## Overview

Follow-up to #2866, which resolved my #2856. The fix is right; it just landed
22 minutes after #2841 changed where the scan's context name comes from, so the
two disagree.

#2841 introduced `ScanInfo.GetClusterContextName()` — the context resolved from
the kubeconfig the scan actually selected — and uses it for the tenant config
(`core/core/scan.go:70`) and for the session metadata
(`core/cautils/scaninfo.go:579`).

#2866 populates the report from the process-global instead:

```go
data.Report.ClusterName = cautils.AdoptClusterName(k8sinterface.GetContextName())
```

Those agree only when no explicit selection was made. With `--kubeconfig`
pointing at a file whose current-context differs from the ambient one, the
report is labelled with the ambient cluster while the scan ran against the
selected one.

That is worse than the empty field #2866 replaced: an empty `clusterName` is
obviously unusable, whereas a wrong one looks authoritative. Anyone scanning
several contexts in CI and collecting the JSON would mis-attribute results.

## Change

`FinalizeResults` now reads the context recorded on the session metadata —
`Metadata.ContextMetadata.ClusterContextMetadata.ContextName`, which #2841
populates from `GetClusterContextName()` — and falls back to
`k8sinterface.GetContextName()` when a session carries no cluster context
metadata.

So the no-selection path behaves exactly as #2866 made it, and an explicit
selection is now honoured.

## How to Test

```bash
go test ./core/core/ -run TestFinalizeResults_ClusterName -count=1 -v
```

Four tests. The ambient context is pinned with `SetClusterContextName` and
restored in `t.Cleanup`, so they do not depend on the runner having a
kubeconfig; the selected context comes from a real kubeconfig file written by
the existing `writeContextKubeconfig` helper.

| Test | Asserts |
|---|---|
| `FollowsScanSelectedContext` | `--kubeconfig` selection wins over the ambient context |
| `FollowsContextOverride` | `--kube-context` selection wins too |
| `FallsBackToAmbientContext` | no selection still uses the ambient name (#2866's behaviour) |
| `DoesNotOverwriteExisting` | an already-set cluster name is preserved |

The first two fail on master:

```
--- FAIL: TestFinalizeResults_ClusterNameFollowsScanSelectedContext
    Error: Not equal:
           expected: "context-a"
           actual  : "context-b"
    Messages: the report must be labelled with the context the scan actually used, not the ambient one
--- FAIL: TestFinalizeResults_ClusterNameFollowsContextOverride
```

The other two pass on master and after, so they pin the behaviour this change
must not break. Both tests added in #2866
(`TestFinalizeResults_SetsClusterNameWhenEmpty`,
`TestFinalizeResults_PreservesExistingClusterName`) still pass unchanged.

I also ran the suite with `KUBECONFIG` unset and an empty `HOME` to confirm the
tests are hermetic — the first revision of this PR was not, and went red on CI
for that reason rather than for the change itself.

Also ran:

```bash
go build ./...
go vet ./core/...
go test ./core/core/... ./core/pkg/resultshandling/... -count=1
go test -race ./core/core/ -run TestFinalizeResults_ClusterName -count=5
```

All clean.

## Related issues/PRs

Follow-up to #2866 and #2841. Original report: #2856.

`customerGUID` is still always empty — @ArneshBanerjee deliberately left it out
of #2866 and asked whether changing `FinalizeResults`' signature for it is
wanted. Not touching it here either, for the same reason.
