### PR TITLE
fix(httphandler): prevent metrics scrapes from hijacking latest scan status and results

### DIFF
--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -155,24 +155,27 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		scanRequestParams.scanInfo.UseArtifactsFrom = getter.DefaultLocalStore
 	}
 
-	handler.state.setBusy(scanID, cancel)
-
-	select {
-	case handler.scanRequestChan <- scanRequestParams:
-		// Record the accepted user scan so Status and the offline Results
-		// fallback resolve "latest" to it rather than to a /v1/metrics scrape.
-		// Done here, not before the send, so a rejected (queue-full) request
-		// does not become the latest user scan.
-		handler.state.setLatestUserScanID(scanID)
-		logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
-	default:
-		handler.state.setNotBusy(scanID)
+	// Mark busy, enqueue, and record the accepted user scan as one atomic
+	// admission step. Status and the offline Results fallback resolve "latest"
+	// through latestUserScanID, so it has to be written in the same critical
+	// section that decides acceptance -- otherwise two concurrent requests can
+	// be accepted in one order and recorded in the other.
+	admitted := handler.state.admitUserScan(scanID, cancel, func() bool {
+		select {
+		case handler.scanRequestChan <- scanRequestParams:
+			return true
+		default:
+			return false
+		}
+	})
+	if !admitted {
 		w.Header().Set("Retry-After", "1")
 		handler.writeErrorWithStatus(w,
 			fmt.Errorf("scan queue is full; retry the request later"),
 			"", http.StatusTooManyRequests)
 		return
 	}
+	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
 
 	response := &utilsmetav1.Response{
 		ID:       scanID,

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -96,23 +96,28 @@ func (handler *HTTPHandler) Status(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.L().Info("requesting status", helpers.String("scanID", statusQueryParams.ScanID), helpers.String("api", "v1/status"))
 
+	scanID := statusQueryParams.ScanID
+	if scanID == "" {
+		// Resolve the implicit "latest" before consulting isBusy: isBusy("")
+		// falls back to latestID, which /v1/metrics scrapes overwrite just as
+		// much as user scans do, so an empty ID would otherwise report on a
+		// metrics scrape. An empty result here means no user scan has run.
+		scanID = handler.state.getLatestUserScanID()
+	}
+
 	w.WriteHeader(http.StatusOK)
-	if !handler.state.isBusy(statusQueryParams.ScanID) {
+	if scanID == "" || !handler.state.isBusy(scanID) {
 		response.Type = utilsapisv1.NotBusyScanResponseType
-		logger.L().Debug("status: not busy", helpers.String("ID", statusQueryParams.ScanID))
+		logger.L().Debug("status: not busy", helpers.String("ID", scanID))
 		w.Write(responseToBytes(&response))
 		return
 	}
 
-	if statusQueryParams.ScanID == "" {
-		statusQueryParams.ScanID = handler.state.getLatestID()
-	}
-
-	response.Response = statusQueryParams.ScanID
-	response.ID = statusQueryParams.ScanID
+	response.Response = scanID
+	response.ID = scanID
 	response.Type = utilsapisv1.BusyScanResponseType
 
-	logger.L().Debug("status: busy", helpers.String("ID", statusQueryParams.ScanID))
+	logger.L().Debug("status: busy", helpers.String("ID", scanID))
 	w.Write(responseToBytes(&response))
 }
 
@@ -154,6 +159,11 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case handler.scanRequestChan <- scanRequestParams:
+		// Record the accepted user scan so Status and the offline Results
+		// fallback resolve "latest" to it rather than to a /v1/metrics scrape.
+		// Done here, not before the send, so a rejected (queue-full) request
+		// does not become the latest user scan.
+		handler.state.setLatestUserScanID(scanID)
 		logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
 	default:
 		handler.state.setNotBusy(scanID)
@@ -217,7 +227,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 
 	scanID := cancelQueryParams.ScanID
 	if scanID == "" {
-		scanID = handler.state.getLatestUserScanID()
+		scanID = handler.state.getRunningUserScanID()
 	}
 
 	logger.L().Info("requesting scan cancellation", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
@@ -260,7 +270,10 @@ func (handler *HTTPHandler) validateScanID(w http.ResponseWriter, resultsQueryPa
 	isLatestFallback := false
 	if resultsQueryParams.ScanID == "" {
 		if handler.offline {
-			resultsQueryParams.ScanID = handler.state.getLatestID()
+			// Latest *user* scan: latestID is also written by /v1/metrics
+			// scrapes, which would make this fallback serve a metrics run's
+			// output as if it were the caller's scan.
+			resultsQueryParams.ScanID = handler.state.getLatestUserScanID()
 			isLatestFallback = true
 		} else {
 			logger.L().Info("empty scan ID")

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -140,7 +140,7 @@ func (handler *HTTPHandler) watchForScan() {
 	for {
 		scanReq := <-handler.scanRequestChan
 		if scanReq.isUserScan {
-			handler.state.setLatestUserScanID(scanReq.scanID)
+			handler.state.setRunningUserScanID(scanReq.scanID)
 		}
 		if handler.state.isCancelled(scanReq.scanID) {
 			logger.L().Info("skipping cancelled scan", helpers.String("scanID", scanReq.scanID))

--- a/httphandler/handlerequests/v1/results_handler_test.go
+++ b/httphandler/handlerequests/v1/results_handler_test.go
@@ -351,8 +351,12 @@ func TestResults_GetEmptyID_OfflineFallback_TableDriven(t *testing.T) {
 			h := newResultsHandler(true) // offline = true
 
 			if c.seedLatest {
+				// Seed a completed *user* scan, the way Scan() does: the
+				// offline fallback resolves via latestUserScanID, which
+				// survives setNotBusy so results stay reachable afterwards.
 				h.state.setBusy(validUUID, func() {})
-				h.state.setNotBusy(validUUID) // latestID survives, scan finished
+				h.state.setLatestUserScanID(validUUID)
+				h.state.setNotBusy(validUUID) // scan finished
 			}
 			resultFile := filepath.Join(out, validUUID)
 			if c.writeFile {
@@ -393,6 +397,47 @@ func TestResults_GetEmptyID_OfflineFallback_TableDriven(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestResults_GetEmptyID_OfflineFallback_IgnoresMetricsScan is the /v1/results
+// half of the hijack. A Prometheus scrape that lands after the user's scan
+// finished overwrites latestID, so resolving the offline fallback through it
+// would serve the metrics run's (absent) output instead of the user's report.
+func TestResults_GetEmptyID_OfflineFallback_IgnoresMetricsScan(t *testing.T) {
+	const userScanID = "11111111-2222-3333-4444-555555555555"
+	const metricsScanID = "99999999-8888-7777-6666-555555555555"
+
+	out := withTempOutputDirs(t)
+	h := newResultsHandler(true) // offline = true
+
+	// A user scan runs to completion and leaves its report on disk.
+	h.state.setBusy(userScanID, func() {})
+	h.state.setLatestUserScanID(userScanID)
+	h.state.setNotBusy(userScanID)
+	if err := os.WriteFile(filepath.Join(out, userScanID), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("setup: write result file: %v", err)
+	}
+
+	// Then a metrics scrape runs. It writes no report and must not become the
+	// scan that an ID-less /v1/results resolves to.
+	h.state.setBusy(metricsScanID, func() {})
+	h.state.setNotBusy(metricsScanID)
+
+	rq := httptest.NewRequest(http.MethodGet, "/results", nil)
+	w := httptest.NewRecorder()
+	h.GetResults(w, rq)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want %d: fallback must resolve to the user scan, not the metrics scrape (body=%q)",
+			w.Result().StatusCode, http.StatusOK, w.Body.String())
+	}
+	resp := decodeResultsResponse(t, w)
+	if resp.ID != userScanID {
+		t.Errorf("response.ID = %q; want %q: a /v1/metrics scrape must not hijack the latest-results fallback", resp.ID, userScanID)
+	}
+	if resp.Type != utilsapisv1.ResultsV1ScanResponseType {
+		t.Errorf("response.Type = %q; want %q", resp.Type, utilsapisv1.ResultsV1ScanResponseType)
 	}
 }
 

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -37,6 +37,37 @@ func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 	s.mtx.Unlock()
 }
 
+// admitUserScan runs the whole admission step for a user scan under a single
+// hold of the state mutex: it marks id busy, attempts the enqueue, and -- only
+// if that succeeded -- records id as the latest accepted user scan. It returns
+// false when enqueue failed, having rolled the busy entry back.
+//
+// enqueue must not block; Scan passes the non-blocking channel send. Holding
+// the mutex across it is what keeps acceptance order and latestUserScanID order
+// identical. With the enqueue and the bookkeeping in separate critical
+// sections, two concurrent Scan handlers can enqueue as A-then-B but run their
+// bookkeeping as B-then-A, leaving latestUserScanID on the older scan -- so
+// Status and the offline Results fallback resolve "latest" to a stale scan.
+//
+// The rollback deliberately leaves latestID pointing at the rejected scan,
+// matching what setBusy followed by setNotBusy did before. runningUserScanID
+// needs no rollback: only watchForScan sets it, and it never saw this id.
+func (s *serverState) admitUserScan(id string, cancel context.CancelFunc, enqueue func() bool) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.statusID[id] = &scanEntry{cancel: cancel}
+	s.latestID = id
+
+	if !enqueue() {
+		delete(s.statusID, id)
+		return false
+	}
+
+	s.latestUserScanID = id
+	return true
+}
+
 func (s *serverState) setNotBusy(id string) {
 	s.mtx.Lock()
 	delete(s.statusID, id)
@@ -54,11 +85,15 @@ func (s *serverState) getLatestID() string {
 }
 
 // setLatestUserScanID records id as the most recent scan accepted from the Scan
-// handler. It is the user-scan counterpart of latestID: Scan calls it once the
-// request is queued, and it is deliberately never cleared, so Status and the
-// offline Results fallback can still resolve "latest" after the scan finishes.
-// Metrics never calls it, which is what keeps a /v1/metrics scrape from
-// hijacking those two endpoints.
+// handler. latestUserScanID is the user-scan counterpart of latestID: it is
+// deliberately never cleared, so Status and the offline Results fallback can
+// still resolve "latest" after the scan finishes, and Metrics never writes it,
+// which is what keeps a /v1/metrics scrape from hijacking those two endpoints.
+//
+// Request handling must not call this directly -- admitUserScan writes the
+// field as part of the admission critical section, and updating it separately
+// is exactly the race that serialization exists to prevent. It remains for
+// tests that need to seed an already-accepted user scan.
 func (s *serverState) setLatestUserScanID(id string) {
 	s.mtx.Lock()
 	s.latestUserScanID = id

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -12,10 +12,11 @@ type scanEntry struct {
 }
 
 type serverState struct {
-	statusID         map[string]*scanEntry
-	latestID         string
-	latestUserScanID string
-	mtx              sync.RWMutex
+	statusID          map[string]*scanEntry
+	latestID          string
+	latestUserScanID  string
+	runningUserScanID string
+	mtx               sync.RWMutex
 }
 
 // isBusy is server busy with ID, if id is empty will check for latest ID
@@ -39,8 +40,8 @@ func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 func (s *serverState) setNotBusy(id string) {
 	s.mtx.Lock()
 	delete(s.statusID, id)
-	if s.latestUserScanID == id {
-		s.latestUserScanID = ""
+	if s.runningUserScanID == id {
+		s.runningUserScanID = ""
 	}
 	s.mtx.Unlock()
 }
@@ -52,10 +53,12 @@ func (s *serverState) getLatestID() string {
 	return id
 }
 
-// setLatestUserScanID records id as the scan currently executing on behalf of
-// the Scan handler (not Metrics). watchForScan calls this when it dequeues a
-// user-submitted request, so it always reflects the scan actually running,
-// not merely the last one accepted into the queue.
+// setLatestUserScanID records id as the most recent scan accepted from the Scan
+// handler. It is the user-scan counterpart of latestID: Scan calls it once the
+// request is queued, and it is deliberately never cleared, so Status and the
+// offline Results fallback can still resolve "latest" after the scan finishes.
+// Metrics never calls it, which is what keeps a /v1/metrics scrape from
+// hijacking those two endpoints.
 func (s *serverState) setLatestUserScanID(id string) {
 	s.mtx.Lock()
 	s.latestUserScanID = id
@@ -65,6 +68,24 @@ func (s *serverState) setLatestUserScanID(id string) {
 func (s *serverState) getLatestUserScanID() string {
 	s.mtx.RLock()
 	id := s.latestUserScanID
+	s.mtx.RUnlock()
+	return id
+}
+
+// setRunningUserScanID records id as the scan currently executing on behalf of
+// the Scan handler (not Metrics). watchForScan calls this when it dequeues a
+// user-submitted request, so it always reflects the scan actually running, not
+// merely the last one accepted into the queue -- which is what CancelScan needs
+// to target. setNotBusy clears it when that scan stops running.
+func (s *serverState) setRunningUserScanID(id string) {
+	s.mtx.Lock()
+	s.runningUserScanID = id
+	s.mtx.Unlock()
+}
+
+func (s *serverState) getRunningUserScanID() string {
+	s.mtx.RLock()
+	id := s.runningUserScanID
 	s.mtx.RUnlock()
 	return id
 }

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -171,13 +171,14 @@ func TestStatus_WhenScanIsRunning_WithExplicitID_ReturnsBusy(t *testing.T) {
 	}
 }
 
-func TestStatus_WhenScanIsRunning_WithEmptyID_ResolvesViaLatestID(t *testing.T) {
+func TestStatus_WhenScanIsRunning_WithEmptyID_ResolvesViaLatestUserScanID(t *testing.T) {
 	// This is the critical path for the in-cluster operator: it calls /status
-	// without an ID to check whether any scan is currently running.
-	// isBusy("") resolves to statusID[latestID], and then the handler
-	// populates the response ID from getLatestID(). Both steps are untested.
+	// without an ID to check whether any scan is currently running. The empty
+	// ID resolves via latestUserScanID (set by Scan when the request is
+	// queued), and the handler echoes that ID back in the response.
 	h := &HTTPHandler{state: newServerState()}
 	h.state.setBusy("scan-456", func() {})
+	h.state.setLatestUserScanID("scan-456")
 
 	rq := httptest.NewRequest(http.MethodGet, "/status", nil) // no ?id= param
 	w := httptest.NewRecorder()
@@ -185,12 +186,85 @@ func TestStatus_WhenScanIsRunning_WithEmptyID_ResolvesViaLatestID(t *testing.T) 
 
 	resp := decodeResponse(t, w)
 	if resp.Type != utilsapisv1.BusyScanResponseType {
-		t.Errorf("Status with empty ID during scan: response.Type = %q; want %q: operator cannot detect running scan without latestID resolution",
+		t.Errorf("Status with empty ID during scan: response.Type = %q; want %q: operator cannot detect running scan without latest-user-scan resolution",
 			resp.Type, utilsapisv1.BusyScanResponseType)
 	}
 	if resp.ID != "scan-456" {
-		t.Errorf("Status with empty ID during scan: response.ID = %q; want \"scan-456\": latestID must be reflected in response",
+		t.Errorf("Status with empty ID during scan: response.ID = %q; want \"scan-456\": latestUserScanID must be reflected in response",
 			resp.ID)
+	}
+}
+
+// TestStatus_EmptyID_IgnoresMetricsScan guards the /v1/status half of the
+// hijack: Metrics() calls setBusy but never setLatestUserScanID, so a scrape
+// running on its own must not make /v1/status report a scan the caller never
+// asked for.
+func TestStatus_EmptyID_IgnoresMetricsScan(t *testing.T) {
+	h := &HTTPHandler{state: newServerState()}
+	h.state.setBusy("metrics-scan", func() {}) // what Metrics() does, and only that
+
+	rq := httptest.NewRequest(http.MethodGet, "/status", nil)
+	w := httptest.NewRecorder()
+	h.Status(w, rq)
+
+	resp := decodeResponse(t, w)
+	if resp.Type != utilsapisv1.NotBusyScanResponseType {
+		t.Errorf("Status with empty ID during a metrics-only scan: response.Type = %q; want %q: a /v1/metrics scrape must not be reported as the caller's scan",
+			resp.Type, utilsapisv1.NotBusyScanResponseType)
+	}
+	if resp.ID != "" {
+		t.Errorf("Status with empty ID during a metrics-only scan: response.ID = %q; want empty", resp.ID)
+	}
+}
+
+// TestStatus_EmptyID_PrefersUserScanOverConcurrentMetricsScan is the exact
+// race from the bug report: a metrics scrape lands while a user scan is still
+// running, overwriting latestID. /v1/status must still report the user scan.
+func TestStatus_EmptyID_PrefersUserScanOverConcurrentMetricsScan(t *testing.T) {
+	h := &HTTPHandler{state: newServerState()}
+	h.state.setBusy("user-scan", func() {})
+	h.state.setLatestUserScanID("user-scan")
+	h.state.setBusy("metrics-scan", func() {}) // scrape lands second, wins latestID
+
+	if got := h.state.getLatestID(); got != "metrics-scan" {
+		t.Fatalf("precondition: getLatestID() = %q; want \"metrics-scan\"", got)
+	}
+
+	rq := httptest.NewRequest(http.MethodGet, "/status", nil)
+	w := httptest.NewRecorder()
+	h.Status(w, rq)
+
+	resp := decodeResponse(t, w)
+	if resp.Type != utilsapisv1.BusyScanResponseType {
+		t.Errorf("Status with empty ID: response.Type = %q; want %q", resp.Type, utilsapisv1.BusyScanResponseType)
+	}
+	if resp.ID != "user-scan" {
+		t.Errorf("Status with empty ID: response.ID = %q; want \"user-scan\": a concurrent /v1/metrics scrape must not hijack the response",
+			resp.ID)
+	}
+}
+
+// TestServerState_UserScanIDLifecycle pins the split between the two
+// user-scan fields. latestUserScanID must outlive the scan so the offline
+// /v1/results fallback can still resolve it, while runningUserScanID must be
+// cleared so CancelScan with no ID does not target a finished scan.
+func TestServerState_UserScanIDLifecycle(t *testing.T) {
+	s := newServerState()
+	s.setBusy("user-scan", func() {})
+	s.setLatestUserScanID("user-scan")  // Scan(), at enqueue
+	s.setRunningUserScanID("user-scan") // watchForScan(), at dequeue
+
+	if id := s.getRunningUserScanID(); id != "user-scan" {
+		t.Errorf("getRunningUserScanID() while running = %q; want \"user-scan\"", id)
+	}
+
+	s.setNotBusy("user-scan") // scan finished
+
+	if id := s.getLatestUserScanID(); id != "user-scan" {
+		t.Errorf("getLatestUserScanID() after setNotBusy = %q; want \"user-scan\": must survive for the offline results fallback", id)
+	}
+	if id := s.getRunningUserScanID(); id != "" {
+		t.Errorf("getRunningUserScanID() after setNotBusy = %q; want empty: no user scan is running", id)
 	}
 }
 

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -265,6 +268,105 @@ func TestServerState_UserScanIDLifecycle(t *testing.T) {
 	}
 	if id := s.getRunningUserScanID(); id != "" {
 		t.Errorf("getRunningUserScanID() after setNotBusy = %q; want empty: no user scan is running", id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// admitUserScan concurrency tests
+//
+// Scan() runs one goroutine per HTTP request, so nothing orders two handlers
+// against each other. If the enqueue and the latestUserScanID write are not in
+// the same critical section, two requests accepted as A-then-B can record
+// themselves as B-then-A, leaving "latest" on the older scan -- the same wrong
+// -scan-reported-as-latest bug as the metrics hijack, from a different source.
+// ---------------------------------------------------------------------------
+
+func TestServerState_AdmitUserScan_BookkeepingFollowsAcceptanceOrder(t *testing.T) {
+	s := newServerState()
+
+	inFirstEnqueue := make(chan struct{})
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	go func() {
+		defer close(firstDone)
+		// scan-A is accepted first and stalls inside its enqueue step. That
+		// stall is the window the race needs: with the steps unserialized,
+		// scan-B runs to completion during it and scan-A's write still lands
+		// last, so "latest" ends up on scan-A.
+		s.admitUserScan("scan-A", func() {}, func() bool {
+			close(inFirstEnqueue)
+			time.Sleep(100 * time.Millisecond)
+			return true
+		})
+	}()
+
+	<-inFirstEnqueue
+	go func() {
+		defer close(secondDone)
+		s.admitUserScan("scan-B", func() {}, func() bool { return true })
+	}()
+
+	<-firstDone
+	<-secondDone
+
+	if id := s.getLatestUserScanID(); id != "scan-B" {
+		t.Errorf("getLatestUserScanID() = %q; want \"scan-B\": latestUserScanID must follow acceptance order, not handler-goroutine scheduling", id)
+	}
+}
+
+// TestServerState_AdmitUserScan_RejectedScanNeverBecomesLatest covers the
+// rollback half: a request that loses the queue-full race must leave no trace,
+// or a 429'd scan becomes the one Status and Results resolve to.
+func TestServerState_AdmitUserScan_RejectedScanNeverBecomesLatest(t *testing.T) {
+	s := newServerState()
+
+	if !s.admitUserScan("accepted", func() {}, func() bool { return true }) {
+		t.Fatal("admitUserScan returned false for a successful enqueue")
+	}
+	if s.admitUserScan("rejected", func() {}, func() bool { return false }) {
+		t.Fatal("admitUserScan returned true for a failed enqueue")
+	}
+
+	if id := s.getLatestUserScanID(); id != "accepted" {
+		t.Errorf("getLatestUserScanID() = %q; want \"accepted\": a rejected scan must not become the latest user scan", id)
+	}
+	if s.isBusy("rejected") {
+		t.Errorf("isBusy(\"rejected\") = true; want false: a failed admission must roll its busy entry back")
+	}
+	if l := s.len(); l != 1 {
+		t.Errorf("len() = %d; want 1: only the accepted scan may remain registered", l)
+	}
+}
+
+// TestServerState_AdmitUserScan_ConcurrentAdmissions is the stress form, most
+// useful under -race: every concurrent admission must register exactly once,
+// and "latest" must be one of the scans that was actually accepted.
+func TestServerState_AdmitUserScan_ConcurrentAdmissions(t *testing.T) {
+	s := newServerState()
+
+	const admissions = 50
+	ids := make([]string, admissions)
+	var wg sync.WaitGroup
+	for i := range ids {
+		ids[i] = fmt.Sprintf("scan-%02d", i)
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			if !s.admitUserScan(id, func() {}, func() bool { return true }) {
+				t.Errorf("admitUserScan(%q) = false; want true", id)
+			}
+		}(ids[i])
+	}
+	wg.Wait()
+
+	if l := s.len(); l != admissions {
+		t.Errorf("len() = %d; want %d: every accepted scan must be registered exactly once", l, admissions)
+	}
+
+	latest := s.getLatestUserScanID()
+	if !slices.Contains(ids, latest) {
+		t.Errorf("getLatestUserScanID() = %q; want one of the admitted scan IDs", latest)
 	}
 }
 


### PR DESCRIPTION
## Overview

- **Current Behavior:** Both `/v1/metrics` scrapes and `POST /v1/scan` updated `latestID`. `Status()` (when called without an `id`) and `validateScanID()` (the offline `GetResults` fallback) resolved through `latestID`, allowing Prometheus metrics scrapes to hijack status reports and results.
- **Future Behavior:** ID tracking is explicitly split into two separate fields:
  - `latestUserScanID`: Tracks the most recent accepted user scan (set upon enqueue, never cleared) used by `Status()` and offline `Results`.
  - `runningUserScanID`: Tracks the currently executing user scan (set at dequeue, cleared on completion) used by `CancelScan()`.
  Metrics scrapes modify neither field, preventing them from hijacking endpoints.

## Additional Information

- **Behavioral Changes:**
  - Offline `GET /v1/results` with no `id` returns `400 latest scan not found` if only metrics scrapes have run, rather than serving scrape output.
  - `GET /v1/status` with no `id` reports `notBusy` when only a metrics scrape is active.
- `Status()` now resolves empty IDs *before* invoking `isBusy()`, preventing `isBusy("")` from falling back to `latestID`.
- `latestID` and `getLatestID()` are retained for `isBusy("")` internal logic and legacy test compatibility.

## How to Test

Run package unit tests:

```bash
cd httphandler && go test ./...
```

*Covered by added tests (`TestStatus_EmptyID_IgnoresMetricsScan`, `TestStatus_EmptyID_PrefersUserScanOverConcurrentMetricsScan`, `TestResults_GetEmptyID_OfflineFallback_IgnoresMetricsScan`, and `TestServerState_UserScanIDLifecycle`).*

**Manual Validation:**
1. Start server and trigger `POST /v1/scan`.
2. Scrape `GET /v1/metrics` concurrently.
3. Poll `GET /v1/status` with no `id` and verify it reports the user scan status rather than the metrics scrape.

## Examples/Screenshots

N/A (HTTP handler state tracking fix)

## Related issues/PRs:

* Resolved #3030

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status and results requests now consistently reference the latest user scan, excluding metrics-only scans.
  * Offline results requests without a scan ID now select the correct user scan.
  * Cancellation requests without an ID now target the currently running user scan.
  * User scan tracking remains accurate after completion and during concurrent metrics activity.
  * Scan status is no longer marked busy when a scan cannot be queued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->