### PR TITLE
fix: resolve data race in display spinner (#2975)

### DIFF
--- a/core/cautils/display.go
+++ b/core/cautils/display.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	spinnerpkg "github.com/briandowns/spinner"
@@ -65,12 +66,19 @@ func StarDisplay(w io.Writer, format string, a ...any) {
 	fmt.Fprintf(w, gchalk.WithAnsi256(238).Bold("* ")+gchalk.White(format), a...)
 }
 
-var spinner *spinnerpkg.Spinner
+var (
+	spinner   *spinnerpkg.Spinner
+	spinnerMu sync.Mutex
+)
 
+// StartSpinner initializes and starts the terminal progress spinner in a thread-safe manner.
 func StartSpinner() {
 	if helpers.ToLevel(logger.L().GetLevel()) >= helpers.WarningLevel {
 		return
 	}
+
+	spinnerMu.Lock()
+	defer spinnerMu.Unlock()
 
 	if spinner != nil {
 		if !spinner.Active() {
@@ -84,7 +92,11 @@ func StartSpinner() {
 	}
 }
 
+// StopSpinner stops the active terminal progress spinner in a thread-safe manner.
 func StopSpinner() {
+	spinnerMu.Lock()
+	defer spinnerMu.Unlock()
+
 	if spinner == nil || !spinner.Active() {
 		return
 	}


### PR DESCRIPTION

Add a `sync.Mutex` to protect concurrent accesses to the global spinner variable. This fixes a data race that causes overlapping spinners and nil pointer panics when `StartSpinner` and `StopSpinner` are called by multiple goroutines concurrently.

## Overview
**Current behavior:** `cautils/display.go` reads and writes to the global `spinner` pointer without a lock. Because Kubescape spawns multiple goroutines (e.g., fetching exceptions, pulling VAP bindings), multiple workers can call `StartSpinner()` and `StopSpinner()` simultaneously. This causes a data race that can corrupt the terminal output or cause `nil` pointer panics in production.
**Future behavior:** A `sync.Mutex` (`spinnerMu`) is introduced alongside the global variable and properly locked/unlocked inside both functions to guarantee thread-safe execution and eliminate the data race.

## How to Test
1. Run the test suite with the race detector enabled before this PR: `go test -race ./core/...` (You will see a `WARNING: DATA RACE` inside `StartSpinner`).
2. Run the same command with this PR applied. The race condition is resolved and all tests pass cleanly.

## Related issues/PRs:
* Resolved #2975

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spinner reliability when start and stop actions occur concurrently.
  * Prevented potential conflicts while updating spinner state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->