### PR TITLE
fix(downloader): exit non-zero on download failures to fail docker builds

### DIFF
--- a/downloader/main.go
+++ b/downloader/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -18,12 +19,18 @@ func main() {
 		{Target: "artifacts"},                         // download all artifacts
 		{Target: "framework", Identifier: "security"}, // force add the "security" framework
 	}
+	var hasError bool
 	for _, download := range downloads {
 		result, err := ks.Download(&download)
 		if err != nil {
 			logger.L().Error("failed to download artifact", helpers.Error(err), helpers.String("target", download.Target))
+			hasError = true
 			continue
 		}
 		logger.L().Success("downloaded artifacts", helpers.String("count", fmt.Sprintf("%d", len(result.Files))), helpers.String("files", strings.Join(result.Files, ", ")))
+	}
+
+	if hasError {
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Overview

This PR fixes a critical but silent supply-chain vulnerability in the `downloader/main.go` binary where it would always return a successful `0` exit code, even if every artifact failed to download.

### The Problem

Previously, the `main()` loop logged `ks.Download()` errors and immediately called `continue`, finally exiting normally at the end of the file. Because this binary is invoked as a `RUN ["downloader"]` step in the `Dockerfile` to bake artifacts into the `ksserver` image, Docker relies on the exit code to determine build success.

If a transient network error, proxy issue, or registry timeout occurred in the CI pipeline, the `downloader` would log the error but exit `0`. Docker would then successfully build and publish an empty/broken image completely missing its required security frameworks.

### The Fix

The binary now tracks errors internally across the download loop using a boolean. If any artifacts failed to download, the code explicitly calls `os.Exit(1)` at the end of execution. This correctly propagates the failure to the OS, ensuring any `docker build` command immediately halts and fails the CI step.

## Additional Information

> N/A

## How to Test

Simulated a broken proxy on the newly compiled binary using `HTTP_PROXY=[http://127.0.0.1:9999](http://127.0.0.1:9999) ./downloader`. The binary correctly logs the errors, attempts the remaining downloads, and then forcefully exits with a non-zero code.

**Real Test Output of Fix:**

```bash
$ go build -o downloader_bin downloader/main.go

$ HTTP_PROXY=[http://127.0.0.1:9999](http://127.0.0.1:9999) HTTPS_PROXY=[http://127.0.0.1:9999](http://127.0.0.1:9999) ./downloader_bin; echo "EXIT_CODE=$?"

[warning] failed to get exceptions from github release, loading exceptions from cache

[warning] error downloading. artifact: exceptions; error: open /Users/lalit/.kubescape/exceptions.json: no such file or directory

[warning] failed to get policies from github release, loading policies from cache

[warning] failed to get attack tracks from github release, loading attack tracks from cache

[warning] failed to get config inputs from github release, loading config inputs from cache

[error] failed to download artifact. error: open /Users/lalit/.kubescape/exceptions.json: no such file or directory

error opening controls-inputs.json file, "controls-config" will be downloaded from ARMO management portal; target: artifacts

[warning] failed to get policies from github release, loading policies from cache

[error] failed to download artifact. error: framework: security: framework from file not matching; target: framework

EXIT_CODE=1
```

*(Notice the **`EXIT_CODE=1`** at the end, proving the process now accurately reports the failure).*

## Related issues/PRs:

- Resolved #2968

## Checklist before requesting a review

put an [x] in the box to get it checked

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The downloader now reports an unsuccessful exit status when one or more downloads fail.
  * Remaining downloads continue even if an individual download encounters an error.
  * Successful downloads and individual error messages continue to be logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->