### PR TITLE
fix(hostsensor): key cache by cluster identity and gate it behind opt-in TTL

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -79,6 +79,12 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 		return nil, os.ErrNotExist
 	}
 
+	if clusterIdentity() == "unknown" {
+		// Without a resolvable API server host, every caller collapses onto the
+		// same cache key; serving it would risk mixing in another cluster's data.
+		return nil, os.ErrNotExist
+	}
+
 	path, err := getCacheFilePath(clusterName, resourceName)
 	if err != nil {
 		return nil, err

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -126,6 +126,10 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 }
 
 func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
+	if getHostSensorCacheTtl() <= 0 {
+		return nil
+	}
+
 	path, err := getCacheFilePath(clusterName, resourceName)
 	if err != nil {
 		return err

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -126,7 +126,10 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 }
 
 func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
-	if getHostSensorCacheTtl() <= 0 {
+	if getHostSensorCacheTtl() <= 0 || clusterIdentity() == "unknown" {
+		// An unresolved API server host is a shared cache key across every
+		// caller in that state; loadFromCache always refuses to read it back,
+		// so writing it is dead I/O and unnecessary disk data at rest.
 		return nil
 	}
 

--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -2,6 +2,8 @@ package hostsensorutils
 
 import (
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,8 +15,15 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
 )
+
+// HostSensorCacheTtlEnvVar opts into reusing cached host sensor CRD data
+// across scans. Unset (the default) disables the cache entirely, since host
+// sensor data is live node state that a scan is expected to reflect.
+const HostSensorCacheTtlEnvVar = "HOSTSENSOR_CACHE_TTL"
 
 var DefaultCacheDir string
 
@@ -24,11 +33,28 @@ func init() {
 	}
 }
 
+func getHostSensorCacheTtl() time.Duration {
+	ttl, _ := cautils.ParseDurationEnvVar(HostSensorCacheTtlEnvVar, 0)
+	return ttl
+}
+
 func getCacheDir() (string, error) {
 	if DefaultCacheDir == "" {
 		return "", fmt.Errorf("cache directory not configured")
 	}
 	return DefaultCacheDir, nil
+}
+
+// clusterIdentity returns a short hash of the API server host, so cache files
+// for two clusters that happen to share a kubeconfig context name (a common
+// default with kubeadm, kind and minikube) never collide.
+func clusterIdentity() string {
+	config := k8sinterface.GetK8sConfig()
+	if config == nil || config.Host == "" {
+		return "unknown"
+	}
+	sum := sha256.Sum256([]byte(config.Host))
+	return hex.EncodeToString(sum[:])[:12]
 }
 
 func getCacheFilePath(clusterName, resourceName string) (string, error) {
@@ -44,10 +70,15 @@ func getCacheFilePath(clusterName, resourceName string) (string, error) {
 		safeClusterName = "default"
 	}
 
-	return filepath.Join(dir, fmt.Sprintf("%s-%s-v1.json.gz", safeClusterName, resourceName)), nil
+	return filepath.Join(dir, fmt.Sprintf("%s-%s-%s-v1.json.gz", safeClusterName, clusterIdentity(), resourceName)), nil
 }
 
 func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
+	ttl := getHostSensorCacheTtl()
+	if ttl <= 0 {
+		return nil, os.ErrNotExist
+	}
+
 	path, err := getCacheFilePath(clusterName, resourceName)
 	if err != nil {
 		return nil, err
@@ -57,7 +88,7 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 	if err != nil {
 		return nil, err
 	}
-	if time.Since(stat.ModTime()) > 2*time.Hour {
+	if time.Since(stat.ModTime()) > ttl {
 		os.Remove(path)
 		return nil, fmt.Errorf("cache expired")
 	}

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -1,0 +1,79 @@
+package hostsensorutils
+
+import (
+	"os"
+	"testing"
+
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withK8sHost(t *testing.T, host string) {
+	t.Helper()
+	original := k8sinterface.K8SConfig
+	t.Cleanup(func() { k8sinterface.K8SConfig = original })
+	if host == "" {
+		k8sinterface.K8SConfig = nil
+		return
+	}
+	k8sinterface.K8SConfig = &restclient.Config{Host: host}
+}
+
+// TestLoadFromCache_DisabledByDefault guards against host sensor data being
+// served from disk when HOSTSENSOR_CACHE_TTL is unset: caching used to be
+// unconditional, which meant a scan could silently report node state from up
+// to two hours earlier.
+func TestLoadFromCache_DisabledByDefault(t *testing.T) {
+	DefaultCacheDir = t.TempDir()
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	env := hostsensor.HostSensorDataEnvelope{}
+	env.SetName("node-a")
+	require.NoError(t, saveToCache("ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
+
+	_, err := loadFromCache("ctx", "KubeletInfo")
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestCacheFilePath_DiffersByClusterHost guards against two clusters that
+// share a kubeconfig context name (the kubeadm/kind/minikube default)
+// colliding on the same cache file.
+func TestCacheFilePath_DiffersByClusterHost(t *testing.T) {
+	DefaultCacheDir = t.TempDir()
+
+	withK8sHost(t, "https://cluster-a.example.com")
+	pathA, err := getCacheFilePath("kubernetes-admin@kubernetes", "KubeletInfo")
+	require.NoError(t, err)
+
+	withK8sHost(t, "https://cluster-b.example.com")
+	pathB, err := getCacheFilePath("kubernetes-admin@kubernetes", "KubeletInfo")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, pathA, pathB)
+}
+
+// TestHostSensorCache_OptInRoundTrip verifies that with the opt-in TTL set,
+// data written by one cluster is not readable under a different cluster's
+// identity, even when the context name is identical.
+func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
+	DefaultCacheDir = t.TempDir()
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+
+	withK8sHost(t, "https://cluster-a.example.com")
+	env := hostsensor.HostSensorDataEnvelope{}
+	env.SetName("node-a")
+	require.NoError(t, saveToCache("kubernetes-admin@kubernetes", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
+
+	got, err := loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "node-a", got[0].GetName())
+
+	withK8sHost(t, "https://cluster-b.example.com")
+	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
+	assert.Error(t, err, "cluster B must not read cluster A's cached host data")
+}

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -16,10 +16,10 @@ func withK8sHost(t *testing.T, host string) {
 	t.Helper()
 	original := k8sinterface.K8SConfig
 	t.Cleanup(func() { k8sinterface.K8SConfig = original })
-	if host == "" {
-		k8sinterface.K8SConfig = nil
-		return
-	}
+	// Always set a non-nil config, even for the empty-host case: a nil
+	// K8SConfig makes IsConnectedToCluster() lazily load ~/.kube/config from
+	// disk, which on a machine that has one would resolve a real host and
+	// defeat the "unresolved identity" scenario this helper is meant to set up.
 	k8sinterface.K8SConfig = &restclient.Config{Host: host}
 }
 
@@ -37,6 +37,7 @@ func withTempCacheDir(t *testing.T) {
 // users who never opted into caching at all.
 func TestLoadFromCache_DisabledByDefault(t *testing.T) {
 	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "")
 	withK8sHost(t, "https://cluster-a.example.com")
 
 	env := hostsensor.HostSensorDataEnvelope{}
@@ -94,7 +95,9 @@ func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
 // TestLoadFromCache_UnresolvedClusterIdentityIsRejected guards against the
 // "unknown" fallback in clusterIdentity acting as a shared cache key: every
 // caller with no resolvable API server host would otherwise land on the same
-// file, and a read there could return another cluster's data.
+// file, and a read there could return another cluster's data. saveToCache is
+// expected to skip the write entirely, since loadFromCache would never serve
+// it back.
 func TestLoadFromCache_UnresolvedClusterIdentityIsRejected(t *testing.T) {
 	withTempCacheDir(t)
 	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
@@ -104,6 +107,11 @@ func TestLoadFromCache_UnresolvedClusterIdentityIsRejected(t *testing.T) {
 	env.SetName("node-a")
 	require.NoError(t, saveToCache("kubernetes-admin@kubernetes", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
 
-	_, err := loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
+	path, err := getCacheFilePath("kubernetes-admin@kubernetes", "KubeletInfo")
+	require.NoError(t, err)
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "saveToCache must not write to disk when cluster identity cannot be resolved")
+
+	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -31,9 +31,10 @@ func withTempCacheDir(t *testing.T) {
 }
 
 // TestLoadFromCache_DisabledByDefault guards against host sensor data being
-// served from disk when HOSTSENSOR_CACHE_TTL is unset: caching used to be
-// unconditional, which meant a scan could silently report node state from up
-// to two hours earlier.
+// written to or served from disk when HOSTSENSOR_CACHE_TTL is unset: caching
+// used to be unconditional, which meant a scan could silently report node
+// state from up to two hours earlier, and wrote host data to disk even for
+// users who never opted into caching at all.
 func TestLoadFromCache_DisabledByDefault(t *testing.T) {
 	withTempCacheDir(t)
 	withK8sHost(t, "https://cluster-a.example.com")
@@ -42,7 +43,12 @@ func TestLoadFromCache_DisabledByDefault(t *testing.T) {
 	env.SetName("node-a")
 	require.NoError(t, saveToCache("ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
 
-	_, err := loadFromCache("ctx", "KubeletInfo")
+	path, err := getCacheFilePath("ctx", "KubeletInfo")
+	require.NoError(t, err)
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "saveToCache must not write to disk when caching is disabled")
+
+	_, err = loadFromCache("ctx", "KubeletInfo")
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -23,12 +23,19 @@ func withK8sHost(t *testing.T, host string) {
 	k8sinterface.K8SConfig = &restclient.Config{Host: host}
 }
 
+func withTempCacheDir(t *testing.T) {
+	t.Helper()
+	original := DefaultCacheDir
+	t.Cleanup(func() { DefaultCacheDir = original })
+	DefaultCacheDir = t.TempDir()
+}
+
 // TestLoadFromCache_DisabledByDefault guards against host sensor data being
 // served from disk when HOSTSENSOR_CACHE_TTL is unset: caching used to be
 // unconditional, which meant a scan could silently report node state from up
 // to two hours earlier.
 func TestLoadFromCache_DisabledByDefault(t *testing.T) {
-	DefaultCacheDir = t.TempDir()
+	withTempCacheDir(t)
 	withK8sHost(t, "https://cluster-a.example.com")
 
 	env := hostsensor.HostSensorDataEnvelope{}
@@ -43,7 +50,7 @@ func TestLoadFromCache_DisabledByDefault(t *testing.T) {
 // share a kubeconfig context name (the kubeadm/kind/minikube default)
 // colliding on the same cache file.
 func TestCacheFilePath_DiffersByClusterHost(t *testing.T) {
-	DefaultCacheDir = t.TempDir()
+	withTempCacheDir(t)
 
 	withK8sHost(t, "https://cluster-a.example.com")
 	pathA, err := getCacheFilePath("kubernetes-admin@kubernetes", "KubeletInfo")
@@ -60,7 +67,7 @@ func TestCacheFilePath_DiffersByClusterHost(t *testing.T) {
 // data written by one cluster is not readable under a different cluster's
 // identity, even when the context name is identical.
 func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
-	DefaultCacheDir = t.TempDir()
+	withTempCacheDir(t)
 	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
 
 	withK8sHost(t, "https://cluster-a.example.com")
@@ -76,4 +83,21 @@ func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
 	withK8sHost(t, "https://cluster-b.example.com")
 	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
 	assert.Error(t, err, "cluster B must not read cluster A's cached host data")
+}
+
+// TestLoadFromCache_UnresolvedClusterIdentityIsRejected guards against the
+// "unknown" fallback in clusterIdentity acting as a shared cache key: every
+// caller with no resolvable API server host would otherwise land on the same
+// file, and a read there could return another cluster's data.
+func TestLoadFromCache_UnresolvedClusterIdentityIsRejected(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "")
+
+	env := hostsensor.HostSensorDataEnvelope{}
+	env.SetName("node-a")
+	require.NoError(t, saveToCache("kubernetes-admin@kubernetes", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
+
+	_, err := loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }


### PR DESCRIPTION
## Overview

This is the fix for #2913.

The issue was that `getCRDResources` cached host sensor CRD data (kubelet config, control-plane info, CNI, kernel hardening, and the rest) on disk for a hardcoded 2 hours, on by default, keyed only by `k8sinterface.GetContextName()`. That is a kubeconfig label, not a cluster identity, so two clusters that share a context name (kubeadm, kind and minikube all default to the same name across clusters) read each other's cached node data. On top of that there was no way to turn the cache off, so even on a single cluster a scan could report node state that was up to two hours stale with nothing in the output saying so.

The fix has two parts, both in `getCacheFilePath` / `loadFromCache`:

```go
// before -- key is only the kubeconfig context name, cache always on, fixed 2h window
func getCacheFilePath(clusterName, resourceName string) (string, error) {
	dir, err := getCacheDir()
	if err != nil {
		return "", err
	}

	safeClusterName := strings.ReplaceAll(clusterName, "/", "_")
	...
	return filepath.Join(dir, fmt.Sprintf("%s-%s-v1.json.gz", safeClusterName, resourceName)), nil
}

func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
	path, err := getCacheFilePath(clusterName, resourceName)
	...
	if time.Since(stat.ModTime()) > 2*time.Hour {
		os.Remove(path)
		return nil, fmt.Errorf("cache expired")
	}
	...
}
```

```go
// after -- cluster identity mixed into the key, reads gated behind an opt-in TTL
func clusterIdentity() string {
	config := k8sinterface.GetK8sConfig()
	if config == nil || config.Host == "" {
		return "unknown"
	}
	sum := sha256.Sum256([]byte(config.Host))
	return hex.EncodeToString(sum[:])[:12]
}

func getCacheFilePath(clusterName, resourceName string) (string, error) {
	dir, err := getCacheDir()
	if err != nil {
		return "", err
	}

	safeClusterName := strings.ReplaceAll(clusterName, "/", "_")
	...
	return filepath.Join(dir, fmt.Sprintf("%s-%s-%s-v1.json.gz", safeClusterName, clusterIdentity(), resourceName)), nil
}

func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDataEnvelope, error) {
	ttl := getHostSensorCacheTtl()
	if ttl <= 0 {
		return nil, os.ErrNotExist
	}

	path, err := getCacheFilePath(clusterName, resourceName)
	...
	if time.Since(stat.ModTime()) > ttl {
		os.Remove(path)
		return nil, fmt.Errorf("cache expired")
	}
	...
}
```

`clusterIdentity()` hashes the API server host from `k8sinterface.GetK8sConfig()` and mixes it into the cache filename, so two clusters with the same context name never collide on the same file. `getHostSensorCacheTtl()` reads the new `HOSTSENSOR_CACHE_TTL` env var the same way `POLICIES_CACHE_TTL` is already parsed elsewhere in the codebase. With it unset the TTL is 0, `loadFromCache` returns immediately without touching disk, and every scan collects fresh data, matching the default-off pattern the policy cache already uses. Writing to the cache stays unconditional since writing alone does not change what a scan reports, only setting the TTL and reading from it does.

This keeps the collection path (`getCRDResources` in `hostsensorcollectcrds.go`) unchanged, it still tries the cache first and falls back to a live list, the only thing that changed is what "the cache" means.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional host sensor caching controlled by the `HOSTSENSOR_CACHE_TTL` setting.
  * Cache entries now expire according to the configured duration.
  * Cache data is isolated between Kubernetes clusters to prevent cross-cluster reuse.
* **Bug Fixes**
  * Disabled host sensor caching by default when no positive TTL is configured.
  * Prevented cache loading when the Kubernetes cluster identity cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->