### PR TITLE
feat: add csv output for list command

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -67,7 +67,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 	}
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
-	listCmd.PersistentFlags().StringVarP(&listPolicies.Format, "format", "f", "pretty-print", "output format. supported: 'pretty-print'/'json'/'yaml'")
+	listCmd.PersistentFlags().StringVarP(&listPolicies.Format, "format", "f", "pretty-print", "output format. supported: 'pretty-print'/'json'/'yaml'/'csv'")
 
 	// Deprecated flags
 	var dummyID bool

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -2,8 +2,10 @@ package core
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -28,6 +30,7 @@ var listFormatFunc = map[string]func(context.Context, string, []string){
 	"pretty-print": prettyPrintListFormat,
 	"json":         jsonListFormat,
 	"yaml":         yamlListFormat,
+	"csv":          csvListFormat,
 }
 
 func ListSupportActions() []string {
@@ -77,14 +80,16 @@ func PrintListResult(ctx context.Context, result *metav1.ListResult, target, for
 			jsonControlsFormat(result.Controls)
 		case "yaml":
 			yamlControlsFormat(result.Controls)
+		case "csv":
+			csvControlsFormat(result.Controls)
 		default:
-			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'", format)
+			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'/'csv'", format)
 		}
 	case "frameworks", "exceptions":
 		if listFormatFunction, ok := listFormatFunc[format]; ok {
 			listFormatFunction(ctx, target, result.Names)
 		} else {
-			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml' ", format)
+			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'/'csv'", format)
 		}
 	default:
 		return fmt.Errorf("invalid target %q, supported targets: 'controls'/'frameworks'/'exceptions'", target)
@@ -230,6 +235,31 @@ func yamlControlsFormat(entries []metav1.ControlListEntry) {
 	}
 
 	fmt.Printf("%s\n", y)
+}
+
+func csvListFormat(_ context.Context, _ string, policies []string) {
+	writer := csv.NewWriter(os.Stdout)
+	_ = writer.Write([]string{"name"})
+	for _, policy := range policies {
+		_ = writer.Write([]string{policy})
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write csv output: %v\n", err)
+	}
+}
+
+func csvControlsFormat(entries []metav1.ControlListEntry) {
+	writer := csv.NewWriter(os.Stdout)
+	_ = writer.Write([]string{"id", "name", "frameworks"})
+	for _, entry := range entries {
+		frameworks := strings.Join(entry.Frameworks, ";")
+		_ = writer.Write([]string{entry.ID, entry.Name, frameworks})
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write csv output: %v\n", err)
+	}
 }
 
 func prettyPrintControls(ctx context.Context, entries []metav1.ControlListEntry) {

--- a/core/core/list_output_test.go
+++ b/core/core/list_output_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"context"
+	"encoding/csv"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	rescueStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() {
+		os.Stdout = rescueStdout
+		_ = r.Close()
+		_ = w.Close()
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestCSVListFormat_RendersPolicyNames(t *testing.T) {
+	out := captureStdout(t, func() {
+		csvListFormat(context.Background(), "frameworks", []string{"nsa", "mitre"})
+	})
+
+	records := readCSVRecords(t, out)
+	require.Len(t, records, 3)
+	assert.Equal(t, []string{"name"}, records[0])
+	assert.Equal(t, []string{"nsa"}, records[1])
+	assert.Equal(t, []string{"mitre"}, records[2])
+}
+
+func TestCSVControlsFormat_RendersStructuredRows(t *testing.T) {
+	entries := []metav1.ControlListEntry{
+		{ID: "C-0001", Name: "Forbidden Registries", Frameworks: []string{"NSA", "MITRE"}},
+		{ID: "C-0002", Name: "Privileged Containers", Frameworks: []string{"AllControls"}},
+	}
+
+	out := captureStdout(t, func() {
+		csvControlsFormat(entries)
+	})
+
+	records := readCSVRecords(t, out)
+	require.Len(t, records, 3)
+	assert.Equal(t, []string{"id", "name", "frameworks"}, records[0])
+	assert.Equal(t, []string{"C-0001", "Forbidden Registries", "NSA;MITRE"}, records[1])
+	assert.Equal(t, []string{"C-0002", "Privileged Containers", "AllControls"}, records[2])
+}
+
+func TestPrintListResult_CSVFormats(t *testing.T) {
+	result := &metav1.ListResult{Names: []string{"nsa"}, Controls: []metav1.ControlListEntry{{ID: "C-0001", Name: "Forbidden Registries", Frameworks: []string{"NSA"}}}}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, PrintListResult(context.Background(), result, "frameworks", "csv"))
+	})
+
+	records := readCSVRecords(t, out)
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{"name"}, records[0])
+	assert.Equal(t, []string{"nsa"}, records[1])
+}
+
+func readCSVRecords(t *testing.T, content string) [][]string {
+	t.Helper()
+
+	r := csv.NewReader(strings.NewReader(content))
+	records, err := r.ReadAll()
+	require.NoError(t, err)
+	return records
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -525,14 +525,16 @@ kubescape list <type> [flags]
 |------|-------------|---------|
 | `--account <id>` | Account ID for custom frameworks | - |
 | `--access-key <key>` | Access key | - |
-| `--format <format>` | Output format: `pretty-print`, `json` | `pretty-print` |
+| `--format <format>` | Output format: `pretty-print`, `json`, `yaml`, `csv` | `pretty-print` |
 
 ### Examples
 
 ```bash
 kubescape list frameworks
+kubescape list frameworks --format csv
 kubescape list controls
 kubescape list controls --format json
+kubescape list controls --format csv
 ```
 
 ---

--- a/docs/list-csv-output.md
+++ b/docs/list-csv-output.md
@@ -1,0 +1,46 @@
+# List command CSV output
+
+Kubescape now supports CSV output for the list command so framework, exception, and control data can be imported into spreadsheets and automation pipelines more easily.
+
+## Supported formats
+
+The list command already supports `pretty-print`, `json`, and `yaml`. It now also accepts `csv`.
+
+## Examples
+
+### Frameworks as CSV
+
+```bash
+kubescape list frameworks --format csv
+```
+
+Example output:
+
+```csv
+name
+nsa
+mitre
+```
+
+### Controls as CSV
+
+```bash
+kubescape list controls --format csv
+```
+
+Example output:
+
+```csv
+id,name,frameworks
+C-0001,Forbidden Registries,NSA;MITRE
+C-0002,Privileged Containers,AllControls
+```
+
+## Why this helps
+
+CSV output makes it easier to:
+
+- open policy lists in Excel or Google Sheets
+- feed results into downstream automation scripts
+- compare control inventories across environments
+- archive inventory data in a simple, portable format


### PR DESCRIPTION
## Summary

Add CSV rendering support for  so frameworks and controls can be exported for spreadsheets, reporting, and automation.

## What changed

- added CSV output support for 
- added CSV output support for 
- added regression tests for the CSV rendering logic
- documented the new output format in the CLI reference and docs

## Why

The existing list command supported pretty-print, JSON, and YAML output, but not CSV. CSV is still the most convenient format for spreadsheet workflows and scripting pipelines.

## Testing

Verified with:

- ok  	github.com/kubescape/kubescape/v3/cmd/list	(cached)
ok  	github.com/kubescape/kubescape/v3/core/core	11.367s

## Related issue

Fixes #2988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV output support for framework, exception, and control listings.
  * CSV results include headers and structured rows for easier export and analysis.
  * Control framework values are represented as semicolon-separated entries.

* **Documentation**
  * Added CSV and YAML formats to the CLI reference.
  * Added CSV examples, sample output, guidance, and use cases for list results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->