### PR TITLE
fix(operator): honor --kube-context in vulnerability scan payload

### DIFF
--- a/cmd/operator/vulnerabilitiesscan.go
+++ b/cmd/operator/vulnerabilitiesscan.go
@@ -19,9 +19,7 @@ var operatorScanVulnerabilitiesExamples = fmt.Sprintf(`
 `, cautils.ExecName())
 
 func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils.OperatorInfo) *cobra.Command {
-	vulnerabilitiesScanInfo := &cautils.VulnerabilitiesScanInfo{
-		ClusterName: k8sinterface.GetContextName(),
-	}
+	vulnerabilitiesScanInfo := &cautils.VulnerabilitiesScanInfo{}
 
 	configCmd := &cobra.Command{
 		Use:     "vulnerabilities",
@@ -33,6 +31,7 @@ func getOperatorScanVulnerabilitiesCmd(ks meta.IKubescape, operatorInfo *cautils
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			vulnerabilitiesScanInfo.ClusterName = k8sinterface.GetContextName()
 			operatorAdapter, err := newOperatorAdapter(vulnerabilitiesScanInfo, operatorInfo.Namespace)
 			if err != nil {
 				return err

--- a/cmd/operator/vulnerabilitiesscan_test.go
+++ b/cmd/operator/vulnerabilitiesscan_test.go
@@ -1,12 +1,17 @@
 package operator
 
 import (
+	"errors"
+	"io"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/core"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
@@ -26,4 +31,43 @@ func TestGetOperatorScanVulnerabilitiesCmd(t *testing.T) {
 
 	err := cmd.Args(&cobra.Command{}, []string{"random-arg"})
 	assert.Nil(t, err)
+}
+
+func TestOperatorScanVulnerabilitiesCmd_ResolvesClusterNameAfterRootPreRun(t *testing.T) {
+	previousContext := k8sinterface.GetContextName()
+	k8sinterface.SetClusterContextName("construction-context")
+	t.Cleanup(func() { k8sinterface.SetClusterContextName(previousContext) })
+
+	previousAdapter := newOperatorAdapter
+	var gotScanInfo cautils.OperatorScanInfo
+	newOperatorAdapter = func(scanInfo cautils.OperatorScanInfo, _ string) (*core.OperatorAdapter, error) {
+		gotScanInfo = scanInfo
+		return nil, errors.New("stub: no real cluster in unit tests")
+	}
+	t.Cleanup(func() { newOperatorAdapter = previousAdapter })
+
+	var kubeContext string
+	rootCmd := &cobra.Command{
+		Use: "kubescape",
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			k8sinterface.SetClusterContextName(kubeContext)
+			return nil
+		},
+	}
+	rootCmd.PersistentFlags().StringVar(&kubeContext, "kube-context", "", "")
+	rootCmd.AddCommand(getOperatorScanVulnerabilitiesCmd(&mocks.MockIKubescape{}, &cautils.OperatorInfo{}))
+	rootCmd.SetArgs([]string{"vulnerabilities", "--kube-context", "selected-context"})
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+
+	err := rootCmd.Execute()
+	require.ErrorContains(t, err, "stub: no real cluster in unit tests")
+
+	vulnerabilitiesScanInfo, ok := gotScanInfo.(*cautils.VulnerabilitiesScanInfo)
+	require.True(t, ok)
+	assert.Equal(t, "selected-context", vulnerabilitiesScanInfo.ClusterName)
+
+	payload := vulnerabilitiesScanInfo.GetRequestPayload()
+	require.Len(t, payload.Commands, 1)
+	assert.Equal(t, "wlid://cluster-selected-context/namespace-", payload.Commands[0].WildWlid)
 }


### PR DESCRIPTION
## Overview

Resolve the operator vulnerability scan cluster name when the command executes, after root persistent pre-run processing has applied `--kube-context`.

The command previously captured `k8sinterface.GetContextName()` while constructing the Cobra tree. Root context selection happens later, so the operator request payload and generated WLID could retain the construction-time context instead of the context selected by the user.

## Changes

- Defer cluster-name resolution from command construction to `RunE`.
- Add a Cobra-level regression test that changes the context in root `PersistentPreRunE`.
- Verify both the adapter input and generated vulnerability-scan WLID use the selected context.

## Validation

The regression test was first run against the previous implementation and failed with `construction-context` instead of `selected-context`.

```sh
go test ./cmd/operator \
  -run '^TestOperatorScanVulnerabilitiesCmd_ResolvesClusterNameAfterRootPreRun$' \
  -count=1
go test ./cmd/operator -count=1
go test ./cmd/... -count=1
go vet ./cmd/...
go test -race ./cmd/operator -count=1
git diff --check
```

## Related issues/PRs

- #2591 covers operator namespace propagation; this fix is limited to cluster-context timing

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The regression test fails on the previous implementation
- [x] New and existing relevant unit tests pass locally
