### PR TITLE
fix(opaprocessor): deduplicate merged paths for resources evaluated in every scope

### DIFF
--- a/core/pkg/opaprocessor/resultmerge.go
+++ b/core/pkg/opaprocessor/resultmerge.go
@@ -16,8 +16,9 @@ import (
 //   - status precedence is failed > skipped > passed: a resource that failed
 //     in any scope failed, and an evaluation error in any scope downgrades a
 //     pass to skipped but never overrides a failure;
-//   - paths accumulate across scopes, because a rule can report a different
-//     failed path per scope;
+//   - paths accumulate as a set, because a rule can report a different failed
+//     path per scope but reports the same path in every scope for a resident
+//     resource;
 //   - related resource IDs accumulate as a set, preserving first-seen order.
 
 // ruleStatusRank orders statuses by how definitive they are.
@@ -59,7 +60,7 @@ func mergeAssociatedRule(existing, incoming *resourcesresults.ResourceAssociated
 		existing.ControlConfigurations = incoming.ControlConfigurations
 	}
 
-	existing.Paths = append(existing.Paths, incoming.Paths...)
+	existing.Paths = appendUnique(existing.Paths, incoming.Paths)
 	existing.RelatedResourcesIDs = appendUnique(existing.RelatedResourcesIDs, incoming.RelatedResourcesIDs)
 
 	return existing
@@ -113,13 +114,14 @@ func mergeAssociatedControls(existing []resourcesresults.ResourceAssociatedContr
 }
 
 // appendUnique appends the values of incoming that existing does not already
-// hold, preserving order.
-func appendUnique(existing, incoming []string) []string {
+// hold, preserving order. One pass over each slice, so merging a resident
+// resource across many scopes stays linear in the number of distinct values.
+func appendUnique[T comparable](existing, incoming []T) []T {
 	if len(incoming) == 0 {
 		return existing
 	}
 
-	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	seen := make(map[T]struct{}, len(existing)+len(incoming))
 	for _, value := range existing {
 		seen[value] = struct{}{}
 	}

--- a/core/pkg/opaprocessor/resultmerge.go
+++ b/core/pkg/opaprocessor/resultmerge.go
@@ -114,8 +114,10 @@ func mergeAssociatedControls(existing []resourcesresults.ResourceAssociatedContr
 }
 
 // appendUnique appends the values of incoming that existing does not already
-// hold, preserving order. One pass over each slice, so merging a resident
-// resource across many scopes stays linear in the number of distinct values.
+// hold, preserving order. A call costs O(len(existing)+len(incoming)). A
+// resident resource reports the same paths in every scope, so existing stays at
+// the distinct count and merging it across scopes stays linear in the number of
+// scopes.
 func appendUnique[T comparable](existing, incoming []T) []T {
 	if len(incoming) == 0 {
 		return existing

--- a/core/pkg/opaprocessor/resultmerge_test.go
+++ b/core/pkg/opaprocessor/resultmerge_test.go
@@ -59,6 +59,40 @@ func TestMergeAssociatedRule_AccumulatesFindings(t *testing.T) {
 	assert.Equal(t, []string{"related-1", "related-2"}, got.RelatedResourcesIDs, "related resources must be a set")
 }
 
+// TestMergeAssociatedRule_DeduplicatesPaths covers a resident resource, which is
+// evaluated once per namespace scope and reports the same path every time.
+func TestMergeAssociatedRule_DeduplicatesPaths(t *testing.T) {
+	merged := &resourcesresults.ResourceAssociatedRule{
+		Name:   "rule",
+		Status: apis.StatusFailed,
+		Paths:  []armotypes.PosturePaths{failedPath("spec.hostNetwork")},
+	}
+	for range 3 {
+		merged = mergeAssociatedRule(merged, &resourcesresults.ResourceAssociatedRule{
+			Name:   "rule",
+			Status: apis.StatusFailed,
+			Paths:  []armotypes.PosturePaths{failedPath("spec.hostNetwork")},
+		})
+	}
+
+	assert.Equal(t, []armotypes.PosturePaths{failedPath("spec.hostNetwork")}, merged.Paths)
+}
+
+func TestAppendUniquePaths(t *testing.T) {
+	assert.Equal(t,
+		[]armotypes.PosturePaths{failedPath("a"), failedPath("b")},
+		appendUnique([]armotypes.PosturePaths{failedPath("a")}, []armotypes.PosturePaths{failedPath("a"), failedPath("b")}),
+	)
+	assert.Equal(t,
+		[]armotypes.PosturePaths{{FixPath: armotypes.FixPath{Path: "a", Value: "1"}}, {FixPath: armotypes.FixPath{Path: "a", Value: "2"}}},
+		appendUnique(
+			[]armotypes.PosturePaths{{FixPath: armotypes.FixPath{Path: "a", Value: "1"}}},
+			[]armotypes.PosturePaths{{FixPath: armotypes.FixPath{Path: "a", Value: "2"}}},
+		),
+		"paths differing only in fix value are distinct findings",
+	)
+}
+
 // TestMergeAssociatedRule_KeepsSubStatus pins that a sub-status recorded by an
 // earlier scope is not erased by a later, more definitive verdict that carries
 // none — the previous in-place update had the same effect.


### PR DESCRIPTION
## Overview

On large clusters the OPA processor evaluates namespace by namespace, and the resident batch (cluster scoped and external objects) is part of the input for every one of those scopes. That means a cluster scoped resource is assessed once per namespace, and `mergeAssociatedRule` combines the per scope verdicts afterwards.

The merge appended `Paths` unconditionally. Since a resident resource reports the same failed path in every scope, the path ends up repeated once per namespace. On a cluster with 200 namespaces a single failed path on a ClusterRole shows up 200 times in the result, which then flows into the JSON, SARIF, HTML, CSV and pretty printer output. `RelatedResourcesIDs` right next to it was already merged as a set, so the paths were just an oversight rather than intended behaviour.

## Change

`appendUnique` is now generic over `comparable` and `Paths` goes through it too. `PosturePaths` is a plain struct of strings, so two paths are equal only when every field matches. Distinct paths from different scopes still accumulate, which is what the original comment was describing.

This also keeps the merge linear. Before, each additional scope grew the slice by the full incoming set regardless of overlap, so the accumulated slice grew with the number of namespaces. Now it is bounded by the number of distinct paths.

## Tests

* `TestMergeAssociatedRule_DeduplicatesPaths` merges the same path across several scopes and asserts a single entry survives. It fails on master and passes here.
* `TestAppendUniquePaths` covers the generic helper on `PosturePaths`, including the case where two paths differ only in the fix value and must stay separate.
* The existing `TestMergeAssociatedRule_AccumulatesFindings` is unchanged and still asserts that different paths accumulate.

`go build ./...`, `go vet ./core/...` and `go test ./core/... ./pkg/... ./cmd/...` all pass. The one failure in the suite, `TestExcludeFilesUnderDirectories` in `core/pkg/resourcehandler`, also fails on master and is unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate paths from appearing when results are merged repeatedly.
  - Preserved distinct paths when their associated fix values differ.
  - Maintained the original order of paths during merging.

- **Tests**
  - Added coverage for repeated result merging and path deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->