### PR TITLE
fix(resourcehandler): propagate file stream cancellation

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -149,6 +149,11 @@ func (fileHandler *FileResourceHandler) StreamResourcesBatches(ctx context.Conte
 }
 
 func publishFileResourceBatch(ctx context.Context, batchChan chan<- *cautils.ResourceBatch, errChan chan<- error, batch *cautils.ResourceBatch) {
+	if err := ctx.Err(); err != nil {
+		errChan <- err
+		return
+	}
+
 	select {
 	case batchChan <- batch:
 	case <-ctx.Done():

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -112,6 +112,9 @@ func (fileHandler *FileResourceHandler) EstimateClusterSize(ctx context.Context,
 // non-streaming path. File-based scans should not rely on --enable-streaming for
 // memory reduction.
 func (fileHandler *FileResourceHandler) StreamResourcesBatches(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (<-chan *cautils.ResourceBatch, <-chan error, int, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, 0, err
+	}
 	batchChan := make(chan *cautils.ResourceBatch, 1)
 	errChan := make(chan error, 1)
 
@@ -121,6 +124,9 @@ func (fileHandler *FileResourceHandler) StreamResourcesBatches(ctx context.Conte
 	// producer goroutine like the eager path did. File collection is local and
 	// fast, so this blocks no longer than the old async body did.
 	k8sResources, allResources, externalResources, excludedRulesMap, err := fileHandler.GetResources(ctx, sessionObj, scanInfo)
+	if err := ctx.Err(); err != nil {
+		return nil, nil, 0, err
+	}
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -136,13 +142,18 @@ func (fileHandler *FileResourceHandler) StreamResourcesBatches(ctx context.Conte
 		batch.AllResources = allResources
 		batch.ExternalResources = externalResources
 
-		select {
-		case batchChan <- batch:
-		case <-ctx.Done():
-		}
+		publishFileResourceBatch(ctx, batchChan, errChan, batch)
 	}()
 
 	return batchChan, errChan, 0, nil
+}
+
+func publishFileResourceBatch(ctx context.Context, batchChan chan<- *cautils.ResourceBatch, errChan chan<- error, batch *cautils.ResourceBatch) {
+	select {
+	case batchChan <- batch:
+	case <-ctx.Done():
+		errChan <- ctx.Err()
+	}
 }
 
 // helmValueOptionsFromScanInfo extracts the user-supplied Helm value/release flags from ScanInfo

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -2,9 +2,11 @@ package resourcehandler
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	gitv5 "github.com/go-git/go-git/v5"
@@ -19,6 +21,102 @@ import (
 func TestNewFileResourceHandler_InitializesNewInstance(t *testing.T) {
 	fileHandler := NewFileResourceHandler()
 	assert.NotNil(t, fileHandler)
+}
+
+func drainFileResourceStream(batchChan <-chan *cautils.ResourceBatch, errChan <-chan error, setupErr error) ([]*cautils.ResourceBatch, []error) {
+	var batches []*cautils.ResourceBatch
+	if batchChan != nil {
+		for batch := range batchChan {
+			batches = append(batches, batch)
+		}
+	}
+
+	var streamErrs []error
+	if setupErr != nil {
+		streamErrs = append(streamErrs, setupErr)
+	}
+	if errChan != nil {
+		for streamErr := range errChan {
+			streamErrs = append(streamErrs, streamErr)
+		}
+	}
+	return batches, streamErrs
+}
+
+func TestFileResourceHandlerStreamResourcesBatchesPreCanceled(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "pod.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(singlePodManifest), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	batchChan, errChan, _, err := NewFileResourceHandler().StreamResourcesBatches(ctx, session, scanInfo)
+	batches, streamErrs := drainFileResourceStream(batchChan, errChan, err)
+
+	assert.Empty(t, batches, "a pre-canceled stream must not emit a resource batch")
+	assert.Nil(t, batchChan, "a setup error must not return a batch channel")
+	assert.Nil(t, errChan, "a setup error must not return an error channel")
+	require.Len(t, streamErrs, 1)
+	assert.True(t, errors.Is(streamErrs[0], context.Canceled), "stream error = %v", streamErrs[0])
+}
+
+// cancelAfterEntryPreflightContext models cancellation immediately after the
+// stream's entry preflight observes an active context. The post-collection
+// preflight must observe the transition before the batch producer starts.
+type cancelAfterEntryPreflightContext struct {
+	context.Context
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (c *cancelAfterEntryPreflightContext) Err() error {
+	err := c.Context.Err()
+	c.once.Do(c.cancel)
+	return err
+}
+
+func TestFileResourceHandlerStreamResourcesBatchesCanceledAfterEntryPreflight(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "pod.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(singlePodManifest), 0o600))
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx := &cancelAfterEntryPreflightContext{Context: baseCtx, cancel: cancel}
+	t.Cleanup(cancel)
+
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{manifestPath}}
+	session := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	batchChan, errChan, _, err := NewFileResourceHandler().StreamResourcesBatches(ctx, session, scanInfo)
+	batches, streamErrs := drainFileResourceStream(batchChan, errChan, err)
+
+	assert.Empty(t, batches, "a stream canceled after entry preflight must not emit a resource batch")
+	assert.Nil(t, batchChan, "a setup error must not return a batch channel")
+	assert.Nil(t, errChan, "a setup error must not return an error channel")
+	require.Len(t, streamErrs, 1)
+	assert.True(t, errors.Is(streamErrs[0], context.Canceled), "stream error = %v", streamErrs[0])
+}
+
+func TestPublishFileResourceBatchPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	batchChan := make(chan *cautils.ResourceBatch)
+	errChan := make(chan error, 1)
+	publishFileResourceBatch(ctx, batchChan, errChan, cautils.NewResourceBatch(cautils.ClusterScope))
+
+	select {
+	case batch := <-batchChan:
+		t.Fatalf("canceled producer emitted batch: %#v", batch)
+	default:
+	}
+
+	select {
+	case err := <-errChan:
+		assert.ErrorIs(t, err, context.Canceled)
+	default:
+		t.Fatal("canceled producer did not report an error")
+	}
 }
 
 // This is deliberately a FileResourceHandler test rather than another parser

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -101,7 +101,7 @@ func TestPublishFileResourceBatchPropagatesCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	batchChan := make(chan *cautils.ResourceBatch)
+	batchChan := make(chan *cautils.ResourceBatch, 1)
 	errChan := make(chan error, 1)
 	publishFileResourceBatch(ctx, batchChan, errChan, cautils.NewResourceBatch(cautils.ClusterScope))
 


### PR DESCRIPTION
## Overview

Propagate context cancellation through the file streaming contract.

The producer previously closed its channels without reporting `ctx.Err()`. A canceled file scan could consequently look like a clean producer EOF or surface a structural missing-batch error instead of `context.Canceled`.

## Changes

- Return a direct setup error for a context canceled before loading resources.
- Recheck cancellation after synchronous resource preparation and return it before starting the producer.
- Prioritize an already-observed cancellation before selecting between a ready buffered batch send and `ctx.Done()`.
- Send `ctx.Err()` if cancellation occurs while publishing the batch.
- Add deterministic regressions for cancellation at entry, immediately after entry preflight, and while the producer is publishing the batch.

The change is limited to the file streaming producer. Eager file scans, resource parsing, and Kubernetes streaming are unchanged.

## Validation

The setup regressions were first run against the previous implementation and failed because cancellation returned no error and non-nil stream channels. The extracted publisher test uses the production capacity-one batch channel: with an already-canceled context both select cases would be ready, so the explicit preflight makes cancellation deterministic.

```sh
go test -p=1 ./core/pkg/resourcehandler \
  -run '^(TestFileResourceHandlerStreamResourcesBatches(PreCanceled|CanceledAfterEntryPreflight)|TestPublishFileResourceBatchPropagatesCancellation)$' \
  -count=100
go test -p=1 ./core/pkg/resourcehandler -count=1
go vet -p=1 ./core/pkg/resourcehandler
go test -race -vet=off -p=1 ./core/pkg/resourcehandler \
  -run '^(TestFileResourceHandlerStreamResourcesBatches(PreCanceled|CanceledAfterEntryPreflight)|TestPublishFileResourceBatchPropagatesCancellation)$' \
  -count=20
git diff --check
```

## Related issues/PRs

- Follow-up to the file streaming work in #2645
- Distinct from the consumer-to-producer cancellation fix in #2813 and #2815

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource loading behavior when cancellation occurs before or during batch processing.
  - Cancellation is now reported reliably instead of being silently ignored.
  - Prevented resource batches from being published after cancellation.
- **Tests**
  - Added coverage for pre-canceled and during-processing cancellation scenarios.
  - Verified correct error reporting and channel behavior when setup is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->