### PR TITLE
fix(prometheus): escape dynamic label values

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -121,9 +121,9 @@ func (mcrs *mControlComplianceScore) metrics() []string {
 	return m
 }
 func (mcrs *mControlComplianceScore) labels() string {
-	r := fmt.Sprintf("name=\"%s\"", mcrs.controlName) + ","
-	r += fmt.Sprintf("severity=\"%s\"", mcrs.severity) + ","
-	r += fmt.Sprintf("link=\"%s\"", mcrs.link)
+	r := fmt.Sprintf("name=\"%s\"", escapePrometheusLabelValue(mcrs.controlName)) + ","
+	r += fmt.Sprintf("severity=\"%s\"", escapePrometheusLabelValue(mcrs.severity)) + ","
+	r += fmt.Sprintf("link=\"%s\"", escapePrometheusLabelValue(mcrs.link))
 	return r
 }
 func (mcrs *mControlComplianceScore) prefix() string {
@@ -166,7 +166,7 @@ func (mfrs *mFrameworkComplianceScore) metrics() []string {
 	return m
 }
 func (mfrs *mFrameworkComplianceScore) labels() string {
-	r := fmt.Sprintf("name=\"%s\"", mfrs.frameworkName)
+	r := fmt.Sprintf("name=\"%s\"", escapePrometheusLabelValue(mfrs.frameworkName))
 	return r
 }
 func (mfrs *mFrameworkComplianceScore) prefix() string {
@@ -191,10 +191,10 @@ func (mrc *mResources) metrics() []string {
 }
 
 func (mrc *mResources) labels() string {
-	r := fmt.Sprintf("apiVersion=\"%s\"", mrc.apiVersion) + ","
-	r += fmt.Sprintf("kind=\"%s\"", mrc.kind) + ","
-	r += fmt.Sprintf("namespace=\"%s\"", mrc.namespace) + ","
-	r += fmt.Sprintf("name=\"%s\"", mrc.name)
+	r := fmt.Sprintf("apiVersion=\"%s\"", escapePrometheusLabelValue(mrc.apiVersion)) + ","
+	r += fmt.Sprintf("kind=\"%s\"", escapePrometheusLabelValue(mrc.kind)) + ","
+	r += fmt.Sprintf("namespace=\"%s\"", escapePrometheusLabelValue(mrc.namespace)) + ","
+	r += fmt.Sprintf("name=\"%s\"", escapePrometheusLabelValue(mrc.name))
 	return r
 }
 func (mrc *mResources) prefix() string {
@@ -216,8 +216,8 @@ func (miv *mImageVulnerability) metrics() []string {
 }
 
 func (miv *mImageVulnerability) labels() string {
-	r := fmt.Sprintf("image=\"%s\"", miv.image) + ","
-	r += fmt.Sprintf("severity=\"%s\"", miv.severity)
+	r := fmt.Sprintf("image=\"%s\"", escapePrometheusLabelValue(miv.image)) + ","
+	r += fmt.Sprintf("severity=\"%s\"", escapePrometheusLabelValue(miv.severity))
 	return r
 }
 
@@ -226,6 +226,14 @@ func (miv *mImageVulnerability) prefix() string {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+func escapePrometheusLabelValue(value string) string {
+	return strings.NewReplacer(
+		`\`, `\\`,
+		"\n", `\n`,
+		`"`, `\"`,
+	).Replace(value)
+}
 
 func toMetricHeader(name, help string) string {
 	return fmt.Sprintf("# HELP %s %s\n# TYPE %s gauge", name, help, name)

--- a/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComplianceScore_MetricsLabelsAndPrefix(t *testing.T) {
@@ -56,6 +59,80 @@ func TestComplianceScore_MetricsLabelsAndPrefix(t *testing.T) {
 			assert.Equal(t, "kubescape_cluster", tt.mrs.prefix())
 		})
 	}
+}
+
+func TestMetricsString_EscapesDynamicLabelValues(t *testing.T) {
+	value := "quote\" slash\\ newline\nnext"
+	parse := func(t *testing.T, exposition string) func(string) map[string]string {
+		t.Helper()
+		parser := expfmt.NewTextParser(model.LegacyValidation)
+		families, err := parser.TextToMetricFamilies(strings.NewReader(exposition))
+		require.NoErrorf(t, err, "invalid Prometheus exposition:\n%s", exposition)
+
+		return func(familyName string) map[string]string {
+			t.Helper()
+			family, ok := families[familyName]
+			require.Truef(t, ok, "metric family %q is missing", familyName)
+			require.Len(t, family.Metric, 1)
+			labels := map[string]string{}
+			for _, label := range family.Metric[0].Label {
+				labels[label.GetName()] = label.GetValue()
+			}
+			return labels
+		}
+	}
+
+	t.Run("posture scan", func(t *testing.T) {
+		// Custom policies loaded with --use-from can define framework and
+		// control names containing any JSON string. Drive the same
+		// SummaryDetails -> Metrics path as the Prometheus printer.
+		controlScore := float32(50)
+		summary := &reportsummary.SummaryDetails{
+			Frameworks: []reportsummary.FrameworkSummary{{Name: value, ComplianceScore: 50}},
+			Controls: reportsummary.ControlSummaries{
+				"C-ESCAPE": {
+					ControlID:       "C-ESCAPE",
+					Name:            value,
+					ComplianceScore: &controlScore,
+				},
+			},
+		}
+		metricsOutput := &Metrics{}
+		metricsOutput.setComplianceScores(summary)
+		metricsOutput.listResources = []mResources{{
+			apiVersion: value,
+			kind:       value,
+			namespace:  value,
+			name:       value,
+		}}
+
+		labelsFor := parse(t, metricsOutput.String())
+		assert.Equal(t, value, labelsFor("kubescape_framework_complianceScore")["name"])
+		assert.Equal(t, value, labelsFor("kubescape_control_complianceScore")["name"])
+		assert.Equal(t, map[string]string{
+			"apiVersion": value,
+			"kind":       value,
+			"namespace":  value,
+			"name":       value,
+		}, labelsFor("kubescape_resource_count_controls_failed"))
+	})
+
+	t.Run("image scan", func(t *testing.T) {
+		metricsOutput := &Metrics{
+			isImageScan: true,
+			listImages: []mImageVulnerability{{
+				image:    value,
+				severity: value,
+				cveCount: 1,
+			}},
+		}
+
+		labelsFor := parse(t, metricsOutput.String())
+		assert.Equal(t, map[string]string{
+			"image":    value,
+			"severity": value,
+		}, labelsFor("kubescape_image_count_cve"))
+	})
 }
 
 func TestControlComplianceScore_MetricsLabelsAndPrefix(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/moby/buildkit v0.29.0
 	github.com/open-policy-agent/opa v1.14.1
 	github.com/owenrumney/go-sarif/v2 v2.2.0
+	github.com/prometheus/common v0.67.5
 	github.com/project-copacetic/copacetic v0.10.0
 	github.com/quay/claircore v1.5.35
 	github.com/schollz/progressbar/v3 v3.13.0
@@ -467,7 +468,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quay/claircore/toolkit v1.2.4 // indirect
 	github.com/quay/zlog v1.1.8 // indirect


### PR DESCRIPTION
## Reproduced bug
This is reachable through supported custom-policy input. `--use-from` loads framework JSON, and its framework/control names are accepted as arbitrary JSON strings. `Metrics.setComplianceScores` copied those strings directly into quoted Prometheus labels.

For a framework name containing a quote and newline, master emits a split, unterminated label. Parsing the complete output fails at runtime with:

```
text format parsing error: unexpected end of label value "quote"
```

Resource fields and image names/severities use the same unescaped rendering path.

## Change
Escape backslashes, line feeds, and double quotes in all dynamic Prometheus label values for controls, frameworks, resources, and images, following the Prometheus text format.

## Regression proof
The test does not call the new helper. It drives existing output paths:

- posture: `SummaryDetails → Metrics.setComplianceScores → Metrics.String`
- image: `Metrics.listImages → Metrics.String`
- the complete exposition is parsed by `prometheus/common/expfmt`
- decoded labels must round-trip to the original strings

The exact test compiles on master and then fails with the parser error above. With this change:

- focused regression and existing label tests pass
- full `go test ./core/pkg/resultshandling/printer/v2 -count=1` passes
- `github.com/prometheus/common` is marked as the direct test dependency it now is
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prometheus metrics now correctly escape labels containing backslashes, quotation marks, and newlines.
  - Metrics with special characters remain valid and can be parsed without altering their original values.

- **Tests**
  - Added coverage for escaping special characters across frameworks, controls, resources, and image vulnerability labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->