### PR TITLE
fix(httphandler): preserve non-JSON HTTP scan results

### DIFF
--- a/httphandler/handlerequests/v1/http_result_format_lifecycle_test.go
+++ b/httphandler/handlerequests/v1/http_result_format_lifecycle_test.go
@@ -1,0 +1,332 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	resultprinter "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type artifactPrinter struct {
+	path    string
+	content []byte
+}
+
+func (p *artifactPrinter) SetWriter(context.Context, string) {}
+func (p *artifactPrinter) PrintNextSteps()                   {}
+func (p *artifactPrinter) Score(float32)                     {}
+func (p *artifactPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
+	return os.WriteFile(p.path, p.content, 0o600)
+}
+
+type noOpPrinter struct{}
+
+func (*noOpPrinter) SetWriter(context.Context, string) {}
+func (*noOpPrinter) PrintNextSteps()                   {}
+func (*noOpPrinter) Score(float32)                     {}
+func (*noOpPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
+	return nil
+}
+
+func newFormatLifecycleResultsHandler(outputPath, suffix string, content []byte) *resultshandling.ResultsHandler {
+	results := resultshandling.NewResultsHandler(
+		nil,
+		[]resultprinter.IPrinter{&artifactPrinter{path: outputPath + suffix, content: content}},
+		&noOpPrinter{},
+	)
+	data := cautils.NewOPASessionObjMock()
+	data.Report.ClusterName = "canonical-cluster"
+	results.SetData(data)
+	return results
+}
+
+func TestScanSyncNonJSONFormatPersistsRetrievableCanonicalResult(t *testing.T) {
+	out := withTempOutputDirs(t)
+
+	originalScanImpl := scanImpl
+	originalRunKubescapeScan := runKubescapeScan
+	t.Cleanup(func() {
+		scanImpl = originalScanImpl
+		runKubescapeScan = originalRunKubescapeScan
+	})
+
+	const sidecar = "requested yaml output\n"
+	var scanID string
+	scanImpl = scan
+	runKubescapeScan = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+		scanID = scanInfo.ScanID
+		return newFormatLifecycleResultsHandler(scanInfo.Output, ".yaml", []byte(sidecar)), nil
+	}
+
+	body, err := json.Marshal(utilsmetav1.PostScanRequest{Format: "yaml"})
+	require.NoError(t, err)
+	h := NewHTTPHandler(false)
+	w := httptest.NewRecorder()
+	h.Scan(w, httptest.NewRequest(http.MethodPost, "/scan?wait=true&keep=true", bytes.NewReader(body)))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	response := decodeResultsResponse(t, w)
+	require.Equal(t, utilsapisv1.ResultsV1ScanResponseType, response.Type)
+	payload, ok := response.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", response.Response)
+	assert.Equal(t, "canonical-cluster", payload["clusterName"])
+
+	require.NotEmpty(t, scanID)
+	canonicalPath := filepath.Join(out, scanID)
+	canonical, err := os.ReadFile(canonicalPath)
+	require.NoError(t, err, "non-JSON scans must persist extensionless canonical JSON")
+	assert.True(t, json.Valid(canonical), "canonical result must be valid JSON: %q", canonical)
+	assert.NotEqual(t, sidecar, string(canonical), "canonical JSON must not reuse the requested sidecar bytes")
+
+	requestedPath := filepath.Join(out, scanID+".yaml")
+	gotSidecar, err := os.ReadFile(requestedPath)
+	require.NoError(t, err, "requested output sidecar must remain available when keep=true")
+	assert.Equal(t, sidecar, string(gotSidecar))
+	_, err = os.Stat(filepath.Join(out, scanID+".json"))
+	assert.True(t, os.IsNotExist(err), "internal canonical persistence must not create an unrequested .json sidecar")
+}
+
+func TestScanSyncNonJSONFormatDefaultCleanupRemovesCanonicalAndSidecar(t *testing.T) {
+	out := withTempOutputDirs(t)
+
+	originalScanImpl := scanImpl
+	originalRunKubescapeScan := runKubescapeScan
+	t.Cleanup(func() {
+		scanImpl = originalScanImpl
+		runKubescapeScan = originalRunKubescapeScan
+	})
+
+	var scanID string
+	scanImpl = scan
+	runKubescapeScan = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+		scanID = scanInfo.ScanID
+		return newFormatLifecycleResultsHandler(scanInfo.Output, ".pdf", []byte("requested pdf output")), nil
+	}
+
+	body, err := json.Marshal(utilsmetav1.PostScanRequest{Format: "pdf"})
+	require.NoError(t, err)
+	h := NewHTTPHandler(false)
+	w := httptest.NewRecorder()
+	h.Scan(w, httptest.NewRequest(http.MethodPost, "/scan?wait=true", bytes.NewReader(body)))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	response := decodeResultsResponse(t, w)
+	require.Equal(t, utilsapisv1.ResultsV1ScanResponseType, response.Type)
+	payload, ok := response.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", response.Response)
+	assert.Equal(t, "canonical-cluster", payload["clusterName"], "cleanup must happen only after the synchronous response reads the canonical result")
+
+	require.NotEmpty(t, scanID)
+	for _, path := range []string{
+		filepath.Join(out, scanID),
+		filepath.Join(out, scanID+".pdf"),
+	} {
+		_, err := os.Stat(path)
+		assert.Truef(t, os.IsNotExist(err), "keep=false left result artifact %q: %v", path, err)
+	}
+}
+
+func TestScanAsyncNonJSONFormatCanBeFetched(t *testing.T) {
+	out := withTempOutputDirs(t)
+
+	originalScanImpl := scanImpl
+	originalRunKubescapeScan := runKubescapeScan
+	t.Cleanup(func() {
+		scanImpl = originalScanImpl
+		runKubescapeScan = originalRunKubescapeScan
+	})
+
+	const sidecar = "requested yaml output\n"
+	scanImpl = scan
+	runKubescapeScan = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+		return newFormatLifecycleResultsHandler(scanInfo.Output, ".yaml", []byte(sidecar)), nil
+	}
+
+	body, err := json.Marshal(utilsmetav1.PostScanRequest{Format: "yaml"})
+	require.NoError(t, err)
+	h := NewHTTPHandler(false)
+	scanRecorder := httptest.NewRecorder()
+	h.Scan(scanRecorder, httptest.NewRequest(http.MethodPost, "/scan", bytes.NewReader(body)))
+
+	require.Equal(t, http.StatusOK, scanRecorder.Code, "body=%s", scanRecorder.Body.String())
+	scanResponse := decodeResultsResponse(t, scanRecorder)
+	require.Equal(t, utilsapisv1.BusyScanResponseType, scanResponse.Type)
+	require.NotEmpty(t, scanResponse.ID)
+	require.Eventually(t, func() bool {
+		return !h.state.isBusy(scanResponse.ID)
+	}, time.Second, 5*time.Millisecond, "asynchronous scan did not finish")
+
+	resultsRecorder := httptest.NewRecorder()
+	h.GetResults(resultsRecorder, httptest.NewRequest(http.MethodGet, "/results?id="+scanResponse.ID+"&keep=true", nil))
+
+	require.Equal(t, http.StatusOK, resultsRecorder.Code, "body=%s", resultsRecorder.Body.String())
+	resultsResponse := decodeResultsResponse(t, resultsRecorder)
+	require.Equal(t, utilsapisv1.ResultsV1ScanResponseType, resultsResponse.Type)
+	payload, ok := resultsResponse.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", resultsResponse.Response)
+	assert.Equal(t, "canonical-cluster", payload["clusterName"])
+
+	canonical, err := os.ReadFile(filepath.Join(out, scanResponse.ID))
+	require.NoError(t, err)
+	assert.True(t, json.Valid(canonical))
+	gotSidecar, err := os.ReadFile(filepath.Join(out, scanResponse.ID+".yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, sidecar, string(gotSidecar))
+}
+
+func TestScanSkipPersistenceNonJSONFormatKeepsCanonicalHTTPArtifact(t *testing.T) {
+	out := withTempOutputDirs(t)
+
+	originalScanImpl := scanImpl
+	originalRunKubescapeScan := runKubescapeScan
+	t.Cleanup(func() {
+		scanImpl = originalScanImpl
+		runKubescapeScan = originalRunKubescapeScan
+	})
+
+	skipPersistenceSeen := make(chan bool, 1)
+	var scanID string
+	scanImpl = func(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier, id string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {
+		skipPersistenceSeen <- skipPersistence
+		return scan(ctx, scanInfo, policyIdentifiers, id, skipPersistence)
+	}
+	runKubescapeScan = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+		scanID = scanInfo.ScanID
+		return newFormatLifecycleResultsHandler(scanInfo.Output, ".yaml", []byte("requested yaml output\n")), nil
+	}
+
+	body, err := json.Marshal(utilsmetav1.PostScanRequest{Format: "yaml"})
+	require.NoError(t, err)
+	h := NewHTTPHandler(false)
+	w := httptest.NewRecorder()
+	h.Scan(w, httptest.NewRequest(http.MethodPost, "/scan?wait=true&keep=true&skipPersistence=true", bytes.NewReader(body)))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	response := decodeResultsResponse(t, w)
+	require.Equal(t, utilsapisv1.ResultsV1ScanResponseType, response.Type)
+	payload, ok := response.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", response.Response)
+	assert.Equal(t, "canonical-cluster", payload["clusterName"])
+	require.True(t, <-skipPersistenceSeen, "query parameter must reach scan persistence control")
+	require.NotEmpty(t, scanID)
+
+	canonical, err := os.ReadFile(filepath.Join(out, scanID))
+	require.NoError(t, err, "skipPersistence must not suppress the HTTP results artifact")
+	assert.True(t, json.Valid(canonical))
+}
+
+func TestScanLiteralJSONFormatDoesNotCreateCanonicalDuplicate(t *testing.T) {
+	out := withTempOutputDirs(t)
+
+	originalRunKubescapeScan := runKubescapeScan
+	t.Cleanup(func() { runKubescapeScan = originalRunKubescapeScan })
+
+	const id = "123e4567-e89b-12d3-a456-426614174010"
+	outputPath := filepath.Join(out, id)
+	runKubescapeScan = func(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+		return newFormatLifecycleResultsHandler(scanInfo.Output, ".json", []byte(`{"reportGUID":"requested-json"}`)), nil
+	}
+
+	_, err := scan(withCanonicalResultPersistence(context.Background()), &cautils.ScanInfo{
+		ScanID: id,
+		Format: "yaml, json",
+		Output: outputPath,
+	}, nil, id, true)
+	require.NoError(t, err)
+
+	requested, err := os.ReadFile(outputPath + ".json")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"reportGUID":"requested-json"}`, string(requested))
+	_, err = os.Stat(outputPath)
+	assert.True(t, os.IsNotExist(err), "literal json requests already have a retrievable .json result; no duplicate canonical file should be created")
+}
+
+func TestResultsGetCanonicalResultWinsOverGitLabSASTJSONSidecar(t *testing.T) {
+	const id = "123e4567-e89b-12d3-a456-426614174011"
+	out := withTempOutputDirs(t)
+	require.NoError(t, os.WriteFile(filepath.Join(out, id), []byte(`{"reportGUID":"canonical"}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(out, id+".json"), []byte(`{"version":"15.0.6","vulnerabilities":[]}`), 0o600))
+
+	h := newResultsHandler(false)
+	w := httptest.NewRecorder()
+	h.GetResults(w, httptest.NewRequest(http.MethodGet, "/results?id="+id+"&keep=true", nil))
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	response := decodeResultsResponse(t, w)
+	payload, ok := response.Response.(map[string]any)
+	require.Truef(t, ok, "response payload type = %T; want JSON object", response.Response)
+	assert.Equal(t, "canonical", payload["reportGUID"], "extensionless canonical JSON must win over gitlab-sast's .json sidecar")
+	assert.NotContains(t, payload, "version")
+
+	_, err := os.Stat(filepath.Join(out, id))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(out, id+".json"))
+	assert.NoError(t, err, "keep=true must retain requested sidecars")
+}
+
+func TestResultsDeleteRemovesOnlyKnownResultArtifacts(t *testing.T) {
+	const id = "123e4567-e89b-12d3-a456-426614174012"
+	const otherID = "123e4567-e89b-12d3-a456-426614174013"
+	withTempOutputDirs(t)
+
+	knownSuffixes := []string{
+		"",
+		".json",
+		".xml",
+		".sarif",
+		".html",
+		".pdf",
+		".txt",
+		".yaml",
+		".csv",
+		".cdx.json",
+		".spdx.json",
+	}
+	for _, dir := range []string{OutputDir, FailedOutputDir} {
+		for _, suffix := range knownSuffixes {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, id+suffix), []byte("result"), 0o600))
+		}
+	}
+
+	preserved := []string{
+		filepath.Join(OutputDir, id+".notes"),
+		filepath.Join(OutputDir, id+".json.bak"),
+		filepath.Join(OutputDir, otherID+".yaml"),
+		filepath.Join(FailedOutputDir, id+".custom"),
+	}
+	for _, path := range preserved {
+		require.NoError(t, os.WriteFile(path, []byte("preserve"), 0o600))
+	}
+
+	h := newResultsHandler(false)
+	w := httptest.NewRecorder()
+	h.DeleteResults(w, httptest.NewRequest(http.MethodDelete, "/results?id="+id, nil))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	for _, dir := range []string{OutputDir, FailedOutputDir} {
+		for _, suffix := range knownSuffixes {
+			path := filepath.Join(dir, id+suffix)
+			_, err := os.Stat(path)
+			assert.Truef(t, os.IsNotExist(err), "known result artifact %q survived DELETE: %v", path, err)
+		}
+	}
+	for _, path := range preserved {
+		got, err := os.ReadFile(path)
+		require.NoErrorf(t, err, "unrelated UUID-adjacent file %q must survive exact cleanup", path)
+		assert.Equal(t, "preserve", string(got))
+	}
+}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/core"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/httphandler/config"
 	"github.com/kubescape/kubescape/v3/httphandler/storage"
 	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -36,6 +38,21 @@ import (
 )
 
 var scanImpl = scan // Override for testing
+
+// runKubescapeScan is the scanner construction seam used by lifecycle tests.
+var runKubescapeScan = func(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return core.NewKubescape(ctx).Scan(scanInfo, policyIdentifiers)
+}
+
+// canonicalResultPersistenceKey marks scans submitted through /v1/scan. The
+// metrics endpoint shares scan(), but owns the extensionless output path for
+// its Prometheus response and must not have that file replaced with JSON.
+type canonicalResultPersistenceKey struct{}
+
+func withCanonicalResultPersistence(ctx context.Context) context.Context {
+	return context.WithValue(ctx, canonicalResultPersistenceKey{}, true)
+}
+
 func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	response := &utilsmetav1.Response{}
 
@@ -62,7 +79,11 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 	}()
 
 	logger.L().Info("scan triggered", helpers.String("ID", scanReq.scanID))
-	_, err := scanImpl(scanReq.ctx, scanReq.scanInfo, scanReq.policyIdentifiers, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
+	scanCtx := scanReq.ctx
+	if scanReq.isUserScan {
+		scanCtx = withCanonicalResultPersistence(scanCtx)
+	}
+	_, err := scanImpl(scanCtx, scanReq.scanInfo, scanReq.policyIdentifiers, scanReq.scanID, scanReq.scanQueryParams.SkipPersistence)
 	if err != nil {
 		if errors.Is(scanReq.ctx.Err(), context.Canceled) {
 			logger.L().Ctx(scanReq.ctx).Info("scan cancelled", helpers.String("ID", scanReq.scanID))
@@ -159,8 +180,6 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []c
 	ctx, spanScan := otel.Tracer("").Start(ctx, "kubescape.scan")
 	defer spanScan.End()
 
-	ks := core.NewKubescape(ctx)
-
 	spanScan.AddEvent("scanning metadata",
 		trace.WithAttributes(attribute.String("version", versioncheck.BuildNumber)),
 		trace.WithAttributes(attribute.String("build", versioncheck.Client)),
@@ -172,12 +191,20 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []c
 		trace.WithAttributes(attribute.String("hostSensorYamlPath", scanInfo.HostSensorYamlPath)),
 	)
 
-	result, err := ks.Scan(scanInfo, policyIdentifiers)
+	result, err := runKubescapeScan(ctx, scanInfo, policyIdentifiers)
 	if err != nil {
 		return nil, writeScanErrorToFile(err, scanID)
 	}
 	if err := result.HandleResults(ctx, scanInfo); err != nil {
 		return nil, writeScanErrorToFile(err, scanID)
+	}
+	// Non-JSON printers write format-specific sidecars (for example .yaml or
+	// .pdf), while /v1/results reads JSON. Keep the requested sidecars and add
+	// the extensionless canonical JSON that the results API reads first.
+	if shouldPersistCanonicalResult(ctx, scanInfo) {
+		if err := persistCanonicalResult(result, scanID); err != nil {
+			return nil, writeScanErrorToFile(err, scanID)
+		}
 	}
 
 	if !skipPersistence {
@@ -202,6 +229,34 @@ func scan(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []c
 	}
 
 	return nil, nil
+}
+
+func shouldPersistCanonicalResult(ctx context.Context, scanInfo *cautils.ScanInfo) bool {
+	persist, _ := ctx.Value(canonicalResultPersistenceKey{}).(bool)
+	if !persist {
+		return false
+	}
+	for _, format := range scanInfo.Formats() {
+		if format == printer.JsonFormat {
+			return false
+		}
+	}
+	return true
+}
+
+func persistCanonicalResult(result *resultshandling.ResultsHandler, scanID string) error {
+	parsedUUID, err := uuid.Parse(scanID)
+	if err != nil {
+		return fmt.Errorf("failed to persist canonical scan results: invalid scan ID: %w", err)
+	}
+	data, err := result.ToJson()
+	if err != nil {
+		return fmt.Errorf("failed to marshal canonical scan results: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(OutputDir, parsedUUID.String()), data, 0o600); err != nil {
+		return fmt.Errorf("failed to persist canonical scan results: %w", err)
+	}
+	return nil
 }
 
 // ScanFailedError carries the plaintext error written by writeScanErrorToFile.
@@ -273,7 +328,21 @@ func removeResultsFile(fileID string) error {
 	cleanID := parsedUUID.String()
 
 	dirs := []string{OutputDir, FailedOutputDir}
-	extensions := []string{"", ".json"}
+	// Exact suffixes that printers can append to the extensionless HTTP output
+	// base. Do not glob cleanID+".*": UUID-adjacent files may be unrelated.
+	extensions := []string{
+		"",
+		printer.JsonOutputExt,
+		printer.JunitOutputExt,
+		printer.SARIFOutputExt,
+		printer.HtmlOutputExt,
+		printer.PdfOutputExt,
+		printer.PrometheusOutputExt,
+		printer.YamlOutputExt,
+		printer.CsvOutputExt,
+		printer.CycloneDXOutputExt,
+		printer.SPDXOutputExt,
+	}
 
 	for _, dir := range dirs {
 		for _, ext := range extensions {


### PR DESCRIPTION
## Overview

Preserve the HTTP results lifecycle when callers request non-JSON output formats.

The scan endpoint previously wrote only the requested YAML/PDF/SARIF-style sidecar, while the results API looked for canonical JSON. A successful `wait=true` scan could therefore return an error, asynchronous GET could find no result, and DELETE left non-JSON artifacts behind.

## Changes

- Mark user `/v1/scan` requests so the shared scan function can distinguish them from the Metrics endpoint.
- When no literal `json` format was requested, persist an extensionless canonical PostureReport JSON after the requested printers finish.
- Keep all requested format sidecars unchanged.
- Remove the exact set of known printer suffixes during result cleanup while preserving unrelated UUID-adjacent files.
- Ensure the extensionless canonical result wins over GitLab SAST's `.json` sidecar.
- Add synchronous lifecycle tests for `keep=true` and default cleanup.
- Add an asynchronous POST-to-GET lifecycle test and pin that `skipPersistence=true` still retains the HTTP artifact while reaching the operator-storage persistence control.
- Cover JSON duplicate avoidance, GitLab SAST precedence, and exact multi-format deletion.

This preserves the existing HTTP response contract and requested output files. Metrics output, scan findings, printer behavior, and storage persistence are unchanged.

## Validation

The new tests were first run against the previous implementation and reproduced a 500 response for a successful YAML scan and surviving non-JSON artifacts after DELETE.

```sh
cd httphandler
go test -p=1 ./handlerequests/v1 \
  -run '^(TestScan(Sync|Async|SkipPersistence)NonJSONFormat.*|TestScanLiteralJSONFormatDoesNotCreateCanonicalDuplicate|TestResultsGetCanonicalResultWinsOverGitLabSASTJSONSidecar|TestResultsDeleteRemovesOnlyKnownResultArtifacts)$' \
  -count=3
go test -p=1 ./handlerequests/v1 -count=1
go vet -p=1 ./handlerequests/v1
go test -race -vet=off -p=1 ./handlerequests/v1 \
  -run '^(TestScan(Sync|Async|SkipPersistence)NonJSONFormat.*|TestScanLiteralJSONFormatDoesNotCreateCanonicalDuplicate|TestResultsGetCanonicalResultWinsOverGitLabSASTJSONSidecar|TestResultsDeleteRemovesOnlyKnownResultArtifacts)$' \
  -count=1
git -C .. diff --check
```

Mutation checks also confirmed that removing canonical persistence, preferring `.json` over the extensionless result, or omitting a known cleanup suffix makes the corresponding regression test fail.

## Related issues/PRs

- #2931 owns the synchronous response-ID change; this PR intentionally leaves it scoped there
- Follow-up to #2483 and the non-JSON HTTP output support in #2625
- Related HTTP result lifecycle work: #2339 and #2109
- Related response enrichment: #2861 and #2862

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression tests fail on the previous implementation
- [x] New and existing relevant unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-JSON scan results can now be retrieved through the standard results endpoint.
  * Scan processing records failures in dedicated result files for improved visibility.
  * Result cleanup now removes all supported output formats while preserving unrelated files.

* **Bug Fixes**
  * Prevented duplicate canonical results for scans already producing JSON.
  * Ensured canonical results take precedence when multiple result formats are available.
  * Improved handling of synchronous, asynchronous, and non-persistent scan workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->