### PR TITLE
fix: resolve triple-calls to setNotBusy with incorrect scanID on queue-full pathFix/metrics setnotbusy leak

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -34,7 +34,7 @@ type MetricsQueryParams struct {
 func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	scanID := uuid.NewString()
-	defer handler.recover(r.Context(), w, scanID)
+	defer handler.recover(r.Context(), w, "")
 
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
@@ -50,7 +50,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	metricsQueryParams := &MetricsQueryParams{}
 	if err := schema.NewDecoder().Decode(metricsQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), scanID)
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err))
 		return
 	}
 	resultsFile := filepath.Join(OutputDir, scanID)
@@ -74,11 +74,10 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	select {
 	case handler.scanRequestChan <- scanParams:
 	default:
-		handler.state.setNotBusy(scanID)
 		w.Header().Set("Retry-After", "1")
 		handler.writeErrorWithStatus(w,
 			fmt.Errorf("scan queue is full; retry the request later"),
-			"", http.StatusTooManyRequests)
+			http.StatusTooManyRequests)
 		return
 	}
 

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -330,3 +330,26 @@ func TestSplitAndTrim(t *testing.T) {
 		})
 	}
 }
+
+func TestMetrics_Panic(t *testing.T) {
+	defer func(o scanner) { scanImpl = o }(scanImpl)
+	
+	scanImpl = func(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier, string, bool) (*reporthandlingv2.PostureReport, error) {
+		panic("metrics panic")
+	}
+
+	h := NewHTTPHandler(false)
+	
+	// Create a recorder and request
+	rq := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil)
+	w := httptest.NewRecorder()
+
+	// Call the handler
+	h.Metrics(w, rq)
+
+	// It should recover and return a 500
+	require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+
+	// Ensure the scan is no longer marked as busy
+	assert.Equal(t, "", h.state.getRunningUserScanID())
+}

--- a/httphandler/handlerequests/v1/requestparser.go
+++ b/httphandler/handlerequests/v1/requestparser.go
@@ -99,7 +99,7 @@ func getScanParamsFromRequest(r *http.Request, scanID string) (*scanRequestParam
 	{
 		readBuffer, err := io.ReadAll(r.Body)
 		if err != nil {
-			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %w", err), scanID)
+			// handler.writeError(w, fmt.Errorf("failed to read request body, reason: %w", err))
 			return nil, fmt.Errorf("failed to read request body: %w", err)
 		}
 		if err := json.Unmarshal(readBuffer, &scanRequest); err != nil {

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -91,7 +91,7 @@ func (handler *HTTPHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	statusQueryParams := &StatusQueryParams{}
 	if err := schema.NewDecoder().Decode(statusQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err))
 		return
 	}
 	logger.L().Info("requesting status", helpers.String("scanID", statusQueryParams.ScanID), helpers.String("api", "v1/status"))
@@ -141,10 +141,10 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		if errors.As(err, &maxBytesErr) {
 			handler.writeErrorWithStatus(w,
 				fmt.Errorf("scan request body exceeds the %d byte limit", handler.maxRequestBodyBytes),
-				"", http.StatusRequestEntityTooLarge)
+				http.StatusRequestEntityTooLarge)
 			return
 		}
-		handler.writeError(w, err, "")
+		handler.writeError(w, err)
 		return
 	}
 	cancelCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
@@ -172,7 +172,7 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "1")
 		handler.writeErrorWithStatus(w,
 			fmt.Errorf("scan queue is full; retry the request later"),
-			"", http.StatusTooManyRequests)
+			http.StatusTooManyRequests)
 		return
 	}
 	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
@@ -224,7 +224,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 
 	cancelQueryParams := &CancelScanQueryParams{}
 	if err := schema.NewDecoder().Decode(cancelQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err))
 		return
 	}
 
@@ -262,7 +262,7 @@ func (handler *HTTPHandler) CancelScan(w http.ResponseWriter, r *http.Request) {
 func (handler *HTTPHandler) parseResultsQueryParams(w http.ResponseWriter, r *http.Request) (*ResultsQueryParams, bool) {
 	resultsQueryParams := &ResultsQueryParams{}
 	if err := schema.NewDecoder().Decode(resultsQueryParams, r.URL.Query()); err != nil {
-		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), "")
+		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err))
 		return nil, false
 	}
 	logger.L().Info("requesting results", helpers.String("scanID", resultsQueryParams.ScanID), helpers.String("api", "v1/results"), helpers.String("method", r.Method))
@@ -414,7 +414,9 @@ func (handler *HTTPHandler) Ready(w http.ResponseWriter, r *http.Request) {
 func (handler *HTTPHandler) recover(ctx context.Context, w http.ResponseWriter, scanID string) {
 	response := utilsmetav1.Response{}
 	if err := recover(); err != nil {
-		handler.state.setNotBusy(scanID)
+		if scanID != "" {
+			handler.state.setNotBusy(scanID)
+		}
 		logger.L().Ctx(ctx).Error("recover", helpers.Error(fmt.Errorf("%v", err)))
 		w.WriteHeader(http.StatusInternalServerError)
 		response.Response = fmt.Sprintf("%v", err)
@@ -423,15 +425,14 @@ func (handler *HTTPHandler) recover(ctx context.Context, w http.ResponseWriter, 
 	}
 }
 
-func (handler *HTTPHandler) writeError(w http.ResponseWriter, err error, scanID string) {
-	handler.writeErrorWithStatus(w, err, scanID, http.StatusBadRequest)
+func (handler *HTTPHandler) writeError(w http.ResponseWriter, err error) {
+	handler.writeErrorWithStatus(w, err, http.StatusBadRequest)
 }
 
-func (handler *HTTPHandler) writeErrorWithStatus(w http.ResponseWriter, err error, scanID string, status int) {
+func (handler *HTTPHandler) writeErrorWithStatus(w http.ResponseWriter, err error, status int) {
 	response := utilsmetav1.Response{}
 	w.WriteHeader(status)
 	response.Response = err.Error()
 	response.Type = utilsapisv1.ErrorScanResponseType
 	w.Write(responseToBytes(&response))
-	handler.state.setNotBusy(scanID)
 }

--- a/httphandler/listener/helpers.go
+++ b/httphandler/listener/helpers.go
@@ -12,9 +12,10 @@ import (
 // RecoverFunc recover function for http requests
 func RecoverFunc(w http.ResponseWriter) {
 	if err := recover(); err != nil {
-		logger.L().Error("", helpers.Error(fmt.Errorf("%v", err)))
+		errMsg := fmt.Sprintf("%v", err)
+		logger.L().Error("", helpers.Error(fmt.Errorf("%s", errMsg)))
 		w.WriteHeader(http.StatusInternalServerError)
-		bErr, _ := json.Marshal(err)
+		bErr, _ := json.Marshal(errMsg)
 		w.Write(bErr)
 	}
 }

--- a/httphandler/listener/helpers_test.go
+++ b/httphandler/listener/helpers_test.go
@@ -30,6 +30,7 @@ func TestRecoverFunc_WithStringPanic(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), "something went wrong")
 }
 
 func TestRecoverFunc_WithErrorPanic(t *testing.T) {
@@ -40,6 +41,8 @@ func TestRecoverFunc_WithErrorPanic(t *testing.T) {
 	}()
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), assert.AnError.Error())
 }
 
 func TestRecoverFunc_WithIntPanic(t *testing.T) {
@@ -50,4 +53,6 @@ func TestRecoverFunc_WithIntPanic(t *testing.T) {
 	}()
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotEmpty(t, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), "42")
 }


### PR DESCRIPTION
Fixes #3109


## Description
Resolves an issue where the Prometheus metrics handler called `setNotBusy()` three times on the queue-full error path, with at least one call using an incorrect or empty (`""`) scanID, leading to potentially corrupted busy/idle metrics states. 

### Root Cause
The `writeError` and `writeErrorWithStatus` HTTP helper functions were implicitly calling `setNotBusy()` under the hood on whatever `scanID` parameter they received. Because of this side-effect, developers were forced to pass empty strings (`""`) across various handlers to avoid triggering premature cleanups, causing operations like `delete(s.statusID, "")`. Meanwhile, in `prometheus.go`, this helper triggered an extra cleanup alongside a redundant manual cleanup and the existing `defer` cleanup, resulting in 3 separate calls.

### Fix
- Removed the `scanID` parameter from `writeError` and `writeErrorWithStatus`, as basic error-writing helpers should not carry implicit side-effects related to scan state lifecycle.
- Removed the implicit `setNotBusy` call from `writeErrorWithStatus`.
- Removed the redundant manual `setNotBusy(scanID)` call in `prometheus.go` on the queue-full path.
- Updated all occurrences of `writeError` across `requestshandler.go` and `prometheus.go` to match the new simplified signature.
- Allowed the `defer setNotBusy(scanID)` at the beginning of the `Metrics` handler to correctly act as the single source of truth for cleanup across all exits.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for request validation, queue capacity, cancellation, metrics, and result processing while preserving existing status codes and messages.
  * Ensured scan state is reliably reset when requests fail or metrics processing encounters a panic.
  * Improved panic recovery responses so they consistently include the original error value.

* **Tests**
  * Expanded coverage for panic recovery across string, error, and numeric panic values.
  * Added coverage verifying metrics failures return an internal server error and reset scan state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->