### PR TITLE
fix(resourcehandler): classify missing LIST resources using typed Kubernetes errors

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -321,19 +322,8 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 
 		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, scanInfo.LabelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
-		for _, se := range selectorErrs {
-			// Match the eager collection path: controls may reference optional
-			// CRDs which are not installed, so a missing resource is not a scan
-			// coverage failure.
-			if strings.Contains(se.err.Error(), "the server could not find the requested resource") {
-				continue
-			}
-			qualifiedKey := qr.GroupVersionResourceTriplet + "/" + se.selector
-			failedQueries[qualifiedKey] = queryFailure{
-				gvr:      qr.GroupVersionResourceTriplet,
-				selector: se.selector,
-				err:      se.err,
-			}
+		for k, v := range classifySelectorFailures(qr.GroupVersionResourceTriplet, selectorErrs) {
+			failedQueries[k] = v
 		}
 		if len(result) == 0 && len(selectorErrs) > 0 {
 			continue
@@ -698,6 +688,33 @@ type selectorFailure struct {
 	err      error
 }
 
+// classifySelectorFailures keys selectorErrs by "<gvrTriplet>/<selector>" for
+// a caller's failedQueries map, dropping failures whose wrapped cause is a
+// missing-resource 404: controls may reference optional CRDs that are not
+// installed, so a missing resource is not a scan coverage failure. Using the
+// typed API status (rather than matching the error message text) avoids
+// missing a NotFound whose message differs, and avoids silently swallowing an
+// unrelated transport/proxy error that happens to contain the same sentence.
+func classifySelectorFailures(gvrTriplet string, selectorErrs []selectorFailure) map[string]queryFailure {
+	if len(selectorErrs) == 0 {
+		return nil
+	}
+
+	failures := make(map[string]queryFailure, len(selectorErrs))
+	for _, se := range selectorErrs {
+		if apierrors.IsNotFound(se.err) {
+			continue
+		}
+		qualifiedKey := gvrTriplet + "/" + se.selector
+		failures[qualifiedKey] = queryFailure{
+			gvr:      gvrTriplet,
+			selector: se.selector,
+			err:      se.err,
+		}
+	}
+	return failures
+}
+
 const maxParallelResourcePulls = 8
 
 func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector, labelSelector string) (cautils.K8SResources, map[string]workloadinterface.IMetadata, map[string]queryFailure) {
@@ -745,18 +762,10 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 				return
 			}
 
-			if len(selectorErrs) > 0 {
+			if failures := classifySelectorFailures(qr.GroupVersionResourceTriplet, selectorErrs); len(failures) > 0 {
 				mu.Lock()
-				for _, se := range selectorErrs {
-					if strings.Contains(se.err.Error(), "the server could not find the requested resource") {
-						continue
-					}
-					qualifiedKey := qr.GroupVersionResourceTriplet + "/" + se.selector
-					failedQueries[qualifiedKey] = queryFailure{
-						gvr:      qr.GroupVersionResourceTriplet,
-						selector: se.selector,
-						err:      se.err,
-					}
+				for k, v := range failures {
+					failedQueries[k] = v
 				}
 				mu.Unlock()
 			}

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -76,7 +78,7 @@ func TestCollectAndStreamBatches_FailsWhenAllQueriesFail(t *testing.T) {
 func TestCollectAndStreamBatches_IgnoresMissingOptionalResource(t *testing.T) {
 	ctx := context.Background()
 	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, fmt.Errorf("the server could not find the requested resource")
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: "example.com", Resource: "somecrds"}, "")
 	})
 	scanInfo, session := streamingTestSession(ctx)
 	namespaced := true

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,11 +143,32 @@ func TestPullResources_NonForbiddenErrorRecorded(t *testing.T) {
 	}
 }
 
-// TestPullResources_NotFoundErrorIgnored verifies that a "server could not find
-// the requested resource" error (CRD not installed) is silently ignored and does
-// NOT appear in failedQueries — this is expected behaviour when a control
+// TestPullResources_NotFoundErrorIgnored verifies that a canonical NotFound
+// API status error (CRD not installed) is silently ignored and does NOT
+// appear in failedQueries — this is expected behaviour when a control
 // references an optional CRD that isn't present on the cluster.
 func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: "example.com", Resource: "somecrds"}, "")
+	})
+
+	qrs := QueryableResources{
+		"/v1/somecrd": QueryableResource{
+			GroupVersionResourceTriplet: "/v1/somecrd",
+		},
+	}
+
+	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
+
+	assert.Empty(t, failedQueries, "404-style errors should not be recorded as failures")
+}
+
+// TestPullResources_SimilarMessageButNotTypedNotFoundIsRecorded verifies that
+// an untyped transport/proxy error whose message happens to resemble the
+// classic "resource not found" sentence is still recorded as a failure.
+// Message-based matching would have silently swallowed this; typed
+// apierrors.IsNotFound classification does not.
+func TestPullResources_SimilarMessageButNotTypedNotFoundIsRecorded(t *testing.T) {
 	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("the server could not find the requested resource")
 	})
@@ -159,7 +181,7 @@ func TestPullResources_NotFoundErrorIgnored(t *testing.T) {
 
 	_, _, failedQueries := handler.pullResources(context.Background(), qrs, &EmptySelector{}, "")
 
-	assert.Empty(t, failedQueries, "404-style errors should not be recorded as failures")
+	require.Len(t, failedQueries, 1, "an untyped error must not be classified as NotFound just because its message resembles one")
 }
 
 // TestPullResources_PartialFailure verifies that when one GVR succeeds and


### PR DESCRIPTION
## Summary

Both the eager and streaming collectors identify a missing LIST resource by matching the English substring `"the server could not find the requested resource"` in the returned error, duplicated across two call sites (`pullResources` and `collectAndStreamBatches`).

`pullSingleResource` already wraps the underlying client-go error with `%w`, so the structured API status is available and doesn't need to be re-derived from message text. Message matching can miss a valid `NotFound` whose text differs, and can silently swallow an unrelated transport/proxy error that happens to contain the same sentence.

## Changes

- Extract the duplicated selector-failure recording loop (present in both `pullResources` and `collectAndStreamBatches`) into a single `classifySelectorFailures` helper.
- Classify using `apierrors.IsNotFound(err)` instead of `strings.Contains`.
- Every other selector failure is still recorded exactly as before.
- Replace the message-based eager and streaming regression fixtures (`TestPullResources_NotFoundErrorIgnored`, `TestCollectAndStreamBatches_IgnoresMissingOptionalResource`) with canonical `apierrors.NewNotFound` values.
- Add `TestPullResources_SimilarMessageButNotTypedNotFoundIsRecorded` to pin that an untyped error is no longer misclassified just because its message resembles a NotFound.

No legacy string-matching fallback is kept: an untyped proxy/transport error is now reported as a collection failure rather than silently classified from English text.

Fixes #2873

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/resourcehandler/...`
- [x] `go test ./pkg/resourcehandler/...` — all passing, including the updated and new regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kubernetes missing-resource responses during resource collection.
  * Optional resources that genuinely return “not found” are now safely ignored.
  * Other selector errors, including messages that merely resemble “not found,” are correctly reported as failures.
  * Streaming and concurrent collection now apply consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->