### PR TITLE
fix: guard `mergeMaps` against nil `new` parameter to prevent panic

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -521,8 +521,15 @@ func parseWorkloadScanRelatedObjectList(relatedObjects []workloadinterface.IMeta
 	return r
 }
 
-// mergeMaps merges new into existing, overwriting existing keys with new values
+// mergeMaps merges new into existing, overwriting existing keys with new values.
+// Both parameters are safe to pass as nil.
 func mergeMaps(existing, new map[string]string) map[string]string {
+	if new == nil {
+		if existing == nil {
+			return make(map[string]string)
+		}
+		return existing
+	}
 	if existing == nil {
 		existing = make(map[string]string)
 	}

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -674,6 +674,12 @@ func TestMergeMaps(t *testing.T) {
 			new:      nil,
 			expected: map[string]string{},
 		},
+		{
+			name:     "merge with nil new map preserves existing",
+			existing: map[string]string{"key1": "value1", "key2": "value2"},
+			new:      nil,
+			expected: map[string]string{"key1": "value1", "key2": "value2"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #3071 
### What this does

Adds a nil guard for the `new` parameter in the `mergeMaps` helper (`httphandler/storage/apiserver.go`).

The function already guards against a nil `existing` (dst) parameter, but does not guard against a nil `new` (src) parameter. While `maps.Copy(dst, nil)` is safe on Go >= 1.21 (ranging over nil is a no-op), adding the explicit guard:

- Makes the function's nil-safety contract **self-documenting** for both parameters
- Skips the unnecessary `maps.Copy` call when `new` is nil
- Ensures consistent defensive coding style
### Changes

**`httphandler/storage/apiserver.go`**
- Added early return in `mergeMaps` when `new` is nil - returns `existing` as-is, or a fresh empty map if both are nil
- Updated doc comment to note both parameters are safe to pass as nil
**`httphandler/storage/apiserver_test.go`**
- Added test case: nil `new` with a populated `existing` map
### Affected call sites

```
Line 204: result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
Line 205: result.Labels = mergeMaps(result.Labels, manifest.Labels)
Line 272: result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
Line 273: result.Labels = mergeMaps(result.Labels, manifest.Labels)
```