### PR TITLE
test(cautils): fix path-quoting and permission-bit assumptions on Windows

### DIFF
--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -59,7 +60,11 @@ func TestTenantConfigCacheLifecycleDataDriven(t *testing.T) {
 			require.NoError(t, config.UpdateCachedConfig())
 			info, err := os.Stat(ConfigFileFullPath())
 			require.NoError(t, err)
-			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+			// Windows has no Unix permission bits: os.Chmod only toggles the
+			// read-only attribute, so a file created 0600 reports 0666.
+			if goruntime.GOOS != "windows" {
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+			}
 
 			var persisted ConfigObj
 			contents, err := os.ReadFile(ConfigFileFullPath())

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,9 @@ func TestLoadResourcesFromFilesReturnsErrorForMissingInput(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, workloads)
 	assert.Contains(t, err.Error(), "no YAML or JSON manifest files")
-	assert.Contains(t, err.Error(), missing)
+	// The error formats the input with %q, which escapes the separators in a
+	// Windows path, so the raw path is not a substring of it.
+	assert.Contains(t, err.Error(), strconv.Quote(missing))
 }
 
 func TestLoadResourcesFromFilesReturnsErrorForEmptyDirectory(t *testing.T) {
@@ -59,7 +62,7 @@ func TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Empty(t, workloads)
-	assert.Contains(t, err.Error(), broken)
+	assert.Contains(t, err.Error(), strconv.Quote(broken))
 	assert.Contains(t, err.Error(), "failed to parse")
 }
 
@@ -74,7 +77,7 @@ func TestLoadResourcesFromFilesReturnsYAMLDocumentNumber(t *testing.T) {
 	require.Contains(t, workloads, path)
 	assert.Len(t, workloads[path], 1, "valid documents should remain available for diagnostics")
 	assert.Contains(t, err.Error(), "document 2")
-	assert.Contains(t, err.Error(), path)
+	assert.Contains(t, err.Error(), strconv.Quote(path))
 }
 
 func TestLoadResourcesFromFilesKeepsValidResourcesFromMixedDirectory(t *testing.T) {


### PR DESCRIPTION
Refs #2951

## Overview

Five tests in `core/cautils` fail on Windows. Neither cause is a defect in kubescape — both are
assumptions in the tests that happen to hold on Linux, which is why CI is green.

**Path quoting.** `LoadResourcesFromFiles` formats its errors with `%q`
(`fileutils.go:447`, `:456`, `:491`). `%q` escapes the separators, so the message contains
`"C:\Users\..."` while the assertions looked for the raw `C:\Users\...`:

```
"...for input \"C:\\Users\\...\\does-not-exist\"" does not contain "C:\Users\...\does-not-exist"
```

On Linux a path has no backslashes to escape, so the substring matches by coincidence.
The assertions now compare against `strconv.Quote(path)`, which is what the error contains on
every platform.

**Permission bits.** `customerloader_data_driven_test.go` asserts the cached config file is
`0600`. Windows has no Unix mode bits — `os.Chmod` only toggles the read-only attribute — so
`Mode().Perm()` reports `0666` and the assertion fails with `expected: 0x180, actual: 0x1b6`.
Skipped on Windows rather than weakened, since it is a real check everywhere that enforces it.

## Scope

Tests only, no production changes. #2951 lists nine further failures in the same package from
two other causes (8.3 short paths vs resolved long paths, and `os.Symlink` needing privilege).
Those are deliberately not in this PR: the short-path one spans six tests across two files and
is easy to get subtly wrong, and the symlink one is a judgement call about whether to skip or
build the fixture differently. Happy to follow up on either.

## Verification

On Windows 11, Go 1.26.5, against `d5f1047`:

```
before:  go test ./core/cautils/   ->  14 failures
after:   go test ./core/cautils/   ->  10 failures
```

The five addressed here:

```
--- PASS: TestTenantConfigCacheLifecycleDataDriven/local_configuration
--- PASS: TestTenantConfigCacheLifecycleDataDriven/cluster_configuration
--- PASS: TestLoadResourcesFromFilesReturnsErrorForMissingInput
--- PASS: TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath
--- PASS: TestLoadResourcesFromFilesReturnsYAMLDocumentNumber
```

Reviewing on Linux: `strconv.Quote` is a no-op for the substring check there (a path with no
backslashes quotes to itself plus the surrounding quotes, and the error already contains those),
and the mode assertion is unchanged off Windows. Behaviour on Linux is identical before and
after.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform test compatibility by skipping Unix-specific file-permission checks on Windows.
  * Updated file error validation to correctly handle quoted and escaped paths across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->