### PR TITLE
fix(resourcehandler): log warnings on directory discovery errors in LoadResourcesFromNestedKustomizeDirectories

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -389,17 +389,20 @@ func LoadResourcesFromKustomizeDirectory(ctx context.Context, basePath string) (
 // handled by LoadResourcesFromKustomizeDirectory. Every discovered directory carries its own
 // Kustomization file, so each is rendered independently; a directory whose render fails is
 // skipped with a warning rather than aborting the scan, leaving its files to the plain-manifest
-// loader as a fallback. The returned directories are exactly those that rendered successfully,
-// for the caller to exclude from the plain-manifest pass.
-func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, []string, error) {
+// loader as a fallback. Directory discovery errors (e.g. an unreadable subdirectory hit during the
+// tree walk) are likewise logged as warnings rather than aborting the scan, matching
+// loadResourcesFromHelmCharts: a permission error on one subtree should not cost the whole scan
+// the Kustomize directories that were discovered successfully. The returned directories are
+// exactly those that rendered successfully, for the caller to exclude from the plain-manifest pass.
+func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, []string) {
 	if isKustomizeDirectory(basePath) || IsKustomizeFile(basePath) {
 		// The direct-input case is handled by LoadResourcesFromKustomizeDirectory.
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	kustomizeDirs, errs := listKustomizeDirs(basePath)
-	if len(errs) > 0 {
-		return nil, nil, fmt.Errorf("failed to discover Kustomize configurations under %q: %w", basePath, errors.Join(errs...))
+	kustomizeDirs, discoveryErrs := listKustomizeDirs(basePath)
+	for _, err := range discoveryErrs {
+		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize directories", helpers.Error(err))
 	}
 
 	sourceToWorkloads := map[string][]workloadinterface.IMetadata{}
@@ -415,7 +418,7 @@ func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath s
 		renderedDirs = append(renderedDirs, dir)
 	}
 
-	return sourceToWorkloads, renderedDirs, nil
+	return sourceToWorkloads, renderedDirs
 }
 
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,4 +173,54 @@ func TestLoadResourcesFromKustomizeDirectoryNoopsForPlainDirectory(t *testing.T)
 	require.NoError(t, err)
 	assert.Nil(t, workloads)
 	assert.Empty(t, name)
+}
+
+// TestLoadResourcesFromNestedKustomizeDirectories_DiscoveryErrorDoesNotAbortScan
+// pins that a directory discovery error (e.g. an unreadable subdirectory hit
+// during the tree walk) is logged as a warning, matching
+// loadResourcesFromHelmCharts, rather than failing the whole broad scan. A
+// Kustomize directory discovered before the unreadable one was hit must still
+// be rendered.
+func TestLoadResourcesFromNestedKustomizeDirectories_DiscoveryErrorDoesNotAbortScan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced the same way on windows")
+	}
+
+	root := t.TempDir()
+
+	// "app" sorts before "unreadable" lexically, so the walk records it
+	// before hitting the permission error.
+	appDir := filepath.Join(root, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o750))
+	writeManifestFixture(t, appDir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+`)
+	writeManifestFixture(t, appDir, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+`)
+
+	unreadableDir := filepath.Join(root, "unreadable")
+	require.NoError(t, os.MkdirAll(unreadableDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadableDir, 0o750) })
+
+	sourceToWorkloads, renderedDirs := LoadResourcesFromNestedKustomizeDirectories(context.Background(), root)
+
+	assert.Contains(t, renderedDirs, appDir, "a directory discovered before the permission error must still be rendered")
+	assert.NotEmpty(t, sourceToWorkloads, "the successfully rendered directory's workloads must still be returned")
 }

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -325,10 +325,7 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// path itself may not be a Kustomize directory (e.g. a repository root), but a child
 	// directory below it can still hold its own Kustomization. Discover and render those too,
 	// so a broad scan applies their transformations instead of falling through to raw manifests.
-	nestedKustomizeSourceToWorkloads, nestedKustomizeDirs, err := cautils.LoadResourcesFromNestedKustomizeDirectories(ctx, path)
-	if err != nil {
-		return nil, nil, err
-	}
+	nestedKustomizeSourceToWorkloads, nestedKustomizeDirs := cautils.LoadResourcesFromNestedKustomizeDirectories(ctx, path)
 	if len(nestedKustomizeSourceToWorkloads) > 0 {
 		if kustomizeSourceToWorkloads == nil {
 			kustomizeSourceToWorkloads = map[string][]workloadinterface.IMetadata{}


### PR DESCRIPTION
## Summary

`LoadResourcesFromNestedKustomizeDirectories` (added in #2888) treats any error from `listKustomizeDirs` as fatal, failing the entire scan even when only one subdirectory was unreadable (e.g. a permission error hit during the tree walk) and other Kustomize directories were discovered successfully.

`loadResourcesFromHelmCharts` already handles the equivalent case correctly: discovery errors are logged as warnings and the render continues with whatever was found.

## Changes

- Apply the same pattern to `LoadResourcesFromNestedKustomizeDirectories`: log discovery errors as warnings instead of returning them, and continue processing the Kustomize directories that were discovered.
- Drop the now-unreachable `error` return from the function's signature — discovery errors were its only failure source, and `LoadResourcesFromKustomizeDirectory` render failures inside the loop were already handled with a warning + continue. Updated the single caller in `filesloader.go` accordingly.
- Add `TestLoadResourcesFromNestedKustomizeDirectories_DiscoveryErrorDoesNotAbortScan`, which hits a real permission-denied subdirectory during the walk and asserts that a Kustomize directory discovered before it is still rendered.

Related PR: #2888
Fixes #2890

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cautils/... ./pkg/resourcehandler/...`
- [x] `go test ./cautils/... ./pkg/resourcehandler/...` — all passing, including the new regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kustomize resource discovery so processing continues when an unreadable directory is encountered.
  - Preserves workloads and successfully processed directories discovered before or after directory access issues.
  - Rendering failures remain isolated to the affected directory instead of stopping the overall process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->