### PR TITLE
feat(patch): support all image scan output formats

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
-	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/spf13/cobra"
 )
@@ -45,12 +44,10 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(printer.ImageFormats, ", "))
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ImageScanFormats, ", "))
 			}
-			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format != "" {
-				if !slices.Contains(printer.ImageFormats, scanInfo.Format) {
-					return fmt.Errorf("invalid format %q, supported formats: %s", scanInfo.Format, strings.Join(printer.ImageFormats, ", "))
-				}
+			if err := shared.ValidateScanFormat(scanInfo.Format, shared.ImageScanFormats); err != nil {
+				return err
 			}
 			if err := shared.ValidateImageScanInfo(&scanInfo); err != nil {
 				return err
@@ -89,7 +86,7 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "Password for registry login")
 
 	patchCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "",
-		fmt.Sprintf("Output file format. Supported formats: %s", strings.Join(printer.ImageFormats, ", ")))
+		fmt.Sprintf("Output file format. Supported formats: %s", strings.Join(shared.ImageScanFormats, ", ")))
 	patchCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
 	patchCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display full report. Default to false")
 

--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/spf13/cobra"
 )
@@ -44,13 +45,11 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
-				return fmt.Errorf("format cannot be empty, supported formats: pretty-printer, json, sarif")
+				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(printer.ImageFormats, ", "))
 			}
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format != "" {
-				supported := []string{"pretty-printer", "json", "sarif"}
-				valid := slices.Contains(supported, scanInfo.Format)
-				if !valid {
-					return fmt.Errorf("invalid format %q, supported formats: pretty-printer, json, sarif", scanInfo.Format)
+				if !slices.Contains(printer.ImageFormats, scanInfo.Format) {
+					return fmt.Errorf("invalid format %q, supported formats: %s", scanInfo.Format, strings.Join(printer.ImageFormats, ", "))
 				}
 			}
 			if err := shared.ValidateImageScanInfo(&scanInfo); err != nil {
@@ -89,7 +88,8 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.Username, "username", "u", "", "Username for registry login")
 	patchCmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "Password for registry login")
 
-	patchCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "", `Output file format. Supported formats: "pretty-printer", "json", "sarif"`)
+	patchCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "",
+		fmt.Sprintf("Output file format. Supported formats: %s", strings.Join(printer.ImageFormats, ", ")))
 	patchCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
 	patchCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display full report. Default to false")
 

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -5,8 +5,8 @@ import (
 
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 
+	"github.com/kubescape/kubescape/v3/cmd/shared"
 	"github.com/kubescape/kubescape/v3/core/mocks"
-	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,12 +72,12 @@ func Test_validateImagePatchInfo_Image(t *testing.T) {
 }
 
 // TestPatchCmd_FormatFlagValidation verifies --format accepts every format supported for image
-// scans (printer.ImageFormats) and rejects formats that are not (e.g. csv, which requires posture
+// scans (shared.ImageScanFormats) and rejects formats that are not (e.g. csv, which requires posture
 // scan data that patch's image-only results never populate), plus the empty-value case.
 func TestPatchCmd_FormatFlagValidation(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 
-	for _, format := range printer.ImageFormats {
+	for _, format := range shared.ImageScanFormats {
 		t.Run("accepts_"+format, func(t *testing.T) {
 			cmd := GetPatchCmd(mockKubescape)
 			cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", format})
@@ -89,6 +89,23 @@ func TestPatchCmd_FormatFlagValidation(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("accepts_comma_separated_formats", func(t *testing.T) {
+		cmd := GetPatchCmd(mockKubescape)
+		cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", "json,sarif"})
+		err := cmd.Execute()
+		if err != nil {
+			assert.NotContains(t, err.Error(), "invalid format")
+		}
+	})
+
+	t.Run("rejects_comma_separated_with_invalid_entry", func(t *testing.T) {
+		cmd := GetPatchCmd(mockKubescape)
+		cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", "json,csv"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid format "csv"`)
+	})
 
 	t.Run("rejects_csv", func(t *testing.T) {
 		cmd := GetPatchCmd(mockKubescape)

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -6,6 +6,7 @@ import (
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,6 +69,43 @@ func Test_validateImagePatchInfo_Image(t *testing.T) {
 	}
 	err := validateImagePatchInfo(patchInfo)
 	assert.Nil(t, err)
+}
+
+// TestPatchCmd_FormatFlagValidation verifies --format accepts every format supported for image
+// scans (printer.ImageFormats) and rejects formats that are not (e.g. csv, which requires posture
+// scan data that patch's image-only results never populate), plus the empty-value case.
+func TestPatchCmd_FormatFlagValidation(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+
+	for _, format := range printer.ImageFormats {
+		t.Run("accepts_"+format, func(t *testing.T) {
+			cmd := GetPatchCmd(mockKubescape)
+			cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", format})
+			err := cmd.Execute()
+			// Past the format check, execution fails later (no buildkit/registry available
+			// in this test environment) - what matters is the error is NOT a format complaint.
+			if err != nil {
+				assert.NotContains(t, err.Error(), "invalid format")
+			}
+		})
+	}
+
+	t.Run("rejects_csv", func(t *testing.T) {
+		cmd := GetPatchCmd(mockKubescape)
+		cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", "csv"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid format "csv"`)
+		assert.Contains(t, err.Error(), "pretty-printer")
+	})
+
+	t.Run("rejects_empty", func(t *testing.T) {
+		cmd := GetPatchCmd(mockKubescape)
+		cmd.SetArgs([]string{"--image", "nginx:1.23", "--format", ""})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "format cannot be empty")
+	})
 }
 
 // TestPatchCmd_OutputModeFlags verifies the --output-mode and --output-path flags exist, default correctly, and


### PR DESCRIPTION
Extend --format on 'kubescape patch' from 3 hardcoded formats (pretty-printer, json, sarif) to all 9 formats already supported for image scans via printer.ImageFormats (adds junit, prometheus, pdf, html, gitlab-sast, yaml). The underlying printer pipeline (GetOutputPrinters -> ValidatePrinter) already handled these for 'scan image' - only the CLI-level allowlist in cmd/patch/patch.go was restricting patch's output.

csv is intentionally excluded: CsvPrinter requires posture scan data patch's image-only results never populate.

Fixes #2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--format` validation for patch output.
  * Supported image formats are now consistently recognized in validation and command help.
  * Invalid, empty, or unsupported format values now produce clearer validation errors.
  * Valid comma-separated image format combinations are accepted.

* **Tests**
  * Added coverage for supported formats, combined formats, empty values, and unsupported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->