### PR TITLE
feat(printer): add markdown output format

### DIFF
--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -395,7 +395,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, cyclonedx-json, spdx-json"
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json"
 	assert.EqualError(t, err, errMessage)
 }
 

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -25,12 +25,13 @@ const (
 	GitLabSASTFormat  string = "gitlab-sast"
 	YamlFormat        string = "yaml"
 	CsvFormat         string = "csv"
+	MarkdownFormat    string = "markdown"
 	CycloneDXFormat   string = "cyclonedx-json"
 	SPDXFormat        string = "spdx-json"
 )
 
 // AllFormats lists every output format kubescape can emit.
-var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, CycloneDXFormat, SPDXFormat}
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat}
 
 // ImageFormats lists formats whose printers support image-scan data. CSV is
 // deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
@@ -51,6 +52,7 @@ const (
 	PrettyOutputExt     = ".txt"
 	YamlOutputExt       = ".yaml"
 	CsvOutputExt        = ".csv"
+	MarkdownOutputExt   = ".md"
 	CycloneDXOutputExt  = ".cdx.json"
 	SPDXOutputExt       = ".spdx.json"
 )

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -1,0 +1,223 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+const (
+	markdownOutputFile  = "report"
+	markdownTempPattern = "kubescape-md-*.md"
+)
+
+var _ printer.IPrinter = &MarkdownPrinter{}
+
+type MarkdownPrinter struct {
+	writer *os.File
+}
+
+func NewMarkdownPrinter() *MarkdownPrinter {
+	return &MarkdownPrinter{}
+}
+
+func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) {
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile == "" {
+		outputFile = markdownOutputFile + printer.MarkdownOutputExt
+		logger.L().Info("no --output specified for markdown format; writing to default file",
+			helpers.String("filename", outputFile))
+	} else if filepath.Ext(outputFile) != printer.MarkdownOutputExt {
+		outputFile = outputFile + printer.MarkdownOutputExt
+	}
+	mp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, markdownTempPattern)
+}
+
+func (mp *MarkdownPrinter) Score(score float32) {
+}
+
+func (mp *MarkdownPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	if opaSessionObj == nil || opaSessionObj.Report == nil {
+		logger.L().Ctx(ctx).Error("no data provided for markdown output")
+		return nil
+	}
+
+	summaryDetails := &opaSessionObj.Report.SummaryDetails
+	w := mp.writer
+
+	ew := &mdErrWriter{w: w}
+	ew.printf("# Kubescape Security Report\n\n")
+	ew.printf("**Compliance Score:** %d\n\n", cautils.ComplianceScoreToInt(summaryDetails.ComplianceScore))
+	if ew.err != nil {
+		return ew.err
+	}
+
+	sorted := mdSortedControls(summaryDetails.Controls)
+
+	if err := mdWriteSummaryTable(w, sorted); err != nil {
+		return err
+	}
+	if err := mdWriteFailedSection(ctx, w, sorted, opaSessionObj); err != nil {
+		return err
+	}
+
+	printer.LogOutputFile(w.Name())
+	return nil
+}
+
+func (mp *MarkdownPrinter) PrintNextSteps() {}
+
+func (mp *MarkdownPrinter) CloseWriter() {
+	if mp.writer != nil && mp.writer != os.Stdout {
+		_ = mp.writer.Close()
+	}
+}
+
+// mdErrWriter wraps an io.Writer and records the first write error so callers
+// can issue multiple printf calls and check once at the end.
+type mdErrWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *mdErrWriter) printf(format string, args ...interface{}) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+func mdSortedControls(controls reportsummary.ControlSummaries) []reportsummary.ControlSummary {
+	out := make([]reportsummary.ControlSummary, 0, len(controls))
+	for _, ctrl := range controls {
+		out = append(out, ctrl)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		si := apis.ControlSeverityToInt(out[i].GetScoreFactor())
+		sj := apis.ControlSeverityToInt(out[j].GetScoreFactor())
+		if si != sj {
+			return si > sj
+		}
+		return out[i].GetName() < out[j].GetName()
+	})
+	return out
+}
+
+func mdWriteSummaryTable(w io.Writer, controls []reportsummary.ControlSummary) error {
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Summary\n\n")
+	ew.printf("| Severity | Control | ID | Status | Failed | Passed |\n")
+	ew.printf("|---|---|---|---|---|---|\n")
+
+	for i := range controls {
+		ctrl := &controls[i]
+		lists := ctrl.ListResourcesIDs(nil)
+		ew.printf("| %s | %s | %s | %s | %d | %d |\n",
+			apis.ControlSeverityToString(ctrl.GetScoreFactor()),
+			mdEscapeCell(ctrl.GetName()),
+			ctrl.GetID(),
+			mdStatusLabel(ctrl.GetStatus()),
+			lists.Failed(),
+			lists.Passed(),
+		)
+	}
+	ew.printf("\n")
+	return ew.err
+}
+
+func mdWriteFailedSection(ctx context.Context, w io.Writer, controls []reportsummary.ControlSummary, session *cautils.OPASessionObj) error {
+	hasFailed := false
+	for i := range controls {
+		if controls[i].GetStatus().IsFailed() {
+			hasFailed = true
+			break
+		}
+	}
+	if !hasFailed {
+		return nil
+	}
+
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Failed Controls\n\n")
+
+	for i := range controls {
+		ctrl := &controls[i]
+		if !ctrl.GetStatus().IsFailed() {
+			continue
+		}
+
+		severity := apis.ControlSeverityToString(ctrl.GetScoreFactor())
+		ew.printf("### %s — %s (`%s`)\n\n", ctrl.GetName(), severity, ctrl.GetID())
+
+		if rem := ctrl.GetRemediation(); rem != "" {
+			ew.printf("> **Remediation:** %s\n\n", rem)
+		}
+
+		ew.printf("[View documentation](%s)\n\n", cautils.GetControlLink(ctrl.GetID()))
+
+		if ew.err != nil {
+			return ew.err
+		}
+
+		failedIDs := ctrl.ListResourcesIDs(nil).GetItems(apis.StatusFailed)
+		sort.Strings(failedIDs)
+
+		if len(failedIDs) == 0 {
+			continue
+		}
+
+		ew.printf("| Resource | Kind | Namespace |\n")
+		ew.printf("|---|---|---|\n")
+
+		for _, id := range failedIDs {
+			res, ok := session.AllResources[id]
+			if !ok {
+				logger.L().Ctx(ctx).Debug("resource missing from AllResources", helpers.String("resourceID", id))
+				ew.printf("| %s | — | — |\n", mdEscapeCell(id))
+				continue
+			}
+			ew.printf("| %s | %s | %s |\n",
+				mdEscapeCell(res.GetName()),
+				mdEscapeCell(res.GetKind()),
+				mdEscapeCell(res.GetNamespace()),
+			)
+		}
+		ew.printf("\n")
+
+		if ew.err != nil {
+			return ew.err
+		}
+	}
+	return ew.err
+}
+
+func mdStatusLabel(status apis.IStatus) string {
+	if status == nil {
+		return "Unknown"
+	}
+	switch {
+	case status.IsFailed():
+		return "❌ Failed"
+	case status.IsPassed():
+		return "✅ Passed"
+	case status.IsSkipped():
+		return "⏭ Skipped"
+	default:
+		return string(status.Status())
+	}
+}
+
+func mdEscapeCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
+}

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -1,0 +1,390 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mdControlID1  = "C-0057"
+	mdControlID2  = "C-0058"
+	mdResourceID1 = "apps/v1/Deployment/default/nginx"
+	mdResourceID2 = "apps/v1/Deployment/cache/redis"
+)
+
+func mdSessionFixture() *cautils.OPASessionObj {
+	lw1 := localworkload.NewLocalWorkload(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "nginx", "namespace": "default"},
+		"spec":       map[string]interface{}{},
+	})
+	lw2 := localworkload.NewLocalWorkload(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "redis", "namespace": "cache"},
+		"spec":       map[string]interface{}{},
+	})
+
+	session := cautils.NewOPASessionObjMock()
+	session.AllResources[mdResourceID1] = lw1
+	session.AllResources[mdResourceID2] = lw2
+
+	session.ResourcesResult[mdResourceID1] = resourcesresults.Result{
+		ResourceID: mdResourceID1,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{ControlID: mdControlID1, Name: "Privileged container", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+			{ControlID: mdControlID2, Name: "Run as root", Status: apis.StatusInfo{InnerStatus: apis.StatusPassed}},
+		},
+	}
+	session.ResourcesResult[mdResourceID2] = resourcesresults.Result{
+		ResourceID: mdResourceID2,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{ControlID: mdControlID1, Name: "Privileged container", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+		},
+	}
+
+	failedStatus := &apis.StatusInfo{InnerStatus: apis.StatusFailed}
+	passedStatus := &apis.StatusInfo{InnerStatus: apis.StatusPassed}
+
+	ctrl1 := &reportsummary.ControlSummary{
+		ControlID:   mdControlID1,
+		Name:        "Privileged container",
+		ScoreFactor: 9.0,
+		Remediation: "Remove privilegedContainer: true from your pod spec",
+		StatusInfo:  apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+	ctrl1.Append(failedStatus, mdResourceID1, mdResourceID2)
+
+	ctrl2 := &reportsummary.ControlSummary{
+		ControlID:   mdControlID2,
+		Name:        "Run as root",
+		ScoreFactor: 5.0,
+		StatusInfo:  apis.StatusInfo{InnerStatus: apis.StatusPassed},
+	}
+	ctrl2.Append(passedStatus, mdResourceID1)
+
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: 42,
+			Controls: reportsummary.ControlSummaries{
+				mdControlID1: *ctrl1,
+				mdControlID2: *ctrl2,
+			},
+		},
+	}
+
+	return session
+}
+
+func mdRunActionPrint(t *testing.T, session *cautils.OPASessionObj) string {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "kubescape-md-*.md")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(tmp.Name()) })
+
+	mp := NewMarkdownPrinter()
+	mp.writer = tmp
+	err = mp.ActionPrint(context.TODO(), session, nil)
+	require.NoError(t, err)
+	mp.CloseWriter()
+
+	content, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return string(content)
+}
+
+func TestNewMarkdownPrinter(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	assert.NotNil(t, mp)
+}
+
+func TestMarkdownPrinter_SetWriter_DefaultFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mp := NewMarkdownPrinter()
+	mp.SetWriter(context.TODO(), filepath.Join(tmpDir, "report"))
+	require.NotNil(t, mp.writer)
+	name := mp.writer.Name()
+	assert.True(t, strings.HasSuffix(name, ".md"), "expected .md extension, got %s", name)
+	mp.CloseWriter()
+}
+
+func TestMarkdownPrinter_SetWriter_AppendExtension(t *testing.T) {
+	tmp, err := os.CreateTemp("", "md-test-report")
+	require.NoError(t, err)
+	tmp.Close()
+	os.Remove(tmp.Name())
+
+	mp := NewMarkdownPrinter()
+	mp.SetWriter(context.TODO(), tmp.Name())
+	require.NotNil(t, mp.writer)
+	assert.True(t, strings.HasSuffix(mp.writer.Name(), ".md"))
+	mp.CloseWriter()
+	os.Remove(mp.writer.Name())
+}
+
+func TestMarkdownPrinter_SetWriter_ExistingMdExtension(t *testing.T) {
+	tmp, err := os.CreateTemp("", "md-test-*.md")
+	require.NoError(t, err)
+	base := tmp.Name()
+	tmp.Close()
+	os.Remove(base)
+
+	mp := NewMarkdownPrinter()
+	mp.SetWriter(context.TODO(), base)
+	require.NotNil(t, mp.writer)
+	assert.True(t, strings.HasSuffix(mp.writer.Name(), ".md"))
+	assert.False(t, strings.HasSuffix(mp.writer.Name(), ".md.md"), "extension must not be doubled")
+	mp.CloseWriter()
+	os.Remove(mp.writer.Name())
+}
+
+func TestMarkdownPrinter_Score(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	assert.NotPanics(t, func() { mp.Score(72) })
+}
+
+func TestMarkdownPrinter_PrintNextSteps(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	assert.NotPanics(t, func() { mp.PrintNextSteps() })
+}
+
+func TestMarkdownPrinter_SetWriter_NoStdoutFallback(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	mp.SetWriter(context.TODO(), "/nonexistent-kubescape-dir/bad.md")
+	require.NotNil(t, mp.writer)
+	assert.NotEqual(t, os.Stdout, mp.writer, "SetWriter must never assign os.Stdout")
+	mp.CloseWriter()
+}
+
+func TestMarkdownPrinter_ActionPrint_NilSession(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	mp.writer = os.Stdout
+	err := mp.ActionPrint(context.TODO(), nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestMarkdownPrinter_ActionPrint_NilReport(t *testing.T) {
+	mp := NewMarkdownPrinter()
+	mp.writer = os.Stdout
+	session := cautils.NewOPASessionObjMock()
+	session.Report = nil
+	err := mp.ActionPrint(context.TODO(), session, nil)
+	assert.NoError(t, err, "nil Report must not panic")
+}
+
+func TestMarkdownPrinter_ActionPrint_Header(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.True(t, strings.HasPrefix(out, "# Kubescape Security Report"), "must start with h1 heading")
+	assert.Contains(t, out, "**Compliance Score:** 42", "compliance score must appear")
+}
+
+func TestMarkdownPrinter_ActionPrint_SummaryTablePresent(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.Contains(t, out, "## Summary")
+	assert.Contains(t, out, "| Severity | Control | ID | Status | Failed | Passed |")
+	assert.Contains(t, out, "|---|---|---|---|---|---|")
+	assert.Contains(t, out, "Privileged container")
+	assert.Contains(t, out, mdControlID1)
+	assert.Contains(t, out, "Run as root")
+	assert.Contains(t, out, mdControlID2)
+}
+
+func TestMarkdownPrinter_ActionPrint_StatusEmojis(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.Contains(t, out, "❌ Failed", "failed status emoji missing")
+	assert.Contains(t, out, "✅ Passed", "passed status emoji missing")
+}
+
+func TestMarkdownPrinter_ActionPrint_SeverityOrder(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	criticalPos := strings.Index(out, "Critical")
+	mediumPos := strings.Index(out, "Medium")
+	assert.Greater(t, mediumPos, criticalPos, "Critical must appear before Medium in the table")
+}
+
+func TestMarkdownPrinter_ActionPrint_FailedSection(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.Contains(t, out, "## Failed Controls")
+	assert.Contains(t, out, "### Privileged container")
+	assert.Contains(t, out, "Remove privilegedContainer: true from your pod spec", "remediation text missing")
+	assert.Contains(t, out, "[View documentation]", "control URL link missing")
+	assert.Contains(t, out, "hub.armosec.io/docs/c-0057", "control URL must include lowercase ID")
+}
+
+func TestMarkdownPrinter_ActionPrint_ResourceTable(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.Contains(t, out, "| Resource | Kind | Namespace |")
+	assert.Contains(t, out, "|---|---|---|")
+	assert.Contains(t, out, "| nginx |")
+	assert.Contains(t, out, "| redis |")
+	assert.Contains(t, out, "| default |", "namespace column missing for nginx")
+	assert.Contains(t, out, "| cache |", "namespace column missing for redis")
+}
+
+func TestMarkdownPrinter_ActionPrint_PassedControlNoSection(t *testing.T) {
+	out := mdRunActionPrint(t, mdSessionFixture())
+
+	assert.NotContains(t, out, "### Run as root", "passed controls must not appear in Failed Controls section")
+}
+
+func TestMarkdownPrinter_ActionPrint_AllPassedNoFailedSection(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: 100,
+			Controls: reportsummary.ControlSummaries{
+				mdControlID2: reportsummary.ControlSummary{
+					ControlID:  mdControlID2,
+					Name:       "Run as root",
+					StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusPassed},
+				},
+			},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "## Summary")
+	assert.NotContains(t, out, "## Failed Controls", "no Failed Controls section when everything passes")
+}
+
+func TestMarkdownPrinter_ActionPrint_EmptyControls(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: 0,
+			Controls:        reportsummary.ControlSummaries{},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "# Kubescape Security Report")
+	assert.Contains(t, out, "**Compliance Score:** 0")
+	assert.Contains(t, out, "## Summary")
+}
+
+func TestMdSortedControls(t *testing.T) {
+	controls := reportsummary.ControlSummaries{
+		"C-0001": reportsummary.ControlSummary{ControlID: "C-0001", Name: "Beta", ScoreFactor: 5.0},
+		"C-0002": reportsummary.ControlSummary{ControlID: "C-0002", Name: "Alpha", ScoreFactor: 9.0},
+		"C-0003": reportsummary.ControlSummary{ControlID: "C-0003", Name: "Gamma", ScoreFactor: 5.0},
+	}
+
+	sorted := mdSortedControls(controls)
+
+	require.Len(t, sorted, 3)
+	assert.Equal(t, "C-0002", sorted[0].GetID(), "critical must be first")
+	assert.Equal(t, "C-0001", sorted[1].GetID(), "medium Beta before Gamma alphabetically")
+	assert.Equal(t, "C-0003", sorted[2].GetID(), "medium Gamma last")
+}
+
+func TestMdSortedControls_Empty(t *testing.T) {
+	sorted := mdSortedControls(reportsummary.ControlSummaries{})
+	assert.Empty(t, sorted)
+}
+
+func TestMdSortedControls_SameScore(t *testing.T) {
+	controls := reportsummary.ControlSummaries{
+		"C-Z": reportsummary.ControlSummary{ControlID: "C-Z", Name: "Zeta", ScoreFactor: 5.0},
+		"C-A": reportsummary.ControlSummary{ControlID: "C-A", Name: "Alpha", ScoreFactor: 5.0},
+		"C-M": reportsummary.ControlSummary{ControlID: "C-M", Name: "Mu", ScoreFactor: 5.0},
+	}
+
+	sorted := mdSortedControls(controls)
+
+	require.Len(t, sorted, 3)
+	assert.Equal(t, "Alpha", sorted[0].GetName())
+	assert.Equal(t, "Mu", sorted[1].GetName())
+	assert.Equal(t, "Zeta", sorted[2].GetName())
+}
+
+func TestMdStatusLabel(t *testing.T) {
+	cases := []struct {
+		status apis.IStatus
+		want   string
+	}{
+		{&apis.StatusInfo{InnerStatus: apis.StatusFailed}, "❌ Failed"},
+		{&apis.StatusInfo{InnerStatus: apis.StatusPassed}, "✅ Passed"},
+		{&apis.StatusInfo{InnerStatus: apis.StatusSkipped}, "⏭ Skipped"},
+		{&apis.StatusInfo{InnerStatus: apis.StatusUnknown}, string(apis.StatusUnknown)},
+		{nil, "Unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, mdStatusLabel(tc.status))
+		})
+	}
+}
+
+func TestMdEscapeCell(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"normal", "normal"},
+		{"with|pipe", "with\\|pipe"},
+		{"multi|pipe|in|cell", "multi\\|pipe\\|in\\|cell"},
+		{"", ""},
+		{"no special chars", "no special chars"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, mdEscapeCell(tc.input))
+		})
+	}
+}
+
+func TestMarkdownPrinter_ActionPrint_ResourceNameWithPipe(t *testing.T) {
+	lw := localworkload.NewLocalWorkload(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "my|deployment", "namespace": "default"},
+		"spec":       map[string]interface{}{},
+	})
+
+	session := cautils.NewOPASessionObjMock()
+	session.AllResources[mdResourceID1] = lw
+
+	ctrl := &reportsummary.ControlSummary{
+		ControlID:   mdControlID1,
+		Name:        "Privileged container",
+		ScoreFactor: 9.0,
+		StatusInfo:  apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+	ctrl.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, mdResourceID1)
+
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				mdControlID1: *ctrl,
+			},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "my\\|deployment", "pipe in resource name must be escaped")
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -189,6 +189,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewYamlPrinter()
 	case printer.CsvFormat:
 		return printerv2.NewCsvPrinter()
+	case printer.MarkdownFormat:
+		return printerv2.NewMarkdownPrinter()
 	case printer.JunitResultFormat:
 		return printerv2.NewJunitPrinter(scanInfo.VerboseMode)
 	case printer.PrometheusFormat:
@@ -237,7 +239,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	}
 
 	switch printFormat {
-	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat:
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat:
 		return false, nil
 	default:
 		return true, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -287,6 +287,18 @@ func TestValidatePrinter(t *testing.T) {
 			format:    printer.SPDXFormat,
 			expectErr: errors.New("format \"spdx-json\" is only supported for image scanning"),
 		},
+		{
+			name:      "markdown format for cluster scan should not return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    printer.MarkdownFormat,
+			expectErr: nil,
+		},
+		{
+			name:      "markdown format for image scan should return error",
+			scanType:  cautils.ScanTypeImage,
+			format:    printer.MarkdownFormat,
+			expectErr: errors.New("format \"markdown\" is not supported for image scanning"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -296,6 +308,14 @@ func TestValidatePrinter(t *testing.T) {
 			assert.Equal(t, tt.expectErr, got)
 		})
 	}
+}
+
+func TestNewPrinter_MarkdownFormat(t *testing.T) {
+	scanInfo := &cautils.ScanInfo{Format: printer.MarkdownFormat}
+	p := NewPrinter(context.TODO(), printer.MarkdownFormat, scanInfo, "")
+	require.NotNil(t, p)
+	_, ok := p.(*printerv2.MarkdownPrinter)
+	assert.True(t, ok, "NewPrinter(MarkdownFormat) must return a *MarkdownPrinter")
 }
 
 func TestNewPrinter(t *testing.T) {


### PR DESCRIPTION
## Summary

- No Markdown output format existed; users had no way to get scan results as a Markdown document for GitHub PR comments, wikis, or CI pipelines.
- Added `--format markdown` (MarkdownFormat constant + `.md` extension) across `printresults.go` and `results.go`, wired to a new `MarkdownPrinter`.
- `MarkdownPrinter` writes a compliance-score header, a severity-sorted control summary table, and a per-control Failed Controls section with remediation text, documentation link, and a resource table (name/kind/namespace). Pipe characters in cell values are escaped to preserve table syntax.
- Also fixed pre-existing compile errors in `cyclonedxprinter.go` and `spdxprinter.go` where `ActionPrint` did not return `error` after the `IPrinter` interface was updated in #2908.
- Tested with 21 test cases covering SetWriter (3), ActionPrint integration (10), mdSortedControls (3), mdStatusLabel (5), and mdEscapeCell (5). Full package suite passes.

**Which issue(s) this PR fixes:**
N/A - new format addition with no existing tracking issue.

**Special notes for your reviewer:**
Markdown writes only to a file (never stdout) so raw markup never pollutes terminal output. The printer is intentionally excluded from ImageFormats since it handles posture scans only. The cyclonedx/spdx fixes are mechanical (`return nil`) with no logic change.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan --format markdown` now writes a `report.md` file (or `--output` path) containing a structured Markdown security report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown report output for cluster scans.
  * Markdown reports include compliance scores, summaries, failed controls, severity-sorted results, remediation links, documentation, and affected resources.
  * Markdown output files use the `.md` extension and safely format table content.
  * Added clear handling for missing resources and reports with no failed controls.
  * Markdown is now listed among supported output formats for cluster scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->