### PR TITLE
fix(portforward): preserve kubeconfig server scheme

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -36,26 +36,29 @@ func getPortForwardingPort() string {
 	return DefaultPortForwardPortValue
 }
 
-func splitHostAndBasePath(host string) (string, string, error) {
+func splitServerURL(host string) (string, string, string, error) {
+	if host == "" {
+		return "https", "", "", nil
+	}
 	if !strings.Contains(host, "://") {
-		return host, "", nil
+		host = "https://" + host
 	}
 
 	baseURL, err := url.Parse(host)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
-	return baseURL.Host, strings.TrimRight(baseURL.Path, "/"), nil
+	return baseURL.Scheme, baseURL.Host, strings.TrimRight(baseURL.Path, "/"), nil
 }
 
 func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, forwardingPort, namespace string) (OperatorConnector, error) {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, pod.Name)
-	hostIP, basePath, err := splitHostAndBasePath(k8sClient.K8SConfig.Host)
+	scheme, hostIP, basePath, err := splitServerURL(k8sClient.K8SConfig.Host)
 	if err != nil {
 		return nil, err
 	}
-	serverURL := &url.URL{Scheme: "https", Path: basePath + path, Host: hostIP}
+	serverURL := &url.URL{Scheme: scheme, Path: basePath + path, Host: hostIP}
 
 	roundTripper, upgrader, err := spdy.RoundTripperFor(k8sClient.K8SConfig)
 	if err != nil {

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -2,11 +2,15 @@ package cautils
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -22,96 +26,169 @@ type FakeCachedDiscoveryClient struct {
 	Invalidations      int
 }
 
-func Test_splitHostAndBasePath(t *testing.T) {
+func Test_splitServerURL(t *testing.T) {
 	testCases := []struct {
 		name         string
 		host         string
+		wantScheme   string
 		wantHost     string
 		wantBasePath string
 		wantErr      bool
 	}{
 		{
-			name:     "https scheme is stripped",
-			host:     "https://1.2.3.4:6443",
-			wantHost: "1.2.3.4:6443",
+			name:       "https scheme is preserved",
+			host:       "https://1.2.3.4:6443",
+			wantScheme: "https",
+			wantHost:   "1.2.3.4:6443",
 		},
 		{
-			name:     "http scheme is stripped",
-			host:     "http://1.2.3.4:6443",
-			wantHost: "1.2.3.4:6443",
+			name:       "http scheme is preserved",
+			host:       "http://1.2.3.4:6443",
+			wantScheme: "http",
+			wantHost:   "1.2.3.4:6443",
 		},
 		{
-			name:     "host without scheme is returned unchanged",
-			host:     "1.2.3.4:6443",
-			wantHost: "1.2.3.4:6443",
+			name:       "host without scheme defaults to https",
+			host:       "1.2.3.4:6443",
+			wantScheme: "https",
+			wantHost:   "1.2.3.4:6443",
 		},
 		{
-			name:     "empty host is returned unchanged",
-			host:     "",
-			wantHost: "",
+			name:         "host without scheme preserves base path",
+			host:         "proxy.example.com/k8s",
+			wantScheme:   "https",
+			wantHost:     "proxy.example.com",
+			wantBasePath: "/k8s",
 		},
 		{
-			name:     "hostname starting with 'h' is preserved after https scheme",
-			host:     "https://hello-cluster.example.com:6443",
-			wantHost: "hello-cluster.example.com:6443",
+			name:       "empty host defaults to https",
+			host:       "",
+			wantScheme: "https",
+			wantHost:   "",
 		},
 		{
-			name:     "hostname starting with 't' is preserved after https scheme",
-			host:     "https://test.example.com:6443",
-			wantHost: "test.example.com:6443",
+			name:       "hostname starting with 'h' is preserved after https scheme",
+			host:       "https://hello-cluster.example.com:6443",
+			wantScheme: "https",
+			wantHost:   "hello-cluster.example.com:6443",
 		},
 		{
-			name:     "hostname starting with 'p' is preserved after https scheme",
-			host:     "https://prod.example.com",
-			wantHost: "prod.example.com",
+			name:       "hostname starting with 't' is preserved after https scheme",
+			host:       "https://test.example.com:6443",
+			wantScheme: "https",
+			wantHost:   "test.example.com:6443",
 		},
 		{
-			name:     "hostname starting with 's' is preserved after https scheme",
-			host:     "https://staging.example.com",
-			wantHost: "staging.example.com",
+			name:       "hostname starting with 'p' is preserved after https scheme",
+			host:       "https://prod.example.com",
+			wantScheme: "https",
+			wantHost:   "prod.example.com",
 		},
 		{
-			name:     "kubernetes.docker.internal is preserved",
-			host:     "https://kubernetes.docker.internal:6443",
-			wantHost: "kubernetes.docker.internal:6443",
+			name:       "hostname starting with 's' is preserved after https scheme",
+			host:       "https://staging.example.com",
+			wantScheme: "https",
+			wantHost:   "staging.example.com",
+		},
+		{
+			name:       "kubernetes.docker.internal is preserved",
+			host:       "https://kubernetes.docker.internal:6443",
+			wantScheme: "https",
+			wantHost:   "kubernetes.docker.internal:6443",
 		},
 		{
 			name:         "host with base path preserves path",
 			host:         "https://proxy.example.com/k8s",
+			wantScheme:   "https",
+			wantHost:     "proxy.example.com",
+			wantBasePath: "/k8s",
+		},
+		{
+			name:         "http host with base path preserves both",
+			host:         "http://proxy.example.com/k8s",
+			wantScheme:   "http",
 			wantHost:     "proxy.example.com",
 			wantBasePath: "/k8s",
 		},
 		{
 			name:         "host with port and base path preserves both",
 			host:         "https://proxy.example.com:6443/k8s",
+			wantScheme:   "https",
 			wantHost:     "proxy.example.com:6443",
 			wantBasePath: "/k8s",
 		},
 		{
 			name:         "trailing slash on base path is trimmed",
 			host:         "https://proxy.example.com/k8s/",
+			wantScheme:   "https",
 			wantHost:     "proxy.example.com",
 			wantBasePath: "/k8s",
 		},
 		{
 			name:         "multi-segment base path is preserved",
 			host:         "https://proxy.example.com/api/v1/k8s",
+			wantScheme:   "https",
 			wantHost:     "proxy.example.com",
 			wantBasePath: "/api/v1/k8s",
+		},
+		{
+			name:    "malformed URL is rejected",
+			host:    "https://proxy.example.com/%zz",
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotHost, gotBasePath, err := splitHostAndBasePath(tc.host)
+			gotScheme, gotHost, gotBasePath, err := splitServerURL(tc.host)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
+			assert.Equal(t, tc.wantScheme, gotScheme)
 			assert.Equal(t, tc.wantHost, gotHost)
 			assert.Equal(t, tc.wantBasePath, gotBasePath)
 		})
+	}
+}
+
+func TestCreatePortForwarder_HTTPServerReceivesPortForwardRequest(t *testing.T) {
+	type receivedRequest struct {
+		method string
+		path   string
+	}
+
+	var requestCount atomic.Int32
+	requests := make(chan receivedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		select {
+		case requests <- receivedRequest{method: r.Method, path: r.URL.Path}:
+		default:
+		}
+		http.Error(w, "test server does not implement SPDY", http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+
+	k8sClient := &k8sinterface.KubernetesApi{
+		K8SConfig: &rest.Config{Host: server.URL + "/proxy"},
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "operator"}}
+	connector, err := CreatePortForwarder(k8sClient, pod, "1234", "kubescape")
+	require.NoError(t, err)
+
+	// The fake server deliberately rejects the SPDY upgrade. Reaching it proves
+	// that the dialer used the explicit HTTP scheme from the kubeconfig.
+	require.Error(t, connector.StartPortForwarder())
+	require.Equal(t, int32(1), requestCount.Load())
+
+	select {
+	case got := <-requests:
+		assert.Equal(t, http.MethodPost, got.method)
+		assert.Equal(t, "/proxy/api/v1/namespaces/kubescape/pods/operator/portforward", got.path)
+	default:
+		t.Fatal("port-forward request did not reach the kubeconfig HTTP endpoint")
 	}
 }
 


### PR DESCRIPTION
## Reproduced bug
`rest.Config.Host` is the Kubernetes API base URL and may explicitly use HTTP. `CreatePortForwarder` parsed that URL, discarded its scheme, and always rebuilt the SPDY endpoint with `https`.

This is reachable through the operator commands:

`kubeconfig clusters[].cluster.server` → `kubescape operator scan|remediate` → `NewOperatorAdapter` → `CreatePortForwarder`.

For `server: http://127.0.0.1:<port>/proxy`, master attempts TLS against the clear-text API endpoint, so the port-forward POST never reaches the configured server.

## Change
- Preserve the explicit scheme from `rest.Config.Host`.
- Continue defaulting scheme-less legacy input to HTTPS.
- Preserve API-server base paths.

## Regression proof
The test starts a plain `httptest.Server`, configures `rest.Config.Host` to its HTTP URL plus `/proxy`, and calls the real port-forward connector. The server deliberately returns 400 instead of implementing SPDY; the assertion is whether it receives the request at all.

- master: **0 requests received** — regression test fails
- this branch: **1 POST** received at `/proxy/api/v1/namespaces/kubescape/pods/operator/portforward`
- fixed test passed 20 consecutive runs
- full `go test ./core/cautils -count=1` passed
- `git diff --check` passed

HTTPS behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved port-forwarding URL handling for HTTP and HTTPS endpoints.
  - Hosts without a specified scheme now default to HTTPS.
  - Preserves explicitly provided schemes and correctly handles base paths.
  - Provides clearer errors for malformed server URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->