### PR TITLE
fix(streaming): initialize cluster metadata before policy planning

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -613,6 +613,11 @@ func estimateClusterSize(resourceHandler resourcehandler.IResourceHandler, ctx c
 // count because sessionObj.AllResources is populated asynchronously by the
 // producer goroutine.
 func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandler resourcehandler.IResourceHandler, scanData *cautils.OPASessionObj, scanInfo *cautils.ScanInfo, clusterName string, excludedNamespaces string, includeNamespaces string, enableRegoPrint bool, controlTimeout time.Duration, estimatedClusterSize int) error {
+	// The eager collector initializes this metadata before constructing the OPA
+	// processor. Do the same here because the cloud provider is a policy input,
+	// not only report metadata.
+	resourcehandler.CollectClusterMetadata(ctx, resourceHandler, scanData)
+
 	// Construct the processor before starting the producer goroutine. The
 	// producer does not touch scanData's resource maps (it carries them on the
 	// resident batch instead), but constructing first means the constructor's

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
+	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/version"
@@ -466,16 +468,58 @@ func TestKubescape_SetContextRestoresOriginal(t *testing.T) {
 
 type streamingCancelMock struct {
 	estimateClusterSizeMock
-	passedCtx context.Context
+	passedCtx                     context.Context
+	apiServerInfo                 *version.Info
+	cloudProvider                 string
+	providerAtStreamingSetup      string
+	apiServerInfoAtStreamingSetup *version.Info
+	scanningScopeAtStreamingSetup reporthandling.ScanningScopeType
 }
 
 func (m *streamingCancelMock) StreamResourcesBatches(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (<-chan *cautils.ResourceBatch, <-chan error, int, error) {
 	m.passedCtx = ctx
+	m.providerAtStreamingSetup = sessionObj.Report.ClusterCloudProvider
+	m.apiServerInfoAtStreamingSetup = sessionObj.Report.ClusterAPIServerInfo
+	m.scanningScopeAtStreamingSetup = cautils.GetScanningScope(sessionObj.Metadata.ContextMetadata)
 	batchChan := make(chan *cautils.ResourceBatch, 1)
 	errChan := make(chan error, 1)
+	batchChan <- cautils.NewResourceBatch(cautils.ClusterScope)
 	close(batchChan)
 	close(errChan)
 	return batchChan, errChan, 0, nil
+}
+
+func (m *streamingCancelMock) GetClusterAPIServerInfo(context.Context) *version.Info {
+	return m.apiServerInfo
+}
+
+func (m *streamingCancelMock) GetCloudProvider() string {
+	return m.cloudProvider
+}
+
+func TestCollectAndProcessResourcesWithStreaming_InitializesProviderScope(t *testing.T) {
+	apiServerInfo := &version.Info{GitVersion: "v1.31.0-eks"}
+	mockHandler := &streamingCancelMock{
+		apiServerInfo: apiServerInfo,
+		cloudProvider: "eks",
+	}
+	sessionObj := cautils.NewOPASessionObjMock()
+	sessionObj.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{
+		ContextName: "arn:aws:eks:us-east-1:123456789012:cluster/production",
+	}
+
+	err := collectAndProcessResourcesWithStreaming(context.Background(), mockHandler, sessionObj, &cautils.ScanInfo{}, "cluster", "", "", false, time.Second, 3000)
+
+	require.NoError(t, err)
+	assert.Same(t, apiServerInfo, sessionObj.Report.ClusterAPIServerInfo)
+	assert.Equal(t, "EKS", sessionObj.Report.ClusterCloudProvider)
+	require.NotNil(t, sessionObj.Metadata.ContextMetadata.ClusterContextMetadata.CloudMetadata)
+	assert.Equal(t, "EKS", mockHandler.providerAtStreamingSetup,
+		"cloud provider must be available before streaming starts")
+	assert.Same(t, apiServerInfo, mockHandler.apiServerInfoAtStreamingSetup,
+		"API server info must be available before streaming starts")
+	assert.Equal(t, reporthandling.ScopeCloudEKS, mockHandler.scanningScopeAtStreamingSetup,
+		"provider-scoped frameworks must not be filtered from streaming scans")
 }
 
 func TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext(t *testing.T) {

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -715,6 +715,7 @@ func TestMakeRegoDeps_InputIsolation(t *testing.T) {
 	_, runtimeExists := opap.regoDependenciesData.PostureControlInputs["runtime"]
 
 	assert.False(t, runtimeExists)
+	assert.Equal(t, "aws", deps.DataControlInputs["cloudProvider"])
 }
 
 func TestRunOPAOnSingleRuleDispatch(t *testing.T) {

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -18,12 +18,7 @@ import (
 func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) error {
 	ctx, span := otel.Tracer("").Start(ctx, "resourcehandler.CollectResources")
 	defer span.End()
-	opaSessionObj.Report.ClusterAPIServerInfo = rsrcHandler.GetClusterAPIServerInfo(ctx)
-
-	// set cloud metadata only when scanning a cluster
-	if rsrcHandler.GetCloudProvider() != "" {
-		setCloudMetadata(opaSessionObj, rsrcHandler.GetCloudProvider())
-	}
+	CollectClusterMetadata(ctx, rsrcHandler, opaSessionObj)
 
 	resourcesMap, allResources, externalResources, excludedRulesMap, getErr := rsrcHandler.GetResources(ctx, opaSessionObj, scanInfo)
 
@@ -46,6 +41,18 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	}
 
 	return nil
+}
+
+// CollectClusterMetadata initializes the report metadata that is also used as
+// policy input. Resource collection modes must call it before policy
+// evaluation so eager and streaming scans evaluate with the same cluster
+// context.
+func CollectClusterMetadata(ctx context.Context, rsrcHandler IResourceHandler, opaSessionObj *cautils.OPASessionObj) {
+	opaSessionObj.Report.ClusterAPIServerInfo = rsrcHandler.GetClusterAPIServerInfo(ctx)
+
+	if provider := rsrcHandler.GetCloudProvider(); provider != "" {
+		setCloudMetadata(opaSessionObj, provider)
+	}
 }
 
 func setCloudMetadata(opaSessionObj *cautils.OPASessionObj, provider string) {


### PR DESCRIPTION
## Overview

Streaming scans currently start policy planning without the cluster metadata initialization used by eager scans. On EKS, AKS, and GKE this leaves the scanning scope as generic `cluster`, so provider-scoped controls and whole managed-cloud frameworks are silently filtered from both resource query planning and evaluation.

This change extracts that initialization into `resourcehandler.CollectClusterMetadata` and calls it from both collection modes. The streaming path now initializes API-server and cloud-provider metadata before constructing the OPA processor or starting the producer.

The regression test verifies that, at `StreamResourcesBatches` entry:

- the EKS provider metadata is already populated;
- the scanning scope is `EKS`, not `cluster`; and
- API-server information is already available.

It also pins that the report cloud provider remains available to Rego dependency construction.

## How to Test

```sh
go test ./core/core ./core/pkg/opaprocessor ./core/pkg/resourcehandler \
  -run 'TestCollectAndProcessResourcesWithStreaming_InitializesProviderScope|TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext|TestMakeRegoDeps_InputIsolation|TestCollectResources$' \
  -count=1
```

The targeted tests pass locally. The complete `core/core` suite also passes.

The complete `core/pkg/opaprocessor` suite reaches one existing environment-dependent failure in `Test_verify/valid_signature` because the test tries to create `/root/.sigstore` in a read-only sandbox; the changed opaprocessor test passes independently.

## Related issues/PRs:

* Resolved #2955

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the ordering requirement
- [x] I have performed a self-review of the code and remote diff
- [x] I have added a regression test for the streaming provider scope
- [x] New and existing unit tests pass locally (one unrelated cosign test requires a writable sigstore home)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming scans now correctly include cluster and cloud-provider metadata in policy evaluation.
  * Scan reports now preserve API server details and normalize cloud-provider information consistently.
  * Cloud scanning scope and metadata are initialized before resource processing begins.

* **Tests**
  * Added coverage validating metadata initialization and cloud-provider handling for streaming scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->