### PR TITLE
fix(host-cache): isolate concurrent temporary files

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -126,6 +126,10 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 }
 
 func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) error {
+	return saveToCacheWithRename(clusterName, resourceName, envelopes, os.Rename)
+}
+
+func saveToCacheWithRename(clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope, rename func(string, string) error) error {
 	if getHostSensorCacheTtl() <= 0 || clusterIdentity() == "unknown" {
 		// An unresolved API server host is a shared cache key across every
 		// caller in that state; loadFromCache always refuses to read it back,
@@ -143,11 +147,11 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 		return err
 	}
 
-	tmpPath := path + ".tmp"
-	f, err := os.OpenFile(filepath.Clean(tmpPath), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.CreateTemp(dir, ".hostsensor-cache-*.tmp")
 	if err != nil {
 		return err
 	}
+	tmpPath := f.Name()
 
 	cleanup := true
 	defer func() {
@@ -178,7 +182,7 @@ func saveToCache(clusterName, resourceName string, envelopes []hostsensor.HostSe
 		return err
 	}
 
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := rename(tmpPath, path); err != nil {
 		return err
 	}
 	cleanup = false

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -3,6 +3,7 @@ package hostsensorutils
 import (
 	"os"
 	"testing"
+	"time"
 
 	restclient "k8s.io/client-go/rest"
 
@@ -90,6 +91,57 @@ func TestHostSensorCache_OptInRoundTrip(t *testing.T) {
 	withK8sHost(t, "https://cluster-b.example.com")
 	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
 	assert.Error(t, err, "cluster B must not read cluster A's cached host data")
+}
+
+func TestSaveToCache_ConcurrentWritersUseDistinctTemporaryFiles(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	renameAtBarrier := func(oldPath, newPath string) error {
+		ready <- struct{}{}
+		<-release
+		return os.Rename(oldPath, newPath)
+	}
+
+	errCh := make(chan error, 2)
+	for _, name := range []string{"node-a", "node-b"} {
+		env := hostsensor.HostSensorDataEnvelope{}
+		env.SetName(name)
+		go func() {
+			errCh <- saveToCacheWithRename("ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{env}, renameAtBarrier)
+		}()
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for range 2 {
+		select {
+		case <-ready:
+		case err := <-errCh:
+			require.NoError(t, err, "writer exited before reaching rename")
+			t.Fatal("writer exited before reaching rename")
+		case <-timer.C:
+			t.Fatal("writers did not reach rename barrier")
+		}
+	}
+	close(release)
+	released = true
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+
+	got, err := loadFromCache("ctx", "KubeletInfo")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Contains(t, []string{"node-a", "node-b"}, got[0].GetName())
 }
 
 // TestLoadFromCache_UnresolvedClusterIdentityIsRejected guards against the


### PR DESCRIPTION
## Reproduced bug
Host-sensor caching is opt-in via `HOSTSENSOR_CACHE_TTL`. Cache keys are shared on disk by kube context, API-server identity, and resource type. Two Kubescape processes running under the same user against the same cluster can therefore miss or expire the same key and save it concurrently.

Master gives every writer the same staging path, `<cache>.tmp`. Once both writers finish and enter rename, one rename consumes that path and the other fails with:

```
rename ...json.gz.tmp ...json.gz: no such file or directory
```

The scan still has its live host-sensor result, so the scoped impact is a failed cache write and an unnecessary live refetch later—not a failed or incorrect scan.

## Change
Use a unique same-directory temporary file per writer, retaining the existing rename into the shared final key.

## Deterministic regression
The committed test starts two writers for the same key and holds both immediately before their real `os.Rename` calls. Its readiness wait is bounded and observes early writer errors, so setup failures cannot hang CI.

- master implementation: second writer fails with `ENOENT` in 3/3 runs
- this branch: focused test passed 20/20
- `go test -race` for the regression passed 10/10
- full `go test ./core/pkg/hostsensorutils` passed
- `git diff --check` passed

A separate 32-writer stress reproduction on master produced 23/32, 22/32, and 20/32 failed saves across three runs; this branch produced 0/32 failures in all three runs.

This replaces #3106. That PR was closed after its original stale-path test was found to be artificial; the concurrency reproduction and deterministic test here establish the actual production trigger.