### PR TITLE
fix(scan): honor only-fixable in combined image scans

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -366,7 +366,8 @@ func enforceImageSeverityThresholds(imageScanData []cautils.ImageScanData, scanI
 				continue
 			}
 
-			if imagescan.ParseSeverity(metadata.Severity) >= thresholdSeverity {
+			if imagescan.ParseSeverity(metadata.Severity) >= thresholdSeverity &&
+				(!scanInfo.OnlyFixable || m.Vulnerability.Fix.State == vulnerability.FixStateFixed) {
 				return fmt.Errorf("image scan result exceeds severity threshold: %s", scanInfo.FailThresholdSeverity)
 			}
 		}

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -687,6 +687,8 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 		name          string
 		threshold     string
 		matchSeverity string
+		fixState      vulnerability.FixState
+		onlyFixable   bool
 		expectedError bool
 	}{
 		{
@@ -719,12 +721,36 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 			matchSeverity: "High",
 			expectedError: false,
 		},
+		{
+			name:          "unfixed vulnerability at threshold is ignored when only fixable is enabled",
+			threshold:     "high",
+			matchSeverity: "High",
+			fixState:      vulnerability.FixStateNotFixed,
+			onlyFixable:   true,
+			expectedError: false,
+		},
+		{
+			name:          "fixed vulnerability at threshold fails when only fixable is enabled",
+			threshold:     "high",
+			matchSeverity: "High",
+			fixState:      vulnerability.FixStateFixed,
+			onlyFixable:   true,
+			expectedError: true,
+		},
+		{
+			name:          "unfixed vulnerability at threshold still fails when only fixable is disabled",
+			threshold:     "high",
+			matchSeverity: "High",
+			fixState:      vulnerability.FixStateNotFixed,
+			expectedError: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scanInfo := &cautils.ScanInfo{
 				FailThresholdSeverity: tt.threshold,
+				OnlyFixable:           tt.onlyFixable,
 			}
 
 			matches := match.NewMatches()
@@ -732,6 +758,7 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 				matches.Add(match.Match{
 					Vulnerability: vulnerability.Vulnerability{
 						Reference: vulnerability.Reference{ID: "CVE-TEST"},
+						Fix:       vulnerability.Fix{State: tt.fixState},
 					},
 				})
 			}


### PR DESCRIPTION
## Overview

Honor `--only-fixable` when the root/bare configuration scan combines posture and image results and enforces its image vulnerability severity threshold.

The standalone image-scan path already gates threshold failures on Grype's `fixed` state. The combined `--scan-images` path added by #2894 used a separate match loop that checked severity but ignored `ScanInfo.OnlyFixable`.

## Changes

- Require `vulnerability.FixStateFixed` before failing the combined image threshold when `OnlyFixable` is enabled.
- Preserve the existing threshold behavior when `OnlyFixable` is disabled.
- Add table-driven regression cases for fixed and unfixed vulnerabilities at the threshold.

This PR changes only `enforceImageSeverityThresholds`; #2929 separately wires that helper into explicit framework/control/workload commands. The shared standalone image-scan service is unchanged.

## Validation

The unfixed regression case was first run against the previous implementation and failed with `image scan result exceeds severity threshold: high`.

```sh
go test ./cmd/scan \
  -run '^TestEnforceImageSeverityThresholds$' \
  -count=100
go test ./cmd/scan -count=1
go vet ./cmd/scan
go test -race ./cmd/scan \
  -run '^TestEnforceImageSeverityThresholds$' \
  -count=20
git diff --check
```

All commands pass against current `master`. The branch retains the nil-provider guard merged in #2902 and adds only the missing fix-state predicate.

## Related issues/PRs

- Follow-up to #2891 and #2894
- Preserves the nil-provider guard added in #2902
- Paired command-wiring follow-up: #2929

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally
