### PR TITLE
fix: replace control merge loops with assignment to clear stale contr…

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -225,46 +225,14 @@ func (a *APIServerStore) StoreWorkloadConfigurationScanResult(ctx context.Contex
 }
 
 func mergeWorkloadConfigurationScanSpec(existingSpec v1beta1.WorkloadConfigurationScanSpec, newSpec v1beta1.WorkloadConfigurationScanSpec) v1beta1.WorkloadConfigurationScanSpec {
-	if existingSpec.Controls == nil {
-		existingSpec.Controls = make(map[string]v1beta1.ScannedControl)
-	}
-	for ctrlID := range newSpec.Controls {
-		newCtrl := newSpec.Controls[ctrlID]
-		_, found := existingSpec.Controls[ctrlID]
-		if !found {
-			existingSpec.Controls[ctrlID] = newCtrl
-			continue
-		}
-
-		// TODOs:
-		// 1. Decide what to do with existing controls (compare statuses, what is the merge strategy)
-		// 2. Do we need to merge the rules?
-		// 3. Do we need to remove non-existing controls?
-		existingSpec.Controls[ctrlID] = newCtrl
-	}
+	existingSpec.Controls = newSpec.Controls
 
 	existingSpec.RelatedObjects = newSpec.RelatedObjects
 	return existingSpec
 }
 
 func mergeWorkloadConfigurationScanSummarySpec(existingSpec v1beta1.WorkloadConfigurationScanSummarySpec, newSpec v1beta1.WorkloadConfigurationScanSummarySpec) v1beta1.WorkloadConfigurationScanSummarySpec {
-	if existingSpec.Controls == nil {
-		existingSpec.Controls = make(map[string]v1beta1.ScannedControlSummary)
-	}
-	for ctrlID := range newSpec.Controls {
-		newCtrl := newSpec.Controls[ctrlID]
-		_, found := existingSpec.Controls[ctrlID]
-		if !found {
-			existingSpec.Controls[ctrlID] = newCtrl
-			continue
-		}
-
-		// TODOs:
-		// 1. Decide what to do with existing controls (compare statuses, what is the merge strategy)
-		// 2. Do we need to merge the rules?
-		// 3. Do we need to remove non-existing controls?
-		existingSpec.Controls[ctrlID] = newCtrl
-	}
+	existingSpec.Controls = newSpec.Controls
 
 	existingSpec.Severities = calculateSeveritiesSummaryFromControls(existingSpec.Controls)
 	return existingSpec


### PR DESCRIPTION
## Related issues/PRs:
* Resolved #3049

## Overview
This PR fixes an issue where stale controls were accumulating in
WorkloadConfigurationScan results and corrupting compliance scores.

Previously, the merge functions inside httphandler/storage/apiserver.go
iterated over new controls and added/updated them into the existing
object — behaving like a maps.Copy operation — meaning controls removed
from a framework between scan cycles were never deleted.

This PR replaces those loops with direct assignment
(existingSpec.Controls = newSpec.Controls), ensuring that only the
controls evaluated in the latest scan persist, bringing it in line
with how kubevuln updates specs.

## Additional Information
Replaces loops in mergeWorkloadConfigurationScanSpec and
mergeWorkloadConfigurationScanSummarySpec to assign maps directly,
overwriting all existing controls with the latest scan result.

## How to Test
1. Deploy kubescape with continuousPostureScan: true
2. Run a scan with a framework containing controls C-001 and C-002
3. Remove C-002 from the framework and allow the continuous scan to re-scan
4. Run: kubectl get workloadconfigurationscans -n kubescape -o json | jq '.items[0].spec.controls | keys'
5. Verify that C-002 is no longer present in the controls list



## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workload scan and summary processing to fully replace outdated control data with the latest results.
  * Ensured related objects are refreshed consistently and summary severity levels are recalculated from the current controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->