### PR TITLE
feat(sarif): show current field values in evidence paths

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -19,6 +19,7 @@ import (
 	grypesarif "github.com/anchore/grype/grype/presenter/sarif"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/fixhandler"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver"
@@ -110,9 +111,15 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 }
 
 // addResult adds a result of checking a rule to the scan run based on the given control summary
-func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location) *sarif.Result {
+func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) *sarif.Result {
+	msg := ctl.GetDescription()
+	if resource != nil {
+		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
+			msg += "\n\nAffected fields:\n" + strings.Join(paths, "\n")
+		}
+	}
 	return scanRun.CreateResultForRule(ctl.GetID()).
-		WithMessage(sarif.NewTextMessage(ctl.GetDescription())).
+		WithMessage(sarif.NewTextMessage(msg)).
 		WithLocations([]*sarif.Location{
 			sarif.NewLocationWithPhysicalLocation(
 				sarif.NewPhysicalLocation().
@@ -246,7 +253,8 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 				}
 				location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
 				sp.addRule(run, ctl)
-				r := sp.addResult(run, ctl, resource.relPath, location)
+				rsrc := opaSessionObj.AllResources[resource.resourceID]
+				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc)
 				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
 			}
 		}


### PR DESCRIPTION
## Overview

`sarifprinter.go` was still using `AssistedRemediationPathsToString` in `addResult`, which emits bare paths but no current values. pretty-printer got this fixed in #2882, html printer in #3032 — sarif was the only one left behind.

`AssistedRemediationPathsWithCurrentValues` already exists and the resource is available via `opaSessionObj.AllResources[resourceID]` at the call site (same map `collectFixes` uses a few lines below). so this just threads the resource through `addResult` and swaps the call.

## Additional Information

nil resource falls back to description-only so existing behavior is preserved for any case where the lookup misses.

## How to Test

```bash
kubescape scan framework nsa --format sarif --output result.sarif
```
open `result.sarif` and check that failing results now have `Affected fields:` appended to the message text, with actual field paths.

## Related issues/PRs

* Resolves #1563
* follows pattern from #2882 and #3032

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [ ] thorough tests — this change is a one-file plumbing fix mirroring the same pattern already tested in #3032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Configuration scan results now identify the affected workload resource.
  * Result messages include relevant remediation details when available, while preserving the control description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->