### PR TITLE
fix(imagescan): add guards for empty Hash and Tag in ECR adaptor

### DIFF
--- a/pkg/imagescan/ecr_adaptor.go
+++ b/pkg/imagescan/ecr_adaptor.go
@@ -71,6 +71,10 @@ func (a *AWSECRAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Cont
 				IsBomAvailable:  false,
 			}
 
+			if imageID.Hash == "" && imageID.Tag == "" {
+				return status, nil
+			}
+
 			var ecrImageID types.ImageIdentifier
 			if imageID.Hash != "" {
 				ecrImageID.ImageDigest = aws.String(imageID.Hash)
@@ -112,6 +116,10 @@ func (a *AWSECRAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 			report := ContainerImageVulnerabilityReport{
 				ImageID:         imageID,
 				Vulnerabilities: []Vulnerability{},
+			}
+
+			if imageID.Hash == "" && imageID.Tag == "" {
+				return report, nil
 			}
 
 			var ecrImageID types.ImageIdentifier

--- a/pkg/imagescan/ecr_adaptor_test.go
+++ b/pkg/imagescan/ecr_adaptor_test.go
@@ -17,6 +17,9 @@ type mockECRClient struct {
 }
 
 func (m *mockECRClient) DescribeImageScanFindings(ctx context.Context, params *ecr.DescribeImageScanFindingsInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error) {
+	if params.ImageId != nil && params.ImageId.ImageDigest == nil && params.ImageId.ImageTag == nil {
+		panic("InvalidParameterException: imageId must contain either imageDigest or imageTag")
+	}
 	return m.describeFindingsOut, m.describeFindingsErr
 }
 
@@ -68,6 +71,13 @@ func TestAWSECRAdaptor_GetImagesScanStatus(t *testing.T) {
 			},
 			expectedScan: false,
 		},
+		{
+			name:    "empty hash and tag should not panic",
+			mockOut: &ecr.DescribeImageScanFindingsOutput{
+				// the mock client will panic if it reaches DescribeImageScanFindings
+			},
+			expectedScan: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -80,6 +90,10 @@ func TestAWSECRAdaptor_GetImagesScanStatus(t *testing.T) {
 
 			images := []ContainerImageIdentifier{
 				{Registry: "123456789012.dkr.ecr.us-east-1.amazonaws.com", Repository: "test-repo", Tag: "latest"},
+			}
+
+			if tt.name == "empty hash and tag should not panic" {
+				images[0].Tag = ""
 			}
 
 			statuses, err := adaptor.GetImagesScanStatus(context.Background(), images)
@@ -203,4 +217,18 @@ func TestAWSECRAdaptor_GetImagesVulnerabilities_EnhancedFindingsFallsBackToTitle
 	assert.Len(t, reports[0].Vulnerabilities, 2)
 	assert.Equal(t, "CVE-2026-1234", reports[0].Vulnerabilities[0].ID)
 	assert.Equal(t, "CVE-2026-5678", reports[0].Vulnerabilities[1].ID)
+}
+
+func TestAWSECRAdaptor_GetImagesVulnerabilities_EmptyHashAndTagShouldNotPanic(t *testing.T) {
+	adaptor := NewAWSECRAdaptor()
+	adaptor.client = &mockECRClient{}
+
+	images := []ContainerImageIdentifier{
+		{Registry: "123456789012.dkr.ecr.us-east-1.amazonaws.com", Repository: "test-repo"},
+	}
+
+	reports, err := adaptor.GetImagesVulnerabilities(context.Background(), images)
+	assert.NoError(t, err)
+	assert.Len(t, reports, 1)
+	assert.Empty(t, reports[0].Vulnerabilities)
 }


### PR DESCRIPTION
## Description

This PR(fixes #3057) fixes a bug in the AWS ECR image vulnerability adaptor where the AWS SDK crashes with an `InvalidParameterException` when processing images that do not have a Hash or a Tag.

**The Issue:** In `pkg/imagescan/ecr_adaptor.go`, the code checks if `imageID.Hash` or `imageID.Tag` are set to construct the `types.ImageIdentifier`. However, unlike the GCP and Azure adaptors, which explicitly guard against empty identifiers with an early return, the ECR adaptor fails to guard against the case where **both the hash and the tag are empty**.

If a `ContainerImageIdentifier` without a `Hash` and `Tag` is passed in, the `ecrImageID` struct is initialized with no fields set (`ImageDigest=nil` and `ImageTag=nil`). This entirely empty `ImageId` is then passed to the AWS SDK's `DescribeImageScanFindings` method, causing it to fail/panic.

**The Fix:** Added explicit guards right before creating `ecrImageID` in both `GetImagesScanStatus` and `GetImagesVulnerabilities` to skip processing if both the hash and tag are missing. This mirrors the safety checks already present in the Azure and GCP adaptors.

### Tests / Logs

Added a mock validation check to `ecr_adaptor_test.go` to mirror the AWS SDK's strict parameter validation, along with a test case simulating an empty hash and tag.

**Before the fix, the AWS SDK parameter validation panic looked like this:**

```text
=== RUN   TestAWSECRAdaptor_GetImagesScanStatus/empty_hash_and_tag_panics_the_aws_sdk

--- FAIL: TestAWSECRAdaptor_GetImagesScanStatus (0.00s)

    --- FAIL: TestAWSECRAdaptor_GetImagesScanStatus/empty_hash_and_tag_panics_the_aws_sdk (0.00s)

panic: InvalidParameterException: imageId must contain either imageDigest or imageTag [recovered, repanicked]

goroutine 44 [running]:

testing.tRunner.func1.2({0x1097f5da0, 0x10a273950})

	/opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:1974 +0x1a0

testing.tRunner.func1()

	/opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:1977 +0x318

panic({0x1097f5da0?, 0x10a273950?})

	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/panic.go:860 +0x12c

github.com/kubescape/kubescape/v3/pkg/imagescan.(*mockECRClient).DescribeImageScanFindings(0x49204902df40, {0x10a2e5318, 0x10a9e5888}, {0x49204902df00?, 0x1, 0x10297b6d4?})

	/Users/lalit/kubescape/pkg/imagescan/ecr_adaptor_test.go:21 +0x5c

github.com/kubescape/kubescape/v3/pkg/imagescan.(*AWSECRAdaptor).GetImagesScanStatus(0x49204902df40, {0x10a2e5318, 0x10a9e5888}, {0x49204902df00?, 0x1, 0x10297b6d4?})

	/Users/lalit/kubescape/pkg/imagescan/ecr_adaptor.go:87 +0x330
```

**After the fix, all tests pass cleanly:**

```text
=== RUN   TestAWSECRAdaptor_GetImagesScanStatus
=== RUN   TestAWSECRAdaptor_GetImagesScanStatus/scan_complete_with_findings
=== RUN   TestAWSECRAdaptor_GetImagesScanStatus/scan_in_progress
=== RUN   TestAWSECRAdaptor_GetImagesScanStatus/empty_hash_and_tag_should_not_panic
--- PASS: TestAWSECRAdaptor_GetImagesScanStatus (0.00s)
    --- PASS: TestAWSECRAdaptor_GetImagesScanStatus/scan_complete_with_findings (0.00s)
    --- PASS: TestAWSECRAdaptor_GetImagesScanStatus/scan_in_progress (0.00s)
    --- PASS: TestAWSECRAdaptor_GetImagesScanStatus/empty_hash_and_tag_should_not_panic (0.00s)

PASS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of images without a digest or tag.
  * Prevented unnecessary registry requests for incomplete image identifiers.
  * Returned an unavailable scan status and empty vulnerability report when image details are missing.
  * Prevented errors when scanning images with incomplete identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->