### PR TITLE
refactor(resourcehandler): use canonical path containment for Kustomize directory file exclusions

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -241,9 +241,15 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	return remaining
 }
 
-// isUnderAnyDir reports whether path is inside one of dirs after normalizing
-// relative paths and resolving symlinks where the path already exists.
-func isUnderAnyDir(path string, dirs []string) bool {
+// IsUnderAnyDir reports whether path is inside one of dirs after normalizing
+// relative paths and resolving symlinks where the path already exists. Unlike
+// a plain strings.HasPrefix comparison, this uses filepath.Rel for canonical
+// containment (so a sibling merely sharing a prefix, e.g. "templates-docs"
+// next to "templates", does not falsely match), resolves symlinks so a
+// directory reached through a symlinked parent is still recognized, and
+// handles root directory "/" and Windows drive paths without the
+// double-separator edge cases a raw prefix join would hit.
+func IsUnderAnyDir(path string, dirs []string) bool {
 	return isUnderAnyNormalizedDir(normalizePath(path), normalizePaths(dirs))
 }
 

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -262,17 +262,9 @@ func excludeFilesUnderDirectories(sourceToWorkloads map[string][]workloadinterfa
 	if len(dirs) == 0 {
 		return
 	}
-	cleanDirs := make([]string, len(dirs))
-	for i, dir := range dirs {
-		cleanDirs[i] = filepath.Clean(dir) + string(filepath.Separator)
-	}
 	for source := range sourceToWorkloads {
-		cleanSource := filepath.Clean(source)
-		for _, dir := range cleanDirs {
-			if strings.HasPrefix(cleanSource, dir) {
-				delete(sourceToWorkloads, source)
-				break
-			}
+		if cautils.IsUnderAnyDir(source, dirs) {
+			delete(sourceToWorkloads, source)
 		}
 	}
 }

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -540,3 +540,34 @@ metadata:
 	assert.Equal(t, 1, counts["Deployment/prod-app"])
 	assert.Equal(t, 1, counts["ConfigMap/standalone"], "a manifest outside the Kustomize directory must still be scanned")
 }
+
+// TestExcludeFilesUnderDirectories_SiblingDirSharingPrefixNotExcluded pins the
+// bug a raw strings.HasPrefix(cleanSource, dir) comparison has: "app-extra" is
+// a lexical prefix match for "app" without a separator boundary check, so a
+// file under the sibling directory "app-extra" would be wrongly excluded when
+// only "app" was rendered as a nested Kustomization. IsUnderAnyDir compares
+// through filepath.Rel, which requires the ".." boundary and so does not
+// false-positive on a shared prefix.
+func TestExcludeFilesUnderDirectories_SiblingDirSharingPrefixNotExcluded(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceToWorkloads := map[string][]workloadinterface.IMetadata{
+		filepath.Join(repoRoot, "app", "deployment.yaml"):      nil,
+		filepath.Join(repoRoot, "app-extra", "configmap.yaml"): nil,
+		filepath.Join(repoRoot, "app", "nested", "job.yaml"):   nil,
+		filepath.Join(repoRoot, "other", "unrelated.yaml"):     nil,
+	}
+
+	excludeFilesUnderDirectories(sourceToWorkloads, []string{filepath.Join(repoRoot, "app")})
+
+	_, underApp := sourceToWorkloads[filepath.Join(repoRoot, "app", "deployment.yaml")]
+	assert.False(t, underApp, "a file directly under the excluded directory must be dropped")
+
+	_, underAppNested := sourceToWorkloads[filepath.Join(repoRoot, "app", "nested", "job.yaml")]
+	assert.False(t, underAppNested, "a file under a nested subdirectory of the excluded directory must be dropped")
+
+	_, sibling := sourceToWorkloads[filepath.Join(repoRoot, "app-extra", "configmap.yaml")]
+	assert.True(t, sibling, "a sibling directory merely sharing a name prefix must not be excluded")
+
+	_, unrelated := sourceToWorkloads[filepath.Join(repoRoot, "other", "unrelated.yaml")]
+	assert.True(t, unrelated, "a file outside every excluded directory must not be excluded")
+}


### PR DESCRIPTION
## Summary

`excludeFilesUnderDirectories` (introduced in #2888) excludes a nested Kustomize directory's local inputs from the plain-manifest scan results once that directory has already been rendered on its own. It currently does this with:

```go
strings.HasPrefix(cleanSource, dir)
```

A raw prefix comparison without a separator boundary check false-positives on a sibling directory that merely shares a name prefix — e.g. a file under `app-extra/` would be wrongly excluded when only `app/` was rendered as a nested Kustomization.

## Changes

- Export the already-existing `cautils.isUnderAnyDir` as `cautils.IsUnderAnyDir` and use it in `excludeFilesUnderDirectories` instead of the raw prefix check. It compares through `filepath.Rel` for canonical containment, resolves symlinks via `EvalSymlinks`, and handles root directory `/` and Windows drive paths without the double-separator edge cases a raw prefix join would hit.
- Add `TestExcludeFilesUnderDirectories_SiblingDirSharingPrefixNotExcluded` to pin the sibling-prefix case (and the nested-subdirectory and unrelated-directory cases) against regressing.

Fixes #2889

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/resourcehandler/... ./cautils/...`
- [x] `go test ./pkg/resourcehandler/... ./cautils/...` — all passing, including the new regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory-based file exclusion to reliably remove files within selected directories and their descendants.
  * Preserved files in sibling and similarly named directories to prevent accidental exclusions.

* **Tests**
  * Added coverage for directory containment and similarly prefixed paths across supported path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->