### PR TITLE
fix(sarif): avoid image scan deadlock on stdout

### DIFF
--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -1,17 +1,22 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/anchore/grype/grype/match"
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -145,7 +150,7 @@ func TestSARIFPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
 	sp := NewSARIFPrinter()
 	sp.writer = tmp
 
-	require.NoError(t, sp.printImageScan(context.Background(), imageScanData))
+	require.NoError(t, sp.printImageScan(imageScanData))
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
@@ -153,4 +158,47 @@ func TestSARIFPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
 	content := string(raw)
 	assert.Contains(t, content, "CVE-KEPT")
 	assert.NotContains(t, content, "CVE-EXCEPTED", "severity-excepted CVE must not appear in SARIF report output")
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.NotEmpty(t, report.Runs)
+	assert.Equal(t, "Kubescape", report.Runs[0].Tool.Driver.Name)
+}
+
+const imageSARIFStdoutHelperEnv = "KUBESCAPE_TEST_IMAGE_SARIF_STDOUT_HELPER"
+
+// TestSARIFPrinter_ImageScan_StdoutPipeCompletes runs the image SARIF printer
+// in a subprocess whose stdout is an actual OS pipe. Reopening /dev/stdout to
+// patch the report deadlocks because the process itself still owns the pipe's
+// write end; the printer must instead render and patch in memory before its
+// single write to stdout.
+func TestSARIFPrinter_ImageScan_StdoutPipeCompletes(t *testing.T) {
+	if os.Getenv(imageSARIFStdoutHelperEnv) == "1" {
+		sp := NewSARIFPrinter()
+		sp.SetWriter(context.Background(), "")
+		if err := sp.printImageScan(buildSeverityExceptionImageScanData()); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSARIFPrinter_ImageScan_StdoutPipeCompletes$") //nolint:gosec // G204: test subprocess re-executes test binary.
+	cmd.Env = append(os.Environ(), imageSARIFStdoutHelperEnv+"=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	raw, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatal("image SARIF output did not complete while stdout was a pipe")
+	}
+	require.NoError(t, err, stderr.String())
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.NotEmpty(t, report.Runs)
+	assert.Equal(t, "Kubescape", report.Runs[0].Tool.Driver.Name)
 }

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -124,7 +125,7 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 		})
 }
 
-func (sp *SARIFPrinter) printImageScan(ctx context.Context, scanResults cautils.ImageScanData) error {
+func (sp *SARIFPrinter) printImageScan(scanResults cautils.ImageScanData) error {
 	model, err := models.NewDocument(clio.Identification{}, scanResults.Packages, scanResults.Context,
 		scanResults.Matches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
 	if err != nil {
@@ -132,20 +133,14 @@ func (sp *SARIFPrinter) printImageScan(ctx context.Context, scanResults cautils.
 	}
 
 	pres := grypesarif.NewPresenter(models.PresenterConfig{Document: model, SBOM: scanResults.SBOM})
-	if err := pres.Present(sp.writer); err != nil {
+	var rendered bytes.Buffer
+	if err := pres.Present(&rendered); err != nil {
 		return err
 	}
 
 	// Change driver name to Kubescape
-
-	jsonReport, err := os.ReadFile(sp.writer.Name())
-	if err != nil {
-		logger.L().Ctx(ctx).Error("failed to read json file - results will not be patched", helpers.Error(err))
-		return nil
-	}
-
 	var sarifReport sarif.Report
-	if err := json.Unmarshal(jsonReport, &sarifReport); err != nil {
+	if err := json.Unmarshal(rendered.Bytes(), &sarifReport); err != nil {
 		return err
 	}
 
@@ -154,13 +149,16 @@ func (sp *SARIFPrinter) printImageScan(ctx context.Context, scanResults cautils.
 		sarifReport.Runs[i].Tool.Driver.Name = "Kubescape"
 	}
 
-	// Write back to file
+	// Write the patched report to the configured destination once. Rendering and
+	// patching in memory is required for non-file destinations such as stdout:
+	// reopening /dev/stdout for reading blocks when stdout is a pipe or terminal.
 	updatedSarifReport, err := json.MarshalIndent(sarifReport, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile(sp.writer.Name(), updatedSarifReport, 0644) //nolint:gosec // Read-only report output, acceptable permissions
+	_, err = sp.writer.Write(updatedSarifReport)
+	return err
 }
 
 func (sp *SARIFPrinter) PrintNextSteps() {
@@ -174,7 +172,7 @@ func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 		}
 
 		// image scan
-		if err := sp.printImageScan(ctx, imageScanData[0]); err != nil {
+		if err := sp.printImageScan(imageScanData[0]); err != nil {
 			logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
 			return fmt.Errorf("failed to write results in sarif format: %w", err)
 		}


### PR DESCRIPTION
## Overview

Image SARIF generation rendered directly to the configured writer and then reopened `writer.Name()` to read, patch, and rewrite the report.

That works for regular output files, but deadlocks when the destination is stdout backed by a pipe. `/dev/stdout` is reopened for reading while the same process still owns the pipe's write end, so `ReadFile` can never observe EOF.

This change:

- renders the Grype SARIF report into an in-memory buffer;
- changes every run's driver name to `Kubescape`;
- marshals the patched report;
- writes the final bytes to the configured destination exactly once;
- preserves the existing output-file setup and behavior.

## Impact

Before this change, commands such as:

```bash
kubescape scan image alpine:3.20 --format sarif |
  jq -r '.runs[0].tool.driver.name'
```

could hang indefinitely in CI or shell pipelines.

After this change, the producer completes, closes the pipe, and the consumer receives valid SARIF with `Kubescape` as the driver name.

## How to Test

```bash
go test ./core/pkg/resultshandling/printer/v2 -count=1
```

The package suite passes. Regression coverage includes:

- a subprocess whose fd 1 is connected to an actual OS pipe;
- a five-second completion deadline that catches the previous circular wait;
- parsing stdout as SARIF and verifying `runs[0].tool.driver.name == "Kubescape"`;
- verifying regular file output remains parseable and uses the same driver name.

## Related issues/PRs

- Resolves #2961
- #1443 introduced driver-name patching through file reopen/read/rewrite.
- #2497 addresses configuration-SARIF write errors and is separate from this deadlock.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have documented the non-obvious pipe behavior
- [x] I have performed a self-review
- [x] I have added focused regression coverage
- [x] Relevant package tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SARIF image-scan output when writing to stdout or other piped destinations.
  * Prevented output from hanging or timing out during pipe-based processing.
  * Improved report reliability by ensuring SARIF results are fully generated and remain valid.
  * Preserved image-scan metadata in the generated SARIF report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->