### PR TITLE
fix(scan): resolve markdown output paths with the .md extension

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -177,33 +177,14 @@ func resolvedOutputPath(format, outputFile string) string {
 	return trimmed
 }
 
+// fileExtForFormat returns the extension the format's printer appends to
+// --output. An unknown format falls back to the pretty extension because
+// NewPrinter falls back to the pretty printer for it.
 func fileExtForFormat(format string) string {
-	switch format {
-	case printer.JsonFormat:
-		return printer.JsonOutputExt
-	case printer.YamlFormat:
-		return printer.YamlOutputExt
-	case printer.JunitResultFormat:
-		return printer.JunitOutputExt
-	case printer.SARIFFormat:
-		return printer.SARIFOutputExt
-	case printer.GitLabSASTFormat:
-		return printer.JsonOutputExt
-	case printer.HtmlFormat:
-		return printer.HtmlOutputExt
-	case printer.PdfFormat:
-		return printer.PdfOutputExt
-	case printer.PrometheusFormat:
-		return printer.PrometheusOutputExt
-	case printer.CsvFormat:
-		return printer.CsvOutputExt
-	case printer.CycloneDXFormat:
-		return printer.CycloneDXOutputExt
-	case printer.SPDXFormat:
-		return printer.SPDXOutputExt
-	default:
-		return printer.PrettyOutputExt
+	if ext, ok := printer.FormatOutputExt[format]; ok {
+		return ext
 	}
+	return printer.PrettyOutputExt
 }
 
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -155,11 +155,31 @@ func TestResolvedOutputPath(t *testing.T) {
 		{"append CycloneDX", printer.CycloneDXFormat, "report.json", "report.json.cdx.json"},
 		{"preserve SPDX", printer.SPDXFormat, "report.spdx.json", "report.spdx.json"},
 		{"append SPDX", printer.SPDXFormat, "report.json", "report.json.spdx.json"},
+		{"append markdown", printer.MarkdownFormat, "report", "report.md"},
+		{"preserve markdown", printer.MarkdownFormat, "report.md", "report.md"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.want, resolvedOutputPath(test.format, test.outputFile))
+		})
+	}
+}
+
+// markdown writes report.md and pretty-printer writes report.txt, so sharing
+// an --output must not be rejected as a collision.
+func TestGetOutputPrintersAllowsMarkdownAlongsideTextFormats(t *testing.T) {
+	for _, format := range []string{printer.PrettyFormat, printer.PrometheusFormat} {
+		t.Run(format, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				ScanType: cautils.ScanTypeControl,
+				Format:   printer.MarkdownFormat + "," + format,
+				Output:   filepath.Join(t.TempDir(), "report"),
+			}
+
+			outputPrinters, err := GetOutputPrinters(scanInfo, context.Background(), "")
+			require.NoError(t, err)
+			assert.Len(t, outputPrinters, 2)
 		})
 	}
 }

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -57,6 +57,26 @@ const (
 	SPDXOutputExt       = ".spdx.json"
 )
 
+// FormatOutputExt maps a format to the extension its printer enforces in
+// SetWriter. Callers resolving an --output path must read it from here rather
+// than re-deriving it, so a format can never resolve to a path its printer
+// does not write. Every entry in AllFormats is covered.
+var FormatOutputExt = map[string]string{
+	PrettyFormat:      PrettyOutputExt,
+	JsonFormat:        JsonOutputExt,
+	JunitResultFormat: JunitOutputExt,
+	PrometheusFormat:  PrometheusOutputExt,
+	PdfFormat:         PdfOutputExt,
+	HtmlFormat:        HtmlOutputExt,
+	SARIFFormat:       SARIFOutputExt,
+	GitLabSASTFormat:  JsonOutputExt,
+	YamlFormat:        YamlOutputExt,
+	CsvFormat:         CsvOutputExt,
+	MarkdownFormat:    MarkdownOutputExt,
+	CycloneDXFormat:   CycloneDXOutputExt,
+	SPDXFormat:        SPDXOutputExt,
+}
+
 type IPrinter interface {
 	PrintNextSteps()
 	ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -176,3 +176,11 @@ func TestLogOutputFile(t *testing.T) {
 		assert.Empty(t, strings.TrimSpace(out), "expected no log for %s", sink)
 	}
 }
+
+func TestFormatOutputExtCoversAllFormats(t *testing.T) {
+	for _, format := range AllFormats {
+		ext, ok := FormatOutputExt[format]
+		assert.True(t, ok, "format %q has no entry in FormatOutputExt", format)
+		assert.NotEmpty(t, ext, "format %q maps to an empty extension", format)
+	}
+}


### PR DESCRIPTION
## Overview

`GetOutputPrinters` guards against two formats writing over each other by resolving the output path each printer will actually use and failing the scan when two of them land on the same file. The resolution goes through `fileExtForFormat`, which was a switch over the format constants.

`markdown` was never added to that switch. It fell into the default branch and resolved to `.txt`, the pretty printer extension, even though `MarkdownPrinter.SetWriter` appends `.md`. So the collision check compared a path the markdown printer never writes.

The result is a scan that refuses to run. Asking for `markdown,pretty-printer` with an output path of `report` reports a collision on `report.txt`, when the two printers were always going to write `report.md` and `report.txt`. Same thing for `markdown,prometheus`, since prometheus also uses `.txt`. There is no way to work around it other than running the scan twice.

## Change

The format to extension mapping now lives in `printer.FormatOutputExt`, next to the format constants and the extension constants it is built from, and `fileExtForFormat` reads from it.

The reason this went unnoticed is that a missing case was indistinguishable from a format that genuinely has no extension of its own: both quietly produced `.txt`. A map makes the absence observable, so `TestFormatOutputExtCoversAllFormats` can walk `AllFormats` and fail when a new format is added without an entry. That is the part that keeps this from happening again, since every format added since the collision check landed has had to remember to update the switch.

Unknown formats still resolve to the pretty extension. That is not a fallback for missing entries, it matches `NewPrinter`, which hands an unrecognised format to the pretty printer.

## Tests

* `TestGetOutputPrintersAllowsMarkdownAlongsideTextFormats` runs markdown against both pretty-printer and prometheus on a shared output path and asserts both printers are built. It fails on master with the collision error.
* `TestResolvedOutputPath` gains markdown cases for appending and preserving the extension.
* `TestFormatOutputExtCoversAllFormats` asserts every entry in `AllFormats` maps to a non empty extension.

`go build ./...`, `go vet ./core/...` and `go test ./core/core/... ./core/pkg/resultshandling/...` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved output-file extension handling across supported report formats.
  - Markdown output paths now correctly append or preserve the `.md` extension.
  - Prevented output-path collisions when combining Markdown with other report formats.

- **Tests**
  - Added coverage verifying extension handling for all supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->