### PR TITLE
chore: remove orphaned firstNonEmpty doc comment

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -628,4 +628,3 @@ func GetTenantConfig(ctx context.Context, accountID, accessKey, clusterName, cus
 	return NewClusterConfig(ctx, k8s, accountID, accessKey, clusterName, customClusterName)
 }
 
-// firstNonEmpty returns the first non-empty string


### PR DESCRIPTION
## Overview
This PR removes a stray, orphaned doc comment (`// firstNonEmpty returns the first non-empty string`) from the bottom of `core/cautils/customerloader.go`. 
The function it references no longer exists in the codebase (likely leftover debris from a deleted or renamed helper function). This is purely a tech-debt cleanup to prevent confusion during code reviews.
## Additional Information
> N/A - Minor tech-debt cleanup.
## How to Test
> N/A - This is a deletion of a single comment line; no functional changes were made.

## Related issues/PRs:
* Closes #2944
## Checklist before requesting a review
put an [x] in the box to get it checked 
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete internal documentation.
  * No user-visible functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->