### PR TITLE
chore(ci): refresh pinned GitHub Actions versions

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -32,7 +32,7 @@ jobs:
       artifact-metadata: read
     runs-on: ubuntu-large
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-large
     steps:
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         name: Installing go
         with:
           go-version-file: go.mod

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        uses: github/codeql-action/upload-sarif@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Overview
This refreshes a small set of pinned GitHub Actions in the repository workflows so the CI configuration stops lagging on deprecated Node 20 era action versions.

## Additional Information
The change is limited to workflow maintenance. It updates the reusable PR scanner, release workflow, and Scorecard workflow without changing the repository build or test commands.

## How to Test
- Run `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.y*ml`
- Confirm the updated workflow files still parse correctly
- Let GitHub Actions re-run on the PR branch

## Related issues/PRs:
* Resolved #2949

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated release and validation workflows to use refreshed, securely pinned tooling.
  - Improved the reliability of source retrieval, build setup, and security reporting during automated checks.
  - No changes to user-facing functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->