### PR TITLE
chore: remove deprecated SA2WLIDmap from RBAC utils

### DIFF
--- a/core/cautils/rbac.go
+++ b/core/cautils/rbac.go
@@ -53,7 +53,6 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 	/*
 		************************************************************************************************************************
 			This code is adding a non valid ID ->
-				(github.com/kubescape/opa-utils v0.0.11): "//SA2WLIDmap/SA2WLIDmap"
 				(github.com/kubescape/opa-utils v0.0.12): "armo.rbac.com/v0beta1//SAID2WLIDmap/SAID2WLIDmap"
 
 			Should be investigated
@@ -61,14 +60,6 @@ func (rbacObjects *RBACObjects) rbacObjectsToResources(resources *rbacutils.Rbac
 	*/
 
 	// wrap rbac aggregated objects in IMetadata and add to AllResources
-	// TODO - DEPRECATE SA2WLIDmap
-	m, err := rbacutils.SA2WLIDmapIMetadataWrapper(resources.SA2WLIDmap)
-	if err != nil {
-		return nil, err
-	}
-
-	sa2WLIDmapIMeta := workloadinterface.NewBaseObject(m)
-	allresources[sa2WLIDmapIMeta.GetID()] = sa2WLIDmapIMeta
 
 	m2, err := rbacutils.SAID2WLIDmapIMetadataWrapper(resources.SAID2WLIDmap)
 	if err != nil {

--- a/core/cautils/rbac_test.go
+++ b/core/cautils/rbac_test.go
@@ -161,7 +161,6 @@ func TestRBACObjectsToResources(t *testing.T) {
 						},
 					},
 				},
-				SA2WLIDmap:   make(map[string][]string),
 				SAID2WLIDmap: make(map[string][]string),
 			},
 		},


### PR DESCRIPTION
## Overview
This PR removes the deprecated `SA2WLIDmap` usage from `core/cautils/rbac.go`. As noted in the codebase comments, this legacy map was injecting an invalid, broken ID (`//SA2WLIDmap/SA2WLIDmap`) into the resource map data. Removing it resolves this data corruption and cleans up long-standing tech debt without negatively affecting existing RBAC controls. Test mocks in `rbac_test.go` have been updated accordingly.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the deprecated `SA2WLIDmap` resource mapping.
  * Updated related warnings to reference the current mapping identifier and utility version.
* **Tests**
  * Updated test fixtures to use the supported resource mapping only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->