### PR TITLE
fix(operator): accept all successful trigger responses

### DIFF
--- a/core/core/clusterconnector.go
+++ b/core/core/clusterconnector.go
@@ -125,7 +125,7 @@ func (a *OperatorAdapter) httpPostOperatorScanRequest(body apis.Commands) (strin
 		return "", err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return "", fmt.Errorf("http-error: %d", resp.StatusCode)
 	}
 	return "success", nil

--- a/core/core/clusterconnector_test.go
+++ b/core/core/clusterconnector_test.go
@@ -274,6 +274,18 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 			expectPost:  true,
 		},
 		{
+			name:        "accepted response is successful",
+			statusCode:  http.StatusAccepted,
+			expectValue: "success",
+			expectPost:  true,
+		},
+		{
+			name:        "no-content response is successful",
+			statusCode:  http.StatusNoContent,
+			expectValue: "success",
+			expectPost:  true,
+		},
+		{
 			name:      "port forwarder fails to start",
 			startErr:  errors.New("boom"),
 			expectErr: "boom",
@@ -287,9 +299,21 @@ func TestOperatorAdapter_httpPostOperatorScanRequest(t *testing.T) {
 			expectPost: true,
 		},
 		{
-			name:       "non-200 status",
+			name:       "server error is not successful",
 			statusCode: http.StatusInternalServerError,
 			expectErr:  "http-error: 500",
+			expectPost: true,
+		},
+		{
+			name:       "redirect is not successful",
+			statusCode: http.StatusMultipleChoices,
+			expectErr:  "http-error: 300",
+			expectPost: true,
+		},
+		{
+			name:       "informational response is not successful",
+			statusCode: 199,
+			expectErr:  "http-error: 199",
 			expectPost: true,
 		},
 	}


### PR DESCRIPTION
## Summary

- Treat every HTTP 2xx response from the operator trigger endpoint as successful.
- Continue rejecting informational, redirect, client-error, and server-error responses.
- Cover both boundaries of the success range in the existing table-driven test.

## Why

The trigger request currently accepts only status 200. Valid successful responses such as 202 Accepted and 204 No Content are returned as errors even though they are within HTTP's success range.

## Validation

- `go test ./core/core -run TestOperatorAdapter_httpPostOperatorScanRequest -count=1`
- `gofmt` verification for the changed Go files
- `git diff --check`
- Regression matrix covers 199, 202, 204, 300, and 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP response handling so all successful 2xx responses are accepted.
  * Operations now correctly support responses such as 202 (Accepted) and 204 (No Content).
  * Informational, redirect, and server-error responses continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->