### PR TITLE
fix(imagescan): scope imagePullSecret resolution to cluster scans

### DIFF
--- a/core/core/registry_creds_test.go
+++ b/core/core/registry_creds_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,6 +158,134 @@ func TestResolveRegistryCredentialsSkipsUnusableSecrets(t *testing.T) {
 
 			assert.Equal(t, tt.expectedToBeFound, found)
 			assert.Equal(t, tt.expected, creds)
+		})
+	}
+}
+
+func TestCollectImageScanTargetsScopesPullSecretsToLiveCluster(t *testing.T) {
+	const (
+		namespace  = "default"
+		secretName = "registry-auth"
+		image      = "registry.example.com/team/app:tag"
+	)
+
+	tests := []struct {
+		name              string
+		scanType          cautils.ScanTypes
+		scanningContext   cautils.ScanningContext
+		singleResource    bool
+		expectSecretRead  bool
+		expectCredentials bool
+	}{
+		{
+			name:            "single file repository scan",
+			scanType:        cautils.ScanTypeRepo,
+			scanningContext: cautils.ContextFile,
+		},
+		{
+			name:            "directory repository scan",
+			scanType:        cautils.ScanTypeRepo,
+			scanningContext: cautils.ContextDir,
+		},
+		{
+			name:            "local Git repository scan",
+			scanType:        cautils.ScanTypeRepo,
+			scanningContext: cautils.ContextGitLocal,
+		},
+		{
+			name:            "remote Git repository scan",
+			scanType:        cautils.ScanTypeRepo,
+			scanningContext: cautils.ContextGitRemote,
+		},
+		{
+			name:            "file workload scan",
+			scanType:        cautils.ScanTypeWorkload,
+			scanningContext: cautils.ContextFile,
+			singleResource:  true,
+		},
+		{
+			name:            "directory workload scan",
+			scanType:        cautils.ScanTypeWorkload,
+			scanningContext: cautils.ContextDir,
+			singleResource:  true,
+		},
+		{
+			name:              "live cluster scan",
+			scanType:          cautils.ScanTypeCluster,
+			scanningContext:   cautils.ContextCluster,
+			expectSecretRead:  true,
+			expectCredentials: true,
+		},
+		{
+			name:              "live cluster workload scan",
+			scanType:          cautils.ScanTypeWorkload,
+			scanningContext:   cautils.ContextCluster,
+			singleResource:    true,
+			expectSecretRead:  true,
+			expectCredentials: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{"registry.example.com":{"username":"user","password":"password"}}}`),
+				},
+			})
+			k8sAPI := &k8sinterface.KubernetesApi{KubernetesClient: client}
+			workload := workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "app",
+					"namespace": namespace,
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{"name": "app", "image": image},
+					},
+					"imagePullSecrets": []interface{}{
+						map[string]interface{}{"name": secretName},
+					},
+				},
+			})
+			scanData := cautils.NewOPASessionObjMock()
+			if tt.singleResource {
+				scanData.SingleResourceScan = workload
+			} else {
+				scanData.AllResources[workload.GetID()] = workload
+			}
+
+			images, credentials := collectImageScanTargets(
+				tt.scanType,
+				scanData,
+				context.Background(),
+				tt.scanningContext,
+				k8sAPI,
+			)
+
+			assert.True(t, images.Contains(image))
+			if tt.expectSecretRead {
+				require.Len(t, client.Actions(), 1)
+				assert.Equal(t, "get", client.Actions()[0].GetVerb())
+				assert.Equal(t, "secrets", client.Actions()[0].GetResource().Resource)
+			} else {
+				assert.Empty(t, client.Actions(), "offline image scans must not read imagePullSecrets from the current cluster")
+			}
+
+			if tt.expectCredentials {
+				require.Len(t, credentials[image], 1)
+				assert.Equal(t, imagescan.RegistryCredentials{
+					Authority: "registry.example.com",
+					Username:  "user",
+					Password:  "password",
+				}, credentials[image][0])
+			} else {
+				assert.NotContains(t, credentials, image)
+			}
 		})
 	}
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -45,6 +45,7 @@ type componentInterfaces struct {
 	uiPrinter         printer.IPrinter
 	hostSensorHandler hostsensorutils.IHostSensor
 	outputPrinters    []printer.IPrinter
+	k8s               *k8sinterface.KubernetesApi
 }
 
 func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (componentInterfaces, error) {
@@ -121,6 +122,7 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdenti
 		outputPrinters:    outputPrinters,
 		uiPrinter:         uiPrinter,
 		hostSensorHandler: hostSensorHandler,
+		k8s:               k8s,
 	}, nil
 }
 
@@ -364,7 +366,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 
 	if scanInfo.ScanImages {
-		scanImages(scanInfo.ScanType, scanData, ks.Context(), resultsHandling, scanInfo)
+		scanImages(scanInfo.ScanType, scanData, ks.Context(), resultsHandling, scanInfo, interfaces.k8s)
 	}
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)
@@ -430,58 +432,8 @@ func resolveClusterContext(scanInfo *cautils.ScanInfo) error {
 	return nil
 }
 
-func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo) {
-	imagesToScan := mapset.NewSet[string]()
-	imageToCreds := make(map[string][]imagescan.RegistryCredentials)
-	k8sApi := k8sinterface.NewKubernetesApi()
-
-	if scanType == cautils.ScanTypeWorkload {
-		wl := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject())
-		containers, err := wl.GetContainers()
-		if err != nil {
-			logger.L().Error("failed to get containers", helpers.Error(err))
-			return
-		}
-		for _, container := range containers {
-			imagesToScan.Add(container.Image)
-			if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
-				found := false
-				for _, c := range imageToCreds[container.Image] {
-					if c == creds {
-						found = true
-						break
-					}
-				}
-				if !found {
-					imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
-				}
-			}
-		}
-	} else {
-		for _, workload := range scanData.AllResources {
-			wl := workloadinterface.NewWorkloadObj(workload.GetObject())
-			containers, err := wl.GetContainers()
-			if err != nil {
-				logger.L().Error(fmt.Sprintf("failed to get containers for kind: %s, name: %s, namespace: %s", workload.GetKind(), workload.GetName(), workload.GetNamespace()), helpers.Error(err))
-				continue
-			}
-			for _, container := range containers {
-				imagesToScan.Add(container.Image)
-				if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
-					found := false
-					for _, c := range imageToCreds[container.Image] {
-						if c == creds {
-							found = true
-							break
-						}
-					}
-					if !found {
-						imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
-					}
-				}
-			}
-		}
-	}
+func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo, k8sApi *k8sinterface.KubernetesApi) {
+	imagesToScan, imageToCreds := collectImageScanTargets(scanType, scanData, ctx, scanInfo.GetScanningContext(), k8sApi)
 
 	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
 	if err != nil {
@@ -547,6 +499,67 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 	if agg := orchestrator.GetErrorAggregator(); agg != nil && agg.HasErrors() {
 		logger.L().Warning(agg.Error())
 	}
+}
+
+func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, scanningContext cautils.ScanningContext, k8sApi *k8sinterface.KubernetesApi) (mapset.Set[string], map[string][]imagescan.RegistryCredentials) {
+	imagesToScan := mapset.NewSet[string]()
+	imageToCreds := make(map[string][]imagescan.RegistryCredentials)
+	if scanningContext != cautils.ContextCluster {
+		// imagePullSecrets belong to a live cluster target. A manifest or repository
+		// may contain the same Secret name as the current kube context, but that must
+		// never grant cluster credentials to an offline image scan.
+		k8sApi = nil
+	}
+
+	if scanType == cautils.ScanTypeWorkload {
+		wl := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject())
+		containers, err := wl.GetContainers()
+		if err != nil {
+			logger.L().Error("failed to get containers", helpers.Error(err))
+			return imagesToScan, imageToCreds
+		}
+		for _, container := range containers {
+			imagesToScan.Add(container.Image)
+			if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
+				found := false
+				for _, c := range imageToCreds[container.Image] {
+					if c == creds {
+						found = true
+						break
+					}
+				}
+				if !found {
+					imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
+				}
+			}
+		}
+	} else {
+		for _, workload := range scanData.AllResources {
+			wl := workloadinterface.NewWorkloadObj(workload.GetObject())
+			containers, err := wl.GetContainers()
+			if err != nil {
+				logger.L().Error(fmt.Sprintf("failed to get containers for kind: %s, name: %s, namespace: %s", workload.GetKind(), workload.GetName(), workload.GetNamespace()), helpers.Error(err))
+				continue
+			}
+			for _, container := range containers {
+				imagesToScan.Add(container.Image)
+				if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
+					found := false
+					for _, c := range imageToCreds[container.Image] {
+						if c == creds {
+							found = true
+							break
+						}
+					}
+					if !found {
+						imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
+					}
+				}
+			}
+		}
+	}
+
+	return imagesToScan, imageToCreds
 }
 
 func registryCredentialsFromScanInfo(scanInfo *cautils.ScanInfo) imagescan.RegistryCredentials {


### PR DESCRIPTION
## Overview

Prevent offline image scans from creating a global Kubernetes client or resolving manifest `imagePullSecrets` against the user's current cluster.

Before this change, `scanImages` unconditionally called `k8sinterface.NewKubernetesApi()`. As a result, file, directory, local Git, remote Git, and file-backed workload scans could:

- fail when kubeconfig or cluster connectivity was unavailable; or
- read a same-named registry Secret from an unrelated current cluster.

This change keeps live-cluster credential resolution for cluster scans while restoring isolation for offline scan targets.

## Implementation

- Retain the context-selected Kubernetes API in `componentInterfaces`.
- Pass that client into the image-scan path instead of constructing another global client.
- Extract image target collection into a focused helper.
- Reject a Kubernetes client for every non-cluster context, even if one is accidentally supplied by a future caller.
- Preserve `imagePullSecrets` resolution for cluster and cluster-workload scans.
- Add table-driven regression coverage for file, directory, local Git, remote Git, offline workload, cluster, and cluster-workload contexts.

The tests deliberately pass a populated fake Kubernetes client to every context. Offline cases assert zero Kubernetes actions and no collected cluster credentials; cluster cases assert the expected Secret lookup and credentials.

## How to Test

```console
go test ./core/core \
  -run 'TestCollectImageScanTargetsScopesPullSecretsToLiveCluster|TestResolveRegistryCredentials' \
  -count=1

go test ./core/core -count=1

go test -race ./core/core \
  -run '^TestCollectImageScanTargetsScopesPullSecretsToLiveCluster$' \
  -count=1
```

All commands pass.

## Related issues/PRs

- Resolves #2963
- Follow-up to #2831 and #2832
- Related but distinct from #2840 and #2841

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review
- [x] I have added regression coverage
- [x] Focused, full-package, and race-enabled tests pass locally
- [x] No documentation changes are required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image scanning across live cluster, offline repository, and workload scans.
  - Offline scans now collect image targets without attempting to access the current cluster.
  - Live cluster scans consistently use the initialized Kubernetes connection to resolve image-pull credentials.
  - Unavailable Kubernetes API connections now return a clear cluster connection error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->