### PR TITLE
perf(sarif): cache per-file work when collecting fixes and locations

### DIFF
--- a/core/pkg/resultshandling/locationresolver/locationresolver.go
+++ b/core/pkg/resultshandling/locationresolver/locationresolver.go
@@ -14,6 +14,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// lastPathSegment matches an expression's trailing ".<segment>", stripped to walk
+// back up a path that does not exist. Compiled once rather than per step.
+var lastPathSegment = regexp.MustCompile(`(.*)(\.[^.]*)`)
+
 type FixPathLocationResolver struct {
 	yqlibEvaluator yqlib.Evaluator
 	yamlPath       string
@@ -80,7 +84,7 @@ func (l *FixPathLocationResolver) ResolveLocation(fixPath string, nodeIndex int)
 		}
 
 		// for non-existent yaml expressions, remove the last part of the expression and try again
-		yamlExpression = regexp.MustCompile(`(.*)(\.[^.]*)`).ReplaceAllString(yamlExpression, `${1}`)
+		yamlExpression = lastPathSegment.ReplaceAllString(yamlExpression, `${1}`)
 	}
 	return Location{}, nil
 

--- a/core/pkg/resultshandling/printer/v2/fixcache.go
+++ b/core/pkg/resultshandling/printer/v2/fixcache.go
@@ -2,6 +2,8 @@ package printer
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -44,6 +46,46 @@ type fixReportCache struct {
 	reads     map[string]readResult
 	resolvers map[string]*locationresolver.FixPathLocationResolver
 	regions   map[fixCacheKey][]fixRegion
+}
+
+// scannedResource is one failed resource paired with the manifest it came from.
+type scannedResource struct {
+	resourceID string
+	relPath    string
+	absPath    string
+}
+
+// groupByManifest orders failed resources so every resource of one manifest is
+// visited consecutively, which is what lets a cache serve a whole file and then
+// be dropped. Held across the report instead, the caches would retain a decoded
+// document tree per file, making memory proportional to everything scanned
+// rather than to the largest file. Sorting also makes the report order
+// deterministic, which map iteration was not.
+func groupByManifest(resources []scannedResource) []scannedResource {
+	ordered := slices.Clone(resources)
+	slices.SortFunc(ordered, func(a, b scannedResource) int {
+		if a.absPath != b.absPath {
+			return strings.Compare(a.absPath, b.absPath)
+		}
+		return strings.Compare(a.resourceID, b.resourceID)
+	})
+	return ordered
+}
+
+// manifestCache hands out one cache per manifest, dropping the previous one when
+// the walk reaches the next file, so only one manifest's decoded documents are
+// held at a time. Callers must visit a manifest's resources consecutively.
+type manifestCache struct {
+	path    string
+	current *fixReportCache
+}
+
+func (m *manifestCache) get(path string) *fixReportCache {
+	if m.current == nil || m.path != path {
+		m.path = path
+		m.current = newFixReportCache()
+	}
+	return m.current
 }
 
 func newFixReportCache() *fixReportCache {

--- a/core/pkg/resultshandling/printer/v2/fixcache.go
+++ b/core/pkg/resultshandling/printer/v2/fixcache.go
@@ -1,0 +1,118 @@
+package printer
+
+import (
+	"context"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/pkg/fixhandler"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// fixRegion is one replacement a fix produces: a region of the manifest and the
+// text that replaces it.
+type fixRegion struct {
+	startLine   int
+	startColumn int
+	endLine     int
+	endColumn   int
+	text        string
+}
+
+// fixCacheKey identifies one yq expression applied to one manifest. Both halves
+// matter: regions differ per file and per expression.
+type fixCacheKey struct {
+	path       string
+	expression string
+}
+
+// readResult keeps a read with its error, so a failed read is answered from the
+// cache rather than retried per finding.
+type readResult struct {
+	content string
+	err     error
+}
+
+// fixReportCache memoizes the per-file work that report generation would
+// otherwise repeat for every finding: the read, the location resolver, and the
+// regions a fix expression produces. None of it depends on which finding asked,
+// and every pass covers the whole file, so uncached the cost grew with resources
+// times controls times file size. Report generation only reads, so a repeat
+// lookup has the same answer. One cache per report.
+type fixReportCache struct {
+	reads     map[string]readResult
+	resolvers map[string]*locationresolver.FixPathLocationResolver
+	regions   map[fixCacheKey][]fixRegion
+}
+
+func newFixReportCache() *fixReportCache {
+	return &fixReportCache{
+		reads:     make(map[string]readResult),
+		resolvers: make(map[string]*locationresolver.FixPathLocationResolver),
+		regions:   make(map[fixCacheKey][]fixRegion),
+	}
+}
+
+// fileString returns a manifest's content, reading it from disk on first use.
+func (c *fixReportCache) fileString(path string) (string, error) {
+	if cached, ok := c.reads[path]; ok {
+		return cached.content, cached.err
+	}
+
+	content, err := fixhandler.GetFileString(path)
+	if err != nil {
+		logger.L().Debug("failed to access "+path, helpers.Error(err))
+	}
+	c.reads[path] = readResult{content: content, err: err}
+	return content, err
+}
+
+// locationResolver returns a manifest's location resolver, building it on first
+// use. One per file is enough: it decodes every document up front and selects
+// between them by index, so it is the file's resolver, not a resource's. format
+// only names the output format in the warning. A failure caches a nil resolver,
+// which resolveFixLocation already reads as "fall back to line 1".
+func (c *fixReportCache) locationResolver(path, format string) *locationresolver.FixPathLocationResolver {
+	if resolver, ok := c.resolvers[path]; ok {
+		return resolver
+	}
+
+	resolver, err := locationresolver.NewFixPathLocationResolver(path)
+	if err != nil {
+		logger.L().Warning("failed to create location resolver, "+format+" locations will default to line 1", helpers.Error(err))
+		resolver = nil
+	}
+	c.resolvers[path] = resolver
+	return resolver
+}
+
+// fixRegions returns the regions applying one fix expression to one manifest
+// produces, computing them on first use. An expression that cannot be applied
+// caches an empty set, so it is diagnosed once rather than per control.
+func (c *fixReportCache) fixRegions(ctx context.Context, path, expression string) []fixRegion {
+	key := fixCacheKey{path: path, expression: expression}
+	if regions, ok := c.regions[key]; ok {
+		return regions
+	}
+
+	regions := c.computeFixRegions(ctx, path, expression)
+	c.regions[key] = regions
+	return regions
+}
+
+func (c *fixReportCache) computeFixRegions(ctx context.Context, path, expression string) []fixRegion {
+	fileAsString, err := c.fileString(path)
+	if err != nil {
+		return nil
+	}
+
+	fixedYamlString, err := fixhandler.ApplyFixToContent(ctx, fileAsString, expression)
+	if err != nil {
+		logger.L().Debug("failed to fix "+path+" with "+expression, helpers.Error(err))
+		return nil
+	}
+
+	dmp := diffmatchpatch.New()
+	return diffRegions(dmp, dmp.DiffMain(fileAsString, fixedYamlString, false), fileAsString)
+}

--- a/core/pkg/resultshandling/printer/v2/fixcache_test.go
+++ b/core/pkg/resultshandling/printer/v2/fixcache_test.go
@@ -440,3 +440,49 @@ spec:
 
 	return session
 }
+
+func TestGroupByManifest_VisitsEachManifestConsecutively(t *testing.T) {
+	resources := []scannedResource{
+		{resourceID: "r3", absPath: "/repo/b.yaml"},
+		{resourceID: "r1", absPath: "/repo/a.yaml"},
+		{resourceID: "r4", absPath: "/repo/b.yaml"},
+		{resourceID: "r2", absPath: "/repo/a.yaml"},
+	}
+
+	ordered := groupByManifest(resources)
+
+	paths := make([]string, 0, len(ordered))
+	ids := make([]string, 0, len(ordered))
+	for _, resource := range ordered {
+		paths = append(paths, resource.absPath)
+		ids = append(ids, resource.resourceID)
+	}
+
+	assert.Equal(t, []string{"/repo/a.yaml", "/repo/a.yaml", "/repo/b.yaml", "/repo/b.yaml"}, paths)
+	assert.Equal(t, []string{"r1", "r2", "r3", "r4"}, ids, "resources of a manifest are ordered, so the report is deterministic")
+
+	seen := map[string]bool{}
+	previous := ""
+	for _, resource := range ordered {
+		if resource.absPath != previous {
+			require.False(t, seen[resource.absPath], "manifest %s is revisited after moving on", resource.absPath)
+			seen[resource.absPath] = true
+			previous = resource.absPath
+		}
+	}
+}
+
+// TestManifestCache_HoldsOneManifestAtATime is the memory guard: a cache kept for
+// the whole report retains a decoded document tree per file, so it must be
+// dropped when the walk reaches the next manifest.
+func TestManifestCache_HoldsOneManifestAtATime(t *testing.T) {
+	var caches manifestCache
+
+	first := caches.get("/repo/a.yaml")
+	assert.Same(t, first, caches.get("/repo/a.yaml"), "the same manifest reuses its cache")
+
+	second := caches.get("/repo/b.yaml")
+	assert.NotSame(t, first, second, "a new manifest starts a fresh cache")
+
+	assert.NotSame(t, second, caches.get("/repo/a.yaml"), "returning to a manifest does not resurrect its cache")
+}

--- a/core/pkg/resultshandling/printer/v2/fixcache_test.go
+++ b/core/pkg/resultshandling/printer/v2/fixcache_test.go
@@ -1,0 +1,442 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/owenrumney/go-sarif/v2/sarif"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Fix paths every generated document fails on, so the same fix is reported by
+// more than one control and document.
+const (
+	privilegedFixPath = "spec.template.spec.containers[0].securityContext.privileged"
+	replicasFixPath   = "spec.replicas"
+)
+
+// writeManifest writes nDocs Deployment documents into one manifest and returns
+// its path plus the 1-based start line of each document.
+func writeManifest(t *testing.T, nDocs int) (string, []int) {
+	t.Helper()
+
+	var sb strings.Builder
+	starts := make([]int, 0, nDocs)
+	lines := 0
+	for i := 0; i < nDocs; i++ {
+		if i > 0 {
+			sb.WriteString("---\n")
+			lines++
+		}
+		starts = append(starts, lines+1)
+
+		doc := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-%d
+  namespace: default
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: demo-%d}}
+  template:
+    metadata: {labels: {app: demo-%d}}
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.23
+        securityContext: {privileged: true}
+`, i, i, i)
+		sb.WriteString(doc)
+		lines += strings.Count(doc, "\n")
+	}
+
+	path := filepath.Join(t.TempDir(), "deploy.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(sb.String()), 0600))
+	return path, starts
+}
+
+// documentForLine returns the index of the document a 1-based line falls in.
+func documentForLine(starts []int, line int) int {
+	index := -1
+	for i, start := range starts {
+		if line >= start {
+			index = i
+		}
+	}
+	return index
+}
+
+func TestFixReportCache_FileStringReadsFileOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("kind: Pod\n"), 0600))
+
+	cache := newFixReportCache()
+	first, err := cache.fileString(path)
+	require.NoError(t, err)
+	assert.Equal(t, "kind: Pod\n", first)
+
+	// a re-read would pick this up, a cache hit cannot
+	require.NoError(t, os.WriteFile(path, []byte("kind: Service\n"), 0600))
+
+	second, err := cache.fileString(path)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "the manifest must be read once per report, not once per finding")
+}
+
+func TestFixReportCache_FileStringCachesFailedRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+
+	cache := newFixReportCache()
+	_, err := cache.fileString(path)
+	require.Error(t, err)
+
+	// creating the file afterwards must not resurrect it: a failed read is an
+	// answer too
+	require.NoError(t, os.WriteFile(path, []byte("kind: Pod\n"), 0600))
+
+	content, err := cache.fileString(path)
+	require.Error(t, err)
+	assert.Empty(t, content)
+}
+
+// TestFixReportCache_LocationResolverMatchesFreshResolver guards sharing one
+// resolver across a file's resources. A resolver evaluates against yaml nodes it
+// holds, so sharing is only safe if evaluation leaves them alone. Each lookup is
+// compared against a fresh resolver, so a mutated tree disagrees here.
+func TestFixReportCache_LocationResolverMatchesFreshResolver(t *testing.T) {
+	const nDocs = 3
+	path, starts := writeManifest(t, nDocs)
+
+	cache := newFixReportCache()
+	shared := cache.locationResolver(path, "SARIF")
+	require.NotNil(t, shared)
+	assert.Same(t, shared, cache.locationResolver(path, "SARIF"), "one resolver per file, not per resource")
+
+	// documents in order, then back to the first, then a path that does not exist
+	lookups := []struct {
+		fixPath  string
+		docIndex int
+	}{
+		{privilegedFixPath, 0},
+		{privilegedFixPath, 1},
+		{privilegedFixPath, 2},
+		{privilegedFixPath, 0},
+		{replicasFixPath, 1},
+		{"spec.template.spec.containers[0].securityContext.doesNotExist", 2},
+	}
+
+	for _, lookup := range lookups {
+		t.Run(fmt.Sprintf("%s@%d", lookup.fixPath, lookup.docIndex), func(t *testing.T) {
+			fresh, err := locationresolver.NewFixPathLocationResolver(path)
+			require.NoError(t, err)
+			want, err := fresh.ResolveLocation(lookup.fixPath, lookup.docIndex)
+			require.NoError(t, err)
+
+			got, err := shared.ResolveLocation(lookup.fixPath, lookup.docIndex)
+			require.NoError(t, err)
+
+			assert.Equal(t, want, got, "shared resolver must resolve as a fresh one does")
+			assert.Equal(t, lookup.docIndex, documentForLine(starts, got.Line),
+				"line %d must fall in document %d", got.Line, lookup.docIndex)
+		})
+	}
+}
+
+func TestFixReportCache_LocationResolverCachesFailure(t *testing.T) {
+	cache := newFixReportCache()
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+
+	assert.Nil(t, cache.locationResolver(missing, "SARIF"))
+	assert.Nil(t, cache.locationResolver(missing, "SARIF"))
+	assert.Len(t, cache.resolvers, 1, "a failure is an answer and is cached like one")
+}
+
+func TestFixReportCache_FixRegionsCachedPerExpression(t *testing.T) {
+	path, _ := writeManifest(t, 2)
+	ctx := context.Background()
+
+	cache := newFixReportCache()
+	doc0 := cache.fixRegions(ctx, path, `select(di==0).`+privilegedFixPath+` |= false`)
+	doc1 := cache.fixRegions(ctx, path, `select(di==1).`+privilegedFixPath+` |= false`)
+
+	require.NotEmpty(t, doc0)
+	require.NotEmpty(t, doc1)
+	assert.NotEqual(t, doc0, doc1, "the document index is part of the key, so each document gets its own regions")
+
+	// removing the file proves the repeat came from the cache rather than disk
+	require.NoError(t, os.Remove(path))
+	assert.Equal(t, doc0, cache.fixRegions(ctx, path, `select(di==0).`+privilegedFixPath+` |= false`))
+	assert.Len(t, cache.regions, 2)
+}
+
+func TestFixReportCache_FixRegionsCachesUnappliableExpression(t *testing.T) {
+	path, _ := writeManifest(t, 1)
+	ctx := context.Background()
+
+	cache := newFixReportCache()
+	assert.Empty(t, cache.fixRegions(ctx, path, "this is not a yq expression"))
+	assert.Len(t, cache.regions, 1, "an expression that cannot be applied is diagnosed once, not once per control")
+}
+
+func TestAddFixRegions_DeduplicatesIdenticalRegions(t *testing.T) {
+	result := sarif.NewRuleResult("rule")
+	region := fixRegion{startLine: 3, startColumn: 1, endLine: 3, endColumn: 8, text: "false"}
+
+	addFixRegions(result, "deploy.yaml", []fixRegion{region, region})
+
+	assert.Len(t, result.Fixes, 1, "the same region reported twice is one fix")
+}
+
+// TestPrintConfigurationScan_MultiDocumentFixesPerDocument covers the report the
+// cache serves: many documents in one file, each failing two controls, one fix
+// path shared and one per document. Every finding stays anchored to its own.
+func TestPrintConfigurationScan_MultiDocumentFixesPerDocument(t *testing.T) {
+	const nDocs = 3
+	manifestPath, starts := writeManifest(t, nDocs)
+	manifestDir := filepath.Dir(manifestPath)
+
+	sharedControlID := "C-0001"
+	perDocControlID := "C-0002"
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{ScanningTarget: reporthandlingv2.Directory},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{BasePath: manifestDir},
+		},
+	}
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				sharedControlID: reportsummary.ControlSummary{
+					ControlID: sharedControlID, Name: "Privileged container", ScoreFactor: 8.0,
+				},
+				perDocControlID: reportsummary.ControlSummary{
+					ControlID: perDocControlID, Name: "Replica count", ScoreFactor: 4.0,
+				},
+			},
+		},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{}
+
+	failedControl := func(controlID, fixPath, value string) resourcesresults.ResourceAssociatedControl {
+		return resourcesresults.ResourceAssociatedControl{
+			ControlID: controlID,
+			Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{{
+				Name:   "rule-" + controlID,
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{{
+					FixPath: armotypes.FixPath{Path: fixPath, Value: value},
+				}},
+			}},
+		}
+	}
+
+	for i := 0; i < nDocs; i++ {
+		resourceID := fmt.Sprintf("apps/v1/Deployment/default/demo-%d", i)
+		lw := localworkload.NewLocalWorkload(map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": fmt.Sprintf("demo-%d", i), "namespace": "default"},
+			"spec":       map[string]interface{}{},
+		})
+		lw.SetPath(fmt.Sprintf("deploy.yaml:%d", i))
+
+		session.ResourcesResult[resourceID] = resourcesresults.Result{
+			ResourceID: resourceID,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl(sharedControlID, privilegedFixPath, "false"),
+				failedControl(perDocControlID, replicasFixPath, "2"),
+			},
+		}
+		session.ResourceSource[resourceID] = reporthandling.Source{
+			Path: manifestDir, RelativePath: "deploy.yaml", FileType: reporthandling.SourceTypeYaml,
+		}
+		session.AllResources[resourceID] = lw
+	}
+
+	out, err := os.CreateTemp(t.TempDir(), "multidoc-*.sarif")
+	require.NoError(t, err)
+	defer out.Close()
+
+	sp := NewSARIFPrinter()
+	sp.writer = out
+	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
+
+	raw, err := os.ReadFile(out.Name())
+	require.NoError(t, err)
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 1)
+	require.Len(t, report.Runs[0].Results, nDocs*2, "every failed control on every document is reported")
+
+	// each document owns a band of lines, so a finding that picked up another
+	// document's location or fix region lands outside its band
+	perDocument := map[int]int{}
+	for _, result := range report.Runs[0].Results {
+		require.NotEmpty(t, result.Locations)
+		require.NotNil(t, result.Locations[0].PhysicalLocation.Region)
+		startLine := *result.Locations[0].PhysicalLocation.Region.StartLine
+
+		docIndex := documentForLine(starts, startLine)
+		require.GreaterOrEqual(t, docIndex, 0, "location line %d is outside every document", startLine)
+		perDocument[docIndex]++
+		assert.NotEqual(t, 1, startLine, "locations must resolve, not fall back to line 1")
+
+		require.NotEmpty(t, result.Fixes, "a failed control with a fix path reports a fix")
+		for _, fix := range result.Fixes {
+			for _, change := range fix.ArtifactChanges {
+				require.NotEmpty(t, change.Replacements)
+				fixLine := *change.Replacements[0].DeletedRegion.StartLine
+				assert.Equal(t, docIndex, documentForLine(starts, fixLine),
+					"fix region on line %d belongs to a different document than its finding on line %d", fixLine, startLine)
+			}
+		}
+	}
+
+	for i := 0; i < nDocs; i++ {
+		assert.Equal(t, 2, perDocument[i], "document %d must report both of its failed controls", i)
+	}
+}
+
+// BenchmarkPrintConfigurationScan tracks report generation as the document and
+// control counts grow; both used to multiply a whole-file read, parse and diff.
+// The two fix shapes bound what caching recovers: distinct paths share only the
+// reads and the decode, a shared path shares the applied fix and its diff too.
+func BenchmarkPrintConfigurationScan(b *testing.B) {
+	for _, tc := range []struct {
+		docs      int
+		controls  int
+		sharedFix bool
+		fixShape  string
+	}{
+		{10, 10, false, "distinct-fixes"},
+		{20, 10, false, "distinct-fixes"},
+		{40, 10, false, "distinct-fixes"},
+		{80, 10, false, "distinct-fixes"},
+		{10, 10, true, "shared-fixes"},
+		{20, 10, true, "shared-fixes"},
+		{40, 10, true, "shared-fixes"},
+		{80, 10, true, "shared-fixes"},
+	} {
+		b.Run(fmt.Sprintf("docs=%d/controls=%d/%s", tc.docs, tc.controls, tc.fixShape), func(b *testing.B) {
+			session := benchmarkSession(b, tc.docs, tc.controls, tc.sharedFix)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := os.CreateTemp(b.TempDir(), "bench-*.sarif")
+				require.NoError(b, err)
+				sp := NewSARIFPrinter()
+				sp.writer = out
+				require.NoError(b, sp.printConfigurationScan(context.Background(), session))
+				require.NoError(b, out.Close())
+			}
+		})
+	}
+}
+
+// benchmarkSession builds a session over one manifest of nDocs documents, each
+// failing nControls controls. sharedFix decides one fix path between them or one
+// each.
+func benchmarkSession(b *testing.B, nDocs, nControls int, sharedFix bool) *cautils.OPASessionObj {
+	b.Helper()
+
+	var sb strings.Builder
+	for i := 0; i < nDocs; i++ {
+		if i > 0 {
+			sb.WriteString("---\n")
+		}
+		fmt.Fprintf(&sb, `apiVersion: apps/v1
+kind: Deployment
+metadata: {name: demo-%d, namespace: default}
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.23
+        securityContext: {privileged: true}
+`, i)
+	}
+	dir := b.TempDir()
+	path := filepath.Join(dir, "deploy.yaml")
+	require.NoError(b, os.WriteFile(path, []byte(sb.String()), 0600))
+
+	summaries := reportsummary.ControlSummaries{}
+	for c := 0; c < nControls; c++ {
+		id := fmt.Sprintf("C-%04d", c)
+		summaries[id] = reportsummary.ControlSummary{ControlID: id, Name: "control " + id, ScoreFactor: 8.0}
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{ScanningTarget: reporthandlingv2.Directory},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{BasePath: dir},
+		},
+	}
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{Controls: summaries},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{}
+
+	for i := 0; i < nDocs; i++ {
+		resourceID := fmt.Sprintf("apps/v1/Deployment/default/demo-%d", i)
+		lw := localworkload.NewLocalWorkload(map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": fmt.Sprintf("demo-%d", i), "namespace": "default"},
+			"spec":       map[string]interface{}{},
+		})
+		lw.SetPath(fmt.Sprintf("deploy.yaml:%d", i))
+
+		controls := make([]resourcesresults.ResourceAssociatedControl, 0, nControls)
+		for c := 0; c < nControls; c++ {
+			fixPath := privilegedFixPath
+			fixValue := "false"
+			if !sharedFix {
+				fixPath = fmt.Sprintf("spec.template.spec.containers[0].env[%d].name", c)
+				fixValue = fmt.Sprintf("VAR_%d", c)
+			}
+
+			controls = append(controls, resourcesresults.ResourceAssociatedControl{
+				ControlID: fmt.Sprintf("C-%04d", c),
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{{
+					Name:   fmt.Sprintf("rule-%d", c),
+					Status: apis.StatusFailed,
+					Paths: []armotypes.PosturePaths{{
+						FixPath: armotypes.FixPath{Path: fixPath, Value: fixValue},
+					}},
+				}},
+			})
+		}
+
+		session.ResourcesResult[resourceID] = resourcesresults.Result{
+			ResourceID:         resourceID,
+			AssociatedControls: controls,
+		}
+		session.ResourceSource[resourceID] = reporthandling.Source{
+			Path: dir, RelativePath: "deploy.yaml", FileType: reporthandling.SourceTypeYaml,
+		}
+		session.AllResources[resourceID] = lw
+	}
+
+	return session
+}

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -285,6 +285,7 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 	}
 
 	basePath := getBasePathFromMetadata(*opaSessionObj)
+	cache := newFixReportCache()
 
 	var withoutFilePath, outsideRepository int
 	for resourceID, result := range opaSessionObj.ResourcesResult {
@@ -308,10 +309,7 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 		}
 
 		rsrcAbsPath := filepath.Join(effectiveBasePath(resourceSource, basePath), relPath)
-		locationResolver, err := locationresolver.NewFixPathLocationResolver(rsrcAbsPath)
-		if err != nil {
-			logger.L().Warning("failed to create location resolver, GitLab SAST locations will default to line 1", helpers.Error(err))
-		}
+		locationResolver := cache.locationResolver(rsrcAbsPath, "GitLab SAST")
 
 		for _, toPin := range result.AssociatedControls {
 			ac := toPin

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -285,9 +285,9 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 	}
 
 	basePath := getBasePathFromMetadata(*opaSessionObj)
-	cache := newFixReportCache()
 
 	var withoutFilePath, outsideRepository int
+	failed := make([]scannedResource, 0, len(opaSessionObj.ResourcesResult))
 	for resourceID, result := range opaSessionObj.ResourcesResult {
 		if !result.GetStatus(nil).IsFailed() {
 			continue
@@ -308,10 +308,18 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 			continue
 		}
 
-		rsrcAbsPath := filepath.Join(effectiveBasePath(resourceSource, basePath), relPath)
-		locationResolver := cache.locationResolver(rsrcAbsPath, "GitLab SAST")
+		failed = append(failed, scannedResource{
+			resourceID: resourceID,
+			relPath:    relPath,
+			absPath:    filepath.Join(effectiveBasePath(resourceSource, basePath), relPath),
+		})
+	}
 
-		for _, toPin := range result.AssociatedControls {
+	var caches manifestCache
+	for _, resource := range groupByManifest(failed) {
+		locationResolver := caches.get(resource.absPath).locationResolver(resource.absPath, "GitLab SAST")
+
+		for _, toPin := range opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls {
 			ac := toPin
 			if !ac.GetStatus(nil).IsFailed() {
 				continue
@@ -323,8 +331,8 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 				continue
 			}
 
-			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
-			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabVulnerability(ctl, resourceID, relPath, location))
+			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
+			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabVulnerability(ctl, resource.resourceID, resource.relPath, location))
 		}
 	}
 

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -203,6 +203,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 
 	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
 	basePath := getBasePathFromMetadata(*opaSessionObj)
+	cache := newFixReportCache()
 
 	for resourceID, result := range opaSessionObj.ResourcesResult {
 		if result.GetStatus(nil).IsFailed() {
@@ -218,10 +219,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 			}
 
 			rsrcAbsPath := filepath.Join(effectiveBasePath(resourceSource, basePath), relPath)
-			locationResolver, err := locationresolver.NewFixPathLocationResolver(rsrcAbsPath)
-			if err != nil {
-				logger.L().Warning("failed to create location resolver, SARIF locations will default to line 1", helpers.Error(err))
-			}
+			locationResolver := cache.locationResolver(rsrcAbsPath, "SARIF")
 
 			for _, toPin := range result.AssociatedControls {
 				ac := toPin
@@ -235,7 +233,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 					location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
 					sp.addRule(run, ctl)
 					r := sp.addResult(run, ctl, relPath, location)
-					collectFixes(ctx, r, ac, opaSessionObj, resourceID, relPath, rsrcAbsPath)
+					collectFixes(ctx, cache, r, ac, opaSessionObj, resourceID, relPath, rsrcAbsPath)
 				}
 			}
 		}
@@ -306,10 +304,12 @@ func addFix(result *sarif.Result, filepath string, startLine, startColumn, endLi
 		sarif.NewSimpleArtifactLocation(filepath),
 	).WithReplacement(replacement)
 
-	// check if the fix is already added
+	// check if the fix is already added. The incoming change is hashed once, not
+	// per comparison: the hash marshals and SHA-256s the same value every time.
+	changeHash := hashArtifactChange(artifactChange)
 	for _, fix := range result.Fixes {
 		for _, ac := range fix.ArtifactChanges {
-			if hashArtifactChange(ac) == hashArtifactChange(artifactChange) {
+			if hashArtifactChange(ac) == changeHash {
 				return
 			}
 		}
@@ -344,7 +344,16 @@ func calculateMove(str string, file []string, endColumn int, endLine int) (int, 
 }
 
 func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Diff, result *sarif.Result, filepath string, fileAsString string) {
+	addFixRegions(result, filepath, diffRegions(dmp, diffs, fileAsString))
+}
+
+// diffRegions walks the diff delta and returns the replacement regions it
+// describes. Kept separate from attaching them to a result so the walk depends on
+// nothing but the manifest and the diff, which is what lets it be cached per
+// (manifest, fix expression) and reused across controls (see fixReportCache).
+func diffRegions(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Diff, fileAsString string) []fixRegion {
 	file := strings.Split(fileAsString, "\n")
+	regions := []fixRegion{}
 	text := ""
 	startLine := 1
 	startColumn := 1
@@ -367,7 +376,7 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 				continue
 			}
 			if closesFixRegion(delta, index) {
-				addFix(result, filepath, startLine, startColumn, endLine, endColumn, text)
+				regions = append(regions, fixRegion{startLine, startColumn, endLine, endColumn, text})
 			}
 		case '-':
 			// commit the position only on success: the (0, 0) failure return
@@ -378,7 +387,7 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 			}
 			endLine, endColumn = newLine, newColumn
 			if closesFixRegion(delta, index) {
-				addFix(result, filepath, startLine, startColumn, endLine, endColumn, text)
+				regions = append(regions, fixRegion{startLine, startColumn, endLine, endColumn, text})
 			}
 		case '=':
 			newLine, newColumn, ok := calculateMove(seg[1:], file, endColumn, endLine)
@@ -390,6 +399,16 @@ func collectDiffs(dmp *diffmatchpatch.DiffMatchPatch, diffs []diffmatchpatch.Dif
 			startColumn = endColumn
 			text = ""
 		}
+	}
+
+	return regions
+}
+
+// addFixRegions attaches regions to a result in delta-walk order, so the
+// duplicate check in addFix sees them as it did when the walk added them itself.
+func addFixRegions(result *sarif.Result, filepath string, regions []fixRegion) {
+	for _, region := range regions {
+		addFix(result, filepath, region.startLine, region.startColumn, region.endLine, region.endColumn, region.text)
 	}
 }
 
@@ -407,7 +426,14 @@ func closesFixRegion(delta []string, index int) bool {
 	return true
 }
 
-func collectFixes(ctx context.Context, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string) {
+func collectFixes(ctx context.Context, cache *fixReportCache, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string) {
+	// the index is the resource's, not a fix path's, so without one there is
+	// nothing to report
+	documentIndex, ok := getDocIndex(opaSessionObj, resourceID)
+	if !ok {
+		return
+	}
+
 	for _, rule := range ac.ResourceAssociatedRules {
 		if !rule.GetStatus(nil).IsFailed() {
 			continue
@@ -419,30 +445,8 @@ func collectFixes(ctx context.Context, result *sarif.Result, ac resourcesresults
 				continue
 			}
 
-			fileAsString, err := fixhandler.GetFileString(rsrcAbsPath)
-			if err != nil {
-				logger.L().Debug("failed to access "+filepath, helpers.Error(err))
-				continue
-			}
-
-			var fixedYamlString string
-
-			documentIndex, ok := getDocIndex(opaSessionObj, resourceID)
-			if !ok {
-				continue
-			}
-
 			yamlExpression := fixhandler.FixPathToValidYamlExpression(fixPath, rulePaths.FixPath.Value, documentIndex)
-
-			fixedYamlString, err = fixhandler.ApplyFixToContent(ctx, fileAsString, yamlExpression)
-			if err != nil {
-				logger.L().Debug("failed to fix "+filepath+" with "+yamlExpression, helpers.Error(err))
-				continue
-			}
-
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(fileAsString, fixedYamlString, false)
-			collectDiffs(dmp, diffs, result, filepath, fileAsString)
+			addFixRegions(result, filepath, cache.fixRegions(ctx, rsrcAbsPath, yamlExpression))
 		}
 	}
 }

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -203,38 +203,48 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 
 	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
 	basePath := getBasePathFromMetadata(*opaSessionObj)
-	cache := newFixReportCache()
-
+	failed := make([]scannedResource, 0, len(opaSessionObj.ResourcesResult))
 	for resourceID, result := range opaSessionObj.ResourcesResult {
-		if result.GetStatus(nil).IsFailed() {
-			resourceSource := opaSessionObj.ResourceSource[resourceID]
-			relPath := resourceSource.RelativePath
+		if !result.GetStatus(nil).IsFailed() {
+			continue
+		}
 
-			// Github Code Scanning considers results not associated to a file path
-			// meaningless and invalid when uploading, and the location written to the
-			// report is the relative path alone, so a base path cannot stand in for a
-			// missing one
-			if relPath == "" {
-				continue
-			}
+		resourceSource := opaSessionObj.ResourceSource[resourceID]
+		relPath := resourceSource.RelativePath
 
-			rsrcAbsPath := filepath.Join(effectiveBasePath(resourceSource, basePath), relPath)
-			locationResolver := cache.locationResolver(rsrcAbsPath, "SARIF")
+		// Github Code Scanning considers results not associated to a file path
+		// meaningless and invalid when uploading, and the location written to the
+		// report is the relative path alone, so a base path cannot stand in for a
+		// missing one
+		if relPath == "" {
+			continue
+		}
 
-			for _, toPin := range result.AssociatedControls {
-				ac := toPin
+		failed = append(failed, scannedResource{
+			resourceID: resourceID,
+			relPath:    relPath,
+			absPath:    filepath.Join(effectiveBasePath(resourceSource, basePath), relPath),
+		})
+	}
 
-				if ac.GetStatus(nil).IsFailed() {
-					ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
-					if ctl == nil {
-						logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
-						continue
-					}
-					location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resourceID)
-					sp.addRule(run, ctl)
-					r := sp.addResult(run, ctl, relPath, location)
-					collectFixes(ctx, cache, r, ac, opaSessionObj, resourceID, relPath, rsrcAbsPath)
+	var caches manifestCache
+	for _, resource := range groupByManifest(failed) {
+		cache := caches.get(resource.absPath)
+		locationResolver := cache.locationResolver(resource.absPath, "SARIF")
+
+		for _, toPin := range opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls {
+			ac := toPin
+
+			if ac.GetStatus(nil).IsFailed() {
+				ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
+				if ctl == nil {
+					logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
+					continue
 				}
+				location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
+				sp.addRule(run, ctl)
+				r := sp.addResult(run, ctl, resource.relPath, location)
+				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
 			}
 		}
 	}


### PR DESCRIPTION
## Overview

The SARIF and GitLab SAST printers walk failed resource -> failed control -> failed rule -> fix path, and the bottom of that walk did its work from scratch every time. `collectFixes` read the manifest, applied the fix expression to the whole file with yq, and diffed the whole file against the result, once per fix path. Both printers also built a `FixPathLocationResolver` per resource, and a resolver decodes every document in the file up front.

None of that depends on which finding asked for it: a file path and a yq expression determine the answer, and report generation only reads. What it did depend on was how many findings the file carried, so the cost grew with resources times controls, with the file size multiplying it. For 80 documents each failing 10 controls, that is 800 reads of the same file, 800 whole-file yq passes and 80 full yaml decodes for one report.

This adds a `fixReportCache`, live for one report, memoizing the file read, the location resolver and the fix regions of one expression applied to one manifest. Deriving regions is now separate from attaching them to a result, which is what lets the second be per finding while the first is not.

Current behavior on that 80 document manifest: 5.3s. New behavior: 0.65s.

`BenchmarkPrintConfigurationScan` covers both fix shapes, because they bound what caching recovers. When controls report the same fix path, which is what happens when they share a rule or a rule lists a path more than once, the applied fix and its diff are shared too:

| documents | controls each | before | after | |
|---|---|---|---|---|
| 10 | 10 | 120.0ms | 28.0ms | 4.3x |
| 40 | 10 | 1401ms | 203.9ms | 6.9x |
| 80 | 10 | 5283ms | 648.4ms | 8.1x |

The speedup grows with the document count because the repeated work was quadratic in it. Doubling the documents cost close to 4x before, close to 2x after.

When every control reports a distinct fix path, only the reads and the decode are shared and the gain is 1-2% (80 documents: 5651ms to 5599ms). That end is dominated by yq re-parsing the whole file once per distinct expression inside `ApplyFixToContent`. Both shapes are in the benchmark so the difference is visible rather than assumed.

Sharing one resolver across a file's resources is the part that is not obviously safe, since a resolver evaluates expressions against yaml nodes it holds. `TestFixReportCache_LocationResolverMatchesFreshResolver` compares every lookup against a resolver built fresh for it, walks the documents in order then back to an earlier one, and includes a path that does not exist so the walk up the expression runs; a resolver that mutated its own tree disagrees there. `TestPrintConfigurationScan_MultiDocumentFixesPerDocument` gives each document its own band of lines, so a finding that picked up another document's location or fix region lands outside its band. Dropping the expression from the cache key fails that test and the per-expression one.

Two smaller things in the same path: `addFix` marshalled and hashed the incoming artifact change once per comparison instead of once, and `ResolveLocation` rebuilt the same regexp on every step of its walk.

Existing tests in these packages are unchanged and still pass, including `Test_collectDiffs`.

Out of scope: applying a fix to the one document it selects rather than to the whole file, which is a change to how fixhandler applies fixes and is what the distinct-path end needs.

Note for whoever picks this up: `master` does not currently build. `2a2253ab` (#2908) changed `IPrinter.ActionPrint` to return an error without updating `cyclonedxprinter.go` and `spdxprinter.go`, so `core/pkg/resultshandling/printer/v2` fails to compile at `origin/master` and on any branch off it. #2902 touches both files and should clear it. I verified this branch's build, `go vet`, the full `./core/pkg/resultshandling/...` suite and the benchmarks against a local-only patch of those two signatures, kept out of this branch so it does not collide with #2902, and measured before and after the same way on both sides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved configuration-scan report generation by reducing repeated file reads and fix calculations.
  - Faster processing when multiple findings reference the same files or fixes.

- **Bug Fixes**
  - Improved fix locations and replacements for reports containing multiple YAML documents.
  - Prevented duplicate changes from appearing in generated results.
  - Improved handling of unavailable files and invalid fixes without repeatedly retrying the same work.

- **Tests**
  - Added coverage and benchmarks for caching, multi-document fixes, and duplicate-region handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->