### PR TITLE
fix(cel): honor failurePolicy Fail for validation eval errors

### DIFF
--- a/core/pkg/opaprocessor/cel/budget_test.go
+++ b/core/pkg/opaprocessor/cel/budget_test.go
@@ -292,6 +292,62 @@ func TestCancelledContextInterruptsAComprehension(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+// TestCancelledContextIsNotAnExpressionError is the regression for the
+// failurePolicy fix: a cancellation that fires while a validation expression is
+// evaluating must NOT be classified as an expressionError, or failurePolicy Fail
+// would turn a cancelled scan into a false deny. ContextEval only notices a
+// cancelled context every CheckFrequency steps INSIDE a comprehension, so
+// pre-cancelling still exercises the mid-evaluation interrupt path (the same one
+// a Ctrl+C during a long comprehension hits), while calling evalExpression
+// directly bypasses the between-validations ctx.Err() guard that would mask the
+// bug.
+func TestCancelledContextIsNotAnExpressionError(t *testing.T) {
+	items := make([]any, 0, 5*celconfig.CheckFrequency)
+	for i := 0; i < 5*celconfig.CheckFrequency; i++ {
+		items = append(items, map[string]any{"name": "c", "image": "nginx"})
+	}
+	obj := map[string]any{"kind": "Pod", "spec": map[string]any{"containers": items}}
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = e.evalExpression(ctx, "object.spec.containers.all(c, c.image == 'nginx')",
+		e.activationFor(ctx, obj, nil, nil, nil, nil), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, IsExpressionError(err),
+		"a cancelled scan must stay skipped, never become a deny")
+}
+
+// TestCancelledVariableIsNotAnExpressionError covers the same classification on
+// the lazy-variable path: a variable whose evaluation is cut short by a
+// cancellation surfaces as an error to the validation that references it, and
+// that error must still read as a cancellation (not an expressionError) so it is
+// skipped rather than denied.
+func TestCancelledVariableIsNotAnExpressionError(t *testing.T) {
+	items := make([]any, 0, 5*celconfig.CheckFrequency)
+	for i := 0; i < 5*celconfig.CheckFrequency; i++ {
+		items = append(items, map[string]any{"name": "c", "image": "nginx"})
+	}
+	obj := map[string]any{"kind": "Pod", "spec": map[string]any{"containers": items}}
+	variables := []Variable{{Name: "all", Expression: "object.spec.containers.all(c, c.image == 'nginx')"}}
+	validations := []Validation{{Expression: "variables.all == true"}}
+
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := e.evaluateValidation(ctx, validations[0], e.activationFor(ctx, obj, nil, nil, variables, nil), nil)
+	require.Error(t, res.Err)
+	assert.False(t, IsExpressionError(res.Err),
+		"a cancelled variable evaluation must not become a deny")
+}
+
 func TestCancelledContextStopsTheRemainingValidations(t *testing.T) {
 	// InterruptCheckFrequency only makes the runtime check every N steps INSIDE
 	// one evaluation, so an ordinary policy of cheap expressions would run every

--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -10,6 +10,11 @@ type ControlEvaluation struct {
 	Applicable bool
 	// Results holds one entry per validation, in order, when Applicable.
 	Results []ValidationResult
+	// FailOnError reports whether the policy's failurePolicy is Fail (the
+	// default, and the only value the embedded bundle uses). When true, a
+	// validation whose expression errored denies the object at admission, and
+	// the scanner reports it as failed rather than skipped.
+	FailOnError bool
 }
 
 // EvaluateControl loads the ValidatingAdmissionPolicy for a control from the
@@ -46,5 +51,5 @@ func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, 
 	if err != nil {
 		return ControlEvaluation{}, err
 	}
-	return ControlEvaluation{Applicable: true, Results: results}, nil
+	return ControlEvaluation{Applicable: true, Results: results, FailOnError: vap.failOnError()}, nil
 }

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -48,6 +49,25 @@ type ValidationResult struct {
 	// passing or unknown verdict has nothing to remediate. Empty is normal: an
 	// expression we cannot read a path out of reports none rather than guess.
 	Paths []PathHint
+}
+
+// expressionError wraps a validation error the CEL expression itself produced
+// while running — a runtime evaluation error or a non-bool result — as opposed
+// to an offline-only failure such as a compile error, an exhausted cost budget,
+// or a cancelled scan. Only the former is a verdict the apiserver can reach, so
+// only it is governed by the policy's failurePolicy.
+type expressionError struct{ err error }
+
+func (e *expressionError) Error() string { return e.err.Error() }
+func (e *expressionError) Unwrap() error { return e.err }
+
+// IsExpressionError reports whether a validation's error was produced by the
+// expression itself. Compile errors, budget exhaustion and cancellation return
+// false; the scanner leaves those as unknown/skipped verdicts rather than
+// letting failurePolicy turn them into a deny.
+func IsExpressionError(err error) bool {
+	var ee *expressionError
+	return errors.As(err, &ee)
 }
 
 // Evaluator runs a VAP's variables and validations against scanned objects. The
@@ -298,7 +318,7 @@ func (e *Evaluator) evaluateValidation(ctx context.Context, val Validation, acti
 
 	passed, ok := out.Value().(bool)
 	if !ok {
-		res.Err = fmt.Errorf("validation expression must return bool, got %T", out.Value())
+		res.Err = &expressionError{fmt.Errorf("validation expression must return bool, got %T", out.Value())}
 		return res
 	}
 
@@ -389,7 +409,7 @@ func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation 
 		return nil, err
 	}
 	if evalErr != nil {
-		return nil, evalErr
+		return nil, &expressionError{evalErr}
 	}
 	return out, nil
 }

--- a/core/pkg/opaprocessor/cel/evaluator.go
+++ b/core/pkg/opaprocessor/cel/evaluator.go
@@ -70,6 +70,23 @@ func IsExpressionError(err error) bool {
 	return errors.As(err, &ee)
 }
 
+// isContextError reports whether a validation's evaluation error came from a
+// cancelled or expired context rather than from the expression itself. The
+// apiserver never reaches a verdict on a request it did not finish evaluating,
+// so a context error must stay an unknown/skipped verdict, never an
+// expressionError that failurePolicy could turn into a deny.
+//
+// ContextEval reports an interrupt as an error wrapping context.Cause(ctx)
+// (context.Canceled or context.DeadlineExceeded), so errors.Is catches the
+// case where the interrupt fired mid-expression. ctx.Err() covers the same
+// cancellation once it has landed, including an error a lazy variable surfaced
+// whose original cause was flattened into a CEL error value on the way out.
+func isContextError(ctx context.Context, err error) bool {
+	return ctx.Err() != nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
 // Evaluator runs a VAP's variables and validations against scanned objects. The
 // CEL env is built once and reused for every object, since compiling the env is
 // far more expensive than evaluating against it.
@@ -296,6 +313,9 @@ func (e *Evaluator) lazyVariables(ctx context.Context, variables []Variable, act
 				return types.NewErr("variable %q: %v", v.Name, reportErr)
 			}
 			if evalErr != nil {
+				if isContextError(ctx, evalErr) {
+					return types.WrapErr(fmt.Errorf("variable %q: %w", v.Name, evalErr))
+				}
 				return types.NewErr("variable %q: %v", v.Name, evalErr)
 			}
 			return out
@@ -409,6 +429,9 @@ func (e *Evaluator) evalExpression(ctx context.Context, expr string, activation 
 		return nil, err
 	}
 	if evalErr != nil {
+		if isContextError(ctx, evalErr) {
+			return nil, evalErr
+		}
 		return nil, &expressionError{evalErr}
 	}
 	return out, nil

--- a/core/pkg/opaprocessor/cel/evaluator_test.go
+++ b/core/pkg/opaprocessor/cel/evaluator_test.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -227,6 +228,44 @@ func TestEvaluateOnObjectValidationEvalErrorSetsErr(t *testing.T) {
 
 	assert.Error(t, results[0].Err)
 	assert.False(t, results[0].Passed)
+}
+
+// TestIsExpressionError pins the classification behind failurePolicy: an error
+// the expression itself produced is governed by failurePolicy, while an
+// offline-only failure (compile error, budget, cancellation) is not.
+func TestIsExpressionError(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	t.Run("runtime eval error", func(t *testing.T) {
+		results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil,
+			[]Validation{{Expression: "object.spec.thisKeyDoesNotExist.value == 1"}})
+		require.NoError(t, err)
+		require.Error(t, results[0].Err)
+		assert.True(t, IsExpressionError(results[0].Err))
+	})
+
+	t.Run("non-bool result", func(t *testing.T) {
+		results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil,
+			[]Validation{{Expression: "object.metadata.name"}})
+		require.NoError(t, err)
+		require.Error(t, results[0].Err)
+		assert.True(t, IsExpressionError(results[0].Err))
+	})
+
+	t.Run("compile error", func(t *testing.T) {
+		results, err := e.EvaluateOnObject(context.Background(), hostNetworkPod(), nil, nil, nil,
+			[]Validation{{Expression: "this is not valid cel {{{"}})
+		require.NoError(t, err)
+		require.Error(t, results[0].Err)
+		assert.False(t, IsExpressionError(results[0].Err),
+			"a compile error is an offline-only failure, never a verdict")
+	})
+
+	t.Run("plain error", func(t *testing.T) {
+		assert.False(t, IsExpressionError(errors.New("something else")))
+		assert.False(t, IsExpressionError(nil))
+	})
 }
 
 // TestEvaluateOnObjectUnreferencedBrokenVariableIsIgnored is a parity guard:

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -68,6 +68,18 @@ type VAP struct {
 	// non-matching kind, which the scan would otherwise record as a pass live
 	// admission never made (the object would not be matched at all).
 	matchConstraints *admissionregistrationv1.MatchResources
+
+	// failurePolicy mirrors spec.failurePolicy: how an evaluation error is
+	// treated. The apiserver defaults an omitted policy to Fail, so newVAP
+	// stores the resolved value (Fail when nil) rather than the raw pointer.
+	failurePolicy admissionregistrationv1.FailurePolicyType
+}
+
+// failOnError reports whether an evaluation error denies the request. Only an
+// explicit failurePolicy: Ignore changes that; every policy in the embedded
+// bundle defaults to Fail.
+func (v *VAP) failOnError() bool {
+	return v.failurePolicy != admissionregistrationv1.Ignore
 }
 
 // requireSupported reports whether the offline engine can honor this policy with
@@ -263,15 +275,22 @@ func indexUnique(index map[string]*VAP, duplicates map[string]struct{}, key stri
 // spec.matchConstraints is kept so the scan can scope evaluation to the kinds
 // the policy actually applies to (see appliesTo); without it a non-matching
 // object slips through the validations' self-guards as a pass. spec.failurePolicy
-// is still dropped: eval errors are always mapped to an errored/skipped status
-// regardless of failurePolicy, which is the parity-safe direction.
+// is resolved here (the apiserver defaults an omitted policy to Fail) so the
+// evaluator can report a validation whose expression errored as a deny, the
+// parity-safe direction that matches admission.
 func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
+	failurePolicy := admissionregistrationv1.Fail
+	if policy.Spec.FailurePolicy != nil {
+		failurePolicy = *policy.Spec.FailurePolicy
+	}
+
 	vap := &VAP{
 		ControlID:        policy.Labels[controlIDLabel],
 		PolicyName:       policy.Name,
 		matchConditions:  policy.Spec.MatchConditions,
 		paramKind:        policy.Spec.ParamKind,
 		matchConstraints: policy.Spec.MatchConstraints,
+		failurePolicy:    failurePolicy,
 	}
 	for _, v := range policy.Spec.Variables {
 		vap.Variables = append(vap.Variables, Variable{Name: v.Name, Expression: v.Expression})

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -71,6 +71,44 @@ func TestLoadVAPUnknownControl(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "C-9999"))
 }
 
+// TestVAPFailurePolicy pins how spec.failurePolicy is resolved: omitted defaults
+// to Fail (the apiserver's default), an explicit Fail stays Fail, and only
+// Ignore flips failOnError to false.
+func TestVAPFailurePolicy(t *testing.T) {
+	doc := func(failurePolicy string) string {
+		return `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: pol
+  labels:
+    controlId: C-1000
+spec:
+` + failurePolicy + `  validations:
+  - expression: "true"
+`
+	}
+
+	tests := []struct {
+		name          string
+		failurePolicy string
+		wantFail      bool
+	}{
+		{name: "omitted defaults to Fail", failurePolicy: "", wantFail: true},
+		{name: "explicit Fail", failurePolicy: "  failurePolicy: Fail\n", wantFail: true},
+		{name: "explicit Ignore", failurePolicy: "  failurePolicy: Ignore\n", wantFail: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog, err := parseVAPBundle([]byte(doc(tt.failurePolicy)))
+			require.NoError(t, err)
+			vap, ok := catalog.byControl["C-1000"]
+			require.True(t, ok)
+			assert.Equal(t, tt.wantFail, vap.failOnError())
+		})
+	}
+}
+
 // vapDoc renders a minimal VAP document for the in-memory bundle tests.
 func vapDoc(name, controlID string) string {
 	labels := ""

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1080,9 +1080,17 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		var messages []string
 		var hints []cel.PathHint
 		var objErrs []error
+		var denyErrs []error
 		for _, res := range eval.Results {
 			if res.Err != nil {
 				objErrs = append(objErrs, res.Err)
+				// Under failurePolicy Fail, a validation whose expression
+				// errored denies the object at admission. Compile errors, budget
+				// exhaustion and cancellation stay unknown verdicts: the cluster
+				// never produces them, so failurePolicy does not apply.
+				if eval.FailOnError && cel.IsExpressionError(res.Err) {
+					denyErrs = append(denyErrs, res.Err)
+				}
 				continue
 			}
 			if !res.Passed {
@@ -1104,6 +1112,11 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 					helpers.String("resource", celResourceID(obj)),
 					helpers.Error(errors.Join(objErrs...)))
 			}
+		case len(denyErrs) > 0:
+			// failurePolicy Fail turned the eval error into a deny, exactly as
+			// admission would. Report it as a failure whose message is the error,
+			// so the finding is visible instead of silently downgraded to a skip.
+			responses = append(responses, celErrorRuleResponse(rule, obj, errors.Join(denyErrs...)))
 		case len(objErrs) > 0:
 			outcome.skipped = append(outcome.skipped, skippedCELResource{obj: obj, err: errors.Join(objErrs...)})
 		}
@@ -1181,6 +1194,23 @@ func celRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, messag
 		RuleStatus:          reporthandling.StatusFailed,
 		PackageName:         rule.Name,
 		Rulename:            rule.Name,
+		AlertObject: reporthandling.AlertObject{
+			K8SApiObjects: []map[string]any{obj},
+		},
+	}
+}
+
+// celErrorRuleResponse builds the failure a validation's eval error produces
+// under failurePolicy Fail: the object is denied with the error as the message,
+// matching what admission does. There is no remediation to offer — the
+// expression never reached a verdict — so the finding carries no paths and is
+// informational rather than fixable.
+func celErrorRuleResponse(rule *reporthandling.PolicyRule, obj map[string]any, err error) reporthandling.RuleResponse {
+	return reporthandling.RuleResponse{
+		AlertMessage: err.Error(),
+		RuleStatus:   reporthandling.StatusFailed,
+		PackageName:  rule.Name,
+		Rulename:     rule.Name,
 		AlertObject: reporthandling.AlertObject{
 			K8SApiObjects: []map[string]any{obj},
 		},

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -968,13 +968,28 @@ func TestRunCELOnK8s(t *testing.T) {
 	t.Run("a broken object does not erase a sibling violation", func(t *testing.T) {
 		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{violatingPod, brokenPod}, nil, "C-0017")
 		require.NoError(t, err, "an eval error on one object must not fail the whole rule")
-		require.Len(t, responses, 1, "the confirmed violation must survive")
-		assert.Equal(t, "mutable", responses[0].GetFailedResources()[0]["metadata"].(map[string]any)["name"])
+		require.Len(t, responses, 2, "the confirmed violation must survive alongside the eval-error deny")
+		assert.Empty(t, outcome.skipped, "an eval error under failurePolicy Fail is a deny, not a skip")
 
-		require.Len(t, outcome.skipped, 1, "the broken object must be reported as an unknown-verdict skip")
-		skippedMeta := objectsenvelopes.NewObject(outcome.skipped[0].obj)
-		require.NotNil(t, skippedMeta)
-		assert.Equal(t, "broken", skippedMeta.GetName())
+		byName := map[string]reporthandling.RuleResponse{}
+		for _, r := range responses {
+			byName[r.GetFailedResources()[0]["metadata"].(map[string]any)["name"].(string)] = r
+		}
+		require.Contains(t, byName, "mutable", "the confirmed violation must survive")
+		assert.Contains(t, byName, "broken", "the eval-error object must be denied, matching admission")
+	})
+
+	// An eval error alone is a deny under failurePolicy Fail, not a skip.
+	t.Run("an eval error is denied under failurePolicy Fail", func(t *testing.T) {
+		responses, outcome, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{brokenPod}, nil, "C-0017")
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+		assert.Empty(t, outcome.skipped)
+
+		failed := responses[0].GetFailedResources()
+		require.Len(t, failed, 1)
+		assert.Equal(t, "broken", failed[0]["metadata"].(map[string]any)["name"])
+		assert.NotEmpty(t, responses[0].AlertMessage)
 	})
 
 	// Blocker 2: an out-of-scope object must be excluded, not left to be


### PR DESCRIPTION
Hey folks! I was following the active discussion on #3059 and had some cycles to explore implementing the "something like 2" direction locally. I figured I'd open up this self-contained PR with my approach in case it helps move the needle forward—feel free to use it, close it, or pull from it as needed!

Following up on the failurePolicy discussion in the issue - this implements the "something like 2" direction, narrowly.

The problem: `newVAP` was throwing away `spec.failurePolicy`, so a validation whose CEL expression errored at runtime always landed as `Skipped/Unknown` offline. But every policy we bundle is `failurePolicy: Fail`, so on a real cluster that exact object gets *denied*. The scan was ending up quieter than admission and silently losing the finding - which is precisely when you'd want it to speak up.

What I did:

- Preserve `failurePolicy` on the VAP, resolving it to `Fail` when omitted (matching the apiserver's default).
- Add a small `expressionError` wrapper + `IsExpressionError` in the `cel` package to tell apart the two kinds of errors that can land on a `ValidationResult.Err`:
  - a *runtime* eval error or a non-bool result - the expression actually ran and blew up, which is a verdict the apiserver can reach, so `failurePolicy` should govern it;
  - *offline-only* failures - compile errors (a broken bundle, which the cluster could never install), cost-budget exhaustion, and cancellation - which stay `Skipped` because the cluster never produces them.
- In `runCELOnK8s`, under `Fail` a runtime eval error now emits a failure (deny) whose message is the error text, instead of dropping into `outcome.skipped`. An explicit `Ignore` keeps the old skipped behavior - I left `Ignore` alone rather than mapping it to `pass`, which felt like a separate call.

I went with the narrow version on purpose: the offline engine evaluates the raw manifest with no schema defaulting, so some expressions can error on things admission would silently default-fill. Those errors stay "unknown" rather than being promoted to a deny, so we don't start inventing failures on perfectly fine workloads. The guarded-bundle work already in `TestNoEvalErrorOnMinimalWorkloads` keeps that class in check; the one real error we know about today (C-0020's missing `params.settings.cloudProvider`) now correctly reports as a failure to match the cluster.

Verification: `go test ./core/pkg/opaprocessor/...` is 339 passed and clean under `-race` (new tests cover the classification and the Fail/Ignore/omitted matrix plus an end-to-end eval-error-denied case through `runCELOnK8s`). Full `go test ./core/...` is 3512 passed with one pre-existing unrelated failure (`TestExcludeFilesUnderDirectories`, also fails on master). `go vet` and `gofmt` are clean.

One thing I'd flag for review: treating an eval error as a deny changes the status of objects whose expression can't be evaluated from "skipped" to "failed" when the policy is `Fail`. That's the intended direction, but it's a verdict change, so worth a second set of eyes on whether the "deny with the raw error as the message" presentation is what you want for the printers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable validation failure handling, allowing policies to deny requests or ignore evaluation errors.
  * Admission responses now identify when denial results from a validation evaluation error.

* **Bug Fixes**
  * Evaluation errors are handled separately from compilation, resource-limit, and cancellation errors.
  * Confirmed policy violations continue to be reported alongside evaluation-error denials.
  * Canceled evaluations no longer trigger unintended denial behavior.

* **Tests**
  * Added coverage for failure policies, error classification, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->