### PR TITLE
fix(cautils): return ConfigMap Get errors instead of discarding them

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -294,23 +295,28 @@ func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap(ctx contex
 	var ksConfigMap *corev1.ConfigMap
 	if len(configMaps.Items) == 0 {
 		// try to find configmaps by name (for backward compatibility)
-		ksConfigMap, _ = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
+		cm, getErr := c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				return nil
+			}
+			return getErr
+		}
+		ksConfigMap = cm
 	} else {
 		// use the first configmap with the label
 		ksConfigMap = &configMaps.Items[0]
 	}
 
-	if ksConfigMap != nil {
-		if jsonConf, ok := ksConfigMap.Data["clusterData"]; ok {
-			tempCO := ConfigObj{}
-			if err = json.Unmarshal([]byte(jsonConf), &tempCO); err != nil {
-				return err
-			}
-			c.configObj.updateEmptyFields(&tempCO)
+	if jsonConf, ok := ksConfigMap.Data["clusterData"]; ok {
+		tempCO := ConfigObj{}
+		if err = json.Unmarshal([]byte(jsonConf), &tempCO); err != nil {
+			return err
 		}
+		c.configObj.updateEmptyFields(&tempCO)
 	}
 
-	return err
+	return nil
 }
 
 func (c *ClusterConfig) updateConfigEmptyFieldsFromCredentialsSecret(ctx context.Context) error {

--- a/core/cautils/customerloader_context_test.go
+++ b/core/cautils/customerloader_context_test.go
@@ -185,3 +185,57 @@ func TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LoadsClusterData(t *testi
 	assert.Equal(t, "acc-123", c.configObj.AccountID)
 	assert.Equal(t, "https://api.example.com", c.configObj.CloudAPIURL)
 }
+
+func TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LegacyGetErrors(t *testing.T) {
+	emptyList := `{"apiVersion":"v1","kind":"ConfigMapList","items":[]}`
+
+	tests := []struct {
+		name       string
+		getStatus  int
+		getBody    string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{
+			name:       "forbidden get is returned",
+			getStatus:  http.StatusForbidden,
+			getBody:    `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"configmaps \"kubescape-config\" is forbidden","reason":"Forbidden","code":403}`,
+			wantErr:    true,
+			wantErrSub: "forbidden",
+		},
+		{
+			name:      "not found get is ignored",
+			getStatus: http.StatusNotFound,
+			getBody:   `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"configmaps \"kubescape-config\" not found","reason":"NotFound","code":404}`,
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				// Labeled list (no resource name in path) vs Get by name.
+				if strings.Contains(req.URL.RawQuery, "labelSelector=") || !strings.Contains(req.URL.Path, "/"+kubescapeConfigMapName) {
+					return jsonResponse(req, emptyList), nil
+				}
+				return &http.Response{
+					StatusCode: tc.getStatus,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(bytes.NewReader([]byte(tc.getBody))),
+					Request:    req,
+				}, nil
+			})
+
+			c := newTestClusterConfig(t, rt)
+			err := c.updateConfigEmptyFieldsFromKubescapeConfigMap(context.Background())
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, strings.ToLower(err.Error()), tc.wantErrSub)
+				assert.Empty(t, c.configObj.AccountID)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Overview
Previously, when the labeled ConfigMap list was empty, the legacy `Get("kubescape-config")` fallback discarded all errors. RBAC Forbidden or API failures looked like success, and Kubescape continued without account/cloud config.

Now that path ignores `NotFound` only and returns other Get errors.

## How to Test
1. Run: `go test ./core/cautils -run TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LegacyGetErrors -v`
2. Confirm Forbidden is returned and NotFound is ignored.

## Related issues/PRs:
* Resolved #2999

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy configuration lookup failures.
  * Missing legacy configuration is now treated as an empty configuration.
  * Other configuration access errors are surfaced correctly without altering existing settings.
* **Tests**
  * Added regression coverage for missing and forbidden configuration responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->