### PR TITLE
fix(hostsensor): remove dead protobuf config code for dynamic client

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -41,9 +41,6 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 		return nil, fmt.Errorf("failed to get k8s config")
 	}
 	config = rest.CopyConfig(config)
-	// force GRPC
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
 
 	// Create dynamic client for CRD access
 	dynamicClient, err := dynamic.NewForConfig(config)


### PR DESCRIPTION
**Description:**
Fixes #3112 
### What does this PR do?

This PR cleans up misleading tech debt in `NewHostSensorHandler`. It removes the explicit assignments to `AcceptContentTypes` and `ContentType` on the copied `rest.Config` that attempted to force the dynamic client to use Protobuf (`application/vnd.kubernetes.protobuf`) for CRDs.

### Why is this necessary?

The Kubernetes `client-go` dynamic client constructor (`dynamic.NewForConfig`) unconditionally overwrites the content type negotiation back to `application/json` internally during its `setConfigDefaults()` phase, because Custom Resources lack built-in Protobuf schemas on the API server.

Consequently, forcing Protobuf on the `rest.Config` right before passing it into the dynamic client constructor was dead code that had zero effect. It was highly misleading, as it could lead future maintainers to falsely assume the host sensor transport was utilizing gRPC for performance, or inadvertently break CRD listing by trying to "fix" it.

### Testing

To prove that the client strictly negotiated JSON even with this setting, we ran an interception test dumping the actual transport headers before removing the dead code:

```text
=== RUN   TestDynamicClientIgnoresProtobuf

Actual Accept header used: application/json

--- PASS: TestDynamicClientIgnoresProtobuf (0.00s)

PASS

ok  	command-line-arguments	0.687s
```

After removing the dead code, the `hostsensorutils` test suite continues to pass as expected (as the underlying behavior of the client remains completely unchanged):

```text
=== RUN   TestHostSensorHandlerLifecycleEdges

--- PASS: TestHostSensorHandlerLifecycleEdges (0.00s)

=== RUN   TestInitAllowsEmptyCRDList

[info] Using CRD-based host sensor data collection (no deployment needed)

[warning] node-agent status: No OsReleaseFile CRDs found - node-agent may not be running or sensing yet

--- PASS: TestInitAllowsEmptyCRDList (0.00s)

=== RUN   TestConvertCRDToEnvelopeKeepsObjectMetadataName

--- PASS: TestConvertCRDToEnvelopeKeepsObjectMetadataName (0.00s)

=== RUN   TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig

--- PASS: TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig (0.00s)

PASS

ok  	github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils	4.458s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Kubernetes API requests by allowing standard content-type negotiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->