### PR TITLE
Add RBAC-police rules for issue #916: impersonate, token-mint, escalate, bind, node-proxy, PV create

### DIFF
--- a/rules/bind-roles-clusterroles-v1/raw.rego
+++ b/rules/bind-roles-clusterroles-v1/raw.rego
@@ -3,9 +3,9 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	verbs := ["bind"]
-	api_groups := ["rbac.authorization.k8s.io"]
-	resources := ["roles", "clusterroles"]
+	verbs := ["bind", "*"]
+	api_groups := ["rbac.authorization.k8s.io", "*"]
+	resources := ["roles", "clusterroles", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]

--- a/rules/bind-roles-clusterroles-v1/raw.rego
+++ b/rules/bind-roles-clusterroles-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["bind"]
+	api_groups := ["rbac.authorization.k8s.io"]
+	resources := ["roles", "clusterroles"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can bind roles/clusterroles with rights they do not already hold", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 9,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/bind-roles-clusterroles-v1/rule.metadata.json
+++ b/rules/bind-roles-clusterroles-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "bind-roles-clusterroles-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Bind roles/clusterroles",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects hold the bind verb on roles or clusterroles, letting them create bindings that grant themselves rights from any role/clusterrole they can bind to, bypassing the normal escalation check",
+  "remediation": "Avoid granting the bind verb outside of cluster-admin equivalent identities. Restrict which roles/clusterroles a subject with bind rights can reference.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/bind-roles-clusterroles-v1/test/serviceaccount/expected.json
+++ b/rules/bind-roles-clusterroles-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-binder-sa can bind roles/clusterroles with rights they do not already hold",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "binder-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "bind-roles-clusterroles-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "bind-roles"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "binder-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "bind-roles" },
+                        "rules": [
+                            { "apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterroles"], "verbs": ["bind"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bind-roles
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["bind"]

--- a/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bind-roles-clusterroles-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: binder-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: bind-roles
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: binder-sa
+  namespace: kube-system

--- a/rules/create-persistentvolumes-v1/raw.rego
+++ b/rules/create-persistentvolumes-v1/raw.rego
@@ -3,9 +3,9 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	verbs := ["create"]
-	api_groups := [""]
-	resources := ["persistentvolumes"]
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["persistentvolumes", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]

--- a/rules/create-persistentvolumes-v1/raw.rego
+++ b/rules/create-persistentvolumes-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["create"]
+	api_groups := [""]
+	resources := ["persistentvolumes"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can create arbitrary PersistentVolumes, including hostPath volumes", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 7,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/create-persistentvolumes-v1/rule.metadata.json
+++ b/rules/create-persistentvolumes-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "create-persistentvolumes-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Create hostPath-capable PersistentVolume",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects can create PersistentVolumes, which allows creation of hostPath-backed volumes that expose the underlying node's filesystem to any pod that mounts them",
+  "remediation": "Restrict create access to persistentvolumes to cluster storage administrators. Prefer StorageClasses with dynamic provisioning and disallow hostPath in a PodSecurity/OPA admission policy.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/create-persistentvolumes-v1/test/serviceaccount/expected.json
+++ b/rules/create-persistentvolumes-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-pv-creator-sa can create arbitrary PersistentVolumes, including hostPath volumes",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "pv-creator-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "create-persistentvolumes-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "create-pvs"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "pv-creator-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "create-pvs" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["persistentvolumes"], "verbs": ["create"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/create-persistentvolumes-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/create-persistentvolumes-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: create-pvs
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["create"]

--- a/rules/create-persistentvolumes-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/create-persistentvolumes-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-persistentvolumes-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: pv-creator-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: create-pvs
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/create-persistentvolumes-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/create-persistentvolumes-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pv-creator-sa
+  namespace: kube-system

--- a/rules/create-serviceaccount-token-v1/raw.rego
+++ b/rules/create-serviceaccount-token-v1/raw.rego
@@ -3,9 +3,9 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	verbs := ["create"]
-	api_groups := [""]
-	resources := ["serviceaccounts/token"]
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["serviceaccounts/token", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]

--- a/rules/create-serviceaccount-token-v1/raw.rego
+++ b/rules/create-serviceaccount-token-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["create"]
+	api_groups := [""]
+	resources := ["serviceaccounts/token"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can mint tokens for existing service accounts", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 8,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/create-serviceaccount-token-v1/rule.metadata.json
+++ b/rules/create-serviceaccount-token-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "create-serviceaccount-token-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Mint service account token",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects can create TokenRequests for the serviceaccounts/token subresource, letting them mint valid tokens for any service account they can name and act as that identity",
+  "remediation": "Restrict create access to serviceaccounts/token to a small, trusted set of subjects. Combine with least-privilege service accounts, since minting a token is equivalent to gaining that account's full RBAC rights.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/create-serviceaccount-token-v1/test/serviceaccount/expected.json
+++ b/rules/create-serviceaccount-token-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-token-minter-sa can mint tokens for existing service accounts",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "token-minter-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "create-serviceaccount-token-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "mint-tokens"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "token-minter-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "mint-tokens" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["serviceaccounts/token"], "verbs": ["create"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/create-serviceaccount-token-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/create-serviceaccount-token-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mint-tokens
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]

--- a/rules/create-serviceaccount-token-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/create-serviceaccount-token-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-serviceaccount-token-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: token-minter-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: mint-tokens
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/create-serviceaccount-token-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/create-serviceaccount-token-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: token-minter-sa
+  namespace: kube-system

--- a/rules/escalate-roles-clusterroles-v1/raw.rego
+++ b/rules/escalate-roles-clusterroles-v1/raw.rego
@@ -3,9 +3,9 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	verbs := ["escalate"]
-	api_groups := ["rbac.authorization.k8s.io"]
-	resources := ["roles", "clusterroles"]
+	verbs := ["escalate", "*"]
+	api_groups := ["rbac.authorization.k8s.io", "*"]
+	resources := ["roles", "clusterroles", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]

--- a/rules/escalate-roles-clusterroles-v1/raw.rego
+++ b/rules/escalate-roles-clusterroles-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["escalate"]
+	api_groups := ["rbac.authorization.k8s.io"]
+	resources := ["roles", "clusterroles"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can escalate roles/clusterroles beyond their own permissions", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 9,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/escalate-roles-clusterroles-v1/rule.metadata.json
+++ b/rules/escalate-roles-clusterroles-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "escalate-roles-clusterroles-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Escalate roles/clusterroles",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects hold the escalate verb on roles or clusterroles, which bypasses Kubernetes' built-in protection against granting more rights than a subject already has",
+  "remediation": "Avoid granting the escalate verb outside of cluster-admin equivalent identities. Review any role/clusterrole granting escalate and confirm it is required.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/escalate-roles-clusterroles-v1/test/serviceaccount/expected.json
+++ b/rules/escalate-roles-clusterroles-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-escalator-sa can escalate roles/clusterroles beyond their own permissions",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "escalator-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "escalate-roles-clusterroles-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "escalate-roles"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "escalator-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "escalate-roles" },
+                        "rules": [
+                            { "apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterroles"], "verbs": ["escalate"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: escalate-roles
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["escalate"]

--- a/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: escalate-roles-clusterroles-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: escalator-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: escalate-roles
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: escalator-sa
+  namespace: kube-system

--- a/rules/impersonate-users-groups-v1/raw.rego
+++ b/rules/impersonate-users-groups-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["impersonate"]
+	api_groups := [""]
+	resources := ["users", "groups", "serviceaccounts", "uids"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can impersonate other identities and gain their RBAC rights", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 8,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/impersonate-users-groups-v1/raw.rego
+++ b/rules/impersonate-users-groups-v1/raw.rego
@@ -3,9 +3,9 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	verbs := ["impersonate"]
-	api_groups := [""]
-	resources := ["users", "groups", "serviceaccounts", "uids"]
+	verbs := ["impersonate", "*"]
+	api_groups := ["", "*"]
+	resources := ["users", "groups", "serviceaccounts", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -32,6 +32,48 @@ deny contains msga if {
 	])
 	msga := {
 		"alertMessage": sprintf("Subject: %s-%s can impersonate other identities and gain their RBAC rights", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 8,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+deny contains msga if {
+	verbs := ["impersonate", "*"]
+	api_groups := ["authentication.k8s.io", "*"]
+	resources := ["uids", "userextras/*", "*"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can impersonate other identities (uids/userextras) and gain their RBAC rights", [subjectVector.kind, subjectVector.name]),
 		"alertScore": 8,
 		"packagename": "armo_builtins",
 		"reviewPaths": finalpath,

--- a/rules/impersonate-users-groups-v1/rule.metadata.json
+++ b/rules/impersonate-users-groups-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "impersonate-users-groups-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Impersonate identity",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects can impersonate other users, groups or service accounts via the impersonate verb, allowing them to act with the RBAC rights of the impersonated identity",
+  "remediation": "Restrict the impersonate verb to a small, trusted set of subjects (e.g. auth proxies). Avoid granting impersonate on '*' or on privileged identities such as system:masters members.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/impersonate-users-groups-v1/test/serviceaccount/expected.json
+++ b/rules/impersonate-users-groups-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-impersonator-sa can impersonate other identities and gain their RBAC rights",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "impersonator-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "impersonate-users-groups-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "impersonate-all"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "impersonator-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "impersonate-all" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["users"], "verbs": ["impersonate"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/impersonate-users-groups-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/impersonate-users-groups-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-all
+rules:
+- apiGroups: [""]
+  resources: ["users"]
+  verbs: ["impersonate"]

--- a/rules/impersonate-users-groups-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/impersonate-users-groups-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: impersonate-users-groups-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: impersonator-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: impersonate-all
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/impersonate-users-groups-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/impersonate-users-groups-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: impersonator-sa
+  namespace: kube-system

--- a/rules/node-proxy-access-v1/raw.rego
+++ b/rules/node-proxy-access-v1/raw.rego
@@ -1,0 +1,66 @@
+# regal ignore:directory-package-mismatch
+package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	verbs := ["get", "create", "update", "patch", "*"]
+	api_groups := [""]
+	resources := ["nodes/proxy"]
+	subjectVector := input[_]
+	role := subjectVector.relatedObjects[i]
+	rolebinding := subjectVector.relatedObjects[j]
+	endswith(role.kind, "Role")
+	endswith(rolebinding.kind, "Binding")
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.roleRef.name == role.metadata.name
+	is_same_namespace(role, rolebinding)
+	rule := role.rules[p]
+	subject := rolebinding.subjects[k]
+	is_same_subjects(subjectVector, subject)
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
+	count(verb_path) > 0
+	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
+	count(api_groups_path) > 0
+	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
+	count(resources_path) > 0
+	path := array.concat(resources_path, verb_path)
+	path2 := array.concat(path, api_groups_path)
+	finalpath := array.concat(path2, [
+		sprintf("relatedObjects[%d].roleRef.name", [j]),
+		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
+	])
+	msga := {
+		"alertMessage": sprintf("Subject: %s-%s can access the node proxy subresource and execute commands via kubelet", [subjectVector.kind, subjectVector.name]),
+		"alertScore": 8,
+		"packagename": "armo_builtins",
+		"reviewPaths": finalpath,
+		"failedPaths": finalpath,
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": subjectVector,
+		},
+	}
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "ClusterRole"
+}
+
+is_same_namespace(role, rolebinding) if {
+	role.kind == "Role"
+	role.metadata.namespace == rolebinding.metadata.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.namespace == subject.namespace
+}
+
+is_same_subjects(subjectVector, subject) if {
+	subjectVector.kind == subject.kind
+	subjectVector.name == subject.name
+	subjectVector.apiGroup == subject.apiGroup
+}

--- a/rules/node-proxy-access-v1/raw.rego
+++ b/rules/node-proxy-access-v1/raw.rego
@@ -4,8 +4,8 @@ import rego.v1
 
 deny contains msga if {
 	verbs := ["get", "create", "update", "patch", "*"]
-	api_groups := [""]
-	resources := ["nodes/proxy"]
+	api_groups := ["", "*"]
+	resources := ["nodes/proxy", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]

--- a/rules/node-proxy-access-v1/rule.metadata.json
+++ b/rules/node-proxy-access-v1/rule.metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "node-proxy-access-v1",
+  "attributes": {
+    "m$K8sThreatMatrix": "Privilege Escalation::Node proxy access",
+    "resourcesAggregator": "subject-role-rolebinding",
+    "useFromKubescapeVersion": "v4.0.11"
+  },
+  "ruleLanguage": "Rego",
+  "match": [
+    {
+      "apiGroups": ["rbac.authorization.k8s.io"],
+      "apiVersions": ["v1"],
+      "resources": ["RoleBinding", "ClusterRoleBinding", "Role", "ClusterRole"]
+    }
+  ],
+  "ruleDependencies": [],
+  "description": "determines which subjects can access the nodes/proxy subresource, which exposes the kubelet API and can be used to execute commands on the node, equivalent to code execution on every pod scheduled there",
+  "remediation": "Restrict access to nodes/proxy to system components that require it (e.g. metrics-server) and avoid granting it to workload service accounts or broad user groups.",
+  "ruleQuery": "armo_builtins"
+}

--- a/rules/node-proxy-access-v1/test/serviceaccount/expected.json
+++ b/rules/node-proxy-access-v1/test/serviceaccount/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-node-proxy-sa can access the node proxy subresource and execute commands via kubelet",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "node-proxy-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "node-proxy-access-v1-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "node-proxy-access"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "node-proxy-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "node-proxy-access" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["nodes/proxy"], "verbs": ["get"] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/node-proxy-access-v1/test/serviceaccount/input/clusterrole.yaml
+++ b/rules/node-proxy-access-v1/test/serviceaccount/input/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-proxy-access
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]

--- a/rules/node-proxy-access-v1/test/serviceaccount/input/clusterrolebinding.yaml
+++ b/rules/node-proxy-access-v1/test/serviceaccount/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-proxy-access-v1-crb
+subjects:
+- kind: ServiceAccount
+  name: node-proxy-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: node-proxy-access
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/node-proxy-access-v1/test/serviceaccount/input/serviceaccount.yaml
+++ b/rules/node-proxy-access-v1/test/serviceaccount/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-proxy-sa
+  namespace: kube-system


### PR DESCRIPTION
## Overview
Adds 6 new RBAC-police-derived rules to close out remaining gaps tracked in #916 (Kubescape RBAC police integration), building on the `subject-role-rolebinding` pattern approved and merged in #3017 (C-0298 attach-ephemeral-container-v1).

Each rule detects subjects (users, groups, service accounts) whose Role/ClusterRole grants a specific high-risk RBAC verb+resource combination, using the same roleRef-linkage check that fixed the false-positive bug found during review of #3017 (rolebinding.roleRef.kind/name/namespace must match the role actually referenced, not just any role/rolebinding pair present in relatedObjects).

New rules:
- **impersonate-users-groups-v1** — subjects that can `impersonate` other users/groups/service accounts/uids
- **create-serviceaccount-token-v1** — subjects that can `create` `serviceaccounts/token` (mint tokens for existing service accounts)
- **escalate-roles-clusterroles-v1** — subjects with the `escalate` verb on roles/clusterroles
- **bind-roles-clusterroles-v1** — subjects with the `bind` verb on roles/clusterroles
- **node-proxy-access-v1** — subjects that can access `nodes/proxy` (kubelet exec-equivalent)
- **create-persistentvolumes-v1** — subjects that can `create` PersistentVolumes (hostPath node-filesystem exposure)

## Additional Information
Each rule's `rule.metadata.json` includes a filled `remediation` field, consistent with the feedback given on #3017.

## How to Test
Each rule includes a `test/serviceaccount/` fixture (ClusterRole + ClusterRoleBinding + ServiceAccount) with matching `expected.json`.

## Related issues/PRs
* Addresses remaining coverage gaps in #916
* Follows the pattern established in #3017

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Kubernetes security checks for privilege-escalation risks, including unauthorized role binding or escalation, service account token creation, PersistentVolume creation, user and group impersonation, and node proxy access.
  - Added detection metadata, severity details, remediation guidance, and actionable resource paths for each finding.
close #916 
- **Tests**
  - Added validation scenarios covering ServiceAccounts, Roles, ClusterRoles, and their bindings for all new detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->