### PR TITLE
Propagate printer and command errors

### DIFF
--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
@@ -12,10 +11,8 @@ func getDeleteCmd(ks meta.IKubescape) *cobra.Command {
 		Use:   "delete",
 		Short: "Delete cached configurations",
 		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := ks.DeleteCachedConfig(&v1.DeleteConfig{}); err != nil {
-				logger.L().Fatal(err.Error())
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ks.DeleteCachedConfig(&v1.DeleteConfig{})
 		},
 	}
 }

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -3,7 +3,6 @@ package config
 import (
 	"os"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	v1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/spf13/cobra"
@@ -16,10 +15,8 @@ func getViewCmd(ks meta.IKubescape) *cobra.Command {
 		Use:   "view",
 		Short: "View cached configurations",
 		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := ks.ViewCachedConfig(&v1.ViewConfig{Writer: os.Stdout}); err != nil {
-				logger.L().Fatal(err.Error())
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ks.ViewCachedConfig(&v1.ViewConfig{Writer: os.Stdout})
 		},
 	}
 }

--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -61,8 +60,8 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 			}
 
 			if diffInfo.FailOnNew && newFailures > 0 {
-				logger.L().Fatal(fmt.Sprintf("found %d new failure(s) at or above severity threshold %q",
-					newFailures, severityLabel(diffInfo.SeverityThreshold)))
+				return fmt.Errorf("found %d new failure(s) at or above severity threshold %q",
+					newFailures, severityLabel(diffInfo.SeverityThreshold))
 			}
 
 			return nil

--- a/cmd/prerequisites/prerequisites.go
+++ b/cmd/prerequisites/prerequisites.go
@@ -1,6 +1,8 @@
 package prerequisites
 
 import (
+	"fmt"
+
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/meta"
@@ -19,10 +21,10 @@ func GetPreReqCmd(ks meta.IKubescape) *cobra.Command {
 	preReqCmd := &cobra.Command{
 		Use:   "prerequisites",
 		Short: "Check prerequisites for installing Kubescape Operator",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			clientSet, inCluster := common.BuildKubeClient(*kubeconfigPath)
 			if clientSet == nil {
-				logger.L().Fatal("Could not create kube client. Exiting.")
+				return fmt.Errorf("could not create kube client")
 			}
 
 			// 1) Collect cluster data
@@ -42,6 +44,7 @@ func GetPreReqCmd(ks meta.IKubescape) *cobra.Command {
 			finalReport.InCluster = inCluster
 
 			common.GenerateOutput(finalReport, inCluster)
+			return nil
 		},
 	}
 

--- a/cmd/prerequisites/prerequisites_test.go
+++ b/cmd/prerequisites/prerequisites_test.go
@@ -15,7 +15,7 @@ func TestGetPreReqCmd(t *testing.T) {
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "prerequisites", cmd.Use)
 	assert.Equal(t, "Check prerequisites for installing Kubescape Operator", cmd.Short)
-	assert.NotNil(t, cmd.Run)
+	assert.NotNil(t, cmd.RunE)
 }
 
 func TestGetPreReqCmdKubeconfigFlag(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,12 +65,17 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 		Use:     "kubescape",
 		Short:   "Kubescape is a tool for testing Kubernetes security posture. Docs: https://kubescape.io/docs/",
 		Example: ksExamples,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			k8sinterface.SetClusterContextName(rootInfo.KubeContext)
 			initLogger()
-			initLoggerLevel(cmd)
-			initEnvironment(ks.Context())
+			if err := initLoggerLevel(cmd); err != nil {
+				return err
+			}
+			if err := initEnvironment(ks.Context()); err != nil {
+				return err
+			}
 			initCacheDir(cmd)
+			return nil
 		},
 	}
 

--- a/cmd/rootutils.go
+++ b/cmd/rootutils.go
@@ -37,7 +37,7 @@ func initLogger() {
 	logger.InitLogger(rootInfo.LoggerName)
 }
 
-func initLoggerLevel(cmd *cobra.Command) {
+func initLoggerLevel(cmd *cobra.Command) error {
 	loggerExplicit := false
 	if cmd != nil {
 		// Persistent flags are parsed on the root while traversing to the subcommand.
@@ -57,8 +57,9 @@ func initLoggerLevel(cmd *cobra.Command) {
 	}
 
 	if err := logger.L().SetLevel(rootInfo.Logger); err != nil {
-		logger.L().Fatal(fmt.Sprintf("supported levels: %s", strings.Join(helpers.SupportedLevels(), "/")), helpers.Error(err))
+		return fmt.Errorf("supported levels: %s: %w", strings.Join(helpers.SupportedLevels(), "/"), err)
 	}
+	return nil
 }
 
 func initCacheDir(cmd *cobra.Command) {
@@ -84,17 +85,16 @@ func initCacheDir(cmd *cobra.Command) {
 		logger.L().Debug("cache dir updated", helpers.String("path", getter.DefaultLocalStore))
 	}
 }
-func initEnvironment(ctx context.Context) {
+func initEnvironment(ctx context.Context) error {
 	if rootInfo.DiscoveryServerURL == "" {
-		return
+		return nil
 	}
 
 	logger.L().Debug("fetching URLs from service discovery server", helpers.String("server", rootInfo.DiscoveryServerURL))
 
 	client, err := sdClientV2.NewServiceDiscoveryClientV2(rootInfo.DiscoveryServerURL)
 	if err != nil {
-		logger.L().Fatal("failed to create service discovery client", helpers.Error(err), helpers.String("server", rootInfo.DiscoveryServerURL))
-		return
+		return fmt.Errorf("failed to create service discovery client for %q: %w", rootInfo.DiscoveryServerURL, err)
 	}
 
 	services, err := servicediscovery.GetServices(
@@ -102,8 +102,7 @@ func initEnvironment(ctx context.Context) {
 	)
 
 	if err != nil {
-		logger.L().Fatal("failed to get services from server", helpers.Error(err), helpers.String("server", rootInfo.DiscoveryServerURL))
-		return
+		return fmt.Errorf("failed to get services from server %q: %w", rootInfo.DiscoveryServerURL, err)
 	}
 
 	logger.L().Debug("configuring service discovery URLs", helpers.String("cloudAPIURL", services.GetApiServerUrl()), helpers.String("cloudReportURL", services.GetReportReceiverHttpUrl()))
@@ -127,9 +126,9 @@ func initEnvironment(ctx context.Context) {
 		"",
 	)
 	if err != nil {
-		logger.L().Fatal("failed to create KS Cloud client", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to create KS Cloud client: %w", err)
 	}
 
 	getter.SetKSCloudAPIConnector(ksCloud)
+	return nil
 }

--- a/cmd/rootutils_test.go
+++ b/cmd/rootutils_test.go
@@ -34,7 +34,7 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		rootInfo.LoggerName = zaplogger.LoggerName
 
 		initLogger()
-		initLoggerLevel(cmd)
+		assert.NoError(t, initLoggerLevel(cmd))
 
 		assert.Equal(t, "debug", rootInfo.Logger)
 	})
@@ -53,7 +53,7 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		rootInfo.LoggerName = zaplogger.LoggerName
 
 		initLogger()
-		initLoggerLevel(cmd)
+		assert.NoError(t, initLoggerLevel(cmd))
 
 		assert.Equal(t, helpers.WarningLevel.String(), rootInfo.Logger)
 	})
@@ -72,7 +72,7 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 		rootInfo.LoggerName = zaplogger.LoggerName
 
 		initLogger()
-		initLoggerLevel(cmd)
+		assert.NoError(t, initLoggerLevel(cmd))
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
 	})
@@ -96,7 +96,7 @@ func TestInitLoggerLevel_KSLoggerPrecedence(t *testing.T) {
 
 		rootInfo.LoggerName = zaplogger.LoggerName
 		initLogger()
-		initLoggerLevel(versionCmd)
+		assert.NoError(t, initLoggerLevel(versionCmd))
 
 		assert.Equal(t, helpers.InfoLevel.String(), rootInfo.Logger)
 	})

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -22,7 +22,8 @@ import (
 type noOpWorkloadPrinter struct{}
 
 func (noOpWorkloadPrinter) PrintNextSteps() {}
-func (noOpWorkloadPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) {
+func (noOpWorkloadPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
+	return nil
 }
 func (noOpWorkloadPrinter) SetWriter(context.Context, string) {}
 func (noOpWorkloadPrinter) Score(float32)                     {}
@@ -519,7 +520,8 @@ func Test_parseWorkloadIdentifierString_Values(t *testing.T) {
 type fakePrinter struct{}
 
 func (p *fakePrinter) PrintNextSteps() {}
-func (p *fakePrinter) ActionPrint(ctx context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) {
+func (p *fakePrinter) ActionPrint(ctx context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
+	return nil
 }
 func (p *fakePrinter) SetWriter(ctx context.Context, _ string) {}
 func (p *fakePrinter) Score(_ float32)                         {}

--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -612,7 +612,8 @@ func initializeCloudAPI(c ITenantConfig) *v1.KSCloudAPI {
 			c.GetAccountID(),
 			c.GetAccessKey())
 		if err != nil {
-			logger.L().Fatal("failed to create KS Cloud client", helpers.Error(err))
+			logger.L().Error("failed to create KS Cloud client", helpers.Error(err))
+			return nil
 		}
 		getter.SetKSCloudAPIConnector(cloud)
 	}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -192,9 +192,11 @@ type Getters struct {
 	AttackTracksGetter   getter.IAttackTracksGetter
 }
 
-func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyIdentifier) {
+func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyIdentifier) error {
 	scanInfo.setUseFrom(policyIdentifiers)
-	scanInfo.setUseArtifactsFrom(ctx)
+	if err := scanInfo.setUseArtifactsFrom(ctx); err != nil {
+		return err
+	}
 	// setUseFrom and setUseArtifactsFrom can resolve to the same file - --use-default and
 	// --use-artifacts-from both point at the local store on the offline HTTP handler path -
 	// and a repeated path costs an extra read and unmarshal per policy load.
@@ -202,6 +204,7 @@ func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyId
 	if scanInfo.ScanID == "" {
 		scanInfo.ScanID = uuid.NewString()
 	}
+	return nil
 }
 
 func (scanInfo *ScanInfo) Cleanup() {
@@ -214,9 +217,9 @@ func (scanInfo *ScanInfo) AddCleanup(cleanup func()) {
 	scanInfo.cleanups = append(scanInfo.cleanups, cleanup)
 }
 
-func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
+func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) error {
 	if scanInfo.UseArtifactsFrom == "" {
-		return
+		return nil
 	}
 	// UseArtifactsFrom must be a path without a filename
 	dir, file := filepath.Split(scanInfo.UseArtifactsFrom)
@@ -228,7 +231,7 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 	// set frameworks files
 	files, err := os.ReadDir(scanInfo.UseArtifactsFrom)
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal("failed to read files from directory", helpers.String("dir", scanInfo.UseArtifactsFrom), helpers.Error(err))
+		return fmt.Errorf("failed to read files from directory %q: %w", scanInfo.UseArtifactsFrom, err)
 	}
 	framework := &reporthandling.Framework{}
 	for _, f := range files {
@@ -253,6 +256,7 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) {
 	if scanInfo.AttackTracks == "" {
 		scanInfo.AttackTracks = filepath.Join(scanInfo.UseArtifactsFrom, LocalAttackTracksFilename)
 	}
+	return nil
 }
 
 func (scanInfo *ScanInfo) setUseFrom(policyIdentifiers []PolicyIdentifier) {

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -37,7 +37,7 @@ func TestSetContextMetadata(t *testing.T) {
 
 		scanInfo := &ScanInfo{}
 		scanInfo.SetKubeconfigSelection(explicitPath, "")
-		scanInfo.Init(context.Background(), nil)
+		require.NoError(t, scanInfo.Init(context.Background(), nil))
 		require.NoError(t, scanInfo.ResolveClusterContextName())
 		metadata := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
 		ctx := metadata.ContextMetadata
@@ -540,7 +540,7 @@ func TestInitDeduplicatesUseFrom(t *testing.T) {
 		UseDefault:       true,
 		UseArtifactsFrom: artifactsDir,
 	}
-	scanInfo.Init(context.Background(), BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework))
+	require.NoError(t, scanInfo.Init(context.Background(), BuildPolicyIdentifiers([]string{"nsa"}, apisv1.KindFramework)))
 
 	assert.Equal(t, []string{filepath.Join(artifactsDir, "nsa.json")}, scanInfo.UseFrom)
 }

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -230,7 +230,7 @@ func TestScanAllWithUseDefaultResolvesCachePaths(t *testing.T) {
 	scanInfo := &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: true}
 
 	policyIdentifiers := resolveDefaultScanAllPolicies(scanInfo, nil)
-	scanInfo.Init(context.Background(), policyIdentifiers)
+	require.NoError(t, scanInfo.Init(context.Background(), policyIdentifiers))
 
 	wantPaths := getDefaultFrameworksPaths()
 	assert.ElementsMatch(t, wantPaths, scanInfo.UseFrom)
@@ -249,7 +249,7 @@ func TestScanAllControlScanWithUseDefaultStaysOnline(t *testing.T) {
 	scanInfo := &cautils.ScanInfo{ScanAll: true, UseDefault: true, FrameworkScan: false}
 
 	policyIdentifiers := resolveDefaultScanAllPolicies(scanInfo, nil)
-	scanInfo.Init(context.Background(), policyIdentifiers)
+	require.NoError(t, scanInfo.Init(context.Background(), policyIdentifiers))
 
 	assert.Empty(t, policyIdentifiers, "a control scan must not gain framework identifiers")
 	assert.Empty(t, scanInfo.UseFrom)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -208,7 +208,10 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 
 	// ===================== Initialization =====================
 	policyIdentifiers = resolveDefaultScanAllPolicies(scanInfo, policyIdentifiers) // resolve the ScanAll expansion while Init can still cache its paths
-	scanInfo.Init(ctxInit, policyIdentifiers)                                      // initialize scan info
+	if err := scanInfo.Init(ctxInit, policyIdentifiers); err != nil {              // initialize scan info
+		spanInit.End()
+		return nil, err
+	}
 	defer scanInfo.Cleanup()
 	if err := resolveClusterContext(scanInfo); err != nil {
 		spanInit.End()

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -50,7 +50,7 @@ const (
 
 type IPrinter interface {
 	PrintNextSteps()
-	ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData)
+	ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error
 	SetWriter(ctx context.Context, outputFile string)
 	Score(score float32)
 }

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 )
@@ -48,7 +47,7 @@ func (jsonPrinter *JsonPrinter) PrintNextSteps() {
 
 }
 
-func (jsonPrinter *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, _ []cautils.ImageScanData) {
+func (jsonPrinter *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
 	report := cautils.ReportV2ToV1(opaSessionObj)
 
 	var postureReportStr []byte
@@ -61,16 +60,17 @@ func (jsonPrinter *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *
 	}
 
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal("failed to convert posture report object")
+		return fmt.Errorf("failed to convert posture report object: %w", err)
 	}
 
 	_, err = jsonPrinter.writer.Write(postureReportStr)
 
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal("failed to Write posture report object into JSON output")
+		return fmt.Errorf("failed to write posture report object into JSON output: %w", err)
 	} else {
 		printer.LogOutputFile(jsonPrinter.writer.Name())
 	}
+	return nil
 }
 
 func (p *JsonPrinter) CloseWriter() {

--- a/core/pkg/resultshandling/printer/v1/prometheusprinter.go
+++ b/core/pkg/resultshandling/printer/v1/prometheusprinter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubescape/go-logger"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
@@ -87,16 +86,16 @@ func (p *PrometheusPrinter) printReports(allResources map[string]workloadinterfa
 	return nil
 }
 
-func (p *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj) {
+func (p *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
 	report := cautils.ReportV2ToV1(opaSessionObj)
 
 	err := p.printReports(opaSessionObj.AllResources, report.FrameworkReports)
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal(err.Error())
-	} else {
-		printer.LogOutputFile(p.writer.Name())
+		return err
 	}
 
+	printer.LogOutputFile(p.writer.Name())
+	return nil
 }
 
 func (p *PrometheusPrinter) CloseWriter() {

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -52,10 +52,9 @@ func (cp *CsvPrinter) Score(score float32) {
 	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
-func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj == nil {
-		logger.L().Ctx(ctx).Error("no data provided for CSV output")
-		return
+		return fmt.Errorf("no data provided for CSV output")
 	}
 
 	finalizedReport := FinalizeResults(opaSessionObj)
@@ -76,7 +75,7 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 	}
 	if err := csvWriter.Write(header); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write CSV header", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
 	for _, result := range reportWithSeverity.Results {
@@ -119,7 +118,7 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 			}
 			if err := csvWriter.Write(row); err != nil {
 				logger.L().Ctx(ctx).Error("failed to write CSV row", helpers.Error(err))
-				return
+				return fmt.Errorf("failed to write CSV row: %w", err)
 			}
 		}
 	}
@@ -127,10 +126,11 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 	csvWriter.Flush()
 	if err := csvWriter.Error(); err != nil {
 		logger.L().Ctx(ctx).Error("failed to flush CSV writer", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to flush CSV writer: %w", err)
 	}
 
 	printer.LogOutputFile(cp.writer.Name())
+	return nil
 }
 
 func (cp *CsvPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -145,25 +145,25 @@ func (gp *GitLabSASTPrinter) PrintNextSteps() {
 
 // ActionPrint writes a GitLab SAST report for a configuration scan, or a GitLab Dependency Scanning
 // report for an image scan (#2782)
-func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (gp *GitLabSASTPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj == nil {
 		if len(imageScanData) == 0 {
-			logger.L().Ctx(ctx).Error("failed to write results in GitLab dependency scanning format: no data provided")
-			return
+			return fmt.Errorf("failed to write results in GitLab dependency scanning format: no data provided")
 		}
 		if err := gp.printImageScan(imageScanData); err != nil {
 			logger.L().Ctx(ctx).Error("failed to write results in GitLab dependency scanning format", helpers.Error(err))
-			return
+			return fmt.Errorf("failed to write results in GitLab dependency scanning format: %w", err)
 		}
 		printer.LogOutputFile(gp.writer.Name())
-		return
+		return nil
 	}
 
 	if err := gp.printConfigurationScan(ctx, opaSessionObj); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results in GitLab SAST format", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results in GitLab SAST format: %w", err)
 	}
 	printer.LogOutputFile(gp.writer.Name())
+	return nil
 }
 
 // printImageScan maps each CVE found in an image scan to a GitLab Dependency Scanning vulnerability and writes the report

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
@@ -64,10 +65,9 @@ func (hp *HtmlPrinter) PrintNextSteps() {
 
 }
 
-func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj == nil && len(imageScanData) == 0 {
-		logger.L().Ctx(ctx).Error("failed to print results, missing data")
-		return
+		return fmt.Errorf("failed to print results, missing data")
 	}
 
 	tplFuncMap := template.FuncMap{
@@ -135,10 +135,11 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	err := tpl.Execute(hp.writer, reportingCtx)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to render template", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to render template: %w", err)
 	}
 	printer.LogOutputFile(hp.writer.Name())
 
+	return nil
 }
 
 func (hp *HtmlPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -80,7 +80,7 @@ func (jp *JsonPrinter) convertToImageScanSummary(imageScanData []cautils.ImageSc
 	return &imageScanSummary, nil
 }
 
-func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var err error
 
 	if opaSessionObj != nil {
@@ -89,8 +89,7 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
 			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 		if err2 != nil {
-			logger.L().Ctx(ctx).Error("failed to create document", helpers.Error(err2))
-			return
+			return fmt.Errorf("failed to create document: %w", err2)
 		}
 		err = grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: imageScanData[0].SBOM}).Present(jp.writer)
 	} else {
@@ -99,10 +98,11 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results in json format", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results in json format: %w", err)
 	}
 
 	printer.LogOutputFile(jp.writer.Name())
+	return nil
 }
 
 func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, jp *JsonPrinter) error {

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -126,7 +126,7 @@ func (jp *JunitPrinter) PrintNextSteps() {
 
 }
 
-func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var junitResult *JUnitTestSuites
 
 	if opaSessionObj != nil {
@@ -134,24 +134,24 @@ func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 	} else if len(imageScanData) > 0 {
 		junitResult = imageTestsSuites(imageScanData)
 	} else {
-		logger.L().Ctx(ctx).Error("failed to print results, missing data")
-		return
+		return fmt.Errorf("failed to print results, missing data")
 	}
 
 	postureReportStr, err := xml.MarshalIndent(junitResult, "", "  ")
 	if err != nil {
-		logger.L().Ctx(ctx).Fatal("failed to Marshal xml result object", helpers.Error(err))
+		return fmt.Errorf("failed to marshal xml result object: %w", err)
 	}
 
 	if _, err := jp.writer.Write([]byte(xml.Header)); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write xml header: %w", err)
 	}
 	if _, err := jp.writer.Write(postureReportStr); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results: %w", err)
 	}
 	printer.LogOutputFile(jp.writer.Name())
+	return nil
 }
 
 // iso8601Timestamp returns the report generation time in ISO 8601 format,

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -68,7 +68,7 @@ func (pp *PdfPrinter) PrintNextSteps() {
 }
 
 // ActionPrint is responsible for generating a report in pdf format
-func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var outBuff []byte
 	var err error
 
@@ -77,20 +77,20 @@ func (pp *PdfPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 	} else if len(imageScanData) > 0 {
 		outBuff, err = pp.generateImagePdf(imageScanData)
 	} else {
-		logger.L().Ctx(ctx).Error("failed to print results, missing data")
-		return
+		return fmt.Errorf("failed to print results, missing data")
 	}
 
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to generate pdf format", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to generate pdf format: %w", err)
 	}
 
 	if _, err := pp.writer.Write(outBuff); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results: %w", err)
 	}
 	printer.LogOutputFile(pp.writer.Name())
+	return nil
 }
 
 // generateImagePdf builds a CVE-table PDF report for an image scan (#2782)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -100,16 +100,17 @@ func (pp *PrettyPrinter) convertToImageScanSummary(imageScanData []cautils.Image
 	return &imageScanSummary, nil
 }
 
-func (pp *PrettyPrinter) PrintImageScan(imageScanData []cautils.ImageScanData) {
+func (pp *PrettyPrinter) PrintImageScan(imageScanData []cautils.ImageScanData) error {
 	imageScanSummary, err := pp.convertToImageScanSummary(imageScanData)
 	if err != nil {
 		logger.L().Error("failed to convert to image scan summary", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to convert to image scan summary: %w", err)
 	}
 	pp.mainPrinter.PrintImageScanning(imageScanSummary)
+	return nil
 }
 
-func (pp *PrettyPrinter) ActionPrint(_ context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (pp *PrettyPrinter) ActionPrint(_ context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj != nil {
 		// TODO line is currently printed on framework scan only
 		if isPrintSeparatorType(pp.scanType) {
@@ -146,8 +147,11 @@ func (pp *PrettyPrinter) ActionPrint(_ context.Context, opaSessionObj *cautils.O
 	}
 
 	if len(imageScanData) > 0 {
-		pp.PrintImageScan(imageScanData)
+		if err := pp.PrintImageScan(imageScanData); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (pp *PrettyPrinter) printOverview(opaSessionObj *cautils.OPASessionObj, printExtraLine bool) {

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -84,7 +84,7 @@ func (pp *PrometheusPrinter) generateImagePrometheusFormat(imageScanData []cauti
 	return m
 }
 
-func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var metrics *Metrics
 
 	if opaSessionObj != nil {
@@ -92,15 +92,15 @@ func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cau
 	} else if len(imageScanData) > 0 {
 		metrics = pp.generateImagePrometheusFormat(imageScanData)
 	} else {
-		logger.L().Ctx(ctx).Error("failed to print results, missing data")
-		return
+		return fmt.Errorf("failed to print results, missing data")
 	}
 
 	if _, err := pp.writer.Write([]byte(metrics.String())); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results: %w", err)
 	}
 	printer.LogOutputFile(pp.writer.Name())
+	return nil
 }
 
 func (p *PrometheusPrinter) CloseWriter() {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -167,27 +167,27 @@ func (sp *SARIFPrinter) PrintNextSteps() {
 
 }
 
-func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj == nil {
 		if len(imageScanData) == 0 {
-			logger.L().Ctx(ctx).Fatal("failed to write results in sarif format: no data provided")
-			return
+			return fmt.Errorf("failed to write results in sarif format: no data provided")
 		}
 
 		// image scan
 		if err := sp.printImageScan(ctx, imageScanData[0]); err != nil {
 			logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
-			return
+			return fmt.Errorf("failed to write results in sarif format: %w", err)
 		}
 	} else {
 		// configuration scan
 		if err := sp.printConfigurationScan(ctx, opaSessionObj); err != nil {
 			logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
-			return
+			return fmt.Errorf("failed to write results in sarif format: %w", err)
 		}
 
 	}
 	printer.LogOutputFile(sp.writer.Name())
+	return nil
 }
 
 func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {

--- a/core/pkg/resultshandling/printer/v2/silentprinter.go
+++ b/core/pkg/resultshandling/printer/v2/silentprinter.go
@@ -17,7 +17,8 @@ func (silentPrinter *SilentPrinter) PrintNextSteps() {
 
 }
 
-func (silentPrinter *SilentPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (silentPrinter *SilentPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	return nil
 }
 
 func (silentPrinter *SilentPrinter) SetWriter(ctx context.Context, outputFile string) {

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -81,7 +81,7 @@ func (yp *YamlPrinter) convertToImageScanSummary(imageScanData []cautils.ImageSc
 	return &imageScanSummary
 }
 
-func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var err error
 
 	if opaSessionObj != nil {
@@ -90,8 +90,7 @@ func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
 			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 		if err2 != nil {
-			logger.L().Ctx(ctx).Error("failed to create document", helpers.Error(err2))
-			return
+			return fmt.Errorf("failed to create document: %w", err2)
 		}
 
 		// Use grype json presenter and convert json to yaml
@@ -110,10 +109,11 @@ func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to write results in yaml format", helpers.Error(err))
-		return
+		return fmt.Errorf("failed to write results in yaml format: %w", err)
 	}
 
 	printer.LogOutputFile(yp.writer.Name())
+	return nil
 }
 
 func printConfigurationsScanningYaml(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, yp *YamlPrinter) error {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -3,6 +3,7 @@ package resultshandling
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -133,18 +134,28 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 
 	// Display scan results in the UI first to give immediate value.
 
-	rh.UiPrinter.ActionPrint(ctx, rh.ScanData, rh.ImageScanData)
+	var printErr error
+
+	if err := rh.UiPrinter.ActionPrint(ctx, rh.ScanData, rh.ImageScanData); err != nil {
+		printErr = errors.Join(printErr, fmt.Errorf("ui printer: %w", err))
+	}
 
 	rh.UiPrinter.PrintNextSteps()
 	closePrinter(rh.UiPrinter)
 
 	// Then print to output files
 	for _, p := range rh.PrinterObjs {
-		p.ActionPrint(ctx, rh.ScanData, rh.ImageScanData)
+		if err := p.ActionPrint(ctx, rh.ScanData, rh.ImageScanData); err != nil {
+			printErr = errors.Join(printErr, fmt.Errorf("output printer %T: %w", p, err))
+		}
 		if rh.ScanData != nil {
 			p.Score(rh.GetComplianceScore())
 		}
 		closePrinter(p)
+	}
+
+	if printErr != nil {
+		return printErr
 	}
 
 	// We should submit only after printing results, so a user can see

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -33,12 +33,14 @@ func (dr *DummyReporter) GetURL() string                          { return "" }
 type SpyPrinter struct {
 	ActionPrintCalls int
 	ScoreCalls       int
+	ActionPrintErr   error
 }
 
 func (sp *SpyPrinter) SetWriter(_ context.Context, _ string) {}
 func (sp *SpyPrinter) PrintNextSteps()                       {}
-func (sp *SpyPrinter) ActionPrint(_ context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) {
+func (sp *SpyPrinter) ActionPrint(_ context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
 	sp.ActionPrintCalls += 1
+	return sp.ActionPrintErr
 }
 func (sp *SpyPrinter) Score(_ float32) {
 	sp.ScoreCalls += 1
@@ -94,6 +96,23 @@ func TestResultsHandlerHandleResultsImageScanNilScanData(t *testing.T) {
 	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
 	// ...but the compliance score is skipped, as it requires ScanData.
 	assert.Equal(t, 0, outputPrinter.ScoreCalls)
+}
+
+func TestResultsHandlerHandleResultsReturnsPrinterErrors(t *testing.T) {
+	uiErr := errors.New("ui print failed")
+	outputErr := errors.New("output print failed")
+	uiPrinter := &SpyPrinter{ActionPrintErr: uiErr}
+	outputPrinter := &SpyPrinter{ActionPrintErr: outputErr}
+	rh := NewResultsHandler(nil, []printer.IPrinter{outputPrinter}, uiPrinter)
+	rh.SetData(cautils.NewOPASessionObjMock())
+
+	err := rh.HandleResults(context.Background(), &cautils.ScanInfo{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, uiErr)
+	assert.ErrorIs(t, err, outputErr)
+	assert.Equal(t, 1, uiPrinter.ActionPrintCalls)
+	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
 }
 
 func TestValidatePrinter(t *testing.T) {


### PR DESCRIPTION
## Summary
- make result printers return errors from `ActionPrint` instead of fatal-exiting or silently swallowing output failures
- aggregate UI/output printer failures in `ResultsHandler.HandleResults` with `errors.Join`
- convert config, diff, prerequisites, and root pre-run fatal exits into returned Cobra errors
- propagate `ScanInfo.Init` failures for `--use-artifacts-from` directory reads

Closes #2904

## Tests
- `go test ./core/pkg/resultshandling/... ./cmd/scan ./cmd/config ./cmd/diff ./cmd/prerequisites`
- `go test ./core/pkg/resultshandling/... ./cmd/... ./core/core -run 'Test'`\n- `go test ./core/cautils -run 'TestSetContextMetadata|TestScanInfo|TestInit|Test_initializeCloudAPI|TestGetTenantConfig|TestUpdateConfigFile'`\n\nFull `go test ./...` was also attempted. It failed only in existing `core/cautils` path-canonicalization expectations on macOS temp paths (`/var/...` expected vs `/private/var/...` actual), while the touched package suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command and scan failures are now reported as errors instead of abruptly terminating execution.
  * Output generation errors across JSON, YAML, CSV, HTML, PDF, XML, SARIF, Prometheus, and GitLab SAST formats are now surfaced clearly.
  * Multiple result-processing errors are collected and reported together while remaining outputs continue processing.

* **Tests**
  * Updated coverage verifies error propagation during command setup, scanning, and result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->