### PR TITLE
fix(core): ignore unusable image pull secret credentials

### DIFF
--- a/core/core/registry_creds.go
+++ b/core/core/registry_creds.go
@@ -122,7 +122,9 @@ func extractCredsFromAuths(auths map[string]dockerAuthConfig, domain string) (im
 					}
 				}
 			}
-			return creds, true
+			if creds.Token != "" || (creds.Username != "" && creds.Password != "") {
+				return creds, true
+			}
 		}
 	}
 	return imagescan.RegistryCredentials{}, false

--- a/core/core/registry_creds_test.go
+++ b/core/core/registry_creds_test.go
@@ -1,0 +1,162 @@
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/pkg/imagescan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestExtractCredsFromAuthsRejectsUnusableCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		auth dockerAuthConfig
+	}{
+		{
+			name: "empty registry entry",
+		},
+		{
+			name: "username without password",
+			auth: dockerAuthConfig{Username: "user"},
+		},
+		{
+			name: "password without username",
+			auth: dockerAuthConfig{Password: "password"},
+		},
+		{
+			name: "encoded empty username and password",
+			auth: dockerAuthConfig{Auth: base64.StdEncoding.EncodeToString([]byte(":"))},
+		},
+		{
+			name: "encoded username without password",
+			auth: dockerAuthConfig{Auth: base64.StdEncoding.EncodeToString([]byte("user:"))},
+		},
+		{
+			name: "encoded password without username",
+			auth: dockerAuthConfig{Auth: base64.StdEncoding.EncodeToString([]byte(":password"))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, found := extractCredsFromAuths(map[string]dockerAuthConfig{
+				"registry.example.com": tt.auth,
+			}, "registry.example.com")
+
+			assert.False(t, found)
+			assert.Equal(t, imagescan.RegistryCredentials{}, creds)
+		})
+	}
+}
+
+func TestExtractCredsFromAuthsPreservesBasicAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		auth dockerAuthConfig
+	}{
+		{
+			name: "explicit username and password",
+			auth: dockerAuthConfig{Username: "user", Password: "password"},
+		},
+		{
+			name: "base64 encoded username and password",
+			auth: dockerAuthConfig{Auth: base64.StdEncoding.EncodeToString([]byte("user:password"))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, found := extractCredsFromAuths(map[string]dockerAuthConfig{
+				"registry.example.com": tt.auth,
+			}, "registry.example.com")
+
+			require.True(t, found)
+			assert.Equal(t, imagescan.RegistryCredentials{
+				Authority: "registry.example.com",
+				Username:  "user",
+				Password:  "password",
+			}, creds)
+		})
+	}
+}
+
+func TestResolveRegistryCredentialsSkipsUnusableSecrets(t *testing.T) {
+	const namespace = "default"
+	tests := []struct {
+		name              string
+		imagePullSecrets  []interface{}
+		expected          imagescan.RegistryCredentials
+		expectedToBeFound bool
+	}{
+		{
+			name: "selects a later usable secret",
+			imagePullSecrets: []interface{}{
+				map[string]interface{}{"name": "empty-auth"},
+				map[string]interface{}{"name": "valid-auth"},
+			},
+			expected: imagescan.RegistryCredentials{
+				Authority: "registry.example.com",
+				Username:  "user",
+				Password:  "password",
+			},
+			expectedToBeFound: true,
+		},
+		{
+			name: "reports no credentials when all secrets are unusable",
+			imagePullSecrets: []interface{}{
+				map[string]interface{}{"name": "empty-auth"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "empty-auth", Namespace: namespace},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte(`{"auths":{"registry.example.com":{}}}`),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "valid-auth", Namespace: namespace},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte(`{"auths":{"registry.example.com":{"username":"user","password":"password"}}}`),
+					},
+				},
+			)
+			k8sAPI := &k8sinterface.KubernetesApi{KubernetesClient: client}
+			workload := workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "app",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"imagePullSecrets": tt.imagePullSecrets,
+				},
+			})
+
+			creds, found := resolveRegistryCredentials(
+				context.Background(),
+				k8sAPI,
+				workload,
+				"registry.example.com/team/app:tag",
+			)
+
+			assert.Equal(t, tt.expectedToBeFound, found)
+			assert.Equal(t, tt.expected, creds)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Ignore matching workload `imagePullSecret` entries that do not contain a usable authenticator.

The resolver previously returned success for an empty or incomplete registry auth entry. That stopped resolution before later pull secrets, so the existing configured-credential fallback was skipped even though the scanner would discard an entry with no authenticator.

## Changes

- Return a resolved pull-secret credential only when it contains either a token or a complete username/password pair.
- Continue searching later registry entries and pull secrets after an unusable match.
- Add table-driven coverage for empty and incomplete credentials.
- Add a fake Kubernetes client regression test proving that a valid later pull secret is selected.
- Preserve existing explicit and base64-encoded basic-auth behavior.

The change is limited to `imagePullSecret` credential extraction. Registry matching, explicit CLI credentials, and image-scan orchestration are unchanged.

## Validation

The regression tests were first run against the previous implementation and failed for all unusable credential cases and the ordered-Secret integration case.

```sh
go test -p=1 ./core/core \
  -run 'Test(ExtractCredsFromAuths|ResolveRegistryCredentialsSkipsUnusableSecrets)' \
  -count=3
go test -p=1 ./core/core -count=1
go vet -p=1 ./core/core
go test -race -vet=off -p=1 ./core/core \
  -run 'Test(ExtractCredsFromAuths|ResolveRegistryCredentialsSkipsUnusableSecrets)' \
  -count=1
git diff --check
```

## Related issues/PRs

- Follow-up to #2831 and #2832
- Complements the explicit registry-auth fallback added by #2695 and #2696

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression tests fail on the previous implementation
- [x] New and existing relevant unit tests pass locally
