### PR TITLE
fix(httphandler): retain scan ID in synchronous responses

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -37,7 +37,7 @@ import (
 
 var scanImpl = scan // Override for testing
 func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
-	response := &utilsmetav1.Response{}
+	response := &utilsmetav1.Response{ID: scanReq.scanID}
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/httphandler/handlerequests/v1/sync_scan_response_id_test.go
+++ b/httphandler/handlerequests/v1/sync_scan_response_id_test.go
@@ -1,0 +1,76 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanSyncResponseIncludesGeneratedID(t *testing.T) {
+	tests := []struct {
+		name       string
+		scanErr    error
+		wantStatus int
+		wantType   utilsapisv1.ScanResponseType
+	}{
+		{
+			name:       "successful scan",
+			wantStatus: http.StatusOK,
+			wantType:   utilsapisv1.ResultsV1ScanResponseType,
+		},
+		{
+			name:       "failed scan",
+			scanErr:    errors.New("deterministic scan failure"),
+			wantStatus: http.StatusInternalServerError,
+			wantType:   utilsapisv1.ErrorScanResponseType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTempOutputDirs(t)
+
+			originalScanImpl := scanImpl
+			t.Cleanup(func() { scanImpl = originalScanImpl })
+
+			generatedID := make(chan string, 1)
+			scanImpl = func(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, scanID string, _ bool) (*reporthandlingv2.PostureReport, error) {
+				generatedID <- scanID
+				if tt.scanErr != nil {
+					return nil, tt.scanErr
+				}
+				if err := os.WriteFile(filepath.Join(OutputDir, scanID+".json"), []byte("{}"), 0o600); err != nil {
+					return nil, err
+				}
+				return nil, nil
+			}
+
+			h := NewHTTPHandler(false)
+			w := httptest.NewRecorder()
+			h.Scan(w, httptest.NewRequest(http.MethodPost, "/scan?wait=true&keep=true", strings.NewReader("{}")))
+
+			require.Equal(t, tt.wantStatus, w.Code, "body=%s", w.Body.String())
+			var response utilsmetav1.Response
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			assert.Equal(t, tt.wantType, response.Type)
+
+			wantID := <-generatedID
+			require.NoError(t, uuid.Validate(wantID), "handler-generated scan ID must be a UUID")
+			assert.Equal(t, wantID, response.ID, "synchronous response must retain the generated scan ID")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Retain the generated scan ID in synchronous `POST /v1/scan?wait=true` responses.

The HTTP handler initially prepared a response containing the ID, but synchronous mode replaced it with a worker completion response initialized as an empty `Response`. Successful and failed scans therefore returned the correct type and payload with `"id":""`.

## Changes

- Initialize the worker completion response with `scanReq.scanID`.
- Preserve that ID across successful scans and scan failures; the same initialization also covers cancellation and panic-recovery responses.
- Add an end-to-end handler regression test that captures the server-generated UUID and checks both HTTP 200 / `v1results` and HTTP 500 / `error` responses.

Asynchronous scan responses are unchanged; they already include the generated ID.

## Validation

The new table test was first run against the previous implementation. Both the successful and failed cases received a valid generated UUID inside the scanner but observed an empty HTTP response ID.

Focused, package, vet, race, and whitespace checks pass:

```sh
cd httphandler
go test -p=1 ./handlerequests/v1 \
  -run '^TestScanSyncResponseIncludesGeneratedID$' -count=20
go test -p=1 ./handlerequests/v1 -count=1
go vet -p=1 ./handlerequests/v1
go test -race -vet=off -p=1 ./handlerequests/v1 \
  -run '^TestScanSyncResponseIncludesGeneratedID$' -count=20
git -C .. diff --check
```

All commands pass against current `master`.

## Related issues/PRs

- Focused follow-up to #2466 and #2483
- Related GET-results ID coverage: #2171

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous scan responses now include the generated scan ID.
  * Scan IDs remain available for both successful and failed scans.

* **Tests**
  * Added coverage to verify valid scan IDs are returned by the synchronous scan endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->