### PR TITLE
fix(downloader): add 10-minute context timeout to prevent indefinite hangs

### DIFF
--- a/downloader/main.go
+++ b/downloader/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -13,7 +14,8 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
 	ks := core.NewKubescape(ctx)
 	downloads := []metav1.DownloadInfo{
 		{Target: "artifacts"},                         // download all artifacts


### PR DESCRIPTION
### Description
Closes #3013 
## Overview

Currently, the `downloader` binary initializes its context using `context.Background()` with no deadline or cancellation applied. Because there is no timeout mechanism, a hung network connection or unresponsive remote server can stall the download (and the overall docker build) indefinitely.

This PR fixes the issue by wrapping the context with a 10-minute timeout (`context.WithTimeout`). If the network stalls, the downloader will now gracefully time out and fail the build instead of hanging forever.

<!-- 

## Additional Information

> Any additional information that may be useful for reviewers to know 

-->

## How to Test

> Please provide instructions on how to test the changes made in this pull request

1. Simulate a completely stalled network connection (e.g. adding an iptables drop rule to block traffic to `github.com`).
2. Run the `downloader` binary.
3. Observe that after 10 minutes, the binary gracefully exits with a `context deadline exceeded` error instead of hanging indefinitely.

<!--



## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10-minute timeout to downloader operations, preventing them from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->