### PR TITLE
fix(vap): bound deploy-library downloads with a default timeout

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -53,6 +53,11 @@ func GetVapHelperCmd() *cobra.Command {
 	return vapHelperCmd
 }
 
+// defaultDownloadTimeout bounds each --from-release download. It matches the
+// 30s used by the other outbound HTTP clients in the codebase (the repository
+// scanner and the cluster connector).
+const defaultDownloadTimeout = 30 * time.Second
+
 func getDeployLibraryCmd() *cobra.Command {
 	var outputFile string
 	var fromRelease string
@@ -72,7 +77,7 @@ func getDeployLibraryCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 	cmd.Flags().StringVar(&fromRelease, "from-release", "", "Download the library from this cel-admission-library release tag (e.g. v0.11) instead of using the embedded copy")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "HTTP request timeout per download, only used with --from-release (e.g. 30s, 1m)")
+	cmd.Flags().DurationVar(&timeout, "timeout", defaultDownloadTimeout, "HTTP request timeout per download, only used with --from-release (e.g. 30s, 1m). 0 disables the timeout")
 
 	return cmd
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -566,7 +566,7 @@ func TestGetDeployLibraryCmd(t *testing.T) {
 
 	timeoutFlag := cmd.Flags().Lookup("timeout")
 	require.NotNil(t, timeoutFlag)
-	assert.Equal(t, "0s", timeoutFlag.DefValue)
+	assert.Equal(t, "30s", timeoutFlag.DefValue)
 
 	fromReleaseFlag := cmd.Flags().Lookup("from-release")
 	require.NotNil(t, fromReleaseFlag)
@@ -759,10 +759,25 @@ func TestCreatePolicyBindingCmdRequiredFlags(t *testing.T) {
 func TestDeployLibraryCmdTimeoutFlag(t *testing.T) {
 	cmd := getDeployLibraryCmd()
 
-	t.Run("timeout flag is registered with default 0s", func(t *testing.T) {
+	t.Run("timeout flag defaults to a bounded value", func(t *testing.T) {
 		timeoutFlag := cmd.Flags().Lookup("timeout")
 		require.NotNil(t, timeoutFlag)
-		assert.Equal(t, "0s", timeoutFlag.DefValue)
+		assert.Equal(t, "30s", timeoutFlag.DefValue)
+
+		// The default must actually bound the request; a zero default would
+		// leave http.Client unbounded and let a stalled download hang forever.
+		got, err := cmd.Flags().GetDuration("timeout")
+		require.NoError(t, err)
+		assert.Equal(t, defaultDownloadTimeout, got)
+		assert.NotZero(t, got)
+	})
+
+	t.Run("timeout can still be disabled explicitly", func(t *testing.T) {
+		cmd := getDeployLibraryCmd()
+		require.NoError(t, cmd.ParseFlags([]string{"--timeout", "0"}))
+		got, err := cmd.Flags().GetDuration("timeout")
+		require.NoError(t, err)
+		assert.Zero(t, got, "--timeout 0 must remain the opt-out")
 	})
 
 	t.Run("timeout flag can be set via args", func(t *testing.T) {


### PR DESCRIPTION
### What's wrong

`vap deploy-library` registers its `--timeout` flag with a default of `0`:

```go
cmd.Flags().DurationVar(&timeout, "timeout", 0, "HTTP request timeout per download, ...")
```

and that value is handed straight to the HTTP client:

```go
client := &http.Client{
    Timeout: timeout,
}
```

`http.Client.Timeout` treats zero as *no timeout*. So the flag whose whole purpose is to bound the download leaves it unbounded unless the user thinks to pass a value.

`downloadLibrary` pulls three files in sequence from GitHub releases. If any connection stalls after the handshake, `kubescape vap deploy-library --from-release v0.11` blocks indefinitely — no output, no progress, nothing to do but Ctrl-C. This is the same failure mode that #2827 fixed for the operator adapter's HTTP client.

### Change

Default to 30s, which is what the other outbound HTTP clients here already use — `core/pkg/resourcehandler/repositoryscanner.go` and `core/core/clusterconnector.go`.

`--timeout 0` still disables the timeout, so unbounded downloads remain available to anyone who wants them; they're just no longer what you get by accident.

Only the `--from-release` path performs network I/O, so the default embedded-bundle behaviour (#2514) is untouched.

### Tests

Two existing assertions expected the old `0s` default and are updated. Added coverage that the default is actually non-zero (a zero default is exactly the bug) and that `--timeout 0` still works as the opt-out.

`go test ./cmd/vap/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a 30-second default timeout for `vap deploy-library` downloads.
  * Custom timeout durations remain supported.
  * Set the timeout to `0` to disable it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->