### PR TITLE
fix(cautils): clone trailing remote inputs for local-first scans

### DIFF
--- a/core/cautils/remotegitutils_lifecycle_test.go
+++ b/core/cautils/remotegitutils_lifecycle_test.go
@@ -250,3 +250,26 @@ func TestScanningContextClonesAndCleansEveryRemoteInput(t *testing.T) {
 		assert.NoDirExists(t, workspaces[i])
 	}
 }
+
+func TestScanningContextClonesTrailingRemoteInputAfterLocalInput(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+	var cloneCalls atomic.Int32
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls.Add(1)
+		return initializeCloneWorkspace(path, options)
+	})
+
+	remoteInput := "https://github.com/example/remote"
+	scanInfo := &ScanInfo{InputPatterns: []string{t.TempDir(), remoteInput}}
+	require.Equal(t, ContextDir, scanInfo.GetScanningContext())
+	assert.Equal(t, int32(1), cloneCalls.Load())
+
+	workspace := GetClonedPath(remoteInput)
+	require.NotEmpty(t, workspace)
+	assert.DirExists(t, workspace)
+
+	scanInfo.Cleanup()
+	assert.Empty(t, GetClonedPath(remoteInput))
+	assert.NoDirExists(t, workspace)
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -425,7 +425,11 @@ func (scanInfo *ScanInfo) GetInputFiles() string {
 
 func (scanInfo *ScanInfo) GetScanningContext() ScanningContext {
 	if scanInfo.scanningContext == nil {
-		scanningContext := scanInfo.getScanningContext(scanInfo.GetInputFiles())
+		input := scanInfo.GetInputFiles()
+		scanningContext := scanInfo.getScanningContext(input)
+		if input != "" {
+			scanInfo.cloneAdditionalRemoteInputs(input)
+		}
 		scanInfo.scanningContext = &scanningContext
 	}
 	return *scanInfo.scanningContext
@@ -510,7 +514,6 @@ func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 						logger.L().Warning("failed to clean up cloned repository", helpers.String("url", originalInput), helpers.Error(err))
 					}
 				})
-				scanInfo.cloneAdditionalRemoteInputs(originalInput)
 				return ContextGitRemote
 			}
 			if err := ReleaseClonedRepo(originalInput); err != nil {


### PR DESCRIPTION
## Overview

Prepare trailing remote Git inputs even when the first scan input is a local file or directory.

`cloneAdditionalRemoteInputs` previously ran only inside the successful remote-primary branch of `getScanningContext`. That fixed multi-remote scans whose first input was remote, but left local-first mixed scans order-dependent: the trailing URL had no cloned workspace and was passed to the file loader as a local path.

## Changes

- Invoke additional-remote preparation once from the cached `GetScanningContext` initialization path, after the primary input has been classified.
- Keep primary remote cloning in its existing path while preserving remote-first multi-input behavior.
- Add a hermetic local-first regression using the existing fake clone lifecycle seam.
- Verify that the trailing repository workspace is registered and removed by `ScanInfo.Cleanup`.

This does not change Git URL parsing, authentication, clone concurrency/reference counting, scan-context metadata, or local input handling.

## Validation

The new regression was first run against the previous implementation. It failed deterministically: the fake clone was called zero times and `GetClonedPath(remoteInput)` was empty.

```sh
go test ./core/cautils \
  -run '^TestScanningContextClones(TrailingRemoteInputAfterLocalInput|AndCleansEveryRemoteInput)$' \
  -count=100
go test ./core/cautils -count=1
go vet ./core/cautils
go test -race ./core/cautils \
  -run '^TestScanningContextClones(TrailingRemoteInputAfterLocalInput|AndCleansEveryRemoteInput)$' \
  -count=20
go test -race ./core/cautils -count=1
git diff --check
```

All listed commands pass.

## Related issues/PRs

- Focused follow-up to the [explicitly deferred local-first case](https://github.com/kubescape/kubescape/pull/2548#pullrequestreview-4783823517) in #2548
- Distinct from #1910 and #1911, which addressed self-hosted URL recognition for a primary input

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of the code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scanning workflows that combine local directories with remote Git inputs.
  - Remote Git inputs are now consistently cloned, tracked in the scanning workspace, and cleaned up after scanning.
- **Tests**
  - Added coverage to verify remote input handling and workspace cleanup in mixed local and remote scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->