### PR TITLE
fix(scan): re-register --fail-threshold as hidden deprecated flag

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -154,6 +154,14 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.OnlyFixable, "only-fixable", false, "When used with --severity-threshold on image scans, only count CVEs that have an available fix toward the pass/fail decision")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release. Has no effect when --account is set (cloud backend is used instead)")
 
+	// --fail-threshold was removed as a functioning flag, but its registration must stay so
+	// pflag/cobra keep accepting it instead of erroring with "unknown flag" for callers who
+	// still pass it (e.g. existing CI pipelines). Same pattern as the --id/--environment/--env
+	// deprecated-flag fix in cmd/list/list.go and cmd/root.go.
+	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Deprecated, use '--compliance-threshold' instead")
+	_ = scanCmd.PersistentFlags().MarkHidden("fail-threshold")
+	_ = scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead")
+
 	// Tri-state flag bound to the same BoolPtrFlag as the removed --enable-host-scan:
 	// not passed -> auto-detect node-agent CRDs; --host-scan=false -> opt out of
 	// host data collection; --host-scan=true -> force host data collection on.

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -157,8 +157,10 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	// --fail-threshold was removed as a functioning flag, but its registration must stay so
 	// pflag/cobra keep accepting it instead of erroring with "unknown flag" for callers who
 	// still pass it (e.g. existing CI pipelines). Same pattern as the --id/--environment/--env
-	// deprecated-flag fix in cmd/list/list.go and cmd/root.go.
-	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Deprecated, use '--compliance-threshold' instead")
+	// deprecated-flag fix in cmd/list/list.go and cmd/root.go: bind to a standalone variable,
+	// not scanInfo, so legacy input can't leak into report metadata or threshold validation.
+	var dummyFailThreshold float32
+	scanCmd.PersistentFlags().Float32VarP(&dummyFailThreshold, "fail-threshold", "t", 100, "Deprecated, use '--compliance-threshold' instead")
 	_ = scanCmd.PersistentFlags().MarkHidden("fail-threshold")
 	_ = scanCmd.PersistentFlags().MarkDeprecated("fail-threshold", "use '--compliance-threshold' flag instead")
 

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -352,7 +352,6 @@ func TestGetScanCommand_DeprecatedFlagsRemoved(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	for _, removed := range []string{
-		"fail-threshold",
 		"create-account",
 		"enable-host-scan",
 		"host-scan-yaml",
@@ -360,6 +359,23 @@ func TestGetScanCommand_DeprecatedFlagsRemoved(t *testing.T) {
 		assert.Nil(t, cmd.PersistentFlags().Lookup(removed),
 			"deprecated flag %q must no longer be registered", removed)
 	}
+}
+
+func TestGetScanCommand_FailThresholdKeptAsHiddenDeprecatedFlag(t *testing.T) {
+	// --fail-threshold's gating logic was removed, but the flag must stay registered
+	// (hidden + deprecated) so cobra keeps accepting it instead of erroring with
+	// "unknown flag" for existing callers - see https://github.com/kubescape/kubescape/issues/3056
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	require.NotNil(t, cmd)
+
+	f := cmd.PersistentFlags().Lookup("fail-threshold")
+	require.NotNil(t, f, "--fail-threshold must stay registered so it doesn't fail with 'unknown flag'")
+	assert.True(t, f.Hidden, "--fail-threshold must be hidden from help output")
+	assert.NotEmpty(t, f.Deprecated, "--fail-threshold must be marked deprecated")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--fail-threshold", "20"}))
+	assert.Equal(t, "20", f.Value.String())
 }
 
 func TestGetScanCommand_HostScanFlagTriState(t *testing.T) {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -372,9 +372,12 @@ func TestGetScanCommand_FailThresholdKeptAsHiddenDeprecatedFlag(t *testing.T) {
 	f := cmd.PersistentFlags().Lookup("fail-threshold")
 	require.NotNil(t, f, "--fail-threshold must stay registered so it doesn't fail with 'unknown flag'")
 	assert.True(t, f.Hidden, "--fail-threshold must be hidden from help output")
-	assert.NotEmpty(t, f.Deprecated, "--fail-threshold must be marked deprecated")
+	assert.Equal(t, "use '--compliance-threshold' flag instead", f.Deprecated)
 
 	require.NoError(t, cmd.ParseFlags([]string{"--fail-threshold", "20"}))
+	assert.Equal(t, "20", f.Value.String())
+
+	require.NoError(t, cmd.ParseFlags([]string{"-t", "20"}))
 	assert.Equal(t, "20", f.Value.String())
 }
 


### PR DESCRIPTION
## Overview

`--fail-threshold` was fully deregistered from the `scan` command in a prior deprecated-flags cleanup, so `kubescape scan ... --fail-threshold N ...` now hard-fails with `Error: unknown flag: --fail-threshold` instead of accepting the flag with a deprecation warning. This breaks existing callers (e.g. CI pipelines built against older kubescape versions) that still pass it.

This PR re-registers `--fail-threshold` as a hidden, deprecated flag (same pattern already used in this repo for `--id`/`--environment`/`--env`), so it is accepted again instead of erroring. It does not restore the old fail-threshold exit-code gating logic, which was intentionally removed in favor of `--compliance-threshold` — the flag is now a no-op accepted for backward compatibility only, matching how the other previously-removed deprecated flags behave.

## How to Test

```
go test ./cmd/scan/...
go build -o kubescape .
./kubescape scan --fail-threshold 20 --format json .
```

The last command should print a `Flag --fail-threshold has been deprecated, use '--compliance-threshold' flag instead` warning and proceed with the scan, instead of exiting with `Error: unknown flag: --fail-threshold`.

## Related issues/PRs:

* Resolved #3056

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Retained the deprecated `--fail-threshold` (`-t`) scan option for existing workflows.
  * The option remains accepted but is hidden and marked deprecated in favor of `--compliance-threshold`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->