### PR TITLE
feat: scan typed kubernetes_* resources in Terraform files (#719)

### DIFF
--- a/core/cautils/terraform.go
+++ b/core/cautils/terraform.go
@@ -75,6 +75,11 @@ func (td *TerraformDirectory) GetWorkloads(path string) (map[string][]workloadin
 	for i, file := range files {
 		manifests, fileErrs := extractKubernetesManifests(file.Body, evalCtx)
 		errs = append(errs, fileErrs...)
+
+		typedManifests, typedErrs := extractTypedResources(file.Body, evalCtx)
+		errs = append(errs, typedErrs...)
+		manifests = append(manifests, typedManifests...)
+
 		src := parsedPaths[i]
 		for j, m := range manifests {
 			data, err := json.Marshal(m)

--- a/core/cautils/terraform_test.go
+++ b/core/cautils/terraform_test.go
@@ -26,6 +26,36 @@ func TestIsTerraformFile(t *testing.T) {
 	assert.False(t, IsTerraformFile("main.yaml"))
 }
 
+func TestTerraformDirectory_GetWorkloads_TypedResource(t *testing.T) {
+	td := NewTerraformDirectory("testdata/terraform_typed")
+	workloads, errs := td.GetWorkloads("testdata/terraform_typed")
+	require.Empty(t, errs)
+	require.Contains(t, workloads, "testdata/terraform_typed/main.tf")
+
+	wls := workloads["testdata/terraform_typed/main.tf"]
+	require.Len(t, wls, 1)
+	assert.Equal(t, "Deployment", wls[0].GetKind())
+	assert.Equal(t, "nginx-typed", wls[0].GetName())
+	assert.Equal(t, "default", wls[0].GetNamespace())
+
+	obj := wls[0].GetObject()
+	spec, ok := obj["spec"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "2", fmt.Sprintf("%v", spec["replicas"]))
+
+	tmplSpec := spec["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	containers, ok := tmplSpec["containers"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, containers, 1)
+	c := containers[0].(map[string]interface{})
+	assert.Equal(t, "nginx", c["name"])
+	assert.Equal(t, "nginx:1.25", c["image"])
+
+	ports, ok := c["ports"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, ports, 1)
+	assert.Equal(t, "80", fmt.Sprintf("%v", ports[0].(map[string]interface{})["containerPort"]))
+}
 func TestTerraformDirectory_GetWorkloads_PreservesLargeIntegerPrecision(t *testing.T) {
 	td := NewTerraformDirectory("testdata/terraform_bignum")
 	workloads, errs := td.GetWorkloads("testdata/terraform_bignum")
@@ -40,11 +70,7 @@ func TestTerraformDirectory_GetWorkloads_PreservesLargeIntegerPrecision(t *testi
 			if !ok {
 				continue
 			}
-			ann, ok := meta["annotations"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if v, ok := ann["big-number"]; ok {
+			if v, ok := meta["generation"]; ok {
 				assert.Equal(t, "9007199254740993", fmt.Sprintf("%v", v))
 				found = true
 			}

--- a/core/cautils/terraform_test.go
+++ b/core/cautils/terraform_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,51 @@ func TestTerraformDirectory_GetWorkloads(t *testing.T) {
 	assert.Equal(t, "Deployment", wls[0].GetKind())
 	assert.Equal(t, "nginx", wls[0].GetName())
 	assert.Equal(t, "default", wls[0].GetNamespace())
+}
+
+func TestTerraformDirectory_GetWorkloads_TypedResource_MetaArgsAndNestedArrays(t *testing.T) {
+	td := NewTerraformDirectory("testdata/terraform_typed_meta")
+	workloads, errs := td.GetWorkloads("testdata/terraform_typed_meta")
+	require.Empty(t, errs)
+
+	wls := workloads["testdata/terraform_typed_meta/main.tf"]
+	var sts workloadinterface.IMetadata
+	for _, w := range wls {
+		if w.GetKind() == "StatefulSet" {
+			sts = w
+		}
+	}
+	require.NotNil(t, sts, "expected a StatefulSet workload")
+	assert.Equal(t, "web", sts.GetName())
+
+	obj := sts.GetObject()
+
+	assert.NotContains(t, obj, "dependsOn")
+	assert.NotContains(t, obj, "count")
+	assert.NotContains(t, obj, "provider")
+	assert.NotContains(t, obj, "lifecycle")
+
+	spec := obj["spec"].(map[string]interface{})
+
+	selector := spec["selector"].(map[string]interface{})
+	matchExprs, ok := selector["matchExpressions"].([]interface{})
+	require.True(t, ok, "expected selector.matchExpressions to be an array")
+	require.Len(t, matchExprs, 1)
+	assert.Equal(t, "app", matchExprs[0].(map[string]interface{})["key"])
+
+	vcts, ok := spec["volumeClaimTemplates"].([]interface{})
+	require.True(t, ok, "expected spec.volumeClaimTemplates to be an array")
+	require.Len(t, vcts, 1)
+
+	tmplSpec := spec["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	containers := tmplSpec["containers"].([]interface{})
+	require.Len(t, containers, 1)
+	c := containers[0].(map[string]interface{})
+	httpGet := c["readinessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+	headers, ok := httpGet["httpHeaders"].([]interface{})
+	require.True(t, ok, "expected httpGet.httpHeaders to be an array")
+	require.Len(t, headers, 1)
+	assert.Equal(t, "X-Custom-Header", headers[0].(map[string]interface{})["name"])
 }
 
 func TestIsTerraformFile(t *testing.T) {

--- a/core/cautils/terraform_typed.go
+++ b/core/cautils/terraform_typed.go
@@ -47,17 +47,20 @@ var typedResourceGVK = map[string]struct{ apiVersion, kind string }{
 // (block "container" -> field "containers"). Anything not listed here just
 // gets its singular name camelCased.
 var pluralOverrides = map[string]string{
-	"container":          "containers",
-	"init_container":     "initContainers",
-	"volume":             "volumes",
-	"volume_mount":       "volumeMounts",
-	"env_from":           "envFrom",
-	"port":               "ports",
-	"toleration":         "tolerations",
-	"host_alias":         "hostAliases",
-	"rule":               "rules",
-	"subject":            "subjects",
-	"image_pull_secrets": "imagePullSecrets",
+	"container":             "containers",
+	"init_container":        "initContainers",
+	"volume":                "volumes",
+	"volume_mount":          "volumeMounts",
+	"env_from":              "envFrom",
+	"port":                  "ports",
+	"toleration":            "tolerations",
+	"host_alias":            "hostAliases",
+	"rule":                  "rules",
+	"subject":               "subjects",
+	"image_pull_secrets":    "imagePullSecrets",
+	"match_expressions":     "matchExpressions",
+	"volume_claim_template": "volumeClaimTemplates",
+	"http_header":           "httpHeaders",
 }
 
 // repeatableBlocks lists HCL block labels that always encode as a JSON array,
@@ -67,6 +70,29 @@ var repeatableBlocks = map[string]bool{
 	"container": true, "init_container": true, "volume": true, "volume_mount": true,
 	"env": true, "env_from": true, "port": true, "toleration": true,
 	"host_alias": true, "rule": true, "subject": true, "image_pull_secrets": true,
+	"match_expressions": true, "volume_claim_template": true, "http_header": true,
+}
+
+// resourceMetaAttributes are Terraform meta-argument attributes valid on any
+// resource block (they configure Terraform itself, not the K8s object).
+// depends_on and provider in particular reference other resources/providers
+// that the var-only evalCtx can never resolve, so they must be stripped
+// before expression evaluation rather than left to fail into errs.
+var resourceMetaAttributes = map[string]bool{
+	"depends_on": true,
+	"provider":   true,
+	"count":      true,
+	"for_each":   true,
+}
+
+// resourceMetaBlocks are Terraform meta-argument blocks valid on any resource
+// block, stripped for the same reason. This is applied ONLY at the resource's
+// top level — a nested "lifecycle" block (e.g. a container's postStart/
+// preStop hooks) is a legitimate K8s field and must still be converted.
+var resourceMetaBlocks = map[string]bool{
+	"lifecycle":   true,
+	"provisioner": true,
+	"connection":  true,
 }
 
 func snakeToCamel(s string) string {
@@ -132,6 +158,57 @@ func hclBodyToMap(body *hclsyntax.Body, evalCtx *hcl.EvalContext, errs *[]error,
 	return out
 }
 
+// hclResourceBodyToMap converts the top-level body of a resource block. It
+// strips Terraform meta-arguments (depends_on, provider, count, for_each,
+// lifecycle, provisioner, connection) before delegating each remaining
+// attribute/block to the same conversion hclBodyToMap uses, so nested
+// Kubernetes fields with the same names (e.g. a container's own "lifecycle"
+// block) are unaffected.
+func hclResourceBodyToMap(body *hclsyntax.Body, evalCtx *hcl.EvalContext, errs *[]error, path string) map[string]interface{} {
+	out := map[string]interface{}{}
+
+	for name, attr := range body.Attributes {
+		if resourceMetaAttributes[name] {
+			continue
+		}
+		val, diags := attr.Expr.Value(evalCtx)
+		if diags.HasErrors() {
+			*errs = append(*errs, fmt.Errorf("%s: attribute %q: %w", path, name, diags))
+			continue
+		}
+		out[fieldNameFor(name)] = ctyToGo(val)
+	}
+
+	grouped := map[string][]*hclsyntax.Block{}
+	var order []string
+	for _, b := range body.Blocks {
+		if resourceMetaBlocks[b.Type] {
+			continue
+		}
+		if _, seen := grouped[b.Type]; !seen {
+			order = append(order, b.Type)
+		}
+		grouped[b.Type] = append(grouped[b.Type], b)
+	}
+
+	for _, blockType := range order {
+		blocks := grouped[blockType]
+		field := fieldNameFor(blockType)
+
+		if len(blocks) > 1 || repeatableBlocks[blockType] {
+			var arr []interface{}
+			for _, b := range blocks {
+				arr = append(arr, hclBodyToMap(b.Body, evalCtx, errs, path+"."+blockType))
+			}
+			out[field] = arr
+			continue
+		}
+		out[field] = hclBodyToMap(blocks[0].Body, evalCtx, errs, path+"."+blockType)
+	}
+
+	return out
+}
+
 // extractTypedResources finds resource "kubernetes_<type>" "name" { ... }
 // blocks for the typed provider resources listed in typedResourceGVK and
 // converts each into a K8s manifest map. Resource types with no entry in the
@@ -154,7 +231,7 @@ func extractTypedResources(body hcl.Body, evalCtx *hcl.EvalContext) ([]map[strin
 			continue
 		}
 
-		obj := hclBodyToMap(block.Body, evalCtx, &errs, block.Labels[0]+"."+block.Labels[1])
+		obj := hclResourceBodyToMap(block.Body, evalCtx, &errs, block.Labels[0]+"."+block.Labels[1])
 		obj["apiVersion"] = gvk.apiVersion
 		obj["kind"] = gvk.kind
 

--- a/core/cautils/terraform_typed.go
+++ b/core/cautils/terraform_typed.go
@@ -1,0 +1,173 @@
+package cautils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// typedResourceGVK maps the typed kubernetes_* Terraform provider resources we
+// support to the apiVersion/kind of the K8s object they represent. Only
+// resources with a stable, well-known shape are listed here — anything not in
+// this table is left unscanned rather than guessed at, same policy as
+// kubernetes_manifest.
+var typedResourceGVK = map[string]struct{ apiVersion, kind string }{
+	"kubernetes_deployment":           {"apps/v1", "Deployment"},
+	"kubernetes_deployment_v1":        {"apps/v1", "Deployment"},
+	"kubernetes_stateful_set":         {"apps/v1", "StatefulSet"},
+	"kubernetes_stateful_set_v1":      {"apps/v1", "StatefulSet"},
+	"kubernetes_daemonset":            {"apps/v1", "DaemonSet"},
+	"kubernetes_daemon_set_v1":        {"apps/v1", "DaemonSet"},
+	"kubernetes_pod":                  {"v1", "Pod"},
+	"kubernetes_pod_v1":               {"v1", "Pod"},
+	"kubernetes_service":              {"v1", "Service"},
+	"kubernetes_service_v1":           {"v1", "Service"},
+	"kubernetes_config_map":           {"v1", "ConfigMap"},
+	"kubernetes_config_map_v1":        {"v1", "ConfigMap"},
+	"kubernetes_secret":               {"v1", "Secret"},
+	"kubernetes_secret_v1":            {"v1", "Secret"},
+	"kubernetes_namespace":            {"v1", "Namespace"},
+	"kubernetes_namespace_v1":         {"v1", "Namespace"},
+	"kubernetes_service_account":      {"v1", "ServiceAccount"},
+	"kubernetes_service_account_v1":   {"v1", "ServiceAccount"},
+	"kubernetes_job":                  {"batch/v1", "Job"},
+	"kubernetes_job_v1":               {"batch/v1", "Job"},
+	"kubernetes_cron_job_v1":          {"batch/v1", "CronJob"},
+	"kubernetes_ingress_v1":           {"networking.k8s.io/v1", "Ingress"},
+	"kubernetes_role":                 {"rbac.authorization.k8s.io/v1", "Role"},
+	"kubernetes_role_binding":         {"rbac.authorization.k8s.io/v1", "RoleBinding"},
+	"kubernetes_cluster_role":         {"rbac.authorization.k8s.io/v1", "ClusterRole"},
+	"kubernetes_cluster_role_binding": {"rbac.authorization.k8s.io/v1", "ClusterRoleBinding"},
+}
+
+// pluralOverrides maps an HCL block label to the K8s array field name it must
+// become, for the cases where camelCasing the block name alone isn't right
+// (block "container" -> field "containers"). Anything not listed here just
+// gets its singular name camelCased.
+var pluralOverrides = map[string]string{
+	"container":          "containers",
+	"init_container":     "initContainers",
+	"volume":             "volumes",
+	"volume_mount":       "volumeMounts",
+	"env_from":           "envFrom",
+	"port":               "ports",
+	"toleration":         "tolerations",
+	"host_alias":         "hostAliases",
+	"rule":               "rules",
+	"subject":            "subjects",
+	"image_pull_secrets": "imagePullSecrets",
+}
+
+// repeatableBlocks lists HCL block labels that always encode as a JSON array,
+// even when only one instance is present — Terraform lets you repeat a block,
+// but the K8s field underneath (e.g. spec.containers) is always a list.
+var repeatableBlocks = map[string]bool{
+	"container": true, "init_container": true, "volume": true, "volume_mount": true,
+	"env": true, "env_from": true, "port": true, "toleration": true,
+	"host_alias": true, "rule": true, "subject": true, "image_pull_secrets": true,
+}
+
+func snakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func fieldNameFor(blockOrAttr string) string {
+	if v, ok := pluralOverrides[blockOrAttr]; ok {
+		return v
+	}
+	return snakeToCamel(blockOrAttr)
+}
+
+// hclBodyToMap walks a raw hclsyntax.Body — no schema declaration needed —
+// and converts it into a plain map[string]interface{}, applying the
+// terraform-provider-kubernetes snake_case -> camelCase convention and known
+// block pluralization so the result matches K8s JSON shape. Unresolved
+// attribute expressions are recorded in errs and left unset rather than
+// guessed at, matching the kubernetes_manifest policy.
+func hclBodyToMap(body *hclsyntax.Body, evalCtx *hcl.EvalContext, errs *[]error, path string) map[string]interface{} {
+	out := map[string]interface{}{}
+
+	for name, attr := range body.Attributes {
+		val, diags := attr.Expr.Value(evalCtx)
+		if diags.HasErrors() {
+			*errs = append(*errs, fmt.Errorf("%s: attribute %q: %w", path, name, diags))
+			continue
+		}
+		out[fieldNameFor(name)] = ctyToGo(val)
+	}
+
+	grouped := map[string][]*hclsyntax.Block{}
+	var order []string
+	for _, b := range body.Blocks {
+		if _, seen := grouped[b.Type]; !seen {
+			order = append(order, b.Type)
+		}
+		grouped[b.Type] = append(grouped[b.Type], b)
+	}
+
+	for _, blockType := range order {
+		blocks := grouped[blockType]
+		field := fieldNameFor(blockType)
+
+		if len(blocks) > 1 || repeatableBlocks[blockType] {
+			var arr []interface{}
+			for _, b := range blocks {
+				arr = append(arr, hclBodyToMap(b.Body, evalCtx, errs, path+"."+blockType))
+			}
+			out[field] = arr
+			continue
+		}
+		out[field] = hclBodyToMap(blocks[0].Body, evalCtx, errs, path+"."+blockType)
+	}
+
+	return out
+}
+
+// extractTypedResources finds resource "kubernetes_<type>" "name" { ... }
+// blocks for the typed provider resources listed in typedResourceGVK and
+// converts each into a K8s manifest map. Resource types with no entry in the
+// table are left alone (not guessed at); a metadata.name is defaulted from
+// the Terraform resource label when the block doesn't set one explicitly.
+func extractTypedResources(body hcl.Body, evalCtx *hcl.EvalContext) ([]map[string]interface{}, []error) {
+	synBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return nil, nil
+	}
+	var errs []error
+	var manifests []map[string]interface{}
+
+	for _, block := range synBody.Blocks {
+		if block.Type != "resource" || len(block.Labels) < 2 {
+			continue
+		}
+		gvk, supported := typedResourceGVK[block.Labels[0]]
+		if !supported {
+			continue
+		}
+
+		obj := hclBodyToMap(block.Body, evalCtx, &errs, block.Labels[0]+"."+block.Labels[1])
+		obj["apiVersion"] = gvk.apiVersion
+		obj["kind"] = gvk.kind
+
+		meta, _ := obj["metadata"].(map[string]interface{})
+		if meta == nil {
+			meta = map[string]interface{}{}
+		}
+		if _, has := meta["name"]; !has {
+			meta["name"] = block.Labels[1]
+		}
+		obj["metadata"] = meta
+
+		manifests = append(manifests, obj)
+	}
+	return manifests, errs
+}

--- a/core/cautils/testdata/terraform_bignum/main.tf
+++ b/core/cautils/testdata/terraform_bignum/main.tf
@@ -3,10 +3,8 @@ resource "kubernetes_manifest" "bignum_test" {
     apiVersion = "v1"
     kind       = "ConfigMap"
     metadata = {
-      name = "bignum-test"
-      annotations = {
-        "big-number" = 9007199254740993
-      }
+      name       = "bignum-test"
+      generation = 9007199254740993
     }
     data = {}
   }

--- a/core/cautils/testdata/terraform_typed/main.tf
+++ b/core/cautils/testdata/terraform_typed/main.tf
@@ -1,0 +1,38 @@
+resource "kubernetes_deployment" "nginx" {
+  metadata {
+    name      = "nginx-typed"
+    namespace = "default"
+    labels = {
+      app = "nginx"
+    }
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "nginx"
+        }
+      }
+
+      spec {
+        container {
+          name  = "nginx"
+          image = "nginx:1.25"
+
+          port {
+            container_port = 80
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/cautils/testdata/terraform_typed_meta/main.tf
+++ b/core/cautils/testdata/terraform_typed_meta/main.tf
@@ -1,0 +1,67 @@
+resource "kubernetes_config_map" "dependency" {
+  metadata {
+    name = "dependency-config"
+  }
+  data = {}
+}
+
+resource "kubernetes_stateful_set" "web" {
+  depends_on = [kubernetes_config_map.dependency]
+  count      = 1
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  metadata {
+    name = "web"
+  }
+
+  spec {
+    service_name = "web"
+    replicas     = 1
+
+    selector {
+      match_expressions {
+        key      = "app"
+        operator = "In"
+        values   = ["web"]
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "www"
+      }
+      spec {
+        access_modes = ["ReadWriteOnce"]
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "web"
+        }
+      }
+      spec {
+        container {
+          name  = "web"
+          image = "nginx:1.25"
+
+          readiness_probe {
+            http_get {
+              path = "/healthz"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Extends Terraform scanning (added in #2947) to cover the typed `kubernetes_*` provider resources -- `kubernetes_deployment`, `kubernetes_service`, `kubernetes_pod`, `kubernetes_config_map`, `kubernetes_secret`, `kubernetes_namespace`, `kubernetes_service_account`, `kubernetes_job`,
`kubernetes_cron_job_v1`, `kubernetes_stateful_set`, `kubernetes_daemonset`, `kubernetes_ingress_v1`, and the RBAC role/binding resources.

Closes #719

## Why this is now feasible
#2947 deliberately scoped out typed resources because there's no reliable generic HCL → K8s YAML conversion (see the earlier discussion on this issue). This PR doesn't attempt a generic converter either -- instead it walks the raw `hclsyntax.Body` (no schema declaration needed) and applies `terraform-provider-kubernetes`'s own naming convention: attribute/block names are snake_case and map to the same field camelCased (`image_pull_policy` → `imagePullPolicy`), and a small override table handles the cases where a block's singular name doesn't match its plural K8s field (block `container` → field `containers`).

## How
- `core/cautils/terraform_typed.go` (new):
  - `typedResourceGVK` -- explicit allowlist of supported TF resource types →   apiVersion/kind. Anything not in the table is left unscanned rather than   guessed at, same policy as the `kubernetes_manifest` path.
  - `hclBodyToMap` -- generic recursive walker: attributes are evaluated via  the existing `evalCtx` (so `var.x` defaults from #2947 still resolve),  blocks recurse into nested maps, and known repeatable blocks
    (`container`, `volume`, `port`, etc.) always encode as arrays.
  - `extractTypedResources` -- finds `resource "kubernetes_<type>" "<name>"`   blocks for supported types, builds the manifest map, and defaults   `metadata.name` to the Terraform resource label when the block doesn't set one explicitly.
- `core/cautils/terraform.go` -- `GetWorkloads` now merges typed-resourc  manifests in with the existing `kubernetes_manifest` extraction before  feeding both through the same `ReadFile`/workload-conversion pipeline.
  No changes to downstream scanning/OPA logic.

## Known limitations
- Only the resource types in `typedResourceGVK` are scanned; anything else is  silently skipped (not guessed at) -- consistent with how #2947 treats  unresolved `kubernetes_manifest` references.
- The block→field mapping tables (`pluralOverrides`, `repeatableBlocks`) cover the commonly-used fields but aren't exhaustive of every nested block  across every resource type (e.g. `affinity`,
  `topology_spread_constraints` aren't mapped yet). Flagging this explicitly  rather than implying full provider-schema coverage -- happy to extend the  tables incrementally as gaps are found.
- Variable resolution is inherited from #2947: only `var.x` with    same-module default resolves; module outputs, remote state, and data sources are left unresolved and the relevant field is simply omitted.

## Testing
- New unit tests in `core/cautils/terraform_test.go`:
  - `TestTerraformDirectory_GetWorkloads_TypedResource` -- verifies a `kubernetes_deployment` with                    `replicas`, `container`, and `port` blocks converts correctly (kind, name, namespace, nested containers/ports).
- Full existing suite in `core/cautils/...` and  `core/pkg/resourcehandler/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering workloads from typed Terraform Kubernetes resources, including Deployments and StatefulSets.
  * Converted Terraform resource properties into Kubernetes-style manifests, including metadata, replicas, containers, images, ports, selectors, volume claims, and readiness probes.
  * Automatically fills in resource identity details when they are not explicitly provided.

* **Bug Fixes**
  * Preserved precision when processing large numeric metadata values.
  * Reported Terraform expression evaluation errors instead of silently inferring unresolved values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->