### PR TITLE
test(scan): add missing test coverage for file-path/chart-path validation

### DIFF
--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -278,6 +278,19 @@ func TestGetWorkloadCmd_ChartPathAndFilePathEmpty(t *testing.T) {
 	assert.Equal(t, expectedErrorMessage, err.Error())
 }
 
+func TestGetWorkloadCmd_FilePathWithoutChartPath(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getWorkloadCmd(mockKubescape, &scanInfo)
+	scanInfo.ChartPath = ""
+	scanInfo.FilePath = "manifests/app.yaml"
+
+	// Should not return an error when FilePath is set without ChartPath
+	err := cmd.Args(cmd, []string{"Deployment/nginx"})
+	assert.NoError(t, err)
+}
+
 func TestGetWorkloadCmd_RejectsFilePathWithPositionalInputPath(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	scanInfo := cautils.ScanInfo{}


### PR DESCRIPTION
## Description

This PR addresses the technical debt around file-path/chart-path validation ambiguity in workload scans (Issue #3043).

**Changes Made:**

- Added `TestGetWorkloadCmd_FilePathWithoutChartPath` to `cmd/scan/workload_test.go`.

### Why is this needed?

Historically, the arguments validator in `cmd/scan/workload.go` carried a literal comment (`// Looks strange, a bug maybe????`) directly above the logic that enforces a `--chart-path` must be accompanied by a `--file-path`. While that comment was removed in a previous refactor (commit `a01225a6`), we never added a test to explicitly verify the *opposite* direction—that providing a `--file-path` without a `--chart-path` is fully supported and intended behavior.

This lack of explicit test coverage left the logic slightly ambiguous for future maintainers. This PR resolves that ambiguity by adding the missing unit test, explicitly codifying that providing a file path without a chart path is completely valid and expected.

### Fixes Issue

Fixes #3043

### Testing Performed

- **Linting:** Passed `golangci-lint run ./cmd/scan/...` and `gofmt`.
- **Unit Tests:** Ran all tests in the `cmd/scan` package. The new `TestGetWorkloadCmd_FilePathWithoutChartPath` successfully verifies that `cmd.Args` allows `FilePath` to be set while `ChartPath` is empty.

---

### Real Test Output Logs

Here is the log proving that the new test was executed and that all tests pass successfully with this validation explicitly verified:

```text
$ go test -v ./cmd/scan/...

=== RUN   TestScanScanInfo
...

=== RUN   TestGetWorkloadCmd_ChartPathAndFilePathEmpty
--- PASS: TestGetWorkloadCmd_ChartPathAndFilePathEmpty (0.00s)

=== RUN   TestGetWorkloadCmd_FilePathWithoutChartPath
--- PASS: TestGetWorkloadCmd_FilePathWithoutChartPath (0.00s)

=== RUN   TestGetWorkloadCmd_RejectsFilePathWithPositionalInputPath
--- PASS: TestGetWorkloadCmd_RejectsFilePathWithPositionalInputPath (0.00s)

=== RUN   TestGetWorkloadCmd_ArgsAcceptsPositionalLocalInputs
--- PASS: TestGetWorkloadCmd_ArgsAcceptsPositionalLocalInputs (0.00s)

=== RUN   TestGetWorkloadCmd_ArgsRejectsAmbiguousFilePathAndPositionalInputs
--- PASS: TestGetWorkloadCmd_ArgsRejectsAmbiguousFilePathAndPositionalInputs (0.00s)

=== RUN   TestGetWorkloadCmd_ArgsRejectsChartPathFilePathAndPositionalInputs
--- PASS: TestGetWorkloadCmd_ArgsRejectsChartPathFilePathAndPositionalInputs (0.00s)

=== RUN   TestGetWorkloadCmd_ArgsRejectsStdinMixedWithOtherInputs
--- PASS: TestGetWorkloadCmd_ArgsRejectsStdinMixedWithOtherInputs (0.00s)

=== RUN   TestPrepareWorkloadInput
=== RUN   TestPrepareWorkloadInput/positional_inputs_populate_input_patterns
=== RUN   TestPrepareWorkloadInput/file_path_flag_populates_input_patterns_when_no_positional_input_is_passed
=== RUN   TestPrepareWorkloadInput/stdin_input_is_copied_to_a_temporary_manifest_and_cleaned_up
--- PASS: TestPrepareWorkloadInput (0.00s)

=== RUN   TestGetWorkloadCmd_RunE_ForwardsPositionalLocalInputs
--- PASS: TestGetWorkloadCmd_RunE_ForwardsPositionalLocalInputs (0.00s)

...

PASS

ok  	github.com/kubescape/kubescape/v3/cmd/scan	1.497s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for workload command argument validation.
  * Confirmed that workload identifiers are accepted when using a file path without a chart path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->