### PR TITLE
fix(printer): keep PDF footnote markers consistent between table and legend

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -146,7 +146,7 @@ func (pp *PdfPrinter) generatePdf(summaryDetails *reportsummary.SummaryDetails) 
 
 	template := pdf.NewReportTemplate()
 	template.GenerateHeader(utils.FrameworksScoresToString(summaryDetails.ListFrameworks()), time.Now().Format(time.DateTime))
-	err := template.GenerateTable(pp.getTableObjects(summaryDetails, sortedControlIDs),
+	err := template.GenerateTable(pp.getTableObjects(summaryDetails, sortedControlIDs, infoToPrintInfo),
 		summaryDetails.NumberOfResources().Failed(), summaryDetails.NumberOfResources().All(), summaryDetails.ComplianceScore)
 
 	if err != nil {
@@ -166,9 +166,9 @@ func (pp *PdfPrinter) getFormattedInformation(infoMap []infoStars) []string {
 	return rows
 }
 
-// getTableData is responsible for getting the table data in a standardized format
-func (pp *PdfPrinter) getTableObjects(summaryDetails *reportsummary.SummaryDetails, sortedControlIDs [][]string) *[]pdf.TableObject {
-	infoToPrintInfoMap := mapInfoToPrintInfo(summaryDetails.Controls)
+// getTableData is responsible for getting the table data in a standardized format.
+// The markers are taken from the caller so the table and the legend share one list.
+func (pp *PdfPrinter) getTableObjects(summaryDetails *reportsummary.SummaryDetails, sortedControlIDs [][]string, infoToPrintInfoMap []infoStars) *[]pdf.TableObject {
 	var controls []pdf.TableObject
 	for _, sortedControlID := range slices.Backward(sortedControlIDs) {
 		for _, c := range sortedControlID {

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -265,11 +265,22 @@ type infoStars struct {
 	info  string
 }
 
+// mapInfoToPrintInfo assigns a footnote marker to every distinct skip reason.
+// Controls are walked in ID order: marker assignment follows iteration order, so
+// ranging over the map directly gives a different marker per run and lets two
+// calls over the same controls disagree.
 func mapInfoToPrintInfo(controls reportsummary.ControlSummaries) []infoStars {
+	controlIDs := make([]string, 0, len(controls))
+	for controlID := range controls {
+		controlIDs = append(controlIDs, controlID)
+	}
+	sort.Strings(controlIDs)
+
 	infoToPrintInfo := []infoStars{}
 	infoToPrintInfoMap := map[string]any{}
 	starCount := indicator
-	for _, control := range controls {
+	for _, controlID := range controlIDs {
+		control := controls[controlID]
 		if control.GetStatus().IsSkipped() && control.GetStatus().Info() != "" {
 			if _, ok := infoToPrintInfoMap[control.GetStatus().Info()]; !ok {
 				infoToPrintInfo = append(infoToPrintInfo, infoStars{

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
@@ -1171,5 +1173,35 @@ func TestFinalizeResults_SortsResultsAndResourcesByResourceID(t *testing.T) {
 			resourceIDs = append(resourceIDs, resource.ResourceID)
 		}
 		require.Equalf(t, expectedResourceIDs, resourceIDs, "resources iteration %d", i)
+	}
+}
+
+func Test_mapInfoToPrintInfo_stableMarkers(t *testing.T) {
+	skipReasons := map[string]string{
+		"C-0001": "no cluster connection",
+		"C-0002": "host scanner is not deployed",
+		"C-0003": "control configuration is missing",
+		"C-0004": "resource kind was not scanned",
+	}
+
+	controls := reportsummary.ControlSummaries{}
+	for controlID, info := range skipReasons {
+		controls[controlID] = reportsummary.ControlSummary{
+			ControlID:  controlID,
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusSkipped, InnerInfo: info},
+		}
+	}
+
+	want := []infoStars{
+		{stars: "†", info: skipReasons["C-0001"]},
+		{stars: "††", info: skipReasons["C-0002"]},
+		{stars: "†††", info: skipReasons["C-0003"]},
+		{stars: "††††", info: skipReasons["C-0004"]},
+	}
+
+	// The PDF printer reads the markers for the table and the legend from
+	// separate calls, so every call must return the same assignment.
+	for i := 0; i < 64; i++ {
+		require.Equalf(t, want, mapInfoToPrintInfo(controls), "iteration %d", i)
 	}
 }


### PR DESCRIPTION
The PDF printer built the skip-reason footnote markers twice: once for the control table and once for the legend below it. Marker assignment followed Go map iteration order, so the two lists could disagree and a control marked with `††` in the table pointed at a different reason in the legend.

`mapInfoToPrintInfo` now walks controls in ID order, and the PDF printer builds the list once and passes it to both the table and the legend. Marker assignment is stable across runs.

Added a test asserting repeated calls return the same assignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF report footnote marker consistency.
  * Ensured table rows and legend entries use matching marker assignments.
  * Marker ordering is now stable across repeated report generations.

* **Tests**
  * Added regression coverage to verify consistent skipped-control markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->