### PR TITLE
test(cautils): resolve symlinks on temp dirs used as expected paths

### DIFF
--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -259,12 +259,12 @@ func TestIsUnderAnyDir(t *testing.T) {
 // symlinked parent is still reported contained when only the physical layout
 // matches one of dirs.
 func TestIsUnderAnyDir_CanonicalizesSymlinks(t *testing.T) {
-	realParent := t.TempDir()
+	realParent := resolvedTempDir(t)
 	dir := filepath.Join(realParent, "app")
 	require.NoError(t, os.MkdirAll(dir, 0o750))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte("apiVersion: v1\n"), 0o600))
 
-	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	linkedParent := filepath.Join(resolvedTempDir(t), "linked-parent")
 	if err := os.Symlink(realParent, linkedParent); err != nil {
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
@@ -316,7 +316,7 @@ func writeHelmChartFixture(t *testing.T, directory, name string) {
 }
 
 func TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	chartHome := filepath.Join(root, "charts")
 	base := filepath.Join(root, "base")
 	ownedChart := filepath.Join(base, "charts", "app")
@@ -380,7 +380,7 @@ helmCharts:
 }
 
 func TestLoadResourcesFromHelmChartsExcludingDirectories_CanonicalizesSymlinkedScanPath(t *testing.T) {
-	realParent := t.TempDir()
+	realParent := resolvedTempDir(t)
 	root := filepath.Join(realParent, "project")
 	ownedChart := filepath.Join(root, "charts", "app")
 	standaloneChart := filepath.Join(root, "charts", "standalone")
@@ -393,7 +393,7 @@ helmCharts:
     releaseName: app
 `)
 
-	linkedParent := filepath.Join(t.TempDir(), "linked-parent")
+	linkedParent := filepath.Join(resolvedTempDir(t), "linked-parent")
 	if err := os.Symlink(realParent, linkedParent); err != nil {
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
@@ -415,11 +415,11 @@ helmCharts:
 }
 
 func TestExcludeHelmTemplateFiles_PreservesLexicalOwnershipOfSymlinkedTemplate(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	templateDir := filepath.Join(root, "chart", "templates")
 	require.NoError(t, os.MkdirAll(templateDir, 0o750))
 
-	externalTemplate := filepath.Join(t.TempDir(), "configmap.yaml")
+	externalTemplate := filepath.Join(resolvedTempDir(t), "configmap.yaml")
 	require.NoError(t, os.WriteFile(externalTemplate, []byte("apiVersion: v1\nkind: ConfigMap\n"), 0o600))
 	linkedTemplate := filepath.Join(templateDir, "configmap.yaml")
 	if err := os.Symlink(externalTemplate, linkedTemplate); err != nil {
@@ -671,7 +671,7 @@ func TestGetFileFormat(t *testing.T) {
 }
 
 func TestIsFileAndIsDir(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := resolvedTempDir(t)
 	tempFile := filepath.Join(tempDir, "test_file.txt")
 	err := os.WriteFile(tempFile, []byte("test"), 0o600)
 	require.NoError(t, err)

--- a/core/cautils/kustomizedirectory_test.go
+++ b/core/cautils/kustomizedirectory_test.go
@@ -75,7 +75,7 @@ func kustomizeTestdataPath() string {
 }
 
 func TestKustomizeHelmChartDirectories_CustomHomeDeduplicatesPhysicalChart(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmGlobals:
@@ -93,7 +93,7 @@ helmCharts:
 }
 
 func TestKustomizeHelmChartDirectories_VersionedRepositoryChart(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	writeManifestFixture(t, root, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 helmGlobals:
@@ -140,7 +140,7 @@ func TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := t.TempDir()
+			root := resolvedTempDir(t)
 			chartHome := tt.chartHome(root)
 			writeManifestFixture(t, root, "kustomization.yaml", fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -159,7 +159,7 @@ helmCharts:
 }
 
 func TestAppendOwnedHelmChartTree_PreservesPartialDiscovery(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	nested := filepath.Join(root, "charts", "dependency")
 	require.NoError(t, os.MkdirAll(nested, 0o750))
 
@@ -179,7 +179,7 @@ func TestAppendOwnedHelmChartTree_PreservesPartialDiscovery(t *testing.T) {
 }
 
 func TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	base := filepath.Join(root, "base")
 	component := filepath.Join(root, "component")
 	require.NoError(t, os.MkdirAll(base, 0o750))
@@ -320,4 +320,20 @@ func TestKustomizeDirectoryWithHelmCharts(t *testing.T) {
 		}
 	}
 	assert.True(t, configMapFound, "helm chart ConfigMap should be present in rendered workloads")
+}
+
+// resolvedTempDir returns t.TempDir() with symlinks resolved.
+//
+// The loaders under test canonicalise their inputs with filepath.EvalSymlinks
+// (fileutils.go), while t.TempDir() hands back an unresolved path: /var/... on
+// macOS where the real directory is /private/var/..., and the 8.3 short form on
+// Windows. Comparing a resolved result against an unresolved expectation fails
+// on both, and passes on Linux only because the two spellings coincide there.
+// localgitrepository_test.go already resolves the expected side for the same
+// reason.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return dir
 }


### PR DESCRIPTION
Refs #2951

## Overview

Seven tests in `core/cautils` build an expected path from `t.TempDir()` and compare it against
a path the loaders produced. The loaders canonicalise with `filepath.EvalSymlinks`
(`fileutils.go:305`, `:325`); `t.TempDir()` does not. The two spellings of the same directory
never compare equal:

| platform | `t.TempDir()` | resolved |
|---|---|---|
| macOS | `/var/folders/...` | `/private/var/folders/...` |
| Windows | `C:\Users\PRIYAN~1\...` | `C:\Users\priyanshu\...` |

On Linux they coincide, so CI never sees it.

This is not only a Windows problem. #2908's description records the same failures on macOS:

> It failed only in existing `core/cautils` path-canonicalization expectations on macOS temp
> paths (`/var/...` expected vs `/private/var/...` actual)

## Change

Adds `resolvedTempDir(t)` — `t.TempDir()` with symlinks resolved — and uses it in the tests
where a temp dir becomes part of an expected value.

This is an existing convention rather than a new one. `localgitrepository_test.go` already
resolves the expected side in four places (`:145`, `:314`, `:377`, `:393`) for exactly this
reason; these tests simply missed it.

Tests only, no production changes.

## Effect

On Windows, `go test ./core/cautils/`:

```
before:  10 failures
after:    4 failures
```

Fixed here:

```
TestKustomizeHelmChartDirectories_CustomHomeDeduplicatesPhysicalChart
TestKustomizeHelmChartDirectories_VersionedRepositoryChart
TestKustomizeHelmChartDirectories_ChartHomeAndDownloadLayout
TestKustomizeHelmChartDirectories_TraversesSelectedLocalGraph
TestLoadResourcesFromHelmChartsExcludingKustomizeOwnedDirectories
TestAppendOwnedHelmChartTree_PreservesPartialDiscovery
TestListHelmChartDirs... (partially; see below)
```

The four that remain are unrelated causes, both noted in #2951: one needs symlink creation
privilege, and three fail when `TempDir` cleanup hits a Windows file lock on a git worktree.
Neither is a path-resolution problem and neither is addressed here.

Reviewing on Linux: `EvalSymlinks` is a no-op where the temp path has no symlinks, so behaviour
there is unchanged.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved filesystem test reliability by resolving temporary directory paths before creating test fixtures.
  * Added coverage for symlink and path-canonicalization scenarios without changing production behavior or test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->