### PR TITLE
fix(imagescan): prevent Grafeas filter injection via resourceURL

### DIFF
--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -148,11 +148,10 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 		}
 
 		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-		safeResourceURL := strings.ReplaceAll(resourceURL, "\"", "\\\"")
 
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent: fmt.Sprintf("projects/%s", a.projectID),
-			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", safeResourceURL),
+			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=%q", resourceURL),
 		}
 
 		it := a.client.ListOccurrences(ctx, req)
@@ -225,10 +224,9 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 		}
 
 		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-		safeResourceURL := strings.ReplaceAll(resourceURL, "\"", "\\\"")
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent:   fmt.Sprintf("projects/%s", a.projectID),
-			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", safeResourceURL),
+			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=%q", resourceURL),
 			PageSize: 1000,
 		}
 

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -148,10 +148,11 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 		}
 
 		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+		safeResourceURL := strings.ReplaceAll(resourceURL, "\"", "\\\"")
 
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent: fmt.Sprintf("projects/%s", a.projectID),
-			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceURL),
+			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", safeResourceURL),
 		}
 
 		it := a.client.ListOccurrences(ctx, req)
@@ -224,9 +225,10 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 		}
 
 		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+		safeResourceURL := strings.ReplaceAll(resourceURL, "\"", "\\\"")
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent:   fmt.Sprintf("projects/%s", a.projectID),
-			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", resourceURL),
+			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", safeResourceURL),
 			PageSize: 1000,
 		}
 

--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -147,11 +147,9 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 			continue
 		}
 
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
-
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent: fmt.Sprintf("projects/%s", a.projectID),
-			Filter: fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=%q", resourceURL),
+			Filter: buildGrafeasFilter("DISCOVERY", imageID),
 		}
 
 		it := a.client.ListOccurrences(ctx, req)
@@ -183,6 +181,11 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 	}
 
 	return statuses, aggErr
+}
+
+func buildGrafeasFilter(kind string, imageID ContainerImageIdentifier) string {
+	resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
+	return fmt.Sprintf("kind=%q AND resourceUrl=%q", kind, resourceURL)
 }
 
 // Helper to normalize GCP severity to Kubescape expected severity
@@ -223,10 +226,9 @@ func (a *GCPAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []Co
 			continue
 		}
 
-		resourceURL := fmt.Sprintf("https://%s/%s@%s", imageID.Registry, imageID.Repository, imageID.Hash)
 		req := &grafeaspb.ListOccurrencesRequest{
 			Parent:   fmt.Sprintf("projects/%s", a.projectID),
-			Filter:   fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=%q", resourceURL),
+			Filter:   buildGrafeasFilter("VULNERABILITY", imageID),
 			PageSize: 1000,
 		}
 

--- a/pkg/imagescan/gcp_adaptor_test.go
+++ b/pkg/imagescan/gcp_adaptor_test.go
@@ -251,26 +251,55 @@ func TestGCPAdaptor_FilterInjectionPrevention(t *testing.T) {
 	adaptor.client = mockClient
 	adaptor.projectID = "test-project"
 
-	// Create an image ID with a malicious hash containing a double quote
-	images := []ContainerImageIdentifier{
-		{Registry: "us-docker.pkg.dev", Repository: "proj/repo/img", Hash: "sha256:malicious\"injection"},
+	tests := []struct {
+		name         string
+		hash         string
+		expectedHash string
+	}{
+		{
+			name:         "quote only",
+			hash:         "sha256:malicious\"injection",
+			expectedHash: "sha256:malicious\\\"injection",
+		},
+		{
+			name:         "backslash before quote",
+			hash:         "sha256:malicious\\\"injection",
+			expectedHash: "sha256:malicious\\\\\\\"injection",
+		},
+		{
+			name:         "trailing backslash",
+			hash:         "sha256:malicious\\",
+			expectedHash: "sha256:malicious\\\\",
+		},
+		{
+			name:         "raw line break",
+			hash:         "sha256:malicious\ninjection",
+			expectedHash: "sha256:malicious\\ninjection",
+		},
 	}
 
-	// Test GetImagesScanStatus
-	_, err := adaptor.GetImagesScanStatus(context.Background(), images)
-	assert.NoError(t, err)
-	require.NotNil(t, mockClient.lastReq)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			images := []ContainerImageIdentifier{
+				{Registry: "us-docker.pkg.dev", Repository: "proj/repo/img", Hash: tc.hash},
+			}
 
-	// The filter should have the double quote escaped
-	expectedResourceURL := "https://us-docker.pkg.dev/proj/repo/img@sha256:malicious\\\"injection"
-	expectedFilter := fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", expectedResourceURL)
-	assert.Equal(t, expectedFilter, mockClient.lastReq.Filter)
+			// Test GetImagesScanStatus
+			_, err := adaptor.GetImagesScanStatus(context.Background(), images)
+			assert.NoError(t, err)
+			require.NotNil(t, mockClient.lastReq)
 
-	// Test GetImagesVulnerabilities
-	_, err = adaptor.GetImagesVulnerabilities(context.Background(), images)
-	assert.NoError(t, err)
-	require.NotNil(t, mockClient.lastReq)
+			expectedResourceURL := "https://us-docker.pkg.dev/proj/repo/img@" + tc.expectedHash
+			expectedFilter := fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", expectedResourceURL)
+			assert.Equal(t, expectedFilter, mockClient.lastReq.Filter)
 
-	expectedVulnFilter := fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", expectedResourceURL)
-	assert.Equal(t, expectedVulnFilter, mockClient.lastReq.Filter)
+			// Test GetImagesVulnerabilities
+			_, err = adaptor.GetImagesVulnerabilities(context.Background(), images)
+			assert.NoError(t, err)
+			require.NotNil(t, mockClient.lastReq)
+
+			expectedVulnFilter := fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", expectedResourceURL)
+			assert.Equal(t, expectedVulnFilter, mockClient.lastReq.Filter)
+		})
+	}
 }

--- a/pkg/imagescan/gcp_adaptor_test.go
+++ b/pkg/imagescan/gcp_adaptor_test.go
@@ -20,9 +20,11 @@ import (
 type mockGCPClient struct {
 	occurrences []*grafeaspb.Occurrence
 	mockErr     error
+	lastReq     *grafeaspb.ListOccurrencesRequest
 }
 
 func (m *mockGCPClient) ListOccurrences(ctx context.Context, req *grafeaspb.ListOccurrencesRequest, opts ...interface{}) GrafeasIterator {
+	m.lastReq = req
 	return &mockGrafeasIterator{
 		occurrences: m.occurrences,
 		err:         m.mockErr,
@@ -239,4 +241,36 @@ func TestGCPAdaptor_Login_CloseFailureStateClearing(t *testing.T) {
 	// State clearing check: client must be nil, owningClient must be retained
 	assert.Nil(t, adaptor.client, "a.client should be cleared before Close()")
 	assert.NotNil(t, adaptor.owningClient, "a.owningClient should be retained when close fails")
+}
+
+func TestGCPAdaptor_FilterInjectionPrevention(t *testing.T) {
+	mockClient := &mockGCPClient{
+		occurrences: []*grafeaspb.Occurrence{},
+	}
+	adaptor := NewGCPAdaptor()
+	adaptor.client = mockClient
+	adaptor.projectID = "test-project"
+
+	// Create an image ID with a malicious hash containing a double quote
+	images := []ContainerImageIdentifier{
+		{Registry: "us-docker.pkg.dev", Repository: "proj/repo/img", Hash: "sha256:malicious\"injection"},
+	}
+
+	// Test GetImagesScanStatus
+	_, err := adaptor.GetImagesScanStatus(context.Background(), images)
+	assert.NoError(t, err)
+	require.NotNil(t, mockClient.lastReq)
+
+	// The filter should have the double quote escaped
+	expectedResourceURL := "https://us-docker.pkg.dev/proj/repo/img@sha256:malicious\\\"injection"
+	expectedFilter := fmt.Sprintf("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", expectedResourceURL)
+	assert.Equal(t, expectedFilter, mockClient.lastReq.Filter)
+
+	// Test GetImagesVulnerabilities
+	_, err = adaptor.GetImagesVulnerabilities(context.Background(), images)
+	assert.NoError(t, err)
+	require.NotNil(t, mockClient.lastReq)
+
+	expectedVulnFilter := fmt.Sprintf("kind=\"VULNERABILITY\" AND resourceUrl=\"%s\"", expectedResourceURL)
+	assert.Equal(t, expectedVulnFilter, mockClient.lastReq.Filter)
 }


### PR DESCRIPTION
# Description

This PR (fixes #3050) addresses a security issue where the `resourceURL` was interpolated into a GCP Grafeas CEL query without escaping, leaving it vulnerable to filter syntax injection if the image hash contains double quotes.

**Changes Made:**

- Sanitized `resourceURL` by replacing `"` with `\"` before passing it to `fmt.Sprintf` in both `ListOccurrences` requests.
- Added `TestGCPAdaptor_FilterInjectionPrevention` in `pkg/imagescan/gcp_adaptor_test.go` to explicitly verify that malicious hashes have their quotes escaped in the resulting filter string.

### Testing Performed

- **Linting:** Passed `golangci-lint run ./pkg/imagescan/...`
- **Unit Tests:**

**Proof of Fix 

```text
=== RUN   TestGCPAdaptor_FilterInjectionPrevention
--- PASS: TestGCPAdaptor_FilterInjectionPrevention (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/pkg/imagescan	1.569s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image scanning for image hashes containing special characters, including double quotes, backslashes, and line breaks.
  * GCP scan-status and vulnerability lookups now safely handle these values, preventing malformed queries and improving scan reliability.
  * Added coverage to verify secure handling across image discovery and vulnerability checks.
  * Scan results are now more dependable when image identifiers contain unexpected formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->