### PR TITLE
feat(imagescan): support scanning local offline tarball images

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -66,9 +67,16 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				return err
 			}
 
+			imageName := args[0]
+			if strings.HasSuffix(imageName, ".tar") && !strings.HasPrefix(imageName, "docker-archive:") && !strings.HasPrefix(imageName, "oci-archive:") {
+				if _, err := os.Stat(imageName); err == nil {
+					imageName = "docker-archive:" + imageName
+				}
+			}
+
 			imgScanInfo := &metav1.ImageScanInfo{
 				Authority:          credentials.Authority,
-				Image:              args[0],
+				Image:              imageName,
 				Username:           credentials.Username,
 				Password:           credentials.Password,
 				Token:              credentials.Token,

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -243,4 +244,24 @@ func TestGetScanCommand_ImageRegistryTokenAndAuthorityReachImageScan(t *testing.
 	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
 	assert.Equal(t, "token", mockKubescape.imgScanInfo.Token)
 	assert.Equal(t, "registry.example.com/app:tag", mockKubescape.imgScanInfo.Image)
+}
+
+func TestGetImageCmd_RunE_ForwardsLocalTarball(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	// Create a dummy tarball file
+	tmpFile, err := os.CreateTemp("", "dummy-*.tar")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	err = cmd.RunE(cmd, []string{tmpFile.Name()})
+	assert.NoError(t, err)
+	assert.Equal(t, "docker-archive:"+tmpFile.Name(), mockKubescape.imgScanInfo.Image)
 }


### PR DESCRIPTION
## Overview
**Current behavior:** 
When users attempt to scan a local offline image archive (e.g., a `.tar` file generated via `docker save`) using `kubescape scan image /path/to/image.tar`, the CLI fails to resolve the image unless the user manually prepends the `docker-archive:` prefix (a requirement that is not obvious to end users).

**Future behavior:** 
The `kubescape scan image` command now automatically detects when a user passes a `.tar` file. If the file exists on the local filesystem, the CLI seamlessly prepends the `docker-archive:` prefix before passing it to the internal scanning engine. This provides a much smoother UX for offline scanning without requiring major engine changes.

## Additional Information

> This change intentionally checks `os.Stat` to ensure the file actually exists locally before mutating the string. This prevents edge cases where a user might be querying a remote registry image that just happens to be named with a `.tar` suffix. It also checks to ensure we don't double-prefix if the user *did* manually include `docker-archive:` or `oci-archive:`.

## How to Test

1. Pull any small image: `docker pull alpine:latest`
2. Save it as a local tarball: `docker save -o test-image.tar alpine:latest`
3. Run the scan command against the local file: `kubescape scan image test-image.tar`
4. The scan will now execute successfully and print the vulnerability report, rather than throwing an "unable to resolve" fatal error.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image scanning now accepts local `.tar` archive paths automatically.
  * Existing `docker-archive:` and `oci-archive:` paths continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->