### PR TITLE
fix(storage): propagate workload scan update errors

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -211,6 +211,7 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResult(ctx context.Contex
 		if retryErr != nil {
 			logger.L().Ctx(ctx).Warning("failed to update WorkloadConfigurationScan manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", manifest.Name))
+			return retryErr
 		} else {
 			logger.L().Debug("updated WorkloadConfigurationScan manifest in storage", helpers.String("name", manifest.Name))
 		}
@@ -310,6 +311,7 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResultSummary(ctx context
 		if retryErr != nil {
 			logger.L().Ctx(ctx).Warning("failed to update WorkloadConfigurationScanSummary manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", manifest.Name))
+			return nil, retryErr
 		} else {
 			logger.L().Debug("updated WorkloadConfigurationScanSummary manifest in storage",
 				helpers.String("name", manifest.Name))

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func NewFakeAPIServerStorage(namespace string) *APIServerStore {
@@ -28,6 +30,44 @@ func NewFakeAPIServerStorage(namespace string) *APIServerStore {
 		StorageClient: fake.NewSimpleClientset().SpdxV1beta1(),
 		namespace:     namespace,
 	}
+}
+
+func TestStoreWorkloadConfigurationScanResult_PropagatesUpdateError(t *testing.T) {
+	ctx := context.Background()
+	existing := &v1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-scan", Namespace: "default"},
+	}
+	client := fake.NewSimpleClientset(existing)
+	updateErr := errors.New("update failed")
+	client.PrependReactor("update", "workloadconfigurationscans", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, updateErr
+	})
+	store := &APIServerStore{StorageClient: client.SpdxV1beta1()}
+
+	err := store.StoreWorkloadConfigurationScanResult(ctx, &v1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-scan", Namespace: "default"},
+	})
+
+	assert.ErrorIs(t, err, updateErr)
+}
+
+func TestStoreWorkloadConfigurationScanResultSummary_PropagatesUpdateError(t *testing.T) {
+	ctx := context.Background()
+	existing := &v1beta1.WorkloadConfigurationScanSummary{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-scan", Namespace: "default"},
+	}
+	client := fake.NewSimpleClientset(existing)
+	updateErr := errors.New("update failed")
+	client.PrependReactor("update", "workloadconfigurationscansummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, updateErr
+	})
+	store := &APIServerStore{StorageClient: client.SpdxV1beta1()}
+
+	_, err := store.StoreWorkloadConfigurationScanResultSummary(ctx, &v1beta1.WorkloadConfigurationScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-scan", Namespace: "default"},
+	})
+
+	assert.ErrorIs(t, err, updateErr)
 }
 
 func Test_getControlsMapFromResult(t *testing.T) {


### PR DESCRIPTION
## Overview

Propagate failures encountered while updating existing workload configuration scan resources.

When `Create` returns `AlreadyExists`, both storage methods use `RetryOnConflict` to retrieve and update the existing resource. A final Get or Update failure was previously logged and then discarded, causing the persistence operation and its caller to report success even though the resource was not updated.

## Changes

- Return the final retry error from `StoreWorkloadConfigurationScanResult`.
- Return the final retry error and no summary from `StoreWorkloadConfigurationScanResultSummary`.
- Add fake-apiserver regression tests for both update paths.

## Validation

The regression tests were first run against the previous implementation. Both failed because the methods returned `nil` after the fake Update operation returned an error.

```sh
cd httphandler
go test ./storage \
  -run '^TestStoreWorkloadConfigurationScan(Result|ResultSummary)_PropagatesUpdateError$' \
  -count=10
go test ./storage -count=1
go test ./... -count=1
go vet ./...
go test -race -vet=off ./storage -count=1
git diff --check
```

All checks pass with the fix.

## Related issues/PRs

- Distinct from the nil-map storage fix in #1998 and #1999
- Related storage context work: #2188

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression tests fail on the previous implementation
- [x] New and existing relevant unit tests pass locally
