### PR TITLE
chore(ci): update pinned GitHub Actions off deprecated Node 20 releases

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -32,7 +32,7 @@ jobs:
       artifact-metadata: read
     runs-on: ubuntu-large
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-large
     steps:
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         name: Installing go
         with:
           go-version-file: go.mod

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Several workflows are pinned to GitHub Actions versions that trigger the Node 20 deprecation warning, and `scorecard.yml` still uploads SARIF via a CodeQL Action v3 release, which is also on the deprecation path.

- `actions/checkout@v4.3.1` → `actions/checkout@v7.0.1` in `scorecard.yml`, `02-release.yaml`, and `a-pr-scanner.yaml`. v7 runs on Node 24 and also picks up the safer `pull_request_target`/`workflow_run` fork-checkout defaults.
- `actions/setup-go@v4.3.0` → `actions/setup-go@v5.6.0` in `a-pr-scanner.yaml` (the reusable PR scanner), matching the Node 24 compatible pin already used in `02-release.yaml`.
- `github/codeql-action/upload-sarif@v3.35.4` → `github/codeql-action/upload-sarif@v4.37.6` in `scorecard.yml`.

All SHAs were resolved directly from each action's GitHub releases/tags to keep the pins verifiable. Change is limited to workflow maintenance so it can be validated independently of any code changes.

Fixes #2949

## Test plan
- [x] `actionlint` run against the three modified workflow files — no new findings introduced (pre-existing `ubuntu-large` custom-runner-label notices are unrelated to this change)
- [x] Workflow files parse cleanly after the pin updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release, pull request scanning, and security workflows to use newer pinned action versions.
  * Improved the reliability and maintenance of repository automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->