### PR TITLE
fix: stringify error before json.Marshal in RecoverFunc to avoid empty bodyFix/recover func empty json

### DIFF
--- a/httphandler/listener/helpers.go
+++ b/httphandler/listener/helpers.go
@@ -12,9 +12,10 @@ import (
 // RecoverFunc recover function for http requests
 func RecoverFunc(w http.ResponseWriter) {
 	if err := recover(); err != nil {
-		logger.L().Error("", helpers.Error(fmt.Errorf("%v", err)))
+		errMsg := fmt.Sprintf("%v", err)
+		logger.L().Error("", helpers.Error(fmt.Errorf("%s", errMsg)))
 		w.WriteHeader(http.StatusInternalServerError)
-		bErr, _ := json.Marshal(err)
+		bErr, _ := json.Marshal(errMsg)
 		w.Write(bErr)
 	}
 }

--- a/httphandler/listener/helpers_test.go
+++ b/httphandler/listener/helpers_test.go
@@ -30,6 +30,7 @@ func TestRecoverFunc_WithStringPanic(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), "something went wrong")
 }
 
 func TestRecoverFunc_WithErrorPanic(t *testing.T) {
@@ -40,6 +41,8 @@ func TestRecoverFunc_WithErrorPanic(t *testing.T) {
 	}()
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), assert.AnError.Error())
 }
 
 func TestRecoverFunc_WithIntPanic(t *testing.T) {
@@ -50,4 +53,6 @@ func TestRecoverFunc_WithIntPanic(t *testing.T) {
 	}()
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), "42")
 }


### PR DESCRIPTION
Fixes #3074

## Problem

The `RecoverFunc` in `httphandler/listener/helpers.go` was passing the recovered error interface directly to `json.Marshal`. Since the error interface doesn't have exported fields, `json.Marshal` serialized it as an empty object `{}`, losing the panic message in the HTTP response.

## Fix

- Converted recovered error to a string using `fmt.Sprintf("%v", err)`
- Marshaled the string representation instead
- Updated tests to ensure the body is not empty on an error panic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error recovery responses so panic details are consistently returned as readable messages.
  - Ensured recovery handling works consistently for text, error, and numeric panic values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->