### PR TITLE
fix(core): detect multipart SBOM output collisions

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -165,13 +164,12 @@ func resolvedOutputPath(format, outputFile string) string {
 		return ""
 	}
 	ext := fileExtForFormat(format)
-	fileExt := filepath.Ext(trimmed)
 
-	if ext == printer.YamlOutputExt && fileExt == ".yml" {
+	if ext == printer.YamlOutputExt && strings.HasSuffix(trimmed, ".yml") {
 		return trimmed
 	}
 
-	if ext != "" && fileExt != ext {
+	if ext != "" && !strings.HasSuffix(trimmed, ext) {
 		return trimmed + ext
 	}
 	return trimmed

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resourcehandler"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,6 +140,65 @@ func TestGetOutputPrintersCollisionReturnsError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "output path collision")
+}
+
+func TestResolvedOutputPath(t *testing.T) {
+	tests := []struct {
+		name, format, outputFile, want string
+	}{
+		{"append JSON", printer.JsonFormat, "report", "report.json"},
+		{"preserve JSON", printer.JsonFormat, "report.json", "report.json"},
+		{"preserve YAML alias", printer.YamlFormat, "report.yml", "report.yml"},
+		{"preserve CycloneDX", printer.CycloneDXFormat, "report.cdx.json", "report.cdx.json"},
+		{"append CycloneDX", printer.CycloneDXFormat, "report.json", "report.json.cdx.json"},
+		{"preserve SPDX", printer.SPDXFormat, "report.spdx.json", "report.spdx.json"},
+		{"append SPDX", printer.SPDXFormat, "report.json", "report.json.spdx.json"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, resolvedOutputPath(test.format, test.outputFile))
+		})
+	}
+}
+
+func TestResolvedOutputPathExposesSBOMCollisions(t *testing.T) {
+	tests := []struct {
+		sbomFormat, outputFile string
+	}{
+		{printer.CycloneDXFormat, "report.cdx.json"},
+		{printer.SPDXFormat, "report.spdx.json"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.sbomFormat, func(t *testing.T) {
+			jsonPath := resolvedOutputPath(printer.JsonFormat, test.outputFile)
+			sbomPath := resolvedOutputPath(test.sbomFormat, test.outputFile)
+			assert.Equal(t, jsonPath, sbomPath)
+		})
+	}
+}
+
+func TestGetOutputPrintersRejectsSBOMMultipartExtensionCollisions(t *testing.T) {
+	tests := []struct {
+		format, outputFile string
+	}{
+		{"json,cyclonedx-json", "report.cdx.json"},
+		{"json,spdx-json", "report.spdx.json"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				ScanType: cautils.ScanTypeImage,
+				Format:   test.format,
+				Output:   filepath.Join(t.TempDir(), test.outputFile),
+			}
+
+			_, err := GetOutputPrinters(scanInfo, context.Background(), "")
+			require.ErrorContains(t, err, "output path collision")
+		})
+	}
 }
 
 func TestIsPrioritizationScanType(t *testing.T) {


### PR DESCRIPTION
## Overview

Detect multi-format output collisions when a requested path already ends in the multipart CycloneDX (`.cdx.json`) or SPDX (`.spdx.json`) extension.

The preflight resolver previously used `filepath.Ext`, which reduced both extensions to `.json` and predicted an extra SBOM suffix. The real SBOM writers use full-suffix matching, so JSON and the selected SBOM printer both targeted the same path while preflight failed to report the collision.

## Changes

- Resolve output paths with the same full-suffix rule used by the printers.
- Preserve the existing `.yml` alias for YAML output.
- Add regression coverage for ordinary single-part extensions, multipart SBOM extensions, path equality, and the real `GetOutputPrinters` collision error for both CycloneDX and SPDX.

Using an extension-free base path is unchanged: `--output report --format json,cyclonedx-json` still resolves to separate `report.json` and `report.cdx.json` files.

## Validation

The integrated collision tests were first run against the previous implementation. Both `json,cyclonedx-json` with `report.cdx.json` and `json,spdx-json` with `report.spdx.json` returned `nil` instead of the expected collision error.

```sh
go test ./core/core \
  -run '^(TestResolvedOutputPath|TestResolvedOutputPathExposesSBOMCollisions|TestGetOutputPrintersRejectsSBOMMultipartExtensionCollisions)$' \
  -count=100
go test ./core/core -count=1
go vet ./core/core
go test -race ./core/core \
  -run '^(TestResolvedOutputPath|TestResolvedOutputPathExposesSBOMCollisions|TestGetOutputPrintersRejectsSBOMMultipartExtensionCollisions)$' \
  -count=20
git diff --check
```

## Related issues/PRs

- Focused follow-up to the collision guard added in #2414 and the SBOM formats added in #2883

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression tests fail on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output filename handling for supported formats, including special YAML extensions.
  * Prevented collisions between JSON and SBOM output files during image scans.
  * Improved detection of conflicting SBOM output filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->