### PR TITLE
fix(scan): enforce image thresholds in explicit subcommands

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -111,6 +111,11 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			if err := enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
 				return err
 			}
+			if scanInfo.ScanImages {
+				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+					return err
+				}
+			}
 			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/explicit_image_threshold_test.go
+++ b/cmd/scan/explicit_image_threshold_test.go
@@ -1,0 +1,116 @@
+package scan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type explicitThresholdPrinter struct{}
+
+func (explicitThresholdPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
+	return nil
+}
+func (explicitThresholdPrinter) PrintNextSteps()                   {}
+func (explicitThresholdPrinter) Score(float32)                     {}
+func (explicitThresholdPrinter) SetWriter(context.Context, string) {}
+
+type explicitThresholdProvider struct {
+	severity string
+}
+
+func (p explicitThresholdProvider) VulnerabilityMetadata(vulnerability.Reference) (*vulnerability.Metadata, error) {
+	return &vulnerability.Metadata{Severity: p.severity}, nil
+}
+func (explicitThresholdProvider) PackageSearchNames(grypepkg.Package) []string { return nil }
+func (explicitThresholdProvider) FindVulnerabilities(...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+func (explicitThresholdProvider) Close() error { return nil }
+
+type explicitThresholdKubescape struct {
+	mocks.MockIKubescape
+	captured *cautils.ScanInfo
+}
+
+func (m *explicitThresholdKubescape) Scan(scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	captured := *scanInfo
+	m.captured = &captured
+
+	matches := match.NewMatches()
+	matches.Add(match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-TEST"},
+		},
+	})
+
+	results := resultshandling.NewResultsHandler(nil, nil, explicitThresholdPrinter{})
+	results.SetData(cautils.NewOPASessionObjMock())
+	results.ImageScanData = []cautils.ImageScanData{
+		{
+			Matches:               matches,
+			VulnerabilityProvider: explicitThresholdProvider{severity: "Critical"},
+		},
+	}
+	return results, nil
+}
+
+func TestExplicitScanCommandsEnforceImageSeverityThreshold(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "framework", args: []string{"framework", "nsa", "--scan-images", "--severity-threshold", "high"}},
+		{name: "control", args: []string{"control", "C-0058", "--scan-images", "--severity-threshold", "high"}},
+		{name: "workload", args: []string{"workload", "Deployment/nginx", "--scan-images", "--severity-threshold", "high"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &explicitThresholdKubescape{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			require.EqualError(t, err, "image scan result exceeds severity threshold: high")
+			require.NotNil(t, ks.captured)
+			assert.True(t, ks.captured.ScanImages)
+			assert.Equal(t, "high", ks.captured.FailThresholdSeverity)
+		})
+	}
+}
+
+func TestExplicitFrameworkAndControlIgnoreImageDataWithoutScanImages(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "framework", args: []string{"framework", "nsa", "--severity-threshold", "high"}},
+		{name: "control", args: []string{"control", "C-0058", "--severity-threshold", "high"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &explicitThresholdKubescape{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			require.NoError(t, cmd.Execute())
+			require.NotNil(t, ks.captured)
+			assert.False(t, ks.captured.ScanImages)
+		})
+	}
+}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -132,6 +132,11 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
 				return err
 			}
+			if scanInfo.ScanImages {
+				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+					return err
+				}
+			}
 			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -112,6 +112,11 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
 				return err
 			}
+			if scanInfo.ScanImages {
+				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+					return err
+				}
+			}
 			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Overview

Apply the existing combined-scan image severity gate to the explicit `scan framework`, `scan control`, and `scan workload` command paths.

#2894 added `enforceImageSeverityThresholds` to `securityScan`, fixing the bare/root scan path. Cobra dispatches explicit subcommands directly to their own `RunE` handlers, however, so those paths never reached the new gate.

## Changes

- Enforce image severity thresholds after the existing posture severity check in the framework command.
- Apply the same gate to control and workload scans.
- Keep the check conditional on `ScanInfo.ScanImages`, matching the existing root scan behavior.
- Add command-level regression coverage that executes all three paths through `GetScanCommand(...).Execute()` and verifies inherited `--scan-images` and `--severity-threshold` values.
- Verify framework and control scans remain unaffected when image scanning is not requested.

The patch reuses the helper introduced by #2894. It does not change vulnerability matching, fixability predicates, output handling, or standalone `scan image` behavior.

## Validation

The command-level regression test was first run against the previous implementation. Framework, control, and workload cases all returned `nil` instead of the expected image-threshold error.

```sh
go test ./cmd/scan \
  -run 'TestExplicitScanCommandsEnforceImageSeverityThreshold|TestExplicitFrameworkAndControlIgnoreImageDataWithoutScanImages' \
  -count=1
go test ./cmd/scan -count=1
go vet ./cmd/scan
go test -race ./cmd/scan \
  -run 'TestExplicitScanCommandsEnforceImageSeverityThreshold|TestExplicitFrameworkAndControlIgnoreImageDataWithoutScanImages' \
  -count=10
git diff --check
```

## Related issues/PRs

- Focused follow-up to #2893 and #2894
- #2928 adds the missing `--only-fixable` predicate to the shared helper; landing it first lets these explicit paths inherit that behavior

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The command-level regression tests fail on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image scans now enforce the configured severity threshold when image scanning is enabled.
  * Framework, control, and workload scans stop with an error when vulnerabilities exceed the threshold.
  * Severity thresholds are ignored when image scanning is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->