### PR TITLE
Add C-0298: detect subjects that can attach ephemeral containers to pods

### DIFF
--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -15,7 +15,23 @@ deny contains msga if {
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(role.kind, "Role")
 	endswith(rolebinding.kind, "Binding")
+	is_referenced_role(role, rolebinding)
 
+	rule := role.rules[p]
+
+is_referenced_role(role, rolebinding) if {
+	role.kind == "ClusterRole"
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+}
+
+is_referenced_role(role, rolebinding) if {
+	role.kind == "Role"
+	rolebinding.kind == "RoleBinding"
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	rolebinding.metadata.namespace == role.metadata.namespace
+}
 	rule := role.rules[p]
 
 	subject := rolebinding.subjects[k]

--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -1,0 +1,68 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+
+import rego.v1
+
+# input: regoResponseVectorObject
+# returns subjects that can create/update ephemeral containers on pods (equivalent to gaining exec-level code execution, and can potentially be used to break out to the node via a privileged ephemeral container)
+
+deny contains msga if {
+	verbs := ["update", "patch", "*"]
+	api_groups := ["", "*"]
+	resources := ["pods/ephemeralcontainers", "pods/*", "*"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+
+	rule := role.rules[p]
+
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+	])
+
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can attach ephemeral containers to pods", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 8,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+# for service accounts
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+# for users/ groups
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -51,8 +51,8 @@ is_referenced_role(role, rolebinding) if {
 	path := array.concat(resources_path, verb_path)
 	path2 := array.concat(path, api_groups_path)
 	finalpath := array.concat(path2, [
-		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
 		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
 	])
 
 	msga := {

--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -12,27 +12,11 @@ deny contains msga if {
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(role.kind, "Role")
 	endswith(rolebinding.kind, "Binding")
-	is_referenced_role(role, rolebinding)
 
 	rolebinding.roleRef.kind == role.kind
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 
-	rule := role.rules[p]
-
-is_referenced_role(role, rolebinding) if {
-	role.kind == "ClusterRole"
-	rolebinding.roleRef.kind == role.kind
-	rolebinding.roleRef.name == role.metadata.name
-}
-
-is_referenced_role(role, rolebinding) if {
-	role.kind == "Role"
-	rolebinding.kind == "RoleBinding"
-	rolebinding.roleRef.kind == role.kind
-	rolebinding.roleRef.name == role.metadata.name
-	rolebinding.metadata.namespace == role.metadata.namespace
-}
 	rule := role.rules[p]
 
 	subject := rolebinding.subjects[k]

--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -3,9 +3,6 @@ package armo_builtins
 
 import rego.v1
 
-# input: regoResponseVectorObject
-# returns subjects that can create/update ephemeral containers on pods (equivalent to gaining exec-level code execution, and can potentially be used to break out to the node via a privileged ephemeral container)
-
 deny contains msga if {
 	verbs := ["update", "patch", "*"]
 	api_groups := ["", "*"]
@@ -15,6 +12,10 @@ deny contains msga if {
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(role.kind, "Role")
 	endswith(rolebinding.kind, "Binding")
+
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
 
 	rule := role.rules[p]
 
@@ -35,8 +36,8 @@ deny contains msga if {
 	path := array.concat(resources_path, verb_path)
 	path2 := array.concat(path, api_groups_path)
 	finalpath := array.concat(path2, [
-		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
 		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
 	])
 
 	msga := {
@@ -53,14 +54,21 @@ deny contains msga if {
 	}
 }
 
-# for service accounts
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
 is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
-# for users/ groups
 is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name

--- a/rules/attach-ephemeral-container-v1/rule.metadata.json
+++ b/rules/attach-ephemeral-container-v1/rule.metadata.json
@@ -1,0 +1,29 @@
+{
+  "name": "attach-ephemeral-container-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Attach ephemeral container",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": [
+        "rbac.authorization.k8s.io"
+      ],
+      "apiVersions": [
+        "v1"
+      ],
+      "resources": [
+        "RoleBinding",
+        "ClusterRoleBinding",
+        "Role",
+        "ClusterRole"
+      ]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects can create/update ephemeral containers on pods, which is equivalent to gaining exec-level code execution and can be used to break out to the node via a privileged ephemeral container",
+  "remediation": "",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/attach-ephemeral-container-v1/rule.metadata.json
+++ b/rules/attach-ephemeral-container-v1/rule.metadata.json
@@ -24,6 +24,6 @@
   ],
   "ruleDependencies": [],
   "description": "determines which subjects can create/update ephemeral containers on pods, which is equivalent to gaining exec-level code execution and can be used to break out to the node via a privileged ephemeral container",
-  "remediation": "",
+  "remediation": "Restrict update/patch access to the pods/ephemeralcontainers subresource to a small, trusted set of subjects. Avoid granting update/patch/* on pods/* or cluster-wide wildcards, and prefer namespace-scoped Roles over ClusterRoles for debugging permissions.",
   "ruleQuery": "armo_builtins"
 }

--- a/rules/attach-ephemeral-container-v1/test/clusterrole/expected.json
+++ b/rules/attach-ephemeral-container-v1/test/clusterrole/expected.json
@@ -1,0 +1,73 @@
+[
+    {
+        "alertMessage": "Subject: User-dave can attach ephemeral containers to pods",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].subjects[0]",
+            "relatedObjects[0].roleRef.name"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].subjects[0]",
+            "relatedObjects[0].roleRef.name"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "User",
+                "name": "dave",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "RoleBinding",
+                        "metadata": {
+                            "name": "read-secrets",
+                            "namespace": "default"
+                        },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "pod-debugger-cluster"
+                        },
+                        "subjects": [
+                            {
+                                "apiGroup": "rbac.authorization.k8s.io",
+                                "kind": "User",
+                                "name": "dave"
+                            }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": {
+                            "name": "pod-debugger-cluster"
+                        },
+                        "rules": [
+                            {
+                                "apiGroups": [
+                                    ""
+                                ],
+                                "resources": [
+                                    "pods/*"
+                                ],
+                                "verbs": [
+                                    "update"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/attach-ephemeral-container-v1/test/clusterrole/input/clusterrole.yaml
+++ b/rules/attach-ephemeral-container-v1/test/clusterrole/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-debugger-cluster
+rules:
+- apiGroups: [""]
+  resources: ["pods/*"]
+  verbs: ["update"]

--- a/rules/attach-ephemeral-container-v1/test/clusterrole/input/clusterrolebinding.yaml
+++ b/rules/attach-ephemeral-container-v1/test/clusterrole/input/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-secrets
+  namespace: default
+subjects:
+- kind: User
+  name: dave
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-debugger-cluster
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/attach-ephemeral-container-v1/test/role/expected.json
+++ b/rules/attach-ephemeral-container-v1/test/role/expected.json
@@ -9,8 +9,8 @@
             "relatedObjects[1].rules[0].verbs[2]",
             "relatedObjects[1].rules[0].apiGroups[0]",
             "relatedObjects[1].rules[0].apiGroups[1]",
-            "relatedObjects[0].subjects[0]",
-            "relatedObjects[0].roleRef.name"
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
         ],
         "failedPaths": [
             "relatedObjects[1].rules[0].resources[0]",
@@ -20,8 +20,8 @@
             "relatedObjects[1].rules[0].verbs[2]",
             "relatedObjects[1].rules[0].apiGroups[0]",
             "relatedObjects[1].rules[0].apiGroups[1]",
-            "relatedObjects[0].subjects[0]",
-            "relatedObjects[0].roleRef.name"
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/attach-ephemeral-container-v1/test/role/expected.json
+++ b/rules/attach-ephemeral-container-v1/test/role/expected.json
@@ -1,0 +1,86 @@
+[
+    {
+        "alertMessage": "Subject: User-jane can attach ephemeral containers to pods",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].resources[1]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].verbs[1]",
+            "relatedObjects[1].rules[0].verbs[2]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[1].rules[0].apiGroups[1]",
+            "relatedObjects[0].subjects[0]",
+            "relatedObjects[0].roleRef.name"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].resources[1]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].verbs[1]",
+            "relatedObjects[1].rules[0].verbs[2]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[1].rules[0].apiGroups[1]",
+            "relatedObjects[0].subjects[0]",
+            "relatedObjects[0].roleRef.name"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "User",
+                "name": "jane",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "RoleBinding",
+                        "metadata": {
+                            "name": "pod",
+                            "namespace": "default"
+                        },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "Role",
+                            "name": "pod-debugger"
+                        },
+                        "subjects": [
+                            {
+                                "apiGroup": "rbac.authorization.k8s.io",
+                                "kind": "User",
+                                "name": "jane"
+                            }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "Role",
+                        "metadata": {
+                            "name": "pod-debugger",
+                            "namespace": "default"
+                        },
+                        "rules": [
+                            {
+                                "apiGroups": [
+                                    "",
+                                    "*"
+                                ],
+                                "resources": [
+                                    "pods/ephemeralcontainers",
+                                    "*"
+                                ],
+                                "verbs": [
+                                    "update",
+                                    "patch",
+                                    "*"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/attach-ephemeral-container-v1/test/role/input/role.yaml
+++ b/rules/attach-ephemeral-container-v1/test/role/input/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-debugger
+rules:
+- apiGroups: ["", "*"]
+  resources: ["pods/ephemeralcontainers", "*"]
+  verbs: ["update", "patch", "*"]

--- a/rules/attach-ephemeral-container-v1/test/role/input/rolebinding.yaml
+++ b/rules/attach-ephemeral-container-v1/test/role/input/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod
+  namespace: default
+subjects:
+- kind: User
+  name: jane
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: pod-debugger
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/attach-ephemeral-container-v1/test/serviceaccount/expected.json
+++ b/rules/attach-ephemeral-container-v1/test/serviceaccount/expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "alertMessage": "Subject: User-dave can attach ephemeral containers to pods",
+        "alertMessage": "Subject: ServiceAccount-debugger-sa can attach ephemeral containers to pods",
         "reviewPaths": [
             "relatedObjects[1].rules[0].resources[0]",
             "relatedObjects[1].rules[0].verbs[0]",
@@ -21,48 +21,29 @@
         "alertScore": 8,
         "alertObject": {
             "externalObjects": {
-                "apiGroup": "rbac.authorization.k8s.io",
-                "kind": "User",
-                "name": "dave",
+                "kind": "ServiceAccount",
+                "name": "debugger-sa",
+                "namespace": "kube-system",
                 "relatedObjects": [
                     {
                         "apiVersion": "rbac.authorization.k8s.io/v1",
-                        "kind": "RoleBinding",
-                        "metadata": {
-                            "name": "read-secrets",
-                            "namespace": "default"
-                        },
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "debugger-crb" },
                         "roleRef": {
                             "apiGroup": "rbac.authorization.k8s.io",
                             "kind": "ClusterRole",
-                            "name": "pod-debugger-cluster"
+                            "name": "ephemeral-debugger"
                         },
                         "subjects": [
-                            {
-                                "apiGroup": "rbac.authorization.k8s.io",
-                                "kind": "User",
-                                "name": "dave"
-                            }
+                            { "kind": "ServiceAccount", "name": "debugger-sa", "namespace": "kube-system" }
                         ]
                     },
                     {
                         "apiVersion": "rbac.authorization.k8s.io/v1",
                         "kind": "ClusterRole",
-                        "metadata": {
-                            "name": "pod-debugger-cluster"
-                        },
+                        "metadata": { "name": "ephemeral-debugger" },
                         "rules": [
-                            {
-                                "apiGroups": [
-                                    ""
-                                ],
-                                "resources": [
-                                    "pods/*"
-                                ],
-                                "verbs": [
-                                    "update"
-                                ]
-                            }
+                            { "apiGroups": [""], "resources": ["pods/ephemeralcontainers"], "verbs": ["patch"] }
                         ]
                     }
                 ]

--- a/rules/attach-ephemeral-container-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/attach-ephemeral-container-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ephemeral-debugger
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]

--- a/rules/attach-ephemeral-container-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/attach-ephemeral-container-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: debugger-crb
+subjects:
+- kind: ServiceAccount
+  name: debugger-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ephemeral-debugger
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
realted  #916 

## Summary
Addresses review feedback from @matthyx on this PR. Fixes a false-positive bug in the
`attach-ephemeral-container-v1` rule and adds the missing test case + remediation text.

## Changes

1. **False positive fix (blocker)** — `raw.rego` previously iterated over *any* Role and
   *any* RoleBinding present in `subjectVector.relatedObjects` without verifying they were
   actually linked. A subject bound to a safe Role, with an unrelated dangerous Role also
   present in `relatedObjects` (e.g. via a different binding), would incorrectly be flagged.
   Added checks that `rolebinding.roleRef.kind == role.kind`,
   `rolebinding.roleRef.name == role.metadata.name`, and matching namespace (for `Role`,
   since `ClusterRole` is cluster-scoped) — so only the role actually referenced by that
   specific binding is considered.

2. **New test case** — added `test/serviceaccount/` covering `ClusterRoleBinding` +
   `ClusterRole` + `ServiceAccount` subject, which wasn't previously covered (only
   `RoleBinding`→`Role` and `RoleBinding`→`ClusterRole` existed).

3. **Filled `remediation`** in `rule.metadata.json`, previously empty.

4. Updated `test/role/expected.json` and `test/clusterrole/expected.json` to match the new
   `finalpath` ordering from the fix.

## Testing
Validated locally with `opa eval` against:
- @matthyx's exact false-positive repro from the review — now returns `[]`
- All 3 existing/new positive fixtures (role, clusterrole, serviceaccount) — still fire correctly
- Negative case (plain `get`/`list` on pods) — still returns `[]`

## Related
Closes gap identified in kubescape/kubescape#916 (RBAC police integration —
`pods/ephemeralcontainers` privilege escalation, not previously covered).

Ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for identities with RBAC permissions to attach ephemeral containers to pods.
  * Supports permissions granted through roles, cluster roles, role bindings, and cluster role bindings.
  * Covers users, groups, and service accounts, including wildcard and relevant update or patch permissions.
  * Added alert metadata and remediation guidance for detected privilege-escalation risks.

* **Tests**
  * Added coverage for role-based, cluster role-based, and service account scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->