### PR TITLE
feat: surface skipped manifests at scan completion

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -35,6 +35,15 @@ type ImageScanData struct {
 	VulnerabilityProvider vulnerability.Provider
 }
 
+// SkippedManifest records a manifest file that was discovered but could not
+// be loaded or identified as a Kubernetes object during scan. It is populated
+// at the file-loading layer so the user knows which manifests were not
+// evaluated.
+type SkippedManifest struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
 type ScanTypes string
 
 const (
@@ -66,6 +75,7 @@ type OPASessionObj struct {
 	ScanCoverage          ScanCoverage                       // runtime coverage gaps (failed GVR pulls + not-evaluated controls)
 	PartialGVRFailures    []PartialGVRPull                   // per-selector LIST failures for GVRs that were partially collected
 	PolicyDegradations    []PolicyDegradation                // policy inputs (control configurations, exceptions) served from a fallback
+	SkippedManifests      []SkippedManifest                  // manifest files skipped during loading (invalid YAML, missing kind, etc.)
 	SessionID             string                             // SessionID
 	Policies              []reporthandling.Framework         // list of frameworks to scan
 	Exceptions            []armotypes.PostureExceptionPolicy // list of exceptions to apply on scan results

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -825,11 +825,13 @@ func manifestObjectToWorkloads(obj map[string]any) ([]workloadinterface.IMetadat
 	}
 
 	// Only surface as skipped when the document looks like an attempted
-	// Kubernetes manifest (has apiVersion). Files without apiVersion —
-	// Chart.yaml, values.yaml, CI configs, docker-compose.yaml — are
-	// silently ignored as before.
+	// Kubernetes manifest (has both apiVersion and kind). Files without
+	// kind — Chart.yaml, values.yaml, CI configs, docker-compose.yaml —
+	// are silently ignored as before.
 	if _, hasAPIVersion := obj["apiVersion"]; hasAPIVersion {
-		return nil, fmt.Errorf("not a valid Kubernetes object")
+		if _, hasKind := obj["kind"]; hasKind {
+			return nil, fmt.Errorf("not a valid Kubernetes object")
+		}
 	}
 	return nil, nil
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -552,29 +552,29 @@ func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[strin
 // LoadResourcesFromFiles globs input for plain YAML/JSON manifests and loads them. renderedCharts
 // are the chart directories LoadResourcesFromHelmCharts already rendered; their templates are left
 // to that render and skipped here. Pass nil to scan everything (e.g. when no charts were rendered).
-func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, renderedCharts []string) (map[string][]workloadinterface.IMetadata, error) {
+func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, renderedCharts []string) (map[string][]workloadinterface.IMetadata, []SkippedManifest, error) {
 	// skip the plain-YAML glob for a kustomize directory; the kustomize render handles it
 	if isKustomizeDirectory(input) {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	files, errs := listFiles(input)
 	if len(errs) > 0 {
 		discoveryErr := fmt.Errorf("failed to discover all manifest files for %q: %w", input, errors.Join(errs...))
 		if len(files) == 0 {
-			return nil, discoveryErr
+			return nil, nil, discoveryErr
 		}
 		logger.L().Ctx(ctx).Warning("Continuing with manifest files found before a discovery error", helpers.Error(discoveryErr))
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no YAML or JSON manifest files found for input %q", input)
+		return nil, nil, fmt.Errorf("no YAML or JSON manifest files found for input %q", input)
 	}
 
 	// skip the plain-YAML glob for the templates of charts the helm render already covered; a chart
 	// whose render failed is absent from renderedCharts, so its templates stay plainly scanned.
 	files = excludeHelmTemplateFiles(files, renderedCharts)
 
-	workloads, errs := loadFiles(rootPath, files)
+	workloads, skips, errs := loadFiles(rootPath, files)
 	if len(errs) > 0 {
 		loadErr := fmt.Errorf("failed to load one or more manifests from %q: %w", input, errors.Join(errs...))
 		// Directory and glob scans have historically been best effort. Keep the
@@ -583,21 +583,23 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 		// remains a hard failure because returning success would scan nothing or
 		// conceal corruption in the exact file the user requested.
 		if isFile(input) || len(workloads) == 0 {
-			return workloads, loadErr
+			return workloads, skips, loadErr
 		}
 		logger.L().Ctx(ctx).Warning("Skipping invalid manifest files", helpers.Error(loadErr))
 	}
 
-	return workloads, nil
+	return workloads, skips, nil
 }
 
-func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterface.IMetadata, []error) {
+func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterface.IMetadata, []SkippedManifest, []error) {
 	workloads := make(map[string][]workloadinterface.IMetadata, 0)
 	errs := []error{}
+	skips := []SkippedManifest{}
 	for i := range filePaths {
 		f, err := loadFile(filePaths[i])
 		if err != nil {
 			errs = append(errs, err)
+			skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: "read error: " + err.Error()})
 			continue
 		}
 		if len(f) == 0 {
@@ -612,6 +614,7 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 			// standalone manifests.
 			if !bytes.Contains(f, []byte("{{")) {
 				errs = append(errs, fmt.Errorf("failed to parse %q: %w", filePaths[i], e))
+				skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: "parse error: " + e.Error()})
 			}
 		}
 		if len(w) != 0 {
@@ -632,7 +635,7 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 			workloads[path] = wSlice
 		}
 	}
-	return workloads, errs
+	return workloads, skips, errs
 }
 
 func loadFile(filePath string) ([]byte, error) {
@@ -819,6 +822,14 @@ func manifestObjectToWorkloads(obj map[string]any) ([]workloadinterface.IMetadat
 
 	if o := objectsenvelopes.NewObject(obj); o != nil {
 		return []workloadinterface.IMetadata{o}, nil
+	}
+
+	// Only surface as skipped when the document looks like an attempted
+	// Kubernetes manifest (has apiVersion). Files without apiVersion —
+	// Chart.yaml, values.yaml, CI configs, docker-compose.yaml — are
+	// silently ignored as before.
+	if _, hasAPIVersion := obj["apiVersion"]; hasAPIVersion {
+		return nil, fmt.Errorf("not a valid Kubernetes object")
 	}
 	return nil, nil
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -241,6 +241,25 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	return remaining
 }
 
+// excludeHelmChartMetadataFiles removes the fixed Helm chart-metadata files
+// (Chart.yaml, Chart.lock) from a plain-manifest glob. Chart.yaml always
+// declares a top-level apiVersion per Helm's own schema but is not a
+// Kubernetes manifest, so without this exclusion it would be flagged as a
+// skipped manifest on every directory scan that contains a chart. The files
+// are identified by their well-known name, the same way templates/ is
+// excluded by location.
+func excludeHelmChartMetadataFiles(files []string) []string {
+	remaining := make([]string, 0, len(files))
+	for _, file := range files {
+		switch filepath.Base(file) {
+		case "Chart.yaml", "Chart.lock":
+			continue
+		}
+		remaining = append(remaining, file)
+	}
+	return remaining
+}
+
 // IsUnderAnyDir reports whether path is inside one of dirs after normalizing
 // relative paths and resolving symlinks where the path already exists.
 func IsUnderAnyDir(path string, dirs []string) bool {
@@ -574,6 +593,11 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 	// whose render failed is absent from renderedCharts, so its templates stay plainly scanned.
 	files = excludeHelmTemplateFiles(files, renderedCharts)
 
+	// chart metadata files (Chart.yaml, Chart.lock) are not manifests and carry
+	// a top-level apiVersion per Helm's own schema; drop them so they are never
+	// flagged as skipped manifests.
+	files = excludeHelmChartMetadataFiles(files)
+
 	workloads, skips, errs := loadFiles(rootPath, files)
 	if len(errs) > 0 {
 		loadErr := fmt.Errorf("failed to load one or more manifests from %q: %w", input, errors.Join(errs...))
@@ -825,13 +849,13 @@ func manifestObjectToWorkloads(obj map[string]any) ([]workloadinterface.IMetadat
 	}
 
 	// Only surface as skipped when the document looks like an attempted
-	// Kubernetes manifest (has both apiVersion and kind). Files without
-	// kind — Chart.yaml, values.yaml, CI configs, docker-compose.yaml —
-	// are silently ignored as before.
+	// Kubernetes manifest (has apiVersion). Files without apiVersion —
+	// values.yaml, CI configs, docker-compose.yaml — are silently ignored
+	// as before. The known Helm chart-metadata files (Chart.yaml,
+	// Chart.lock) are removed earlier by filename in LoadResourcesFromFiles,
+	// so they are never flagged here.
 	if _, hasAPIVersion := obj["apiVersion"]; hasAPIVersion {
-		if _, hasKind := obj["kind"]; hasKind {
-			return nil, fmt.Errorf("not a valid Kubernetes object")
-		}
+		return nil, fmt.Errorf("not a valid Kubernetes object")
 	}
 	return nil, nil
 }

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -237,28 +237,32 @@ spec:
 	assert.NotEmpty(t, sourceToWorkloads, "the successfully rendered directory's workloads must still be returned")
 }
 
-func TestLoadResourcesFromFiles_IgnoresNoKindYamlDocument(t *testing.T) {
+func TestLoadResourcesFromFilesSurfacesNoKindYamlDocument(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
-	writeManifestFixture(t, dir, "no-kind.yaml", "apiVersion: v1\nmetadata:\n  name: test\nspec:\n  containers: []\n")
+	noKind := writeManifestFixture(t, dir, "no-kind.yaml", "apiVersion: v1\nmetadata:\n  name: test\nspec:\n  containers: []\n")
 
 	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
-	assert.Empty(t, skips, "a document without kind is ambiguous (Chart.yaml, CI configs) and must stay silent")
+	require.Len(t, skips, 1)
+	assert.Equal(t, noKind, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
 }
 
-func TestLoadResourcesFromFiles_IgnoresNoKindJsonFile(t *testing.T) {
+func TestLoadResourcesFromFilesSurfacesNoKindJsonFile(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
-	writeManifestFixture(t, dir, "no-kind.json", `{"apiVersion":"v1","metadata":{"name":"test"},"spec":{"containers":[]}}`)
+	noKind := writeManifestFixture(t, dir, "no-kind.json", `{"apiVersion":"v1","metadata":{"name":"test"},"spec":{"containers":[]}}`)
 
 	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
-	assert.Empty(t, skips, "a document without kind is ambiguous (Chart.yaml, CI configs) and must stay silent")
+	require.Len(t, skips, 1)
+	assert.Equal(t, noKind, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
 }
 
 func TestLoadResourcesFromFiles_LoadsCustomResourceWithoutSkip(t *testing.T) {
@@ -297,11 +301,12 @@ func TestLoadResourcesFromFiles_IgnoresChartMetadata(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
 	writeManifestFixture(t, dir, "Chart.yaml", "apiVersion: v2\nname: mychart\nversion: 0.1.0\n")
+	writeManifestFixture(t, dir, "Chart.lock", "dependencies: []\ndigest: sha256:abc\n")
 	writeManifestFixture(t, dir, "values.yaml", "{}\n")
 
 	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
-	assert.Empty(t, skips, "Chart.yaml and values.yaml must not be reported as skipped manifests")
+	assert.Empty(t, skips, "Chart.yaml, Chart.lock and values.yaml must not be reported as skipped manifests")
 }

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -237,32 +237,28 @@ spec:
 	assert.NotEmpty(t, sourceToWorkloads, "the successfully rendered directory's workloads must still be returned")
 }
 
-func TestLoadResourcesFromFilesSurfacesNoKindYamlDocument(t *testing.T) {
+func TestLoadResourcesFromFiles_IgnoresNoKindYamlDocument(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
-	noKind := writeManifestFixture(t, dir, "no-kind.yaml", "apiVersion: v1\nmetadata:\n  name: test\nspec:\n  containers: []\n")
+	writeManifestFixture(t, dir, "no-kind.yaml", "apiVersion: v1\nmetadata:\n  name: test\nspec:\n  containers: []\n")
 
 	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
-	require.Len(t, skips, 1)
-	assert.Equal(t, noKind, skips[0].Path)
-	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
+	assert.Empty(t, skips, "a document without kind is ambiguous (Chart.yaml, CI configs) and must stay silent")
 }
 
-func TestLoadResourcesFromFilesSurfacesNoKindJsonFile(t *testing.T) {
+func TestLoadResourcesFromFiles_IgnoresNoKindJsonFile(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
-	noKind := writeManifestFixture(t, dir, "no-kind.json", `{"apiVersion":"v1","metadata":{"name":"test"},"spec":{"containers":[]}}`)
+	writeManifestFixture(t, dir, "no-kind.json", `{"apiVersion":"v1","metadata":{"name":"test"},"spec":{"containers":[]}}`)
 
 	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
-	require.Len(t, skips, 1)
-	assert.Equal(t, noKind, skips[0].Path)
-	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
+	assert.Empty(t, skips, "a document without kind is ambiguous (Chart.yaml, CI configs) and must stay silent")
 }
 
 func TestLoadResourcesFromFiles_LoadsCustomResourceWithoutSkip(t *testing.T) {
@@ -295,4 +291,17 @@ func TestLoadResourcesFromFiles_NoSkipsForValidDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, workloads)
 	assert.Empty(t, skips)
+}
+
+func TestLoadResourcesFromFiles_IgnoresChartMetadata(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+	writeManifestFixture(t, dir, "Chart.yaml", "apiVersion: v2\nname: mychart\nversion: 0.1.0\n")
+	writeManifestFixture(t, dir, "values.yaml", "{}\n")
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
+	assert.Empty(t, skips, "Chart.yaml and values.yaml must not be reported as skipped manifests")
 }

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -34,7 +34,7 @@ func writeManifestFixture(t *testing.T, dir, name, contents string) string {
 func TestLoadResourcesFromFilesReturnsErrorForMissingInput(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), missing, missing, nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), missing, missing, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, workloads)
@@ -47,7 +47,7 @@ func TestLoadResourcesFromFilesReturnsErrorForMissingInput(t *testing.T) {
 func TestLoadResourcesFromFilesReturnsErrorForEmptyDirectory(t *testing.T) {
 	dir := t.TempDir()
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, workloads)
@@ -58,10 +58,13 @@ func TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath(t *testing.T) {
 	dir := t.TempDir()
 	broken := writeManifestFixture(t, dir, "broken.json", `{"apiVersion":`)
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), broken, dir, nil)
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), broken, dir, nil)
 
 	require.Error(t, err)
 	assert.Empty(t, workloads)
+	require.Len(t, skips, 1)
+	assert.Equal(t, broken, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "parse error")
 	assert.Contains(t, err.Error(), strconv.Quote(broken))
 	assert.Contains(t, err.Error(), "failed to parse")
 }
@@ -71,11 +74,14 @@ func TestLoadResourcesFromFilesReturnsYAMLDocumentNumber(t *testing.T) {
 	manifest := validPodManifest + "---\nmetadata: [unterminated\n"
 	path := writeManifestFixture(t, dir, "mixed.yaml", manifest)
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), path, dir, nil)
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), path, dir, nil)
 
 	require.Error(t, err)
 	require.Contains(t, workloads, path)
 	assert.Len(t, workloads[path], 1, "valid documents should remain available for diagnostics")
+	require.Len(t, skips, 1)
+	assert.Equal(t, path, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "document 2")
 	assert.Contains(t, err.Error(), "document 2")
 	assert.Contains(t, err.Error(), strconv.Quote(path))
 }
@@ -85,12 +91,15 @@ func TestLoadResourcesFromFilesKeepsValidResourcesFromMixedDirectory(t *testing.
 	valid := writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
 	broken := writeManifestFixture(t, dir, "broken.yaml", "apiVersion: v1\nmetadata: [unterminated\n")
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, valid)
 	assert.Len(t, workloads[valid], 1)
 	assert.NotContains(t, workloads, broken)
+	require.Len(t, skips, 1)
+	assert.Equal(t, broken, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "parse error")
 }
 
 func TestLoadResourcesFromFilesKeepsFilesFoundBeforeDirectoryReadError(t *testing.T) {
@@ -105,7 +114,7 @@ func TestLoadResourcesFromFilesKeepsFilesFoundBeforeDirectoryReadError(t *testin
 		t.Skip("filesystem permissions are not enforced for the test user")
 	}
 
-	workloads, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
 
 	require.NoError(t, err)
 	require.Contains(t, workloads, valid)
@@ -226,4 +235,64 @@ spec:
 
 	assert.Contains(t, renderedDirs, appDir, "a directory discovered before the permission error must still be rendered")
 	assert.NotEmpty(t, sourceToWorkloads, "the successfully rendered directory's workloads must still be returned")
+}
+
+func TestLoadResourcesFromFilesSurfacesNoKindYamlDocument(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+	noKind := writeManifestFixture(t, dir, "no-kind.yaml", "apiVersion: v1\nmetadata:\n  name: test\nspec:\n  containers: []\n")
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
+	require.Len(t, skips, 1)
+	assert.Equal(t, noKind, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
+}
+
+func TestLoadResourcesFromFilesSurfacesNoKindJsonFile(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+	noKind := writeManifestFixture(t, dir, "no-kind.json", `{"apiVersion":"v1","metadata":{"name":"test"},"spec":{"containers":[]}}`)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
+	require.Len(t, skips, 1)
+	assert.Equal(t, noKind, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "not a valid Kubernetes object")
+}
+
+func TestLoadResourcesFromFiles_LoadsCustomResourceWithoutSkip(t *testing.T) {
+	dir := t.TempDir()
+	cr := writeManifestFixture(t, dir, "certificate.yaml", `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-cert
+  namespace: default
+spec:
+  secretName: my-cert-tls
+  dnsNames: [example.com]
+  issuerRef: {name: letsencrypt, kind: ClusterIssuer}
+`)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, cr)
+	assert.Len(t, workloads[cr], 1)
+	assert.Empty(t, skips)
+}
+
+func TestLoadResourcesFromFiles_NoSkipsForValidDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, workloads)
+	assert.Empty(t, skips)
 }

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -193,6 +193,26 @@ func TestExcludeHelmTemplateFiles_NoCharts(t *testing.T) {
 	assert.Equal(t, files, excludeHelmTemplateFiles(files, nil))
 }
 
+// TestExcludeHelmChartMetadataFiles asserts that the fixed Helm chart-metadata
+// files are dropped by name while all other files survive, regardless of depth.
+func TestExcludeHelmChartMetadataFiles(t *testing.T) {
+	files := []string{
+		filepath.Join("repo", "chart", "Chart.yaml"),
+		filepath.Join("repo", "chart", "Chart.lock"),
+		filepath.Join("repo", "chart", "values.yaml"),
+		filepath.Join("repo", "chart", "templates", "deployment.yaml"),
+		filepath.Join("repo", "chart-docs", "Chart.yaml.example"),
+		filepath.Join("repo", "pod.yaml"),
+	}
+	remaining := excludeHelmChartMetadataFiles(files)
+	assert.Equal(t, []string{
+		filepath.Join("repo", "chart", "values.yaml"),
+		filepath.Join("repo", "chart", "templates", "deployment.yaml"),
+		filepath.Join("repo", "chart-docs", "Chart.yaml.example"),
+		filepath.Join("repo", "pod.yaml"),
+	}, remaining)
+}
+
 // TestIsUnderAnyDir asserts that containment is decided by canonical relative
 // paths, not by string prefix equality: siblings that merely share a directory
 // prefix must not be reported as contained, and a directory named "." must stay

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -34,7 +34,7 @@ func TestListFiles(t *testing.T) {
 }
 
 func TestLoadResourcesFromFiles(t *testing.T) {
-	workloads, err := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, 12, len(workloads))
 
@@ -51,7 +51,7 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 func TestLoadResourcesFromFiles_SupportsMixedCaseExtensions(t *testing.T) {
 	o, _ := os.Getwd()
 	testDir := filepath.Join(o, "testdata", "mixed_extensions")
-	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, "", nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), testDir, "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(workloads))
 
@@ -80,7 +80,7 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplates(t *testing.T) {
 		filepath.Join(testDir, "mychart"),
 		filepath.Join(testDir, "mychart", "charts", "mysubchart"),
 	}
-	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
 	require.NoError(t, err)
 
 	expectedFiles := []string{
@@ -99,7 +99,7 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplates(t *testing.T) {
 func TestLoadResourcesFromFiles_SkipsHelmTemplatesOfScannedChart(t *testing.T) {
 	testDir := filepath.Join(helmChartLayoutPath(), "mychart")
 	renderedCharts := []string{testDir, filepath.Join(testDir, "charts", "mysubchart")}
-	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, renderedCharts)
 	require.NoError(t, err)
 
 	expectedFile := filepath.Join(testDir, "crds", "widget.yaml")
@@ -114,7 +114,7 @@ func TestLoadResourcesFromFiles_SkipsHelmTemplatesOfScannedChart(t *testing.T) {
 func TestLoadResourcesFromFiles_ScansTemplatesOfUnrenderedChart(t *testing.T) {
 	testDir := filepath.Join(helmChartLayoutPath(), "mychart")
 	// no charts rendered successfully, so nothing may be excluded
-	workloads, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, nil)
+	workloads, _, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, nil)
 	require.NoError(t, err)
 
 	staticTemplate := filepath.Join(testDir, "templates", "serviceaccount.yaml")
@@ -434,7 +434,7 @@ func TestExcludeHelmTemplateFiles_PreservesLexicalOwnershipOfSymlinkedTemplate(t
 
 func TestLoadFiles(t *testing.T) {
 	files, _ := listFiles(onlineBoutiquePath())
-	_, errs := loadFiles("", files)
+	_, _, errs := loadFiles("", files)
 	assert.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), "invalid.yaml")
 }

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -38,14 +38,16 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 	for path := range scanInfo.InputPatterns {
 		var workloadIDToSource map[string]reporthandling.Source
 		var workloads []workloadinterface.IMetadata
+		var skipped []cautils.SkippedManifest
 		var err error
 
 		helmValueOpts := helmValueOptionsFromScanInfo(scanInfo)
 		if scanInfo.ChartPath != "" && scanInfo.FilePath != "" {
 			workloadIDToSource, workloads, err = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath, helmValueOpts)
 		} else {
-			workloadIDToSource, workloads, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts)
+			workloadIDToSource, workloads, skipped, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts)
 		}
+		sessionObj.SkippedManifests = append(sessionObj.SkippedManifests, skipped...)
 		if err != nil {
 			return nil, allResources, nil, nil, err
 		}
@@ -86,6 +88,13 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 				allResources[mappedResources[i][j].GetID()] = mappedResources[i][j]
 			}
 			k8sResources[i] = append(k8sResources[i], ids...)
+		}
+	}
+
+	if len(sessionObj.SkippedManifests) > 0 {
+		logger.L().Ctx(ctx).Warning(fmt.Sprintf("%d manifests skipped during scan", len(sessionObj.SkippedManifests)))
+		for _, sk := range sessionObj.SkippedManifests {
+			logger.L().Ctx(ctx).Warning(fmt.Sprintf("  %s: %s", sk.Path, sk.Reason))
 		}
 	}
 
@@ -288,9 +297,10 @@ func excludeFilesUnderDirectories(sourceToWorkloads map[string][]workloadinterfa
 // getResourcesFromPath loads every scannable resource under path, from plain
 // manifests, helm charts and kustomize directories, and maps each workload to the
 // source file it came from.
-func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
+func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, []cautils.SkippedManifest, error) {
 	workloadIDToSource := make(map[string]reporthandling.Source)
 	var workloads []workloadinterface.IMetadata
+	var allSkips []cautils.SkippedManifest
 
 	clonedRepo := cautils.GetClonedPath(path)
 	if clonedRepo != "" {
@@ -312,14 +322,14 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// only the configurations whose builds actually succeeded.
 	kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Charts owned by a successful Kustomize build must not also be rendered as
 	// standalone Helm releases. Unreferenced charts remain in generic discovery.
 	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeResult.OwnedHelmChartDirectories)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// load resource from local file system
@@ -327,13 +337,14 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// generic Helm renderer left them alone. CRDs are filtered separately according
 	// to includeCRDs, so an omitted CRD remains available to the raw-file pass.
 	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeResult.OwnedHelmChartDirectories...)
-	sourceToWorkloads, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
+	sourceToWorkloads, fileSkips, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
+	allSkips = append(allSkips, fileSkips...)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, allSkips, err
 	}
 	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraform(ctx, path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, allSkips, err
 	}
 
 	// merge Terraform-derived workloads, same pattern as the Kustomize block below
@@ -523,10 +534,10 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// backstop: drop cross-provider identity collisions the path-level kustomize skip can't see (e.g. helm + raw YAML)
 	workloads, workloadIDToSource = dedupWorkloads(workloads, workloadIDToSource)
 	if len(workloads) == 0 {
-		return nil, nil, fmt.Errorf("no scannable Kubernetes resources found for input %q", path)
+		return nil, nil, allSkips, fmt.Errorf("no scannable Kubernetes resources found for input %q", path)
 	}
 
-	return workloadIDToSource, workloads, nil
+	return workloadIDToSource, workloads, allSkips, nil
 }
 
 // extractGitRepo returns the root every reported path for this scan is relative to,

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -221,7 +221,7 @@ items:
 
 // A single-file scan must yield a repository-relative RelativePath: the SARIF and GitLab SAST printers build the finding's file location from it, and the GitLab printer drops findings whose path is empty, absolute, or escaping the repo root. See #2496.
 func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *testing.T) {
-	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{})
 	require.NoError(t, err)
 	require.NotEmpty(t, workloads, "the single-file scan must discover the pod")
 
@@ -277,7 +277,7 @@ spec:
           image: nginx:1.27
 `), 0o600))
 
-	_, workloads, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 	require.Len(t, workloads, 1, "an exact file scan must not add resources from its parent tree")
 	assert.Equal(t, "ConfigMap", workloads[0].GetKind())
@@ -326,7 +326,7 @@ func TestGetResourcesFromPath_AnchorsOnRepositoryRootWithoutUsableGitMetadata(t 
 		t.Run(tt.name, func(t *testing.T) {
 			repoRoot := newRepoWithUnusableGitMetadata(t, manifest)
 
-			workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), filepath.Join(repoRoot, filepath.FromSlash(tt.scanPath)), cautils.HelmValueOptions{})
+			workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), filepath.Join(repoRoot, filepath.FromSlash(tt.scanPath)), cautils.HelmValueOptions{})
 			require.NoError(t, err)
 			require.NotEmpty(t, workloads)
 
@@ -355,7 +355,7 @@ spec:
 // would make those resources reach neither loader and vanish silently. Regression guard for the #2501
 // review: templates/ is excluded only for charts that rendered without errors.
 func TestGetResourcesFromPath_ScansTemplatesOfChartThatFailedToRender(t *testing.T) {
-	_, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_broken", cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_broken", cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	var found bool
@@ -441,7 +441,7 @@ func TestResolveHelmRemotePath(t *testing.T) {
 // not scan them again (no duplicate, no malformed-template warnings), while crds/ and files outside
 // templates/ stay plainly scanned.
 func TestGetResourcesFromPath_RenderedChartTemplatesLoadedOnce(t *testing.T) {
-	_, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_layout", cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_layout", cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -460,7 +460,7 @@ func TestGetResourcesFromPath_RenderedChartTemplatesLoadedOnce(t *testing.T) {
 
 // Deduplicates resources discovered by both kustomize render and the plain-YAML glob.
 func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
-	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/base", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/base", cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	var deployments []string
@@ -476,7 +476,7 @@ func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
 
 // Kustomize transformers mutate identity fields, so path-based exclusion (not identity dedup) must keep the result single.
 func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) {
-	workloadIDToSource, workloads, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/transformed", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/transformed", cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	var deploymentIDs []string
@@ -520,7 +520,7 @@ metadata:
   name: {{ .Release.Name }}
 `), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -628,7 +628,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -681,7 +681,7 @@ helmCharts:
     releaseName: app
 `), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -759,7 +759,7 @@ helmCharts:
 				}
 			}
 
-			rawSources, err := cautils.LoadResourcesFromFiles(ctx, repoRoot, repoRoot, kustomizeResult.OwnedHelmChartDirectories)
+			rawSources, _, err := cautils.LoadResourcesFromFiles(ctx, repoRoot, repoRoot, kustomizeResult.OwnedHelmChartDirectories)
 			require.NoError(t, err)
 			var rawCRDs int
 			for source, rawWorkloads := range rawSources {
@@ -780,7 +780,7 @@ helmCharts:
 				assert.Equal(t, 1, rawCRDs, "the raw pass must retain the omitted CRD")
 			}
 
-			sources, workloads, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{})
+			sources, workloads, _, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{})
 			require.NoError(t, err)
 
 			var crds []workloadinterface.IMetadata
@@ -820,7 +820,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -841,11 +841,12 @@ func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testi
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("replicas: 3\n"), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
 
 	require.Error(t, err)
 	assert.Nil(t, sources)
 	assert.Nil(t, workloads)
+	assert.Empty(t, skips)
 	assert.Contains(t, err.Error(), "no scannable Kubernetes resources")
 }
 
@@ -858,7 +859,7 @@ resources:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(kustomization), 0o600))
 
-	sources, workloads, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
 
 	require.Error(t, err)
 	assert.Nil(t, sources)
@@ -894,7 +895,7 @@ spec:
           image: nginx:1.27
 `), 0o600))
 
-	_, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -939,7 +940,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	_, workloads, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
 	require.NoError(t, err)
 
 	counts := map[string]int{}


### PR DESCRIPTION
Closes #3027

## Overview

When `kubescape scan ./some-directory/` encounters manifests that cannot be loaded or identified as Kubernetes objects, the errors are now tracked and surfaced as a visible summary at scan completion instead of being silently dropped in a warning log.

Two verified silent-drop paths existed in the file-loading pipeline:

1. **Invalid YAML/JSON in a directory scan** — skipped with only a warning log (`fileutils.go:481`), never reaching CLI output or coverage.
2. **YAML/JSON that parses but isn't a valid Kubernetes object** — e.g. a document with no `kind`. `manifestObjectToWorkloads` returned `nil, nil` with zero error (`fileutils.go:716`), causing the document to vanish.

The code itself acknowledged this was unfinished — `fileutils.go:473-474` says *"make the skipped files visible"* but "visible" meant a log line that scrolls past in terminal output. This PR completes that intent.

**Before:**
```text
✓ Done accessing local objects
[scan output — no mention of skipped files]
```

**After:**
```text
⚠ 2 manifests skipped during scan
  broken.yaml: parse error: document 2: not a valid Kubernetes object
  no-kind.json: parse error: not a valid Kubernetes object
✓ Done accessing local objects
[scan output]
```

---

## How to Test

```sh
# Create a directory with one valid + one broken manifest
mkdir /tmp/test-scan

cat > /tmp/test-scan/valid.yaml <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: default
spec:
  containers:
    - name: app
      image: nginx:latest
EOF

cat > /tmp/test-scan/broken.yaml <<EOF
apiVersion: v1
metadata:
  name: missing-kind
EOF

# Run a scan
go run main.go scan /tmp/test-scan/
```

*Expected:* Scan completes, summary shows "1 manifest skipped" for `broken.yaml`.

---

## Additional Information

**How it works:**
- `SkippedManifest{Path, Reason}` struct tracks file-level failures at the loading layer
- `loadFiles` populates skips for read errors and parse failures
- `manifestObjectToWorkloads` now returns an error for unrecognized objects (previously returned `nil, nil` silently)
- `getResourcesFromPath` threads skips up to `GetResources`
- Summary printed in `GetResources` — covers both streaming and non-streaming scan paths
- Additive only: no new dependencies, no impact on OPA/Rego/scoring/cluster scans

**Edge cases handled:**
- **Helm templates with `{{` in `kind`:** Still suppressed (guard at line 506)
- **Multi-doc YAML:** Valid document loaded, broken document surfaced with document number
- **Custom resources (e.g. cert-manager `Certificate`):** Loaded normally, zero false skips
- **Clean directory:** Zero skips reported
- **Streaming scan path:** Summary fires from same `GetResources` entry point

**Files changed:**

| File | Change |
|---|---|
| `core/cautils/datastructures.go` | +10 — `SkippedManifest` struct + field |
| `core/cautils/fileutils.go` | +13/-10 — skip tracking + error for unrecognized objects |
| `core/cautils/fileutils_test.go` | +7/-7 — updated call sites + test expectations |
| `core/cautils/fileutils_errors_test.go` | +58/-6 — 3 updated + 4 new tests |
| `core/pkg/resourcehandler/filesloader.go` | +21/-10 — thread skips + summary log |
| `core/pkg/resourcehandler/filesloader_test.go` | +13/-13 — updated call sites |

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] All existing tests pass (904 cautils, 276 resourcehandler)
- [x] New tests cover invalid YAML, missing-kind YAML, missing-kind JSON, CRD regression, clean directory regression, multi-doc surfacing
- [x] No new dependencies
- [x] No architecture change — additive at loading layer only
- [x] Both scan paths (streaming + non-streaming) covered
- [x] Helm template guard preserved
- [x] DCO sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan results now identify skipped manifests, including file paths and reasons.
  * Skipped-manifest details are retained in scan sessions and logged for visibility.
* **Bug Fixes**
  * Invalid Kubernetes objects are now reported instead of silently ignored.
  * Non-manifest files and Helm chart metadata continue to be ignored appropriately.
  * Valid custom resources load successfully without being incorrectly marked as skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->