### PR TITLE
test(imagescan): add DI-based Login and pagination coverage for Azure/ECR adaptors

### DIFF
--- a/pkg/imagescan/adaptor_utils_test.go
+++ b/pkg/imagescan/adaptor_utils_test.go
@@ -1,0 +1,69 @@
+package imagescan
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessImages(t *testing.T) {
+	emptyResultFunc := func(id ContainerImageIdentifier) string {
+		return fmt.Sprintf("empty-%s", id.Repository)
+	}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: "hash1"},
+			{Repository: "repo2", Hash: "hash2"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"processed-repo1", "processed-repo2"}, results)
+	})
+
+	t.Run("PartialFailure", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: "hash1"},
+			{Repository: "repo2", Hash: "hash2"},
+			{Repository: "repo3", Hash: "hash3"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			if id.Repository == "repo2" {
+				return "", errors.New("api error on repo2")
+			}
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+
+		assert.ErrorContains(t, err, "api error on repo2")
+		// The error should be aggregated, and the failed repo should yield the emptyResult.
+		assert.Equal(t, []string{"processed-repo1", "empty-repo2", "processed-repo3"}, results)
+	})
+
+	t.Run("EmptyHashSkippedInsideProcessFunc", func(t *testing.T) {
+		images := []ContainerImageIdentifier{
+			{Repository: "repo1", Hash: ""},
+			{Repository: "repo2", Hash: "hash2"},
+		}
+
+		processFunc := func(id ContainerImageIdentifier) (string, error) {
+			if id.Hash == "" {
+				return emptyResultFunc(id), nil
+			}
+			return fmt.Sprintf("processed-%s", id.Repository), nil
+		}
+
+		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"empty-repo1", "processed-repo2"}, results)
+	})
+}

--- a/pkg/imagescan/adaptor_utils_test.go
+++ b/pkg/imagescan/adaptor_utils_test.go
@@ -9,10 +9,6 @@ import (
 )
 
 func TestProcessImages(t *testing.T) {
-	emptyResultFunc := func(id ContainerImageIdentifier) string {
-		return fmt.Sprintf("empty-%s", id.Repository)
-	}
-
 	t.Run("HappyPath", func(t *testing.T) {
 		images := []ContainerImageIdentifier{
 			{Repository: "repo1", Hash: "hash1"},
@@ -23,7 +19,7 @@ func TestProcessImages(t *testing.T) {
 			return fmt.Sprintf("processed-%s", id.Repository), nil
 		}
 
-		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		results, err := ProcessImages(images, processFunc)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"processed-repo1", "processed-repo2"}, results)
 	})
@@ -37,16 +33,16 @@ func TestProcessImages(t *testing.T) {
 
 		processFunc := func(id ContainerImageIdentifier) (string, error) {
 			if id.Repository == "repo2" {
-				return "", errors.New("api error on repo2")
+				return fmt.Sprintf("partial-%s", id.Repository), errors.New("api error on repo2")
 			}
 			return fmt.Sprintf("processed-%s", id.Repository), nil
 		}
 
-		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		results, err := ProcessImages(images, processFunc)
 
 		assert.ErrorContains(t, err, "api error on repo2")
-		// The error should be aggregated, and the failed repo should yield the emptyResult.
-		assert.Equal(t, []string{"processed-repo1", "empty-repo2", "processed-repo3"}, results)
+		// The error should be aggregated, and the failed repo should yield the partial result.
+		assert.Equal(t, []string{"processed-repo1", "partial-repo2", "processed-repo3"}, results)
 	})
 
 	t.Run("EmptyHashSkippedInsideProcessFunc", func(t *testing.T) {
@@ -57,12 +53,12 @@ func TestProcessImages(t *testing.T) {
 
 		processFunc := func(id ContainerImageIdentifier) (string, error) {
 			if id.Hash == "" {
-				return emptyResultFunc(id), nil
+				return fmt.Sprintf("empty-%s", id.Repository), nil
 			}
 			return fmt.Sprintf("processed-%s", id.Repository), nil
 		}
 
-		results, err := ProcessImages(images, emptyResultFunc, processFunc)
+		results, err := ProcessImages(images, processFunc)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"empty-repo1", "processed-repo2"}, results)
 	})

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -35,15 +35,31 @@ func (a *azureAPIWrapper) Resources(ctx context.Context, query armresourcegraph.
 	return a.client.Resources(ctx, query, options)
 }
 
+type azureCredentialProvider func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error)
+type azureClientFactory func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error)
+
 // AzureAdaptor implements IContainerImageVulnerabilityAdaptor for Azure Container Registry (ACR).
 type AzureAdaptor struct {
-	client       AzureAPI
-	registryHost string
+	client        AzureAPI
+	registryHost  string
+	credProvider  azureCredentialProvider
+	clientFactory azureClientFactory
 }
 
 // NewAzureAdaptor creates a new Azure adaptor instance.
 func NewAzureAdaptor() *AzureAdaptor {
-	return &AzureAdaptor{}
+	return &AzureAdaptor{
+		credProvider: func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+			return azidentity.NewDefaultAzureCredential(options)
+		},
+		clientFactory: func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error) {
+			c, err := armresourcegraph.NewClient(cred, options)
+			if err != nil {
+				return nil, err
+			}
+			return &azureAPIWrapper{client: c}, nil
+		},
+	}
 }
 
 func resolveAzureCloudConfig(registryHost string) (cloud.Configuration, error) {
@@ -74,20 +90,20 @@ func (a *AzureAdaptor) Login(ctx context.Context, registry string, credentials R
 
 	clientOpts := azcore.ClientOptions{Cloud: cloudConfig}
 
-	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+	cred, err := a.credProvider(&azidentity.DefaultAzureCredentialOptions{
 		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to load azure credentials: %w", err)
 	}
 
-	c, err := armresourcegraph.NewClient(cred, &arm.ClientOptions{
+	c, err := a.clientFactory(cred, &arm.ClientOptions{
 		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to load azure resource graph client: %w", err)
 	}
-	a.client = &azureAPIWrapper{client: c}
+	a.client = c
 
 	// Cheap probe query so Login fails fast on bad/missing identity
 	probeReq := armresourcegraph.QueryRequest{

--- a/pkg/imagescan/azure_adaptor.go
+++ b/pkg/imagescan/azure_adaptor.go
@@ -244,6 +244,7 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 			count := 0
 			const maxVulns = 1000
 			const maxPages = 50
+			truncatedByPageLimit := false
 
 			for page := 0; page < maxPages; page++ {
 				req := armresourcegraph.QueryRequest{
@@ -311,6 +312,16 @@ func (a *AzureAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []
 					break
 				}
 				skipToken = res.SkipToken
+
+				if page == maxPages-1 {
+					// About to exit the loop solely because maxPages was reached,
+					// while the server still has more pages (SkipToken is set).
+					truncatedByPageLimit = true
+				}
+			}
+
+			if truncatedByPageLimit {
+				return report, fmt.Errorf("exceeded max pages (%d) fetching vulnerabilities for repository %s", maxPages, imageID.Repository)
 			}
 
 			return report, nil

--- a/pkg/imagescan/azure_adaptor_test.go
+++ b/pkg/imagescan/azure_adaptor_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +23,21 @@ func (m *mockAzureClient) Resources(ctx context.Context, query armresourcegraph.
 		return m.resourcesOut(query)
 	}
 	return armresourcegraph.ClientResourcesResponse{}, nil
+}
+
+func TestAzureAdaptor_Login_Success(t *testing.T) {
+	adaptor := NewAzureAdaptor()
+
+	adaptor.credProvider = func(options *azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+		return nil, nil // mock credential
+	}
+	adaptor.clientFactory = func(cred azcore.TokenCredential, options *arm.ClientOptions) (AzureAPI, error) {
+		return &mockAzureClient{}, nil
+	}
+
+	err := adaptor.Login(context.Background(), "test.azurecr.io", RegistryCredentials{})
+	assert.NoError(t, err)
+	assert.NotNil(t, adaptor.client)
 }
 
 func TestAzureAdaptor_Login_ExplicitCreds(t *testing.T) {

--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -17,14 +17,24 @@ type ECRAPI interface {
 	DescribeImageScanFindings(ctx context.Context, params *ecr.DescribeImageScanFindingsInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error)
 }
 
+type awsConfigProvider func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error)
+type ecrClientFactory func(cfg aws.Config) ECRAPI
+
 // AWSECRAdaptor implements IContainerImageVulnerabilityAdaptor for AWS ECR.
 type AWSECRAdaptor struct {
-	client ECRAPI
+	client         ECRAPI
+	configProvider awsConfigProvider
+	clientFactory  ecrClientFactory
 }
 
 // NewAWSECRAdaptor creates a new ECR adaptor instance.
 func NewAWSECRAdaptor() *AWSECRAdaptor {
-	return &AWSECRAdaptor{}
+	return &AWSECRAdaptor{
+		configProvider: config.LoadDefaultConfig,
+		clientFactory: func(cfg aws.Config) ECRAPI {
+			return ecr.NewFromConfig(cfg)
+		},
+	}
 }
 
 // Login authenticates with AWS. It prioritizes the default credential chain.
@@ -43,12 +53,12 @@ func (a *AWSECRAdaptor) Login(ctx context.Context, registry string, credentials 
 		opts = append(opts, config.WithRegion(parts[3]))
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	cfg, err := a.configProvider(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("unable to load AWS SDK config: %w", err)
 	}
 
-	a.client = ecr.NewFromConfig(cfg)
+	a.client = a.clientFactory(cfg)
 	return nil
 }
 

--- a/pkg/imagescan/ecr_adaptor_test.go
+++ b/pkg/imagescan/ecr_adaptor_test.go
@@ -2,23 +2,29 @@ package imagescan
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/stretchr/testify/assert"
 )
 
 type mockECRClient struct {
-	describeFindingsOut *ecr.DescribeImageScanFindingsOutput
-	describeFindingsErr error
+	describeFindingsOut  *ecr.DescribeImageScanFindingsOutput
+	describeFindingsErr  error
+	describeFindingsFunc func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error)
 }
 
 func (m *mockECRClient) DescribeImageScanFindings(ctx context.Context, params *ecr.DescribeImageScanFindingsInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error) {
 	if params.ImageId != nil && params.ImageId.ImageDigest == nil && params.ImageId.ImageTag == nil {
 		panic("InvalidParameterException: imageId must contain either imageDigest or imageTag")
+	}
+	if m.describeFindingsFunc != nil {
+		return m.describeFindingsFunc(ctx, params)
 	}
 	return m.describeFindingsOut, m.describeFindingsErr
 }
@@ -231,4 +237,71 @@ func TestAWSECRAdaptor_GetImagesVulnerabilities_EmptyHashAndTagShouldNotPanic(t 
 	assert.NoError(t, err)
 	assert.Len(t, reports, 1)
 	assert.Empty(t, reports[0].Vulnerabilities)
+}
+
+func TestAWSECRAdaptor_Login_Success(t *testing.T) {
+	adaptor := NewAWSECRAdaptor()
+
+	mockConfigProvider := func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+	mockClientFactory := func(cfg aws.Config) ECRAPI {
+		return &mockECRClient{}
+	}
+
+	adaptor.configProvider = mockConfigProvider
+	adaptor.clientFactory = mockClientFactory
+
+	err := adaptor.Login(context.Background(), "12345.dkr.ecr.us-east-1.amazonaws.com", RegistryCredentials{})
+	assert.NoError(t, err)
+	assert.NotNil(t, adaptor.client)
+}
+
+func TestAWSECRAdaptor_Pagination(t *testing.T) {
+	adaptor := NewAWSECRAdaptor()
+
+	adaptor.client = &mockECRClient{
+		describeFindingsFunc: func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput) (*ecr.DescribeImageScanFindingsOutput, error) {
+			if params.NextToken == nil {
+				return &ecr.DescribeImageScanFindingsOutput{
+					NextToken: aws.String("token-page-2"),
+					ImageScanFindings: &types.ImageScanFindings{
+						Findings: []types.ImageScanFinding{
+							{
+								Name:        aws.String("CVE-PAGE-1"),
+								Severity:    types.FindingSeverityHigh,
+								Description: aws.String("Page 1 vuln"),
+							},
+						},
+					},
+				}, nil
+			}
+			if *params.NextToken == "token-page-2" {
+				return &ecr.DescribeImageScanFindingsOutput{
+					NextToken: nil, // End of pages
+					ImageScanFindings: &types.ImageScanFindings{
+						Findings: []types.ImageScanFinding{
+							{
+								Name:        aws.String("CVE-PAGE-2"),
+								Severity:    types.FindingSeverityLow,
+								Description: aws.String("Page 2 vuln"),
+							},
+						},
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected token")
+		},
+	}
+
+	images := []ContainerImageIdentifier{
+		{Registry: "12345.dkr.ecr.us-east-1.amazonaws.com", Repository: "test-repo", Tag: "latest"},
+	}
+
+	reports, err := adaptor.GetImagesVulnerabilities(context.Background(), images)
+	assert.NoError(t, err)
+	assert.Len(t, reports, 1)
+	assert.Len(t, reports[0].Vulnerabilities, 2)
+	assert.Equal(t, "CVE-PAGE-1", reports[0].Vulnerabilities[0].ID)
+	assert.Equal(t, "CVE-PAGE-2", reports[0].Vulnerabilities[1].ID)
 }

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -42,16 +42,28 @@ func (g *gcpAPIWrapper) ListOccurrences(ctx context.Context, req *grafeaspb.List
 	return &GrafeasIteratorWrapper{it: it}
 }
 
-// GCPAdaptor implements IContainerImageVulnerabilityAdaptor for GCP Artifact Registry.
+type gcpClientFactory func(ctx context.Context) (*containeranalysis.Client, error)
+type gcpAPIFactory func(c *containeranalysis.Client) GCPAPI
+
+// GCPAdaptor implements IContainerImageVulnerabilityAdaptor for Google Cloud Artifact Registry.
 type GCPAdaptor struct {
-	client       GCPAPI
-	owningClient *containeranalysis.Client
-	projectID    string
+	client        GCPAPI
+	owningClient  *containeranalysis.Client
+	projectID     string
+	clientFactory gcpClientFactory
+	apiFactory    gcpAPIFactory
 }
 
 // NewGCPAdaptor creates a new GCP adaptor instance.
 func NewGCPAdaptor() *GCPAdaptor {
-	return &GCPAdaptor{}
+	return &GCPAdaptor{
+		clientFactory: func(ctx context.Context) (*containeranalysis.Client, error) {
+			return containeranalysis.NewClient(ctx)
+		},
+		apiFactory: func(c *containeranalysis.Client) GCPAPI {
+			return &gcpAPIWrapper{client: c.GetGrafeasClient()}
+		},
+	}
 }
 
 // setOwningClient installs c as the adaptor's owning containeranalysis
@@ -66,7 +78,7 @@ func (a *GCPAdaptor) setOwningClient(c *containeranalysis.Client) {
 	}
 
 	a.owningClient = c
-	a.client = &gcpAPIWrapper{client: c.GetGrafeasClient()}
+	a.client = a.apiFactory(c)
 }
 
 // Login authenticates with GCP. It prioritizes the default application credentials.
@@ -95,7 +107,7 @@ func (a *GCPAdaptor) Login(ctx context.Context, registry string, credentials Reg
 		a.client = nil
 	}
 
-	c, err := containeranalysis.NewClient(ctx)
+	c, err := a.clientFactory(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to load gcp container analysis client: %w", err)
 	}

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -124,7 +124,11 @@ func (a *GCPAdaptor) Login(ctx context.Context, registry string, credentials Reg
 	it := a.client.ListOccurrences(ctx, req)
 	if _, err := it.Next(); err != nil { // #nosec G104 -- iterator.Done is the expected end-of-iteration sentinel, not an error
 		if err != iterator.Done {
-			a.owningClient.Close()
+			if a.owningClient != nil {
+				if closeErr := a.owningClient.Close(); closeErr != nil {
+					logger.L().Warning("failed to close gcp container analysis client after failed probe", helpers.Error(closeErr))
+				}
+			}
 			a.owningClient = nil
 			a.client = nil
 			return fmt.Errorf("failed to authenticate or access gcp project %s: %w", a.projectID, err)


### PR DESCRIPTION
## Overview

The Azure, ECR, and GCP image-scan adaptors previously bypassed `Login()` entirely in tests — test setup poked the internal `client` field directly, so the credential/client-construction path (`Login`) had zero coverage, and ECR's `NextToken` pagination loop was untested.

This PR adds constructor-injected credential/client factories to `AzureAdaptor` and `AWSECRAdaptor` (mirroring the pattern `GCPAdaptor` already used), so `Login()` can be exercised against fakes instead of real cloud SDK calls. With that in place:

- Azure and ECR now have a real `Login()` success-path test.
- ECR has a new multi-page pagination test (`NextToken` loop) using a mock that actually varies its response per call.
- `ProcessImages` (the shared per-image iteration helper) gets its own dedicated table-driven tests (`adaptor_utils_test.go`) covering the happy path, partial failure/aggregation, and the empty-hash skip case.

No production behavior changes — this is test-infrastructure only, adding seams that didn't previously exist.

## Additional Information

Builds on the shared-boilerplate refactor already merged in #3026. That PR gave GCP a `clientFactory`/`apiFactory` seam; this PR brings Azure and ECR up to the same shape so all three adaptors are testable the same way.

## How to Test

```bash
go test ./pkg/imagescan/... -v -run "Login|Pagination|ProcessImages"
go test ./pkg/imagescan/...
golangci-lint run ./pkg/imagescan/...
```

Real output from this branch:

```text
=== RUN   TestProcessImages
=== RUN   TestProcessImages/HappyPath
=== RUN   TestProcessImages/PartialFailure
[warning] skipping image due to api error. error: api error on repo2
=== RUN   TestProcessImages/EmptyHashSkippedInsideProcessFunc
--- PASS: TestProcessImages (0.00s)
--- PASS: TestProcessImages/HappyPath (0.00s)
--- PASS: TestProcessImages/PartialFailure (0.00s)
--- PASS: TestProcessImages/EmptyHashSkippedInsideProcessFunc (0.00s)
=== RUN   TestAzureAdaptor_Login_Success
--- PASS: TestAzureAdaptor_Login_Success (0.00s)
=== RUN   TestAzureAdaptor_Login_ExplicitCreds
--- PASS: TestAzureAdaptor_Login_ExplicitCreds (0.00s)
=== RUN   TestAzureAdaptor_GetImagesVulnerabilities_PaginationAndCVE
--- PASS: TestAzureAdaptor_GetImagesVulnerabilities_PaginationAndCVE (0.00s)
=== RUN   TestAWSECRAdaptor_Login_Success
--- PASS: TestAWSECRAdaptor_Login_Success (0.00s)
=== RUN   TestAWSECRAdaptor_Pagination
--- PASS: TestAWSECRAdaptor_Pagination (0.00s)
=== RUN   TestGCPAdaptor_Login_CloseFailureStateClearing
--- PASS: TestGCPAdaptor_Login_CloseFailureStateClearing (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/pkg/imagescan	1.595s

Full package suite:

go test ./pkg/imagescan/...
ok  	github.com/kubescape/kubescape/v3/pkg/imagescan	1.162s

Lint (matches CI's `a-pr-scanner.yaml` golangci-lint step):

golangci-lint run ./pkg/imagescan/...
0 issues.
```

## Related issues/PRs

- Closes #3029
- Builds on #3026

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image scan handling across Azure, ECR, and GCP.
  - Preserved partial vulnerability results while reporting per-image errors.
  - Added clearer handling for invalid image identifiers and incomplete pagination.
  - Improved severity normalization and vulnerability retrieval across paginated results.
  - Improved credential and client error reporting, including cleanup after failed authentication.

- **Tests**
  - Expanded coverage for successful logins, multi-page vulnerability results, partial failures, and empty image hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->