### PR TITLE
test(printer): close leaked file handles and skip POSIX mode check on Windows

### DIFF
--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -19,6 +20,11 @@ func captureLog(t *testing.T, fn func()) string {
 	t.Helper()
 	buf, err := os.CreateTemp(t.TempDir(), "log-*")
 	require.NoError(t, err)
+	// Registered before the writer restore so it runs after it (cleanups are
+	// LIFO), and after t.TempDir's own removal was registered so it runs
+	// before that. Windows refuses to delete a file that is still open, so
+	// leaving the handle around fails the test in TempDir cleanup.
+	t.Cleanup(func() { _ = buf.Close() })
 	prev := logger.L().GetWriter()
 	logger.L().SetWriter(buf)
 	t.Cleanup(func() { logger.L().SetWriter(prev) })
@@ -102,6 +108,13 @@ func TestGetWriter_ValidFileName(t *testing.T) {
 // this repo also ships Windows builds.
 func assertDirNotMorePermissiveThan0750(t *testing.T, dir string) {
 	t.Helper()
+	// Windows does not model POSIX permission bits at all: os.Stat reports
+	// 0777 for every directory, so the check below can only fail there, never
+	// catch anything. Return rather than t.Skip so the assertions the caller
+	// already made still count.
+	if runtime.GOOS == "windows" {
+		return
+	}
 	info, err := os.Stat(dir)
 	require.NoError(t, err)
 	mode := info.Mode().Perm()

--- a/core/pkg/resultshandling/printer/v2/pdf_test.go
+++ b/core/pkg/resultshandling/printer/v2/pdf_test.go
@@ -133,6 +133,11 @@ func TestSetWriter_Pdf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pp.SetWriter(ctx, tt.outputFile)
+			// Each call opens a new file and overwrites the previous writer,
+			// so every iteration leaks a handle. Windows will not remove the
+			// temp dir these land in while any of them is still open.
+			w := pp.writer
+			defer w.Close()
 			assert.Equal(t, tt.expected, pp.writer.Name())
 			assert.NotEqual(t, "/dev/stdout", pp.writer.Name(),
 				"PDF printer must never write to stdout")

--- a/core/pkg/resultshandling/printer/v2/prometheus_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus_test.go
@@ -43,6 +43,12 @@ func TestSetWriter(t *testing.T) {
 	base := filepath.Join(t.TempDir(), "test-prom")
 	promPrinter = &PrometheusPrinter{}
 	promPrinter.SetWriter(context.Background(), base)
+	// SetWriter leaves the report file open. Windows refuses to delete a file
+	// that still has an open handle, so t.TempDir's cleanup fails the test
+	// unless the writer is closed too. Captured in a local because promPrinter
+	// is reassigned below.
+	baseWriter := promPrinter.writer
+	defer baseWriter.Close()
 	expectedPath := base + printer.PrometheusOutputExt
 	f, err := os.Open(expectedPath)
 	assert.NoError(t, err)
@@ -52,6 +58,7 @@ func TestSetWriter(t *testing.T) {
 	withExt := filepath.Join(t.TempDir(), "test-prom"+printer.PrometheusOutputExt)
 	promPrinter = &PrometheusPrinter{}
 	promPrinter.SetWriter(context.Background(), withExt)
+	defer promPrinter.writer.Close()
 	f2, err := os.Open(withExt)
 	assert.NoError(t, err)
 	defer f2.Close()


### PR DESCRIPTION
Six tests across `core/pkg/resultshandling/printer` and `printer/v2` fail when the suite runs on Windows. Neither cause has anything to do with the code being tested, so the failures are noise for anyone developing there.

Three of them leak an open file handle. `captureLog` creates a temp file with `os.CreateTemp` and never closes it. `TestSetWriter_Pdf` calls `SetWriter` once per loop iteration, and each call opens a new file and overwrites the previous writer, so every iteration but the last leaks. `TestSetWriter` does the same thing across two printer instances. On Linux the handles are simply dropped, but Windows will not delete a file that is still open, so `t.TempDir`'s cleanup fails and takes the test with it:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...\log-2800909572:
The process cannot access the file because it is being used by another process.
```

In `captureLog` the close is registered before the logger-writer restore, so cleanup runs it after the restore (cleanups are LIFO) and before the temp dir removal that `t.TempDir` registered earlier.

The other cause is `assertDirNotMorePermissiveThan0750`, which guards against `GetWriter` creating a world-readable output directory. Windows has no POSIX permission bits, and `os.Stat` reports `0777` for every directory, so `mode&0o027` is never zero and the check can only fail there:

```
Error: Should be zero, but was -----w-rwx
```

It now returns early on Windows. I used a plain `return` rather than `t.Skip` so the assertions the calling test already made still count toward the result.

No production code changes, and behaviour on Linux is identical, so CI should be unaffected. Verified with `go test ./core/pkg/resultshandling/printer/...` on Windows: the `printer` package now passes fully.

Two other Windows failures in `printer/v2` are out of scope here. One is a real defect in `isRepositoryRelative`, which I've sent separately in #3076. The other is `TestJunitGoldenFile`, where the golden XML is checked out with CRLF while `encoding/xml` emits LF; that one is an environment question rather than a defect, and I'd rather hear a preference than guess at repo policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform test reliability, particularly on Windows.
  - Prevented temporary files and output writers from remaining open after tests.
  - Adjusted permission-related checks to run only where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->