### PR TITLE
Add opt-in audit for posture exceptions

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -170,6 +170,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsInputs, "controls-config", "", "Path to an controls-config obj. If not set will download controls-config from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.AuditExceptions, "audit-exceptions", false, "Include an exception usage audit in supported scan outputs")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. e.g: --exclude-namespaces ns-a,ns-b. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.MinSeverity, "min-severity", "", "Only include controls at or above this severity (low, medium, high, critical) in the output. Currently applies to JSON output only.")

--- a/core/cautils/config_output.go
+++ b/core/cautils/config_output.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type configOutputField struct {
+	name  string
+	value string
+}
+
 // FormatConfigOutput renders configuration data in the requested output format.
 // Supported values: json, yaml, text. The default format is text.
 func FormatConfigOutput(cfg *ConfigObj, format string, includeEmpty bool) ([]byte, error) {
@@ -34,16 +39,7 @@ func FormatConfigOutput(cfg *ConfigObj, format string, includeEmpty bool) ([]byt
 
 func formatConfigOutputJSON(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	payload := map[string]string{}
-	for _, field := range []struct {
-		name  string
-		value string
-	}{
-		{name: "accountID", value: cfg.AccountID},
-		{name: "clusterName", value: cfg.ClusterName},
-		{name: "cloudReportURL", value: cfg.CloudReportURL},
-		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
-		{name: "accessKey", value: cfg.AccessKey},
-	} {
+	for _, field := range configOutputFields(cfg) {
 		if includeEmpty || field.value != "" {
 			payload[field.name] = field.value
 		}
@@ -53,16 +49,7 @@ func formatConfigOutputJSON(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 
 func formatConfigOutputYAML(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	payload := map[string]string{}
-	for _, field := range []struct {
-		name  string
-		value string
-	}{
-		{name: "accountID", value: cfg.AccountID},
-		{name: "clusterName", value: cfg.ClusterName},
-		{name: "cloudReportURL", value: cfg.CloudReportURL},
-		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
-		{name: "accessKey", value: cfg.AccessKey},
-	} {
+	for _, field := range configOutputFields(cfg) {
 		if includeEmpty || field.value != "" {
 			payload[field.name] = field.value
 		}
@@ -72,19 +59,20 @@ func formatConfigOutputYAML(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 
 func formatConfigOutputText(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	var lines []string
-	for _, field := range []struct {
-		name  string
-		value string
-	}{
-		{name: "accountID", value: cfg.AccountID},
-		{name: "clusterName", value: cfg.ClusterName},
-		{name: "cloudReportURL", value: cfg.CloudReportURL},
-		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
-		{name: "accessKey", value: cfg.AccessKey},
-	} {
+	for _, field := range configOutputFields(cfg) {
 		if includeEmpty || field.value != "" {
 			lines = append(lines, fmt.Sprintf("%s: %s", field.name, field.value))
 		}
 	}
 	return []byte(strings.Join(lines, "\n") + "\n"), nil
+}
+
+func configOutputFields(cfg *ConfigObj) []configOutputField {
+	return []configOutputField{
+		{name: "accountID", value: cfg.AccountID},
+		{name: "clusterName", value: cfg.ClusterName},
+		{name: "cloudReportURL", value: cfg.CloudReportURL},
+		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
+		{name: "accessKey", value: cfg.AccessKey},
+	}
 }

--- a/core/cautils/config_output_test.go
+++ b/core/cautils/config_output_test.go
@@ -1,10 +1,12 @@
 package cautils
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestFormatConfigOutputJSON(t *testing.T) {
@@ -90,4 +92,74 @@ func TestFormatConfigOutputYAMLIncludesEmptyValuesWhenRequested(t *testing.T) {
 	assert.Contains(t, string(output), "accountID: account-123")
 	assert.Contains(t, string(output), "clusterName: \"\"")
 	assert.Contains(t, string(output), "accessKey: \"\"")
+}
+
+func TestFormatConfigOutputDefaultFormatIsText(t *testing.T) {
+	cfg := &ConfigObj{AccountID: "account-123"}
+
+	output, err := FormatConfigOutput(cfg, "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "accountID: account-123\n", string(output))
+}
+
+func TestFormatConfigOutputNormalizesFormat(t *testing.T) {
+	cfg := &ConfigObj{AccountID: "account-123"}
+
+	output, err := FormatConfigOutput(cfg, " YAML ", false)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(output), "accountID: account-123")
+}
+
+func TestFormatConfigOutputNilConfig(t *testing.T) {
+	output, err := FormatConfigOutput(nil, "json", true)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(output, &payload))
+
+	assert.Equal(t, "", payload["accountID"])
+	assert.Equal(t, "", payload["clusterName"])
+	assert.Equal(t, "", payload["cloudReportURL"])
+	assert.Equal(t, "", payload["cloudAPIURL"])
+	assert.Equal(t, "", payload["accessKey"])
+}
+
+func TestFormatConfigOutputJSONOmitsOnlyEmptyFields(t *testing.T) {
+	cfg := &ConfigObj{
+		AccountID:   "account-123",
+		ClusterName: "prod-cluster",
+		AccessKey:   "",
+	}
+
+	output, err := FormatConfigOutput(cfg, "json", false)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(output, &payload))
+
+	assert.Equal(t, map[string]string{
+		"accountID":   "account-123",
+		"clusterName": "prod-cluster",
+	}, payload)
+}
+
+func TestFormatConfigOutputYAMLParsesAsMap(t *testing.T) {
+	cfg := &ConfigObj{
+		AccountID:      "account-123",
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "https://report.example.com",
+	}
+
+	output, err := FormatConfigOutput(cfg, "yaml", false)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, yaml.Unmarshal(output, &payload))
+
+	assert.Equal(t, "account-123", payload["accountID"])
+	assert.Equal(t, "https://api.example.com", payload["cloudAPIURL"])
+	assert.Equal(t, "https://report.example.com", payload["cloudReportURL"])
+	assert.NotContains(t, payload, "accessKey")
 }

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -69,6 +69,8 @@ type OPASessionObj struct {
 	SessionID             string                             // SessionID
 	Policies              []reporthandling.Framework         // list of frameworks to scan
 	Exceptions            []armotypes.PostureExceptionPolicy // list of exceptions to apply on scan results
+	ExceptionAudit        *ExceptionAudit                    // optional exception usage audit
+	AuditExceptions       bool                               // include exception usage audit in supported outputs
 	OmitRawResources      bool                               // omit raw resources from output
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
@@ -94,9 +96,44 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		SessionID:             scanInfo.ScanID,
 		Metadata:              scanInfoToScanMetadata(ctx, scanInfo, policyIdentifiers),
 		OmitRawResources:      scanInfo.OmitRawResources,
+		AuditExceptions:       scanInfo.AuditExceptions,
 		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		LabelsToCopy:          scanInfo.LabelsToCopy,
 	}
+}
+
+type ExceptionAudit struct {
+	Summary   ExceptionAuditSummary `json:"summary"`
+	Items     []ExceptionAuditItem  `json:"items"`
+	Generated bool                  `json:"generated"`
+}
+
+type ExceptionAuditSummary struct {
+	Total          int `json:"total"`
+	Active         int `json:"active"`
+	Expired        int `json:"expired"`
+	Matched        int `json:"matched"`
+	Unused         int `json:"unused"`
+	InvalidControl int `json:"invalidControl"`
+}
+
+type ExceptionAuditItem struct {
+	Name             string                `json:"name"`
+	Status           string                `json:"status"`
+	MatchCount       int                   `json:"matchCount"`
+	Expired          bool                  `json:"expired,omitempty"`
+	InvalidControls  []string              `json:"invalidControls,omitempty"`
+	ControlIDs       []string              `json:"controlIDs,omitempty"`
+	MatchedResources []ExceptionAuditMatch `json:"matchedResources,omitempty"`
+}
+
+type ExceptionAuditMatch struct {
+	ResourceID string `json:"resourceID"`
+	Kind       string `json:"kind,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ControlID  string `json:"controlID"`
+	RuleName   string `json:"ruleName,omitempty"`
 }
 
 func estimateClusterSize(k8sResources K8SResources) int {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -115,6 +115,7 @@ type PolicyIdentifier struct {
 
 type ScanInfo struct {
 	UseExceptions         string   // Load file with exceptions configuration
+	AuditExceptions       bool     // Include exception usage audit in supported scan outputs
 	ControlsInputs        string   // Load file with inputs for controls
 	AttackTracks          string   // Load file with attack tracks
 	UseFrom               []string // Load framework from local file (instead of download). Use when running offline

--- a/core/pkg/opaprocessor/exceptionaudit.go
+++ b/core/pkg/opaprocessor/exceptionaudit.go
@@ -106,7 +106,7 @@ func buildExceptionAudit(
 
 func exceptionAuditItem(exception armotypes.PostureExceptionPolicy, policies *cautils.Policies, processor *exceptions.Processor) cautils.ExceptionAuditItem {
 	item := cautils.ExceptionAuditItem{
-		Name:       exceptionAuditKey(exception),
+		Name:       exceptionAuditName(exception),
 		Expired:    exceptionIsExpired(exception),
 		ControlIDs: exceptionControlIDs(exception),
 	}
@@ -115,6 +115,13 @@ func exceptionAuditItem(exception armotypes.PostureExceptionPolicy, policies *ca
 }
 
 func exceptionAuditKey(exception armotypes.PostureExceptionPolicy) string {
+	if exception.GUID != "" {
+		return exception.GUID
+	}
+	return exceptionAuditName(exception)
+}
+
+func exceptionAuditName(exception armotypes.PostureExceptionPolicy) string {
 	if exception.Name != "" {
 		return exception.Name
 	}

--- a/core/pkg/opaprocessor/exceptionaudit.go
+++ b/core/pkg/opaprocessor/exceptionaudit.go
@@ -1,0 +1,181 @@
+package opaprocessor
+
+import (
+	"sort"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+)
+
+const (
+	exceptionAuditStatusExpired        = "expired"
+	exceptionAuditStatusInvalidControl = "invalid-control"
+	exceptionAuditStatusMatched        = "matched"
+	exceptionAuditStatusUnused         = "unused"
+)
+
+func buildExceptionAudit(
+	loadedExceptions []armotypes.PostureExceptionPolicy,
+	activeExceptions []armotypes.PostureExceptionPolicy,
+	results map[string]resourcesresults.Result,
+	allResources map[string]workloadinterface.IMetadata,
+	policies *cautils.Policies,
+	processor *exceptions.Processor,
+) *cautils.ExceptionAudit {
+	items := make(map[string]*cautils.ExceptionAuditItem, len(loadedExceptions))
+	active := make(map[string]struct{}, len(activeExceptions))
+
+	for _, exception := range loadedExceptions {
+		key := exceptionAuditKey(exception)
+		item := exceptionAuditItem(exception, policies, processor)
+		items[key] = &item
+	}
+
+	for _, exception := range activeExceptions {
+		active[exceptionAuditKey(exception)] = struct{}{}
+	}
+
+	for resourceID, result := range results {
+		resource := allResources[resourceID]
+		for _, control := range result.AssociatedControls {
+			controlID := control.GetID()
+			for _, rule := range control.ResourceAssociatedRules {
+				for _, exception := range rule.Exception {
+					key := exceptionAuditKey(exception)
+					if _, ok := items[key]; !ok {
+						item := exceptionAuditItem(exception, policies, processor)
+						items[key] = &item
+					}
+					items[key].MatchCount++
+					items[key].MatchedResources = append(items[key].MatchedResources, exceptionAuditMatch(resourceID, controlID, rule.GetName(), resource))
+				}
+			}
+		}
+	}
+
+	audit := &cautils.ExceptionAudit{
+		Generated: true,
+		Items:     make([]cautils.ExceptionAuditItem, 0, len(items)),
+	}
+
+	keys := make([]string, 0, len(items))
+	for key := range items {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	audit.Summary.Total = len(keys)
+	for _, key := range keys {
+		item := items[key]
+		if _, ok := active[key]; ok {
+			audit.Summary.Active++
+		}
+		if item.Expired {
+			item.Status = exceptionAuditStatusExpired
+			audit.Summary.Expired++
+		} else if len(item.InvalidControls) > 0 {
+			item.Status = exceptionAuditStatusInvalidControl
+			audit.Summary.InvalidControl++
+		} else if item.MatchCount > 0 {
+			item.Status = exceptionAuditStatusMatched
+			audit.Summary.Matched++
+		} else {
+			item.Status = exceptionAuditStatusUnused
+			audit.Summary.Unused++
+		}
+		sort.Strings(item.ControlIDs)
+		sort.Strings(item.InvalidControls)
+		sort.Slice(item.MatchedResources, func(i, j int) bool {
+			if item.MatchedResources[i].ResourceID == item.MatchedResources[j].ResourceID {
+				if item.MatchedResources[i].ControlID == item.MatchedResources[j].ControlID {
+					return item.MatchedResources[i].RuleName < item.MatchedResources[j].RuleName
+				}
+				return item.MatchedResources[i].ControlID < item.MatchedResources[j].ControlID
+			}
+			return item.MatchedResources[i].ResourceID < item.MatchedResources[j].ResourceID
+		})
+		audit.Items = append(audit.Items, *item)
+	}
+
+	return audit
+}
+
+func exceptionAuditItem(exception armotypes.PostureExceptionPolicy, policies *cautils.Policies, processor *exceptions.Processor) cautils.ExceptionAuditItem {
+	item := cautils.ExceptionAuditItem{
+		Name:       exceptionAuditKey(exception),
+		Expired:    exceptionIsExpired(exception),
+		ControlIDs: exceptionControlIDs(exception),
+	}
+	item.InvalidControls = invalidExceptionControls(item.ControlIDs, policies, processor)
+	return item
+}
+
+func exceptionAuditKey(exception armotypes.PostureExceptionPolicy) string {
+	if exception.Name != "" {
+		return exception.Name
+	}
+	return exception.GetName()
+}
+
+func exceptionIsExpired(exception armotypes.PostureExceptionPolicy) bool {
+	return exception.ExpirationDate != nil && !exception.ExpirationDate.After(time.Now())
+}
+
+func exceptionControlIDs(exception armotypes.PostureExceptionPolicy) []string {
+	seen := map[string]struct{}{}
+	var controlIDs []string
+	for _, posturePolicy := range exception.PosturePolicies {
+		if posturePolicy.ControlID == "" {
+			continue
+		}
+		if _, ok := seen[posturePolicy.ControlID]; ok {
+			continue
+		}
+		seen[posturePolicy.ControlID] = struct{}{}
+		controlIDs = append(controlIDs, posturePolicy.ControlID)
+	}
+	return controlIDs
+}
+
+func invalidExceptionControls(controlIDs []string, policies *cautils.Policies, processor *exceptions.Processor) []string {
+	if len(controlIDs) == 0 || policies == nil || len(policies.Controls) == 0 {
+		return nil
+	}
+	if processor == nil {
+		processor = exceptions.NewProcessor()
+	}
+
+	var invalid []string
+	for _, controlID := range controlIDs {
+		found := false
+		for existingID := range policies.Controls {
+			if processor.RegexCompareControlID(controlID, existingID) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			invalid = append(invalid, controlID)
+		}
+	}
+	return invalid
+}
+
+func exceptionAuditMatch(resourceID, controlID, ruleName string, resource workloadinterface.IMetadata) cautils.ExceptionAuditMatch {
+	match := cautils.ExceptionAuditMatch{
+		ResourceID: resourceID,
+		ControlID:  controlID,
+		RuleName:   ruleName,
+	}
+	if resource == nil {
+		return match
+	}
+	match.Kind = resource.GetKind()
+	match.Namespace = resource.GetNamespace()
+	match.Name = resource.GetName()
+	return match
+}

--- a/core/pkg/opaprocessor/exceptionaudit_test.go
+++ b/core/pkg/opaprocessor/exceptionaudit_test.go
@@ -1,0 +1,123 @@
+package opaprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildExceptionAudit(t *testing.T) {
+	expiredAt := time.Now().Add(-time.Hour)
+	matchedException := auditException("matched-exception", "C-0001", nil)
+	unusedException := auditException("unused-exception", "C-0002", nil)
+	expiredException := auditException("expired-exception", "C-0003", &expiredAt)
+	invalidControlException := auditException("invalid-control-exception", "C-9999", nil)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "nginx",
+			"namespace": "default",
+		},
+	})
+
+	audit := buildExceptionAudit(
+		[]armotypes.PostureExceptionPolicy{matchedException, unusedException, expiredException, invalidControlException},
+		[]armotypes.PostureExceptionPolicy{matchedException, unusedException, invalidControlException},
+		map[string]resourcesresults.Result{
+			resource.GetID(): {
+				ResourceID: resource.GetID(),
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: "C-0001",
+						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+							{
+								Name:      "rule-a",
+								Exception: []armotypes.PostureExceptionPolicy{matchedException},
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]workloadinterface.IMetadata{resource.GetID(): resource},
+		&cautils.Policies{
+			Controls: map[string]reporthandling.Control{
+				"C-0001": {ControlID: "C-0001"},
+				"C-0002": {ControlID: "C-0002"},
+				"C-0003": {ControlID: "C-0003"},
+			},
+		},
+		exceptions.NewProcessor(),
+	)
+
+	require.NotNil(t, audit)
+	assert.True(t, audit.Generated)
+	assert.Equal(t, 4, audit.Summary.Total)
+	assert.Equal(t, 3, audit.Summary.Active)
+	assert.Equal(t, 1, audit.Summary.Expired)
+	assert.Equal(t, 1, audit.Summary.Matched)
+	assert.Equal(t, 1, audit.Summary.Unused)
+	assert.Equal(t, 1, audit.Summary.InvalidControl)
+
+	items := map[string]cautils.ExceptionAuditItem{}
+	for _, item := range audit.Items {
+		items[item.Name] = item
+	}
+
+	assert.Equal(t, exceptionAuditStatusMatched, items["matched-exception"].Status)
+	assert.Equal(t, 1, items["matched-exception"].MatchCount)
+	require.Len(t, items["matched-exception"].MatchedResources, 1)
+	assert.Equal(t, "Deployment", items["matched-exception"].MatchedResources[0].Kind)
+	assert.Equal(t, "default", items["matched-exception"].MatchedResources[0].Namespace)
+	assert.Equal(t, "nginx", items["matched-exception"].MatchedResources[0].Name)
+	assert.Equal(t, "C-0001", items["matched-exception"].MatchedResources[0].ControlID)
+	assert.Equal(t, "rule-a", items["matched-exception"].MatchedResources[0].RuleName)
+
+	assert.Equal(t, exceptionAuditStatusUnused, items["unused-exception"].Status)
+	assert.Equal(t, exceptionAuditStatusExpired, items["expired-exception"].Status)
+	assert.True(t, items["expired-exception"].Expired)
+	assert.Equal(t, exceptionAuditStatusInvalidControl, items["invalid-control-exception"].Status)
+	assert.Equal(t, []string{"C-9999"}, items["invalid-control-exception"].InvalidControls)
+}
+
+func TestBuildExceptionAuditTreatsRegexControlAsValid(t *testing.T) {
+	regexException := auditException("regex-exception", "C-000[12]", nil)
+
+	audit := buildExceptionAudit(
+		[]armotypes.PostureExceptionPolicy{regexException},
+		[]armotypes.PostureExceptionPolicy{regexException},
+		nil,
+		nil,
+		&cautils.Policies{
+			Controls: map[string]reporthandling.Control{
+				"C-0001": {ControlID: "C-0001"},
+			},
+		},
+		exceptions.NewProcessor(),
+	)
+
+	require.NotNil(t, audit)
+	require.Len(t, audit.Items, 1)
+	assert.Empty(t, audit.Items[0].InvalidControls)
+	assert.Equal(t, exceptionAuditStatusUnused, audit.Items[0].Status)
+}
+
+func auditException(name, controlID string, expirationDate *time.Time) armotypes.PostureExceptionPolicy {
+	return armotypes.PostureExceptionPolicy{
+		PortalBase: armotypes.PortalBase{Name: name},
+		PosturePolicies: []armotypes.PosturePolicy{
+			{ControlID: controlID},
+		},
+		ExpirationDate: expirationDate,
+	}
+}

--- a/core/pkg/opaprocessor/exceptionaudit_test.go
+++ b/core/pkg/opaprocessor/exceptionaudit_test.go
@@ -112,9 +112,45 @@ func TestBuildExceptionAuditTreatsRegexControlAsValid(t *testing.T) {
 	assert.Equal(t, exceptionAuditStatusUnused, audit.Items[0].Status)
 }
 
+func TestBuildExceptionAuditDoesNotCollapseDuplicateNamesWithDifferentGUIDs(t *testing.T) {
+	firstException := auditExceptionWithGUID("guid-1", "dup-name", "C-0001", nil)
+	secondException := auditExceptionWithGUID("guid-2", "dup-name", "C-0002", nil)
+
+	audit := buildExceptionAudit(
+		[]armotypes.PostureExceptionPolicy{firstException, secondException},
+		[]armotypes.PostureExceptionPolicy{firstException, secondException},
+		nil,
+		nil,
+		&cautils.Policies{
+			Controls: map[string]reporthandling.Control{
+				"C-0001": {ControlID: "C-0001"},
+				"C-0002": {ControlID: "C-0002"},
+			},
+		},
+		exceptions.NewProcessor(),
+	)
+
+	require.NotNil(t, audit)
+	require.Len(t, audit.Items, 2)
+	assert.Equal(t, 2, audit.Summary.Total)
+	assert.Equal(t, 2, audit.Summary.Active)
+
+	var gotControlIDs []string
+	for _, item := range audit.Items {
+		assert.Equal(t, "dup-name", item.Name)
+		require.Len(t, item.ControlIDs, 1)
+		gotControlIDs = append(gotControlIDs, item.ControlIDs[0])
+	}
+	assert.ElementsMatch(t, []string{"C-0001", "C-0002"}, gotControlIDs)
+}
+
 func auditException(name, controlID string, expirationDate *time.Time) armotypes.PostureExceptionPolicy {
+	return auditExceptionWithGUID("", name, controlID, expirationDate)
+}
+
+func auditExceptionWithGUID(guid, name, controlID string, expirationDate *time.Time) armotypes.PostureExceptionPolicy {
 	return armotypes.PostureExceptionPolicy{
-		PortalBase: armotypes.PortalBase{Name: name},
+		PortalBase: armotypes.PortalBase{GUID: guid, Name: name},
 		PosturePolicies: []armotypes.PosturePolicy{
 			{ControlID: controlID},
 		},

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -42,6 +42,7 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	}
 
 	processor := exceptions.NewProcessor()
+	loadedExceptions := append([]armotypes.PostureExceptionPolicy(nil), opap.Exceptions...)
 
 	// filter expired exceptions before applying them
 	opap.Exceptions = filterExpiredExceptions(opap.Exceptions)
@@ -76,6 +77,10 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	// map control to error
 	controlToInfoMap := mapControlToInfo(opap.ResourceToControlsMap, opap.InfoMap, opap.Report.SummaryDetails.Controls)
 	opap.Report.SummaryDetails.InitResourcesSummary(controlToInfoMap)
+
+	if opap.AuditExceptions {
+		opap.ExceptionAudit = buildExceptionAudit(loadedExceptions, opap.Exceptions, opap.ResourcesResult, opap.AllResources, opap.AllPolicies, processor)
+	}
 }
 
 // applyExceptionsToManualControls marks manual controls as passed+w/exceptions when

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -124,6 +124,7 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 	// extract specified labels from workloads, and attach scan coverage gaps.
 	finalizedReport := FinalizeResults(opaSessionObj)
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
+	reportWithSeverity.ExceptionAudit = opaSessionObj.ExceptionAudit
 	FilterBySeverity(reportWithSeverity, jp.minSeverity)
 
 	r, err := json.Marshal(reportWithSeverity)

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -1,15 +1,19 @@
 package printer
 
 import (
+	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewJsonPrinter(t *testing.T) {
@@ -92,6 +96,75 @@ func TestScore_Json(t *testing.T) {
 		})
 	}
 }
+
+func TestActionPrintIncludesExceptionAuditWhenSet(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.ExceptionAudit = &cautils.ExceptionAudit{
+		Generated: true,
+		Summary: cautils.ExceptionAuditSummary{
+			Total:   1,
+			Active:  1,
+			Matched: 1,
+		},
+		Items: []cautils.ExceptionAuditItem{
+			{
+				Name:       "matched-exception",
+				Status:     "matched",
+				MatchCount: 1,
+				ControlIDs: []string{"C-0001"},
+			},
+		},
+	}
+
+	got := jsonPrinterOutput(t, session)
+
+	exceptionAudit, ok := got["exceptionAudit"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, exceptionAudit["generated"])
+
+	summary, ok := exceptionAudit["summary"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), summary["total"])
+	assert.Equal(t, float64(1), summary["active"])
+	assert.Equal(t, float64(1), summary["matched"])
+
+	items, ok := exceptionAudit["items"].([]any)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	item, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "matched-exception", item["name"])
+}
+
+func TestActionPrintOmitsExceptionAuditWhenNil(t *testing.T) {
+	got := jsonPrinterOutput(t, cautils.NewOPASessionObjMock())
+
+	_, ok := got["exceptionAudit"]
+	assert.False(t, ok)
+}
+
+func jsonPrinterOutput(t *testing.T, session *cautils.OPASessionObj) map[string]any {
+	t.Helper()
+
+	tmpJson, err := os.CreateTemp("", "json-exception-audit-*.json")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpJson.Name())
+	}()
+
+	jp := NewJsonPrinter("")
+	jp.writer = tmpJson
+	require.NoError(t, jp.ActionPrint(context.Background(), session, nil))
+	require.NoError(t, tmpJson.Close())
+
+	rawJson, err := os.ReadFile(tmpJson.Name())
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rawJson, &got))
+	return got
+}
+
 func TestConvertToCVESummary(t *testing.T) {
 	cves := []imageprinter.CVE{
 		{

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -68,6 +68,7 @@ type PostureReportWithSeverity struct {
 	Metadata             reporthandlingv2.Metadata         `json:"metadata"`
 	ResourceLabels       map[string]map[string]string      `json:"resourceLabels,omitempty"` // map[resourceID]map[labelKey]labelValue - extracted labels from workloads
 	ScanCoverage         *cautils.ScanCoverage             `json:"scanCoverage,omitempty"`
+	ExceptionAudit       *cautils.ExceptionAudit           `json:"exceptionAudit,omitempty"`
 }
 
 // enrichControlsWithSeverity adds severity field to controls based on scoreFactor

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,6 +43,7 @@ kubescape scan [target] [flags]
 | `-e, --exclude-namespaces <ns>` | Namespaces to exclude (comma-separated) | - |
 | `--encrypt` | Encrypt sensitive report metadata using the master key provided through the `KUBESCAPE_MASTER_KEY` environment variable. Requires `--format json` for reports that will later be decrypted with `kubescape decrypt`. If both `--encrypt` and `--hide` are specified, `--encrypt` takes precedence. | `false` |
 | `--exceptions <path>` | Path to exceptions file | - |
+| `--audit-exceptions` | Include exception usage details in supported scan outputs | `false` |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
 | `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `csv` | `pretty-printer` |
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
@@ -59,6 +60,19 @@ kubescape scan [target] [flags]
 | `--use-from <path>` | Load specific policy from path | - |
 | `-v, --verbose` | Display all resources, not just failed ones | `false` |
 | `--view <type>` | View type: `security`, `control`, `resource` | `security` |
+
+### Exception Audit
+
+Use `--audit-exceptions --format json` to include an `exceptionAudit` object in scan output. The audit contains:
+
+| Field | Description |
+|-------|-------------|
+| `summary` | Counts for total, active, expired, matched, unused, and invalid-control exceptions |
+| `items` | One entry per loaded exception, including name, status, match count, control IDs, invalid controls, and matched resources when present |
+| `generated` | Indicates that the audit was requested and generated |
+
+Item `status` values are `matched`, `unused`, `expired`, and `invalid-control`.
+
 ### Examples
 
 ```bash

--- a/docs/config-output.md
+++ b/docs/config-output.md
@@ -107,6 +107,52 @@ This output formatting is helpful when you want to:
 3. compare a local cached configuration with a generated YAML or JSON payload
 4. debug configuration drift between environments
 
+## Output contract
+
+The rendered fields use stable lower camel case names:
+
+- `accountID`
+- `clusterName`
+- `cloudReportURL`
+- `cloudAPIURL`
+- `accessKey`
+
+By default, fields with empty values are not rendered. This keeps terminal
+output short and avoids noisy structured payloads in scripts that only need
+configured values.
+
+When `--include-empty` is set, every supported field is rendered even if its
+value is empty. This is useful for tools that validate the expected shape of
+the cached configuration.
+
+The `text` format renders one `key: value` pair per line. It is designed for
+operators reading logs or terminals, not for strict machine parsing.
+
+The `json` format renders a JSON object. Scripts can read the fields with tools
+such as `jq` without depending on the text layout.
+
+The `yaml` format renders a YAML mapping. This is convenient when comparing the
+cached values with Kubernetes manifests, Helm values, or other YAML-oriented
+configuration files.
+
+Unknown output formats return an error instead of falling back to text. This
+helps automation fail early when a flag value is misspelled.
+
+The command only reads and renders the cached configuration. It does not create,
+update, delete, or normalize the saved configuration file.
+
+### Scripting guidance
+
+For scripts, prefer `-o json` and check for missing keys explicitly.
+
+For reviews, prefer `-o yaml --include-empty` so unset fields are visible.
+
+For logs, prefer the default text format because it is compact.
+
+Do not treat omitted fields as deleted configuration values.
+
+Quote shell variables that may contain URLs or access keys.
+
 ## Use cases
 
 ### Troubleshooting a missing account ID


### PR DESCRIPTION
## Overview

Adds an opt-in posture exception audit for scan JSON output via `--audit-exceptions`. The audit compares loaded exceptions with exceptions attached to matched rule results and reports matched, unused, expired, and invalid-control exception states without changing normal scan behavior when the flag is disabled.

Fixes kubescape/kubescape#3094

## Changes

- Adds `kubescape scan --audit-exceptions`.
- Preserves the pre-expiration-filter exception list so expired exceptions can be reported in the audit.
- Builds an `exceptionAudit` JSON object with summary counts, per-exception status, match counts, matched resources, control IDs, and invalid control IDs.
- Adds unit tests for matched, unused, expired, invalid-control, and regex-control audit cases.

## Tests

- `go test ./core/pkg/opaprocessor`
- `go test ./cmd/scan`
- `go test ./core/pkg/resultshandling/printer/v2`
- `go test ./core/cautils ./core/pkg/opaprocessor ./core/pkg/resultshandling/printer/v2 ./cmd/scan ./core/core`

## Notes

`go test ./...` was also run. It passes the touched packages but currently fails in `github.com/kubescape/kubescape/v3/core/pkg/resourcehandler` at `TestExcludeFilesUnderDirectories`, where files under the excluded `app` directory are still present in the returned map. That failure reproduces when running `go test ./core/pkg/resourcehandler` by itself and is unrelated to this exception-audit change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the optional `--audit-exceptions` scan flag.
  - Scan results can include exception status, expiration, control validity, matched resources, and summary counts.
  - JSON reports now provide exception-audit details when enabled.
- **Bug Fixes**
  - Exception audits distinguish active, expired, unused, matched, and invalid-control exceptions.
  - Configuration output consistently omits empty fields across text, JSON, and YAML formats.
- **Documentation**
  - Documented configuration output formats, field behavior, validation, scripting guidance, and exception-audit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->