### PR TITLE
fix(fixhandler): reject yq expression syntax in report fix paths

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -953,6 +954,12 @@ func (rfi *ResourceFixInfo) addYamlExpressionsFromResourceAssociatedControl(docu
 			}
 
 			yamlExpression := FixPathToValidYamlExpression(rulePaths.FixPath.Path, rulePaths.FixPath.Value, documentIndex)
+			if yamlExpression == "" {
+				logger.L().Debug("skipping fix path that is not a plain yaml path",
+					helpers.String("fixPath", sanitizeForLog(rulePaths.FixPath.Path)))
+				skippedReasons = append(skippedReasons, "skipped: fix path is not a plain yaml path")
+				continue
+			}
 			rfi.YamlExpressions[yamlExpression] = rulePaths.FixPath
 			added++
 		}
@@ -976,7 +983,36 @@ func reduceYamlExpressions(resource *ResourceFixInfo) string {
 	return strings.Join(expressions, " | ")
 }
 
+// safeFixPath matches the subset of yq's expression grammar that a fix path is
+// allowed to use: dot-separated keys — bare or double-quoted — each optionally
+// followed by list indices. Everything else yq accepts in that position
+// (pipes, parentheses, comparison and assignment operators, function calls
+// such as strenv() or load_str()) is expression syntax, not a path.
+var safeFixPath = regexp.MustCompile(`^(?:[A-Za-z0-9_/-]+|"[^"\\]*")(?:\[(?:\d+|\*)\])*(?:\.(?:[A-Za-z0-9_/-]+|"[^"\\]*")(?:\[(?:\d+|\*)\])*)*$`)
+
+// safeSequenceValue matches a flow sequence of plain scalars, which is the
+// only shape of value that may be spliced into the expression unquoted.
+var safeSequenceValue = regexp.MustCompile(`^\[\s*(?:(?:"[^"\\]*"|-?\d+(?:\.\d+)?|true|false)(?:\s*,\s*(?:"[^"\\]*"|-?\d+(?:\.\d+)?|true|false))*\s*)?\]$`)
+
+// FixPathToValidYamlExpression builds the yq expression that writes value at
+// fixPath in document documentIndexInYaml. It returns an empty string when
+// fixPath is not a plain yaml path, and callers must skip such paths.
+//
+// Both operands come from the report file, which `kubescape fix` treats as
+// untrusted input (hence --base-path), and both are spliced into an expression
+// that yq then evaluates. A path such as
+//
+//	metadata.annotations.leak |= strenv(KUBESCAPE_ACCESS_KEY) | select(di==0).spec.hostNetwork
+//
+// parses as valid yq and makes `fix` copy an environment variable — or, via
+// load_str(), any local file — into the user's manifest, which is then written
+// back to disk. Validating both operands against a path/scalar grammar keeps a
+// crafted report from steering the expression.
 func FixPathToValidYamlExpression(fixPath, value string, documentIndexInYaml int) string {
+	if !safeFixPath.MatchString(fixPath) {
+		return ""
+	}
+
 	isStringValue := true
 	if _, err := strconv.ParseBool(value); err == nil {
 		isStringValue = false
@@ -989,8 +1025,14 @@ func FixPathToValidYamlExpression(fixPath, value string, documentIndexInYaml int
 	// Strings should be quoted. Escape only `"` — yq's expression lexer
 	// (lexer_participle.go stringValue) unescapes \" and nothing else, so any
 	// other Go-style escape would be written to the file literally.
-	// Do not quote if the value is meant to be a YAML sequence.
-	if isStringValue && (!strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]")) {
+	//
+	// Do not quote if the value is meant to be a YAML sequence — but only when
+	// it really is one. Looking at the brackets alone is not enough: yq reads
+	// `[strenv(SECRET)]` as a collect operator around a function call, and
+	// `[] | (...) | [1]` as a pipeline, so both would evaluate rather than land
+	// as a literal sequence. Anything that is not a sequence of plain scalars
+	// is quoted like any other string value.
+	if isStringValue && !safeSequenceValue.MatchString(value) {
 		value = `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
 	}
 

--- a/core/pkg/fixhandler/fixhandler_test.go
+++ b/core/pkg/fixhandler/fixhandler_test.go
@@ -370,6 +370,120 @@ func Test_fixPathToValidYamlExpression(t *testing.T) {
 	}
 }
 
+// TestFixPathToValidYamlExpression_RejectsExpressionSyntax covers fix paths that
+// are yq expressions rather than paths. Both halves of a FixPath come out of the
+// report file, which `kubescape fix` treats as untrusted input (that is what
+// --base-path exists for), and the path used to be spliced into the expression
+// verbatim — so a crafted report could pipe strenv()/load_str() into the
+// assignment and have `fix` write an environment variable or a local file into
+// the user's manifest.
+func TestFixPathToValidYamlExpression_RejectsExpressionSyntax(t *testing.T) {
+	hostilePaths := []string{
+		`metadata.annotations.leak |= strenv(KUBESCAPE_ACCESS_KEY) | select(di==0).spec.hostNetwork`,
+		`metadata.annotations.file |= load_str("/etc/hosts") | select(di==0).spec.hostNetwork`,
+		`spec.hostNetwork) | (.. | select(tag=="!!str"))`,
+		`spec.hostNetwork | del(.metadata)`,
+		`spec["hostNetwork" + strenv(X)]`,
+		`.spec.hostNetwork`, // a leading dot doubles the root separator
+		`spec.hostNetwork = "x"`,
+		`spec.containers[0 | 1].image`,
+		"spec.hostNetwork\n| del(.metadata)",
+	}
+	for _, fixPath := range hostilePaths {
+		t.Run(fixPath, func(t *testing.T) {
+			assert.Empty(t, FixPathToValidYamlExpression(fixPath, "false", 0),
+				"a fix path carrying yq expression syntax must not produce an expression")
+		})
+	}
+}
+
+// TestFixPathToValidYamlExpression_KeepsPlainPaths makes sure the validation
+// above leaves the paths real controls emit alone: nested keys, list indices,
+// and annotation keys (bare or quoted, with dots and slashes in them).
+func TestFixPathToValidYamlExpression_KeepsPlainPaths(t *testing.T) {
+	tests := []struct {
+		fixPath string
+		value   string
+		want    string
+	}{
+		{"spec.hostNetwork", "false", `select(di==0).spec.hostNetwork |= false`},
+		{"spec.template.spec.containers[0].securityContext.runAsNonRoot", "true", `select(di==0).spec.template.spec.containers[0].securityContext.runAsNonRoot |= true`},
+		{"spec.containers[0].image", "nginx:1.28", `select(di==0).spec.containers[0].image |= "nginx:1.28"`},
+		{"metadata.annotations.foo/bar", "hello", `select(di==0).metadata.annotations.foo/bar |= "hello"`},
+		{`metadata.annotations."foo.bar/baz"`, "hello", `select(di==0).metadata.annotations."foo.bar/baz" |= "hello"`},
+		{"spec.containers[*].image", "nginx:1.28", `select(di==0).spec.containers[*].image |= "nginx:1.28"`},
+		{"spec.containers[0].securityContext.capabilities.drop", `["ALL","NET_RAW"]`, `select(di==0).spec.containers[0].securityContext.capabilities.drop |= ["ALL","NET_RAW"]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixPath, func(t *testing.T) {
+			assert.Equal(t, tt.want, FixPathToValidYamlExpression(tt.fixPath, tt.value, 0))
+		})
+	}
+}
+
+// TestFixPathToValidYamlExpression_QuotesSequenceLookalikeValues covers the same
+// injection through the value operand: a value is spliced in unquoted when it is
+// meant to be a sequence, and square brackets alone don't make it one — yq reads
+// `[strenv(SECRET)]` as a collect operator wrapped around a function call.
+func TestFixPathToValidYamlExpression_QuotesSequenceLookalikeValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "genuine sequence stays a sequence",
+			value: `["ALL","NET_RAW"]`,
+			want:  `select(di==0).spec.x |= ["ALL","NET_RAW"]`,
+		},
+		{
+			name:  "empty sequence stays a sequence",
+			value: `[]`,
+			want:  `select(di==0).spec.x |= []`,
+		},
+		{
+			name:  "function call in sequence clothing is quoted",
+			value: `[strenv(KUBESCAPE_ACCESS_KEY)]`,
+			want:  `select(di==0).spec.x |= "[strenv(KUBESCAPE_ACCESS_KEY)]"`,
+		},
+		{
+			name:  "pipeline wrapped in brackets is quoted",
+			value: `[] | (select(di==0).metadata.annotations.leak |= strenv(X)) | [1]`,
+			want:  `select(di==0).spec.x |= "[] | (select(di==0).metadata.annotations.leak |= strenv(X)) | [1]"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FixPathToValidYamlExpression("spec.x", tt.value, 0))
+		})
+	}
+}
+
+// TestApplyFixToContent_CraftedFixPathLeaksNothing is the end-to-end check: a
+// report whose fix path is a yq expression must leave the manifest untouched
+// rather than have the environment copied into it.
+func TestApplyFixToContent_CraftedFixPathLeaksNothing(t *testing.T) {
+	t.Setenv("KUBESCAPE_ACCESS_KEY", "super-secret-token")
+	yamlContent := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: demo\nspec:\n  hostNetwork: true\n"
+
+	rfi := &ResourceFixInfo{YamlExpressions: map[string]armotypes.FixPath{}}
+	ac := failedControl("C-0001", "crafted",
+		failedRuleWithFix(`metadata.annotations.leak |= strenv(KUBESCAPE_ACCESS_KEY) | select(di==0).spec.hostNetwork`, "false"),
+	)
+
+	added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(0, &ac, false)
+
+	assert.Equal(t, 0, added, "a crafted fix path must not become a fix")
+	assert.Empty(t, rfi.YamlExpressions)
+	if assert.Len(t, skipped, 1, "the crafted path must be surfaced as skipped") {
+		assert.Contains(t, skipped[0], "not a plain yaml path")
+	}
+
+	got, err := ApplyFixToContent(context.Background(), yamlContent, reduceYamlExpressions(rfi))
+	require.NoError(t, err)
+	assert.NotContains(t, got, "super-secret-token")
+}
+
 func TestJoinStrings(t *testing.T) {
 	tests := []struct {
 		name string

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -466,7 +466,12 @@ func collectFixes(ctx context.Context, cache *fixReportCache, result *sarif.Resu
 				continue
 			}
 
+			// Empty means the path is not a plain yaml path and must not be
+			// evaluated as a yq expression.
 			yamlExpression := fixhandler.FixPathToValidYamlExpression(fixPath, rulePaths.FixPath.Value, documentIndex)
+			if yamlExpression == "" {
+				continue
+			}
 			addFixRegions(result, filepath, cache.fixRegions(ctx, rsrcAbsPath, yamlExpression))
 		}
 	}


### PR DESCRIPTION
## Overview

`kubescape fix` builds the yq expression it applies to a manifest by interpolating both halves of a report's `fixPath` into a format string ([`FixPathToValidYamlExpression`](https://github.com/kubescape/kubescape/blob/master/core/pkg/fixhandler/fixhandler.go)):

```go
return fmt.Sprintf("select(di==%d).%s |= %s", documentIndexInYaml, fixPath, value)
```

Only the value was escaped, and only when it didn't look like a sequence. The path went in verbatim, so a fix path that is itself yq syntax steers the whole expression rather than naming a field in it.

The report file is untrusted input here — that's what `--base-path` exists for ("If the report comes from a source you don't fully trust (e.g. a shared CI artifact)…"). A crafted report therefore makes `fix` write attacker-chosen content into the user's manifests:

```json
{ "fixPath": { "path": "metadata.annotations.leak |= strenv(KUBESCAPE_ACCESS_KEY) | select(di==0).spec.hostNetwork", "value": "false" } }
```

expands to a valid two-assignment expression and produces:

```yaml
metadata:
  name: demo
  annotations:
    leak: super-secret-token   # from the environment
spec:
  hostNetwork: false
```

`load_str("/etc/hosts")` in place of `strenv(...)` does the same for any local file the user can read. The patched file is then written back to disk (and typically committed), so this is a working exfiltration primitive, not just a crash.

The value operand has the same hole in a narrower form: it is spliced in unquoted whenever it starts with `[` and ends with `]`, and yq reads `[strenv(SECRET)]` as a collect operator wrapped around a function call, not as a literal sequence.

**This PR** validates both operands before interpolating:

* the path must be dot-separated keys — bare or double-quoted — with optional list indices (`spec.template.spec.containers[0].securityContext.runAsNonRoot`, `metadata.annotations."foo.bar/baz"`, `spec.containers[*].image` all still pass);
* an unquoted value must be a flow sequence of plain scalars (`["ALL","NET_RAW"]`), which is what the capability-drop fixes emit.

A path that fails validation yields no expression: it is skipped and reported in the unfixed-controls output ("skipped: fix path is not a plain yaml path") instead of being handed to yq, and the SARIF fix-region path skips it too. A value that fails is quoted like any other string value, exactly as before.

## Additional Information

* Paths built internally (`prioritizationhandler.go`) are literals plus an integer index, so they are unaffected.
* `locationresolver.FixPathToValidYamlExpression` is a separate, read-only variant (it resolves line/column for evidence output and never writes a file); it is left alone here to keep this change to the write path.

## How to Test

```
go test ./core/pkg/fixhandler/... ./core/pkg/resultshandling/printer/...
```

New tests:

* `TestFixPathToValidYamlExpression_RejectsExpressionSyntax` — hostile paths produce no expression.
* `TestFixPathToValidYamlExpression_KeepsPlainPaths` — the path shapes controls actually emit are unchanged.
* `TestFixPathToValidYamlExpression_QuotesSequenceLookalikeValues` — genuine sequences stay sequences; `[strenv(...)]` and bracket-wrapped pipelines get quoted.
* `TestApplyFixToContent_CraftedFixPathLeaksNothing` — end-to-end: the crafted path is skipped and the environment variable never reaches the manifest.

Manually verified before/after with a report carrying the payload above: before the change the access key is written into the manifest, after it the manifest is untouched and the control is listed as skipped.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of automated fix paths and values to prevent malformed or unsafe YAML expressions.
  * Prevented crafted paths from exposing environment data or modifying manifests unexpectedly.
  * Ensured invalid fixes are skipped safely instead of producing empty expressions.
  * Corrected quoting behavior for bracketed values that are not valid sequences.
* **Tests**
  * Added security-focused coverage for path validation, quoting, and safe fix application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->