### PR TITLE
fix(prometheus): group metric samples by family in the exposition output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -235,23 +235,42 @@ func toRowInMetrics(name string, row string, value int) string {
 	return fmt.Sprintf("%s{%s} %d", name, row, value)
 
 }
+
+// emitMetricFamily renders lines as one group per metric family: the HELP/TYPE
+// header followed by every sample of that family. Grouping is required because
+// each item contributes one line to several families (a resource emits a failed
+// and a skipped counter), so writing the lines in the order they were collected
+// interleaves the families once there is more than one item. The text exposition
+// format requires a family's samples to be contiguous.
+//
+// Families keep the order in which they were first seen, so the metric layout
+// still follows the order the caller collected the lines in.
 func emitMetricFamily(lines []string) string {
 	if len(lines) == 0 {
 		return ""
 	}
-	emitted := map[string]bool{}
-	var r strings.Builder
+	// keyed by family, not by sample: a scan emits a fixed handful of families and a
+	// line per item within each, so both stay small next to len(lines).
+	var order []string
+	samples := map[string][]string{}
 	for _, line := range lines {
 		// extract metric name (everything before '{')
 		name := line
 		if before, _, ok := strings.Cut(line, "{"); ok {
 			name = before
 		}
-		if !emitted[name] {
-			r.WriteString(toMetricHeader(name, name) + "\n")
-			emitted[name] = true
+		if _, seen := samples[name]; !seen {
+			order = append(order, name)
 		}
-		r.WriteString(line + "\n")
+		samples[name] = append(samples[name], line)
+	}
+
+	var r strings.Builder
+	for _, name := range order {
+		r.WriteString(toMetricHeader(name, name) + "\n")
+		for _, line := range samples[name] {
+			r.WriteString(line + "\n")
+		}
 	}
 	return r.String()
 }

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -386,6 +386,61 @@ func TestMetrics_String_MultiItem_NoDuplicateHeaders(t *testing.T) {
 	assert.Contains(t, output, "kubescape_resource_count_controls_failed{apiVersion=\"v1\",kind=\"Pod\",namespace=\"ns2\",name=\"Resource B\"} 4")
 }
 
+func TestMetrics_String_MultiItem_SamplesGroupedPerFamily(t *testing.T) {
+	// The exposition format requires a family's samples to be contiguous. Each item
+	// contributes a line to several families, so collecting them item by item and
+	// writing them in that order splits every family once there is a second item.
+	m := Metrics{
+		listFrameworks: []mFrameworkComplianceScore{
+			{frameworkName: "Framework A", complianceScore: 80, resourcesCountFailed: 5},
+			{frameworkName: "Framework B", complianceScore: 60, resourcesCountFailed: 10},
+		},
+		listControls: []mControlComplianceScore{
+			{controlName: "Control A", severity: "high", link: "https://link-a.com", complianceScore: 50},
+			{controlName: "Control B", severity: "low", link: "https://link-b.com", complianceScore: 90},
+		},
+		listResources: []mResources{
+			{name: "Resource A", namespace: "ns1", apiVersion: "v1", kind: "Pod", controlsCountFailed: 2},
+			{name: "Resource B", namespace: "ns2", apiVersion: "v1", kind: "Pod", controlsCountFailed: 4},
+		},
+		listImages: []mImageVulnerability{
+			{image: "nginx:latest", severity: "High", cveCount: 3, fixableCVECount: 1},
+			{image: "nginx:latest", severity: "Low", cveCount: 7, fixableCVECount: 2},
+		},
+	}
+
+	// closed records a family that a later sample would reopen: a family is closed
+	// once a line belonging to a different family follows it.
+	seen := map[string]bool{}
+	closed := map[string]bool{}
+	current := ""
+	for _, line := range strings.Split(m.String(), "\n") {
+		if line == "" || strings.HasPrefix(line, "# ") {
+			continue
+		}
+		name, _, ok := strings.Cut(line, "{")
+		assert.True(t, ok, "sample %q has no labels", line)
+
+		assert.False(t, closed[name], "family %q is split: sample %q comes after another family", name, line)
+		if current != "" && current != name {
+			closed[current] = true
+		}
+		seen[name] = true
+		current = name
+	}
+
+	// the families the fixture populates, so a silently empty output fails too
+	for _, name := range []string{
+		"kubescape_framework_complianceScore",
+		"kubescape_control_complianceScore",
+		"kubescape_resource_count_controls_failed",
+		"kubescape_image_count_cve",
+		"kubescape_image_count_cve_fixable",
+	} {
+		assert.True(t, seen[name], "family %q is missing from the output", name)
+	}
+}
+
 func TestSetComplianceScores_ClusterMetricUsesComplianceScore(t *testing.T) {
 	// The cluster gauge is named complianceScore, so it must not be fed the risk score.
 	summaryDetails := &reportsummary.SummaryDetails{


### PR DESCRIPTION
## Overview

`emitMetricFamily` wrote the collected metric lines in the order they arrived and emitted a `# HELP`/`# TYPE` header the first time it saw each family. The callers build those lines per item, and one item contributes to several families: a resource emits both a failed and a skipped counter, a framework emits seven. So the first item opens every family and the second item reopens them, after the headers have already been written.

With two resources the output is:

```
# HELP kubescape_resource_count_controls_failed ...
kubescape_resource_count_controls_failed{...,name="A"} 2
# HELP kubescape_resource_count_controls_skipped ...
kubescape_resource_count_controls_skipped{...,name="A"} 1
kubescape_resource_count_controls_failed{...,name="B"} 4
kubescape_resource_count_controls_skipped{...,name="B"} 3
```

The text exposition format requires all samples of a metric family to be contiguous, so a scan with more than one resource, framework, control or image produced output that no longer satisfies it. Single-item scans were unaffected, which is why the existing tests passed.

`emitMetricFamily` now buckets the lines by family in one pass and writes each family as a single group. Families keep the order in which they were first seen, so the metric layout still follows the order the caller collected them in and single-item output is byte-identical.

`TestMetrics_String_MultiItem_SamplesGroupedPerFamily` walks the output and fails if a family's samples are split by another family, across all four multi-item lists. It fails on master. Existing tests in the package are unchanged and still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus metrics are now emitted in contiguous metric families, keeping each family’s metadata and samples together.
  * Preserved the original order in which metric families first appear.
  * Ensured populated image and compliance metrics are consistently included in output.

* **Tests**
  * Added coverage for metric grouping across multiple frameworks, controls, resources, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->