### PR TITLE
fix(cautils): validate file-scan YAML manifests against the client-go scheme

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -947,6 +947,18 @@ func convertYamlToJson(i any) any {
 	return i
 }
 
+// removedButRealKinds are built-in Kubernetes kinds the bundled client-go scheme
+// no longer registers because the API itself was removed — not renamed, not
+// mistyped. A manifest still carrying one of these is legitimate historical
+// input (PodSecurityPolicy YAMLs are still common in older Helm charts), so it
+// must not be reported as a typo.
+var removedButRealKinds = map[schema.GroupKind]struct{}{
+	{Group: "policy", Kind: "PodSecurityPolicy"}:               {}, // removed in Kubernetes 1.25
+	{Group: "policy", Kind: "PodSecurityPolicyList"}:           {},
+	{Group: "auditregistration.k8s.io", Kind: "AuditSink"}:     {}, // removed in Kubernetes 1.19
+	{Group: "auditregistration.k8s.io", Kind: "AuditSinkList"}: {},
+}
+
 // validateManifestAgainstScheme checks a parsed YAML document against the
 // Kubernetes type scheme bundled with client-go. It is intentionally narrow:
 //
@@ -956,16 +968,38 @@ func convertYamlToJson(i any) any {
 //     custom resources (CRDs) and are ignored — a CRD is not a typo.
 //   - A kind that no version of a built-in group registers is reported:
 //     Kubernetes forbids CRDs in built-in groups, so such a kind is reliably
-//     a typo (e.g. apps/v1 kind Deplyment).
+//     a typo (e.g. apps/v1 kind Deplyment) — unless the kind is a known
+//     removal (see removedButRealKinds), which is left alone.
 //   - A known kind in an unknown version (e.g. a future apiVersion) is left
 //     alone, since kubescape deliberately scans resources newer than the
 //     bundled scheme.
 //   - A registered kind that fails to decode (for example a string where a
 //     number is expected) is reported as structurally invalid.
 //
-// The document is still loaded and scanned by the caller; this only surfaces
-// the missing diagnostic through the existing error path.
+// List envelopes are recursed into so a bad built-in resource nested inside a
+// List or typed list is surfaced too. The document is still loaded and scanned
+// by the caller; this only surfaces the missing diagnostic through the existing
+// error path.
 func validateManifestAgainstScheme(obj map[string]any) error {
+	var errs []error
+	if err := validateSingleManifest(obj); err != nil {
+		errs = append(errs, err)
+	}
+	if items, ok := obj["items"].([]any); ok {
+		for i, item := range items {
+			if itemObj, ok := item.(map[string]any); ok {
+				if err := validateManifestAgainstScheme(itemObj); err != nil {
+					errs = append(errs, fmt.Errorf("item %d: %w", i, err))
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// validateSingleManifest validates one document's own type metadata and
+// structure, without descending into a list envelope.
+func validateSingleManifest(obj map[string]any) error {
 	apiVersion, _ := obj["apiVersion"].(string)
 	kind, _ := obj["kind"].(string)
 	if apiVersion == "" || kind == "" {
@@ -983,6 +1017,10 @@ func validateManifestAgainstScheme(obj map[string]any) error {
 	}
 
 	if len(scheme.Scheme.VersionsForGroupKind(gvk.GroupKind())) == 0 {
+		if _, removed := removedButRealKinds[gvk.GroupKind()]; removed {
+			// A real kind dropped from the bundled scheme, not a typo.
+			return nil
+		}
 		// The group is built-in but no version of it registers this kind, so
 		// the kind itself is a typo rather than a future apiVersion.
 		return fmt.Errorf("%s %q is not a valid Kubernetes kind", apiVersion, kind)

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
@@ -713,6 +715,9 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err 
 			continue
 		}
 		if obj, ok := j.(map[string]any); ok {
+			if validationErr := validateManifestAgainstScheme(obj); validationErr != nil {
+				parseErrs = append(parseErrs, fmt.Errorf("document %d: %w", i+1, validationErr))
+			}
 			objects, objectErr := manifestObjectToWorkloads(obj)
 			yamlObjs = append(yamlObjs, objects...)
 			if objectErr != nil {
@@ -940,6 +945,64 @@ func convertYamlToJson(i any) any {
 		}
 	}
 	return i
+}
+
+// validateManifestAgainstScheme checks a parsed YAML document against the
+// Kubernetes type scheme bundled with client-go. It is intentionally narrow:
+//
+//   - Documents without an apiVersion (values.yaml, Chart.yaml, CI configs)
+//     are ignored, matching the existing non-manifest handling.
+//   - Documents whose group is not registered in the client-go scheme are
+//     custom resources (CRDs) and are ignored — a CRD is not a typo.
+//   - A kind that no version of a built-in group registers is reported:
+//     Kubernetes forbids CRDs in built-in groups, so such a kind is reliably
+//     a typo (e.g. apps/v1 kind Deplyment).
+//   - A known kind in an unknown version (e.g. a future apiVersion) is left
+//     alone, since kubescape deliberately scans resources newer than the
+//     bundled scheme.
+//   - A registered kind that fails to decode (for example a string where a
+//     number is expected) is reported as structurally invalid.
+//
+// The document is still loaded and scanned by the caller; this only surfaces
+// the missing diagnostic through the existing error path.
+func validateManifestAgainstScheme(obj map[string]any) error {
+	apiVersion, _ := obj["apiVersion"].(string)
+	kind, _ := obj["kind"].(string)
+	if apiVersion == "" || kind == "" {
+		// Not a Kubernetes manifest (or missing type metadata); nothing to
+		// validate against the scheme.
+		return nil
+	}
+
+	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+
+	if !scheme.Scheme.IsGroupRegistered(gvk.Group) {
+		// Unregistered group: a custom resource that is not part of the
+		// client-go scheme by design. Skip silently to avoid false positives.
+		return nil
+	}
+
+	if len(scheme.Scheme.VersionsForGroupKind(gvk.GroupKind())) == 0 {
+		// The group is built-in but no version of it registers this kind, so
+		// the kind itself is a typo rather than a future apiVersion.
+		return fmt.Errorf("%s %q is not a valid Kubernetes kind", apiVersion, kind)
+	}
+
+	if !scheme.Scheme.Recognizes(gvk) {
+		// A known kind in a version the bundled scheme does not register yet
+		// (e.g. autoscaling/v99): there is no concrete type to decode into, so
+		// structural validation is not possible. This is not a typo.
+		return nil
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to re-encode %s %q for validation: %w", apiVersion, kind, err)
+	}
+	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil); err != nil {
+		return fmt.Errorf("%s %q is structurally invalid: %w", apiVersion, kind, err)
+	}
+	return nil
 }
 
 func IsYaml(filePath string) bool {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -772,6 +772,107 @@ metadata:
 	}
 }
 
+func TestReadYamlFileValidatesAgainstScheme(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		wantCount     int
+		wantErrSubstr string
+	}{
+		{
+			name: "valid Pod is accepted",
+			content: `apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+  namespace: default`,
+			wantCount: 1,
+		},
+		{
+			name: "valid custom resource is ignored",
+			content: `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-cert
+spec:
+  secretName: tls-cert`,
+			wantCount: 1,
+		},
+		{
+			name: "wrong field type is surfaced",
+			content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment
+spec:
+  replicas: "not-a-number"`,
+			wantCount:     1,
+			wantErrSubstr: "structurally invalid",
+		},
+		{
+			name: "typo'd kind in a built-in group is surfaced",
+			content: `apiVersion: apps/v1
+kind: Deplyment
+metadata:
+  name: typo-deployment`,
+			wantCount:     1,
+			wantErrSubstr: "is not a valid Kubernetes kind",
+		},
+		{
+			name: "typo'd kind in the core group is surfaced",
+			content: `apiVersion: v1
+kind: Pods
+metadata:
+  name: typo-pod`,
+			wantCount:     1,
+			wantErrSubstr: "is not a valid Kubernetes kind",
+		},
+		{
+			name: "known kind in a future apiVersion is ignored",
+			content: `apiVersion: autoscaling/v99
+kind: HorizontalPodAutoscaler
+metadata:
+  name: future-hpa
+  namespace: default`,
+			wantCount: 1,
+		},
+		{
+			name: "non-manifest YAML without apiVersion is ignored",
+			content: `foo: bar
+baz: qux`,
+			wantCount: 0,
+		},
+		{
+			name: "multi-document manifest keeps valid docs and surfaces invalid ones",
+			content: `apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deplyment
+metadata:
+  name: typo-deployment`,
+			wantCount:     2,
+			wantErrSubstr: "is not a valid Kubernetes kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readYamlFile([]byte(tt.content))
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, len(got))
+		})
+	}
+}
+
 func TestReadJsonFile(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -837,6 +837,50 @@ metadata:
 			wantCount: 1,
 		},
 		{
+			name: "removed-but-real kind is not flagged as a typo",
+			content: `apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: legacy-psp
+spec:
+  privileged: false`,
+			wantCount: 1,
+		},
+		{
+			name: "invalid built-in kind inside a List is surfaced",
+			content: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: good-pod
+      namespace: default
+  - apiVersion: apps/v1
+    kind: Deplyment
+    metadata:
+      name: typo-deployment`,
+			wantCount:     2,
+			wantErrSubstr: "is not a valid Kubernetes kind",
+		},
+		{
+			name: "valid List is accepted without errors",
+			content: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: good-pod
+      namespace: default
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: good-svc
+      namespace: default`,
+			wantCount: 2,
+		},
+		{
 			name: "non-manifest YAML without apiVersion is ignored",
 			content: `foo: bar
 baz: qux`,


### PR DESCRIPTION
Fixes #3061.

Hey! Ran into a gap in the file-scan pipeline and figured I'd close it out. Right now `readYamlFile` only checks that YAML is *syntactically* valid - it never confirms that a document carrying Kubernetes type metadata actually lines up with a real registered type. So if someone hands us a `Deplyoment` with `spec.replicas: "abc"` (a string where a number should be), we happily load it as an unstructured object and scan it like nothing's wrong. We produce a posture result for a manifest a real cluster would reject, and never tell anyone why.

The fix is pretty simple: run each document through the `client-go` universal deserializer we already pull in, and surface problems through the existing `parseErrs` path. Zero new dependencies. The only tricky part was making sure we *don't* fire off false positives, so the classification is:

- No `apiVersion`? (`values.yaml`, `Chart.yaml`, CI configs) - ignore it, not a manifest.
- Unregistered group? (a CRD like `cert-manager.io/v1`) - ignore it, a CRD isn't a typo.
- Registered group but no version of it knows the kind (`apps/v1, kind: Deplyoment`, `v1, kind: Pods`) - that's a real typo, flag it as "not a valid Kubernetes kind". Built-in groups can't hold CRDs, so this is about as close to a guaranteed typo as we can get.
- Known kind but a version we don't have yet (`autoscaling/v99`) - leave it alone. We deliberately scan resources newer than the bundled scheme, and `TestFileResourceHandlerBuildsWildcardMatchesFromManifestCatalog` relies on that.
- Registered kind that fails to decode (string vs int32) - flag it as "structurally invalid".

The document still loads and gets scanned as before; this just adds the missing diagnostic rather than changing what's scanned. I used `Scheme.VersionsForGroupKind` to tell "typo'd kind" apart from "future version" instead of trying to regex decoder error strings, which felt fragile.

Verified with `go test ./core/cautils/` (719 pass, including a new `TestReadYamlFileValidatesAgainstScheme` covering valid Pod, valid CRD, wrong field type, both typo'd-kind cases, future apiVersion, non-manifest YAML, and a multi-doc manifest), plus `go test ./core/pkg/resourcehandler/ -run TestFileResourceHandlerBuildsWildcardMatchesFromManifestCatalog` to confirm the future-version fixture stays green. Ran `go test ./core/...` too - 3511 pass, with one pre-existing failure (`TestExcludeFilesUnderDirectories`) that's also failing on `master` without this change, so unrelated. `go vet` and `gofmt` are both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes YAML validation during manifest loading.
  * Invalid built-in resource kinds, unsupported structures, invalid field types, and decoding errors are now reported clearly.
  * Validation also applies to resources nested in lists.
  * Valid documents continue loading when other documents in the same YAML file are invalid.
  * Custom resources, non-manifest documents, recognized future API versions, and supported legacy kinds remain accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->