### PR TITLE
fix(cautils): record individual formats in scan metadata

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -364,7 +364,7 @@ func splitNamespaceList(s string) []string {
 func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *reporthandlingv2.Metadata {
 	metadata := &reporthandlingv2.Metadata{}
 
-	metadata.ScanMetadata.Formats = []string{scanInfo.Format}
+	metadata.ScanMetadata.Formats = scanInfo.Formats()
 	metadata.ScanMetadata.FormatVersion = scanInfo.FormatVersion
 	metadata.ScanMetadata.Submit = scanInfo.Submit.GetBool()
 

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -415,6 +415,45 @@ func TestScanInfoFormatsDeduplicatesInOrder(t *testing.T) {
 	}
 }
 
+func TestScanInfoToScanMetadataFormats(t *testing.T) {
+	testCases := []struct {
+		name   string
+		format string
+		want   []string
+	}{
+		{
+			name:   "multiple formats are separate metadata entries",
+			format: "json,junit,html",
+			want:   []string{"json", "junit", "html"},
+		},
+		{
+			name:   "formats are trimmed and deduplicated",
+			format: " json, ,pdf,json,pdf ",
+			want:   []string{"json", "pdf"},
+		},
+		{
+			name:   "single format is preserved",
+			format: "sarif",
+			want:   []string{"sarif"},
+		},
+		{
+			name:   "empty format does not produce an empty metadata entry",
+			format: "",
+			want:   []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanInfo := &ScanInfo{Format: tc.format}
+
+			metadata := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
+
+			assert.Equal(t, tc.want, metadata.ScanMetadata.Formats)
+		})
+	}
+}
+
 func TestAppendPolicyIdentifiers(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Overview

Record individual output formats in scan metadata using the same normalized list that drives printer creation.

Multi-format scans previously stored the raw comma-separated string as one `formats[]` entry, so report and submission consumers could not enumerate the requested formats.

## Changes

- Initialize `ScanMetadata.Formats` from `ScanInfo.Formats()` instead of wrapping the raw `ScanInfo.Format` string.
- Add regression coverage for multiple formats, whitespace and duplicate normalization, a single format, and an empty programmatic value.

The deprecated singular metadata field is unchanged. Findings, printer selection, and output generation are also unchanged.

## Validation

The new regression test was first run against the previous implementation and failed for multi-format, normalized, and empty inputs.

```sh
go test -p=1 ./core/cautils -run '^TestScanInfoToScanMetadataFormats$' -count=3
go test -p=1 ./core/cautils -count=1
go vet -p=1 ./core/cautils
go test -race -vet=off -p=1 ./core/cautils \
  -run '^TestScanInfoToScanMetadataFormats$' -count=1
git diff --check
```

## Related issues/PRs

- Related multi-format work: #983, #2079, and #2143

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan metadata now reports all available formats accurately.
  * Format values are cleaned up by trimming whitespace and removing duplicates.
  * Empty format information is handled correctly.

* **Tests**
  * Added coverage for multiple, single, trimmed, duplicate, and empty format values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->