### PR TITLE
fix(storage): propagate non-NotFound API errors

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -127,7 +127,7 @@ func (a *APIServerStore) GetWorkloadConfigurationScanResult(ctx context.Context,
 	case err != nil:
 		logger.L().Ctx(ctx).Warning("failed to get workload configuration scan manifest from apiserver", helpers.Error(err),
 			helpers.String("name", name))
-		return &v1beta1.WorkloadConfigurationScan{}, nil
+		return nil, fmt.Errorf("get workload configuration scan %q from namespace %q: %w", name, namespace, err)
 	}
 
 	logger.L().Debug("got workload configuration scan manifest from storage", helpers.String("name", name))

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -32,6 +32,31 @@ func NewFakeAPIServerStorage(namespace string) *APIServerStore {
 	}
 }
 
+func TestGetWorkloadConfigurationScanResult_PropagatesAPIServerError(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	getErr := errors.New("apiserver unavailable")
+	client.PrependReactor("get", "workloadconfigurationscans", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, getErr
+	})
+	store := &APIServerStore{StorageClient: client.SpdxV1beta1()}
+
+	manifest, err := store.GetWorkloadConfigurationScanResult(ctx, "test-scan", "default")
+
+	assert.Nil(t, manifest)
+	assert.ErrorIs(t, err, getErr)
+}
+
+func TestGetWorkloadConfigurationScanResult_NotFoundRemainsEmpty(t *testing.T) {
+	store := NewFakeAPIServerStorage("default")
+
+	manifest, err := store.GetWorkloadConfigurationScanResult(context.Background(), "missing", "default")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, manifest)
+	assert.Empty(t, manifest.Name)
+}
+
 func TestStoreWorkloadConfigurationScanResult_PropagatesUpdateError(t *testing.T) {
 	ctx := context.Background()
 	existing := &v1beta1.WorkloadConfigurationScan{


### PR DESCRIPTION
## Summary
- Return a wrapped error when reading a WorkloadConfigurationScan fails for reasons other than Kubernetes NotFound.
- Preserve the existing empty-result behavior for NotFound.
- Add fake-client regressions for both paths.

## Why
Forbidden, timeout, and API-server failures were logged and converted into an empty successful result, making infrastructure failures indistinguishable from missing scan data.

## Validation
- `go test ./httphandler/storage -run 'TestGetWorkloadConfigurationScanResult_(PropagatesAPIServerError|NotFoundRemainsEmpty)' -count=1`
- `gofmt` verification for all changed Go files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving workload configuration scan results.
  * API server retrieval failures are now reported instead of appearing as empty results.
  * Missing scans continue to return an empty result without an error.

* **Tests**
  * Added coverage for retrieval error propagation and missing-scan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->