### PR TITLE
fix(printer): update CycloneDX and SPDX printers to return error from ActionPrint

### DIFF
--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -44,34 +44,35 @@ func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) {
 // against image scans, so it is never invoked in practice.
 func (cp *CycloneDXPrinter) Score(score float32) {}
 
-func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj != nil || len(imageScanData) == 0 {
 		logger.L().Ctx(ctx).Error("cyclonedx-json output is only supported for image scans")
-		return
+		return nil
 	}
 	if imageScanData[0].SBOM == nil {
 		logger.L().Ctx(ctx).Error("no SBOM data available for cyclonedx-json output")
-		return
+		return nil
 	}
 
 	encoder, err := cyclonedxjson.NewFormatEncoderWithConfig(cyclonedxjson.DefaultEncoderConfig())
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to create cyclonedx-json encoder", helpers.Error(err))
-		return
+		return err
 	}
 
 	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to encode SBOM as cyclonedx-json", helpers.Error(err))
-		return
+		return err
 	}
 
 	if _, err := cp.writer.Write(data); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write cyclonedx-json output", helpers.Error(err))
-		return
+		return err
 	}
 
 	printer.LogOutputFile(cp.writer.Name())
+	return nil
 }
 
 func (cp *CycloneDXPrinter) PrintNextSteps() {}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -44,34 +44,35 @@ func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) {
 // against image scans, so it is never invoked in practice.
 func (sp *SPDXPrinter) Score(score float32) {}
 
-func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) {
+func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	if opaSessionObj != nil || len(imageScanData) == 0 {
 		logger.L().Ctx(ctx).Error("spdx-json output is only supported for image scans")
-		return
+		return nil
 	}
 	if imageScanData[0].SBOM == nil {
 		logger.L().Ctx(ctx).Error("no SBOM data available for spdx-json output")
-		return
+		return nil
 	}
 
 	encoder, err := spdxjson.NewFormatEncoderWithConfig(spdxjson.DefaultEncoderConfig())
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to create spdx-json encoder", helpers.Error(err))
-		return
+		return err
 	}
 
 	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to encode SBOM as spdx-json", helpers.Error(err))
-		return
+		return err
 	}
 
 	if _, err := sp.writer.Write(data); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write spdx-json output", helpers.Error(err))
-		return
+		return err
 	}
 
 	printer.LogOutputFile(sp.writer.Name())
+	return nil
 }
 
 func (sp *SPDXPrinter) PrintNextSteps() {}


### PR DESCRIPTION


## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->


fix(printer): return errors from CycloneDX and SPDX printer ActionPrint

The IPrinter interface requires ActionPrint to return error, but the
CycloneDX and SPDX printers were missed when the signature changed,
causing build + test failures.

Update both printers to return the underlying encoder/write errors and
nil on success.

Validation:
- go build ./... passes
- go test -race ./core/pkg/resultshandling/printer/v2/ passes

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when generating CycloneDX and SPDX SBOM output.
  * Failures during SBOM encoding or output writing are now surfaced to callers.
  * Invalid scan types and missing SBOM data are handled with clearer error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->