### PR TITLE
feat(scan): add --dry-run RBAC preflight check

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -220,6 +220,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ControlTimeout, "control-timeout", 0, "Maximum duration for evaluating a single control (e.g. 30s, 1m). 0 means no timeout. Controls that exceed this are marked as not evaluated and the scan continues. Must be lower than --scan-timeout when both are set.")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EnableStreaming, "enable-streaming", false, "Enable resource streaming for large clusters to reduce memory usage. Resources are processed in batches instead of loading all at once. Automatically enabled for clusters with >2500 resources.")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.DryRun, "dry-run", false, "Check whether the current credentials can list every resource type the requested policies need, without collecting resources or evaluating controls. Cluster scans only.")
 
 	// Helm value override flags. Mirror `helm install` so users can pass overrides through verbatim
 	// when scanning a Helm chart directory. Note: -f is already taken by --format, so --values is long-only.

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -162,6 +162,7 @@ type ScanInfo struct {
 	ScanTimeout           time.Duration // Maximum duration for the entire scan (0 = no timeout)
 	ControlTimeout        time.Duration // Maximum duration for evaluating a single control (0 = no timeout)
 	EnableStreaming       bool          // Enable resource streaming for large clusters to keep the evaluation input bounded
+	DryRun                bool          // Check RBAC access for the resources the scan would need, without collecting or evaluating anything
 	ChartPath             string
 	FilePath              string
 	HelmValueFiles        []string // -f / --values: paths to Helm values YAML files (repeatable)

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -294,6 +294,16 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 	spanPolicies.End()
 
+	if scanInfo.DryRun {
+		spanInit.End()
+		result, err := interfaces.resourceHandler.Preflight(ctxInit, scanData, scanInfo)
+		if err != nil {
+			return resultsHandling, err
+		}
+		printPreflightResult(result)
+		return resultsHandling, nil
+	}
+
 	// ===================== resources =====================
 	ctxResources, spanResources := otel.Tracer("").Start(ctxInit, "resources")
 
@@ -687,4 +697,25 @@ func getAllWorkloadImages(wl *workloadinterface.Workload) []string {
 		}
 	}
 	return images
+}
+
+// printPreflightResult prints the --dry-run RBAC check to stdout.
+func printPreflightResult(result *resourcehandler.PreflightResult) {
+	for _, f := range result.DiscoveryFailures {
+		fmt.Printf("DISCOVERY FAILED  %s: %s\n", f.GVR, f.Error)
+	}
+
+	denied := result.Denied()
+	if len(denied) == 0 {
+		fmt.Printf("All %d required resource type(s) can be listed with the current credentials.\n", len(result.Checks))
+		return
+	}
+
+	for _, c := range denied {
+		fmt.Printf("DENIED  list %s\n", c.GVR)
+		if len(c.AffectedControls) > 0 {
+			fmt.Printf("        -> %s will not evaluate\n", strings.Join(c.AffectedControls, ", "))
+		}
+	}
+	fmt.Printf("\n%d/%d required resource type(s) can be listed. %d denied.\n", len(result.Checks)-len(denied), len(result.Checks), len(denied))
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -296,11 +296,15 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 
 	if scanInfo.DryRun {
 		spanInit.End()
+		resultsHandling.SetData(scanData)
 		result, err := interfaces.resourceHandler.Preflight(ctxInit, scanData, scanInfo)
 		if err != nil {
 			return resultsHandling, err
 		}
 		printPreflightResult(result)
+		if denied := result.Denied(); len(denied) > 0 {
+			return resultsHandling, fmt.Errorf("dry-run: %d required resource type(s) cannot be listed with the current credentials", len(denied))
+		}
 		return resultsHandling, nil
 	}
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -705,8 +705,13 @@ func printPreflightResult(result *resourcehandler.PreflightResult) {
 		fmt.Printf("DISCOVERY FAILED  %s: %s\n", f.GVR, f.Error)
 	}
 
+	errored := result.Errored()
+	for _, c := range errored {
+		fmt.Printf("CHECK FAILED  list %s: %s\n", c.GVR, c.Reason)
+	}
+
 	denied := result.Denied()
-	if len(denied) == 0 {
+	if len(denied) == 0 && len(errored) == 0 {
 		fmt.Printf("All %d required resource type(s) can be listed with the current credentials.\n", len(result.Checks))
 		return
 	}
@@ -717,5 +722,7 @@ func printPreflightResult(result *resourcehandler.PreflightResult) {
 			fmt.Printf("        -> %s will not evaluate\n", strings.Join(c.AffectedControls, ", "))
 		}
 	}
-	fmt.Printf("\n%d/%d required resource type(s) can be listed. %d denied.\n", len(result.Checks)-len(denied), len(result.Checks), len(denied))
+
+	allowed := len(result.Checks) - len(denied) - len(errored)
+	fmt.Printf("\n%d/%d required resource type(s) can be listed. %d denied, %d could not be checked.\n", allowed, len(result.Checks), len(denied), len(errored))
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -62,6 +62,10 @@ func (m estimateClusterSizeMock) GetCloudProvider() string {
 	return ""
 }
 
+func (m estimateClusterSizeMock) Preflight(context.Context, *cautils.OPASessionObj, *cautils.ScanInfo) (*resourcehandler.PreflightResult, error) {
+	return nil, nil
+}
+
 func TestEstimateClusterSize(t *testing.T) {
 	// A ScanInfo with no input patterns is treated as a cluster scan.
 	clusterScanInfo := &cautils.ScanInfo{}
@@ -495,6 +499,10 @@ func (m *streamingCancelMock) GetClusterAPIServerInfo(context.Context) *version.
 
 func (m *streamingCancelMock) GetCloudProvider() string {
 	return m.cloudProvider
+}
+
+func (m *streamingCancelMock) Preflight(context.Context, *cautils.OPASessionObj, *cautils.ScanInfo) (*resourcehandler.PreflightResult, error) {
+	return nil, nil
 }
 
 func TestCollectAndProcessResourcesWithStreaming_InitializesProviderScope(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -100,6 +100,12 @@ func (fileHandler *FileResourceHandler) GetCloudProvider() string {
 	return ""
 }
 
+// Preflight is not supported for file-based scans: there is no API server to
+// check RBAC access against.
+func (fileHandler *FileResourceHandler) Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error) {
+	return nil, ErrPreflightNotSupported
+}
+
 // EstimateClusterSize always returns 0 for file-based scans since streaming
 // is not needed for local or URL-based resources.
 func (fileHandler *FileResourceHandler) EstimateClusterSize(ctx context.Context, scanInfo *cautils.ScanInfo) (int, error) {

--- a/core/pkg/resourcehandler/handlerpullresources_extra_test.go
+++ b/core/pkg/resourcehandler/handlerpullresources_extra_test.go
@@ -43,6 +43,10 @@ func (m collectResourcesMock) EstimateClusterSize(ctx context.Context, scanInfo 
 	return 0, nil
 }
 
+func (m collectResourcesMock) Preflight(context.Context, *cautils.OPASessionObj, *cautils.ScanInfo) (*PreflightResult, error) {
+	return nil, nil
+}
+
 func TestCollectResources(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/core/pkg/resourcehandler/interface.go
+++ b/core/pkg/resourcehandler/interface.go
@@ -23,4 +23,7 @@ type IResourceHandler interface {
 	EstimateClusterSize(ctx context.Context, scanInfo *cautils.ScanInfo) (int, error)
 	GetClusterAPIServerInfo(ctx context.Context) *version.Info
 	GetCloudProvider() string
+	// Preflight checks, without collecting any resources, whether the current
+	// credentials can list every resource type the given policies require.
+	Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error)
 }

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -12,9 +12,14 @@ import (
 )
 
 // GVRCheck is the preflight result for a single resource type the scan needs to list.
+// Errored is set when the SelfSubjectAccessReview request itself could not be
+// completed (timeout, API failure, ...), which is not the same as the API
+// server answering that "list" is denied — Allowed stays false in both cases,
+// so callers must check Errored before treating a check as a real denial.
 type GVRCheck struct {
 	GVR              string
 	Allowed          bool
+	Errored          bool
 	Reason           string
 	AffectedControls []string
 }
@@ -26,15 +31,29 @@ type PreflightResult struct {
 	DiscoveryFailures []cautils.PartialGVRPull
 }
 
-// Denied returns the checks that failed, in the order they were checked.
+// Denied returns the checks the API server answered with "not allowed", in
+// the order they were checked. Checks whose request itself failed are
+// excluded — see Errored.
 func (r *PreflightResult) Denied() []GVRCheck {
 	var denied []GVRCheck
 	for _, c := range r.Checks {
-		if !c.Allowed {
+		if !c.Allowed && !c.Errored {
 			denied = append(denied, c)
 		}
 	}
 	return denied
+}
+
+// Errored returns the checks whose SelfSubjectAccessReview request itself
+// failed, so no access decision was obtained.
+func (r *PreflightResult) Errored() []GVRCheck {
+	var errored []GVRCheck
+	for _, c := range r.Checks {
+		if c.Errored {
+			errored = append(errored, c)
+		}
+	}
+	return errored
 }
 
 // ErrPreflightNotSupported is returned by resource handlers that cannot
@@ -88,6 +107,7 @@ func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTr
 
 	resp, err := k8sHandler.k8s.KubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
 	if err != nil {
+		check.Errored = true
 		check.Reason = err.Error()
 		return check
 	}

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -1,0 +1,98 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GVRCheck is the preflight result for a single resource type the scan needs to list.
+type GVRCheck struct {
+	GVR              string
+	Allowed          bool
+	Reason           string
+	AffectedControls []string
+}
+
+// PreflightResult is the outcome of checking whether the current credentials
+// can list every resource type the requested policies depend on.
+type PreflightResult struct {
+	Checks            []GVRCheck
+	DiscoveryFailures []cautils.PartialGVRPull
+}
+
+// Denied returns the checks that failed, in the order they were checked.
+func (r *PreflightResult) Denied() []GVRCheck {
+	var denied []GVRCheck
+	for _, c := range r.Checks {
+		if !c.Allowed {
+			denied = append(denied, c)
+		}
+	}
+	return denied
+}
+
+// ErrPreflightNotSupported is returned by resource handlers that cannot
+// evaluate RBAC access, such as file-based scans with no API server to ask.
+var ErrPreflightNotSupported = errors.New("dry-run RBAC preflight is only supported for cluster scans")
+
+// Preflight resolves the resource types the given policies require and
+// checks, via SelfSubjectAccessReview, whether the current credentials can
+// list each one, without collecting any resources. Kubescape lists every
+// resource type with a single cluster-wide LIST (namespace filtering happens
+// against the returned items, not via a namespaced list call), so a
+// cluster-wide "list" access review is the same check the real collection
+// would need to pass, regardless of --include-namespaces/--exclude-namespaces.
+func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error) {
+	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)
+
+	resourceToControl := make(map[string][]string)
+	scanningScope := cautils.GetScanningScope(sessionObj.Metadata.ContextMetadata)
+	queryableResources, _ := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
+	setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
+
+	result := &PreflightResult{DiscoveryFailures: discoveryFailures}
+	seen := make(map[string]struct{}, len(queryableResources))
+	for _, qr := range queryableResources {
+		if _, ok := seen[qr.GroupVersionResourceTriplet]; ok {
+			continue
+		}
+		seen[qr.GroupVersionResourceTriplet] = struct{}{}
+
+		result.Checks = append(result.Checks, k8sHandler.checkListAccess(ctx, qr.GroupVersionResourceTriplet, resourceToControl[qr.GroupVersionResourceTriplet]))
+	}
+
+	sort.Slice(result.Checks, func(i, j int) bool { return result.Checks[i].GVR < result.Checks[j].GVR })
+	return result, nil
+}
+
+func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTriplet string, affectedControls []string) GVRCheck {
+	group, version, resource := k8sinterface.StringToResourceGroup(gvrTriplet)
+	check := GVRCheck{GVR: gvrTriplet, AffectedControls: affectedControls}
+
+	ssar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Verb:     "list",
+				Group:    group,
+				Version:  version,
+				Resource: resource,
+			},
+		},
+	}
+
+	resp, err := k8sHandler.k8s.KubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
+	if err != nil {
+		check.Reason = err.Error()
+		return check
+	}
+
+	check.Allowed = resp.Status.Allowed
+	check.Reason = resp.Status.Reason
+	return check
+}

--- a/core/pkg/resourcehandler/preflight_test.go
+++ b/core/pkg/resourcehandler/preflight_test.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -14,11 +15,17 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// ssarReactor allows "list" access for every resource except those named in denied.
-func ssarReactor(denied map[string]bool) k8stesting.ReactionFunc {
+// ssarReactor allows "list" access for every resource except those named in
+// denied. It also asserts that Preflight always asks for the cluster-wide
+// "list" access the real collector needs, not a namespace-scoped one.
+func ssarReactor(t *testing.T, denied map[string]bool) k8stesting.ReactionFunc {
+	t.Helper()
 	return func(action k8stesting.Action) (bool, runtime.Object, error) {
 		createAction := action.(k8stesting.CreateAction)
 		ssar := createAction.GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		require.Equal(t, "list", ssar.Spec.ResourceAttributes.Verb)
+		require.Empty(t, ssar.Spec.ResourceAttributes.Namespace)
+
 		ssar.Status.Allowed = !denied[ssar.Spec.ResourceAttributes.Resource]
 		if !ssar.Status.Allowed {
 			ssar.Status.Reason = "forbidden"
@@ -33,7 +40,7 @@ func TestPreflight_ReportsDeniedResourceWithAffectedControls(t *testing.T) {
 		return true, nil, nil
 	})
 	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
-	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(map[string]bool{"clusterrolebindings": true}))
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(t, map[string]bool{"clusterrolebindings": true}))
 
 	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
 	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
@@ -61,7 +68,7 @@ func TestPreflight_AllAllowed(t *testing.T) {
 		return true, nil, nil
 	})
 	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
-	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(nil))
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(t, nil))
 
 	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
 	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
@@ -74,6 +81,37 @@ func TestPreflight_AllAllowed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Denied())
 	assert.NotEmpty(t, result.Checks)
+}
+
+// TestPreflight_RequestFailureIsNotADenial guards against a failed
+// SelfSubjectAccessReview request (timeout, API error, ...) being reported as
+// the API server denying "list" - the two are not the same thing, and only
+// the latter should count as a real denial.
+func TestPreflight_RequestFailureIsNotADenial(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection reset")
+	})
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
+	framework := mockFramework("test-framework", []reporthandling.Control{podControl})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Denied(), "a failed request must not be reported as a denial")
+	require.NotEmpty(t, result.Errored())
+	for _, c := range result.Errored() {
+		assert.Contains(t, c.Reason, "connection reset")
+	}
 }
 
 func TestFileResourceHandler_PreflightNotSupported(t *testing.T) {

--- a/core/pkg/resourcehandler/preflight_test.go
+++ b/core/pkg/resourcehandler/preflight_test.go
@@ -1,0 +1,83 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// ssarReactor allows "list" access for every resource except those named in denied.
+func ssarReactor(denied map[string]bool) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		ssar := createAction.GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ssar.Status.Allowed = !denied[ssar.Spec.ResourceAttributes.Resource]
+		if !ssar.Status.Allowed {
+			ssar.Status.Reason = "forbidden"
+		}
+		return true, ssar, nil
+	}
+}
+
+func TestPreflight_ReportsDeniedResourceWithAffectedControls(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(map[string]bool{"clusterrolebindings": true}))
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
+	podControl.ControlID = "C-0001"
+	crbRule := mockRule("crb-rule", []reporthandling.RuleMatchObjects{mockMatch(5)}, "")
+	crbControl := mockControl("C-0002", []reporthandling.PolicyRule{crbRule})
+	crbControl.ControlID = "C-0002"
+	framework := mockFramework("test-framework", []reporthandling.Control{podControl, crbControl})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	denied := result.Denied()
+	require.Len(t, denied, 1)
+	assert.Contains(t, denied[0].GVR, "clusterrolebindings")
+	assert.Contains(t, denied[0].AffectedControls, "C-0002")
+}
+
+func TestPreflight_AllAllowed(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", ssarReactor(nil))
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
+	framework := mockFramework("test-framework", []reporthandling.Control{podControl})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+	assert.Empty(t, result.Denied())
+	assert.NotEmpty(t, result.Checks)
+}
+
+func TestFileResourceHandler_PreflightNotSupported(t *testing.T) {
+	handler := NewFileResourceHandler()
+	_, err := handler.Preflight(context.Background(), &cautils.OPASessionObj{}, &cautils.ScanInfo{})
+	assert.ErrorIs(t, err, ErrPreflightNotSupported)
+}


### PR DESCRIPTION
## Overview

This is the implementation for #3002.

Today there is no way to know whether a scan will actually work with the credentials it is given without running the whole scan. `GetResources` already computes the exact set of resource types a policy set needs, and which controls depend on each one, before it ever touches the cluster:

```go
queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(...)
ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
sessionObj.ResourceToControlsMap = resourceToControl
```

What's missing is asking the API server whether those LISTs are actually permitted. Right now the only way to find out is to run the scan, let the LISTs fail, and read `FailedGVRPulls`/`NotEvaluatedControls` afterwards. On a large cluster that means paying a multi-minute scan to discover a permission gap that a handful of `SelfSubjectAccessReview` calls would surface in under a second.

`kubescape scan ... --dry-run` resolves the policies, works out the required GVRs the same way `GetResources` does, and checks list access for each one via `SelfSubjectAccessReview`, without collecting any resources or evaluating any controls.

```go
// new: core/pkg/resourcehandler/preflight.go
func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error) {
	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)

	resourceToControl := make(map[string][]string)
	scanningScope := cautils.GetScanningScope(sessionObj.Metadata.ContextMetadata)
	queryableResources, _ := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
	setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)

	result := &PreflightResult{DiscoveryFailures: discoveryFailures}
	seen := make(map[string]struct{}, len(queryableResources))
	for _, qr := range queryableResources {
		if _, ok := seen[qr.GroupVersionResourceTriplet]; ok {
			continue
		}
		seen[qr.GroupVersionResourceTriplet] = struct{}{}
		result.Checks = append(result.Checks, k8sHandler.checkListAccess(ctx, qr.GroupVersionResourceTriplet, resourceToControl[qr.GroupVersionResourceTriplet]))
	}
	...
}
```

Kubescape collects every resource type with a single cluster-wide LIST, namespace filtering happens against the returned items, not via a namespaced list call, confirmed by reading `pullSingleResource`. That means one cluster-wide access check per GVR is the same permission the real collection needs, regardless of `--include-namespaces`/`--exclude-namespaces`, so there's no per-namespace check to add.

`checkListAccess` issues one `SelfSubjectAccessReview` per resource type:

```go
func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTriplet string, affectedControls []string) GVRCheck {
	group, version, resource := k8sinterface.StringToResourceGroup(gvrTriplet)
	check := GVRCheck{GVR: gvrTriplet, AffectedControls: affectedControls}

	ssar := &authorizationv1.SelfSubjectAccessReview{
		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
			ResourceAttributes: &authorizationv1.ResourceAttributes{
				Verb: "list", Group: group, Version: version, Resource: resource,
			},
		},
	}

	resp, err := k8sHandler.k8s.KubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
	if err != nil {
		check.Reason = err.Error()
		return check
	}
	check.Allowed = resp.Status.Allowed
	check.Reason = resp.Status.Reason
	return check
}
```

`create` on `selfsubjectaccessreviews` is granted to every authenticated user by the built-in `system:basic-user` ClusterRole, so the preflight itself cannot fail for the same reason the scan would, and `k8s.io/client-go/kubernetes/typed/authorization/v1` is already in the module graph via `client-go`. No new dependency.

Output is plain text for now, joining denials against the control-ID map:

```
DENIED  list validatingadmissionpolicies (admissionregistration.k8s.io/v1)
        -> C-0261, C-0262 will not evaluate

11/12 required resource type(s) can be listed. 1 denied.
```

`--dry-run` plugs in right after policy resolution in `core/core/scan.go`, before the resources section starts, and returns early:

```go
spanPolicies.End()

if scanInfo.DryRun {
	spanInit.End()
	result, err := interfaces.resourceHandler.Preflight(ctxInit, scanData, scanInfo)
	if err != nil {
		return resultsHandling, err
	}
	printPreflightResult(result)
	return resultsHandling, nil
}
```

File-based scans have no API server to check against, so `FileResourceHandler.Preflight` returns `ErrPreflightNotSupported` and the command fails with a clear message rather than silently doing nothing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--dry-run` option for scan commands, disabled by default.
  * Cluster scans can check required resource-list permissions without collecting resources or evaluating controls.
  * Results report successful checks, denied resources, discovery failures, access errors, and affected controls.
* **Bug Fixes**
  * Improved visibility into permission issues before full cluster scans.
  * File-based scans now clearly report that permission preflight checks are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->