### PR TITLE
fix(hostsensor): avoid mutating shared Kubernetes config

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -39,6 +40,7 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 	if config == nil {
 		return nil, fmt.Errorf("failed to get k8s config")
 	}
+	config = rest.CopyConfig(config)
 	// force GRPC
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
 	config.ContentType = "application/vnd.kubernetes.protobuf"

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler_config_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler_config_test.go
@@ -1,0 +1,38 @@
+package hostsensorutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig(t *testing.T) {
+	sharedConfig := &rest.Config{
+		Host: "https://cluster.example.test",
+		ContentConfig: rest.ContentConfig{
+			AcceptContentTypes: "application/json",
+			ContentType:        "application/json",
+		},
+	}
+	originalConfig := k8sinterface.K8SConfig
+	k8sinterface.K8SConfig = sharedConfig
+	t.Cleanup(func() {
+		k8sinterface.K8SConfig = originalConfig
+	})
+
+	k8sObj := NewKubernetesApiMock(WithNode(v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}))
+	k8sObj.Context = context.Background()
+
+	handler, err := NewHostSensorHandler(k8sObj, "")
+
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	assert.Equal(t, "application/json", sharedConfig.AcceptContentTypes)
+	assert.Equal(t, "application/json", sharedConfig.ContentType)
+}


### PR DESCRIPTION
## Overview

`NewHostSensorHandler` receives the package-level `*rest.Config` returned by `k8sinterface.GetK8sConfig()` and sets its content types to Kubernetes protobuf in place. Because that pointer is shared, constructing the host sensor can change the configuration observed by unrelated Kubernetes clients created later.

Copy the REST config before applying the host-sensor-specific content-type overrides. This keeps the existing host sensor behavior while preventing the overrides from leaking into shared process state.

## Changes

- Copy the shared Kubernetes REST config before applying protobuf content types.
- Add a regression test that constructs a valid handler and verifies the shared JSON configuration remains unchanged.

## Validation

The regression test was first run against the previous implementation and failed because both shared content-type fields became `application/vnd.kubernetes.protobuf`.

```sh
go test ./core/pkg/hostsensorutils \
  -run '^TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig$' \
  -count=1
go test ./core/pkg/hostsensorutils -count=1
go vet ./core/pkg/hostsensorutils
go test -race ./core/pkg/hostsensorutils -count=1
git diff --check
```

## Related issues/PRs

- #1916 introduced the CRD-based host sensor handler
- #2702 addresses a separate race while lazily loading the global Kubernetes config; it does not prevent this in-place mutation

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally
