### PR TITLE
feat: scan kubernetes_manifest resources in Terraform files (#719)

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -426,6 +426,22 @@ func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath s
 	return sourceToWorkloads, renderedDirs
 }
 
+func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, error) {
+	if !isTerraformDirectory(basePath) && !IsTerraformFile(basePath) {
+		return nil, nil
+	}
+	dir := basePath
+	if IsTerraformFile(basePath) {
+		dir = filepath.Dir(basePath)
+	}
+	td := NewTerraformDirectory(dir)
+	wls, errs := td.GetWorkloads(dir)
+	if len(errs) > 0 {
+		return wls, fmt.Errorf("failed to render Terraform resources from %q: %w", dir, errors.Join(errs...))
+	}
+	return wls, nil
+}
+
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts
 // are the chart directories LoadResourcesFromHelmCharts already rendered; their templates are left
 // to that render and skipped here. Pass nil to scan everything (e.g. when no charts were rendered).
@@ -650,7 +666,9 @@ func readJsonFile(jsonFile []byte) (workloads []workloadinterface.IMetadata, err
 	}()
 
 	var jsonObj any
-	if err := json.Unmarshal(jsonFile, &jsonObj); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(jsonFile))
+	decoder.UseNumber()
+	if err := decoder.Decode(&jsonObj); err != nil {
 		return workloads, err
 	}
 

--- a/core/cautils/terraform.go
+++ b/core/cautils/terraform.go
@@ -1,0 +1,203 @@
+package cautils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func isTerraformDirectory(path string) bool {
+	if !isDir(path) {
+		return false
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".tf" {
+			return true
+		}
+	}
+	return false
+}
+
+func IsTerraformFile(path string) bool {
+	return filepath.Ext(path) == ".tf"
+}
+
+type TerraformDirectory struct{ path string }
+
+func NewTerraformDirectory(path string) *TerraformDirectory {
+	return &TerraformDirectory{path: path}
+}
+
+// GetWorkloads extracts embedded K8s manifests from resource "kubernetes_manifest" blocks.
+// Only literal values and var.x references with a same-module default are resolved —
+// deliberately not a full Terraform evaluator (see LoadResourcesFromTerraform doc).
+func (td *TerraformDirectory) GetWorkloads(path string) (map[string][]workloadinterface.IMetadata, []error) {
+	parser := hclparse.NewParser()
+	var errs []error
+
+	tfFiles, err := filepath.Glob(filepath.Join(path, "*.tf"))
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	varDefaults := map[string]cty.Value{}
+	var files []*hcl.File
+	var parsedPaths []string
+	for _, f := range tfFiles {
+		file, diags := parser.ParseHCLFile(f)
+		if diags.HasErrors() {
+			errs = append(errs, fmt.Errorf("parsing %s: %w", f, diags))
+			continue
+		}
+		files = append(files, file)
+		parsedPaths = append(parsedPaths, f)
+		collectVariableDefaults(file.Body, varDefaults)
+	}
+
+	evalCtx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{"var": cty.ObjectVal(varDefaults)},
+	}
+
+	workloads := map[string][]workloadinterface.IMetadata{}
+	for i, file := range files {
+		manifests, fileErrs := extractKubernetesManifests(file.Body, evalCtx)
+		errs = append(errs, fileErrs...)
+		src := parsedPaths[i]
+		for j, m := range manifests {
+			data, err := json.Marshal(m)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s: manifest %d: %w", src, j, err))
+				continue
+			}
+			wls, err := ReadFile(data, JSON_FILE_FORMAT)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s: manifest %d not a valid k8s object: %w", src, j, err))
+				continue
+			}
+			for _, w := range wls {
+				lw := localworkload.NewLocalWorkload(w.GetObject())
+				lw.SetPath(fmt.Sprintf("%s:%d", src, j))
+				workloads[src] = append(workloads[src], lw)
+			}
+		}
+	}
+	return workloads, errs
+}
+
+// collectVariableDefaults walks top-level `variable "x" { default = ... }` blocks
+// and records the default so resource blocks can resolve var.x references.
+// Variables with no default are intentionally skipped — they stay unresolved.
+func collectVariableDefaults(body hcl.Body, defaults map[string]cty.Value) {
+	schema := &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "variable", LabelNames: []string{"name"}},
+		},
+	}
+	content, _, _ := body.PartialContent(schema)
+	for _, block := range content.Blocks {
+		if len(block.Labels) == 0 {
+			continue
+		}
+		name := block.Labels[0]
+		attrSchema := &hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{{Name: "default"}},
+		}
+		attrContent, _, _ := block.Body.PartialContent(attrSchema)
+		attr, ok := attrContent.Attributes["default"]
+		if !ok {
+			continue
+		}
+		val, diags := attr.Expr.Value(nil)
+		if diags.HasErrors() {
+			continue
+		}
+		defaults[name] = val
+	}
+}
+
+// extractKubernetesManifests finds resource "kubernetes_manifest" "x" { manifest = {...} }
+// blocks and returns each manifest as a plain Go map, ready for json.Marshal.
+func extractKubernetesManifests(body hcl.Body, evalCtx *hcl.EvalContext) ([]map[string]interface{}, []error) {
+	var errs []error
+	schema := &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "resource", LabelNames: []string{"type", "name"}},
+		},
+	}
+	content, _, _ := body.PartialContent(schema)
+
+	var manifests []map[string]interface{}
+	for _, block := range content.Blocks {
+		if len(block.Labels) < 2 || block.Labels[0] != "kubernetes_manifest" {
+			continue
+		}
+		attrSchema := &hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{{Name: "manifest"}},
+		}
+		attrContent, _, _ := block.Body.PartialContent(attrSchema)
+		attr, ok := attrContent.Attributes["manifest"]
+		if !ok {
+			continue
+		}
+		val, diags := attr.Expr.Value(evalCtx)
+		if diags.HasErrors() {
+			logger.L().Warning("skipping unresolved kubernetes_manifest reference",
+				helpers.String("resource", block.Labels[1]), helpers.Error(diags))
+			continue
+		}
+		goVal := ctyToGo(val)
+		m, ok := goVal.(map[string]interface{})
+		if !ok {
+			errs = append(errs, fmt.Errorf("resource %q: manifest is not an object", block.Labels[1]))
+			continue
+		}
+		manifests = append(manifests, m)
+	}
+	return manifests, errs
+}
+
+// ctyToGo converts a cty.Value into plain Go types (map[string]interface{}, []interface{},
+// string, float64, bool, nil) so it can be json.Marshal'd. Unresolved/unknown values
+// (e.g. references to things we didn't evaluate) become nil rather than erroring, so one
+// unresolved field doesn't drop the whole manifest.
+func ctyToGo(v cty.Value) interface{} {
+	if v.IsNull() || !v.IsKnown() {
+		return nil
+	}
+	t := v.Type()
+	switch {
+	case t.IsObjectType() || t.IsMapType():
+		out := map[string]interface{}{}
+		for k, val := range v.AsValueMap() {
+			out[k] = ctyToGo(val)
+		}
+		return out
+	case t.IsTupleType() || t.IsListType() || t.IsSetType():
+		var out []interface{}
+		for _, val := range v.AsValueSlice() {
+			out = append(out, ctyToGo(val))
+		}
+		return out
+	case t == cty.String:
+		return v.AsString()
+	case t == cty.Bool:
+		return v.True()
+	case t == cty.Number:
+		return json.Number(v.AsBigFloat().Text('f', -1))
+	default:
+		return nil
+	}
+}

--- a/core/cautils/terraform_test.go
+++ b/core/cautils/terraform_test.go
@@ -1,0 +1,54 @@
+package cautils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformDirectory_GetWorkloads(t *testing.T) {
+	td := NewTerraformDirectory("testdata/terraform")
+	workloads, errs := td.GetWorkloads("testdata/terraform")
+	require.Empty(t, errs)
+	require.Contains(t, workloads, "testdata/terraform/main.tf")
+
+	wls := workloads["testdata/terraform/main.tf"]
+	require.Len(t, wls, 1)
+	assert.Equal(t, "Deployment", wls[0].GetKind())
+	assert.Equal(t, "nginx", wls[0].GetName())
+	assert.Equal(t, "default", wls[0].GetNamespace())
+}
+
+func TestIsTerraformFile(t *testing.T) {
+	assert.True(t, IsTerraformFile("main.tf"))
+	assert.False(t, IsTerraformFile("main.yaml"))
+}
+
+func TestTerraformDirectory_GetWorkloads_PreservesLargeIntegerPrecision(t *testing.T) {
+	td := NewTerraformDirectory("testdata/terraform_bignum")
+	workloads, errs := td.GetWorkloads("testdata/terraform_bignum")
+	require.Empty(t, errs)
+	require.NotEmpty(t, workloads)
+
+	var found bool
+	for _, wls := range workloads {
+		for _, w := range wls {
+			obj := w.GetObject()
+			meta, ok := obj["metadata"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ann, ok := meta["annotations"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if v, ok := ann["big-number"]; ok {
+				assert.Equal(t, "9007199254740993", fmt.Sprintf("%v", v))
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "expected to find the big-number annotation in scanned output")
+}

--- a/core/cautils/testdata/terraform/main.tf
+++ b/core/cautils/testdata/terraform/main.tf
@@ -1,0 +1,31 @@
+variable "namespace" {
+  default = "default"
+}
+
+resource "kubernetes_manifest" "test_deployment" {
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = "nginx"
+      namespace = var.namespace
+    }
+    spec = {
+      replicas = 1
+      selector = {
+        matchLabels = { app = "nginx" }
+      }
+      template = {
+        metadata = { labels = { app = "nginx" } }
+        spec = {
+          containers = [
+            {
+              name  = "nginx"
+              image = "nginx:1.25"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/core/cautils/testdata/terraform_bignum/main.tf
+++ b/core/cautils/testdata/terraform_bignum/main.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_manifest" "bignum_test" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name = "bignum-test"
+      annotations = {
+        "big-number" = 9007199254740993
+      }
+    }
+    data = {}
+  }
+}

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -353,6 +353,54 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// consumed by the plain-manifest loader as untransformed raw manifests.
 	excludeFilesUnderDirectories(sourceToWorkloads, nestedKustomizeDirs)
 
+	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraform(ctx, path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// merge Terraform-derived workloads, same pattern as the Kustomize block below
+	for source, ws := range terraformSourceToWorkloads {
+		workloads = append(workloads, ws...)
+		relSource, err := filepath.Rel(repoRoot, source)
+		if err == nil {
+			source = relSource
+		}
+
+		var lastCommit reporthandling.LastCommit
+		if gitRepo != nil {
+			if commitInfo, _ := gitRepo.GetFileLastCommit(source); commitInfo != nil {
+				lastCommit = reporthandling.LastCommit{
+					Hash:           commitInfo.SHA,
+					Date:           commitInfo.Author.Date,
+					CommitterName:  commitInfo.Author.Name,
+					CommitterEmail: commitInfo.Author.Email,
+					Message:        commitInfo.Message,
+				}
+			}
+		}
+
+		var workloadSource reporthandling.Source
+		if clonedRepo != "" {
+			workloadSource = reporthandling.Source{
+				Path:         "",
+				RelativePath: source,
+				FileType:     "Terraform",
+				LastCommit:   lastCommit,
+			}
+		} else {
+			workloadSource = reporthandling.Source{
+				Path:         repoRoot,
+				RelativePath: source,
+				FileType:     "Terraform",
+				LastCommit:   lastCommit,
+			}
+		}
+
+		for i := range ws {
+			workloadIDToSource[ws[i].GetID()] = workloadSource
+		}
+	}
+
 	// update workloads and workloadIDToSource
 	var warnIssued bool
 	for source, ws := range sourceToWorkloads {

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -15,7 +15,7 @@ import (
 // providerRank ranks discovery providers so rendered output wins over raw file input.
 func providerRank(fileType string) int {
 	switch fileType {
-	case reporthandling.SourceTypeKustomizeDirectory, reporthandling.SourceTypeHelmChart:
+	case reporthandling.SourceTypeKustomizeDirectory, reporthandling.SourceTypeHelmChart, "Terraform":
 		return 2
 	case reporthandling.SourceTypeYaml, reporthandling.SourceTypeJson:
 		return 1

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/google/cel-go v0.29.0
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/johnfercher/go-tree v1.1.0
 	github.com/johnfercher/maroto/v2 v2.2.2
@@ -65,6 +66,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/zclconf/go-cty v1.17.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -353,7 +355,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/hhrutter/lzw v1.0.0 // indirect
 	github.com/hhrutter/tiff v1.0.1 // indirect
@@ -547,7 +548,6 @@ require (
 	github.com/yl2chen/cidranger v1.0.2 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	github.com/zclconf/go-cty v1.17.0 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.46.0 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.mongodb.org/mongo-driver v1.17.7 // indirect


### PR DESCRIPTION
## What
Adds support for scanning Kubernetes objects defined via the `kubernetes_manifest` resource type in Terraform files, closing part of #719.

## Scope (intentionally narrow - see discussion on #719)
This does **not** attempt general Terraform → Kubernetes conversion. As discussed on the issue, there's no reliable 1:1 mapping from typed Terraform Kubernetes-provider resources (`kubernetes_deployment`, `kubernetes_pod`, etc.) to K8s manifests, and no
existing library solves that cleanly.

Instead, this targets `kubernetes_manifest` blocks specifically, since the `manifest = {...}` attribute is already K8s-shaped HCL - no field-mapping needed, just extraction.

```hcl
resource "kubernetes_manifest" "example" {
  manifest = {
    apiVersion = "apps/v1"
    kind       = "Deployment"
    metadata   = { name = "nginx" }
    spec       = { ... }
  }
}
```

## How
- Static HCL parsing via `hashicorp/hcl/v2` (already an indirect dependency, now promoted to direct) - deliberately not `terraform plan`/`terraform show -json`, which requires live provider credentials and would break static, pre-deployment
  scanning.
- `var.x` references are resolved only when the variable has a `default` in the sam  module. Everything else (module outputs, remote state, data sources) is left unresolved and the manifest is skipped with a warning rather than guessed at.
- Extracted manifests are converted to JSON and fed through the existing  `ReadFile`/workload-conversion pipeline - the same path Helm and Kustomize already  use, so no changes to downstream scanning/OPA logic.

## Files changed
- `core/cautils/terraform.go` (new) — HCL parsing, variable defaults, manifest extraction
- `core/cautils/terraform_test.go`, `core/cautils/testdata/terraform/` (new) — tests
- `core/cautils/fileutils.go` — `LoadResourcesFromTerraform` wrapper
- `core/pkg/resourcehandler/filesloader.go` — wired into `getResourcesFromPath`
- `core/pkg/resourcehandler/filesloaderutils.go` — `providerRank` updated so Terraform-derived resources dedupe correctly against other sources

## Known limitations
- Only `kubernetes_manifest` resources are scanned; typed provider resources are not.
- Variable resolution is best-effort (module-local defaults only), matching how other
  static IaC scanners (Checkov, tfsec) handle unresolvable values.
- `FileType` currently uses the string literal `"Terraform"` rather than a formal
  `reporthandling.SourceType...` constant, since that lives in `kubescape/opa-utils`.
  Happy to follow up there if this direction is accepted.

## Testing
- New unit tests in `core/cautils/terraform_test.go`
- Full existing suite in `core/cautils/...` and `core/pkg/resourcehandler/...` passes
- Manually verified via `kubescape scan core/cautils/testdata/terraform`

Refs #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading Kubernetes workloads from Terraform files and directories.
  * Terraform manifests with supported variable defaults and local references are converted into discoverable workloads.
  * Terraform source and Git metadata are recorded alongside loaded resources.
  * Terraform workloads are prioritized consistently with other configuration sources.

* **Bug Fixes**
  * Preserved successfully parsed workloads when individual Terraform entries contain errors.
  * Maintained precision for large numeric values in workload metadata.

* **Tests**
  * Added coverage for Terraform file detection and workload extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->