### PR TITLE
refactor: extract shared image adaptor boilerplate 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/briandowns/spinner v1.23.2
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/deckarep/golang-set/v2 v2.8.0
@@ -212,7 +213,6 @@ require (
 	github.com/buildkite/go-pipeline v0.16.0 // indirect
 	github.com/buildkite/interpolate v0.1.5 // indirect
 	github.com/buildkite/roko v1.4.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/pkg/imagescan/adaptor_utils.go
+++ b/pkg/imagescan/adaptor_utils.go
@@ -1,0 +1,63 @@
+package imagescan
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+)
+
+// FetchImagesInformation provides a shared implementation for GetImagesInformation across adaptors.
+func FetchImagesInformation(imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error) {
+	var infos []ContainerImageInformation
+	for _, imageID := range imageIDs {
+		infos = append(infos, ContainerImageInformation{
+			ImageID: imageID,
+			Bom:     []string{},
+		})
+	}
+	return infos, nil
+}
+
+// NormalizeSeverity converts common provider severity strings to Kubescape standard.
+func NormalizeSeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "Critical"
+	case "high":
+		return "High"
+	case "medium":
+		return "Medium"
+	case "low":
+		return "Low"
+	case "minimal", "informational", "untriaged", "unassigned":
+		return "Negligible"
+	default:
+		return "Unknown"
+	}
+}
+
+// ProcessImages iterates over imageIDs and calls the provided fetch function, handling boilerplate nil-hashes and errors.
+func ProcessImages[T any](
+	imageIDs []ContainerImageIdentifier,
+	emptyResult func(imageID ContainerImageIdentifier) T,
+	processFunc func(imageID ContainerImageIdentifier) (T, error),
+) ([]T, error) {
+	var results []T
+	var aggErr error
+
+	for _, imageID := range imageIDs {
+		res, err := processFunc(imageID)
+		if err != nil {
+			logger.L().Warning("skipping image due to api error", helpers.Error(err))
+			aggErr = errors.Join(aggErr, err)
+			results = append(results, emptyResult(imageID))
+			continue
+		}
+
+		results = append(results, res)
+	}
+
+	return results, aggErr
+}

--- a/pkg/imagescan/adaptor_utils.go
+++ b/pkg/imagescan/adaptor_utils.go
@@ -38,10 +38,9 @@ func NormalizeSeverity(severity string) string {
 	}
 }
 
-// ProcessImages iterates over imageIDs and calls the provided fetch function, handling boilerplate nil-hashes and errors.
+// ProcessImages iterates over imageIDs and calls the provided fetch function, handling errors and aggregating results.
 func ProcessImages[T any](
 	imageIDs []ContainerImageIdentifier,
-	emptyResult func(imageID ContainerImageIdentifier) T,
 	processFunc func(imageID ContainerImageIdentifier) (T, error),
 ) ([]T, error) {
 	var results []T
@@ -52,8 +51,6 @@ func ProcessImages[T any](
 		if err != nil {
 			logger.L().Warning("skipping image due to api error", helpers.Error(err))
 			aggErr = errors.Join(aggErr, err)
-			results = append(results, emptyResult(imageID))
-			continue
 		}
 
 		results = append(results, res)

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -122,31 +121,34 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
 	parts := strings.Split(a.registryHost, ".")
 	registryName := parts[0]
 
-	for _, imageID := range imageIDs {
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
 
-		if imageID.Hash == "" {
-			statuses = append(statuses, status)
-			continue
-		}
+			if imageID.Hash == "" {
+				return status, nil
+			}
 
-		if err := a.validateImageID(imageID); err != nil {
-			logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
-			statuses = append(statuses, status)
-			continue
-		}
+			if err := a.validateImageID(imageID); err != nil {
+				return status, fmt.Errorf("invalid image id: %w", err)
+			}
 
-		// Query ARG for parent assessment to determine scan availability
-		queryStr := fmt.Sprintf(`
+			// Query ARG for parent assessment to determine scan availability
+			queryStr := fmt.Sprintf(`
 			securityresources
 			| where type == "microsoft.security/assessments"
 			| extend registryName = extract(@"(?i)/registries/([^/]+)/", 1, id)
@@ -156,57 +158,36 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 			| limit 1
 		`, registryName, imageID.Hash)
 
-		req := armresourcegraph.QueryRequest{
-			Query: to.Ptr(queryStr),
-			Options: &armresourcegraph.QueryRequestOptions{
-				ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
-			},
-		}
+			req := armresourcegraph.QueryRequest{
+				Query: to.Ptr(queryStr),
+				Options: &armresourcegraph.QueryRequestOptions{
+					ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
+				},
+			}
 
-		res, err := a.client.Resources(ctx, req, nil)
-		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err))
-			statuses = append(statuses, status)
-			continue
-		}
+			res, err := a.client.Resources(ctx, req, nil)
+			if err != nil {
+				return status, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
+			}
 
-		if res.TotalRecords != nil && *res.TotalRecords > 0 {
-			status.IsScanAvailable = true
-			if res.Data != nil {
-				if dataList, ok := res.Data.([]interface{}); ok && len(dataList) > 0 {
-					if row, ok := dataList[0].(map[string]interface{}); ok {
-						if tg := getStringSafe(row, "timeGenerated"); tg != "" {
-							if parsedTime, err := time.Parse(time.RFC3339Nano, tg); err == nil {
-								status.LastScanDate = parsedTime
+			if res.TotalRecords != nil && *res.TotalRecords > 0 {
+				status.IsScanAvailable = true
+				if res.Data != nil {
+					if dataList, ok := res.Data.([]interface{}); ok && len(dataList) > 0 {
+						if row, ok := dataList[0].(map[string]interface{}); ok {
+							if tg := getStringSafe(row, "timeGenerated"); tg != "" {
+								if parsedTime, err := time.Parse(time.RFC3339Nano, tg); err == nil {
+									status.LastScanDate = parsedTime
+								}
 							}
 						}
 					}
 				}
 			}
-		}
 
-		statuses = append(statuses, status)
-	}
-
-	return statuses, aggErr
-}
-
-// Helper to normalize Azure severity to Kubescape expected severity
-func normalizeAzureSeverity(azureSeverity string) string {
-	switch strings.ToLower(azureSeverity) {
-	case "critical":
-		return "Critical"
-	case "high":
-		return "High"
-	case "medium":
-		return "Medium"
-	case "low":
-		return "Low"
-	case "unassigned", "informational":
-		return "Negligible"
-	default:
-		return "Unknown"
-	}
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -215,29 +196,31 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
 	parts := strings.Split(a.registryHost, ".")
 	registryName := parts[0]
 
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
+			}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
+			}
 
-		if imageID.Hash == "" {
-			reports = append(reports, report)
-			continue
-		}
+			if imageID.Hash == "" {
+				return report, nil
+			}
 
-		if err := a.validateImageID(imageID); err != nil {
-			logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
-			reports = append(reports, report)
-			continue
-		}
+			if err := a.validateImageID(imageID); err != nil {
+				return report, fmt.Errorf("invalid image id: %w", err)
+			}
 
-		queryStr := fmt.Sprintf(`
+			queryStr := fmt.Sprintf(`
 			securityresources
 			| where type == "microsoft.security/assessments/subassessments"
 			| extend registryName = extract(@"(?i)/registries/([^/]+)/", 1, id)
@@ -252,86 +235,82 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 				cve = properties.additionalData.cve
 		`, registryName, imageID.Repository, imageID.Hash)
 
-		var skipToken *string
-		count := 0
-		const maxVulns = 1000
-		const maxPages = 50
+			var skipToken *string
+			count := 0
+			const maxVulns = 1000
+			const maxPages = 50
 
-		for page := 0; page < maxPages; page++ {
-			req := armresourcegraph.QueryRequest{
-				Query: to.Ptr(queryStr),
-				Options: &armresourcegraph.QueryRequestOptions{
-					ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
-					SkipToken:    skipToken,
-					Top:          to.Ptr[int32](1000),
-				},
-			}
-
-			res, err := a.client.Resources(ctx, req, nil)
-			if err != nil {
-				aggErr = errors.Join(aggErr, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err))
-				break
-			}
-
-			if res.Data != nil {
-				dataList, ok := res.Data.([]interface{})
-				if !ok {
-					aggErr = errors.Join(aggErr, fmt.Errorf("failed to decode ARG response data format for repository %s", imageID.Repository))
-					break
+			for page := 0; page < maxPages; page++ {
+				req := armresourcegraph.QueryRequest{
+					Query: to.Ptr(queryStr),
+					Options: &armresourcegraph.QueryRequestOptions{
+						ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
+						SkipToken:    skipToken,
+						Top:          to.Ptr[int32](1000),
+					},
 				}
-				malformed := false
-				for _, item := range dataList {
-					if count >= maxVulns {
-						// Log truncation rather than failing hard
-						logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
-						break
-					}
 
-					row, ok := item.(map[string]interface{})
+				res, err := a.client.Resources(ctx, req, nil)
+				if err != nil {
+					return report, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
+				}
+
+				if res.Data != nil {
+					dataList, ok := res.Data.([]interface{})
 					if !ok {
-						aggErr = errors.Join(aggErr, fmt.Errorf("malformed vulnerability row for repository %s: expected map[string]interface{}, got %T", imageID.Repository, item))
-						malformed = true
-						break
+						return report, fmt.Errorf("failed to decode ARG response data format for repository %s", imageID.Repository)
 					}
+					malformed := false
+					for _, item := range dataList {
+						if count >= maxVulns {
+							// Log truncation rather than failing hard
+							logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
+							break
+						}
 
-					vuln := Vulnerability{
-						ID:          getStringSafe(row, "id"),
-						Severity:    normalizeAzureSeverity(getStringSafe(row, "severity")),
-						Description: getStringSafe(row, "description"),
-						Links:       []string{},
-					}
+						row, ok := item.(map[string]interface{})
+						if !ok {
+							malformed = true
+							break
+						}
 
-					// Try to get primary CVE if it exists
-					if cves := getMultipleNestedStringSafe(row, "cve", "title"); len(cves) > 0 {
-						for _, cve := range cves {
-							if count >= maxVulns {
-								break
+						vuln := Vulnerability{
+							ID:          getStringSafe(row, "id"),
+							Severity:    NormalizeSeverity(getStringSafe(row, "severity")),
+							Description: getStringSafe(row, "description"),
+							Links:       []string{},
+						}
+
+						// Try to get primary CVE if it exists
+						if cves := getMultipleNestedStringSafe(row, "cve", "title"); len(cves) > 0 {
+							for _, cve := range cves {
+								if count >= maxVulns {
+									break
+								}
+								newVuln := vuln
+								newVuln.ID = cve
+								report.Vulnerabilities = append(report.Vulnerabilities, newVuln)
+								count++
 							}
-							newVuln := vuln
-							newVuln.ID = cve
-							report.Vulnerabilities = append(report.Vulnerabilities, newVuln)
+						} else {
+							report.Vulnerabilities = append(report.Vulnerabilities, vuln)
 							count++
 						}
-					} else {
-						report.Vulnerabilities = append(report.Vulnerabilities, vuln)
-						count++
+					}
+					if malformed {
+						return report, fmt.Errorf("malformed vulnerability row for repository %s", imageID.Repository)
 					}
 				}
-				if malformed {
+
+				if count >= maxVulns || res.SkipToken == nil || *res.SkipToken == "" {
 					break
 				}
+				skipToken = res.SkipToken
 			}
 
-			if count >= maxVulns || res.SkipToken == nil || *res.SkipToken == "" {
-				break
-			}
-			skipToken = res.SkipToken
-		}
-
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -339,18 +318,7 @@ func (a *AzureAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Cont
 	if a.client == nil {
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -125,13 +125,6 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 	registryName := parts[0]
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageScanStatus {
-			return ContainerImageScanStatus{
-				ImageID:         id,
-				IsScanAvailable: false,
-				IsBomAvailable:  false,
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
 			status := ContainerImageScanStatus{
 				ImageID:         imageID,
@@ -144,7 +137,8 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 			}
 
 			if err := a.validateImageID(imageID); err != nil {
-				return status, fmt.Errorf("invalid image id: %w", err)
+				logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
+				return status, nil
 			}
 
 			// Query ARG for parent assessment to determine scan availability
@@ -200,12 +194,6 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 	registryName := parts[0]
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
-			return ContainerImageVulnerabilityReport{
-				ImageID:         id,
-				Vulnerabilities: []Vulnerability{},
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
 			report := ContainerImageVulnerabilityReport{
 				ImageID:         imageID,
@@ -217,7 +205,8 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 			}
 
 			if err := a.validateImageID(imageID); err != nil {
-				return report, fmt.Errorf("invalid image id: %w", err)
+				logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
+				return report, nil
 			}
 
 			queryStr := fmt.Sprintf(`

--- a/pkg/imagescan/azure_adaptor_test.go
+++ b/pkg/imagescan/azure_adaptor_test.go
@@ -65,12 +65,12 @@ func TestAzureAdaptor_GetImagesInformation_Guards(t *testing.T) {
 }
 
 func TestAzureAdaptor_NormalizeSeverity(t *testing.T) {
-	assert.Equal(t, "Critical", normalizeAzureSeverity("Critical"))
-	assert.Equal(t, "High", normalizeAzureSeverity("High"))
-	assert.Equal(t, "Medium", normalizeAzureSeverity("Medium"))
-	assert.Equal(t, "Low", normalizeAzureSeverity("Low"))
-	assert.Equal(t, "Negligible", normalizeAzureSeverity("Informational"))
-	assert.Equal(t, "Unknown", normalizeAzureSeverity("SomethingElse"))
+	assert.Equal(t, "Critical", NormalizeSeverity("Critical"))
+	assert.Equal(t, "High", NormalizeSeverity("High"))
+	assert.Equal(t, "Medium", NormalizeSeverity("Medium"))
+	assert.Equal(t, "Low", NormalizeSeverity("Low"))
+	assert.Equal(t, "Negligible", NormalizeSeverity("Informational"))
+	assert.Equal(t, "Unknown", NormalizeSeverity("SomethingElse"))
 }
 
 func TestAzureAdaptor_GetImagesScanStatus(t *testing.T) {

--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -64,66 +63,49 @@ func (a *AWSECRAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Cont
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		var ecrImageID types.ImageIdentifier
-		if imageID.Hash != "" {
-			ecrImageID.ImageDigest = aws.String(imageID.Hash)
-		} else if imageID.Tag != "" {
-			ecrImageID.ImageTag = aws.String(imageID.Tag)
-		}
-
-		input := &ecr.DescribeImageScanFindingsInput{
-			RepositoryName: aws.String(imageID.Repository),
-			ImageId:        &ecrImageID,
-			MaxResults:     aws.Int32(1),
-		}
-
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
-
-		out, err := a.client.DescribeImageScanFindings(ctx, input)
-		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to describe image scan findings for repository %s: %w", imageID.Repository, err))
-			statuses = append(statuses, status)
-			continue
-		}
-
-		if out.ImageScanStatus != nil && (out.ImageScanStatus.Status == types.ScanStatusComplete || out.ImageScanStatus.Status == types.ScanStatusActive) {
-			status.IsScanAvailable = true
-			if out.ImageScanFindings != nil && out.ImageScanFindings.ImageScanCompletedAt != nil {
-				status.LastScanDate = *out.ImageScanFindings.ImageScanCompletedAt
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
-		}
-		statuses = append(statuses, status)
-	}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
 
-	return statuses, aggErr
-}
+			var ecrImageID types.ImageIdentifier
+			if imageID.Hash != "" {
+				ecrImageID.ImageDigest = aws.String(imageID.Hash)
+			} else if imageID.Tag != "" {
+				ecrImageID.ImageTag = aws.String(imageID.Tag)
+			}
 
-// Helper to normalize ECR severity to Kubescape expected severity
-func normalizeSeverity(ecrSeverity string) string {
-	switch ecrSeverity {
-	case "CRITICAL":
-		return "Critical"
-	case "HIGH":
-		return "High"
-	case "MEDIUM":
-		return "Medium"
-	case "LOW":
-		return "Low"
-	case "INFORMATIONAL":
-		return "Negligible"
-	case "UNDEFINED":
-		fallthrough
-	default:
-		return "Unknown"
-	}
+			input := &ecr.DescribeImageScanFindingsInput{
+				RepositoryName: aws.String(imageID.Repository),
+				ImageId:        &ecrImageID,
+				MaxResults:     aws.Int32(1),
+			}
+
+			out, err := a.client.DescribeImageScanFindings(ctx, input)
+			if err != nil {
+				return status, fmt.Errorf("failed to describe image scan findings for repository %s: %w", imageID.Repository, err)
+			}
+
+			if out.ImageScanStatus != nil && (out.ImageScanStatus.Status == types.ScanStatusComplete || out.ImageScanStatus.Status == types.ScanStatusActive) {
+				status.IsScanAvailable = true
+				if out.ImageScanFindings != nil && out.ImageScanFindings.ImageScanCompletedAt != nil {
+					status.LastScanDate = *out.ImageScanFindings.ImageScanCompletedAt
+				}
+			}
+
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -132,86 +114,88 @@ func (a *AWSECRAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
-
-		var ecrImageID types.ImageIdentifier
-		if imageID.Hash != "" {
-			ecrImageID.ImageDigest = aws.String(imageID.Hash)
-		} else if imageID.Tag != "" {
-			ecrImageID.ImageTag = aws.String(imageID.Tag)
-		}
-
-		input := &ecr.DescribeImageScanFindingsInput{
-			RepositoryName: aws.String(imageID.Repository),
-			ImageId:        &ecrImageID,
-		}
-
-		var fetchErr error
-		const maxPages = 1000
-
-		for page := 0; ; page++ {
-			out, err := a.client.DescribeImageScanFindings(ctx, input)
-			if err != nil {
-				fetchErr = err
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
 			}
-			if out.ImageScanFindings != nil {
-				for _, finding := range out.ImageScanFindings.Findings {
-					report.Vulnerabilities = append(report.Vulnerabilities, Vulnerability{
-						ID:          aws.ToString(finding.Name),
-						Severity:    normalizeSeverity(string(finding.Severity)),
-						Description: aws.ToString(finding.Description),
-						Links:       []string{aws.ToString(finding.Uri)},
-					})
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
+			}
+
+			var ecrImageID types.ImageIdentifier
+			if imageID.Hash != "" {
+				ecrImageID.ImageDigest = aws.String(imageID.Hash)
+			} else if imageID.Tag != "" {
+				ecrImageID.ImageTag = aws.String(imageID.Tag)
+			}
+
+			input := &ecr.DescribeImageScanFindingsInput{
+				RepositoryName: aws.String(imageID.Repository),
+				ImageId:        &ecrImageID,
+			}
+
+			var fetchErr error
+			const maxPages = 1000
+
+			for page := 0; ; page++ {
+				out, err := a.client.DescribeImageScanFindings(ctx, input)
+				if err != nil {
+					fetchErr = err
+					break
 				}
-				for _, finding := range out.ImageScanFindings.EnhancedFindings {
-					vulnerability := Vulnerability{
-						Severity:    normalizeSeverity(aws.ToString(finding.Severity)),
-						Description: aws.ToString(finding.Description),
+				if out.ImageScanFindings != nil {
+					for _, finding := range out.ImageScanFindings.Findings {
+						report.Vulnerabilities = append(report.Vulnerabilities, Vulnerability{
+							ID:          aws.ToString(finding.Name),
+							Severity:    NormalizeSeverity(string(finding.Severity)),
+							Description: aws.ToString(finding.Description),
+							Links:       []string{aws.ToString(finding.Uri)},
+						})
 					}
-
-					if details := finding.PackageVulnerabilityDetails; details != nil {
-						vulnerability.ID = aws.ToString(details.VulnerabilityId)
-						vulnerability.Links = append(vulnerability.Links, details.ReferenceUrls...)
-
-						if sourceURL := aws.ToString(details.SourceUrl); sourceURL != "" && !slices.Contains(vulnerability.Links, sourceURL) {
-							vulnerability.Links = append(vulnerability.Links, sourceURL)
+					for _, finding := range out.ImageScanFindings.EnhancedFindings {
+						vulnerability := Vulnerability{
+							Severity:    NormalizeSeverity(aws.ToString(finding.Severity)),
+							Description: aws.ToString(finding.Description),
 						}
-					}
-					if vulnerability.ID == "" {
-						vulnerability.ID = aws.ToString(finding.Title)
-					}
 
-					report.Vulnerabilities = append(report.Vulnerabilities, vulnerability)
+						if details := finding.PackageVulnerabilityDetails; details != nil {
+							vulnerability.ID = aws.ToString(details.VulnerabilityId)
+							vulnerability.Links = append(vulnerability.Links, details.ReferenceUrls...)
+
+							if sourceURL := aws.ToString(details.SourceUrl); sourceURL != "" && !slices.Contains(vulnerability.Links, sourceURL) {
+								vulnerability.Links = append(vulnerability.Links, sourceURL)
+							}
+						}
+						if vulnerability.ID == "" {
+							vulnerability.ID = aws.ToString(finding.Title)
+						}
+
+						report.Vulnerabilities = append(report.Vulnerabilities, vulnerability)
+					}
 				}
+
+				if out.NextToken == nil {
+					break
+				}
+				if page >= maxPages {
+					fetchErr = fmt.Errorf("exceeded max pages (%d) fetching vulnerabilities for image %s", maxPages, imageID.Repository)
+					break
+				}
+				input.NextToken = out.NextToken
 			}
 
-			if out.NextToken == nil {
-				break
+			if fetchErr != nil {
+				return report, fmt.Errorf("failed to fetch vulnerabilities for repository %s: %w", imageID.Repository, fetchErr)
 			}
-			if page >= maxPages {
-				fetchErr = fmt.Errorf("exceeded max pages (%d) fetching vulnerabilities for image %s", maxPages, imageID.Repository)
-				break
-			}
-			input.NextToken = out.NextToken
-		}
 
-		if fetchErr != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to fetch vulnerabilities for repository %s: %w", imageID.Repository, fetchErr))
-			// we don't return nil, we append the partial report
-		}
-
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -219,19 +203,7 @@ func (a *AWSECRAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Con
 	if a.client == nil {
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.

--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -64,13 +64,6 @@ func (a *AWSECRAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Cont
 	}
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageScanStatus {
-			return ContainerImageScanStatus{
-				ImageID:         id,
-				IsScanAvailable: false,
-				IsBomAvailable:  false,
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
 			status := ContainerImageScanStatus{
 				ImageID:         imageID,
@@ -115,12 +108,6 @@ func (a *AWSECRAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 	}
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
-			return ContainerImageVulnerabilityReport{
-				ImageID:         id,
-				Vulnerabilities: []Vulnerability{},
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
 			report := ContainerImageVulnerabilityReport{
 				ImageID:         imageID,

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -132,13 +132,6 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 	}
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageScanStatus {
-			return ContainerImageScanStatus{
-				ImageID:         id,
-				IsScanAvailable: false,
-				IsBomAvailable:  false,
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
 			status := ContainerImageScanStatus{
 				ImageID:         imageID,
@@ -191,12 +184,6 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 	}
 
 	return ProcessImages(imageIDs,
-		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
-			return ContainerImageVulnerabilityReport{
-				ImageID:         id,
-				Vulnerabilities: []Vulnerability{},
-			}
-		},
 		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
 			report := ContainerImageVulnerabilityReport{
 				ImageID:         imageID,

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -132,75 +131,57 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
-
-		if imageID.Hash == "" {
-			statuses = append(statuses, status)
-			continue
-		}
-
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-
-		req := &grafeaspb.ListOccurrencesRequest{
-			Parent: fmt.Sprintf("projects/%s", a.projectID),
-			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceURL),
-		}
-
-		it := a.client.ListOccurrences(ctx, req)
-		for {
-			occurrence, err := it.Next()
-			if err == iterator.Done {
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
-			if err != nil {
-				fetchErr := fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
-				logger.L().Warning("skipping image scan status due to api error", helpers.Error(fetchErr))
-				aggErr = errors.Join(aggErr, fetchErr)
-				break
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
 
-			if occurrence != nil && occurrence.GetDiscovery() != nil {
-				discovery := occurrence.GetDiscovery()
-				if discovery != nil && discovery.GetAnalysisStatus() == grafeaspb.DiscoveryOccurrence_FINISHED_SUCCESS {
-					status.IsScanAvailable = true
-					if occurrence.UpdateTime != nil {
-						status.LastScanDate = occurrence.UpdateTime.AsTime()
-					}
+			if imageID.Hash == "" {
+				return status, nil
+			}
+
+			resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+
+			req := &grafeaspb.ListOccurrencesRequest{
+				Parent: fmt.Sprintf("projects/%s", a.projectID),
+				Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceURL),
+			}
+
+			it := a.client.ListOccurrences(ctx, req)
+			for {
+				occurrence, err := it.Next()
+				if err == iterator.Done {
 					break
 				}
+				if err != nil {
+					return status, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
+				}
+
+				if occurrence != nil && occurrence.GetDiscovery() != nil {
+					discovery := occurrence.GetDiscovery()
+					if discovery != nil && discovery.GetAnalysisStatus() == grafeaspb.DiscoveryOccurrence_FINISHED_SUCCESS {
+						status.IsScanAvailable = true
+						if occurrence.UpdateTime != nil {
+							status.LastScanDate = occurrence.UpdateTime.AsTime()
+						}
+						break
+					}
+				}
 			}
-		}
 
-		statuses = append(statuses, status)
-	}
-
-	return statuses, aggErr
-}
-
-// Helper to normalize GCP severity to Kubescape expected severity
-func normalizeGCPSeverity(severity grafeaspb.Severity) string {
-	switch severity {
-	case grafeaspb.Severity_CRITICAL:
-		return "Critical"
-	case grafeaspb.Severity_HIGH:
-		return "High"
-	case grafeaspb.Severity_MEDIUM:
-		return "Medium"
-	case grafeaspb.Severity_LOW:
-		return "Low"
-	case grafeaspb.Severity_MINIMAL:
-		return "Negligible"
-	default:
-		return "Unknown"
-	}
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -209,73 +190,72 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
-
-		if imageID.Hash == "" {
-			reports = append(reports, report)
-			continue
-		}
-
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-		req := &grafeaspb.ListOccurrencesRequest{
-			Parent:   fmt.Sprintf("projects/%s", a.projectID),
-			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", resourceURL),
-			PageSize: 1000,
-		}
-
-		it := a.client.ListOccurrences(ctx, req)
-		const maxVulns = 1000
-
-		for {
-			occurrence, err := it.Next()
-			if err == iterator.Done {
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
 			}
-			if err != nil {
-				fetchErr := fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
-				logger.L().Warning("skipping image vulnerabilities due to api error", helpers.Error(fetchErr))
-				aggErr = errors.Join(aggErr, fetchErr)
-				break
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
 			}
 
-			if len(report.Vulnerabilities) >= maxVulns {
-				logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
-				break
+			if imageID.Hash == "" {
+				return report, nil
 			}
 
-			if vulnDetails := occurrence.GetVulnerability(); vulnDetails != nil {
-				id := vulnDetails.GetShortDescription()
-				if id == "" && occurrence.GetNoteName() != "" {
-					parts := strings.Split(occurrence.GetNoteName(), "/")
-					id = parts[len(parts)-1]
+			resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+			req := &grafeaspb.ListOccurrencesRequest{
+				Parent:   fmt.Sprintf("projects/%s", a.projectID),
+				Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", resourceURL),
+				PageSize: 1000,
+			}
+
+			it := a.client.ListOccurrences(ctx, req)
+			const maxVulns = 1000
+
+			for {
+				occurrence, err := it.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					return report, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
 				}
 
-				vuln := Vulnerability{
-					ID:          id,
-					Severity:    normalizeGCPSeverity(vulnDetails.GetEffectiveSeverity()),
-					Description: vulnDetails.GetLongDescription(),
-					Links:       []string{},
+				if len(report.Vulnerabilities) >= maxVulns {
+					logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
+					break
 				}
 
-				for _, uri := range vulnDetails.GetRelatedUrls() {
-					vuln.Links = append(vuln.Links, uri.GetUrl())
-				}
+				if vulnDetails := occurrence.GetVulnerability(); vulnDetails != nil {
+					id := vulnDetails.GetShortDescription()
+					if id == "" && occurrence.GetNoteName() != "" {
+						parts := strings.Split(occurrence.GetNoteName(), "/")
+						id = parts[len(parts)-1]
+					}
 
-				report.Vulnerabilities = append(report.Vulnerabilities, vuln)
+					vuln := Vulnerability{
+						ID:          id,
+						Severity:    NormalizeSeverity(vulnDetails.GetEffectiveSeverity().String()),
+						Description: vulnDetails.GetLongDescription(),
+						Links:       []string{},
+					}
+
+					for _, uri := range vulnDetails.GetRelatedUrls() {
+						vuln.Links = append(vuln.Links, uri.GetUrl())
+					}
+
+					report.Vulnerabilities = append(report.Vulnerabilities, vuln)
+				}
 			}
-		}
 
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -283,18 +263,7 @@ func (a *GCPAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Contai
 	if a.client == nil {
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.


### PR DESCRIPTION
**Description:**

## Overview

This PR extracts significant duplicated boilerplate across the three cloud image adaptors (`azure_adaptor.go`, `gcp_adaptor.go`, and `ecr_adaptor.go`). It introduces `adaptor_utils.go` containing:

* A generic `ProcessImages[T]` harness to eliminate identical for-loops.

* A shared `NormalizeSeverity` function to map all provider-specific severity strings into Kubescape's standard (`Critical`, `High`, `Medium`, `Low`, `Negligible`, `Unknown`).

* `FetchImagesInformation` to unify the identical `GetImagesInformation` stub implementations.

<!-- 

## Additional Information

> Any additional information that may be useful for reviewers to know 

-->

This cleanup significantly improves the maintainability of the `pkg/imagescan` package. Any shared fix (e.g. the Token check or error-handling policy) now only has to be applied in one central place instead of three.

## How to Test

You can run the existing unit tests to verify that the logic is identical and fully preserved for all three adaptors:

```bash
go test -v ./pkg/imagescan/...
```

Click to view real test logs confirming the fix

## Related issues/PRs:

- Closes #3024

## Checklist before requesting a review

- My code follows the style guidelines of this project
- I have commented on my code, particularly in hard-to-understand areas
- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image scanning across Azure, Amazon ECR, and Google Cloud providers.
  * Processing now continues for other images when an individual image request fails.
  * Scan results include clearer per-image errors and partial vulnerability reports where available.
  * Standardized vulnerability severity levels across providers.
  * Preserved pagination, CVE details, and vulnerability result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->