### PR TITLE
fix(cautils): return non-NotFound errors from legacy ConfigMap lookup

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -294,7 +295,11 @@ func (c *ClusterConfig) updateConfigEmptyFieldsFromKubescapeConfigMap(ctx contex
 	var ksConfigMap *corev1.ConfigMap
 	if len(configMaps.Items) == 0 {
 		// try to find configmaps by name (for backward compatibility)
-		ksConfigMap, _ = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
+		var getErr error
+		ksConfigMap, getErr = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
+		if getErr != nil && !apierrors.IsNotFound(getErr) {
+			return getErr
+		}
 	} else {
 		// use the first configmap with the label
 		ksConfigMap = &configMaps.Items[0]

--- a/core/cautils/customerloader_data_driven_test.go
+++ b/core/cautils/customerloader_data_driven_test.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
@@ -14,10 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func useTemporaryConfigStore(t *testing.T) {
@@ -223,6 +226,46 @@ func TestClusterConfigMapOnlyFillsMissingValues(t *testing.T) {
 	assert.Equal(t, "https://service-discovery-api.example.com", config.GetCloudAPIURL(), "service discovery must keep precedence")
 	assert.Equal(t, "configmap-cluster", config.GetContextName(), "a missing cluster name should be filled")
 	assert.Equal(t, "https://configmap-report.example.com", config.GetCloudReportURL(), "a missing report URL should be filled")
+}
+
+func TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LegacyGetErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		reactErr  error
+		wantError string
+	}{
+		{
+			name:     "not found is treated as absent config and ignored",
+			reactErr: apierrors.NewNotFound(corev1.Resource("configmaps"), kubescapeConfigMapName),
+		},
+		{
+			name:      "forbidden must not be silently discarded",
+			reactErr:  apierrors.NewForbidden(corev1.Resource("configmaps"), kubescapeConfigMapName, errors.New("user cannot get resource")),
+			wantError: "forbidden",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			k8s := k8sinterface.NewKubernetesApiMock()
+			clientset := fake.NewClientset()
+			// No labelled ConfigMaps exist, so updateConfigEmptyFieldsFromKubescapeConfigMap
+			// falls back to the legacy get-by-name lookup, which is the call this reactor fails.
+			clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.reactErr
+			})
+			k8s.KubernetesClient = clientset
+			config := &ClusterConfig{k8s: k8s, configObj: &ConfigObj{}, configMapNamespace: "security"}
+
+			err := config.updateConfigEmptyFieldsFromKubescapeConfigMap(context.Background())
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, ConfigObj{}, *config.configObj)
+		})
+	}
 }
 
 func Test_GetDefaultNS(t *testing.T) {


### PR DESCRIPTION
## Overview

`updateConfigEmptyFieldsFromKubescapeConfigMap()` in `core/cautils/customerloader.go` first lists ConfigMaps by the `kubescape.io/infra=config` label. When that list is empty, it falls back to a legacy `Get("kubescape-config")` lookup for backward compatibility — and that `Get` call's error was discarded:

```go
ksConfigMap, _ = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
```

That means a `Forbidden` response (or any other API failure) from the Kubernetes API server was indistinguishable from "no such ConfigMap": the function returned `nil` either way, and Kubescape silently continued with empty account/cloud config fields instead of surfacing the RBAC problem.

This PR keeps the current behavior for the case the fallback exists to handle (`NotFound` — no legacy ConfigMap present, nothing to do), but returns every other error instead of swallowing it:

```go
var getErr error
ksConfigMap, getErr = c.k8s.KubernetesClient.CoreV1().ConfigMaps(c.configMapNamespace).Get(ctx, kubescapeConfigMapName, metav1.GetOptions{})
if getErr != nil && !apierrors.IsNotFound(getErr) {
    return getErr
}
```

## How to Test

Added `TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LegacyGetErrors` in `core/cautils/customerloader_data_driven_test.go`, table-driven over two cases using a fake clientset reactor on `get configmaps`:
- `NotFound` → still returns `nil` and leaves the config object empty (existing behavior preserved).
- `Forbidden` → now returns the error (this is the regression check; it fails on `master` and passes with this fix).

```
go test ./core/cautils/... -run TestUpdateConfigEmptyFieldsFromKubescapeConfigMap_LegacyGetErrors -v
go test ./core/cautils/...
go build ./...
```
All pass locally.

## Related issues/PRs

Resolved #2999

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of errors when loading legacy Kubernetes configuration.
  - Missing legacy configuration remains ignored for compatibility.
  - Other access or lookup errors are now reported instead of being silently discarded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->