### PR TITLE
refactor(resourcehandler): use canonical path containment for kustomze exclusion

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -234,16 +234,16 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 
 	remaining := make([]string, 0, len(files))
 	for _, file := range files {
-		if !isAnyPathAliasUnderAnyDir(file, templateDirs) {
+		if !IsAnyPathAliasUnderAnyDir(file, templateDirs) {
 			remaining = append(remaining, file)
 		}
 	}
 	return remaining
 }
 
-// isUnderAnyDir reports whether path is inside one of dirs after normalizing
+// IsUnderAnyDir reports whether path is inside one of dirs after normalizing
 // relative paths and resolving symlinks where the path already exists.
-func isUnderAnyDir(path string, dirs []string) bool {
+func IsUnderAnyDir(path string, dirs []string) bool {
 	return isUnderAnyNormalizedDir(normalizePath(path), normalizePaths(dirs))
 }
 
@@ -277,7 +277,12 @@ func pathAliasesForPaths(paths []string) []string {
 	return aliases
 }
 
-func isAnyPathAliasUnderAnyDir(path string, dirs []string) bool {
+// IsAnyPathAliasUnderAnyDir reports whether any alias of path (its absolute
+// lexical form and, when different, its symlink-resolved physical form) is
+// inside one of dirs. dirs must already be normalized. Keeping the lexical
+// alias matters for a symlinked file whose link target lives elsewhere: it is
+// still owned by the directory that lexically contains it.
+func IsAnyPathAliasUnderAnyDir(path string, dirs []string) bool {
 	for _, alias := range pathAliases(path) {
 		if isUnderAnyNormalizedDir(alias, dirs) {
 			return true

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -193,6 +193,87 @@ func TestExcludeHelmTemplateFiles_NoCharts(t *testing.T) {
 	assert.Equal(t, files, excludeHelmTemplateFiles(files, nil))
 }
 
+// TestIsUnderAnyDir asserts that containment is decided by canonical relative
+// paths, not by string prefix equality: siblings that merely share a directory
+// prefix must not be reported as contained, and a directory named "." must stay
+// confined to its location (#2889).
+func TestIsUnderAnyDir(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		dirs      []string
+		contained bool
+	}{
+		{
+			name:      "file directly inside directory",
+			path:      "/repo/app/deployment.yaml",
+			dirs:      []string{"/repo/app"},
+			contained: true,
+		},
+		{
+			name:      "file nested below directory",
+			path:      "/repo/app/config/base/pod.yaml",
+			dirs:      []string{"/repo/app"},
+			contained: true,
+		},
+		{
+			name:      "sibling sharing a prefix is outside",
+			path:      "/repo/app-docs/deployment.yaml",
+			dirs:      []string{"/repo/app"},
+			contained: false,
+		},
+		{
+			name:      "unrelated path is outside",
+			path:      "/repo/other/pod.yaml",
+			dirs:      []string{"/repo/app"},
+			contained: false,
+		},
+		{
+			name:      "every path is under the root directory",
+			path:      "/repo/app/deployment.yaml",
+			dirs:      []string{string(filepath.Separator)},
+			contained: true,
+		},
+		{
+			name:      "parent directory does not claim a sibling",
+			path:      "/repo/app/deployment.yaml",
+			dirs:      []string{"/repo"},
+			contained: true,
+		},
+		{
+			name:      "relative path is resolved against the working directory",
+			path:      "app/deployment.yaml",
+			dirs:      []string{"app"},
+			contained: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.contained, IsUnderAnyDir(tt.path, tt.dirs))
+		})
+	}
+}
+
+// TestIsUnderAnyDir_CanonicalizesSymlinks asserts that a path reached through a
+// symlinked parent is still reported contained when only the physical layout
+// matches one of dirs.
+func TestIsUnderAnyDir_CanonicalizesSymlinks(t *testing.T) {
+	realParent := t.TempDir()
+	dir := filepath.Join(realParent, "app")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte("apiVersion: v1\n"), 0o600))
+
+	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	assert.True(t, IsUnderAnyDir(
+		filepath.Join(linkedParent, "app", "deployment.yaml"), []string{dir},
+	), "a symlinked copy of the directory must still be treated as contained")
+}
+
 func TestLoadResourcesFromHelmCharts(t *testing.T) {
 	sourceToWorkloads, sourceToChartName, _, err := LoadResourcesFromHelmCharts(context.Background(), helmChartPath(), HelmValueOptions{})
 	assert.NoError(t, err)

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -262,17 +262,9 @@ func excludeFilesUnderDirectories(sourceToWorkloads map[string][]workloadinterfa
 	if len(dirs) == 0 {
 		return
 	}
-	cleanDirs := make([]string, len(dirs))
-	for i, dir := range dirs {
-		cleanDirs[i] = filepath.Clean(dir) + string(filepath.Separator)
-	}
 	for source := range sourceToWorkloads {
-		cleanSource := filepath.Clean(source)
-		for _, dir := range cleanDirs {
-			if strings.HasPrefix(cleanSource, dir) {
-				delete(sourceToWorkloads, source)
-				break
-			}
+		if cautils.IsUnderAnyDir(source, dirs) {
+			delete(sourceToWorkloads, source)
 		}
 	}
 }

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -540,3 +540,69 @@ metadata:
 	assert.Equal(t, 1, counts["Deployment/prod-app"])
 	assert.Equal(t, 1, counts["ConfigMap/standalone"], "a manifest outside the Kustomize directory must still be scanned")
 }
+
+// TestExcludeFilesUnderDirectories asserts that only sources inside the given
+// directories are dropped: siblings that merely share an ancestor, or unrelated
+// files, survive. The containment check is directory-aware, so a root located
+// just above the scan tree must not swallow unrelated inputs.
+func TestExcludeFilesUnderDirectories(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	nestedDir := filepath.Join(appDir, "config", "base")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o750))
+
+	sources := map[string][]workloadinterface.IMetadata{
+		filepath.Join(nestedDir, "deployment.yaml"):    {localWorkloadWithPath("apps/v1", "Deployment", "", "app", filepath.Join(nestedDir, "deployment.yaml"))},
+		filepath.Join(appDir, "service.yaml"):          {localWorkloadWithPath("v1", "Service", "", "app", filepath.Join(appDir, "service.yaml"))},
+		filepath.Join(root, "app-docs", "policy.yaml"): {localWorkloadWithPath("v1", "Pod", "default", "docs", filepath.Join(root, "app-docs", "policy.yaml"))},
+		filepath.Join(root, "standalone.yaml"):         {localWorkloadWithPath("v1", "ConfigMap", "default", "standalone", filepath.Join(root, "standalone.yaml"))},
+	}
+
+	excludeFilesUnderDirectories(sources, []string{appDir})
+
+	assert.NotContains(t, sources, filepath.Join(nestedDir, "deployment.yaml"), "a file nested below the directory must be excluded")
+	assert.NotContains(t, sources, filepath.Join(appDir, "service.yaml"), "a file directly inside the directory must be excluded")
+	assert.Contains(t, sources, filepath.Join(root, "app-docs", "policy.yaml"), "a sibling sharing a name prefix must survive")
+	assert.Contains(t, sources, filepath.Join(root, "standalone.yaml"), "an unrelated file must survive")
+}
+
+// TestExcludeFilesUnderDirectories_RootDirectory asserts that a directory at the
+// filesystem root matches through the canonical relative-path comparison, where
+// the old string-prefix approach mangled the joined separator (#2889).
+func TestExcludeFilesUnderDirectories_RootDirectory(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "deployment.yaml")
+	sources := map[string][]workloadinterface.IMetadata{
+		source: {localWorkloadWithPath("apps/v1", "Deployment", "", "app", source)},
+	}
+
+	excludeFilesUnderDirectories(sources, []string{string(filepath.Separator)})
+
+	assert.NotContains(t, sources, source, "every absolute path lives under the root directory")
+}
+
+// TestExcludeFilesUnderDirectories_CanonicalizesSymlinkedDirs asserts that a Kustomize
+// directory discovered under a symlinked scan path still excludes its inputs, which are
+// reported with the symlinked (lexical) prefix while the directory is reported physically.
+// The old string-prefix comparison could not see the match across the link (#2889).
+func TestExcludeFilesUnderDirectories_CanonicalizesSymlinkedDirs(t *testing.T) {
+	realParent := t.TempDir()
+	physicalApp := filepath.Join(realParent, "app")
+	source := filepath.Join(physicalApp, "deployment.yaml")
+	require.NoError(t, os.MkdirAll(physicalApp, 0o750))
+	require.NoError(t, os.WriteFile(source, []byte(singlePodManifest), 0o600))
+
+	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	lexicalSource := filepath.Join(linkedParent, "app", "deployment.yaml")
+
+	sources := map[string][]workloadinterface.IMetadata{
+		lexicalSource: {localWorkloadWithPath("apps/v1", "Deployment", "", "app", lexicalSource)},
+	}
+
+	excludeFilesUnderDirectories(sources, []string{physicalApp})
+
+	assert.NotContains(t, sources, lexicalSource, "the input is under the physical directory, so it must be excluded")
+}


### PR DESCRIPTION


## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->


excludeFilesUnderDirectories matched sources with a cleaned string prefix, which missed symlinked scan paths, mishandled the filesystem root, and could collide on siblings sharing a directory name prefix. Replace the prefix check with cautils.IsUnderAnyDir, which compares canonical paths via filepath.Rel and resolves symlinks. Export IsUnderAnyDir and IsAnyPathAliasUnderAnyDir from cautils so the helm-template exclusion can share them too.

Resolves #2889
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Helm template file exclusions for nested directories, filesystem roots, and paths accessed through symbolic links.
  - Prevented similarly named sibling directories and unrelated files from being excluded unintentionally.
  - Improved path handling for both absolute and relative locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->