### PR TITLE
fix(anonymizer): replace broken type assertions with IWorkload-based container deserialization

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -21,6 +21,12 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 		return nil
 	}
 
+	if wl, ok := resource.(workloadinterface.IWorkload); ok {
+		if err := transformTypedWorkloadContainers(wl, transformer); err != nil {
+			return err
+		}
+	}
+
 	obj := resource.GetObject()
 	if obj == nil {
 		return nil
@@ -31,6 +37,94 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 	}
 
 	resource.SetObject(obj)
+
+	return nil
+}
+
+func transformTypedWorkloadContainers(wl workloadinterface.IWorkload, transformer Transformer) error {
+	kind := wl.GetKind()
+	scope := workloadinterface.PodSpec(kind)
+
+	if containers, err := wl.GetContainers(); err == nil && len(containers) > 0 {
+		if err := transformTypedContainerList(containers, transformer); err != nil {
+			return err
+		}
+		workloadinterface.SetInMap(wl.GetObject(), scope, "containers", containers)
+	}
+
+	if initContainers, err := wl.GetInitContainers(); err == nil && len(initContainers) > 0 {
+		if err := transformTypedContainerList(initContainers, transformer); err != nil {
+			return err
+		}
+		workloadinterface.SetInMap(wl.GetObject(), scope, "initContainers", initContainers)
+	}
+
+	if ephemeralContainers, err := wl.GetEphemeralContainers(); err == nil && len(ephemeralContainers) > 0 {
+		if err := transformTypedEphemeralContainerList(ephemeralContainers, transformer); err != nil {
+			return err
+		}
+		workloadinterface.SetInMap(wl.GetObject(), scope, "ephemeralContainers", ephemeralContainers)
+	}
+
+	return nil
+}
+
+func transformTypedContainerList(containers []corev1.Container, transformer Transformer) error {
+	var err error
+
+	for i := range containers {
+		if containers[i].Name != "" {
+			containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
+			if err != nil {
+				return err
+			}
+		}
+
+		if containers[i].Image != "" {
+			containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+			return err
+		}
+
+		if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer, transformer Transformer) error {
+	var err error
+
+	for i := range containers {
+		if containers[i].Name != "" {
+			containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
+			if err != nil {
+				return err
+			}
+		}
+
+		if containers[i].Image != "" {
+			containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+			return err
+		}
+
+		if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -164,38 +258,6 @@ func transformContainerList(obj map[string]any, key string, transformer Transfor
 		return nil
 	}
 
-	var err error
-
-	if containers, ok := rawContainers.([]corev1.Container); ok {
-		for i := range containers {
-
-			if containers[i].Name != "" {
-				containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
-				if err != nil {
-					return err
-				}
-			}
-
-			if containers[i].Image != "" {
-				containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
-				if err != nil {
-					return err
-				}
-			}
-
-			if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
-				return err
-			}
-
-			if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
-				return err
-			}
-		}
-
-		obj[key] = containers
-		return nil
-	}
-
 	if containers, ok := rawContainers.([]any); ok {
 		for _, item := range containers {
 			container, ok := item.(map[string]any)
@@ -225,38 +287,6 @@ func transformEphemeralContainerList(obj map[string]any, key string, transformer
 
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
-		return nil
-	}
-
-	var err error
-
-	if containers, ok := rawContainers.([]corev1.EphemeralContainer); ok {
-		for i := range containers {
-
-			if containers[i].Name != "" {
-				containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
-				if err != nil {
-					return err
-				}
-			}
-
-			if containers[i].Image != "" {
-				containers[i].Image, err = transformValue(transformer, "img", containers[i].Image)
-				if err != nil {
-					return err
-				}
-			}
-
-			if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
-				return err
-			}
-
-			if err := transformTypedEnvFrom(containers[i].EnvFrom, transformer); err != nil {
-				return err
-			}
-		}
-
-		obj[key] = containers
 		return nil
 	}
 

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -17,6 +17,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed containers should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"containers": []corev1.Container{
 						{
@@ -76,6 +78,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed init containers should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"initContainers": []corev1.Container{
 						{
@@ -103,6 +107,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed ephemeral containers should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"ephemeralContainers": []corev1.EphemeralContainer{
 						{
@@ -164,6 +170,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed container env references should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"containers": []corev1.Container{
 						{
@@ -302,6 +310,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed container envFrom references should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"containers": []corev1.Container{
 						{
@@ -415,6 +425,8 @@ func TestTransformContainerMetadata(t *testing.T) {
 		{
 			name: "typed container literal env values should be anonymized",
 			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
 				"spec": map[string]any{
 					"containers": []corev1.Container{
 						{


### PR DESCRIPTION
## Description

Fixes #2135: `transformContainerList` and `transformEphemeralContainerList` contained dead typed-assertion code paths (`[]corev1.Container` / `[]corev1.EphemeralContainer`) that can never be reached in production because `resource.GetObject()` returns `map[string]interface{}` with `[]interface{}` arrays (JSON/YAML deserialization). These dead paths were the only code that handled typed container lists, leaving only the `[]any` fallback.

The correct approach is to use `workloadinterface.IWorkload` methods (`GetContainers`, `GetInitContainers`, `GetEphemeralContainers`) which properly deserialize via JSON marshal/unmarshal - the same pattern used by `removeContainersData` in `processorhandlerutils.go`.

## Changes

### `core/pkg/anonymizer/container.go`

1. **New `transformTypedWorkloadContainers`** - Casts `IMetadata` to `IWorkload` and uses typed accessor methods to retrieve containers, transforms them with typed field access, and writes back via `workloadinterface.SetInMap`.

2. **New `transformTypedContainerList` / `transformTypedEphemeralContainerList`** - Dedicated helpers for transforming typed `[]corev1.Container` and `[]corev1.EphemeralContainer` slices (lifted from the removed dead paths).

3. **`transformContainerMetadata`** - Now calls `transformTypedWorkloadContainers` before the recursive `transformPodSpecs` traversal. Since `SetInMap` stores containers back as typed slices, the `[]any` fallback in `transformContainerList`/`transformEphemeralContainerList` correctly skips them (no double transformation), while still handling `[]interface{}` containers in nested pod specs.

4. **`transformContainerList` / `transformEphemeralContainerList`** - Removed the dead `[]corev1.Container` / `[]corev1.EphemeralContainer` type assertion branches. Only the `[]any` path remains for unstructured nested traversal.

### `core/pkg/anonymizer/container_test.go`

- Added `apiVersion: "v1"` and `kind: "Pod"` to all 6 typed container test cases so `PodSpec("Pod")` resolves to `["spec"]`, matching the test object structure and enabling the `IWorkload` path.

## Verification

```bash
go test -race ./core/pkg/anonymizer/
# 74 passed - no races, no regressions

go build ./...
# Success
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymization for typed Kubernetes workloads.
  * Ensured regular, init, and ephemeral containers are consistently transformed, including names, images, environment values, and references.
  * Enhanced handling of typed Pod metadata and container-related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->