### PR TITLE
fix(coverage): sort partial GVR pull diagnostics

### DIFF
--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -138,7 +138,8 @@ type NotEvaluatedControl struct {
 // entries whose key is also a key in ResourceToControlsMap are considered.
 //
 // partialPulls carries per-selector LIST failures for GVRs that were partially
-// collected; they are included as-is in ScanCoverage.PartialGVRPulls. A
+// collected; they are included in canonical order in
+// ScanCoverage.PartialGVRPulls. A
 // discovery-stage failure that has a synthetic ResourceToControlsMap edge also
 // participates in the all-dependencies-failed check without being duplicated
 // in FailedGVRPulls.
@@ -147,8 +148,18 @@ type NotEvaluatedControl struct {
 // exceptions) that were served from a fallback; they are included as-is in
 // ScanCoverage.PolicyDegradations.
 func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull, policyDegradations []PolicyDegradation) ScanCoverage {
+	sortedPartialPulls := append([]PartialGVRPull(nil), partialPulls...)
+	sort.Slice(sortedPartialPulls, func(i, j int) bool {
+		if sortedPartialPulls[i].GVR != sortedPartialPulls[j].GVR {
+			return sortedPartialPulls[i].GVR < sortedPartialPulls[j].GVR
+		}
+		if sortedPartialPulls[i].Selector != sortedPartialPulls[j].Selector {
+			return sortedPartialPulls[i].Selector < sortedPartialPulls[j].Selector
+		}
+		return sortedPartialPulls[i].Error < sortedPartialPulls[j].Error
+	})
 	coverage := ScanCoverage{
-		PartialGVRPulls:    partialPulls,
+		PartialGVRPulls:    sortedPartialPulls,
 		PolicyDegradations: policyDegradations,
 	}
 

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -347,6 +347,26 @@ func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
 
+func TestBuildScanCoverage_SortsPartialGVRPullsWithoutMutatingInput(t *testing.T) {
+	partials := []PartialGVRPull{
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==b", Error: "z error"},
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==b", Error: "a error"},
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==a", Error: "forbidden"},
+		{GVR: "/v1/pods", Selector: "metadata.namespace==z", Error: "denied"},
+	}
+	original := append([]PartialGVRPull(nil), partials...)
+
+	coverage := BuildScanCoverage(nil, nil, nil, partials, nil)
+
+	assert.Equal(t, []PartialGVRPull{
+		{GVR: "/v1/pods", Selector: "metadata.namespace==z", Error: "denied"},
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==a", Error: "forbidden"},
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==b", Error: "a error"},
+		{GVR: "apps/v1/deployments", Selector: "metadata.namespace==b", Error: "z error"},
+	}, coverage.PartialGVRPulls)
+	assert.Equal(t, original, partials)
+}
+
 func TestComputeCoverageScore_Float32PrecisionLoss(t *testing.T) {
 	// 53 out of 100 evaluated controls: float32(53)/float32(100)*100
 	// evaluates to 52.999996 internally, but Float32ToIntFloor snaps it


### PR DESCRIPTION
## Overview

Sort partial GVR pull diagnostics before storing them in finalized scan coverage.

The resource collectors build selector failures from a Go map. `BuildScanCoverage` previously exposed that map-derived order unchanged, so JSON/YAML reports and pretty output could vary between otherwise identical scans.

## Changes

- Copy `partialPulls` before finalization so the caller's slice is not mutated.
- Sort the copy by GVR, selector, and error.
- Add a deterministic regression test covering every comparison key and input immutability.

This PR only stabilizes `ScanCoverage.PartialGVRPulls`. It does not change collection, coverage scoring, security verdicts, or fatal error text.

## Validation

The new regression test was first run against the previous implementation and failed deterministically because the input order was preserved.

```sh
go test -p=1 ./core/cautils \
  -run 'TestBuildScanCoverage_(SortsPartialGVRPullsWithoutMutatingInput|PartialGVRPullsPassedThrough|DeterministicOrder)' \
  -count=3
go test -p=1 ./core/cautils -count=1
go vet -p=1 ./core/cautils
go test -race -vet=off -p=1 ./core/cautils \
  -run '^TestBuildScanCoverage_SortsPartialGVRPullsWithoutMutatingInput$' \
  -count=1
git diff --check
```

## Related issues/PRs

- Follow-up to #2170
- Related deterministic-result work: #2773

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Partial scan results are now presented in a consistent, predictable order.
  - Input data remains unchanged when scan coverage is generated.

- **Documentation**
  - Clarified that partial resource pulls are emitted in canonical order.

- **Tests**
  - Added coverage to verify sorting behavior and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->