### PR TITLE
test(imagescan): add DI-based Login and pagination coverage for Azure/ECR adaptors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/briandowns/spinner v1.23.2
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/deckarep/golang-set/v2 v2.8.0
@@ -212,7 +213,6 @@ require (
 	github.com/buildkite/go-pipeline v0.16.0 // indirect
 	github.com/buildkite/interpolate v0.1.5 // indirect
 	github.com/buildkite/roko v1.4.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/pkg/imagescan/adaptor_utils.go
+++ b/pkg/imagescan/adaptor_utils.go
@@ -1,0 +1,63 @@
+package imagescan
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+)
+
+// FetchImagesInformation provides a shared implementation for GetImagesInformation across adaptors.
+func FetchImagesInformation(imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error) {
+	var infos []ContainerImageInformation
+	for _, imageID := range imageIDs {
+		infos = append(infos, ContainerImageInformation{
+			ImageID: imageID,
+			Bom:     []string{},
+		})
+	}
+	return infos, nil
+}
+
+// NormalizeSeverity converts common provider severity strings to Kubescape standard.
+func NormalizeSeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "Critical"
+	case "high":
+		return "High"
+	case "medium":
+		return "Medium"
+	case "low":
+		return "Low"
+	case "minimal", "informational", "untriaged", "unassigned":
+		return "Negligible"
+	default:
+		return "Unknown"
+	}
+}
+
+// ProcessImages iterates over imageIDs and calls the provided fetch function, handling boilerplate nil-hashes and errors.
+func ProcessImages[T any](
+	imageIDs []ContainerImageIdentifier,
+	emptyResult func(imageID ContainerImageIdentifier) T,
+	processFunc func(imageID ContainerImageIdentifier) (T, error),
+) ([]T, error) {
+	var results []T
+	var aggErr error
+
+	for _, imageID := range imageIDs {
+		res, err := processFunc(imageID)
+		if err != nil {
+			logger.L().Warning("skipping image due to api error", helpers.Error(err))
+			aggErr = errors.Join(aggErr, err)
+			results = append(results, emptyResult(imageID))
+			continue
+		}
+
+		results = append(results, res)
+	}
+
+	return results, aggErr
+}

--- a/pkg/imagescan/adaptor_utils_test.go
+++ b/pkg/imagescan/adaptor_utils_test.go
@@ -1,0 +1,69 @@
+package imagescan
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessImages(t *testing.T) {
+	emptyResultFunc := func(id ContainerImageIdentifier) string {
+		return fmt.Sprintf("empty-%s", id.Repository)
+	}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: "hash1"},
+			{Repository: "repo2", Hash: "hash2"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"processed-repo1", "processed-repo2"}, results)
+	})
+
+	t.Run("PartialFailure", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: "hash1"},
+			{Repository: "repo2", Hash: "hash2"},
+			{Repository: "repo3", Hash: "hash3"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			if id.Repository == "repo2" {
+				return "", errors.New("api error on repo2")
+			}
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+
+		assert.ErrorContains(t, err, "api error on repo2")
+		// The error should be aggregated, and the failed repo should yield the emptyResult.
+		assert.Equal(t, []string{"processed-repo1", "empty-repo2", "processed-repo3"}, results)
+	})
+
+	t.Run("EmptyHashSkippedInsideProcessFunc", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: ""},
+			{Repository: "repo2", Hash: "hash2"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			if id.Hash == "" {
+				return emptyResultFunc(id), nil
+			}
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"empty-repo1", "processed-repo2"}, results)
+	})
+}

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -35,15 +35,31 @@ func (a *azureAPIWrapper) Resources(ctx context.Context, query armresourcegraph.
 	return a.client.Resources(ctx, query, options)
 }
 
+type azureCredentialProvider func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error)
+type azureClientFactory func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error)
+
 // AzureAdaptor implements IContainerImageVulnerabilityAdaptor for Azure Container Registry (ACR).
 type AzureAdaptor struct {
-	client       AzureAPI
-	registryHost string
+	client        AzureAPI
+	registryHost  string
+	credProvider  azureCredentialProvider
+	clientFactory azureClientFactory
 }
 
 // NewAzureAdaptor creates a new Azure adaptor instance.
 func NewAzureAdaptor() *AzureAdaptor {
-	return &AzureAdaptor{}
+	return &AzureAdaptor{
+		credProvider: func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+			return azidentity.NewDefaultAzureCredential(options)
+		},
+		clientFactory: func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error) {
+			c, err := armresourcegraph.NewClient(cred, options)
+			if err != nil {
+				return nil, err
+			}
+			return &azureAPIWrapper{client: c}, nil
+		},
+	}
 }
 
 func resolveAzureCloudConfig(registryHost string) (cloud.Configuration, error) {
@@ -74,20 +90,20 @@ func (a *AzureAdaptor) Login(ctx context.Context, registry string, credentials R
 
 	clientOpts := azcore.ClientOptions{Cloud: cloudConfig}
 
-	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+	cred, err := a.credProvider(&azidentity.DefaultAzureCredentialOptions{
 		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to load azure credentials: %w", err)
 	}
 
-	c, err := armresourcegraph.NewClient(cred, &arm.ClientOptions{
+	c, err := a.clientFactory(cred, &arm.ClientOptions{
 		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to load azure resource graph client: %w", err)
 	}
-	a.client = &azureAPIWrapper{client: c}
+	a.client = c
 
 	// Cheap probe query so Login fails fast on bad/missing identity
 	probeReq := armresourcegraph.QueryRequest{

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -122,31 +121,34 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
 	parts := strings.Split(a.registryHost, ".")
 	registryName := parts[0]
 
-	for _, imageID := range imageIDs {
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
 
-		if imageID.Hash == "" {
-			statuses = append(statuses, status)
-			continue
-		}
+			if imageID.Hash == "" {
+				return status, nil
+			}
 
-		if err := a.validateImageID(imageID); err != nil {
-			logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
-			statuses = append(statuses, status)
-			continue
-		}
+			if err := a.validateImageID(imageID); err != nil {
+				return status, fmt.Errorf("invalid image id: %w", err)
+			}
 
-		// Query ARG for parent assessment to determine scan availability
-		queryStr := fmt.Sprintf(`
+			// Query ARG for parent assessment to determine scan availability
+			queryStr := fmt.Sprintf(`
 			securityresources
 			| where type == "microsoft.security/assessments"
 			| extend registryName = extract(@"(?i)/registries/([^/]+)/", 1, id)
@@ -156,57 +158,36 @@ func (a *AzureAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Conta
 			| limit 1
 		`, registryName, imageID.Hash)
 
-		req := armresourcegraph.QueryRequest{
-			Query: to.Ptr(queryStr),
-			Options: &armresourcegraph.QueryRequestOptions{
-				ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
-			},
-		}
+			req := armresourcegraph.QueryRequest{
+				Query: to.Ptr(queryStr),
+				Options: &armresourcegraph.QueryRequestOptions{
+					ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
+				},
+			}
 
-		res, err := a.client.Resources(ctx, req, nil)
-		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err))
-			statuses = append(statuses, status)
-			continue
-		}
+			res, err := a.client.Resources(ctx, req, nil)
+			if err != nil {
+				return status, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
+			}
 
-		if res.TotalRecords != nil && *res.TotalRecords > 0 {
-			status.IsScanAvailable = true
-			if res.Data != nil {
-				if dataList, ok := res.Data.([]interface{}); ok && len(dataList) > 0 {
-					if row, ok := dataList[0].(map[string]interface{}); ok {
-						if tg := getStringSafe(row, "timeGenerated"); tg != "" {
-							if parsedTime, err := time.Parse(time.RFC3339Nano, tg); err == nil {
-								status.LastScanDate = parsedTime
+			if res.TotalRecords != nil && *res.TotalRecords > 0 {
+				status.IsScanAvailable = true
+				if res.Data != nil {
+					if dataList, ok := res.Data.([]interface{}); ok && len(dataList) > 0 {
+						if row, ok := dataList[0].(map[string]interface{}); ok {
+							if tg := getStringSafe(row, "timeGenerated"); tg != "" {
+								if parsedTime, err := time.Parse(time.RFC3339Nano, tg); err == nil {
+									status.LastScanDate = parsedTime
+								}
 							}
 						}
 					}
 				}
 			}
-		}
 
-		statuses = append(statuses, status)
-	}
-
-	return statuses, aggErr
-}
-
-// Helper to normalize Azure severity to Kubescape expected severity
-func normalizeAzureSeverity(azureSeverity string) string {
-	switch strings.ToLower(azureSeverity) {
-	case "critical":
-		return "Critical"
-	case "high":
-		return "High"
-	case "medium":
-		return "Medium"
-	case "low":
-		return "Low"
-	case "unassigned", "informational":
-		return "Negligible"
-	default:
-		return "Unknown"
-	}
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -215,29 +196,31 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
 	parts := strings.Split(a.registryHost, ".")
 	registryName := parts[0]
 
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
+			}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
+			}
 
-		if imageID.Hash == "" {
-			reports = append(reports, report)
-			continue
-		}
+			if imageID.Hash == "" {
+				return report, nil
+			}
 
-		if err := a.validateImageID(imageID); err != nil {
-			logger.L().Warning("skipping image", helpers.String("repository", imageID.Repository), helpers.Error(err))
-			reports = append(reports, report)
-			continue
-		}
+			if err := a.validateImageID(imageID); err != nil {
+				return report, fmt.Errorf("invalid image id: %w", err)
+			}
 
-		queryStr := fmt.Sprintf(`
+			queryStr := fmt.Sprintf(`
 			securityresources
 			| where type == "microsoft.security/assessments/subassessments"
 			| extend registryName = extract(@"(?i)/registries/([^/]+)/", 1, id)
@@ -252,86 +235,82 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 				cve = properties.additionalData.cve
 		`, registryName, imageID.Repository, imageID.Hash)
 
-		var skipToken *string
-		count := 0
-		const maxVulns = 1000
-		const maxPages = 50
+			var skipToken *string
+			count := 0
+			const maxVulns = 1000
+			const maxPages = 50
 
-		for page := 0; page < maxPages; page++ {
-			req := armresourcegraph.QueryRequest{
-				Query: to.Ptr(queryStr),
-				Options: &armresourcegraph.QueryRequestOptions{
-					ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
-					SkipToken:    skipToken,
-					Top:          to.Ptr[int32](1000),
-				},
-			}
-
-			res, err := a.client.Resources(ctx, req, nil)
-			if err != nil {
-				aggErr = errors.Join(aggErr, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err))
-				break
-			}
-
-			if res.Data != nil {
-				dataList, ok := res.Data.([]interface{})
-				if !ok {
-					aggErr = errors.Join(aggErr, fmt.Errorf("failed to decode ARG response data format for repository %s", imageID.Repository))
-					break
+			for page := 0; page < maxPages; page++ {
+				req := armresourcegraph.QueryRequest{
+					Query: to.Ptr(queryStr),
+					Options: &armresourcegraph.QueryRequestOptions{
+						ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
+						SkipToken:    skipToken,
+						Top:          to.Ptr[int32](1000),
+					},
 				}
-				malformed := false
-				for _, item := range dataList {
-					if count >= maxVulns {
-						// Log truncation rather than failing hard
-						logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
-						break
-					}
 
-					row, ok := item.(map[string]interface{})
+				res, err := a.client.Resources(ctx, req, nil)
+				if err != nil {
+					return report, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
+				}
+
+				if res.Data != nil {
+					dataList, ok := res.Data.([]interface{})
 					if !ok {
-						aggErr = errors.Join(aggErr, fmt.Errorf("malformed vulnerability row for repository %s: expected map[string]interface{}, got %T", imageID.Repository, item))
-						malformed = true
-						break
+						return report, fmt.Errorf("failed to decode ARG response data format for repository %s", imageID.Repository)
 					}
+					malformed := false
+					for _, item := range dataList {
+						if count >= maxVulns {
+							// Log truncation rather than failing hard
+							logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
+							break
+						}
 
-					vuln := Vulnerability{
-						ID:          getStringSafe(row, "id"),
-						Severity:    normalizeAzureSeverity(getStringSafe(row, "severity")),
-						Description: getStringSafe(row, "description"),
-						Links:       []string{},
-					}
+						row, ok := item.(map[string]interface{})
+						if !ok {
+							malformed = true
+							break
+						}
 
-					// Try to get primary CVE if it exists
-					if cves := getMultipleNestedStringSafe(row, "cve", "title"); len(cves) > 0 {
-						for _, cve := range cves {
-							if count >= maxVulns {
-								break
+						vuln := Vulnerability{
+							ID:          getStringSafe(row, "id"),
+							Severity:    NormalizeSeverity(getStringSafe(row, "severity")),
+							Description: getStringSafe(row, "description"),
+							Links:       []string{},
+						}
+
+						// Try to get primary CVE if it exists
+						if cves := getMultipleNestedStringSafe(row, "cve", "title"); len(cves) > 0 {
+							for _, cve := range cves {
+								if count >= maxVulns {
+									break
+								}
+								newVuln := vuln
+								newVuln.ID = cve
+								report.Vulnerabilities = append(report.Vulnerabilities, newVuln)
+								count++
 							}
-							newVuln := vuln
-							newVuln.ID = cve
-							report.Vulnerabilities = append(report.Vulnerabilities, newVuln)
+						} else {
+							report.Vulnerabilities = append(report.Vulnerabilities, vuln)
 							count++
 						}
-					} else {
-						report.Vulnerabilities = append(report.Vulnerabilities, vuln)
-						count++
+					}
+					if malformed {
+						return report, fmt.Errorf("malformed vulnerability row for repository %s", imageID.Repository)
 					}
 				}
-				if malformed {
+
+				if count >= maxVulns || res.SkipToken == nil || *res.SkipToken == "" {
 					break
 				}
+				skipToken = res.SkipToken
 			}
 
-			if count >= maxVulns || res.SkipToken == nil || *res.SkipToken == "" {
-				break
-			}
-			skipToken = res.SkipToken
-		}
-
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -339,18 +318,7 @@ func (a *AzureAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Cont
 	if a.client == nil {
 		return nil, fmt.Errorf("azure client not initialized, call Login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.

--- a/pkg/imagescan/azure_adaptor_test.go
+++ b/pkg/imagescan/azure_adaptor_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +23,21 @@ func (m *mockAzureClient) Resources(ctx context.Context, query armresourcegraph.
 		return m.resourcesOut(query)
 	}
 	return armresourcegraph.ClientResourcesResponse{}, nil
+}
+
+func TestAzureAdaptor_Login_Success(t *testing.T) {
+	adaptor := NewAzureAdaptor()
+
+	adaptor.credProvider = func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+		return nil, nil // mock credential
+	}
+	adaptor.clientFactory = func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error) {
+		return &mockAzureClient{}, nil
+	}
+
+	err := adaptor.Login(context.Background(), "test.azurecr.io", RegistryCredentials{})
+	assert.NoError(t, err)
+	assert.NotNil(t, adaptor.client)
 }
 
 func TestAzureAdaptor_Login_ExplicitCreds(t *testing.T) {

--- a/pkg/imagescan/azure_adaptor_test.go
+++ b/pkg/imagescan/azure_adaptor_test.go
@@ -65,12 +65,12 @@ func TestAzureAdaptor_GetImagesInformation_Guards(t *testing.T) {
 }
 
 func TestAzureAdaptor_NormalizeSeverity(t *testing.T) {
-	assert.Equal(t, "Critical", normalizeAzureSeverity("Critical"))
-	assert.Equal(t, "High", normalizeAzureSeverity("High"))
-	assert.Equal(t, "Medium", normalizeAzureSeverity("Medium"))
-	assert.Equal(t, "Low", normalizeAzureSeverity("Low"))
-	assert.Equal(t, "Negligible", normalizeAzureSeverity("Informational"))
-	assert.Equal(t, "Unknown", normalizeAzureSeverity("SomethingElse"))
+	assert.Equal(t, "Critical", NormalizeSeverity("Critical"))
+	assert.Equal(t, "High", NormalizeSeverity("High"))
+	assert.Equal(t, "Medium", NormalizeSeverity("Medium"))
+	assert.Equal(t, "Low", NormalizeSeverity("Low"))
+	assert.Equal(t, "Negligible", NormalizeSeverity("Informational"))
+	assert.Equal(t, "Unknown", NormalizeSeverity("SomethingElse"))
 }
 
 func TestAzureAdaptor_GetImagesScanStatus(t *testing.T) {

--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -64,66 +63,49 @@ func (a *AWSECRAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Cont
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		var ecrImageID types.ImageIdentifier
-		if imageID.Hash != "" {
-			ecrImageID.ImageDigest = aws.String(imageID.Hash)
-		} else if imageID.Tag != "" {
-			ecrImageID.ImageTag = aws.String(imageID.Tag)
-		}
-
-		input := &ecr.DescribeImageScanFindingsInput{
-			RepositoryName: aws.String(imageID.Repository),
-			ImageId:        &ecrImageID,
-			MaxResults:     aws.Int32(1),
-		}
-
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
-
-		out, err := a.client.DescribeImageScanFindings(ctx, input)
-		if err != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to describe image scan findings for repository %s: %w", imageID.Repository, err))
-			statuses = append(statuses, status)
-			continue
-		}
-
-		if out.ImageScanStatus != nil && (out.ImageScanStatus.Status == types.ScanStatusComplete || out.ImageScanStatus.Status == types.ScanStatusActive) {
-			status.IsScanAvailable = true
-			if out.ImageScanFindings != nil && out.ImageScanFindings.ImageScanCompletedAt != nil {
-				status.LastScanDate = *out.ImageScanFindings.ImageScanCompletedAt
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
-		}
-		statuses = append(statuses, status)
-	}
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
+			}
 
-	return statuses, aggErr
-}
+			var ecrImageID types.ImageIdentifier
+			if imageID.Hash != "" {
+				ecrImageID.ImageDigest = aws.String(imageID.Hash)
+			} else if imageID.Tag != "" {
+				ecrImageID.ImageTag = aws.String(imageID.Tag)
+			}
 
-// Helper to normalize ECR severity to Kubescape expected severity
-func normalizeSeverity(ecrSeverity string) string {
-	switch ecrSeverity {
-	case "CRITICAL":
-		return "Critical"
-	case "HIGH":
-		return "High"
-	case "MEDIUM":
-		return "Medium"
-	case "LOW":
-		return "Low"
-	case "INFORMATIONAL":
-		return "Negligible"
-	case "UNDEFINED":
-		fallthrough
-	default:
-		return "Unknown"
-	}
+			input := &ecr.DescribeImageScanFindingsInput{
+				RepositoryName: aws.String(imageID.Repository),
+				ImageId:        &ecrImageID,
+				MaxResults:     aws.Int32(1),
+			}
+
+			out, err := a.client.DescribeImageScanFindings(ctx, input)
+			if err != nil {
+				return status, fmt.Errorf("failed to describe image scan findings for repository %s: %w", imageID.Repository, err)
+			}
+
+			if out.ImageScanStatus != nil && (out.ImageScanStatus.Status == types.ScanStatusComplete || out.ImageScanStatus.Status == types.ScanStatusActive) {
+				status.IsScanAvailable = true
+				if out.ImageScanFindings != nil && out.ImageScanFindings.ImageScanCompletedAt != nil {
+					status.LastScanDate = *out.ImageScanFindings.ImageScanCompletedAt
+				}
+			}
+
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -132,86 +114,88 @@ func (a *AWSECRAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
-
-		var ecrImageID types.ImageIdentifier
-		if imageID.Hash != "" {
-			ecrImageID.ImageDigest = aws.String(imageID.Hash)
-		} else if imageID.Tag != "" {
-			ecrImageID.ImageTag = aws.String(imageID.Tag)
-		}
-
-		input := &ecr.DescribeImageScanFindingsInput{
-			RepositoryName: aws.String(imageID.Repository),
-			ImageId:        &ecrImageID,
-		}
-
-		var fetchErr error
-		const maxPages = 1000
-
-		for page := 0; ; page++ {
-			out, err := a.client.DescribeImageScanFindings(ctx, input)
-			if err != nil {
-				fetchErr = err
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
 			}
-			if out.ImageScanFindings != nil {
-				for _, finding := range out.ImageScanFindings.Findings {
-					report.Vulnerabilities = append(report.Vulnerabilities, Vulnerability{
-						ID:          aws.ToString(finding.Name),
-						Severity:    normalizeSeverity(string(finding.Severity)),
-						Description: aws.ToString(finding.Description),
-						Links:       []string{aws.ToString(finding.Uri)},
-					})
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
+			}
+
+			var ecrImageID types.ImageIdentifier
+			if imageID.Hash != "" {
+				ecrImageID.ImageDigest = aws.String(imageID.Hash)
+			} else if imageID.Tag != "" {
+				ecrImageID.ImageTag = aws.String(imageID.Tag)
+			}
+
+			input := &ecr.DescribeImageScanFindingsInput{
+				RepositoryName: aws.String(imageID.Repository),
+				ImageId:        &ecrImageID,
+			}
+
+			var fetchErr error
+			const maxPages = 1000
+
+			for page := 0; ; page++ {
+				out, err := a.client.DescribeImageScanFindings(ctx, input)
+				if err != nil {
+					fetchErr = err
+					break
 				}
-				for _, finding := range out.ImageScanFindings.EnhancedFindings {
-					vulnerability := Vulnerability{
-						Severity:    normalizeSeverity(aws.ToString(finding.Severity)),
-						Description: aws.ToString(finding.Description),
+				if out.ImageScanFindings != nil {
+					for _, finding := range out.ImageScanFindings.Findings {
+						report.Vulnerabilities = append(report.Vulnerabilities, Vulnerability{
+							ID:          aws.ToString(finding.Name),
+							Severity:    NormalizeSeverity(string(finding.Severity)),
+							Description: aws.ToString(finding.Description),
+							Links:       []string{aws.ToString(finding.Uri)},
+						})
 					}
-
-					if details := finding.PackageVulnerabilityDetails; details != nil {
-						vulnerability.ID = aws.ToString(details.VulnerabilityId)
-						vulnerability.Links = append(vulnerability.Links, details.ReferenceUrls...)
-
-						if sourceURL := aws.ToString(details.SourceUrl); sourceURL != "" && !slices.Contains(vulnerability.Links, sourceURL) {
-							vulnerability.Links = append(vulnerability.Links, sourceURL)
+					for _, finding := range out.ImageScanFindings.EnhancedFindings {
+						vulnerability := Vulnerability{
+							Severity:    NormalizeSeverity(aws.ToString(finding.Severity)),
+							Description: aws.ToString(finding.Description),
 						}
-					}
-					if vulnerability.ID == "" {
-						vulnerability.ID = aws.ToString(finding.Title)
-					}
 
-					report.Vulnerabilities = append(report.Vulnerabilities, vulnerability)
+						if details := finding.PackageVulnerabilityDetails; details != nil {
+							vulnerability.ID = aws.ToString(details.VulnerabilityId)
+							vulnerability.Links = append(vulnerability.Links, details.ReferenceUrls...)
+
+							if sourceURL := aws.ToString(details.SourceUrl); sourceURL != "" && !slices.Contains(vulnerability.Links, sourceURL) {
+								vulnerability.Links = append(vulnerability.Links, sourceURL)
+							}
+						}
+						if vulnerability.ID == "" {
+							vulnerability.ID = aws.ToString(finding.Title)
+						}
+
+						report.Vulnerabilities = append(report.Vulnerabilities, vulnerability)
+					}
 				}
+
+				if out.NextToken == nil {
+					break
+				}
+				if page >= maxPages {
+					fetchErr = fmt.Errorf("exceeded max pages (%d) fetching vulnerabilities for image %s", maxPages, imageID.Repository)
+					break
+				}
+				input.NextToken = out.NextToken
 			}
 
-			if out.NextToken == nil {
-				break
+			if fetchErr != nil {
+				return report, fmt.Errorf("failed to fetch vulnerabilities for repository %s: %w", imageID.Repository, fetchErr)
 			}
-			if page >= maxPages {
-				fetchErr = fmt.Errorf("exceeded max pages (%d) fetching vulnerabilities for image %s", maxPages, imageID.Repository)
-				break
-			}
-			input.NextToken = out.NextToken
-		}
 
-		if fetchErr != nil {
-			aggErr = errors.Join(aggErr, fmt.Errorf("failed to fetch vulnerabilities for repository %s: %w", imageID.Repository, fetchErr))
-			// we don't return nil, we append the partial report
-		}
-
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -219,19 +203,7 @@ func (a *AWSECRAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Con
 	if a.client == nil {
 		return nil, fmt.Errorf("ECR client not initialized, call Login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.

--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -17,14 +17,24 @@ type ECRAPI interface {
 	DescribeImageScanFindings(ctx context.Context, params *ecr.DescribeImageScanFindingsInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error)
 }
 
+type awsConfigProvider func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error)
+type ecrClientFactory func(cfg aws.Config) ECRAPI
+
 // AWSECRAdaptor implements IContainerImageVulnerabilityAdaptor for AWS ECR.
 type AWSECRAdaptor struct {
-	client ECRAPI
+	client         ECRAPI
+	configProvider awsConfigProvider
+	clientFactory  ecrClientFactory
 }
 
 // NewAWSECRAdaptor creates a new ECR adaptor instance.
 func NewAWSECRAdaptor() *AWSECRAdaptor {
-	return &AWSECRAdaptor{}
+	return &AWSECRAdaptor{
+		configProvider: config.LoadDefaultConfig,
+		clientFactory: func(cfg aws.Config) ECRAPI {
+			return ecr.NewFromConfig(cfg)
+		},
+	}
 }
 
 // Login authenticates with AWS. It prioritizes the default credential chain.
@@ -43,12 +53,12 @@ func (a *AWSECRAdaptor) Login(ctx context.Context, registry string, credentials 
 		opts = append(opts, config.WithRegion(parts[3]))
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	cfg, err := a.configProvider(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("unable to load AWS SDK config: %w", err)
 	}
 
-	a.client = ecr.NewFromConfig(cfg)
+	a.client = a.clientFactory(cfg)
 	return nil
 }
 

--- a/pkg/imagescan/ecr_adaptor_test.go
+++ b/pkg/imagescan/ecr_adaptor_test.go
@@ -2,21 +2,27 @@ package imagescan
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/stretchr/testify/assert"
 )
 
 type mockECRClient struct {
-	describeFindingsOut *ecr.DescribeImageScanFindingsOutput
-	describeFindingsErr error
+	describeFindingsOut  *ecr.DescribeImageScanFindingsOutput
+	describeFindingsErr  error
+	describeFindingsFunc func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error)
 }
 
 func (m *mockECRClient) DescribeImageScanFindings(ctx context.Context, params *ecr.DescribeImageScanFindingsInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error) {
+	if m.describeFindingsFunc != nil {
+		return m.describeFindingsFunc(ctx, params)
+	}
 	return m.describeFindingsOut, m.describeFindingsErr
 }
 
@@ -203,4 +209,71 @@ func TestAWSECRAdaptor_GetImagesVulnerabilities_EnhancedFindingsFallsBackToTitle
 	assert.Len(t, reports[0].Vulnerabilities, 2)
 	assert.Equal(t, "CVE-2026-1234", reports[0].Vulnerabilities[0].ID)
 	assert.Equal(t, "CVE-2026-5678", reports[0].Vulnerabilities[1].ID)
+}
+
+func TestAWSECRAdaptor_Login_Success(t *testing.T) {
+	adaptor := NewAWSECRAdaptor()
+
+	mockConfigProvider := func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+	mockClientFactory := func(cfg aws.Config) ECRAPI {
+		return &mockECRClient{}
+	}
+
+	adaptor.configProvider = mockConfigProvider
+	adaptor.clientFactory = mockClientFactory
+
+	err := adaptor.Login(context.Background(), "12345.dkr.ecr.us-east-1.amazonaws.com", RegistryCredentials{})
+	assert.NoError(t, err)
+	assert.NotNil(t, adaptor.client)
+}
+
+func TestAWSECRAdaptor_Pagination(t *testing.T) {
+	adaptor := NewAWSECRAdaptor()
+
+	adaptor.client = &mockECRClient{
+		describeFindingsFunc: func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error) {
+			if params.NextToken == nil {
+				return &ecr.DescribeImageScanFindingsOutput{
+					NextToken: aws.String("token-page-2"),
+					ImageScanFindings: &types.ImageScanFindings{
+						Findings: []types.ImageScanFinding{
+							{
+								Name:        aws.String("CVE-PAGE-1"),
+								Severity:    types.FindingSeverityHigh,
+								Description: aws.String("Page 1 vuln"),
+							},
+						},
+					},
+				}, nil
+			}
+			if *params.NextToken == "token-page-2" {
+				return &ecr.DescribeImageScanFindingsOutput{
+					NextToken: nil, // End of pages
+					ImageScanFindings: &types.ImageScanFindings{
+						Findings: []types.ImageScanFinding{
+							{
+								Name:        aws.String("CVE-PAGE-2"),
+								Severity:    types.FindingSeverityLow,
+								Description: aws.String("Page 2 vuln"),
+							},
+						},
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected token")
+		},
+	}
+
+	images := []ContainerImageIdentifier{
+		{Registry: "12345.dkr.ecr.us-east-1.amazonaws.com", Repository: "test-repo", Tag: "latest"},
+	}
+
+	reports, err := adaptor.GetImagesVulnerabilities(context.Background(), images)
+	assert.NoError(t, err)
+	assert.Len(t, reports, 1)
+	assert.Len(t, reports[0].Vulnerabilities, 2)
+	assert.Equal(t, "CVE-PAGE-1", reports[0].Vulnerabilities[0].ID)
+	assert.Equal(t, "CVE-PAGE-2", reports[0].Vulnerabilities[1].ID)
 }

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -42,16 +42,28 @@ func (g *gcpAPIWrapper) ListOccurrences(ctx context.Context, req *grafeaspb.List
 	return &GrafeasIteratorWrapper{it: it}
 }
 
-// GCPAdaptor implements IContainerImageVulnerabilityAdaptor for GCP Artifact Registry.
+type gcpClientFactory func(ctx context.Context) (*containeranalysis.Client, error)
+type gcpAPIFactory func(c *containeranalysis.Client) GCPAPI
+
+// GCPAdaptor implements IContainerImageVulnerabilityAdaptor for Google Cloud Artifact Registry.
 type GCPAdaptor struct {
-	client       GCPAPI
-	owningClient *containeranalysis.Client
-	projectID    string
+	client        GCPAPI
+	owningClient  *containeranalysis.Client
+	projectID     string
+	clientFactory gcpClientFactory
+	apiFactory    gcpAPIFactory
 }
 
 // NewGCPAdaptor creates a new GCP adaptor instance.
 func NewGCPAdaptor() *GCPAdaptor {
-	return &GCPAdaptor{}
+	return &GCPAdaptor{
+		clientFactory: func(ctx context.Context) (*containeranalysis.Client, error) {
+			return containeranalysis.NewClient(ctx)
+		},
+		apiFactory: func(c *containeranalysis.Client) GCPAPI {
+			return &gcpAPIWrapper{client: c.GetGrafeasClient()}
+		},
+	}
 }
 
 // setOwningClient installs c as the adaptor's owning containeranalysis
@@ -66,7 +78,7 @@ func (a *GCPAdaptor) setOwningClient(c *containeranalysis.Client) {
 	}
 
 	a.owningClient = c
-	a.client = &gcpAPIWrapper{client: c.GetGrafeasClient()}
+	a.client = a.apiFactory(c)
 }
 
 // Login authenticates with GCP. It prioritizes the default application credentials.
@@ -95,7 +107,7 @@ func (a *GCPAdaptor) Login(ctx context.Context, registry string, credentials Reg
 		a.client = nil
 	}
 
-	c, err := containeranalysis.NewClient(ctx)
+	c, err := a.clientFactory(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to load gcp container analysis client: %w", err)
 	}

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -2,7 +2,6 @@ package imagescan
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -132,75 +131,57 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
 
-	var statuses []ContainerImageScanStatus
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		status := ContainerImageScanStatus{
-			ImageID:         imageID,
-			IsScanAvailable: false,
-			IsBomAvailable:  false,
-		}
-
-		if imageID.Hash == "" {
-			statuses = append(statuses, status)
-			continue
-		}
-
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-
-		req := &grafeaspb.ListOccurrencesRequest{
-			Parent: fmt.Sprintf("projects/%s", a.projectID),
-			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceURL),
-		}
-
-		it := a.client.ListOccurrences(ctx, req)
-		for {
-			occurrence, err := it.Next()
-			if err == iterator.Done {
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageScanStatus {
+			return ContainerImageScanStatus{
+				ImageID:         id,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
-			if err != nil {
-				fetchErr := fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
-				logger.L().Warning("skipping image scan status due to api error", helpers.Error(fetchErr))
-				aggErr = errors.Join(aggErr, fetchErr)
-				break
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageScanStatus, error) {
+			status := ContainerImageScanStatus{
+				ImageID:         imageID,
+				IsScanAvailable: false,
+				IsBomAvailable:  false,
 			}
 
-			if occurrence != nil && occurrence.GetDiscovery() != nil {
-				discovery := occurrence.GetDiscovery()
-				if discovery != nil && discovery.GetAnalysisStatus() == grafeaspb.DiscoveryOccurrence_FINISHED_SUCCESS {
-					status.IsScanAvailable = true
-					if occurrence.UpdateTime != nil {
-						status.LastScanDate = occurrence.UpdateTime.AsTime()
-					}
+			if imageID.Hash == "" {
+				return status, nil
+			}
+
+			resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+
+			req := &grafeaspb.ListOccurrencesRequest{
+				Parent: fmt.Sprintf("projects/%s", a.projectID),
+				Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceURL),
+			}
+
+			it := a.client.ListOccurrences(ctx, req)
+			for {
+				occurrence, err := it.Next()
+				if err == iterator.Done {
 					break
 				}
+				if err != nil {
+					return status, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
+				}
+
+				if occurrence != nil && occurrence.GetDiscovery() != nil {
+					discovery := occurrence.GetDiscovery()
+					if discovery != nil && discovery.GetAnalysisStatus() == grafeaspb.DiscoveryOccurrence_FINISHED_SUCCESS {
+						status.IsScanAvailable = true
+						if occurrence.UpdateTime != nil {
+							status.LastScanDate = occurrence.UpdateTime.AsTime()
+						}
+						break
+					}
+				}
 			}
-		}
 
-		statuses = append(statuses, status)
-	}
-
-	return statuses, aggErr
-}
-
-// Helper to normalize GCP severity to Kubescape expected severity
-func normalizeGCPSeverity(severity grafeaspb.Severity) string {
-	switch severity {
-	case grafeaspb.Severity_CRITICAL:
-		return "Critical"
-	case grafeaspb.Severity_HIGH:
-		return "High"
-	case grafeaspb.Severity_MEDIUM:
-		return "Medium"
-	case grafeaspb.Severity_LOW:
-		return "Low"
-	case grafeaspb.Severity_MINIMAL:
-		return "Negligible"
-	default:
-		return "Unknown"
-	}
+			return status, nil
+		},
+	)
 }
 
 // GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
@@ -209,73 +190,72 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
 
-	var reports []ContainerImageVulnerabilityReport
-	var aggErr error
-
-	for _, imageID := range imageIDs {
-		report := ContainerImageVulnerabilityReport{
-			ImageID:         imageID,
-			Vulnerabilities: []Vulnerability{},
-		}
-
-		if imageID.Hash == "" {
-			reports = append(reports, report)
-			continue
-		}
-
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-		req := &grafeaspb.ListOccurrencesRequest{
-			Parent:   fmt.Sprintf("projects/%s", a.projectID),
-			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", resourceURL),
-			PageSize: 1000,
-		}
-
-		it := a.client.ListOccurrences(ctx, req)
-		const maxVulns = 1000
-
-		for {
-			occurrence, err := it.Next()
-			if err == iterator.Done {
-				break
+	return ProcessImages(imageIDs,
+		func(id ContainerImageIdentifier) ContainerImageVulnerabilityReport {
+			return ContainerImageVulnerabilityReport{
+				ImageID:         id,
+				Vulnerabilities: []Vulnerability{},
 			}
-			if err != nil {
-				fetchErr := fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
-				logger.L().Warning("skipping image vulnerabilities due to api error", helpers.Error(fetchErr))
-				aggErr = errors.Join(aggErr, fetchErr)
-				break
+		},
+		func(imageID ContainerImageIdentifier) (ContainerImageVulnerabilityReport, error) {
+			report := ContainerImageVulnerabilityReport{
+				ImageID:         imageID,
+				Vulnerabilities: []Vulnerability{},
 			}
 
-			if len(report.Vulnerabilities) >= maxVulns {
-				logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
-				break
+			if imageID.Hash == "" {
+				return report, nil
 			}
 
-			if vulnDetails := occurrence.GetVulnerability(); vulnDetails != nil {
-				id := vulnDetails.GetShortDescription()
-				if id == "" && occurrence.GetNoteName() != "" {
-					parts := strings.Split(occurrence.GetNoteName(), "/")
-					id = parts[len(parts)-1]
+			resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+			req := &grafeaspb.ListOccurrencesRequest{
+				Parent:   fmt.Sprintf("projects/%s", a.projectID),
+				Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", resourceURL),
+				PageSize: 1000,
+			}
+
+			it := a.client.ListOccurrences(ctx, req)
+			const maxVulns = 1000
+
+			for {
+				occurrence, err := it.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					return report, fmt.Errorf("failed to query vulnerabilities for repository %s: %w", imageID.Repository, err)
 				}
 
-				vuln := Vulnerability{
-					ID:          id,
-					Severity:    normalizeGCPSeverity(vulnDetails.GetEffectiveSeverity()),
-					Description: vulnDetails.GetLongDescription(),
-					Links:       []string{},
+				if len(report.Vulnerabilities) >= maxVulns {
+					logger.L().Warning("truncated vulnerabilities", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxVulns))
+					break
 				}
 
-				for _, uri := range vulnDetails.GetRelatedUrls() {
-					vuln.Links = append(vuln.Links, uri.GetUrl())
-				}
+				if vulnDetails := occurrence.GetVulnerability(); vulnDetails != nil {
+					id := vulnDetails.GetShortDescription()
+					if id == "" && occurrence.GetNoteName() != "" {
+						parts := strings.Split(occurrence.GetNoteName(), "/")
+						id = parts[len(parts)-1]
+					}
 
-				report.Vulnerabilities = append(report.Vulnerabilities, vuln)
+					vuln := Vulnerability{
+						ID:          id,
+						Severity:    NormalizeSeverity(vulnDetails.GetEffectiveSeverity().String()),
+						Description: vulnDetails.GetLongDescription(),
+						Links:       []string{},
+					}
+
+					for _, uri := range vulnDetails.GetRelatedUrls() {
+						vuln.Links = append(vuln.Links, uri.GetUrl())
+					}
+
+					report.Vulnerabilities = append(report.Vulnerabilities, vuln)
+				}
 			}
-		}
 
-		reports = append(reports, report)
-	}
-
-	return reports, aggErr
+			return report, nil
+		},
+	)
 }
 
 // GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
@@ -283,18 +263,7 @@ func (a *GCPAdaptor) GetImagesInformation(ctx context.Context, imageIDs []Contai
 	if a.client == nil {
 		return nil, fmt.Errorf("gcp client not initialized, call login first")
 	}
-
-	var infos []ContainerImageInformation
-
-	for _, imageID := range imageIDs {
-		info := ContainerImageInformation{
-			ImageID: imageID,
-			Bom:     []string{},
-		}
-		infos = append(infos, info)
-	}
-
-	return infos, nil
+	return FetchImagesInformation(imageIDs)
 }
 
 // Destroy cleans up any persistent resources used by the adaptor.


### PR DESCRIPTION
## Overview

The Azure, ECR, and GCP image-scan adaptors previously bypassed `Login()` entirely in tests — test setup poked the internal `client` field directly, so the credential/client-construction path (`Login`) had zero coverage, and ECR's `NextToken` pagination loop was untested.

This PR adds constructor-injected credential/client factories to `AzureAdaptor` and `AWSECRAdaptor` (mirroring the pattern `GCPAdaptor` already used), so `Login()` can be exercised against fakes instead of real cloud SDK calls. With that in place:

- Azure and ECR now have a real `Login()` success-path test.
- ECR has a new multi-page pagination test (`NextToken` loop) using a mock that actually varies its response per call.
- `ProcessImages` (the shared per-image iteration helper) gets its own dedicated table-driven tests (`adaptor_utils_test.go`) covering the happy path, partial failure/aggregation, and the empty-hash skip case.

No production behavior changes — this is test-infrastructure only, adding seams that didn't previously exist.

## Additional Information

Builds on the shared-boilerplate refactor already merged in #3026. That PR gave GCP a `clientFactory`/`apiFactory` seam; this PR brings Azure and ECR up to the same shape so all three adaptors are testable the same way.

## How to Test

```bash
go test ./pkg/imagescan/... -v -run "Login|Pagination|ProcessImages"
go test ./pkg/imagescan/...
golangci-lint run ./pkg/imagescan/...
```

Real output from this branch:

```text
=== RUN   TestProcessImages
=== RUN   TestProcessImages/HappyPath
=== RUN   TestProcessImages/PartialFailure
[warning] skipping image due to api error. error: api error on repo2
=== RUN   TestProcessImages/EmptyHashSkippedInsideProcessFunc
--- PASS: TestProcessImages (0.00s)
--- PASS: TestProcessImages/HappyPath (0.00s)
--- PASS: TestProcessImages/PartialFailure (0.00s)
--- PASS: TestProcessImages/EmptyHashSkippedInsideProcessFunc (0.00s)
=== RUN   TestAzureAdaptor_Login_Success
--- PASS: TestAzureAdaptor_Login_Success (0.00s)
=== RUN   TestAzureAdaptor_Login_ExplicitCreds
--- PASS: TestAzureAdaptor_Login_ExplicitCreds (0.00s)
=== RUN   TestAzureAdaptor_GetImagesVulnerabilities_PaginationAndCVE
--- PASS: TestAzureAdaptor_GetImagesVulnerabilities_PaginationAndCVE (0.00s)
=== RUN   TestAWSECRAdaptor_Login_Success
--- PASS: TestAWSECRAdaptor_Login_Success (0.00s)
=== RUN   TestAWSECRAdaptor_Pagination
--- PASS: TestAWSECRAdaptor_Pagination (0.00s)
=== RUN   TestGCPAdaptor_Login_CloseFailureStateClearing
--- PASS: TestGCPAdaptor_Login_CloseFailureStateClearing (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/pkg/imagescan	1.595s

Full package suite:

go test ./pkg/imagescan/...
ok  	github.com/kubescape/kubescape/v3/pkg/imagescan	1.162s

Lint (matches CI's `a-pr-scanner.yaml` golangci-lint step):

golangci-lint run ./pkg/imagescan/...
0 issues.
```

## Related issues/PRs

- Closes #3029
- Builds on #3026

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image scan error handling, preserving per-image results when some scans fail.
  * Added clearer handling for malformed vulnerability data and paginated scan responses.
  * Standardized vulnerability severity labels across cloud providers.
  * Improved image information retrieval with consistent fallback results.

* **Tests**
  * Expanded coverage for login initialization, pagination, partial failures, severity normalization, and empty image hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->