### PR TITLE
fix: include initContainers and ephemeralContainers in image scan (#2979)

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -513,46 +513,36 @@ func collectImageScanTargets(scanType cautils.ScanTypes, scanData *cautils.OPASe
 
 	if scanType == cautils.ScanTypeWorkload {
 		wl := workloadinterface.NewWorkloadObj(scanData.SingleResourceScan.GetObject())
-		containers, err := wl.GetContainers()
-		if err != nil {
-			logger.L().Error("failed to get containers", helpers.Error(err))
-			return imagesToScan, imageToCreds
-		}
-		for _, container := range containers {
-			imagesToScan.Add(container.Image)
-			if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
+		for _, image := range getAllWorkloadImages(wl) {
+			imagesToScan.Add(image)
+			if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, image); ok {
 				found := false
-				for _, c := range imageToCreds[container.Image] {
+				for _, c := range imageToCreds[image] {
 					if c == creds {
 						found = true
 						break
 					}
 				}
 				if !found {
-					imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
+					imageToCreds[image] = append(imageToCreds[image], creds)
 				}
 			}
 		}
 	} else {
 		for _, workload := range scanData.AllResources {
 			wl := workloadinterface.NewWorkloadObj(workload.GetObject())
-			containers, err := wl.GetContainers()
-			if err != nil {
-				logger.L().Error(fmt.Sprintf("failed to get containers for kind: %s, name: %s, namespace: %s", workload.GetKind(), workload.GetName(), workload.GetNamespace()), helpers.Error(err))
-				continue
-			}
-			for _, container := range containers {
-				imagesToScan.Add(container.Image)
-				if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, container.Image); ok {
+			for _, image := range getAllWorkloadImages(wl) {
+				imagesToScan.Add(image)
+				if creds, ok := resolveRegistryCredentials(ctx, k8sApi, wl, image); ok {
 					found := false
-					for _, c := range imageToCreds[container.Image] {
+					for _, c := range imageToCreds[image] {
 						if c == creds {
 							found = true
 							break
 						}
 					}
 					if !found {
-						imageToCreds[container.Image] = append(imageToCreds[container.Image], creds)
+						imageToCreds[image] = append(imageToCreds[image], creds)
 					}
 				}
 			}
@@ -664,4 +654,30 @@ func collectAndProcessResourcesWithStreaming(ctx context.Context, resourceHandle
 	}
 
 	return nil
+}
+
+func getAllWorkloadImages(wl *workloadinterface.Workload) []string {
+	var images []string
+	if containers, err := wl.GetContainers(); err == nil {
+		for _, c := range containers {
+			if c.Image != "" {
+				images = append(images, c.Image)
+			}
+		}
+	}
+	if initContainers, err := wl.GetInitContainers(); err == nil {
+		for _, c := range initContainers {
+			if c.Image != "" {
+				images = append(images, c.Image)
+			}
+		}
+	}
+	if ephemeralContainers, err := wl.GetEphemeralContainers(); err == nil {
+		for _, c := range ephemeralContainers {
+			if c.Image != "" {
+				images = append(images, c.Image)
+			}
+		}
+	}
+	return images
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -535,3 +535,41 @@ func TestCollectAndProcessResourcesWithStreaming_CancelsProducerContext(t *testi
 	assert.NoError(t, parentCtx.Err(), "parent context must remain uncanceled")
 	assert.Equal(t, context.Canceled, mockHandler.passedCtx.Err(), "derived producer context must be canceled when function returns")
 }
+
+func TestGetAllWorkloadImages(t *testing.T) {
+	podData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "main-app",
+					"image": "app:v1",
+				},
+			},
+			"initContainers": []interface{}{
+				map[string]interface{}{
+					"name":  "init-setup",
+					"image": "init:v1",
+				},
+			},
+			"ephemeralContainers": []interface{}{
+				map[string]interface{}{
+					"name":  "debug-tool",
+					"image": "debug:v1",
+				},
+			},
+		},
+	}
+
+	wl := workloadinterface.NewWorkloadObj(podData)
+	images := getAllWorkloadImages(wl)
+
+	assert.Contains(t, images, "app:v1")
+	assert.Contains(t, images, "init:v1")
+	assert.Contains(t, images, "debug:v1")
+	assert.Len(t, images, 3)
+}


### PR DESCRIPTION


**Description:**

Update `scanImages` to extract container images from `initContainers` and `ephemeralContainers` in addition to standard spec containers. This ensures image vulnerability scanning covers all workloads completely.

## Overview
- **Current behavior:** `scanImages()` in `core/core/scan.go` calls only `wl.GetContainers()`, which extracts images from standard spec containers while ignoring `initContainers` and `ephemeralContainers`.
- **Future behavior:** Added `getAllWorkloadImages()` helper to extract container images from `GetContainers()`, `GetInitContainers()`, and `GetEphemeralContainers()`, guaranteeing complete vulnerability scanning coverage across all container types.

## How to Test
1. Run `go test -run TestGetAllWorkloadImages ./core/core` to verify image extraction for main containers, init containers, and ephemeral containers.

## Related issues/PRs:
* Resolved #2979

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image scanning now includes images from regular, initialization, and ephemeral containers.
  - Empty image references are excluded from scan results.

- **Bug Fixes**
  - Workload image collection now handles container extraction issues without interrupting scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->