### PR TITLE
fix(cautils): use filesystem check instead of .json string heuristic in setUseArtifactsFrom

### DIFF
--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -227,9 +227,11 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) error {
 	// heuristic (a directory named "*.json" is still a directory). A bare
 	// filename with no path separator is left untouched so os.ReadDir below
 	// surfaces the existing clear error instead of silently scanning ".".
+	// An explicit current-directory path like "./<file>" has a separator, so
+	// it falls back to "." as its parent directory.
 	if info, err := os.Stat(scanInfo.UseArtifactsFrom); err == nil && !info.IsDir() {
-		if dir := filepath.Dir(scanInfo.UseArtifactsFrom); dir != "." {
-			scanInfo.UseArtifactsFrom = dir
+		if filepath.Base(scanInfo.UseArtifactsFrom) != scanInfo.UseArtifactsFrom {
+			scanInfo.UseArtifactsFrom = filepath.Dir(scanInfo.UseArtifactsFrom)
 		}
 	}
 	// set frameworks files

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -222,12 +222,15 @@ func (scanInfo *ScanInfo) setUseArtifactsFrom(ctx context.Context) error {
 	if scanInfo.UseArtifactsFrom == "" {
 		return nil
 	}
-	// UseArtifactsFrom must be a path without a filename
-	dir, file := filepath.Split(scanInfo.UseArtifactsFrom)
-	if dir == "" {
-		scanInfo.UseArtifactsFrom = file
-	} else if strings.Contains(file, ".json") {
-		scanInfo.UseArtifactsFrom = dir
+	// UseArtifactsFrom must be a directory. If it points at a single file,
+	// fall back to its parent directory based on the filesystem, not a name
+	// heuristic (a directory named "*.json" is still a directory). A bare
+	// filename with no path separator is left untouched so os.ReadDir below
+	// surfaces the existing clear error instead of silently scanning ".".
+	if info, err := os.Stat(scanInfo.UseArtifactsFrom); err == nil && !info.IsDir() {
+		if dir := filepath.Dir(scanInfo.UseArtifactsFrom); dir != "." {
+			scanInfo.UseArtifactsFrom = dir
+		}
 	}
 	// set frameworks files
 	files, err := os.ReadDir(scanInfo.UseArtifactsFrom)

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -562,6 +562,44 @@ func TestSetUseFrom(t *testing.T) {
 	}
 }
 
+func TestSetUseArtifactsFrom(t *testing.T) {
+	t.Run("directory whose name contains .json is kept as-is", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "my.json-artifacts")
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		scanInfo := &ScanInfo{UseArtifactsFrom: dir}
+		require.NoError(t, scanInfo.setUseArtifactsFrom(context.Background()))
+
+		assert.Equal(t, dir, scanInfo.UseArtifactsFrom)
+	})
+
+	t.Run("a file path falls back to its parent directory", func(t *testing.T) {
+		parent := t.TempDir()
+		file := filepath.Join(parent, "controls-inputs.json")
+		require.NoError(t, os.WriteFile(file, []byte(`{}`), 0600))
+
+		scanInfo := &ScanInfo{UseArtifactsFrom: file}
+		require.NoError(t, scanInfo.setUseArtifactsFrom(context.Background()))
+
+		assert.Equal(t, parent, scanInfo.UseArtifactsFrom)
+	})
+
+	t.Run("bare filename without separator is left untouched", func(t *testing.T) {
+		t.Chdir(t.TempDir()) // hermetic: behavior must not depend on the package dir contents
+
+		scanInfo := &ScanInfo{UseArtifactsFrom: "controls-inputs.json"}
+		require.Error(t, scanInfo.setUseArtifactsFrom(context.Background()))
+		assert.Equal(t, "controls-inputs.json", scanInfo.UseArtifactsFrom)
+	})
+
+	t.Run("nonexistent path is left untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing")
+		scanInfo := &ScanInfo{UseArtifactsFrom: path}
+		require.Error(t, scanInfo.setUseArtifactsFrom(context.Background()))
+		assert.Equal(t, path, scanInfo.UseArtifactsFrom)
+	})
+}
+
 // TestInitDeduplicatesUseFrom covers the offline HTTP handler configuration, where UseDefault
 // and UseArtifactsFrom both point at the local store: setUseFrom resolves a cache path per
 // identifier and setUseArtifactsFrom then discovers the very same file by reading the directory.

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -592,6 +592,16 @@ func TestSetUseArtifactsFrom(t *testing.T) {
 		assert.Equal(t, "controls-inputs.json", scanInfo.UseArtifactsFrom)
 	})
 
+	t.Run("explicit current-directory file path falls back to .", func(t *testing.T) {
+		t.Chdir(t.TempDir()) // hermetic: behavior must not depend on the package dir contents
+		require.NoError(t, os.WriteFile("./controls-inputs.json", []byte(`{}`), 0600))
+
+		scanInfo := &ScanInfo{UseArtifactsFrom: "./controls-inputs.json"}
+		require.NoError(t, scanInfo.setUseArtifactsFrom(context.Background()))
+
+		assert.Equal(t, ".", scanInfo.UseArtifactsFrom)
+	})
+
 	t.Run("nonexistent path is left untouched", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "missing")
 		scanInfo := &ScanInfo{UseArtifactsFrom: path}


### PR DESCRIPTION
Resolved #3008

## Overview

- **Current behavior:** `setUseArtifactsFrom()` (`core/cautils/scaninfo.go:226-231`) decides whether `--use-artifacts-from` points at a file or a directory using a string heuristic: `strings.Contains(file, ".json")`. A real directory whose name contains `.json` (e.g., `my.json-artifacts`, no trailing slash) is misclassified as a file, and the scan path is silently rewritten to its parent — loading frameworks from the wrong directory with no error.
- **Future behavior:** The decision is made by the filesystem, not by string matching:
  - A directory (any name) is kept as-is.
  - A file path falls back to its parent directory.
  - A bare filename with no path separator is left untouched, so `os.ReadDir` keeps surfacing the existing clear error instead of silently scanning `.`.

---

## Additional Information

**Behavior note:**
- `setUseArtifactsFrom` is unexported — no external-API change.
- One cosmetic difference: the file-path fallback now yields the parent directory *without* a trailing slash (previously `filepath.Split` produced one). `os.ReadDir` and `filepath.Join` handle both identically — no functional impact.

**Break-check (verified):**
- The `dir != "."` guard preserves the existing clear-error path for a bare filename (no silent fallback to the working directory).
- No caller depends on the old `.json` heuristic; `TestSetUseFrom` and `TestInitDeduplicatesUseFrom` (real directories) are unaffected.
- A symlink-to-directory whose name contains `.json` is now correctly kept (`os.Stat` follows the link).

---

## How to Test

```bash
go build ./...
go vet ./core/cautils/...
go test ./core/cautils/... ./core/core/...
golangci-lint run ./core/cautils/...
```

**New/updated coverage:**
- `TestSetUseArtifactsFrom/directory_whose_name_contains_.json_is_kept_as-is`
- `TestSetUseArtifactsFrom/a_file_path_falls_back_to_its_parent_directory`
- `TestSetUseArtifactsFrom/bare_filename_without_separator_is_left_untouched`
- `TestSetUseArtifactsFrom/nonexistent_path_is_left_untouched`

All four tests are hermetic (isolated temp dirs, `t.Chdir` where the test depends on cwd).

---

## Examples/Screenshots

N/A — behavior is preserved for all existing callers; no visual change.

---

## Related Issues/PRs

- Resolved #3008

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact source path handling when a file is provided, automatically using its containing directory where appropriate.
  * Preserved behavior for bare filenames and nonexistent paths.
  * Improved handling of directories with JSON-style names.

* **Tests**
  * Added coverage for artifact source paths, including files, directories, bare filenames, and invalid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->