### PR TITLE
feat(html): show current field values in evidence paths

### DIFF
--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
@@ -155,7 +156,7 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 					helpers.String("resourceID", resourceID))
 				continue
 			}
-			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails)
+			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails, resource)
 			resourceTableView = append(resourceTableView, ResourceResult{resource, ctlResults})
 		}
 	}
@@ -186,17 +187,17 @@ func buildImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.
 	return imageScanSummary
 }
 
-func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary) ResourceControlResult {
+func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary, resource workloadinterface.IMetadata) ResourceControlResult {
 	ctlSeverity := apis.ControlSeverityToString(control.GetScoreFactor())
 	ctlName := resourceControl.GetName()
 	ctlID := resourceControl.GetID()
 	ctlURL := cautils.GetControlLink(resourceControl.GetID())
-	failedPaths := AssistedRemediationPathsToString(&resourceControl)
+	failedPaths := AssistedRemediationPathsWithCurrentValues(&resourceControl, resource)
 
 	return ResourceControlResult{ctlSeverity, ctlName, ctlID, ctlURL, failedPaths}
 }
 
-func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails) []ResourceControlResult {
+func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata) []ResourceControlResult {
 	var ctlResults []ResourceControlResult
 	for _, resourceControl := range resourceControls {
 		if resourceControl.GetStatus(nil).IsFailed() {
@@ -204,7 +205,7 @@ func buildResourceControlResultTable(resourceControls []resourcesresults.Resourc
 			if control == nil {
 				continue
 			}
-			ctlResult := buildResourceControlResult(resourceControl, control)
+			ctlResult := buildResourceControlResult(resourceControl, control, resource)
 
 			ctlResults = append(ctlResults, ctlResult)
 		}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -87,7 +87,7 @@ func TestBuildResourceControlResultTable_MissingControl(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails)
+		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails, nil)
 		assert.Empty(t, results)
 	})
 }


### PR DESCRIPTION
## What this fixes

HTML reports were calling `AssistedRemediationPathsToString` which emits bare paths like:

spec.containers[0].securityContext.privileged


This PR switches to `AssistedRemediationPathsWithCurrentValues` so each path includes the live field value:

spec.containers[0].securityContext.privileged (current: true)


Closes #1563

## How

The infrastructure already existed in `pathvalue.go` and was already used by the pretty-printer (`resourcetable.go:87`). This change threads the resource object through:

`buildResourceTableView` → `buildResourceControlResultTable` → `buildResourceControlResult`

to reach the call site. No new logic added — just wiring what was already there into the HTML path.

## Changes

- `htmlprinter.go`: update all 3 functions to accept and thread the resource object, switch to `AssistedRemediationPathsWithCurrentValues`
- `htmlprinter_test.go`: add `nil` as the new third arg to `buildResourceControlResultTable` call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remediation paths in resource control results now include current resource values.
  * Resource metadata is preserved when generating resource tables, improving the accuracy of remediation guidance.
* **Tests**
  * Updated resource control table coverage to reflect the revised result generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->