### PR TITLE
chore: remove orphaned doc comment in customerloader.go

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -627,5 +627,3 @@ func GetTenantConfig(ctx context.Context, accountID, accessKey, clusterName, cus
 	}
 	return NewClusterConfig(ctx, k8s, accountID, accessKey, clusterName, customClusterName)
 }
-
-// firstNonEmpty returns the first non-empty string


### PR DESCRIPTION
## Summary
- Removes a stray, orphaned doc comment (`// firstNonEmpty returns the first non-empty string`) left at the end of `core/cautils/customerloader.go`.
- No function named `firstNonEmpty` exists anywhere in the repository — a project-wide search confirms it. This appears to be leftover debris from a deleted or renamed helper.
- No functional change; this is a pure documentation/readability cleanup.

Fixes #2944

## Test plan
- [x] `go build ./core/cautils/...` succeeds
- [x] `gofmt -l core/cautils/customerloader.go` reports no formatting issues
- [x] `go vet ./core/cautils/...` reports no issues
- [x] `go test ./core/cautils/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an obsolete internal code comment.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->