### PR TITLE
fix(cel): populate request.resource plural from the same guess appliesTo scopes with

### DIFF
--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -53,9 +53,9 @@ func stubBindings(obj, namespaceObject map[string]any) map[string]any {
 // Known gaps (issue #2001), present-but-zero so selection never errors:
 //   - userInfo carries no identity (offline we don't know the requester), so
 //     checks depending on the requesting user are a documented limitation.
-//   - resource/requestResource carry the group and version but an empty
-//     resource (plural) name: resolving the GVR plural offline needs a
-//     RESTMapper we don't have, so it stays the zero value.
+//   - subResource/requestSubResource are always empty: the scan does not
+//     evaluate subresources (the same reason matchesResource declines a
+//     "resource/subresource" rule).
 func stubRequest(obj map[string]any) map[string]any {
 	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
 	namespace, _, _ := unstructured.NestedString(obj, "metadata", "namespace")
@@ -67,7 +67,7 @@ func stubRequest(obj map[string]any) map[string]any {
 	// share group/version. requestKind/requestResource equal kind/resource
 	// when no API conversion is involved, which is always the case offline.
 	gvk := map[string]any{"group": group, "version": version, "kind": kind}
-	gvr := map[string]any{"group": group, "version": version, "resource": ""}
+	gvr := map[string]any{"group": group, "version": version, "resource": resourcePlural(obj)}
 
 	return map[string]any{
 		"uid":                "",
@@ -94,6 +94,25 @@ func stubRequest(obj map[string]any) map[string]any {
 		"dryRun":  false,
 		"options": map[string]any{},
 	}
+}
+
+// resourcePlural is the plural resource name for request.resource, taken from
+// the same objectGVR guess appliesTo scopes with. Sharing the guess is the
+// point: a policy that narrows by resource can do it through matchConstraints
+// or by reading request.resource.resource, and the two must agree.
+//
+// Leaving it empty (the old behavior) was a silent parity break rather than a
+// loud one, because request is cel.DynType: a guard like
+// `request.resource.resource != 'pods' || ...` does not error offline, it
+// short-circuits to true and records a pass the cluster never made. Empty is
+// kept only for an object with no determinable kind, which objectGVR reports
+// and appliesTo already treats as "evaluate and let it error".
+func resourcePlural(obj map[string]any) string {
+	gvr, ok := objectGVR(obj)
+	if !ok {
+		return ""
+	}
+	return gvr.Resource
 }
 
 // stubNamespaceObject resolves the value bound to "namespaceObject".

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -68,13 +68,92 @@ func TestStubRequestHasFullAdmissionRequestShape(t *testing.T) {
 		assert.Truef(t, ok, "request is missing field %q", key)
 	}
 
-	// resource is a GroupVersionResource: group/version are real, the plural
-	// resource name is the zero value (can't resolve a GVR plural offline).
+	// resource is a GroupVersionResource: group, version and the plural
+	// resource name are all real.
 	resource, ok := req["resource"].(map[string]any)
 	require.True(t, ok, "resource should be a map")
 	assert.Equal(t, "", resource["group"])
 	assert.Equal(t, "v1", resource["version"])
-	assert.Equal(t, "", resource["resource"])
+	assert.Equal(t, "pods", resource["resource"])
+}
+
+// TestStubRequestResourcePlural pins request.resource.resource to the plural a
+// cluster would report. An empty plural is a silent parity break, not an eval
+// error: request is cel.DynType, so a policy guarding on the plural just
+// compares against "" and passes (issue #3098).
+func TestStubRequestResourcePlural(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want string
+	}{
+		{
+			name: "core group",
+			obj:  namespacedPod(),
+			want: "pods",
+		},
+		{
+			name: "grouped api version",
+			obj:  clusterScopedRole(),
+			want: "clusterroles",
+		},
+		{
+			name: "kind ending in y pluralizes to ies",
+			obj: map[string]any{
+				"apiVersion": "networking.k8s.io/v1",
+				"kind":       "NetworkPolicy",
+			},
+			want: "networkpolicies",
+		},
+		{
+			name: "kind ending in s pluralizes to es",
+			obj: map[string]any{
+				"apiVersion": "policy/v1",
+				"kind":       "PodDisruptionBudget",
+			},
+			want: "poddisruptionbudgets",
+		},
+		{
+			name: "custom resource kind",
+			obj: map[string]any{
+				"apiVersion": "agents.x-k8s.io/v1alpha1",
+				"kind":       "ActorTemplate",
+			},
+			want: "actortemplates",
+		},
+		{
+			name: "undeterminable kind stays empty",
+			obj:  map[string]any{"apiVersion": "v1"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := stubRequest(tt.obj)
+
+			for _, field := range []string{"resource", "requestResource"} {
+				gvr, ok := req[field].(map[string]any)
+				require.Truef(t, ok, "%s should be a map", field)
+				assert.Equalf(t, tt.want, gvr["resource"], "%s.resource", field)
+			}
+		})
+	}
+}
+
+// TestStubRequestResourceMatchesScoping is the anti-drift guard: appliesTo
+// scopes a policy by the guessed plural, so a policy reading the plural off
+// request must see the same string. Two guesses that can disagree would let a
+// policy be scoped in and then self-guard itself back out.
+func TestStubRequestResourceMatchesScoping(t *testing.T) {
+	for _, obj := range []map[string]any{namespacedPod(), clusterScopedRole()} {
+		gvr, ok := objectGVR(obj)
+		require.True(t, ok)
+
+		req := stubRequest(obj)
+		resource := req["resource"].(map[string]any)
+		assert.Equal(t, gvr.Resource, resource["resource"])
+	}
 }
 
 func TestStubRequestGroupedAPIVersion(t *testing.T) {
@@ -100,7 +179,7 @@ func TestStubRequestSelectableAgainstEnv(t *testing.T) {
 		"request.namespace == 'production'",
 		"request.uid == ''",
 		"request.kind.kind == 'Pod'",
-		"request.resource.resource == ''",
+		"request.resource.resource == 'pods'",
 		"request.resource.group == ''",
 		"request.subResource == ''",
 		"request.requestKind.kind == 'Pod'",


### PR DESCRIPTION
## Overview

Fixes #3098.

The offline CEL engine builds a stub `request` variable so a policy sees the same input it would get from the apiserver at admission. Everything on it was real except one field: the plural resource name on `request.resource` and `request.requestResource` was hardcoded to the empty string, with a comment saying we cannot resolve a plural offline without a RESTMapper.

We can, and we already do. `objectGVR` in `scope.go` guesses the plural with apimachinery's `UnsafeGuessKindToResource`, and `appliesTo` uses that guess to decide whether an object is inside a policy's `matchConstraints` at all. So the engine already trusts the guessed plural for the bigger decision of whether a policy runs, it just was not putting the same string somewhere a policy could read it.

That gap is quiet rather than loud. `request` is declared as `cel.DynType`, so reading `request.resource.resource` never errored, it returned an empty string and the expression carried on. A policy bound across several resources that narrows itself with something like `request.resource.resource != 'pods' || object.spec.hostNetwork != true` short circuits to true offline and the resource comes out as a pass, while a cluster reads `pods`, falls through to the real check, and denies. That is the same shape of false pass `appliesTo` was written to close for `object.kind`, one field over.

This change routes the plural through the existing guess instead of hardcoding it. A `resourcePlural` helper calls `objectGVR` and returns the empty string only when the object has no determinable kind, which is the case `objectGVR` already reports and `appliesTo` already treats as "evaluate it and let it error". One guess feeding both the scoping decision and the request stub means the two cannot drift apart as more kinds get scanned, which matters for the CRD targeted policies coming out of #2557.

`subResource` and `requestSubResource` stay empty on purpose. The scan does not evaluate subresources, and `matchesResource` already declines to match a `resource/subresource` rule for the same reason, so the stub is consistent with the scoping side there too.

## Changes

- `core/pkg/opaprocessor/cel/stub.go`: add `resourcePlural`, feed it into the `resource` and `requestResource` bindings, and correct the stale doc note about the known gaps.
- `core/pkg/opaprocessor/cel/stub_test.go`: cover the plural across core group, grouped API version, the `y` to `ies` and `s` to `es` pluralization rules, a custom resource kind, and the undeterminable kind that stays empty. Add a guard asserting the stub and `objectGVR` agree, so the two cannot silently diverge later.

## Testing

`go build ./...`, `go vet`, and `gofmt` are clean.

`go test ./core/pkg/opaprocessor/...` and `go test ./cmd/vap/...` pass.

`go test ./core/...` has one failure in `TestExcludeFilesUnderDirectories` under `core/pkg/resourcehandler`. It fails the same way on a clean master with no changes applied, so it is not from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offline CEL admission requests now include the inferred resource plural for core, grouped, irregular, and custom resources.
  * Resource information is consistently populated for both the target resource and requested resource.
  * Resource plural remains empty when the object’s resource type cannot be determined.
  * Documentation now clearly identifies subresources as a limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->