### PR TITLE
fix(operator): make GetRequestPayload side-effect-free, default --frameworks to all at the flag

### DIFF
--- a/cmd/operator/configscan.go
+++ b/cmd/operator/configscan.go
@@ -47,7 +47,7 @@ func getOperatorScanConfigCmd(ks meta.IKubescape, operatorInfo *cautils.Operator
 
 	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.IncludedNamespaces, "include-namespaces", nil, "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.ExcludedNamespaces, "exclude-namespaces", nil, "Namespaces to exclude from scanning. e.g: --exclude-namespaces ns-a,ns-b. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")
-	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.Frameworks, "frameworks", nil, "Load frameworks for configuration scanning")
+	configCmd.PersistentFlags().StringSliceVar(&configScanInfo.Frameworks, "frameworks", []string{"all"}, "Load frameworks for configuration scanning (default: all)")
 	configCmd.PersistentFlags().BoolVarP(&configScanInfo.HostScanner, "enable-host-scan", "", false, "Deploy Kubescape host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://github.com/kubescape/kubescape/blob/master/core/pkg/hostsensorutils/hostsensor.yaml")
 
 	return configCmd

--- a/cmd/operator/scan_test.go
+++ b/cmd/operator/scan_test.go
@@ -88,3 +88,50 @@ func TestOperatorScanCmd_NamespaceFlagPropagatesToChildCommands(t *testing.T) {
 	assert.Equal(t, "custom-ns", gotNamespace)
 	assert.IsType(t, &cautils.ConfigScanInfo{}, gotScanInfo)
 }
+
+// TestOperatorScanConfigCmd_FrameworksDefaultsToAll guards the flag-level
+// default: with no --frameworks passed, the scan info received by the operator
+// adapter must carry ["all"], not an empty slice. The default lives at the
+// flag boundary (cmd/operator/configscan.go), not inside GetRequestPayload.
+func TestOperatorScanConfigCmd_FrameworksDefaultsToAll(t *testing.T) {
+	var gotScanInfo cautils.OperatorScanInfo
+	prev := newOperatorAdapter
+	newOperatorAdapter = func(si cautils.OperatorScanInfo, _ string) (*core.OperatorAdapter, error) {
+		gotScanInfo = si
+		return nil, errors.New("stub")
+	}
+	t.Cleanup(func() { newOperatorAdapter = prev })
+
+	cmd := getOperatorScanCmd(&mocks.MockIKubescape{}, &cautils.OperatorInfo{})
+	cmd.SetArgs([]string{"configurations"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_ = cmd.Execute()
+
+	cfg, ok := gotScanInfo.(*cautils.ConfigScanInfo)
+	require.True(t, ok)
+	assert.Equal(t, []string{"all"}, cfg.Frameworks)
+}
+
+// TestOperatorScanConfigCmd_ExplicitFrameworksReplacesDefault guards pflag's
+// replace-on-first-set semantics: an explicit --frameworks value must replace
+// the ["all"] default, not append to it (pflag v1.0.10 string_slice.go Set()).
+func TestOperatorScanConfigCmd_ExplicitFrameworksReplacesDefault(t *testing.T) {
+	var gotScanInfo cautils.OperatorScanInfo
+	prev := newOperatorAdapter
+	newOperatorAdapter = func(si cautils.OperatorScanInfo, _ string) (*core.OperatorAdapter, error) {
+		gotScanInfo = si
+		return nil, errors.New("stub")
+	}
+	t.Cleanup(func() { newOperatorAdapter = prev })
+
+	cmd := getOperatorScanCmd(&mocks.MockIKubescape{}, &cautils.OperatorInfo{})
+	cmd.SetArgs([]string{"configurations", "--frameworks", "nsa,mitre"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_ = cmd.Execute()
+
+	cfg, ok := gotScanInfo.(*cautils.ConfigScanInfo)
+	require.True(t, ok)
+	assert.Equal(t, []string{"nsa", "mitre"}, cfg.Frameworks)
+}

--- a/core/cautils/operatorscaninfo.go
+++ b/core/cautils/operatorscaninfo.go
@@ -89,9 +89,6 @@ func (c *ConfigScanInfo) ValidatePayload(commands *apis.Commands) error {
 }
 
 func (c *ConfigScanInfo) GetRequestPayload() *apis.Commands {
-	if len(c.Frameworks) == 0 {
-		c.Frameworks = append(c.Frameworks, "all")
-	}
 	return &apis.Commands{
 		Commands: []apis.Command{
 			{

--- a/core/cautils/operatorscaninfo_test.go
+++ b/core/cautils/operatorscaninfo_test.go
@@ -71,8 +71,8 @@ func TestConfigScanInfo_ValidatePayload(t *testing.T) {
 }
 
 func TestConfigScanInfo_GetRequestPayload(t *testing.T) {
-	t.Run("default frameworks when none specified", func(t *testing.T) {
-		info := &ConfigScanInfo{}
+	t.Run("passes through explicitly set frameworks", func(t *testing.T) {
+		info := &ConfigScanInfo{Frameworks: []string{"all"}}
 		payload := info.GetRequestPayload()
 		request := requireConfigScanRequest(t, payload)
 
@@ -82,6 +82,12 @@ func TestConfigScanInfo_GetRequestPayload(t *testing.T) {
 		assert.Empty(t, request.ExcludedNamespaces)
 		require.NotNil(t, request.HostScanner)
 		assert.False(t, *request.HostScanner)
+	})
+
+	t.Run("does not mutate the receiver", func(t *testing.T) {
+		info := &ConfigScanInfo{}
+		info.GetRequestPayload()
+		assert.Empty(t, info.Frameworks)
 	})
 
 	t.Run("uses provided frameworks", func(t *testing.T) {


### PR DESCRIPTION
Resolved #3005

## Overview

- **Current behavior:** `ConfigScanInfo.GetRequestPayload()` currently mutates the receiver: when `Frameworks` is empty, it executes `c.Frameworks = append(c.Frameworks, "all")` (`core/cautils/operatorscaninfo.go:92-94`). This getter with a side effect silently changes the caller's object, is not thread-safe if shared across goroutines, and conceals the "default to all" behavior from `--help` and the flag boundary.
- **Future behavior:** Per maintainer feedback, the "default to all" logic is moved to the flag boundary, making `GetRequestPayload()` a pure, side-effect-free passthrough:
  - `--frameworks` defaults to `[]string{"all"}` (explicitly visible in `--help`).
  - `GetRequestPayload()` operates as a plain passthrough with no append or copy side effects.

---

## Additional Information

**Behavior notes (exported API + edge case):**
1. **Exported API:** `GetRequestPayload` is exported from `github.com/kubescape/kubescape/v3`. External callers constructing `ConfigScanInfo{}` directly that previously relied on the getter defaulting `TargetNames` to `["all"]` now receive the value as set. The default now lives exclusively in the CLI `--frameworks` flag. No in-repo caller depends on the old implicit default.
2. **Edge case:** An explicit `--frameworks ""` now yields empty `TargetNames` (previously defaulted to `["all"]`), respecting the user's explicit input. No in-repo caller uses this edge case.

**Break-check (verified):**
- The CLI is the sole production construction site of `ConfigScanInfo` (grep-verified).
- `OperatorAdapter.OperatorScan` (`core/core/clusterconnector.go:135`) reads only the returned payload, never `Frameworks` afterwards.
- The `/v1/metrics` path in `httphandler` builds its scan info via `getPrometheusDefaultScanCommand` and never uses `ConfigScanInfo`.
- No `Flags().Changed("frameworks")` usage exists in `cmd/` (grep-verified), so changing the default does not interfere with explicit-set detection.
- `--frameworks` is not documented in `docs/cli-reference.md` (verified) — no documentation update required.
- `pflag` v1.0.10 replaces the default on first `Set` (`string_slice.go:42-54`), ensuring explicit `--frameworks nsa,mitre` yields `["nsa","mitre"]` rather than `["all","nsa","mitre"]`.

---

## How to Test

```bash
go build ./...
go test ./core/cautils/... ./cmd/operator/... ./core/core/...
```

**New/updated coverage:**
- `TestConfigScanInfo_GetRequestPayload/passes_through_explicitly_set_frameworks`
- `TestConfigScanInfo_GetRequestPayload/does_not_mutate_the_receiver`
- `TestOperatorScanConfigCmd_FrameworksDefaultsToAll`
- `TestOperatorScanConfigCmd_ExplicitFrameworksReplacesDefault`

---

## Examples/Screenshots

N/A — behavior is identical for all existing callers; no visual change.

---

## Related Issues/PRs

- Resolved #3005

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configuration scans now include all frameworks by default.
  * When specific frameworks are selected, they replace the default instead of being added to it.

* **Bug Fixes**
  * Framework selections are preserved accurately when preparing configuration scan requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->