### PR TITLE
fix(opaprocessor): evaluate whole-cluster controls once after per-namespace batching

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -35,6 +35,24 @@ import (
 
 const ScoreConfigPath = "/resources/config"
 
+// ControlAttributeRequiresWholeClusterInput marks a control whose rules join
+// objects that live in different namespaces. Such a control must be evaluated
+// once against the whole cluster — after per-namespace evaluation has merged
+// every batch — rather than once per namespace, or the join silently
+// disappears and the control passes resources it should flag. The value is a
+// boolean (or the string "true").
+const ControlAttributeRequiresWholeClusterInput = "requiresWholeClusterInput"
+
+// wholeClusterControlIDsFallback lists the shipped controls known to require
+// whole-cluster input until the regolibrary ships the
+// requiresWholeClusterInput attribute on them. Keep it in sync with the
+// regolibrary: remove an ID once its control carries the attribute.
+var wholeClusterControlIDsFallback = map[string]struct{}{
+	"C-0266": {}, // Exposure to internet via Gateway API or Istio Ingress (Gateway/Service/VirtualService across namespaces)
+	"C-0267": {}, // Workload with cluster takeover roles (RoleBinding -> ServiceAccount in another namespace)
+	"C-0272": {}, // Workload with administrative roles (RoleBinding -> ServiceAccount in another namespace)
+}
+
 type IJobProgressNotificationClient interface {
 	Start(allSteps int)
 	ProgressJob(step int, message string)
@@ -235,10 +253,11 @@ func (opap *OPAProcessor) ProcessWithStreaming(ctx context.Context, batchChan <-
 	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.ExcludedRules, cautils.GetScanningScope(opap.Metadata.ContextMetadata))
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 
-	controlIDs := sortedControlIDs(opap.AllPolicies)
+	scopeControlIDs, wholeClusterControlIDs := splitWholeClusterControls(opap.AllPolicies, sortedControlIDs(opap.AllPolicies))
 
-	// Calculate total progress steps: controls × (resident scope + namespace scopes)
-	totalSteps := len(controlIDs) * (1 + expectedNamespaceBatches)
+	// Calculate total progress steps: per-scope controls × (resident scope +
+	// namespace scopes), plus one whole-cluster pass per deferred control.
+	totalSteps := len(scopeControlIDs)*(1+expectedNamespaceBatches) + len(wholeClusterControlIDs)
 	if progressListener != nil {
 		progressListener.Start(totalSteps)
 		defer progressListener.Stop()
@@ -310,7 +329,7 @@ haveResident:
 
 	// Process resident batch first
 	residentScope := newEvaluationScope(residentBatch.Scope, nil, residentGroups)
-	if err := opap.processScope(ctx, opap.AllPolicies, controlIDs, residentScope, progressListener); err != nil {
+	if err := opap.processScope(ctx, opap.AllPolicies, scopeControlIDs, residentScope, progressListener); err != nil {
 		return err
 	}
 
@@ -332,7 +351,7 @@ haveResident:
 
 			// Process this namespace batch
 			namespaceScope := newEvaluationScope(batch.Scope, batch, residentGroups)
-			if err := opap.processScope(ctx, opap.AllPolicies, controlIDs, namespaceScope, progressListener); err != nil {
+			if err := opap.processScope(ctx, opap.AllPolicies, scopeControlIDs, namespaceScope, progressListener); err != nil {
 				return err
 			}
 
@@ -365,6 +384,19 @@ done:
 			return err
 		}
 	default:
+	}
+
+	// Every namespace batch has been merged into the session resource maps, so
+	// the whole-cluster controls can now be evaluated once against the full
+	// input. Doing this after the merge (rather than per namespace) keeps their
+	// cross-namespace joins intact.
+	if len(wholeClusterControlIDs) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := opap.processScope(ctx, opap.AllPolicies, wholeClusterControlIDs, opap.wholeClusterScope(), progressListener); err != nil {
+			return err
+		}
 	}
 
 	// Rebuild scan coverage
@@ -463,10 +495,10 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 	defer opap.loggerDoneScanning()
 
 	scopes := opap.evaluationScopes()
-	controlIDs := sortedControlIDs(policies)
+	scopeControlIDs, wholeClusterControlIDs := splitWholeClusterControls(policies, sortedControlIDs(policies))
 
 	if progressListener != nil {
-		progressListener.Start(len(controlIDs) * len(scopes))
+		progressListener.Start(len(scopeControlIDs)*len(scopes) + len(wholeClusterControlIDs))
 		defer progressListener.Stop()
 	}
 
@@ -478,7 +510,18 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 			processErrs = append(processErrs, err)
 			break
 		}
-		if err := opap.processScope(ctx, policies, controlIDs, scope, progressListener); err != nil {
+		if err := opap.processScope(ctx, policies, scopeControlIDs, scope, progressListener); err != nil {
+			processErrs = append(processErrs, err)
+		}
+	}
+
+	// Whole-cluster controls are evaluated once against the full input, after
+	// the per-scope pass, so a cross-namespace join is never lost to
+	// partitioning.
+	if len(wholeClusterControlIDs) > 0 {
+		if err := ctx.Err(); err != nil {
+			processErrs = append(processErrs, err)
+		} else if err := opap.processScope(ctx, policies, wholeClusterControlIDs, opap.wholeClusterScope(), progressListener); err != nil {
 			processErrs = append(processErrs, err)
 		}
 	}
@@ -575,6 +618,23 @@ func (opap *OPAProcessor) evaluationScopes() []evaluationScope {
 	return scopes
 }
 
+// wholeClusterScope returns a scope whose input is every resource the scan
+// collected, independent of namespace. It is the scope used to evaluate
+// whole-cluster controls once, after per-namespace evaluation has merged every
+// batch, reproducing the single-input behaviour of clusters below the
+// large-cluster threshold. Indexing everything as the resident batch means
+// matchedObjects returns all matching objects, mirroring the small-cluster
+// eager path exactly.
+func (opap *OPAProcessor) wholeClusterScope() evaluationScope {
+	batch := &cautils.ResourceBatch{
+		Scope:             cautils.ClusterScope,
+		K8SResources:      opap.K8SResources,
+		ExternalResources: opap.ExternalResources,
+		AllResources:      opap.AllResources,
+	}
+	return newEvaluationScope(cautils.ClusterScope, nil, newResidentIndex(batch))
+}
+
 type policyControl struct {
 	key     string
 	control reporthandling.Control
@@ -618,6 +678,40 @@ func policyControlSortKey(item policyControl) string {
 		return item.control.ControlID
 	}
 	return item.key
+}
+
+// controlRequiresWholeClusterInput reports whether a control joins objects
+// across namespaces and therefore must see the whole cluster as one input.
+func controlRequiresWholeClusterInput(control *reporthandling.Control) bool {
+	if control == nil {
+		return false
+	}
+	if flag, ok := control.Attributes[ControlAttributeRequiresWholeClusterInput]; ok {
+		switch v := flag.(type) {
+		case bool:
+			return v
+		case string:
+			return strings.EqualFold(v, "true")
+		}
+	}
+	_, ok := wholeClusterControlIDsFallback[control.ControlID]
+	return ok
+}
+
+// splitWholeClusterControls partitions controlIDs into the controls evaluated
+// once per scope and the controls deferred to a single whole-cluster pass. The
+// order within each returned slice follows the input order, so the evaluation
+// order remains deterministic.
+func splitWholeClusterControls(policies *cautils.Policies, controlIDs []string) (scopeControlIDs, wholeClusterControlIDs []string) {
+	for _, id := range controlIDs {
+		control, ok := policies.Controls[id]
+		if ok && controlRequiresWholeClusterInput(&control) {
+			wholeClusterControlIDs = append(wholeClusterControlIDs, id)
+			continue
+		}
+		scopeControlIDs = append(scopeControlIDs, id)
+	}
+	return scopeControlIDs, wholeClusterControlIDs
 }
 
 func (opap *OPAProcessor) loggerStartScanning() {

--- a/core/pkg/opaprocessor/processorhandler_parity_test.go
+++ b/core/pkg/opaprocessor/processorhandler_parity_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/opa-utils/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -425,4 +426,130 @@ func slicesOfKeys(results map[string]resourcesresults.Result) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// wholeClusterAggregatingControl is the aggregating control fixture marked
+// requiresWholeClusterInput, so it must be evaluated once against the whole
+// cluster regardless of how the scan is partitioned.
+func wholeClusterAggregatingControl() reporthandling.Control {
+	control := reporthandling.Control{
+		ControlID: "C-AGGREGATE",
+		Rules: []reporthandling.PolicyRule{
+			{
+				Rule:         aggregatingRule,
+				RuleLanguage: reporthandling.RegoLanguage,
+				Match: []reporthandling.RuleMatchObjects{
+					{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}},
+				},
+			},
+		},
+	}
+	control.Name = "aggregating control"
+	control.Rules[0].Name = "aggregating-rule"
+	control.Attributes = map[string]interface{}{
+		ControlAttributeRequiresWholeClusterInput: true,
+	}
+	return control
+}
+
+func wholeClusterAggregatingPolicies() (*cautils.Policies, []reporthandling.Framework) {
+	frameworks := []reporthandling.Framework{{Controls: []reporthandling.Control{wholeClusterAggregatingControl()}}}
+	return convertFrameworksToPolicies(frameworks, nil, reporthandling.ScopeCluster), frameworks
+}
+
+// TestWholeClusterControlParityAcrossPaths pins the fix for #2871: a control
+// that joins objects across namespaces must reach the same verdict whether the
+// cluster is evaluated as a single input, partitioned per namespace (eager), or
+// streamed namespace by namespace. The aggregating rule only fires when more
+// than one Pod is in the input, so it silently passes under per-namespace
+// evaluation unless the control is deferred to a whole-cluster pass.
+func TestWholeClusterControlParityAcrossPaths(t *testing.T) {
+	policies, frameworks := wholeClusterAggregatingPolicies()
+	const podID = "/v1/ns-a/Pod/clean"
+
+	t.Run("single scope", func(t *testing.T) {
+		t.Setenv("LARGE_CLUSTER_SIZE", "100000")
+		opap := newParityProcessor(policies)
+		require.NoError(t, opap.Process(context.Background(), policies, nil))
+		require.Contains(t, opap.ResourcesResult, podID)
+		singleResult := opap.ResourcesResult[podID]
+		require.True(t, singleResult.GetStatus(nil).IsFailed(),
+			"single input holds every namespace's pods, so the rule fires")
+	})
+
+	t.Run("partitioned eager", func(t *testing.T) {
+		t.Setenv("LARGE_CLUSTER_SIZE", "1")
+		opap := newParityProcessor(policies)
+		require.Greater(t, len(opap.evaluationScopes()), 1, "fixture must be split into scopes")
+		require.NoError(t, opap.Process(context.Background(), policies, nil))
+		require.Contains(t, opap.ResourcesResult, podID)
+		partitionedResult := opap.ResourcesResult[podID]
+		require.True(t, partitionedResult.GetStatus(nil).IsFailed(),
+			"whole-cluster control must be evaluated once after the scopes merge")
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		t.Setenv("LARGE_CLUSTER_SIZE", "1")
+
+		k8sResources, allResources := parityFixture()
+		sessionObj := cautils.NewOPASessionObjMock()
+		sessionObj.Policies = frameworks
+		sessionObj.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+
+		opap := NewOPAProcessor(sessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+
+		resident, batches := cautils.PartitionResources(len(allResources), k8sResources, nil, allResources)
+		require.NotEmpty(t, batches, "fixture must be split into namespace batches")
+
+		batchChan := make(chan *cautils.ResourceBatch, len(batches)+1)
+		errChan := make(chan error, 1)
+		close(errChan)
+		batchChan <- resident
+		for _, batch := range batches {
+			batchChan <- batch
+		}
+		close(batchChan)
+
+		require.NoError(t, opap.ProcessWithStreaming(context.Background(), batchChan, errChan, cautils.NewProgressHandler(""), len(batches)))
+		require.Contains(t, opap.ResourcesResult, podID)
+		streamingResult := opap.ResourcesResult[podID]
+		require.True(t, streamingResult.GetStatus(nil).IsFailed(),
+			"whole-cluster control must be evaluated once after streaming merges every batch")
+	})
+}
+
+func TestControlRequiresWholeClusterInput(t *testing.T) {
+	withAttr := func(controlID string, value any) *reporthandling.Control {
+		c := &reporthandling.Control{ControlID: controlID}
+		c.Attributes = map[string]interface{}{ControlAttributeRequiresWholeClusterInput: value}
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		control *reporthandling.Control
+		want    bool
+	}{
+		{name: "nil control", control: nil, want: false},
+		{
+			name:    "no attribute, no fallback",
+			control: &reporthandling.Control{ControlID: "C-0001"},
+			want:    false,
+		},
+		{name: "boolean attribute true", control: withAttr("C-X", true), want: true},
+		{name: "boolean attribute false", control: withAttr("C-X", false), want: false},
+		{name: "string attribute true", control: withAttr("C-X", "true"), want: true},
+		{name: "string attribute false", control: withAttr("C-X", "false"), want: false},
+		{
+			name:    "fallback control ID",
+			control: &reporthandling.Control{ControlID: "C-0267"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, controlRequiresWholeClusterInput(tt.control))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #2871.

So this one's been bugging me — on a cluster big enough to trip the streaming threshold (or `--enable-streaming`), some controls just... quietly pass. Not because the workload is fine, but because the join they depend on never exists in any single input.

Here's the concrete failure. C-0267 and C-0272 check whether a RoleBinding grants a ServiceAccount some dangerous role. In the real cluster the RoleBinding lives in one namespace and the ServiceAccount in another, and the ClusterRole is cluster-scoped. The whole-cluster input has all three, so the rule fires. But per-namespace evaluation builds each scope's input as just "that namespace's stuff + the resident cluster-scoped batch". So the namespace holding the ServiceAccount never sees the RoleBinding, the namespace holding the RoleBinding never sees the ServiceAccount, and the rule emits no deny in either place. Then normal pass-inference marks the workload green. Same story for C-0266 (the Istio ingress rule, where the VirtualService, Gateway, and public Service all live in different namespaces).

The eager path has the same bug once the large-cluster threshold is crossed, because `PartitionResources` splits namespaces there too. `TestProcess_PartitioningChangesCrossNamespaceAggregation` already pinned the divergence as a "known limitation", so this is really about removing that asterisk.

The fix adds a `requiresWholeClusterInput` control attribute. Controls carrying it get pulled out of the per-scope loop and evaluated exactly once, after every batch has been merged, against an input that holds every collected resource — identical to what a sub-threshold cluster already sees. The key design points:

- Both `Process` and `ProcessWithStreaming` go through the same `splitWholeClusterControls` + `wholeClusterScope` helpers, so eager and streaming stay in lockstep.
- Namespace-local controls are untouched — they still get the bounded, per-namespace evaluation, so streaming's memory benefit is preserved. Only the small marked subset pays for the full input.
- If a scan has no whole-cluster controls, the code path is a no-op (the whole-cluster block is gated on `len(...) > 0`), so there's no overhead for the common case.

One thing to be upfront about: the regolibrary doesn't ship this attribute yet, so I added a small fallback registry for the three controls known to need it (C-0266, C-0267, C-0272), with a comment to drop each entry once the corresponding control carries the attribute. That keeps the fix live today while the metadata lands in the library. Happy to drop the fallback entirely if you'd rather the attribute be the only source.

Verified with a new `TestWholeClusterControlParityAcrossPaths` that drives an aggregating rule (fires only when more than one pod is in the input) through single-scope, partitioned-eager, and streaming, asserting all three report the same failed workload. Also a unit test for the attribute/fallback detection. `go test ./core/pkg/opaprocessor/` is 185 passed, clean under `-race`, and the full `./core/...` run is 3514 passed with one pre-existing failure (`TestExcludeFilesUnderDirectories`, unrelated, also fails on master).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controls that require whole-cluster data, enabling evaluation across namespaces and scopes.
  * Cluster-wide controls are evaluated after relevant resources are combined for a complete assessment.
  * Added consistent support for both streaming and non-streaming evaluations.

* **Bug Fixes**
  * Improved progress tracking, scope handling, and error reporting when cluster-wide controls are evaluated.
  * Ensured consistent aggregation results across single-scope, partitioned, and streaming evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->