### PR TITLE
fix(imagescan): close the previous gRPC client on repeated GCP Login calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	golang.org/x/term v0.44.0
 	google.golang.org/api v0.280.0
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 	gopkg.in/yaml.v3 v3.0.1
@@ -593,7 +594,6 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -55,6 +55,21 @@ func NewGCPAdaptor() *GCPAdaptor {
 	return &GCPAdaptor{}
 }
 
+// setOwningClient installs c as the adaptor's owning containeranalysis
+// client, closing any previously held client first. Without this, repeated
+// Login calls on the same adaptor instance would leak the previous client's
+// underlying gRPC connection pool.
+func (a *GCPAdaptor) setOwningClient(c *containeranalysis.Client) {
+	if a.owningClient != nil {
+		if closeErr := a.owningClient.Close(); closeErr != nil {
+			logger.L().Warning("failed to close previous gcp container analysis client", helpers.Error(closeErr))
+		}
+	}
+
+	a.owningClient = c
+	a.client = &gcpAPIWrapper{client: c.GetGrafeasClient()}
+}
+
 // Login authenticates with GCP. It prioritizes the default application credentials.
 // Explicit credentials passed via RegistryCredentials are intentionally unsupported
 // as GCP SDK relies heavily on Workload Identity and Application Default Credentials.
@@ -75,8 +90,7 @@ func (a *GCPAdaptor) Login(ctx context.Context, registry string, credentials Reg
 		return fmt.Errorf("unable to load gcp container analysis client: %w", err)
 	}
 
-	a.owningClient = c
-	a.client = &gcpAPIWrapper{client: c.GetGrafeasClient()}
+	a.setOwningClient(c)
 
 	// Fail-fast probe to ensure identity is valid
 	req := &grafeaspb.ListOccurrencesRequest{

--- a/pkg/imagescan/gcp_adaptor_test.go
+++ b/pkg/imagescan/gcp_adaptor_test.go
@@ -6,9 +6,14 @@ import (
 	"testing"
 	"time"
 
+	containeranalysis "cloud.google.com/go/containeranalysis/apiv1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -181,4 +186,38 @@ func TestGCPAdaptor_GetImagesVulnerabilities_Cap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, reports, 1)
 	assert.Len(t, reports[0].Vulnerabilities, 1000) // Should truncate at 1000 without returning an error
+}
+
+// newFakeContainerAnalysisClient builds a real *containeranalysis.Client
+// backed by a non-blocking, unauthenticated local dial target, so tests can
+// exercise client lifecycle (in particular Close()) without needing live GCP
+// credentials or network access.
+func newFakeContainerAnalysisClient(t *testing.T) *containeranalysis.Client {
+	t.Helper()
+	c, err := containeranalysis.NewClient(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithEndpoint("localhost:0"),
+	)
+	require.NoError(t, err)
+	return c
+}
+
+func TestGCPAdaptor_setOwningClient_ClosesPreviousClient(t *testing.T) {
+	adaptor := NewGCPAdaptor()
+
+	first := newFakeContainerAnalysisClient(t)
+	adaptor.setOwningClient(first)
+	require.Same(t, first, adaptor.owningClient)
+
+	second := newFakeContainerAnalysisClient(t)
+	adaptor.setOwningClient(second)
+	require.Same(t, second, adaptor.owningClient)
+
+	// setOwningClient must have already closed the first client when it was
+	// replaced; closing an already-closed connection returns an error, which
+	// proves it wasn't leaked open.
+	assert.Error(t, first.Close(), "previous client should already be closed by setOwningClient")
+
+	assert.NoError(t, adaptor.Destroy())
 }


### PR DESCRIPTION
## Summary
- `GCPAdaptor.Login()` (`pkg/imagescan/gcp_adaptor.go:72-78`) created a new `containeranalysis.Client` (which maintains an underlying gRPC connection pool) on every call and unconditionally overwrote `a.owningClient` without closing the previously held client. `Destroy()` only closes the most recently assigned client, so a caller that logs in, hits a transient failure later, and retries login on the same adaptor instance leaks the previous gRPC connection on every successful re-login — leading to socket/goroutine exhaustion over time.
- Extracted the client-swap logic into a new `setOwningClient` method that closes any existing `owningClient` before installing the new one (logging a warning if the close itself fails, without failing the login). `Login` now calls this instead of assigning the fields directly.
- The swap only happens **after** the new client has already been created successfully — if `containeranalysis.NewClient` fails, the existing (still valid) client is left untouched, matching the pre-existing retry-safety behavior.

Fixes #2953

## Test plan
- [x] `go build ./pkg/imagescan/...` succeeds
- [x] `gofmt -l` reports no formatting issues
- [x] `go vet ./pkg/imagescan/...` reports no issues
- [x] Added `TestGCPAdaptor_setOwningClient_ClosesPreviousClient`, which builds two real (but unauthenticated, non-networked) `*containeranalysis.Client` instances via `option.WithoutAuthentication()` + an insecure local dial target — no live GCP credentials needed — and verifies that after a second `setOwningClient` call, the first client is already closed (closing it again deterministically returns a "connection is closing" error, proving it wasn't left dangling)
- [x] `go test ./pkg/imagescan/...` passes, including all pre-existing GCP adaptor tests
- [x] `go mod tidy` promoted `google.golang.org/grpc` (already an indirect dependency) to direct in `go.mod` since the new test imports it directly; no other dependency changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of repeated Google Cloud logins by properly closing previously held connections.
  - Ensured active connections are closed when the image-scanning component is shut down.
  - Added safeguards to log connection-close failures without interrupting normal operation.

- **Tests**
  - Added coverage verifying connection cleanup during client replacement and component destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->