### PR TITLE
fix(shared): prioritize auth conflict error over missing password

### DIFF
--- a/cmd/shared/image_scan.go
+++ b/cmd/shared/image_scan.go
@@ -53,6 +53,9 @@ func ValidateRegistryCredentials(username, password, token, authority string) er
 	hasToken := token != ""
 
 	if hasUsernamePassword && !hasCompleteUsernamePassword {
+		if hasToken {
+			return ErrRegistryAuthConflict
+		}
 		return ErrRegistryUsernamePassword
 	}
 	if hasCompleteUsernamePassword && hasToken {

--- a/cmd/shared/image_scan_test.go
+++ b/cmd/shared/image_scan_test.go
@@ -200,3 +200,14 @@ func TestValidateWorkloadImageCredentialsRequiresAuthority(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRegistryCredentials_EnvVarBug(t *testing.T) {
+	username := "my-username"
+	password := ""
+	token := "my-token"
+
+	err := ValidateRegistryCredentials(username, password, token, "")
+
+	// Should return conflict error because both token and username are present
+	assert.Equal(t, ErrRegistryAuthConflict, err)
+}


### PR DESCRIPTION
## Description

This PR addresses the registry credentials bug (Issue #3041) where mixing username and token authentication via environment variables causes a misleading error message.

**Changes Made:**

- Updated `ValidateRegistryCredentials` in `cmd/shared/image_scan.go`.
- Added a specific check inside the incomplete username/password logic: if a token is also present, it now prioritizes returning `ErrRegistryAuthConflict`.
- Added `TestValidateRegistryCredentials_EnvVarBug` to `cmd/shared/image_scan_test.go` to explicitly test this regression.

### Why is this needed?

When users set `KUBESCAPE_REGISTRY_USERNAME` and `KUBESCAPE_REGISTRY_TOKEN` together via environment variables, the system populates both variables but leaves the password empty. Previously, the validation logic flagged the incomplete username/password pair first and returned `ErrRegistryUsernamePassword` ("username and password must be provided together"). This masked the real issue—mixing two conflicting authentication methods—making troubleshooting difficult for users configuring auth via environment variables.

### Fixes Issue

Fixes #3041

### Testing Performed

- **Linting:** Passed `golangci-lint run ./cmd/shared/...` and `gofmt`.
- **Unit Tests:** Ran all tests in the `cmd/shared` package. The new `TestValidateRegistryCredentials_EnvVarBug` successfully verified that the conflict error is returned correctly, and no other credential validation permutations were broken.

---

### Real Test Output Logs

Here is the log proving that the new test and all existing tests pass successfully with this fix in place:

```text
$ go test -v ./cmd/shared/...

=== RUN   TestValidateImageScanInfo
=== RUN   TestValidateImageScanInfo/Empty_scanInfo_is_valid
=== RUN   TestValidateImageScanInfo/Empty_severity_is_valid
=== RUN   TestValidateImageScanInfo/High_severity_is_valid
=== RUN   TestValidateImageScanInfo/HIGH_severity_is_valid
=== RUN   TestValidateImageScanInfo/high_severity_is_valid
=== RUN   TestValidateImageScanInfo/Unknown_severity_is_invalid
=== RUN   TestValidateImageScanInfo/Fail_threshold_above_100_should_be_invalid
=== RUN   TestValidateImageScanInfo/Fail_threshold_below_0_should_be_invalid
=== RUN   TestValidateImageScanInfo/Compliance_threshold_above_100_should_be_invalid
=== RUN   TestValidateImageScanInfo/Compliance_threshold_below_0_should_be_invalid
=== RUN   TestValidateImageScanInfo/Coverage_threshold_above_100_should_be_invalid
=== RUN   TestValidateImageScanInfo/Coverage_threshold_below_0_should_be_invalid
=== RUN   TestValidateImageScanInfo/Valid_thresholds_should_be_accepted
=== RUN   TestValidateImageScanInfo/NaN_fail_threshold_should_be_invalid
=== RUN   TestValidateImageScanInfo/NaN_compliance_threshold_should_be_invalid
=== RUN   TestValidateImageScanInfo/NaN_fail_coverage_threshold_should_be_invalid
--- PASS: TestValidateImageScanInfo (0.00s)

=== RUN   TestValidateImageCredentials
=== RUN   TestValidateImageCredentials/Empty_credentials_are_valid
=== RUN   TestValidateImageCredentials/Registry_username_and_password_should_be_accepted
=== RUN   TestValidateImageCredentials/Registry_token_should_be_accepted
=== RUN   TestValidateImageCredentials/Registry_authority_with_token_should_be_accepted
=== RUN   TestValidateImageCredentials/Registry_username_without_password_should_be_invalid
=== RUN   TestValidateImageCredentials/Registry_password_without_username_should_be_invalid
=== RUN   TestValidateImageCredentials/Registry_token_with_username_and_password_should_be_invalid
=== RUN   TestValidateImageCredentials/Registry_authority_without_credentials_should_be_invalid
--- PASS: TestValidateImageCredentials (0.00s)

=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority
=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority/Username_and_password_without_authority_are_rejected
=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority/Token_without_authority_is_rejected
=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority/Username_and_password_with_authority_are_accepted
=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority/Token_with_authority_is_accepted
=== RUN   TestValidateWorkloadImageCredentialsRequiresAuthority/Partial_credentials_keep_the_more_specific_validation_error
--- PASS: TestValidateWorkloadImageCredentialsRequiresAuthority (0.00s)

=== RUN   TestValidateRegistryCredentials_EnvVarBug
--- PASS: TestValidateRegistryCredentials_EnvVarBug (0.00s)

=== RUN   TestValidateScanFormat
=== RUN   TestValidateScanFormat/valid_single_format
=== RUN   TestValidateScanFormat/valid_default_format
=== RUN   TestValidateScanFormat/valid_comma-separated_formats
=== RUN   TestValidateScanFormat/comma-separated_with_whitespace_and_empty_entry
=== RUN   TestValidateScanFormat/empty_string_is_not_an_invalid_format
=== RUN   TestValidateScanFormat/separator-only_input_is_rejected
=== RUN   TestValidateScanFormat/whitespace-and-separator-only_input_is_rejected
=== RUN   TestValidateScanFormat/invalid_format
=== RUN   TestValidateScanFormat/mixed_valid_and_invalid_formats
=== RUN   TestValidateScanFormat/valid_image_format
=== RUN   TestValidateScanFormat/junit_format_is_now_supported_for_image_scanning
=== RUN   TestValidateScanFormat/junit_is_supported_for_image_scanning
=== RUN   TestValidateScanFormat/csv_is_not_supported_for_image_scanning
--- PASS: TestValidateScanFormat (0.00s)

=== RUN   TestValidateSeverity
=== RUN   TestValidateSeverity/low_should_be_a_valid_severity
=== RUN   TestValidateSeverity/Low_should_be_a_valid_severity
=== RUN   TestValidateSeverity/medium_should_be_a_valid_severity
=== RUN   TestValidateSeverity/Medium_should_be_a_valid_severity
=== RUN   TestValidateSeverity/high_should_be_a_valid_severity
=== RUN   TestValidateSeverity/Critical_should_be_a_valid_severity
=== RUN   TestValidateSeverity/critical_should_be_a_valid_severity
=== RUN   TestValidateSeverity/Unknown_should_be_an_invalid_severity
--- PASS: TestValidateSeverity (0.00s)

PASS
ok  	github.com/kubescape/kubescape/v3/cmd/shared	1.390s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry credential validation when username/password credentials are incomplete but a registry token is also provided.
  * Credential conflicts are now reported consistently instead of returning an incomplete-credentials error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->