### PR TITLE
perf(fileutils): resolve directory ownership by ancestor lookup instead of scanning every directory

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -253,10 +253,14 @@ func IsUnderAnyDir(path string, dirs []string) bool {
 // Members must already be normalized, as must the paths passed to contains.
 type dirSet map[string]struct{}
 
+// newDirSet indexes dirs for lookup. Members are cleaned because the ancestor
+// walk compares exact strings, where the filepath.Rel comparison it replaces
+// cleaned its arguments itself: without this a trailing separator or a "."
+// segment would stop a directory matching the paths below it.
 func newDirSet(normalizedDirs []string) dirSet {
 	set := make(dirSet, len(normalizedDirs))
 	for _, dir := range normalizedDirs {
-		set[dir] = struct{}{}
+		set[filepath.Clean(dir)] = struct{}{}
 	}
 	return set
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -70,10 +70,10 @@ func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
 	}
 	if len(excludedChartDirectories) > 0 {
-		normalizedExcludedDirectories := normalizePaths(excludedChartDirectories)
+		excludedDirectories := newDirSet(normalizePaths(excludedChartDirectories))
 		remaining := make([]string, 0, len(helmDirectories))
 		for _, directory := range helmDirectories {
-			if !isUnderAnyNormalizedDir(normalizePath(directory), normalizedExcludedDirectories) {
+			if !excludedDirectories.contains(normalizePath(directory)) {
 				remaining = append(remaining, directory)
 			}
 		}
@@ -230,11 +230,11 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 	for _, helmDir := range renderedCharts {
 		templateDirs = append(templateDirs, filepath.Join(helmDir, "templates"))
 	}
-	templateDirs = pathAliasesForPaths(templateDirs)
+	templates := newDirSet(pathAliasesForPaths(templateDirs))
 
 	remaining := make([]string, 0, len(files))
 	for _, file := range files {
-		if !IsAnyPathAliasUnderAnyDir(file, templateDirs) {
+		if !templates.containsAnyAlias(file) {
 			remaining = append(remaining, file)
 		}
 	}
@@ -244,21 +244,58 @@ func excludeHelmTemplateFiles(files, renderedCharts []string) []string {
 // IsUnderAnyDir reports whether path is inside one of dirs after normalizing
 // relative paths and resolving symlinks where the path already exists.
 func IsUnderAnyDir(path string, dirs []string) bool {
-	return isUnderAnyNormalizedDir(normalizePath(path), normalizePaths(dirs))
+	return newDirSet(normalizePaths(dirs)).contains(normalizePath(path))
 }
 
-func isUnderAnyNormalizedDir(path string, dirs []string) bool {
-	for _, dir := range dirs {
-		rel, err := filepath.Rel(dir, path)
-		if err != nil {
-			continue
+// dirSet decides containment by walking a path's ancestors, so a lookup costs
+// path depth instead of one filepath.Rel per directory. Callers scanning many
+// paths against the same directories must build it once and reuse it.
+// Members must already be normalized, as must the paths passed to contains.
+type dirSet map[string]struct{}
+
+func newDirSet(normalizedDirs []string) dirSet {
+	set := make(dirSet, len(normalizedDirs))
+	for _, dir := range normalizedDirs {
+		set[dir] = struct{}{}
+	}
+	return set
+}
+
+// contains reports whether path is the set's member directory or lives below
+// it. A sibling merely sharing a prefix ("templates-docs" next to "templates")
+// is not an ancestor, so it stays outside.
+func (s dirSet) contains(path string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for dir := path; ; {
+		if _, ok := s[dir]; ok {
+			return true
 		}
-		// a sibling merely sharing a prefix (e.g. "templates-docs" next to "templates") escapes with ".."
-		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// containsAny reports whether any of the already-normalized paths is contained.
+func (s dirSet) containsAny(paths []string) bool {
+	for _, path := range paths {
+		if s.contains(path) {
 			return true
 		}
 	}
 	return false
+}
+
+// containsAnyAlias resolves path's aliases and reports whether any is contained.
+func (s dirSet) containsAnyAlias(path string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s.containsAny(pathAliases(path))
 }
 
 func normalizePaths(paths []string) []string {
@@ -283,12 +320,7 @@ func pathAliasesForPaths(paths []string) []string {
 // alias matters for a symlinked file whose link target lives elsewhere: it is
 // still owned by the directory that lexically contains it.
 func IsAnyPathAliasUnderAnyDir(path string, dirs []string) bool {
-	for _, alias := range pathAliases(path) {
-		if isUnderAnyNormalizedDir(alias, dirs) {
-			return true
-		}
-	}
-	return false
+	return newDirSet(dirs).containsAnyAlias(path)
 }
 
 // pathAliases returns both the absolute lexical path and, when different, its
@@ -399,9 +431,9 @@ type KustomizeRenderResult struct {
 	OwnedSourcePaths          []string
 	OwnedHelmChartDirectories []string
 	OwnedHelmCRDDirectories   []string
-	ownedSourcePathAliases    []string
-	ownedHelmChartAliases     []string
-	ownedHelmCRDAliases       []string
+	ownedSourcePathSet        dirSet
+	ownedHelmChartSet         dirSet
+	ownedHelmCRDSet           dirSet
 }
 
 // OwnsPlainFile reports whether a successfully rendered Kustomize input already
@@ -409,11 +441,13 @@ type KustomizeRenderResult struct {
 // Helm-template exclusion, while raw CRDs are removed here only when the owning
 // helmCharts entry requested includeCRDs.
 func (result KustomizeRenderResult) OwnsPlainFile(path string) bool {
-	if IsAnyPathAliasUnderAnyDir(path, result.ownedHelmChartAliases) {
-		return IsAnyPathAliasUnderAnyDir(path, result.ownedHelmCRDAliases) ||
-			IsAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+	// Resolve once: every alias resolution walks the path's symlinks.
+	aliases := pathAliases(path)
+	if result.ownedHelmChartSet.containsAny(aliases) {
+		return result.ownedHelmCRDSet.containsAny(aliases) ||
+			result.ownedSourcePathSet.containsAny(aliases)
 	}
-	return IsAnyPathAliasUnderAnyDir(path, result.ownedSourcePathAliases)
+	return result.ownedSourcePathSet.containsAny(aliases)
 }
 
 // LoadResourcesFromKustomizeDirectories renders the Kustomize configuration at
@@ -463,9 +497,9 @@ func LoadResourcesFromKustomizeDirectories(ctx context.Context, basePath string)
 		appendUniquePaths(&result.OwnedHelmChartDirectories, seenOwnedCharts, ownership.HelmChartDirectories...)
 		appendUniquePaths(&result.OwnedHelmCRDDirectories, seenOwnedCRDs, ownership.HelmCRDDirectories...)
 	}
-	result.ownedSourcePathAliases = pathAliasesForPaths(result.OwnedSourcePaths)
-	result.ownedHelmChartAliases = pathAliasesForPaths(result.OwnedHelmChartDirectories)
-	result.ownedHelmCRDAliases = pathAliasesForPaths(result.OwnedHelmCRDDirectories)
+	result.ownedSourcePathSet = newDirSet(pathAliasesForPaths(result.OwnedSourcePaths))
+	result.ownedHelmChartSet = newDirSet(pathAliasesForPaths(result.OwnedHelmChartDirectories))
+	result.ownedHelmCRDSet = newDirSet(pathAliasesForPaths(result.OwnedHelmCRDDirectories))
 
 	return result, nil
 }

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -252,6 +253,57 @@ func TestIsUnderAnyDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.contained, IsUnderAnyDir(tt.path, tt.dirs))
 		})
+	}
+}
+
+// TestDirSetContains asserts that the ancestor walk decides containment exactly
+// as the per-directory relative-path comparison it replaces, including for a
+// sibling sharing a name prefix and for a directory absent from the set.
+func TestDirSetContains(t *testing.T) {
+	set := newDirSet([]string{"/repo/app", "/repo/charts/web/templates"})
+
+	tests := []struct {
+		name      string
+		path      string
+		contained bool
+	}{
+		{name: "the directory itself", path: "/repo/app", contained: true},
+		{name: "file directly inside", path: "/repo/app/deployment.yaml", contained: true},
+		{name: "file nested below", path: "/repo/app/config/base/pod.yaml", contained: true},
+		{name: "second member of the set", path: "/repo/charts/web/templates/svc.yaml", contained: true},
+		{name: "sibling sharing a prefix", path: "/repo/app-docs/deployment.yaml", contained: false},
+		{name: "parent of a member", path: "/repo/charts/web/Chart.yaml", contained: false},
+		{name: "unrelated path", path: "/other/pod.yaml", contained: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.contained, set.contains(tt.path))
+		})
+	}
+
+	assert.False(t, newDirSet(nil).contains("/repo/app/deployment.yaml"), "an empty set contains nothing")
+	assert.True(t, newDirSet([]string{string(filepath.Separator)}).contains("/repo/app/deployment.yaml"),
+		"every absolute path is under the filesystem root")
+}
+
+// BenchmarkExcludeHelmTemplateFiles covers the repository-scan shape the lookup
+// is built for: many files checked against many rendered chart directories.
+func BenchmarkExcludeHelmTemplateFiles(b *testing.B) {
+	root := b.TempDir()
+
+	charts := make([]string, 0, 200)
+	for i := range 200 {
+		charts = append(charts, filepath.Join(root, "charts", strconv.Itoa(i)))
+	}
+	files := make([]string, 0, 2000)
+	for i := range 2000 {
+		files = append(files, filepath.Join(root, "manifests", strconv.Itoa(i), "deployment.yaml"))
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		excludeHelmTemplateFiles(files, charts)
 	}
 }
 

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -287,6 +287,19 @@ func TestDirSetContains(t *testing.T) {
 		"every absolute path is under the filesystem root")
 }
 
+// TestDirSetContains_UncleanDirs asserts that a member that is not lexically
+// clean still claims the paths below it, matching the filepath.Rel comparison
+// this lookup replaced, which cleaned its arguments itself.
+func TestDirSetContains_UncleanDirs(t *testing.T) {
+	for _, dir := range []string{"/repo/app/", "/repo/./app", "/repo//app", "/repo/other/../app"} {
+		t.Run(dir, func(t *testing.T) {
+			set := newDirSet([]string{dir})
+			assert.True(t, set.contains("/repo/app/deployment.yaml"), "an unclean member must still claim files below it")
+			assert.False(t, set.contains("/repo/app-docs/deployment.yaml"), "a prefix sibling stays outside")
+		})
+	}
+}
+
 // BenchmarkExcludeHelmTemplateFiles covers the repository-scan shape the lookup
 // is built for: many files checked against many rendered chart directories.
 func BenchmarkExcludeHelmTemplateFiles(b *testing.B) {


### PR DESCRIPTION
## Overview

When kubescape scans a repository it has to decide, for every file it discovered, whether some other renderer already owns that file. Helm template exclusion asks this for each file against each rendered chart, and the Kustomize ownership check asks it three separate times for the same file. Both went through `isUnderAnyNormalizedDir`, which ran a `filepath.Rel` against every candidate directory, so the work grew as files multiplied by directories. On a monorepo with a few hundred charts that turns into millions of comparisons that mostly answer "no".

This swaps the scan for a small set type that walks the path's own ancestors and looks each one up in a map. A lookup now costs path depth instead of one `filepath.Rel` per directory, so adding charts to a repo no longer makes every file check slower. Callers that check many paths against the same directories build the set once and reuse it.

`OwnsPlainFile` had a second problem: it resolved the same path's symlinks up to three times per file, and each resolution walks the whole path. It now resolves once and reuses the result across the three membership checks.

## Behaviour

Containment semantics are unchanged. A path counts as contained when it is a member directory itself or lives below one, and a sibling that merely shares a name prefix (`templates-docs` sitting next to `templates`) stays outside, exactly as before. The exported helpers `IsUnderAnyDir` and `IsAnyPathAliasUnderAnyDir` keep their signatures and behaviour.

## Numbers

`BenchmarkExcludeHelmTemplateFiles` with 2000 files against 200 rendered charts:

* before: 142 ms/op
* after: 17.5 ms/op

Roughly 8x on that shape, and the gap widens as the chart count grows since the per directory scan is what disappears.

## Testing

`go build ./...`, `go vet ./...` and the full test suite. `TestDirSetContains` covers the new lookup directly, including the prefix sibling case and the filesystem root. The existing `TestIsUnderAnyDir`, `TestExcludeHelmTemplateFiles` and `TestLoadResourcesFromFiles_SkipsHelmTemplates` cover the call sites and still pass unchanged.

One unrelated test, `TestExcludeFilesUnderDirectories` in `core/pkg/resourcehandler`, fails on macOS both with and without this change. It is a pre existing environment issue: `t.TempDir()` returns a `/var` path that symlinks to `/private/var`, and the test compares a resolved directory against unresolved file paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and directory ownership detection for Helm and Kustomize projects.
  * Correctly handles symlink aliases and similarly named directories.
  * Improved template exclusion across nested chart directories.

* **Performance**
  * Optimized path containment checks for projects with many files.

* **Tests**
  * Added coverage for directory containment, root paths, empty sets, unrelated paths, and similarly prefixed directories.
  * Added benchmark coverage for Helm template file exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->