### PR TITLE
fix(gitlabsast): reject absolute paths filepath.IsAbs does not recognise

### DIFF
--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -406,12 +407,18 @@ func toGitLabVulnerability(ctl reportsummary.IControlSummary, resourceID, filePa
 	}
 }
 
-// isRepositoryRelative reports whether path is a repository-relative file path, i.e. not empty, absolute, or escaping the repository root via ".."
-func isRepositoryRelative(path string) bool {
-	if path == "" || filepath.IsAbs(path) {
+// isRepositoryRelative reports whether p is a repository-relative file path, i.e. not empty, absolute, or escaping the repository root via ".."
+func isRepositoryRelative(p string) bool {
+	// GitLab resolves these paths against a repository tree using POSIX
+	// semantics, so what counts as absolute must not depend on the host that
+	// produced the report. filepath.IsAbs alone is host-dependent: on Windows
+	// it reports false for "/etc/x", because it wants a drive letter or a UNC
+	// prefix, and such a path would then be emitted as if it were relative.
+	slashed := filepath.ToSlash(p)
+	if p == "" || filepath.IsAbs(p) || path.IsAbs(slashed) {
 		return false
 	}
-	cleaned := filepath.ToSlash(filepath.Clean(path))
+	cleaned := path.Clean(slashed)
 	return cleaned != ".." && !strings.HasPrefix(cleaned, "../")
 }
 


### PR DESCRIPTION
`isRepositoryRelative` guards the GitLab SAST printer against emitting findings that GitLab cannot anchor to a file in the repository. It rejects empty paths, absolute paths, and paths escaping the root via `..`.

The absolute check uses `filepath.IsAbs`, which follows the host's convention. On Windows that returns false for `/etc/manifests/deploy.yaml`, since it wants a drive letter or a UNC prefix. The path then falls through to the `..` check, which it passes, and the finding is emitted with a location GitLab has no way to resolve.

GitLab resolves these paths against a repository tree using POSIX semantics, so whether a path counts as absolute shouldn't depend on the machine that produced the report. The fix checks both conventions and cleans the slash form:

```go
slashed := filepath.ToSlash(p)
if p == "" || filepath.IsAbs(p) || path.IsAbs(slashed) {
	return false
}
cleaned := path.Clean(slashed)
```

On Linux this is a no-op: `filepath.IsAbs` already catches `/etc/...`, and for a slash-separated path `path.Clean` and `filepath.Clean` agree. The behaviour only changes on Windows.

Two existing tests already asserted the correct result and were failing on Windows — `TestIsRepositoryRelative` for the `/etc/manifests/deploy.yaml` case, and `TestGitLabSASTPrintConfigurationScan_SkipsUnanchorablePaths/absolute_path`. Both pass now, with no other change to the package and no new test needed.

The parameter is renamed `path` → `p` so it doesn't shadow the imported package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository-relative path validation for consistent behavior across operating systems.
  * Prevented absolute paths and directory traversal paths from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->