### PR TITLE
fix(scan): propagate combined image scan failures

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -540,9 +540,13 @@ func (o *ImageScanOrchestrator) ScanImages(ctx context.Context, jobs []ImageScan
 			for job := range jobChan {
 				select {
 				case <-ctx.Done():
+					cancelErr := fmt.Errorf("scan canceled: %w", ctx.Err())
+					if o.errorAggregator != nil {
+						o.errorAggregator.Add(job.Image, cancelErr)
+					}
 					resultChan <- ImageScanResult{
 						Image: job.Image,
-						Error: fmt.Errorf("scan canceled: %w", ctx.Err()),
+						Error: cancelErr,
 					}
 					continue
 				default:

--- a/core/core/image_scan_concurrent_test.go
+++ b/core/core/image_scan_concurrent_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockImageScanService struct {
@@ -167,4 +170,99 @@ func TestImageScanOrchestrator_Concurrency(t *testing.T) {
 
 	assert.LessOrEqual(t, mockSvc.maxInFlight, 4, "Maximum in-flight calls should not exceed configured concurrency of 4")
 	assert.Greater(t, mockSvc.maxInFlight, 0, "Should have executed concurrently")
+}
+
+func TestScanImageJobsReturnsErrorsAndPreservesPartialResults(t *testing.T) {
+	mockSvc := newMockImageScanService(0)
+	scanErr := errors.New("unauthorized: authentication required")
+	mockSvc.errByImage["private.example/fail:latest"] = scanErr
+	mockSvc.dataByImage["example/success:latest"] = &cautils.ImageScanData{Image: "example/success:latest"}
+	results := &resultshandling.ResultsHandler{}
+
+	err := scanImageJobs(context.Background(), mockSvc, 2, []ImageScanJob{
+		{Image: "private.example/fail:latest"},
+		{Image: "example/success:latest"},
+	}, results)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private.example/fail:latest")
+	assert.Contains(t, err.Error(), scanErr.Error())
+	require.Len(t, results.ImageScanData, 1)
+	assert.Equal(t, "example/success:latest", results.ImageScanData[0].Image)
+}
+
+func TestScanImageJobsReturnsCancellationError(t *testing.T) {
+	mockSvc := newMockImageScanService(0)
+	results := &resultshandling.ResultsHandler{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := scanImageJobs(ctx, mockSvc, 1, []ImageScanJob{
+		{Image: "example/canceled:latest"},
+	}, results)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "example/canceled:latest")
+	assert.Contains(t, err.Error(), context.Canceled.Error())
+	assert.Zero(t, mockSvc.scanCalls)
+	assert.Empty(t, results.ImageScanData)
+}
+
+func TestScanImageJobsReturnsDiscoveryAndWorkerErrorsWithPartialResults(t *testing.T) {
+	newPod := func(name string, containers interface{}) *workloadinterface.Workload {
+		return workloadinterface.NewWorkloadObj(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "image-scan-test",
+			},
+			"spec": map[string]interface{}{
+				"containers": containers,
+			},
+		})
+	}
+
+	malformed := newPod("malformed", "not-a-container-list")
+	failing := newPod("worker-failure", []interface{}{
+		map[string]interface{}{"name": "app", "image": "private.example/fail:latest"},
+	})
+	successful := newPod("worker-success", []interface{}{
+		map[string]interface{}{"name": "app", "image": "example/success:latest"},
+	})
+	scanData := cautils.NewOPASessionObjMock()
+	for _, workload := range []*workloadinterface.Workload{malformed, failing, successful} {
+		scanData.AllResources[workload.GetID()] = workload
+	}
+
+	images, _, discoveryErrors := collectImageScanTargets(
+		cautils.ScanTypeCluster,
+		scanData,
+		context.Background(),
+		cautils.ContextFile,
+		nil,
+	)
+	require.Len(t, discoveryErrors, 1)
+	assert.Contains(t, discoveryErrors[0].Error(), "kind: Pod")
+	assert.Contains(t, discoveryErrors[0].Error(), "name: malformed")
+	assert.Contains(t, discoveryErrors[0].Error(), "namespace: image-scan-test")
+
+	jobs := make([]ImageScanJob, 0, images.Cardinality())
+	for image := range images.Iter() {
+		jobs = append(jobs, ImageScanJob{Image: image})
+	}
+	mockSvc := newMockImageScanService(0)
+	workerErr := errors.New("unauthorized: authentication required")
+	mockSvc.errByImage["private.example/fail:latest"] = workerErr
+	mockSvc.dataByImage["example/success:latest"] = &cautils.ImageScanData{Image: "example/success:latest"}
+	results := &resultshandling.ResultsHandler{}
+
+	err := scanImageJobsWithDiscoveryErrors(context.Background(), mockSvc, 2, jobs, results, discoveryErrors)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), discoveryErrors[0].Error())
+	assert.Contains(t, err.Error(), "private.example/fail:latest")
+	assert.Contains(t, err.Error(), workerErr.Error())
+	require.Len(t, results.ImageScanData, 1)
+	assert.Equal(t, "example/success:latest", results.ImageScanData[0].Image)
 }

--- a/core/core/registry_creds_test.go
+++ b/core/core/registry_creds_test.go
@@ -259,7 +259,7 @@ func TestCollectImageScanTargetsScopesPullSecretsToLiveCluster(t *testing.T) {
 				scanData.AllResources[workload.GetID()] = workload
 			}
 
-			images, credentials := collectImageScanTargets(
+			images, credentials, containerErrors := collectImageScanTargets(
 				tt.scanType,
 				scanData,
 				context.Background(),
@@ -267,6 +267,7 @@ func TestCollectImageScanTargetsScopesPullSecretsToLiveCluster(t *testing.T) {
 				k8sAPI,
 			)
 
+			assert.Empty(t, containerErrors)
 			assert.True(t, images.Contains(image))
 			if tt.expectSecretRead {
 				require.Len(t, client.Actions(), 1)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -366,7 +366,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 
 	if scanInfo.ScanImages {
-		scanImages(scanInfo.ScanType, scanData, ks.Context(), resultsHandling, scanInfo, interfaces.k8s)
+		resultsHandling.SetScanError(scanImages(scanInfo.ScanType, scanData, ks.Context(), resultsHandling, scanInfo, interfaces.k8s))
 	}
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)
@@ -432,25 +432,25 @@ func resolveClusterContext(scanInfo *cautils.ScanInfo) error {
 	return nil
 }
 
-func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo, k8sApi *k8sinterface.KubernetesApi) {
+func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, resultsHandling *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo, k8sApi *k8sinterface.KubernetesApi) error {
 	var scanningContext cautils.ScanningContext
 	if scanInfo != nil {
 		scanningContext = scanInfo.GetScanningContext()
 	}
-	imagesToScan, imageToCreds := collectImageScanTargets(scanType, scanData, ctx, scanningContext, k8sApi)
+	imagesToScan, imageToCreds, containerErrors := collectImageScanTargets(scanType, scanData, ctx, scanningContext, k8sApi)
 	if imagesToScan.IsEmpty() {
-		return
+		return errors.Join(containerErrors...)
 	}
 
 	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Invalid Grype database URL '%s': %v", scanInfo.ListingURL, err))
-		return
+		return errors.Join(append(containerErrors, fmt.Errorf("invalid Grype database URL %q: %w", scanInfo.ListingURL, err))...)
 	}
 	svc, err := imagescan.NewScanServiceWithMatchers(distCfg, installCfg, scanInfo.UseDefaultMatchers)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Failed to initialize image scanner: %s", err))
-		return
+		return errors.Join(append(containerErrors, fmt.Errorf("failed to initialize image scanner: %w", err))...)
 	}
 	defer svc.Close()
 	defaultCreds := registryCredentialsFromScanInfo(scanInfo)
@@ -489,6 +489,15 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 		concurrency = 1
 	}
 
+	return scanImageJobsWithDiscoveryErrors(ctx, svc, concurrency, jobs, resultsHandling, containerErrors)
+}
+
+func scanImageJobsWithDiscoveryErrors(ctx context.Context, svc imageScanService, concurrency int, jobs []ImageScanJob, resultsHandling *resultshandling.ResultsHandler, discoveryErrors []error) error {
+	errs := append([]error{}, discoveryErrors...)
+	return errors.Join(append(errs, scanImageJobs(ctx, svc, concurrency, jobs, resultsHandling))...)
+}
+
+func scanImageJobs(ctx context.Context, svc imageScanService, concurrency int, jobs []ImageScanJob, resultsHandling *resultshandling.ResultsHandler) error {
 	logger.L().Info(fmt.Sprintf("Scanning %d images concurrently with %d workers...", len(jobs), concurrency))
 	orchestrator := NewImageScanOrchestrator(svc, concurrency)
 	results := orchestrator.ScanImages(ctx, jobs)
@@ -505,12 +514,15 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 	}
 	if agg := orchestrator.GetErrorAggregator(); agg != nil && agg.HasErrors() {
 		logger.L().Warning(agg.Error())
+		return agg
 	}
+	return nil
 }
 
-func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, scanningContext cautils.ScanningContext, k8sApi *k8sinterface.KubernetesApi) (mapset.Set[string], map[string][]imagescan.RegistryCredentials) {
+func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx context.Context, scanningContext cautils.ScanningContext, k8sApi *k8sinterface.KubernetesApi) (mapset.Set[string], map[string][]imagescan.RegistryCredentials, []error) {
 	imagesToScan := mapset.NewSet[string]()
 	imageToCreds := make(map[string][]imagescan.RegistryCredentials)
+	var containerErrors []error
 	if scanningContext != cautils.ContextCluster {
 		// imagePullSecrets belong to a live cluster target. A manifest or repository
 		// may contain the same Secret name as the current kube context, but that must
@@ -518,9 +530,13 @@ func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASe
 		k8sApi = nil
 	}
 
-	if scanType == cautils.ScanTypeWorkload {
-		wl := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject())
-		for _, image := range getAllWorkloadImages(wl) {
+	collectWorkload := func(wl *workloadinterface.Workload) {
+		images, workloadContainerErrors := getAllWorkloadImages(wl)
+		for _, containerErr := range workloadContainerErrors {
+			logger.L().Error("failed to collect image scan targets", helpers.Error(containerErr))
+			containerErrors = append(containerErrors, containerErr)
+		}
+		for _, image := range images {
 			imagesToScan.Add(image)
 			if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, image); ok {
 				found := false
@@ -535,28 +551,17 @@ func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASe
 				}
 			}
 		}
+	}
+
+	if scanType == cautils.ScanTypeWorkload {
+		collectWorkload(workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject()))
 	} else {
 		for _, workload := range scanData.AllResources {
-			wl := workloadinterface.NewWorkloadObj(workload.GetObject())
-			for _, image := range getAllWorkloadImages(wl) {
-				imagesToScan.Add(image)
-				if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, image); ok {
-					found := false
-					for _, c := range imageToCreds[image] {
-						if c == creds {
-							found = true
-							break
-						}
-					}
-					if !found {
-						imageToCreds[image] = append(imageToCreds[image], creds)
-					}
-				}
-			}
+			collectWorkload(workloadinterface.NewWorkloadObj(workload.GetObject()))
 		}
 	}
 
-	return imagesToScan, imageToCreds
+	return imagesToScan, imageToCreds, containerErrors
 }
 
 func registryCredentialsFromScanInfo(scanInfo *cautils.ScanInfo) imagescan.RegistryCredentials {
@@ -663,28 +668,39 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	return nil
 }
 
-func getAllWorkloadImages(wl *workloadinterface.Workload) []string {
+func getAllWorkloadImages(wl *workloadinterface.Workload) ([]string, []error) {
 	var images []string
-	if containers, err := wl.GetContainers(); err == nil {
+	var containerErrors []error
+	addContainerError := func(containerClass string, err error) {
+		containerErrors = append(containerErrors, fmt.Errorf("failed to get %s for kind: %s, name: %s, namespace: %s: %w", containerClass, wl.GetKind(), wl.GetName(), wl.GetNamespace(), err))
+	}
+
+	if containers, err := wl.GetContainers(); err != nil {
+		addContainerError("containers", err)
+	} else {
 		for _, c := range containers {
 			if c.Image != "" {
 				images = append(images, c.Image)
 			}
 		}
 	}
-	if initContainers, err := wl.GetInitContainers(); err == nil {
+	if initContainers, err := wl.GetInitContainers(); err != nil {
+		addContainerError("init containers", err)
+	} else {
 		for _, c := range initContainers {
 			if c.Image != "" {
 				images = append(images, c.Image)
 			}
 		}
 	}
-	if ephemeralContainers, err := wl.GetEphemeralContainers(); err == nil {
+	if ephemeralContainers, err := wl.GetEphemeralContainers(); err != nil {
+		addContainerError("ephemeral containers", err)
+	} else {
 		for _, c := range ephemeralContainers {
 			if c.Image != "" {
 				images = append(images, c.Image)
 			}
 		}
 	}
-	return images
+	return images, containerErrors
 }

--- a/core/core/scan_images_test.go
+++ b/core/core/scan_images_test.go
@@ -20,8 +20,9 @@ func TestScanImagesSkipsInitializationWhenNoImagesFound(t *testing.T) {
 			"ephemeralContainers": []any{},
 		},
 	})
-	images := getAllWorkloadImages(emptyPod)
+	images, containerErrors := getAllWorkloadImages(emptyPod)
 	assert.Empty(t, images)
+	assert.Empty(t, containerErrors)
 
 	tests := []struct {
 		name     string
@@ -45,7 +46,7 @@ func TestScanImagesSkipsInitializationWhenNoImagesFound(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.NotPanics(t, func() {
-				scanImages(tt.scanType, tt.scanData, context.Background(), nil, nil, nil)
+				assert.NoError(t, scanImages(tt.scanType, tt.scanData, context.Background(), nil, nil, nil))
 			})
 		})
 	}

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -566,10 +566,74 @@ func TestGetAllWorkloadImages(t *testing.T) {
 	}
 
 	wl := workloadinterface.NewWorkloadObj(podData)
-	images := getAllWorkloadImages(wl)
+	images, containerErrors := getAllWorkloadImages(wl)
 
+	require.Empty(t, containerErrors)
 	assert.Contains(t, images, "app:v1")
 	assert.Contains(t, images, "init:v1")
 	assert.Contains(t, images, "debug:v1")
 	assert.Len(t, images, 3)
+}
+
+func TestGetAllWorkloadImagesReturnsGetterErrorsAndPreservesOtherClasses(t *testing.T) {
+	tests := []struct {
+		name           string
+		malformedField string
+		containerClass string
+		wantImages     []string
+	}{
+		{
+			name:           "regular containers",
+			malformedField: "containers",
+			containerClass: "containers",
+			wantImages:     []string{"init:v1", "debug:v1"},
+		},
+		{
+			name:           "init containers",
+			malformedField: "initContainers",
+			containerClass: "init containers",
+			wantImages:     []string{"app:v1", "debug:v1"},
+		},
+		{
+			name:           "ephemeral containers",
+			malformedField: "ephemeralContainers",
+			containerClass: "ephemeral containers",
+			wantImages:     []string{"app:v1", "init:v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{"name": "main-app", "image": "app:v1"},
+				},
+				"initContainers": []interface{}{
+					map[string]interface{}{"name": "init-setup", "image": "init:v1"},
+				},
+				"ephemeralContainers": []interface{}{
+					map[string]interface{}{"name": "debug-tool", "image": "debug:v1"},
+				},
+			}
+			spec[tt.malformedField] = "not-a-container-list"
+			wl := workloadinterface.NewWorkloadObj(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "malformed",
+					"namespace": "image-scan-test",
+				},
+				"spec": spec,
+			})
+
+			images, containerErrors := getAllWorkloadImages(wl)
+
+			assert.ElementsMatch(t, tt.wantImages, images)
+			require.Len(t, containerErrors, 1)
+			assert.Contains(t, containerErrors[0].Error(), "failed to get "+tt.containerClass)
+			assert.Contains(t, containerErrors[0].Error(), "kind: Pod")
+			assert.Contains(t, containerErrors[0].Error(), "name: malformed")
+			assert.Contains(t, containerErrors[0].Error(), "namespace: image-scan-test")
+		})
+	}
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -26,6 +26,7 @@ type ResultsHandler struct {
 	ScanData      *cautils.OPASessionObj
 	PrinterObjs   []printer.IPrinter
 	ImageScanData []cautils.ImageScanData
+	scanError     error
 }
 
 func NewResultsHandler(reporterObj reporter.IReport, printerObjs []printer.IPrinter, uiPrinter printer.IPrinter) *ResultsHandler {
@@ -57,6 +58,13 @@ func (rh *ResultsHandler) GetData() *cautils.OPASessionObj {
 // SetData sets the scan/action related data
 func (rh *ResultsHandler) SetData(data *cautils.OPASessionObj) {
 	rh.ScanData = data
+}
+
+// SetScanError records a scan error that must be returned after any partial
+// results have been printed. This lets callers preserve useful scan output
+// without reporting a successful exit status for incomplete results.
+func (rh *ResultsHandler) SetScanError(err error) {
+	rh.scanError = err
 }
 
 // GetPrinters returns all printers
@@ -154,8 +162,8 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 		closePrinter(p)
 	}
 
-	if printErr != nil {
-		return printErr
+	if err := errors.Join(printErr, rh.scanError); err != nil {
+		return err
 	}
 
 	// We should submit only after printing results, so a user can see

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -115,6 +115,21 @@ func TestResultsHandlerHandleResultsReturnsPrinterErrors(t *testing.T) {
 	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
 }
 
+func TestResultsHandlerHandleResultsPrintsBeforeReturningScanError(t *testing.T) {
+	scanErr := errors.New("image scan failed")
+	uiPrinter := &SpyPrinter{}
+	outputPrinter := &SpyPrinter{}
+	rh := NewResultsHandler(nil, []printer.IPrinter{outputPrinter}, uiPrinter)
+	rh.SetData(cautils.NewOPASessionObjMock())
+	rh.SetScanError(scanErr)
+
+	err := rh.HandleResults(context.Background(), &cautils.ScanInfo{})
+
+	require.ErrorIs(t, err, scanErr)
+	assert.Equal(t, 1, uiPrinter.ActionPrintCalls)
+	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
+}
+
 func TestValidatePrinter(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Overview

Make combined posture scans return a failure when one or more requested image scans cannot be completed, while preserving any partial posture and image output.

Before this change, `scanImages` returned no error. Scanner configuration/initialization failures and all per-image worker failures were logged, then discarded. A CI job could therefore exit `0` even when every requested image scan failed.

## Implementation

- Make `scanImages` return scanner setup and regular/init/ephemeral container-enumeration errors with workload identity.
- Extract image job execution into a focused helper that returns the existing `ScanErrorAggregator`.
- Preserve every successful image result when other jobs fail.
- Store the aggregate error on `ResultsHandler`.
- Let `HandleResults` print UI and output-file results before returning the scan error.
- Combine printer and scan failures with `errors.Join`.
- Do not submit an incomplete report after a scan error.

The CLI therefore retains useful partial results but exits non-zero before severity and coverage gates can mistake missing image data for a clean result.

## How to Test

```bash
go test ./core/core ./core/pkg/resultshandling ./cmd/scan -count=1
```

All three packages pass.

Regression coverage verifies that:

1. a failed image job is returned in the aggregate error;
2. a successful image job from the same batch remains in `ImageScanData`;
3. UI and output printers run before the stored scan error is returned;
4. container getter failures are joined with worker failures while valid images and successful results from other classes/workloads are preserved.

## Related issues/PRs

- Resolves #2960
- #2759 introduced aggregation but only surfaced it as a warning.
- #2893 / #2894 cover severity gates for successful image results.
- #2630 / #2631 cover misleading log output, not exit status.
- #2941 covers cloud-adaptor error propagation.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review
- [x] I have added partial-success and result-printing regression tests
- [x] Relevant package tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image scan errors are now reported clearly while successful results remain available and displayed.
  * Results are printed before scan errors are returned, preventing partial output from being lost.
  * Errors from workload extraction, discovery, database configuration, scanner initialization, and canceled scans are surfaced properly.
  * Image collection continues when some workload containers fail, preserving results from successfully processed containers.

* **Tests**
  * Added coverage for aggregated errors, cancellation, and partial results.
  * Added regression coverage confirming output is printed before errors are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->