### PR TITLE
fix(sarif): render and patch image scan SARIF in memory instead of reopening the writer

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -132,33 +132,38 @@ func (sp *SARIFPrinter) printImageScan(scanResults cautils.ImageScanData) error 
 		return fmt.Errorf("failed to create document: %w", err)
 	}
 
-	pres := grypesarif.NewPresenter(models.PresenterConfig{Document: model, SBOM: scanResults.SBOM})
+	// Render into an in-memory buffer rather than sp.writer directly: when no
+	// --output file is given, sp.writer is os.Stdout, and reopening it by
+	// name below to patch the driver name would deadlock if stdout is a pipe
+	// (this process still holds the write end open, so a second reader on
+	// the same pipe never sees EOF). Rendering and patching in memory, then
+	// writing to sp.writer exactly once, avoids that entirely.
 	var rendered bytes.Buffer
+	pres := grypesarif.NewPresenter(models.PresenterConfig{Document: model, SBOM: scanResults.SBOM})
 	if err := pres.Present(&rendered); err != nil {
 		return err
 	}
 
-	// Change driver name to Kubescape
 	var sarifReport sarif.Report
 	if err := json.Unmarshal(rendered.Bytes(), &sarifReport); err != nil {
 		return err
 	}
 
-	// Patch driver name
+	// Patch driver name to Kubescape
 	for i := range sarifReport.Runs {
 		sarifReport.Runs[i].Tool.Driver.Name = "Kubescape"
 	}
 
-	// Write the patched report to the configured destination once. Rendering and
-	// patching in memory is required for non-file destinations such as stdout:
-	// reopening /dev/stdout for reading blocks when stdout is a pipe or terminal.
 	updatedSarifReport, err := json.MarshalIndent(sarifReport, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	_, err = sp.writer.Write(updatedSarifReport)
-	return err
+	if _, err := sp.writer.Write(updatedSarifReport); err != nil {
+		return fmt.Errorf("failed to write SARIF report: %w", err)
+	}
+
+	return nil
 }
 
 func (sp *SARIFPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -912,4 +913,55 @@ spec:
 		"SARIF must resolve the privileged field to line %d, got startLines=%v", privilegedLine, startLines)
 	assert.NotEqual(t, []int{1}, startLines,
 		"all findings must not collapse to line 1 for absolute-path file scans")
+}
+
+// TestPrintImageScan_WriterIsNonSeekablePipe is a regression test for image
+// SARIF output hanging when the destination is a pipe (e.g. stdout in a Unix
+// pipeline). printImageScan used to render the report to sp.writer, then
+// reopen sp.writer.Name() to patch the driver name and write it back. For a
+// pipe there is nothing meaningful to reopen by name, so the fix renders and
+// patches the report in memory and writes it to sp.writer exactly once. This
+// test uses a real os.Pipe() as the writer, with a concurrent reader (playing
+// the role of a downstream consumer like `tee` or `jq`), and asserts
+// ActionPrint returns promptly with a correctly patched report.
+func TestPrintImageScan_WriterIsNonSeekablePipe(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	sp := NewSARIFPrinter()
+	sp.writer = w
+
+	imageScanData := buildSeverityExceptionImageScanData()
+
+	printDone := make(chan error, 1)
+	go func() {
+		printDone <- sp.ActionPrint(context.Background(), nil, []cautils.ImageScanData{imageScanData})
+	}()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		readDone <- data
+	}()
+
+	select {
+	case err := <-printDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ActionPrint did not return within 5s: image SARIF output is hanging on a pipe writer")
+	}
+
+	require.NoError(t, w.Close())
+
+	var raw []byte
+	select {
+	case raw = <-readDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out reading the piped SARIF output")
+	}
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 1)
+	assert.Equal(t, "Kubescape", report.Runs[0].Tool.Driver.Name, "driver name must still be patched when writing to a pipe")
 }


### PR DESCRIPTION
## Summary
`kubescape scan image ... --format sarif` hangs when SARIF is written to stdout and stdout is a pipe (the normal case in CI and Unix pipelines).

**Root cause** (`core/pkg/resultshandling/printer/v2/sarifprinter.go`, `printImageScan`): the function
1. asked the Grype SARIF presenter to write directly to `sp.writer`;
2. called `os.ReadFile(sp.writer.Name())` to read the report back;
3. patched `runs[].tool.driver.name` to `"Kubescape"`;
4. called `os.WriteFile(sp.writer.Name(), ...)` to rewrite it.

When no `--output` file is supplied, `sp.writer` is `os.Stdout`, whose name is `/dev/stdout`. If fd 1 is a pipe, reopening `/dev/stdout` for reading opens another reader on the same pipe — but this process still owns the original write end, so that read waits for an EOF that can't occur until the process exits. Downstream consumers (`jq`, `tee`, an upload step, command substitution) never see EOF either, and the scan hangs until an external timeout kills it. `--output report.sarif` was unaffected, since a real file can be reopened for reading without blocking.

**Fix**: render the Grype presenter's output into an in-memory `bytes.Buffer`, patch the driver name there, and write the result to `sp.writer` exactly once — removing the reopen-by-name step entirely. This mirrors how `printConfigurationScan` already builds its `sarif.Report` in memory and writes it a single time, so both SARIF code paths now follow the same pattern.

Fixes #2961

## Test plan
- [x] `go build ./core/pkg/resultshandling/printer/v2/...` succeeds
- [x] `gofmt -l` reports no formatting issues
- [x] `go vet ./core/pkg/resultshandling/printer/v2/...` reports no issues
- [x] Added `TestPrintImageScan_WriterIsNonSeekablePipe`, which sets `sp.writer` to the write end of a real `os.Pipe()` (with a concurrent goroutine draining the read end, playing the role of a downstream pipeline consumer), and asserts `ActionPrint` returns promptly with a correctly patched `"Kubescape"` driver name
- [x] Verified this test is a genuine regression test: temporarily reverted the production fix and confirmed the test fails against the old code — it doesn't literally hang in this synthetic pipe setup (`os.Pipe()`'s `Name()` isn't a real reopenable path, so the old code's `os.ReadFile` fails fast with ENOENT), but it does reproduce the same underlying defect: the old code's silent fallback (`logger.Error(...); return nil`) swallows that failure and never patches the driver name, so the assertion correctly catches it
- [x] `go test ./core/pkg/resultshandling/printer/v2/...` passes in full, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SARIF report generation for image scans when writing to streaming or non-seekable outputs.
  - Ensured generated reports retain the correct `Kubescape` driver name.
  - Improved handling and reporting of final output write errors.

- **Tests**
  - Added coverage confirming SARIF output is successfully generated and parsed through pipe-based streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->