### PR TITLE
chore(deps): tidy go.mod for backoff import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/briandowns/spinner v1.23.2
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/deckarep/golang-set/v2 v2.8.0
@@ -212,7 +213,6 @@ require (
 	github.com/buildkite/go-pipeline v0.16.0 // indirect
 	github.com/buildkite/interpolate v0.1.5 // indirect
 	github.com/buildkite/roko v1.4.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect


### PR DESCRIPTION
## Overview
This PR runs `go mod tidy` to clean up the module dependencies. This moves `github.com/cenkalti/backoff/v4` from the `indirect` block to the direct `require` block in `go.mod`, as it is now directly imported by `downloader/main.go`. 
This is a minor tidiness follow-up to the maintainer's review feedback on PR #3016.
<!-- 
## Additional Information
> Any additional information that may be useful for reviewers to know 
-->
## How to Test

This is purely a dependency configuration change. It does not affect building or tests, but you can confirm `go test ./downloader/...` and `go build ./downloader/...` still run seamlessly.
<!--
## Examples/Screenshots
> Here you add related screenshots 
-->
## Related issues/PRs:
Follow-up to:
* PR #3016 (which resolved Issue #3015)
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency configuration to use the backoff library directly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->