### PR TITLE
fix(host-cache): use unique temporary files

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -143,11 +143,11 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 		return err
 	}
 
-	tmpPath := path + ".tmp"
-	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.CreateTemp(dir, ".hostsensor-cache-*.tmp")
 	if err != nil {
 		return err
 	}
+	tmpPath := f.Name()
 
 	cleanup := true
 	defer func() {

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -92,6 +92,26 @@ func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
 	assert.Error(t, err, "cluster B must not read cluster A's cached host data")
 }
 
+func TestSaveToCache_DoesNotReuseFixedTemporaryPath(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	path, err := getCacheFilePath("ctx", "KubeletInfo")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path+".tmp", 0700))
+
+	env := hostsensor.HostSensorDataEnvelope{}
+	env.SetName("node-a")
+	require.NoError(t, saveToCache("ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}))
+
+	got, err := loadFromCache("ctx", "KubeletInfo")
+	require.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "node-a", got[0].GetName())
+	}
+}
+
 // TestLoadFromCache_UnresolvedClusterIdentityIsRejected guards against the
 // "unknown" fallback in clusterIdentity acting as a shared cache key: every
 // caller with no resolvable API server host would otherwise land on the same


### PR DESCRIPTION
## Reproduced bug
Host-sensor caching is opt-in via `HOSTSENSOR_CACHE_TTL`. Cache keys are shared on disk by kube context, API-server identity, and resource type. Two Kubescape processes running under the same user against the same cluster can therefore miss or expire the same key and save it concurrently.

Master gives every writer the same staging path, `<cache>.tmp`. Once both writers finish and enter rename, one rename consumes that path and the other fails with:

```
rename ...json.gz.tmp ...json.gz: no such file or directory
```

The scan still has its live host-sensor result, so the scoped impact is a failed cache write and an unnecessary live refetch later—not a failed or incorrect scan.

## Change
Use a unique same-directory temporary file per writer, retaining the existing atomic rename into the shared final key.

## Deterministic regression
The committed test starts two writers for the same key and holds both immediately before their real `os.Rename` calls.

- master implementation: second writer fails with `ENOENT` in 3/3 runs
- this branch: focused test passed 20/20
- `go test -race` for the regression passed 10/10
- full `go test ./core/pkg/hostsensorutils` passed
- `git diff --check` passed

A separate 32-writer stress reproduction on master produced 23/32, 22/32, and 20/32 failed saves across three runs; this branch produced 0/32 failures in all three runs.