### PR TITLE
fix(policyhandler): bound registry growth with idle eviction

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/go-logger"
@@ -20,42 +21,41 @@ const (
 	PoliciesCacheTtlEnvVar = "POLICIES_CACHE_TTL"
 )
 
-var policyHandlerInstance *PolicyHandler
-
 // PolicyHandler
 type PolicyHandler struct {
 	clusterName             string
 	getters                 *cautils.Getters
+	scanMu                  sync.Mutex // guards getters against concurrent CollectPolicies calls on a shared handler
 	cachedPolicyIdentifiers *TimedCache[[]string]
 	cachedFrameworks        *TimedCache[[]reporthandling.Framework]
 	cachedExceptions        *TimedCache[[]armotypes.PostureExceptionPolicy]
 	cachedControlInputs     *TimedCache[map[string][]string]
 }
 
-// NewPolicyHandler creates and returns an instance of the `PolicyHandler`. The function initializes the `PolicyHandler` only if it hasn't been previously created.
-// The PolicyHandler supports caching of downloaded policies and exceptions by setting the `POLICIES_CACHE_TTL` environment variable (default is no caching).
-//
-// This is a process-wide singleton, reused as long as clusterName does not
-// change, so long-running callers that repeatedly scan the same cluster (the
-// httphandler HTTP service, in particular - see core/core/scan.go) keep the
-// POLICIES_CACHE_TTL caching benefit across requests instead of re-downloading
-// policies/exceptions/control-inputs on every call. When clusterName differs
-// from the cached instance's, exceptions and control-inputs are fetched
-// scoped by clusterName (see getExceptions/getControlInputs below), so
-// blindly reusing an instance built for a different cluster would silently
-// apply the wrong cluster's exception policies to this one; the httphandler
-// service can serve /v1/scan requests for different clusters/accounts across
-// the lifetime of one process, and previously always got the first request's
-// PolicyHandler regardless of what later requests asked for. Close the
-// stale instance first so its background TTL goroutines don't leak.
+// NewPolicyHandler returns the shared, cluster-isolated *PolicyHandler for
+// clusterName from the process-wide registry (see registry.go). Callers that
+// repeatedly scan the same cluster (the httphandler HTTP service, in
+// particular - see core/core/scan.go) keep the POLICIES_CACHE_TTL caching
+// benefit across calls; callers for a different cluster get a completely
+// separate instance, so a later call never silently reuses an earlier
+// cluster's exception/control-input caches. Handlers with nothing actively
+// using them are reclaimed by an idle sweep rather than requiring callers to
+// release them, so this stays memory-bounded even in a long-running process
+// that sees many distinct cluster names over its lifetime.
 func NewPolicyHandler(clusterName string) *PolicyHandler {
-	if policyHandlerInstance == nil || policyHandlerInstance.clusterName != clusterName {
-		if policyHandlerInstance != nil {
-			policyHandlerInstance.Close()
-		}
-		policyHandlerInstance = NewRequestScopedPolicyHandler(clusterName)
-	}
-	return policyHandlerInstance
+	return globalRegistry.getHandler(clusterName)
+}
+
+// NewPolicyHandlerWithRelease returns the shared PolicyHandler for
+// clusterName and a release function that must be deferred. Intended for
+// orchestration paths - e.g. the fleet work in issue #1990 - that scan the
+// same cluster sequentially in one goroutine and want the cache reuse
+// guaranteed for that duration rather than left to the idle sweep.
+// CollectPolicies guards its own state, so concurrent same-cluster calls are
+// safe even without this; acquire/release only controls when an idle entry
+// becomes eligible for eviction.
+func NewPolicyHandlerWithRelease(clusterName string) (*PolicyHandler, func()) {
+	return globalRegistry.acquireHandler(clusterName)
 }
 
 // NewRequestScopedPolicyHandler creates and returns a new, independent instance of the `PolicyHandler`.
@@ -88,6 +88,11 @@ func (policyHandler *PolicyHandler) Close() {
 }
 
 func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (*cautils.OPASessionObj, error) {
+	// A shared handler (same cluster, concurrent callers) must not let one
+	// caller's getters be observed or overwritten mid-scan by another.
+	policyHandler.scanMu.Lock()
+	defer policyHandler.scanMu.Unlock()
+
 	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier)
 
 	policyHandler.getters = getters

--- a/core/pkg/policyhandler/registry.go
+++ b/core/pkg/policyhandler/registry.go
@@ -1,0 +1,136 @@
+package policyhandler
+
+import (
+	"sync"
+	"time"
+)
+
+// defaultIdleEvictionWindow bounds how long a shared PolicyHandler survives in
+// the registry with nothing actively holding it, even when POLICIES_CACHE_TTL
+// is 0 (caching disabled) and there is therefore no cache-driven reason to
+// keep reusing it. Without an upper bound here, every distinct cluster name
+// ever passed to NewPolicyHandler would leave a permanent entry behind for
+// the life of the process -- the exact long-running httphandler scenario
+// that motivated the original singleton in the first place (issue #2004).
+const defaultIdleEvictionWindow = 5 * time.Minute
+
+// policyHandlerEntry is one registry slot: the shared handler for a cluster,
+// how many active acquireHandler callers are using it, and when it was last
+// touched by any path (getHandler or acquireHandler).
+type policyHandlerEntry struct {
+	handler    *PolicyHandler
+	refCount   int
+	lastAccess time.Time
+}
+
+// policyHandlerRegistry is a mutex-guarded, cluster-keyed registry of
+// PolicyHandlers. It replaces the previous bare singleton, which caused two
+// bugs under concurrent or long-running multi-cluster use: a stale-cache leak
+// (a later call for a different cluster silently reused the first cluster's
+// caches) and, if fixed naively by never evicting, an unbounded memory leak
+// (one entry retained forever per distinct cluster name).
+//
+// Entries with no active acquireHandler caller (refCount == 0) are reclaimed
+// by an idle sweep run on every registry access, so getHandler -- used by
+// every existing call site, none of which release explicitly -- stays
+// memory-bounded without requiring any caller changes.
+type policyHandlerRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*policyHandlerEntry
+}
+
+var globalRegistry = &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+
+// idleWindow returns how long an unreferenced entry may sit idle before a
+// sweep evicts it. Tied to POLICIES_CACHE_TTL when caching is on, since
+// there's no reason to hold a handler open longer than its cache is useful;
+// falls back to defaultIdleEvictionWindow when caching is disabled.
+func (r *policyHandlerRegistry) idleWindow() time.Duration {
+	if ttl := getPoliciesCacheTtl(); ttl > 0 {
+		return ttl
+	}
+	return defaultIdleEvictionWindow
+}
+
+// sweepLocked evicts and closes every unreferenced entry idle past window.
+// Must be called with r.mu held. Close runs in the background so a slow
+// TimedCache shutdown never blocks a caller that's just trying to get a
+// handler for an unrelated cluster.
+func (r *policyHandlerRegistry) sweepLocked(now time.Time, window time.Duration) {
+	for name, entry := range r.entries {
+		if entry.refCount <= 0 && now.Sub(entry.lastAccess) > window {
+			delete(r.entries, name)
+			go entry.handler.Close()
+		}
+	}
+}
+
+// getHandler returns the shared, cluster-isolated PolicyHandler for
+// clusterName, creating it if needed. There is no release call here by
+// design -- this is what NewPolicyHandler exposes, and none of its existing
+// callers are structured to release a handler when they're done. The idle
+// sweep reclaims it instead.
+func (r *policyHandlerRegistry) getHandler(clusterName string) *PolicyHandler {
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.sweepLocked(now, r.idleWindow())
+
+	entry, ok := r.entries[clusterName]
+	if !ok {
+		entry = &policyHandlerEntry{handler: NewRequestScopedPolicyHandler(clusterName)}
+		r.entries[clusterName] = entry
+	}
+	entry.lastAccess = now
+	return entry.handler
+}
+
+// acquireHandler returns the shared PolicyHandler for clusterName and a
+// release function that must be deferred. Meant for orchestration paths --
+// e.g. the fleet work in issue #1990 -- that scan the same cluster
+// sequentially in one goroutine and want the caching benefit guaranteed for
+// the duration of that use, rather than left to the idle sweep.
+func (r *policyHandlerRegistry) acquireHandler(clusterName string) (*PolicyHandler, func()) {
+	now := time.Now()
+	r.mu.Lock()
+	r.sweepLocked(now, r.idleWindow())
+
+	entry, ok := r.entries[clusterName]
+	if !ok {
+		entry = &policyHandlerEntry{handler: NewRequestScopedPolicyHandler(clusterName)}
+		r.entries[clusterName] = entry
+	}
+	entry.refCount++
+	entry.lastAccess = now
+	r.mu.Unlock()
+
+	var once sync.Once
+	release := func() {
+		once.Do(func() {
+			r.mu.Lock()
+			entry.refCount--
+			entry.lastAccess = time.Now()
+			r.mu.Unlock()
+		})
+	}
+	return entry.handler, release
+}
+
+// size reports the current number of live registry entries. Test helper.
+func (r *policyHandlerRegistry) size() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.entries)
+}
+
+// closeAll evicts and closes every entry regardless of refCount. Test helper
+// for tearing down a registry built in a test.
+func (r *policyHandlerRegistry) closeAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for name, entry := range r.entries {
+		delete(r.entries, name)
+		entry.handler.Close()
+	}
+}

--- a/core/pkg/policyhandler/registry_test.go
+++ b/core/pkg/policyhandler/registry_test.go
@@ -1,0 +1,156 @@
+package policyhandler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistry_DifferentClustersGetIsolatedHandlers is the same isolation
+// guarantee TestNewPolicyHandler_DifferentClusterNameGetsFreshInstance checks
+// through NewPolicyHandler, exercised directly against the registry with
+// every cache field checked, not just the top-level pointer.
+func TestRegistry_DifferentClustersGetIsolatedHandlers(t *testing.T) {
+	reg := &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+	defer reg.closeAll()
+
+	hA := reg.getHandler("prod-cluster-us")
+	hB := reg.getHandler("dev-cluster-eu")
+
+	assert.NotSame(t, hA, hB)
+	assert.NotSame(t, hA.cachedExceptions, hB.cachedExceptions)
+	assert.NotSame(t, hA.cachedControlInputs, hB.cachedControlInputs)
+	assert.NotSame(t, hA.cachedFrameworks, hB.cachedFrameworks)
+	assert.NotSame(t, hA.cachedPolicyIdentifiers, hB.cachedPolicyIdentifiers)
+}
+
+// TestRegistry_GetHandlerNeverLeavesMoreThanOneEntryPerActiveCluster is the
+// regression test for the leak in PR #2899: getHandler creates a registry
+// entry per clusterName and nothing ever removed it, so a long-running
+// process (the httphandler service) accumulated one permanent entry for
+// every distinct cluster name it ever scanned. Here we simulate that by
+// calling getHandler for many distinct clusters and confirming the registry
+// does not grow without bound once entries go idle.
+func TestRegistry_GetHandlerNeverLeavesMoreThanOneEntryPerActiveCluster(t *testing.T) {
+	reg := &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+	defer reg.closeAll()
+
+	past := time.Now().Add(-2 * defaultIdleEvictionWindow)
+	for i := 0; i < 50; i++ {
+		h := reg.getHandler(fmt.Sprintf("cluster-%d", i))
+		require.NotNil(t, h)
+		// Backdate this entry's lastAccess so the next getHandler call sees
+		// it as idle, the same as if 2*defaultIdleEvictionWindow had really
+		// passed since it was touched.
+		reg.mu.Lock()
+		reg.entries[fmt.Sprintf("cluster-%d", i)].lastAccess = past
+		reg.mu.Unlock()
+	}
+
+	// One more access triggers a sweep. Every backdated entry should be
+	// evicted; only the freshly created one should remain.
+	reg.getHandler("cluster-fresh")
+
+	assert.Equal(t, 1, reg.size(),
+		"idle entries from earlier clusters must be swept, not retained forever")
+}
+
+// TestRegistry_ActiveAcquireSurvivesSweep confirms the idle sweep never
+// evicts an entry something is still actively holding via acquireHandler,
+// even if it's been idle a long time by clock alone.
+func TestRegistry_ActiveAcquireSurvivesSweep(t *testing.T) {
+	reg := &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+	defer reg.closeAll()
+
+	h, release := reg.acquireHandler("long-running-cluster")
+	require.NotNil(t, h)
+
+	reg.mu.Lock()
+	reg.entries["long-running-cluster"].lastAccess = time.Now().Add(-2 * defaultIdleEvictionWindow)
+	reg.mu.Unlock()
+
+	// Trigger a sweep via an unrelated access.
+	reg.getHandler("other-cluster")
+
+	assert.Equal(t, 2, reg.size(),
+		"an entry with an active acquireHandler caller must survive the sweep regardless of idle time")
+
+	release()
+}
+
+// TestRegistry_SameClusterSharesHandler checks the TTL-cache-reuse guarantee:
+// concurrent requests for the same cluster share one warm handler.
+func TestRegistry_SameClusterSharesHandler(t *testing.T) {
+	reg := &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+	defer reg.closeAll()
+
+	h1 := reg.getHandler("shared-cluster")
+	h2 := reg.getHandler("shared-cluster")
+
+	assert.Same(t, h1, h2)
+	assert.Equal(t, 1, reg.size())
+}
+
+// TestRegistry_ConcurrentMultiCluster is the TOCTOU stress test: many
+// goroutines simultaneously acquire and release handlers across a handful of
+// clusters. Run with -race; it must produce zero warnings.
+func TestRegistry_ConcurrentMultiCluster(t *testing.T) {
+	const goroutines = 200
+	const clusters = 5
+
+	reg := &policyHandlerRegistry{entries: make(map[string]*policyHandlerEntry)}
+	defer reg.closeAll()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("cluster-%d", idx%clusters)
+			if idx%2 == 0 {
+				h := reg.getHandler(name)
+				require.NotNil(t, h)
+				require.Equal(t, name, h.clusterName)
+				return
+			}
+			h, release := reg.acquireHandler(name)
+			require.NotNil(t, h)
+			require.Equal(t, name, h.clusterName)
+			release()
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestCollectPolicies_ConcurrentSameClusterDoesNotRaceOnGetters guards the
+// scanMu addition: concurrent CollectPolicies calls on one shared handler
+// must not race on the request-scoped getters field. Run with -race.
+func TestCollectPolicies_ConcurrentSameClusterDoesNotRaceOnGetters(t *testing.T) {
+	const goroutines = 20
+
+	handler := NewRequestScopedPolicyHandler("race-cluster")
+	defer handler.Close()
+
+	getters := &cautils.Getters{
+		PolicyGetter:         &PolicyGetterMock{},
+		ExceptionsGetter:     &ExceptionsGetterMock{},
+		ControlsInputsGetter: &ControlsInputsGetterMock{},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			ident := []cautils.PolicyIdentifier{{Identifier: FrameworkName, Kind: "Framework"}}
+			_, _ = handler.CollectPolicies(context.Background(), ident, &cautils.ScanInfo{}, getters)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #2004. Replaces the PolicyHandler singleton with a registry that isolates handlers per cluster and fixes the concurrent-access race on the getters field.

The main thing to flag: a correct fix needs entries to actually get evicted, not just isolated. Otherwise a long-running process scanning many clusters over time keeps one handler alive per cluster forever, which is a slower version of the same problem. This adds an idle sweep so entries get cleaned up once nothing's using them, no caller changes needed.

NewPolicyHandlerWithRelease is included for code that wants a handler held for a set duration, which is what sequential fleet scanning (#1990) would want.

Tests cover cluster isolation, same-cluster sharing, an active entry surviving the sweep, unbounded growth not happening, and a concurrency stress test with -race (zero warnings).

go build, go vet, and the full test suite are all clean.

Feel free to ping me for any issues or questions!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved policy collection reliability during concurrent requests.
  - Prevented policy state from being shared incorrectly across clusters.
  - Reduced the risk of stale policy handlers affecting later operations.
  - Improved cleanup of inactive policy resources.

- **Tests**
  - Added coverage for concurrent policy collection, cluster isolation, handler reuse, and safe cleanup under active workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->