### PR TITLE
fix(makefile): verify sync-vap downloads against pinned SHA256 digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test all build sync-vap
+.PHONY: test all build sync-vap sync-vap-digests
 
 # default task invoked while running make
 all: build
@@ -23,8 +23,64 @@ CEL_VAP_FILES := \
 	basic-control-configuration.yaml \
 	policy-configuration-definition.yaml
 
+# SHA256 of each $(CEL_LIBRARY_VERSION) asset. The bundle is //go:embed-ed into
+# the binary, so an unverified download bakes whatever the release serves into
+# every build: a compromised release asset, a CDN, or an on-path attacker would
+# silently replace the admission policies a security scanner enforces. The
+# release publishes no checksum manifest or signature to verify against, so the
+# digests are pinned here and sync-vap refuses to install a file that does not
+# match. Refresh deliberately when bumping CEL_LIBRARY_VERSION: run
+# `make sync-vap-digests`, check the values against the upstream release, then
+# paste them below in the same commit as the version bump.
+CEL_VAP_DIGESTS := \
+	kubescape-validating-admission-policies.yaml=848f99c52370b768383e7bec4c6799dca1745d9684ad665ba8be1ea99908f5ac \
+	basic-control-configuration.yaml=e309eac48242573cb9814c62367a675f09c06f9288d8fb1f7bdd421db82e51c9 \
+	policy-configuration-definition.yaml=f1e1d0bda1e82ef880223a429fc5ecf99c957b5069b1ec759a9b65ab8620c7ef
+
+# sha256sum on GNU coreutils, shasum on macOS; both print "<digest>  <file>".
+CEL_SHA256_FN := sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$$1"; else shasum -a 256 "$$1"; fi | awk '{ print $$1 }'; }
+
+# Every file is downloaded and verified before any of them is installed, so a
+# mismatch on the last asset cannot leave vapdata/ holding a half-updated
+# bundle.
 sync-vap:
-	@for f in $(CEL_VAP_FILES); do \
-		echo "syncing $$f"; \
-		curl -fsSL "$(CEL_LIBRARY_BASE_URL)/$$f" -o "$(CEL_VAPDATA_DIR)/$$f"; \
+	@set -eu; \
+	$(CEL_SHA256_FN); \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT INT TERM; \
+	for pair in $(CEL_VAP_DIGESTS); do \
+		f="$${pair%%=*}"; want="$${pair#*=}"; \
+		echo "fetching $$f"; \
+		curl -fsSL "$(CEL_LIBRARY_BASE_URL)/$$f" -o "$$tmp/$$f"; \
+		got="$$(sha256 "$$tmp/$$f")"; \
+		if [ "$$got" != "$$want" ]; then \
+			printf 'sync-vap: SHA256 mismatch for %s\n  expected: %s\n  actual:   %s\nrefusing to update %s\n' \
+				"$$f" "$$want" "$$got" "$(CEL_VAPDATA_DIR)" >&2; \
+			exit 1; \
+		fi; \
+	done; \
+	for pair in $(CEL_VAP_DIGESTS); do \
+		f="$${pair%%=*}"; \
+		mv "$$tmp/$$f" "$(CEL_VAPDATA_DIR)/$$f"; \
+		echo "installed $$f"; \
+	done; \
+	echo "sync-vap: $(CEL_LIBRARY_VERSION) bundle verified against pinned SHA256 digests"
+
+# Prints a CEL_VAP_DIGESTS block for the current CEL_LIBRARY_VERSION. Review the
+# digests against the upstream release before pasting them in above.
+sync-vap-digests:
+	@set -eu; \
+	$(CEL_SHA256_FN); \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT INT TERM; \
+	last=""; \
+	for f in $(CEL_VAP_FILES); do last="$$f"; done; \
+	echo "CEL_VAP_DIGESTS := \\"; \
+	for f in $(CEL_VAP_FILES); do \
+		curl -fsSL "$(CEL_LIBRARY_BASE_URL)/$$f" -o "$$tmp/$$f"; \
+		if [ "$$f" = "$$last" ]; then \
+			printf '\t%s=%s\n' "$$f" "$$(sha256 "$$tmp/$$f")"; \
+		else \
+			printf '\t%s=%s \\\n' "$$f" "$$(sha256 "$$tmp/$$f")"; \
+		fi; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,14 @@ CEL_VAP_DIGESTS := \
 	policy-configuration-definition.yaml=f1e1d0bda1e82ef880223a429fc5ecf99c957b5069b1ec759a9b65ab8620c7ef
 
 # sha256sum on GNU coreutils, shasum on macOS; both print "<digest>  <file>".
-CEL_SHA256_FN := sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$$1"; else shasum -a 256 "$$1"; fi | awk '{ print $$1 }'; }
+# Each branch pipes its own command into awk so a missing tool surfaces as a
+# non-zero return instead of an empty digest: piping the whole if/else into awk
+# would let awk's zero exit status mask "command not found".
+CEL_SHA256_FN := sha256() { \
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$$1" | awk '{ print $$1 }'; \
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256 "$$1" | awk '{ print $$1 }'; \
+  else echo "sync-vap: neither sha256sum nor shasum is available; cannot verify downloads" >&2; return 1; fi; \
+}
 
 # Every file is downloaded and verified before any of them is installed, so a
 # mismatch on the last asset cannot leave vapdata/ holding a half-updated
@@ -78,9 +85,10 @@ sync-vap-digests:
 	echo "CEL_VAP_DIGESTS := \\"; \
 	for f in $(CEL_VAP_FILES); do \
 		curl -fsSL "$(CEL_LIBRARY_BASE_URL)/$$f" -o "$$tmp/$$f"; \
+		d="$$(sha256 "$$tmp/$$f")"; \
 		if [ "$$f" = "$$last" ]; then \
-			printf '\t%s=%s\n' "$$f" "$$(sha256 "$$tmp/$$f")"; \
+			printf '\t%s=%s\n' "$$f" "$$d"; \
 		else \
-			printf '\t%s=%s \\\n' "$$f" "$$(sha256 "$$tmp/$$f")"; \
+			printf '\t%s=%s \\\n' "$$f" "$$d"; \
 		fi; \
 	done

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -11,6 +11,20 @@ Do not edit these files by hand. They are a verbatim copy of a pinned release
 make sync-vap
 ```
 
+Because these files are compiled into the binary, `sync-vap` verifies every
+download against the SHA256 digests pinned in `CEL_VAP_DIGESTS` (the upstream
+release publishes no checksum manifest of its own) and refuses to install a
+bundle that does not match, so a tampered release asset cannot silently change
+the policies kubescape enforces. Nothing is written unless every file verifies.
+
+To move to a new release, bump `CEL_LIBRARY_VERSION`, then regenerate the
+digests and check them against the upstream release before committing both
+changes together:
+
+```sh
+make sync-vap-digests
+```
+
 Files:
 
 - `kubescape-validating-admission-policies.yaml` — the ValidatingAdmissionPolicy

--- a/core/pkg/opaprocessor/cel/vapdata/README.md
+++ b/core/pkg/opaprocessor/cel/vapdata/README.md
@@ -17,13 +17,17 @@ release publishes no checksum manifest of its own) and refuses to install a
 bundle that does not match, so a tampered release asset cannot silently change
 the policies kubescape enforces. Nothing is written unless every file verifies.
 
-To move to a new release, bump `CEL_LIBRARY_VERSION`, then regenerate the
-digests and check them against the upstream release before committing both
-changes together:
+To move to a new release, bump `CEL_LIBRARY_VERSION` in the Makefile, then:
 
 ```sh
-make sync-vap-digests
+make sync-vap-digests   # prints a CEL_VAP_DIGESTS block for the new version
+make sync-vap           # refreshes the files here, once the digests are pasted in
 ```
+
+The first target only computes digests; it does not touch this directory. Check
+the printed values against the upstream release and paste them into
+`CEL_VAP_DIGESTS` before running the second. Commit the version bump, the new
+digests, and the refreshed files together.
 
 Files:
 


### PR DESCRIPTION
## What

`make sync-vap` downloaded the cel-admission-library bundle straight into `core/pkg/opaprocessor/cel/vapdata/` with no integrity check:

```make
sync-vap:
	@for f in $(CEL_VAP_FILES); do \
		curl -fsSL "$(CEL_LIBRARY_BASE_URL)/$$f" -o "$(CEL_VAPDATA_DIR)/$$f"; \
	done
```

Those files are `//go:embed`-ed by `core/pkg/opaprocessor/cel/loader.go`, so whatever the release URL serves is compiled into the binary. A compromised release asset, a CDN, or an on-path attacker could replace the admission policies kubescape enforces and the substitution would land in the shipped scanner unnoticed. `curl -f` only rejects HTTP error statuses — it does not detect a 200 carrying different bytes.

## Why pinned digests

The upstream release publishes no checksum manifest and no signature to verify against (assets for `v0.13` are the YAML files only), so there is nothing to fetch-and-compare. The digests are therefore pinned in-repo, and `sync-vap` refuses to install a file that does not match.

All three files are downloaded and verified **before any of them is moved into place**, so a mismatch on the last asset cannot leave `vapdata/` holding a half-updated bundle.

`make sync-vap-digests` regenerates the block when `CEL_LIBRARY_VERSION` is bumped, so re-pinning is one command rather than a manual chore.

## Verification

The pinned values are the `v0.13` assets already vendored in the tree — freshly downloaded release bytes hash identically to the committed files, so this pins the current state rather than changing it.

**Genuine release accepted, tree unchanged:**
```
$ make sync-vap
sync-vap: v0.13 bundle verified against pinned SHA256 digests
$ git status --porcelain core/pkg/opaprocessor/cel/vapdata/
(no output)
```

**Tampered asset rejected** (local mirror, one file modified):
```
$ make sync-vap CEL_LIBRARY_BASE_URL="file:///tmp/evil"
fetching kubescape-validating-admission-policies.yaml
fetching basic-control-configuration.yaml
fetching policy-configuration-definition.yaml
sync-vap: SHA256 mismatch for policy-configuration-definition.yaml
  expected: f1e1d0bda1e82ef880223a429fc5ecf99c957b5069b1ec759a9b65ab8620c7ef
  actual:   bbfdf26141d1d3eda105222b22f33fb123880475d851b2b7f776672923335d40
refusing to update core/pkg/opaprocessor/cel/vapdata
make: *** [sync-vap] Error 1
```

Note there is no `installed` line: the first two files verified fine and were still not written. Against the same mirror, the previous recipe exited 0 and silently installed the modified file.

`go test ./core/pkg/opaprocessor/cel/...` passes, and `make build` is unaffected.

## Notes

- No Go code changes; this touches only the Makefile and the `vapdata/README.md` that documents the target.
- `sha256sum` (coreutils) and `shasum -a 256` (macOS) are both handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CEL asset synchronization by verifying downloaded files against pinned SHA256 checksums before installation.
  * Added portable checksum verification support across common environments.
  * Prevented incomplete or invalid asset bundles from replacing existing data.
  * Added a command to generate checksums when updating pinned asset releases.

* **Documentation**
  * Documented asset verification requirements and the workflow for updating releases and checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->