### PR TITLE
fix(resourcehandler): propagate estimator cancellation

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1066,8 +1066,17 @@ func (k8sHandler *K8sResourceHandler) EstimateClusterSize(ctx context.Context, s
 	var total int
 	var ok int
 	for _, gvr := range namespacedResourcesToEstimate {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
 		result, err := k8sHandler.k8s.DynamicClient.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{Limit: 1})
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return 0, ctxErr
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return 0, err
+			}
 			continue
 		}
 		ok++
@@ -1075,6 +1084,9 @@ func (k8sHandler *K8sResourceHandler) EstimateClusterSize(ctx context.Context, s
 		if rc := result.GetRemainingItemCount(); rc != nil {
 			total += int(*rc)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
 	}
 
 	if ok == 0 {

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -177,6 +177,30 @@ func TestEstimateClusterSize_ListErrors(t *testing.T) {
 	assert.Equal(t, 1515, size)
 }
 
+func TestEstimateClusterSize_ContextCancellationDiscardsPartialEstimate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	mockClient := &gvrAwareDynamicClient{
+		listFunc: func(_ schema.GroupVersionResource, _ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			calls++
+			if calls == 1 {
+				cancel()
+				return newLimitOneListWithRemaining(100), nil
+			}
+			return nil, context.Canceled
+		},
+	}
+
+	handler := &K8sResourceHandler{
+		k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient},
+	}
+
+	size, err := handler.EstimateClusterSize(ctx, &cautils.ScanInfo{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, size, "a canceled estimate must not be mistaken for a successful partial count")
+	assert.Equal(t, 1, calls, "estimation should not issue another LIST after cancellation")
+}
+
 func TestEstimateClusterSize_AllListErrors(t *testing.T) {
 	mockClient := &gvrAwareDynamicClient{
 		listFunc: func(gvr schema.GroupVersionResource, ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {


### PR DESCRIPTION
## Summary

- Stop cluster-size estimation promptly when its context is canceled or expires.
- Discard partial counts rather than treating cancellation as an ordinary per-resource failure.
- Preserve the existing tolerance for unrelated unavailable or forbidden resource types.

## Why

The estimator skips individual LIST errors so one unavailable resource type does not break automatic streaming selection. That also caused context cancellation to be swallowed after an earlier LIST succeeded, returning a partial size as if the estimate were complete.

## Validation

- `go test ./core/pkg/resourcehandler -run TestEstimateClusterSize_ContextCancellationDiscardsPartialEstimate -count=1`
- `gofmt` verification for the changed Go files
- `git diff --check`
- Regression cancels after the first successful LIST and verifies no second request is issued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cluster size estimation now stops promptly when an operation is canceled or reaches its deadline.
  - Partial estimates are discarded when cancellation occurs, preventing incomplete results from being returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->