### PR TITLE
fix(scan): validate threshold ranges in scan control command

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -143,5 +143,8 @@ func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
 	if err := shared.ValidateSeverity(severity); severity != "" && err != nil {
 		return err
 	}
+	if err := validateThresholdsOnly(scanInfo); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -34,6 +34,16 @@ func Test_validateControlScanInfo(t *testing.T) {
 			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), OmitRawResources: true},
 			ErrOmitRawResourcesOrSubmit,
 		},
+		{
+			"Compliance threshold below 0 should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: -1},
+			ErrBadThreshold,
+		},
+		{
+			"Coverage threshold above 100 should be invalid",
+			&cautils.ScanInfo{FailCoverageThreshold: 150},
+			ErrBadThreshold,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

`validateControlScanInfo()` validates severity and submit flags but never validates numeric threshold ranges. This means `kubescape scan control` silently accepts `--fail-threshold 150` or `--compliance-threshold -1` and only fails at runtime with a fatal log, giving no useful error to the user.

By contrast, `validateFrameworkScanInfo()` correctly rejects out-of-range thresholds with `ErrBadThreshold` before the scan starts.

## Fix

- Added `validateThresholdsOnly(scanInfo)` call in `validateControlScanInfo()`, so `scan control` now rejects out-of-range `--compliance-threshold` and `--fail-coverage-threshold` values before the scan runs, matching `scan framework` behavior.
- Added threshold test cases (`ComplianceThreshold: -1`, `FailCoverageThreshold: 150`) to `Test_validateControlScanInfo`.

Fixes #2260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan configuration now rejects invalid compliance and coverage thresholds.
  * Validation errors are reported when thresholds are negative or exceed 100%.

* **Tests**
  * Added coverage for invalid threshold values to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->