### PR TITLE
Remove Helm binary dependency from kustomize tests.

### DIFF
--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -17,7 +17,8 @@ import (
 )
 
 type KustomizeDirectory struct {
-	path string
+	path        string
+	helmCommand string
 }
 
 // Used for checking if there is "Kustomization" file in the given Directory
@@ -64,6 +65,10 @@ func NewKustomizeDirectory(path string) *KustomizeDirectory {
 	return &KustomizeDirectory{
 		path: path,
 	}
+}
+
+func (kd *KustomizeDirectory) SetHelmCommand(cmd string) {
+	kd.helmCommand = cmd
 }
 
 func getKustomizeDirectoryName(path string) string {
@@ -250,7 +255,11 @@ func (kd *KustomizeDirectory) GetWorkloads(kustomizeDirectoryPath string) (map[s
 	opts := krusty.MakeDefaultOptions()
 	opts.LoadRestrictions = types.LoadRestrictionsNone
 	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
-	opts.PluginConfig.HelmConfig.Command = "helm"
+	helmCommand := "helm"
+	if kd.helmCommand != "" {
+		helmCommand = kd.helmCommand
+	}
+	opts.PluginConfig.HelmConfig.Command = helmCommand
 	kustomizer := krusty.MakeKustomizer(opts)
 	resmap, err := kustomizer.Run(fSys, kustomizeDirectoryPath)
 

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -295,18 +295,38 @@ func TestKustomizeDirectoryWithHelmCharts(t *testing.T) {
 
 	assert.True(t, isKustomizeDirectory(helmPath), "helm directory should be detected as kustomize directory")
 
-	kd := NewKustomizeDirectory(helmPath)
-	workloads, errs := kd.GetWorkloads(helmPath)
-
-	for _, err := range errs {
-		assert.NotContains(t, err.Error(), "must specify --enable-helm", "kustomize should run with helm enabled")
-		if strings.Contains(err.Error(), `exec: "helm": executable file not found`) {
-			t.Skip("helm is not installed in test environment")
-		}
-		if strings.Contains(err.Error(), "unknown shorthand flag") || strings.Contains(err.Error(), "unknown flag") || strings.Contains(err.Error(), "unable to run: 'helm version -c --short'") {
-			t.Skip("installed helm version is incompatible with the kustomize version used (removed -c/--short flags)")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("fake helm script not implemented for Windows")
 	}
+
+	helmDir := t.TempDir()
+	fakeHelm := filepath.Join(helmDir, "helm")
+	rendered := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+`
+	script := `#!/bin/sh
+if [ "$1" = "version" ]; then
+    echo "v3.12.0"
+    exit 0
+fi
+cat <<'EOF'
+` + rendered + `EOF
+`
+	if err := os.WriteFile(fakeHelm, []byte(script), 0600); err != nil {
+		t.Fatalf("failed to write fake helm: %v", err)
+	}
+	if err := os.Chmod(fakeHelm, 0755); err != nil {
+		t.Fatalf("failed to chmod fake helm: %v", err)
+	}
+
+	kd := NewKustomizeDirectory(helmPath)
+	kd.SetHelmCommand(fakeHelm)
+	workloads, errs := kd.GetWorkloads(helmPath)
 
 	assert.Empty(t, errs, "kustomize with helm charts should render without errors")
 	assert.NotEmpty(t, workloads, "rendered workloads should include resources from helm chart")


### PR DESCRIPTION
## Description:
close - #2925 
The TestKustomizeDirectoryWithHelmCharts test in kustomizedirectory_test.go was previously skipped whenever helm was not installed on the host PATH. This made the test unreliable in CI environments and fresh development clones.

This change makes the helm command used by KustomizeDirectory overridable via a new SetHelmCommand method. The test now creates a temporary, self-contained fake helm executable that:

Prints v3.12.0 for helm version --short so kustomize's Helm version check passes.
Prints the expected rendered chart manifest for helm template ....
The t.Skip("helm is not installed in test environment") block is removed, and the test now runs without a real Helm installation on Unix-like systems. Windows is still skipped because the fake is a shell script; a cross-platform fake can be added in a follow-up.

## Files changed:

kustomizedirectory.go
kustomizedirectory_test.go
Verification:

go test ./core/cautils -run TestKustomizeDirectoryWithHelmCharts -v passes.
go test ./core/cautils passes.
golangci-lint run --new-from-rev=master ./core/cautils/... reports 0 new issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Helm command when processing Kustomize directories.
  * Processing continues to use the standard Helm command automatically when no custom command is configured.
  * This provides greater flexibility for environments that require a specific Helm executable or invocation.

* **Bug Fixes**
  * Improved reliability of Helm-based processing across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->