### PR TITLE
fix(httphandler): stop honoring client-supplied account/accessKey in scan requests

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -170,8 +170,6 @@ Delete cached scan results.
   "includeNamespaces": ["production", "staging"],
   "useCachedArtifacts": false,
   "keepLocal": true,
-  "account": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-  "accessKey": "your-access-key",
   "targetType": "framework",
   "targetNames": ["nsa", "mitre"]
 }
@@ -184,10 +182,15 @@ Delete cached scan results.
 | `includeNamespaces` | []string | Namespaces to include in scan |
 | `useCachedArtifacts` | bool | Use cached artifacts (offline mode) |
 | `keepLocal` | bool | Don't submit results to backend |
-| `account` | string | Kubescape SaaS account ID |
-| `accessKey` | string | Kubescape SaaS access key |
 | `targetType` | string | `"framework"` or `"control"` |
 | `targetNames` | []string | Frameworks/controls to scan |
+
+> **`account` / `accessKey` are ignored.** These endpoints are unauthenticated,
+> so the server never takes its Kubescape SaaS identity from the request body —
+> otherwise any caller could redirect results to an account they control. The
+> identity comes from the server's own configuration (`KS_ACCOUNT_ID` /
+> `KS_ACCESS_KEY`, or the credentials loaded at startup). The fields are still
+> accepted in the payload for backward compatibility, but have no effect.
 
 ### Response Object
 
@@ -257,12 +260,20 @@ curl -X POST http://127.0.0.1:8080/v1/scan \
 
 ### Scan with Account Integration
 
+The account and access key are configured on the server, not sent per request
+(see the note under [Trigger Scan Object](#trigger-scan-object)):
+
+```bash
+# on the server / in the Helm values
+export KS_ACCOUNT_ID="YOUR-ACCOUNT-ID"
+export KS_ACCESS_KEY="YOUR-ACCESS-KEY"
+```
+
 ```bash
 curl -X POST http://127.0.0.1:8080/v1/scan \
   -H "Content-Type: application/json" \
   -d '{
-    "account": "YOUR-ACCOUNT-ID",
-    "accessKey": "YOUR-ACCESS-KEY",
+    "submit": true,
     "targetType": "framework",
     "targetNames": ["nsa"]
   }'
@@ -282,7 +293,8 @@ Configure the HTTP handler using environment variables:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `KS_ACCOUNT` | Default account ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `KS_ACCOUNT_ID` | Kubescape SaaS account ID used for every scan | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `KS_ACCESS_KEY` | Kubescape SaaS access key used for every scan | `your-access-key` |
 | `KS_EXCLUDE_NAMESPACES` | Default namespaces to exclude | `kube-system,kube-public` |
 | `KS_INCLUDE_NAMESPACES` | Default namespaces to include | `production,staging` |
 | `KS_FORMAT` | Default output format | `json` |

--- a/httphandler/handlerequests/v1/datastructuremethods.go
+++ b/httphandler/handlerequests/v1/datastructuremethods.go
@@ -21,12 +21,13 @@ func ToScanInfo(scanRequest *utilsmetav1.PostScanRequest) (*cautils.ScanInfo, []
 
 	policyIdentifiers := setTargetInScanInfo(scanRequest, scanInfo)
 
-	if scanRequest.Account != "" {
-		scanInfo.AccountID = scanRequest.Account
-	}
-	if scanRequest.AccessKey != "" {
-		scanInfo.AccessKey = scanRequest.AccessKey
-	}
+	// scanRequest.Account/AccessKey are intentionally ignored: this endpoint has
+	// no authentication, so honoring client-supplied values would let any caller
+	// redirect scan results (which can include cluster secrets/RBAC data, see
+	// Submit below) to an attacker-controlled Kubescape Cloud account. The
+	// account/access key are only ever taken from this server's own trusted
+	// config, set in defaultScanInfo from KS_ACCOUNT_ID/KS_ACCESS_KEY or the
+	// credentials fetched at startup - never from the request body.
 	if len(scanRequest.ExcludedNamespaces) > 0 {
 		scanInfo.ExcludedNamespaces = strings.Join(scanRequest.ExcludedNamespaces, ",")
 	}

--- a/httphandler/handlerequests/v1/datastructuremethods_test.go
+++ b/httphandler/handlerequests/v1/datastructuremethods_test.go
@@ -37,7 +37,7 @@ func TestToScanInfo(t *testing.T) {
 	{
 		req := &utilsmetav1.PostScanRequest{
 			TargetType:         apisv1.KindFramework,
-			Account:            "abc",
+			Account:            "abc", // must NOT reach s.AccountID - see TestToScanInfo_IgnoresClientSuppliedIdentity
 			Logger:             "info",
 			Format:             "pdf",
 			FailThreshold:      50,
@@ -45,7 +45,6 @@ func TestToScanInfo(t *testing.T) {
 			TargetNames:        []string{"nsa", "mitre"},
 		}
 		s, policyIdentifiers := ToScanInfo(req)
-		assert.Equal(t, "abc", s.AccountID)
 		assert.Equal(t, "v2", s.FormatVersion)
 		assert.Equal(t, "pdf", s.Format)
 		assert.Equal(t, 2, len(policyIdentifiers))
@@ -101,6 +100,28 @@ func TestToScanInfo(t *testing.T) {
 		assert.Equal(t, "nginx", s.ScanObject.GetName())
 		assert.Equal(t, "ns1", s.ScanObject.GetNamespace())
 	}
+}
+
+// TestToScanInfo_IgnoresClientSuppliedIdentity is a regression test for a
+// critical vuln: an unauthenticated caller of POST /v1/scan could set
+// account/accessKey in the request body and redirect the cluster scan report
+// (RBAC, workload details, etc.) to an attacker-controlled Kubescape Cloud
+// account. AccountID/AccessKey must always come from this server's own
+// trusted config (env vars / credentials fetched at startup), never from the
+// request body.
+func TestToScanInfo_IgnoresClientSuppliedIdentity(t *testing.T) {
+	t.Setenv("KS_ACCOUNT_ID", "trusted-account")
+	t.Setenv("KS_ACCESS_KEY", "trusted-access-key")
+
+	req := &utilsmetav1.PostScanRequest{
+		TargetType: apisv1.KindFramework,
+		Account:    "attacker-account",
+		AccessKey:  "attacker-access-key",
+	}
+	s, _ := ToScanInfo(req)
+
+	assert.Equal(t, "trusted-account", s.AccountID, "client-supplied Account must not override the server's configured identity")
+	assert.Equal(t, "trusted-access-key", s.AccessKey, "client-supplied AccessKey must not override the server's configured identity")
 }
 
 func TestToScanInfoExceptionsCleanup(t *testing.T) {

--- a/httphandler/handlerequests/v1/requestparser_test.go
+++ b/httphandler/handlerequests/v1/requestparser_test.go
@@ -43,7 +43,9 @@ func TestGetScanParamsFromRequest(t *testing.T) {
 		assert.True(t, req.scanQueryParams.ReturnResults)
 		assert.True(t, req.scanInfo.HostSensorEnabled.GetBool())
 		assert.True(t, req.scanInfo.Submit.GetBool())
-		assert.Equal(t, "aaaaaaaaaa", req.scanInfo.AccountID)
+		// A client-supplied Account must never override the server's own
+		// configured identity (see TestToScanInfo_IgnoresClientSuppliedIdentity).
+		assert.Empty(t, req.scanInfo.AccountID)
 	}
 
 	{
@@ -73,7 +75,9 @@ func TestGetScanParamsFromRequest(t *testing.T) {
 		assert.False(t, req.scanQueryParams.ReturnResults)
 		assert.False(t, req.scanInfo.HostSensorEnabled.GetBool())
 		assert.False(t, req.scanInfo.Submit.GetBool())
-		assert.Equal(t, "aaaaaaaaaa", req.scanInfo.AccountID)
+		// A client-supplied Account must never override the server's own
+		// configured identity (see TestToScanInfo_IgnoresClientSuppliedIdentity).
+		assert.Empty(t, req.scanInfo.AccountID)
 	}
 }
 


### PR DESCRIPTION
## Overview

`POST /v1/scan` has no authentication, and `ToScanInfo` let the request body override the server's own configured `AccountID`/`AccessKey`:

```go
if scanRequest.Account != "" {
    scanInfo.AccountID = scanRequest.Account
}
if scanRequest.AccessKey != "" {
    scanInfo.AccessKey = scanRequest.AccessKey
}
```

Those two fields are not inert. They flow into `GetTenantConfig` at `core/core/scan.go:70`, which builds the `tenantConfig` handed to `getReporter(...)` — the tenant the report is actually submitted to. Combined with `submit: true`, settable from the same unauthenticated body, **any network caller can redirect a full cluster posture report — RBAC misconfigurations, workload details — to a Kubescape Cloud account they control.**

`AccountID`/`AccessKey` now always come from the server's own trusted config (`KS_ACCOUNT_ID` / `KS_ACCESS_KEY`, or the credentials fetched at startup via `defaultScanInfo`), never from the request body.

### Scope of the change

- **`submit` is deliberately left client-settable.** On its own it can only publish to the server's *own* account, which is the operator's decision to expose. The dangerous half was controlling the *destination*, and that is what this closes.
- **Not a breaking change.** The fields are still accepted in the payload; they simply have no effect. The only in-tree caller, `ConfigScanInfo.GetRequestPayload` in `core/cautils/operatorscaninfo.go`, never set them, so the operator path is unaffected.
- This is the request-body half of the problem. It does not add authentication to the endpoint — that is #2640's scope, and the two are complementary.

## Additional Information

Server-side configuration is now the only way to set the identity, which surfaced a docs bug that would have left users stranded:

- `httphandler/README.md` documented **`KS_ACCOUNT`**, which is read nowhere in the codebase. The variable `defaultScanInfo` actually reads is **`KS_ACCOUNT_ID`**. Corrected, and documented `KS_ACCESS_KEY` alongside it — otherwise following the README leaves no working way to configure the account.
- The "Scan with Account Integration" example sent `account`/`accessKey` in the request body, i.e. taught exactly the pattern this PR removes. It now shows env-var configuration.

Note the swagger model for `PostScanRequest` comes from `kubescape/opa-utils`, so the field descriptions in `httphandler/docs/swagger.yaml` are generated from that external type and are not updated here. Happy to raise a follow-up there to mark the fields as ignored.

## How to Test

`TestToScanInfo_IgnoresClientSuppliedIdentity` is a regression test that pins the behaviour: it sets the server identity via env and asserts an attacker-supplied body cannot displace it.

Verified it genuinely covers the bug by reverting **only** the production file to `master` and re-running — the test fails exactly as it should:

```
--- FAIL: TestToScanInfo_IgnoresClientSuppliedIdentity
    expected: "trusted-access-key"
    actual  : "attacker-access-key"
    Messages: client-supplied AccessKey must not override the server's configured identity

--- FAIL: TestGetScanParamsFromRequest
    requestparser_test.go:48: Should be empty, but was aaaaaaaaaa
    requestparser_test.go:80: Should be empty, but was aaaaaaaaaa
```

With the fix in place the whole `httphandler` module is green:

```
ok  github.com/kubescape/kubescape/v3/httphandler
ok  github.com/kubescape/kubescape/v3/httphandler/config
ok  github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1
ok  github.com/kubescape/kubescape/v3/httphandler/listener
ok  github.com/kubescape/kubescape/v3/httphandler/storage
```

`go build ./...` and `go vet ./handlerequests/...` are clean.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Scan identity now comes exclusively from server-configured credentials.
  * Client-supplied account and access key values are ignored, while remaining accepted for backward compatibility.

* **Documentation**
  * Updated request examples and configuration guidance to reflect server-managed credentials.

* **Tests**
  * Added coverage confirming client-provided identity values cannot override trusted server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->