### PR TITLE
fix(prerequisites): exit non-zero when cluster data collection fails

### DIFF
--- a/cmd/prerequisites/prerequisites.go
+++ b/cmd/prerequisites/prerequisites.go
@@ -1,6 +1,7 @@
 package prerequisites
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kubescape/go-logger"
@@ -14,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	buildKubeClient    = common.BuildKubeClient
+	collectClusterData = common.CollectClusterData
+)
+
 func GetPreReqCmd(ks meta.IKubescape) *cobra.Command {
 	var kubeconfigPath *string
 
@@ -22,33 +28,39 @@ func GetPreReqCmd(ks meta.IKubescape) *cobra.Command {
 		Use:   "prerequisites",
 		Short: "Check prerequisites for installing Kubescape Operator",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientSet, inCluster := common.BuildKubeClient(*kubeconfigPath)
-			if clientSet == nil {
-				return fmt.Errorf("could not create kube client")
-			}
-
-			// 1) Collect cluster data
-			clusterData, err := common.CollectClusterData(ks.Context(), clientSet)
-			if err != nil {
-				logger.L().Error("Failed to collect cluster data", helpers.Error(err))
-			}
-
-			// 2) Run checks
-			sizingResult := sizing.RunSizingChecker(clusterData)
-			pvResult := pvcheck.RunPVProvisioningCheck(ks.Context(), clientSet, clusterData, inCluster)
-			connectivityResult := connectivitycheck.RunConnectivityChecks(ks.Context(), clientSet, clusterData, inCluster)
-			ebpfResult := ebpfcheck.RunEbpfCheck(ks.Context(), clientSet, clusterData, inCluster)
-
-			// 3) Build and export the final ReportData
-			finalReport := common.BuildReportData(clusterData, sizingResult, pvResult, connectivityResult, ebpfResult)
-			finalReport.InCluster = inCluster
-
-			common.GenerateOutput(finalReport, inCluster)
-			return nil
+			return runPrerequisites(ks.Context(), *kubeconfigPath)
 		},
 	}
 
 	kubeconfigPath = preReqCmd.PersistentFlags().String("kubeconfig", "", "Path to the kubeconfig file. If not set, in-cluster config is used or $HOME/.kube/config if outside a cluster.")
 
 	return preReqCmd
+}
+
+// runPrerequisites collects cluster data and runs operator prerequisite checks.
+// Collection failures must abort before checks/report generation: partial data
+// previously produced false-negative PV results and unsafe Helm recommendations
+// while still exiting 0.
+func runPrerequisites(ctx context.Context, kubeconfigPath string) error {
+	clientSet, inCluster := buildKubeClient(kubeconfigPath)
+	if clientSet == nil {
+		return fmt.Errorf("could not create kube client")
+	}
+
+	clusterData, err := collectClusterData(ctx, clientSet)
+	if err != nil {
+		logger.L().Error("Failed to collect cluster data", helpers.Error(err))
+		return fmt.Errorf("failed to collect cluster data: %w", err)
+	}
+
+	sizingResult := sizing.RunSizingChecker(clusterData)
+	pvResult := pvcheck.RunPVProvisioningCheck(ctx, clientSet, clusterData, inCluster)
+	connectivityResult := connectivitycheck.RunConnectivityChecks(ctx, clientSet, clusterData, inCluster)
+	ebpfResult := ebpfcheck.RunEbpfCheck(ctx, clientSet, clusterData, inCluster)
+
+	finalReport := common.BuildReportData(clusterData, sizingResult, pvResult, connectivityResult, ebpfResult)
+	finalReport.InCluster = inCluster
+
+	common.GenerateOutput(finalReport, inCluster)
+	return nil
 }

--- a/cmd/prerequisites/prerequisites_test.go
+++ b/cmd/prerequisites/prerequisites_test.go
@@ -1,10 +1,15 @@
 package prerequisites
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/sizing-checker/pkg/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
 )
 
 func TestGetPreReqCmd(t *testing.T) {
@@ -27,4 +32,43 @@ func TestGetPreReqCmdKubeconfigFlag(t *testing.T) {
 	assert.NotNil(t, flag)
 	assert.Equal(t, "", flag.DefValue)
 	assert.Equal(t, "Path to the kubeconfig file. If not set, in-cluster config is used or $HOME/.kube/config if outside a cluster.", flag.Usage)
+}
+
+func TestRunPrerequisites_NilClientReturnsError(t *testing.T) {
+	origBuild := buildKubeClient
+	t.Cleanup(func() { buildKubeClient = origBuild })
+
+	buildKubeClient = func(string) (*kubernetes.Clientset, bool) {
+		return nil, false
+	}
+
+	err := runPrerequisites(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not create kube client")
+}
+
+func TestRunPrerequisites_CollectClusterDataErrorAborts(t *testing.T) {
+	origBuild := buildKubeClient
+	origCollect := collectClusterData
+	t.Cleanup(func() {
+		buildKubeClient = origBuild
+		collectClusterData = origCollect
+	})
+
+	buildKubeClient = func(string) (*kubernetes.Clientset, bool) {
+		// Non-nil sentinel is enough: collectClusterData is stubbed and never uses it.
+		return &kubernetes.Clientset{}, false
+	}
+
+	collectCalled := false
+	collectClusterData = func(context.Context, *kubernetes.Clientset) (*common.ClusterData, error) {
+		collectCalled = true
+		return &common.ClusterData{}, errors.New("pods is forbidden")
+	}
+
+	err := runPrerequisites(context.Background(), "/tmp/restricted.kubeconfig")
+	require.Error(t, err)
+	assert.True(t, collectCalled)
+	assert.ErrorContains(t, err, "failed to collect cluster data")
+	assert.ErrorContains(t, err, "pods is forbidden")
 }


### PR DESCRIPTION
## Overview
`kubescape prerequisites` used to log collection failures and still exit `0`, which could produce wrong Helm recommendations from incomplete data.

It now returns an error immediately when cluster data collection fails, so no report or values are generated.

## How to Test
1. Run with a normal kubeconfig → exit `0`, report generated.
2. Run with a kubeconfig that can list nodes but not pods → exit `1`, no report/values.

## Related issues/PRs:
* Resolved #2996

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prerequisite checks and reports no longer run when cluster data collection fails.
  * Errors from Kubernetes client setup and cluster data collection are now surfaced clearly.
  * Prevents reports from being generated using incomplete cluster information.

* **Tests**
  * Added coverage for Kubernetes client creation and cluster data collection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->