### PR TITLE
perf(opaprocessor): index a scope's resources once instead of per rule

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -304,8 +304,12 @@ haveResident:
 	// so CEL's namespaceObject binding is populated for this scope's objects.
 	opap.indexNamespacesFrom(residentBatch.AllResources)
 
+	// Index the resident batch once: every namespace scope below is evaluated
+	// together with it and reads the same index.
+	residentGroups := newResidentIndex(residentBatch)
+
 	// Process resident batch first
-	residentScope := evaluationScope{name: residentBatch.Scope, resident: residentBatch}
+	residentScope := newEvaluationScope(residentBatch.Scope, nil, residentGroups)
 	if err := opap.processScope(ctx, opap.AllPolicies, controlIDs, residentScope, progressListener); err != nil {
 		return err
 	}
@@ -327,7 +331,7 @@ haveResident:
 			opap.indexNamespacesFrom(batch.AllResources)
 
 			// Process this namespace batch
-			namespaceScope := evaluationScope{name: batch.Scope, batch: batch, resident: residentBatch}
+			namespaceScope := newEvaluationScope(batch.Scope, batch, residentGroups)
 			if err := opap.processScope(ctx, opap.AllPolicies, controlIDs, namespaceScope, progressListener); err != nil {
 				return err
 			}
@@ -486,11 +490,45 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 // the resident batch every scope depends on.
 type evaluationScope struct {
 	name string
-	// batch holds the scope's own resources. It is nil for the resident scope,
-	// which is evaluated on its own so that cluster-scoped resources are still
-	// assessed on clusters with no namespaced resources at all.
-	batch    *cautils.ResourceBatch
-	resident *cautils.ResourceBatch
+	// ownBatch reports whether the scope brings resources of its own. It is
+	// false for the resident scope, which is evaluated on its own so that
+	// cluster-scoped resources are still assessed on clusters with no namespaced
+	// resources at all.
+	ownBatch bool
+	// batchGroups indexes the scope's own batch, zero when ownBatch is false.
+	batchGroups resourceGroupIndex
+	// residentGroups indexes the resident batch, shared by every scope.
+	residentGroups *residentIndex
+}
+
+// residentIndex holds the resident batch indexed for matching. Every scope is
+// evaluated together with the resident batch, so it is built once per scan and
+// shared, rather than re-indexed once per namespace.
+type residentIndex struct {
+	k8s      resourceGroupIndex
+	external resourceGroupIndex
+}
+
+func newResidentIndex(resident *cautils.ResourceBatch) *residentIndex {
+	return &residentIndex{
+		k8s:      newResourceGroupIndex(resident.K8SResources, resident.AllResources),
+		external: newResourceGroupIndex(cautils.K8SResources(resident.ExternalResources), resident.AllResources),
+	}
+}
+
+// newEvaluationScope builds a scope and the index its rule matching reads,
+// keeping that work off the per-rule path (see resourceGroupIndex). batch is nil
+// for the resident scope, which is already indexed in residentGroups.
+func newEvaluationScope(name string, batch *cautils.ResourceBatch, residentGroups *residentIndex) evaluationScope {
+	scope := evaluationScope{
+		name:           name,
+		residentGroups: residentGroups,
+	}
+	if batch != nil {
+		scope.ownBatch = true
+		scope.batchGroups = newResourceGroupIndex(batch.K8SResources, batch.AllResources)
+	}
+	return scope
 }
 
 // matchedObjects returns the rule's input for this scope: the scope's own
@@ -502,14 +540,14 @@ type evaluationScope struct {
 // which the resident scope already did.
 func (scope evaluationScope) matchedObjects(rule *reporthandling.PolicyRule) []workloadinterface.IMetadata {
 	var objects []workloadinterface.IMetadata
-	if scope.batch != nil {
-		objects = getKubernetesObjects(scope.batch.K8SResources, scope.batch.AllResources, rule.Match)
+	if scope.ownBatch {
+		objects = getKubernetesObjects(scope.batchGroups, rule.Match)
 		if len(objects) == 0 {
 			return nil
 		}
 	}
-	objects = append(objects, getKubernetesObjects(scope.resident.K8SResources, scope.resident.AllResources, rule.Match)...)
-	objects = append(objects, getKubernetesObjectsFromExternalResources(scope.resident.ExternalResources, scope.resident.AllResources, rule.DynamicMatch)...)
+	objects = append(objects, getKubernetesObjects(scope.residentGroups.k8s, rule.Match)...)
+	objects = append(objects, getKubernetesObjects(scope.residentGroups.external, rule.DynamicMatch)...)
 	return objects
 }
 
@@ -522,10 +560,12 @@ func (scope evaluationScope) matchedObjects(rule *reporthandling.PolicyRule) []w
 func (opap *OPAProcessor) evaluationScopes() []evaluationScope {
 	resident, batches := cautils.PartitionResources(opap.initialResourceCount, opap.K8SResources, opap.ExternalResources, opap.AllResources)
 
+	residentGroups := newResidentIndex(resident)
+
 	scopes := make([]evaluationScope, 0, len(batches)+1)
-	scopes = append(scopes, evaluationScope{name: resident.Scope, resident: resident})
+	scopes = append(scopes, newEvaluationScope(resident.Scope, nil, residentGroups))
 	for _, batch := range batches {
-		scopes = append(scopes, evaluationScope{name: batch.Scope, batch: batch, resident: resident})
+		scopes = append(scopes, newEvaluationScope(batch.Scope, batch, residentGroups))
 	}
 
 	logger.L().Debug("partitioned resources for evaluation",

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -204,50 +204,126 @@ func isEmptyResources(counters reportsummary.ICounters) bool {
 	return counters.Failed() == 0 && counters.Skipped() == 0 && counters.Passed() == 0
 }
 
-func getKubernetesObjectsFromExternalResources(externalResources cautils.ExternalResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
-	return getKubernetesObjects(cautils.K8SResources(externalResources), allResources, match)
+// indexedObject is one resolved object in a resourceGroupIndex. kind is cached
+// so matching does not re-read it, and ordinal is the object's slot in the
+// index's de-duplicated ID space.
+type indexedObject struct {
+	object  workloadinterface.IMetadata
+	kind    string
+	ordinal int
+}
+
+// resourceGroup is one collected GVR key, parsed, with the objects under it.
+type resourceGroup struct {
+	group    string
+	version  string
+	resource string
+	objects  []indexedObject
+}
+
+// resourceGroupIndex holds a scope's resources ready for matching: GVR keys
+// parsed and sorted, IDs resolved to objects, ordinals assigned.
+//
+// Matching runs once per rule per scope, but none of that work depends on the
+// rule, and a scope's resources do not change during a scan. Doing it per call
+// made it the scan's dominant source of allocations on large clusters, so it is
+// done once per scope instead (see newEvaluationScope).
+type resourceGroupIndex struct {
+	groups []resourceGroup
+	// objectCount is the number of distinct objects, sizing the emitted bitset.
+	objectCount int
+}
+
+// newResourceGroupIndex parses and sorts a scope's GVR keys and resolves the IDs
+// under them. Keys are sorted raw, the order the match loop used to establish,
+// so a rule's input array keeps the same resource ordering. An ID that
+// allResources does not hold is dropped, as the per-match lookup used to.
+func newResourceGroupIndex(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata) resourceGroupIndex {
+	keys := make([]string, 0, len(k8sResources))
+	for key := range k8sResources {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	index := resourceGroupIndex{groups: make([]resourceGroup, 0, len(keys))}
+	// One ID can be collected under several GVR keys, so ordinals are assigned
+	// per ID rather than per slot, keeping the dedup in getKubernetesObjects.
+	ordinals := make(map[string]int)
+
+	for _, key := range keys {
+		// Match the collected GVR keys directly. Re-resolving policy matches
+		// through k8s-interface here would make file scans depend on its
+		// discovery snapshot again and would lose manifest versions that the
+		// snapshot does not contain.
+		group, version, resource := k8sinterface.StringToResourceGroup(key)
+		ids := k8sResources[key]
+
+		objects := make([]indexedObject, 0, len(ids))
+		for _, id := range ids {
+			object, ok := allResources[id]
+			if !ok || object == nil {
+				continue
+			}
+			ordinal, seen := ordinals[id]
+			if !seen {
+				ordinal = index.objectCount
+				ordinals[id] = ordinal
+				index.objectCount++
+			}
+			objects = append(objects, indexedObject{
+				object:  object,
+				kind:    object.GetKind(),
+				ordinal: ordinal,
+			})
+		}
+
+		index.groups = append(index.groups, resourceGroup{
+			group:    group,
+			version:  version,
+			resource: resource,
+			objects:  objects,
+		})
+	}
+
+	return index
 }
 
 // getKubernetesObjects returns the objects of a single scope that the rule
 // matches, in match-declaration order. Callers evaluate one scope at a time,
 // so no per-namespace bucketing happens here: the caller's batch already is
 // the bucket (see cautils.PartitionResources).
-func getKubernetesObjects(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
+func getKubernetesObjects(index resourceGroupIndex, match []reporthandling.RuleMatchObjects) []workloadinterface.IMetadata {
 	k8sObjects := []workloadinterface.IMetadata{}
-	seenResourceIDs := make(map[string]struct{})
-	// Match the collected GVR keys directly. Re-resolving policy matches through
-	// k8s-interface here would make file scans depend on its discovery snapshot
-	// again and would lose manifest versions that the snapshot does not contain.
-	resourceGroups := make([]string, 0, len(k8sResources))
-	for resourceGroup := range k8sResources {
-		resourceGroups = append(resourceGroups, resourceGroup)
-	}
-	sort.Strings(resourceGroups)
+	// A match block often names the same object under several combinations, so
+	// emitted objects are tracked by ordinal to keep the input free of
+	// duplicates. Allocated on first emission: most rules match nothing in a
+	// given scope, and those must not pay for a buffer sized to the index.
+	var emitted []bool
 
 	for m := range match {
 		for _, groups := range match[m].APIGroups {
 			for _, version := range match[m].APIVersions {
 				for _, resource := range match[m].Resources {
-					for _, resourceGroup := range resourceGroups {
-						objectGroup, objectVersion, objectResource := k8sinterface.StringToResourceGroup(resourceGroup)
-						if !matchesKubernetesObjectValue(groups, objectGroup) || !matchesKubernetesObjectValue(version, objectVersion) {
+					for g := range index.groups {
+						group := &index.groups[g]
+						if !matchesKubernetesObjectValue(groups, group.group) || !matchesKubernetesObjectValue(version, group.version) {
 							continue
 						}
 
-						directResourceMatch := resource == "*" || strings.EqualFold(resource, objectResource)
-						for _, id := range k8sResources[resourceGroup] {
-							if _, seen := seenResourceIDs[id]; seen {
+						directResourceMatch := resource == "*" || strings.EqualFold(resource, group.resource)
+						for i := range group.objects {
+							object := &group.objects[i]
+							if len(emitted) != 0 && emitted[object.ordinal] {
 								continue
 							}
-							object, ok := allResources[id]
-							if !ok || object == nil {
+							if !directResourceMatch && !strings.EqualFold(resource, object.kind) {
 								continue
 							}
-							if !directResourceMatch && !strings.EqualFold(resource, object.GetKind()) {
-								continue
+							if emitted == nil {
+								emitted = make([]bool, index.objectCount)
 							}
-							k8sObjects = append(k8sObjects, object)
-							seenResourceIDs[id] = struct{}{}
+							k8sObjects = append(k8sObjects, object.object)
+							emitted[object.ordinal] = true
 						}
 					}
 				}

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -38,7 +38,7 @@ func TestGetKubernetesObjectsDeduplicatesResourceAliases(t *testing.T) {
 		Resources:   []string{"Sandbox", "sandboxes"},
 	}}
 
-	objects := getKubernetesObjects(resources, allResources, match)
+	objects := getKubernetesObjects(newResourceGroupIndex(resources, allResources), match)
 	assert.Equal(t, 1, len(objects))
 }
 
@@ -62,7 +62,7 @@ func TestGetKubernetesObjectsMatchesFutureAPIVersionWithWildcards(t *testing.T) 
 		Resources:   []string{"HorizontalPodAutoscaler"},
 	}}
 
-	objects := getKubernetesObjects(resources, allResources, match)
+	objects := getKubernetesObjects(newResourceGroupIndex(resources, allResources), match)
 	require.Len(t, objects, 1)
 	assert.Same(t, workload, objects[0])
 }

--- a/core/pkg/opaprocessor/resourcegroupindex_test.go
+++ b/core/pkg/opaprocessor/resourcegroupindex_test.go
@@ -1,0 +1,291 @@
+package opaprocessor
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestWorkload(apiVersion, kind, name string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+	})
+}
+
+func TestNewResourceGroupIndexSortsGroupsAndParsesKeys(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	pod := newTestWorkload("v1", "Pod", "p")
+
+	// Insertion order is deliberately the reverse of the sorted order; Go map
+	// iteration would otherwise leave the group order undefined.
+	k8sResources := cautils.K8SResources{
+		"apps/v1/deployments": {deployment.GetID()},
+		"/v1/pods":            {pod.GetID()},
+	}
+	allResources := map[string]workloadinterface.IMetadata{
+		deployment.GetID(): deployment,
+		pod.GetID():        pod,
+	}
+
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	require.Len(t, index.groups, 2)
+	assert.Equal(t, 2, index.objectCount)
+
+	assert.Equal(t, "", index.groups[0].group, "%q sorts first", "/v1/pods")
+	assert.Equal(t, "v1", index.groups[0].version)
+	assert.Equal(t, "pods", index.groups[0].resource)
+
+	assert.Equal(t, "apps", index.groups[1].group)
+	assert.Equal(t, "v1", index.groups[1].version)
+	assert.Equal(t, "deployments", index.groups[1].resource)
+}
+
+func TestNewResourceGroupIndexResolvesObjectsAndKinds(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	k8sResources := cautils.K8SResources{"apps/v1/deployments": {deployment.GetID()}}
+	allResources := map[string]workloadinterface.IMetadata{deployment.GetID(): deployment}
+
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	require.Len(t, index.groups, 1)
+	require.Len(t, index.groups[0].objects, 1)
+	assert.Same(t, deployment, index.groups[0].objects[0].object)
+	assert.Equal(t, "Deployment", index.groups[0].objects[0].kind, "kind is resolved once at build time")
+}
+
+// A collected ID with no object behind it was dropped by the per-match lookup
+// before the index existed; it must be dropped at build time now, and must not
+// consume an ordinal.
+func TestNewResourceGroupIndexDropsUnresolvableIDs(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	k8sResources := cautils.K8SResources{
+		"apps/v1/deployments": {"missing-id", deployment.GetID(), "nil-id"},
+	}
+	allResources := map[string]workloadinterface.IMetadata{
+		deployment.GetID(): deployment,
+		"nil-id":           nil,
+	}
+
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	require.Len(t, index.groups, 1)
+	require.Len(t, index.groups[0].objects, 1)
+	assert.Same(t, deployment, index.groups[0].objects[0].object)
+	assert.Equal(t, 1, index.objectCount)
+}
+
+// The same object can be collected under several GVR keys. Ordinals are the
+// de-duplication key during matching, so both slots must share one.
+func TestNewResourceGroupIndexSharesOrdinalsAcrossAliases(t *testing.T) {
+	sandbox := newTestWorkload("agents.x-k8s.io/v1alpha1", "Sandbox", "s")
+	k8sResources := cautils.K8SResources{
+		"agents.x-k8s.io/v1alpha1/sandbox":   {sandbox.GetID()},
+		"agents.x-k8s.io/v1alpha1/sandboxes": {sandbox.GetID()},
+	}
+	allResources := map[string]workloadinterface.IMetadata{sandbox.GetID(): sandbox}
+
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	require.Len(t, index.groups, 2)
+	require.Len(t, index.groups[0].objects, 1)
+	require.Len(t, index.groups[1].objects, 1)
+	assert.Equal(t, index.groups[0].objects[0].ordinal, index.groups[1].objects[0].ordinal)
+	assert.Equal(t, 1, index.objectCount, "one object, one ordinal")
+}
+
+func TestNewResourceGroupIndexEmpty(t *testing.T) {
+	index := newResourceGroupIndex(cautils.K8SResources{}, map[string]workloadinterface.IMetadata{})
+
+	assert.Empty(t, index.groups)
+	assert.Equal(t, 0, index.objectCount)
+	assert.Empty(t, getKubernetesObjects(index, []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"*"},
+	}}))
+}
+
+// The rule's input is an array, so the objects must come back in
+// match-declaration order rather than in the index's own group order.
+func TestGetKubernetesObjectsPreservesMatchDeclarationOrder(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	pod := newTestWorkload("v1", "Pod", "p")
+	k8sResources := cautils.K8SResources{
+		"apps/v1/deployments": {deployment.GetID()},
+		"/v1/pods":            {pod.GetID()},
+	}
+	allResources := map[string]workloadinterface.IMetadata{
+		deployment.GetID(): deployment,
+		pod.GetID():        pod,
+	}
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	// "apps/v1/deployments" sorts after "/v1/pods", so an index-ordered result
+	// would put the pod first.
+	objects := getKubernetesObjects(index, []reporthandling.RuleMatchObjects{
+		{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+	})
+
+	require.Len(t, objects, 2)
+	assert.Same(t, deployment, objects[0])
+	assert.Same(t, pod, objects[1])
+}
+
+// A match block routinely names the same object under several combinations
+// (a wildcard group alongside the concrete one, say). It must be emitted once.
+func TestGetKubernetesObjectsEmitsEachObjectOnce(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	k8sResources := cautils.K8SResources{"apps/v1/deployments": {deployment.GetID()}}
+	allResources := map[string]workloadinterface.IMetadata{deployment.GetID(): deployment}
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	objects := getKubernetesObjects(index, []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"apps", "*"},
+		APIVersions: []string{"v1", "*"},
+		Resources:   []string{"deployments", "Deployment", "*"},
+	}})
+
+	require.Len(t, objects, 1)
+	assert.Same(t, deployment, objects[0])
+}
+
+// When the match names a kind rather than the collected resource name, the
+// fallback compares against the object's kind, which the index caches.
+func TestGetKubernetesObjectsFallsBackToObjectKind(t *testing.T) {
+	deployment := newTestWorkload("apps/v1", "Deployment", "d")
+	statefulSet := newTestWorkload("apps/v1", "StatefulSet", "s")
+	k8sResources := cautils.K8SResources{
+		"apps/v1/workloads": {deployment.GetID(), statefulSet.GetID()},
+	}
+	allResources := map[string]workloadinterface.IMetadata{
+		deployment.GetID():  deployment,
+		statefulSet.GetID(): statefulSet,
+	}
+	index := newResourceGroupIndex(k8sResources, allResources)
+
+	objects := getKubernetesObjects(index, []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"apps"},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"statefulset"}, // case-insensitive, kind-based
+	}})
+
+	require.Len(t, objects, 1)
+	assert.Same(t, statefulSet, objects[0])
+}
+
+// benchIndexFixture builds a scope-sized resource set: groups distinct GVRs,
+// each holding perGroup objects, shaped like what a namespace batch carries.
+func benchIndexFixture(groups, perGroup int) (cautils.K8SResources, map[string]workloadinterface.IMetadata) {
+	k8sResources := make(cautils.K8SResources, groups)
+	allResources := make(map[string]workloadinterface.IMetadata, groups*perGroup)
+
+	kinds := []string{"Deployment", "Pod", "Service", "ConfigMap", "Role", "StatefulSet"}
+	for g := 0; g < groups; g++ {
+		kind := kinds[g%len(kinds)]
+		apiVersion := fmt.Sprintf("group%d.example.com/v1", g)
+		ids := make([]string, 0, perGroup)
+		for i := 0; i < perGroup; i++ {
+			workload := newTestWorkload(apiVersion, kind, fmt.Sprintf("obj-%d-%d", g, i))
+			ids = append(ids, workload.GetID())
+			allResources[workload.GetID()] = workload
+		}
+		k8sResources[fmt.Sprintf("%s/%ss", apiVersion, kind)] = ids
+	}
+	return k8sResources, allResources
+}
+
+func benchIndexMatch() []reporthandling.RuleMatchObjects {
+	return []reporthandling.RuleMatchObjects{
+		{
+			APIGroups:   []string{"apps", "*"},
+			APIVersions: []string{"v1", "*"},
+			Resources:   []string{"Deployment", "StatefulSet", "DaemonSet"},
+		},
+		{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"Pod"},
+		},
+	}
+}
+
+func BenchmarkNewResourceGroupIndex(b *testing.B) {
+	k8sResources, allResources := benchIndexFixture(80, 25)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = newResourceGroupIndex(k8sResources, allResources)
+	}
+}
+
+// BenchmarkScopeRuleMatching is one scope's share of a scan: the index is built
+// once, then every rule in the framework is matched against it.
+func BenchmarkScopeRuleMatching(b *testing.B) {
+	const rules = 250
+	k8sResources, allResources := benchIndexFixture(80, 25)
+	match := benchIndexMatch()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		index := newResourceGroupIndex(k8sResources, allResources)
+		for r := 0; r < rules; r++ {
+			_ = getKubernetesObjects(index, match)
+		}
+	}
+}
+
+// Once resources partition per namespace, most rules match nothing in most
+// scopes. Those calls must not pay for an emitted buffer sized to the index.
+func TestGetKubernetesObjectsAllocatesNothingWhenNothingMatches(t *testing.T) {
+	k8sResources, allResources := benchIndexFixture(80, 25)
+	index := newResourceGroupIndex(k8sResources, allResources)
+	noMatch := []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"nonexistent.example.com"},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"widgets"},
+	}}
+	require.Empty(t, getKubernetesObjects(index, noMatch))
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = getKubernetesObjects(index, noMatch)
+	})
+	assert.Zero(t, allocs, "a rule matching nothing must not allocate")
+}
+
+// An index is read-only once built, so one can back concurrent matching. This
+// is what would let control evaluation be parallelised (#2824).
+func TestGetKubernetesObjectsConcurrentReads(t *testing.T) {
+	k8sResources, allResources := benchIndexFixture(40, 10)
+	index := newResourceGroupIndex(k8sResources, allResources)
+	match := benchIndexMatch()
+
+	want := len(getKubernetesObjects(index, match))
+	require.NotZero(t, want, "fixture must match something")
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				assert.Len(t, getKubernetesObjects(index, match), want)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Addresses the OPA evaluation part of #2919.

`getKubernetesObjects` rebuilt everything it needed on every call: it sorted the scope's GVR keys, re-parsed each one with `StringToResourceGroup`, resolved every collected ID against `AllResources`, and called `GetKind()`. None of that depends on the rule, but it runs once per rule per scope, and the parse sits under `match x APIGroups x APIVersions x Resources` so it also repeated within a single call.

A scope's resources are fixed for the scan, so the work moves into a `resourceGroupIndex` built once per scope. The resident batch is indexed once per scan and shared, since every scope is evaluated alongside it. Matching then walks resolved objects with a cached kind and dedups on a bitset of ordinals instead of a map keyed on the full resource ID.

Behaviour is unchanged: groups stay sorted by raw key, results stay in match-declaration order, aliased IDs still emit once, and IDs with no object behind them are still dropped (now at build time).

One scope, 250 rules, 2000 objects across 80 GVRs (`BenchmarkScopeRuleMatching`):

| | time | bytes | allocs |
|---|---|---|---|
| old | 87.3 ms/op | 35.2 MB/op | 266,250 |
| new | 10.0 ms/op | 9.6 MB/op | 2,691 |

Index construction is 148 us/op per scope, amortised over every rule matched against it.

`resourcegroupindex_test.go` covers key sorting and parsing, object/kind resolution, dropped unresolvable and nil IDs, shared ordinals across aliases, the empty index, match ordering, single emission, and the kind fallback. `go test ./core/pkg/opaprocessor/... -race` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved evaluation efficiency by indexing resources once and reusing the results across scopes.
  * Reduced repeated resource lookups during Kubernetes resource matching.

* **Behavior**
  * Preserved resident-resource evaluation while limiting namespace scopes to matching local resources.
  * Improved matching consistency, including duplicate suppression and kind-based fallback matching.

* **Tests**
  * Added comprehensive coverage and benchmarks for resource indexing and scope matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->