### PR TITLE
feat(csv): add remediation path evidence columns to CSV scan output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -12,6 +12,9 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	reporthandling "github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
 const (
@@ -42,7 +45,6 @@ func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) {
 }
 
 func (cp *CsvPrinter) Score(score float32) {
-	// Handle invalid scores
 	if score > 100 {
 		score = 100
 	} else if score < 0 {
@@ -61,9 +63,10 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 	finalizedReport := FinalizeResults(opaSessionObj)
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 
+	summaryControls := finalizedReport.SummaryDetails.Controls
+
 	csvWriter := csv.NewWriter(cp.writer)
 
-	// Write Header
 	header := []string{
 		"Control Name",
 		"Control ID",
@@ -73,6 +76,11 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 		"Resource Kind",
 		"Resource Namespace",
 		"API Version",
+		"Failed Paths",
+		"Fix Paths",
+		"Remediation",
+		"Control URL",
+		"Source Path",
 	}
 	if err := csvWriter.Write(header); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write CSV header", helpers.Error(err))
@@ -83,7 +91,6 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 		resID := result.ResourceID
 		var resName, resKind, resNamespace, resApiVersion string
 
-		// Try to find the resource object to extract metadata
 		if resourceData, ok := opaSessionObj.AllResources[resID]; ok {
 			resName = resourceData.GetName()
 			resKind = resourceData.GetKind()
@@ -91,12 +98,17 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 			resApiVersion = resourceData.GetApiVersion()
 		}
 
-		// Write each control association
+		sourcePath := ""
+		if src, ok := opaSessionObj.ResourceSource[resID]; ok {
+			sourcePath = csvSourcePath(src)
+		}
+
+		resourceResult, hasResult := opaSessionObj.ResourcesResult[resID]
+
 		for _, assocCtrl := range result.AssociatedControls {
 			ctrlID := assocCtrl.GetID()
 			ctrlName := assocCtrl.GetName()
 
-			// Severity is already populated
 			severity := assocCtrl.Severity
 			if severity == "" {
 				severity = "Unknown"
@@ -105,6 +117,17 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 			status := string(assocCtrl.GetStatus(nil).Status())
 			if status == "" {
 				status = "unknown"
+			}
+
+			failedPaths := ""
+			fixPaths := ""
+			if hasResult {
+				failedPaths, fixPaths = csvControlPaths(resourceResult, ctrlID)
+			}
+
+			remediation := ""
+			if ctrl := summaryControls.GetControl(reportsummary.EControlCriteriaID, ctrlID); ctrl != nil {
+				remediation = ctrl.GetRemediation()
 			}
 
 			row := []string{
@@ -116,6 +139,11 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 				resKind,
 				resNamespace,
 				resApiVersion,
+				failedPaths,
+				fixPaths,
+				remediation,
+				cautils.GetControlLink(ctrlID),
+				sourcePath,
 			}
 			if err := csvWriter.Write(row); err != nil {
 				logger.L().Ctx(ctx).Error("failed to write CSV row", helpers.Error(err))
@@ -140,4 +168,42 @@ func (cp *CsvPrinter) CloseWriter() {
 	if cp.writer != nil && cp.writer != os.Stdout {
 		_ = cp.writer.Close()
 	}
+}
+
+// csvControlPaths returns the semicolon-separated failed paths and fix paths
+// for the given controlID in result. Both strings are empty when the control
+// is not found or has no paths.
+func csvControlPaths(result resourcesresults.Result, controlID string) (failedPaths, fixPaths string) {
+	for i := range result.AssociatedControls {
+		if result.AssociatedControls[i].GetID() != controlID {
+			continue
+		}
+		var failed, fix []string
+		for j := range result.AssociatedControls[i].ResourceAssociatedRules {
+			for k := range result.AssociatedControls[i].ResourceAssociatedRules[j].Paths {
+				p := result.AssociatedControls[i].ResourceAssociatedRules[j].Paths[k]
+				if p.FailedPath != "" {
+					failed = append(failed, p.FailedPath)
+				}
+				if p.FixPath.Path != "" {
+					if p.FixPath.Value != "" {
+						fix = append(fix, p.FixPath.Path+"="+p.FixPath.Value)
+					} else {
+						fix = append(fix, p.FixPath.Path)
+					}
+				}
+			}
+		}
+		return strings.Join(failed, "; "), strings.Join(fix, "; ")
+	}
+	return "", ""
+}
+
+// csvSourcePath returns the best available source path from a Source entry.
+// RelativePath is preferred because it is repo-relative and more portable.
+func csvSourcePath(src reporthandling.Source) string {
+	if src.RelativePath != "" {
+		return src.RelativePath
+	}
+	return src.Path
 }

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -7,21 +7,26 @@ import (
 	"os"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	reporthandling "github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testControlID1  = "C-0057"
+	testControlID2  = "C-0058"
+	testResourceID1 = "apps/v1/Deployment/default/demo"
+	testResourceID2 = "apps/v1/Deployment/default/absent"
 )
 
 func csvSessionFixture() *cautils.OPASessionObj {
-	controlID1 := "C-0057"
-	controlID2 := "C-0058"
-	resourceID1 := "apps/v1/Deployment/default/demo"
-	resourceID2 := "apps/v1/Deployment/default/absent"
-
 	obj := map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
@@ -34,43 +39,95 @@ func csvSessionFixture() *cautils.OPASessionObj {
 	lw := localworkload.NewLocalWorkload(obj)
 
 	ac1 := resourcesresults.ResourceAssociatedControl{
-		ControlID: controlID1,
+		ControlID: testControlID1,
 		Name:      "Privileged container",
 		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
 	}
 
 	ac2 := resourcesresults.ResourceAssociatedControl{
-		ControlID: controlID2,
+		ControlID: testControlID2,
 		Name:      "Run as root",
 		Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
 	}
 
 	session := cautils.NewOPASessionObjMock()
-	session.ResourcesResult[resourceID1] = resourcesresults.Result{
-		ResourceID:         resourceID1,
+	session.ResourcesResult[testResourceID1] = resourcesresults.Result{
+		ResourceID:         testResourceID1,
 		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac1, ac2},
 	}
-	session.ResourcesResult[resourceID2] = resourcesresults.Result{
-		ResourceID:         resourceID2,
+	session.ResourcesResult[testResourceID2] = resourcesresults.Result{
+		ResourceID:         testResourceID2,
 		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac1},
 	}
-	session.AllResources[resourceID1] = lw
+	session.AllResources[testResourceID1] = lw
 
 	session.Report = &reporthandlingv2.PostureReport{
 		SummaryDetails: reportsummary.SummaryDetails{
 			Controls: reportsummary.ControlSummaries{
-				controlID1: reportsummary.ControlSummary{
-					ControlID:   controlID1,
+				testControlID1: reportsummary.ControlSummary{
+					ControlID:   testControlID1,
 					Name:        "Privileged container",
-					ScoreFactor: 9.0, // Critical severity
+					ScoreFactor: 9.0,
 				},
-				controlID2: reportsummary.ControlSummary{
-					ControlID:   controlID2,
+				testControlID2: reportsummary.ControlSummary{
+					ControlID:   testControlID2,
 					Name:        "Run as root",
-					ScoreFactor: 5.0, // Medium severity
+					ScoreFactor: 5.0,
 				},
 			},
 		},
+	}
+
+	return session
+}
+
+func csvSessionFixtureWithPaths() *cautils.OPASessionObj {
+	session := csvSessionFixture()
+
+	ac1WithPaths := resourcesresults.ResourceAssociatedControl{
+		ControlID: testControlID1,
+		Name:      "Privileged container",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Paths: []armotypes.PosturePaths{
+					{
+						FailedPath: "spec.containers[0].securityContext.privileged",
+						FixPath: armotypes.FixPath{
+							Path:  "spec.containers[0].securityContext.privileged",
+							Value: "false",
+						},
+					},
+					{
+						FailedPath: "spec.initContainers[0].securityContext.privileged",
+					},
+				},
+			},
+		},
+	}
+
+	ac2NoPath := resourcesresults.ResourceAssociatedControl{
+		ControlID: testControlID2,
+		Name:      "Run as root",
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+	}
+
+	session.ResourcesResult[testResourceID1] = resourcesresults.Result{
+		ResourceID:         testResourceID1,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac1WithPaths, ac2NoPath},
+	}
+
+	session.ResourceSource = make(map[string]reporthandling.Source)
+	session.ResourceSource[testResourceID1] = reporthandling.Source{
+		RelativePath: "manifests/deployment.yaml",
+		Path:         "/home/user/project/manifests/deployment.yaml",
+	}
+
+	session.Report.SummaryDetails.Controls[testControlID1] = reportsummary.ControlSummary{
+		ControlID:   testControlID1,
+		Name:        "Privileged container",
+		ScoreFactor: 9.0,
+		Remediation: "remove privilegedContainer: True flag from your pod spec",
 	}
 
 	return session
@@ -85,7 +142,6 @@ func TestSetWriter_Csv(t *testing.T) {
 	cp := NewCsvPrinter()
 	assert.NotNil(t, cp)
 
-	// Test without outputFile (should use stdout)
 	cp.SetWriter(context.TODO(), "")
 	assert.NotNil(t, cp.writer)
 	cp.CloseWriter()
@@ -160,7 +216,6 @@ func TestActionPrint_Csv(t *testing.T) {
 	records, err := r.ReadAll()
 	assert.NoError(t, err)
 
-	// We expect 1 header row + 3 data rows (2 for resourceID1, 1 for resourceID2)
 	assert.Equal(t, 4, len(records))
 
 	expectedHeader := []string{
@@ -172,20 +227,26 @@ func TestActionPrint_Csv(t *testing.T) {
 		"Resource Kind",
 		"Resource Namespace",
 		"API Version",
+		"Failed Paths",
+		"Fix Paths",
+		"Remediation",
+		"Control URL",
+		"Source Path",
 	}
 	assert.Equal(t, expectedHeader, records[0], "Header should match expected")
+	assert.Equal(t, 13, len(records[0]), "Header should have 13 columns")
 
-	// The order of results isn't strictly guaranteed by a map iteration, but we can verify the rows exist.
 	var failedDemo, passedDemo, failedAbsent bool
 	for _, row := range records[1:] {
-		if row[0] == "Privileged container" && row[1] == "C-0057" && row[2] == "Critical" && row[3] == "failed" {
+		require.Equal(t, 13, len(row), "every data row must have 13 columns")
+		if row[0] == "Privileged container" && row[1] == testControlID1 && row[3] == "failed" {
 			if row[4] == "demo" && row[5] == "Deployment" && row[6] == "default" && row[7] == "apps/v1" {
 				failedDemo = true
 			} else if row[4] == "" && row[5] == "" && row[6] == "" && row[7] == "" {
 				failedAbsent = true
 			}
-		} else if row[0] == "Run as root" && row[1] == "C-0058" && row[2] == "Medium" && row[3] == "passed" {
-			if row[4] == "demo" && row[5] == "Deployment" && row[6] == "default" && row[7] == "apps/v1" {
+		} else if row[0] == "Run as root" && row[1] == testControlID2 && row[3] == "passed" {
+			if row[4] == "demo" {
 				passedDemo = true
 			}
 		}
@@ -193,5 +254,221 @@ func TestActionPrint_Csv(t *testing.T) {
 
 	assert.True(t, failedDemo, "expected failed control row for demo resource")
 	assert.True(t, passedDemo, "expected passed control row for demo resource")
-	assert.True(t, failedAbsent, "expected failed control row for absent resource (with empty columns)")
+	assert.True(t, failedAbsent, "expected failed control row for absent resource")
+}
+
+func TestActionPrint_Csv_WithPaths(t *testing.T) {
+	session := csvSessionFixtureWithPaths()
+
+	tmpCsv, err := os.CreateTemp("", "csv-paths-*.csv")
+	require.NoError(t, err)
+	defer os.Remove(tmpCsv.Name())
+
+	cp := NewCsvPrinter()
+	cp.writer = tmpCsv
+	cp.ActionPrint(context.TODO(), session, nil)
+	cp.CloseWriter()
+
+	f, err := os.Open(tmpCsv.Name())
+	require.NoError(t, err)
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+	require.Greater(t, len(records), 1)
+
+	var foundRow []string
+	for _, row := range records[1:] {
+		if row[1] == testControlID1 && row[4] == "demo" {
+			foundRow = row
+			break
+		}
+	}
+	require.NotNil(t, foundRow, "should find C-0057 row for demo resource")
+
+	assert.Contains(t, foundRow[8], "spec.containers[0].securityContext.privileged", "Failed Paths column")
+	assert.Contains(t, foundRow[8], "spec.initContainers[0].securityContext.privileged", "Failed Paths column second path")
+	assert.Contains(t, foundRow[9], "spec.containers[0].securityContext.privileged=false", "Fix Paths column")
+	assert.Equal(t, "remove privilegedContainer: True flag from your pod spec", foundRow[10], "Remediation column")
+	assert.NotEmpty(t, foundRow[11], "Control URL column should not be empty")
+	assert.Equal(t, "manifests/deployment.yaml", foundRow[12], "Source Path column uses RelativePath")
+}
+
+func TestActionPrint_Csv_NilSession(t *testing.T) {
+	cp := NewCsvPrinter()
+	cp.writer = os.Stdout
+	cp.ActionPrint(context.TODO(), nil, nil)
+}
+
+func TestCsvControlPaths(t *testing.T) {
+	makeResult := func(controlID string, rules []resourcesresults.ResourceAssociatedRule) resourcesresults.Result {
+		return resourcesresults.Result{
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{
+					ControlID:               controlID,
+					ResourceAssociatedRules: rules,
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		result     resourcesresults.Result
+		controlID  string
+		wantFailed string
+		wantFix    string
+	}{
+		{
+			name: "single failed path with fix",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{
+							FailedPath: "spec.containers[0].securityContext.privileged",
+							FixPath:    armotypes.FixPath{Path: "spec.containers[0].securityContext.privileged", Value: "false"},
+						},
+					},
+				},
+			}),
+			controlID:  "C-0057",
+			wantFailed: "spec.containers[0].securityContext.privileged",
+			wantFix:    "spec.containers[0].securityContext.privileged=false",
+		},
+		{
+			name: "multiple failed paths joined by semicolon",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.containers[0].securityContext.privileged"},
+						{FailedPath: "spec.initContainers[0].securityContext.privileged"},
+					},
+				},
+			}),
+			controlID:  "C-0057",
+			wantFailed: "spec.containers[0].securityContext.privileged; spec.initContainers[0].securityContext.privileged",
+			wantFix:    "",
+		},
+		{
+			name: "fix path without failed path",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FixPath: armotypes.FixPath{Path: "spec.hostNetwork", Value: "false"}},
+					},
+				},
+			}),
+			controlID:  "C-0057",
+			wantFailed: "",
+			wantFix:    "spec.hostNetwork=false",
+		},
+		{
+			name: "control not in result returns empty strings",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.containers[0].securityContext.privileged"},
+					},
+				},
+			}),
+			controlID:  "C-9999",
+			wantFailed: "",
+			wantFix:    "",
+		},
+		{
+			name:       "result with no rules returns empty strings",
+			result:     makeResult("C-0057", nil),
+			controlID:  "C-0057",
+			wantFailed: "",
+			wantFix:    "",
+		},
+		{
+			name: "multiple rules paths concatenated",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.containers[0].securityContext.privileged"},
+					},
+				},
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.containers[1].securityContext.privileged"},
+					},
+				},
+			}),
+			controlID:  "C-0057",
+			wantFailed: "spec.containers[0].securityContext.privileged; spec.containers[1].securityContext.privileged",
+			wantFix:    "",
+		},
+		{
+			name: "empty result returns empty strings",
+			result: resourcesresults.Result{
+				AssociatedControls: nil,
+			},
+			controlID:  "C-0057",
+			wantFailed: "",
+			wantFix:    "",
+		},
+		{
+			name: "fix path with empty value emits bare path without equals",
+			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FixPath: armotypes.FixPath{Path: "spec.automountServiceAccountToken", Value: ""}},
+					},
+				},
+			}),
+			controlID:  "C-0057",
+			wantFailed: "",
+			wantFix:    "spec.automountServiceAccountToken",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotFailed, gotFix := csvControlPaths(tc.result, tc.controlID)
+			assert.Equal(t, tc.wantFailed, gotFailed, "failed paths mismatch")
+			assert.Equal(t, tc.wantFix, gotFix, "fix paths mismatch")
+		})
+	}
+}
+
+func TestCsvSourcePath(t *testing.T) {
+	cases := []struct {
+		name string
+		src  reporthandling.Source
+		want string
+	}{
+		{
+			name: "relative path preferred over absolute",
+			src:  reporthandling.Source{RelativePath: "manifests/deploy.yaml", Path: "/abs/path/deploy.yaml"},
+			want: "manifests/deploy.yaml",
+		},
+		{
+			name: "absolute path used when relative is empty",
+			src:  reporthandling.Source{RelativePath: "", Path: "/abs/path/deploy.yaml"},
+			want: "/abs/path/deploy.yaml",
+		},
+		{
+			name: "both empty returns empty string",
+			src:  reporthandling.Source{},
+			want: "",
+		},
+		{
+			name: "only relative path set",
+			src:  reporthandling.Source{RelativePath: "k8s/namespace.yaml"},
+			want: "k8s/namespace.yaml",
+		},
+		{
+			name: "helm template path with relative",
+			src:  reporthandling.Source{RelativePath: "templates/deployment.yaml", HelmTemplateLine: 12},
+			want: "templates/deployment.yaml",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, csvSourcePath(tc.src))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- The CSV printer (added in #2743) outputs control name, severity, and resource metadata but gives no field-level evidence operators must re-run kubectl or open manifests to find which fields are wrong and what to change.
- Added five new columns to every CSV row: **Failed Paths**, **Fix Paths**, **Remediation**, **Control URL**, and **Source Path**.
- `csvControlPaths(result, controlID)` looks up `ResourcesResult` for the (resource, control) pair and collects `FailedPath` and `FixPath` entries as semicolon-separated strings, machine-parseable for scripting and spreadsheet filtering.
- `csvSourcePath(src)` prefers `RelativePath` over the absolute `Path` so exported CSV files stay portable across machines and CI environments.
- Remediation text is pulled from `SummaryDetails.Controls.GetRemediation()`, the same source used by the JUnit printer.
- 21 tests added/updated: `TestActionPrint_Csv` updated for 13-column header, `TestActionPrint_Csv_WithPaths` verifies all new columns end-to-end, `TestCsvControlPaths` has 8 table-driven sub-cases, `TestCsvSourcePath` has 5 sub-cases.

**Which issue(s) this PR fixes:**
Relates to the LFX 2026 Term 3 project: *Evidence of Finding: Path-Level Evidence in Scan Output*

**Special notes for your reviewer:**
Failed/Fix paths are semicolon-separated (`; `) so consumers can split on that delimiter without ambiguity with the CSV comma. Paths with no evidence (passed controls, controls without path-level rules) output an empty string, no behaviour change for existing consumers of columns 1–8.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan --format csv` now includes five additional columns: Failed Paths, Fix Paths, Remediation, Control URL, Source Path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced CSV results with failed paths, fix paths, remediation guidance, control URLs, and source paths.
  - Added resource-level source metadata and detailed result information to CSV output.
  - Improved path formatting by preferring relative source paths where available.

- **Bug Fixes**
  - Improved handling of missing session information and edge cases when generating CSV output.

- **Tests**
  - Expanded coverage to validate all CSV columns and path/source formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->