### PR TITLE
docs(workflows): correct default branch and stale CI process in workflows README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ Kubescape's default branch is `master`; open every PR against `master`.
 
 ### Opening a PR
 
-Opening a PR triggers `00-pr-scanner.yaml`, which calls the reusable `a-pr-scanner.yaml` workflow. That runs, in order: `go test -race ./...`; a second race-enabled run over `./core/cautils/...` with `CGO_ENABLED=1`; the `httphandler` module tests, which run without the race detector; a cross-platform GoReleaser snapshot build; the `smoke_testing/init.py` smoke test against the built binary; and `golangci-lint` in `only-new-issues` mode.
+Opening a PR triggers `00-pr-scanner.yaml`, which calls the reusable `a-pr-scanner.yaml` workflow. That runs, in order: `go test -race ./...`; a second race-enabled run over `./core/cautils/...` with `CGO_ENABLED=1`; the `httphandler` module tests, which run without the race detector; a GoReleaser snapshot build for the runner's own platform only (`build --clean --snapshot --single-target`); the `smoke_testing/init.py` smoke test against that binary; and `golangci-lint` in `only-new-issues` mode. Note that the job is named "Create cross-platform build" — it is not one. The cross-platform build happens in `02-release.yaml`.
 
 Two GitHub Apps report alongside it: the DCO check, which requires a `Signed-off-by:` trailer on every commit, and GitGuardian secret scanning.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,11 +8,11 @@ Kubescape's default branch is `master`; open every PR against `master`.
 
 ### Opening a PR
 
-Opening a PR triggers `00-pr-scanner.yaml`, which calls the reusable `a-pr-scanner.yaml` workflow. That runs the unit tests (`go test -race ./...`, plus a separate race-enabled run over `./core/cautils/...` and the `httphandler` module), a cross-platform GoReleaser snapshot build, the `smoke_testing/init.py` smoke test against the built binary, and `golangci-lint` in `only-new-issues` mode.
+Opening a PR triggers `00-pr-scanner.yaml`, which calls the reusable `a-pr-scanner.yaml` workflow. That runs, in order: `go test -race ./...`; a second race-enabled run over `./core/cautils/...` with `CGO_ENABLED=1`; the `httphandler` module tests, which run without the race detector; a cross-platform GoReleaser snapshot build; the `smoke_testing/init.py` smoke test against the built binary; and `golangci-lint` in `only-new-issues` mode.
 
 Two GitHub Apps report alongside it: the DCO check, which requires a `Signed-off-by:` trailer on every commit, and GitGuardian secret scanning.
 
-Documentation-only PRs do not run the build: `00-pr-scanner.yaml` filters out Markdown, YAML, shell, `docs/`, `build/` and `examples/` changes via `paths-ignore`.
+`00-pr-scanner.yaml` carries a `paths-ignore` filter, so a PR that touches nothing else can skip the build entirely. It ignores `**.md`, `**.yaml`, `**.yml` and `**.sh` at any depth, plus files sitting directly in `website/`, `examples/`, `docs/`, `build/` and `.github/`. Those last five are single-level patterns: a nested file such as `docs/guide/diagram.svg` does not match and will still start the workflow. The build is skipped only when *every* changed file in the PR matches one of the patterns.
 
 ### Reviewing a PR
 
@@ -55,7 +55,7 @@ The workflow can also be started manually via `workflow_dispatch`, which exposes
 
 ## Additional Information
 
-Reusable workflows — the ones invoked by another workflow through `on: workflow_call` — carry an alphabetic prefix (`a-pr-scanner.yaml`). The event-triggered entrypoints that invoke them carry a numeric prefix (`00-pr-scanner.yaml`, `02-release.yaml`). Standalone workflows that are neither, such as `scorecard.yml` and `comments.yaml`, sit outside the convention.
+Reusable workflows — the ones invoked by another workflow through `on: workflow_call` — carry an alphabetic prefix (`a-pr-scanner.yaml`). A workflow that invokes one carries a numeric prefix (`00-pr-scanner.yaml`). `02-release.yaml` also carries a numeric prefix, but it invokes nothing: it is an event-triggered entrypoint that does its work inline. Workflows that are neither reusable nor callers, such as `scorecard.yml` and `comments.yaml`, sit outside the convention.
 
 ## Screenshot
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,19 +4,25 @@ Tag terminology: `v<major>.<minor>.<patch>`
 
 ## Developing process
 
-Kubescape's main branch is `main`, any PR will be opened against the main branch.
+Kubescape's default branch is `master`; open every PR against `master`.
 
 ### Opening a PR
 
-When a user opens a PR, this will trigger some basic tests (units, license, etc.)
+Opening a PR triggers `00-pr-scanner.yaml`, which calls the reusable `a-pr-scanner.yaml` workflow. That runs the unit tests (`go test -race ./...`, plus a separate race-enabled run over `./core/cautils/...` and the `httphandler` module), a cross-platform GoReleaser snapshot build, the `smoke_testing/init.py` smoke test against the built binary, and `golangci-lint` in `only-new-issues` mode.
+
+Two GitHub Apps report alongside it: the DCO check, which requires a `Signed-off-by:` trailer on every commit, and GitGuardian secret scanning.
+
+Documentation-only PRs do not run the build: `00-pr-scanner.yaml` filters out Markdown, YAML, shell, `docs/`, `build/` and `examples/` changes via `paths-ignore`.
 
 ### Reviewing a PR
 
-The reviewer/maintainer of a PR will decide whether the PR introduces changes that require running the E2E system tests. If so, the reviewer will add the `trigger-integration-test` label.
+The E2E system tests do not live in this repository. `00-pr-scanner.yaml` dispatches them to a private repository and polls for the result.
+
+They run automatically on every PR — there is no label to add and no approval gate. The `run-system-tests` job is gated only on the `wf-preparation` job finding the required organization secrets, which means it is **skipped on PRs from forks**. If you are contributing from a fork, the unit tests and the smoke test are the only automated verification available to you, so cover your change with unit tests.
 
 ### Approving a PR
 
-Once a maintainer approves the PR, if the `trigger-integration-test` label was added to the PR, the GitHub actions will trigger the system test. The PR will be merged only after the system tests passed successfully. If the label was not added, the PR can be merged. 
+Once a maintainer approves and the required checks are green, the PR can be merged.
 
 ### Merging a PR
 
@@ -25,27 +31,31 @@ The code is merged, no other actions are needed
 
 ## Release process
 
-Every two weeks, we will create a new tag by bumping the minor version, this will create the release and publish the artifacts. 
+Every two weeks, we will create a new tag by bumping the minor version, this will create the release and publish the artifacts.
 If we are introducing breaking changes, we will update the `major` version instead.
 
 When we wish to push a hot-fix/feature within the two weeks, we will bump the `patch`.
 
 ### Creating a new tag
+
 Every two weeks or upon the decision of the maintainers, a maintainer can create a tag.
 
-The tag should look as follows: `v<A>.<B>.<C>-rc.D` (release candidate). 
+The tag should look as follows: `v<A>.<B>.<C>`. Pushing it triggers `02-release.yaml`, whose tag filter matches release tags only — a pre-release suffix such as `-rc.0` will not start a release.
 
-When creating a tag, GitHub will trigger the following actions:
-1. Basic tests - unit tests, license, etc.
-2. System tests (integration tests). If the tests fail, the actions will stop here.
-3. Create a new tag: `v<A>.<B>.<C>` (same tag just without the `rc` suffix)
-4. Create a release
-5. Publish artifacts
-6. Build and publish the docker image (this is meanwhile until we separate the microservice code from the LCI codebase)
- 
+`02-release.yaml` then:
+
+1. Builds the cross-platform binaries and container images with GoReleaser.
+2. Runs the system tests against a Kind cluster and publishes a JUnit report.
+3. Signs the artifacts with Cosign and generates an SBOM with Syft.
+4. Attests the build provenance.
+5. Publishes the artifacts and the container images to `quay.io`.
+6. Opens the version bump against the krew index.
+
+The workflow can also be started manually via `workflow_dispatch`, which exposes a `skip_publish` input for dry runs.
+
 ## Additional Information
 
-The "callers" have the alphabetic prefix and the "executes" have the numeric prefix
+Reusable workflows — the ones invoked by another workflow through `on: workflow_call` — carry an alphabetic prefix (`a-pr-scanner.yaml`). The event-triggered entrypoints that invoke them carry a numeric prefix (`00-pr-scanner.yaml`, `02-release.yaml`). Standalone workflows that are neither, such as `scorecard.yml` and `comments.yaml`, sit outside the convention.
 
 ## Screenshot
 

--- a/internal/ghworkflows/readme_test.go
+++ b/internal/ghworkflows/readme_test.go
@@ -1,0 +1,212 @@
+// Package ghworkflows holds repository-hygiene tests that keep
+// .github/workflows/README.md honest about the workflows sitting next to it.
+//
+// The README is the first thing a new contributor reads to learn which branch
+// to target and what CI will do to their PR, but nothing linked it to the
+// workflow definitions, so it silently rotted: it documented `main` as the
+// default branch, a `trigger-integration-test` label that no workflow reads,
+// and a caller/reusable naming convention that was stated backwards. These
+// tests turn each of those claims into an assertion against the YAML.
+//
+// Deliberately test-only: this is a documentation guard, so it adds no
+// production surface.
+package ghworkflows
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	readmeName = "README.md"
+
+	// scorecardWorkflow is the source of truth for the repository's default
+	// branch. It is the only workflow that pins a branch by name
+	// (on.push.branches), so it stays checked in, machine-readable, and
+	// correct without a network call.
+	scorecardWorkflow = "scorecard.yml"
+)
+
+// workflowsDir resolves .github/workflows from this test's own location so the
+// test does not depend on the working directory `go test` is invoked from.
+func workflowsDir(t *testing.T) string {
+	t.Helper()
+
+	// internal/ghworkflows -> repository root
+	repoRoot := filepath.Join(testutils.CurrentDir(), "..", "..")
+	dir := filepath.Join(repoRoot, ".github", "workflows")
+
+	info, err := os.Stat(dir)
+	require.NoErrorf(t, err, "cannot locate %s", dir)
+	require.True(t, info.IsDir(), "%s is not a directory", dir)
+
+	return dir
+}
+
+// workflowFiles returns every workflow definition, keyed by file name. The
+// README itself is excluded; .yaml and .yml are both in use in this directory.
+func workflowFiles(t *testing.T) map[string][]byte {
+	t.Helper()
+
+	dir := workflowsDir(t)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	files := make(map[string][]byte, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoErrorf(t, err, "failed to read %s", name)
+		files[name] = content
+	}
+
+	require.NotEmpty(t, files, "no workflow files found")
+	return files
+}
+
+func readme(t *testing.T) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(workflowsDir(t), readmeName))
+	require.NoError(t, err)
+	return string(content)
+}
+
+// workflowTriggers is the subset of a workflow's `on:` block this test needs.
+// gopkg.in/yaml.v3 follows the YAML 1.2 core schema, where only true/false are
+// booleans, so the `on:` key unmarshals as the plain string "on".
+type workflowTriggers struct {
+	On struct {
+		Push struct {
+			Branches []string `yaml:"branches"`
+		} `yaml:"push"`
+		// WorkflowCall is present-but-null for a reusable workflow that
+		// declares no inputs, so its presence is detected via the node kind
+		// rather than a typed value.
+		WorkflowCall yaml.Node `yaml:"workflow_call"`
+	} `yaml:"on"`
+}
+
+func parseTriggers(t *testing.T, name string, content []byte) workflowTriggers {
+	t.Helper()
+
+	var triggers workflowTriggers
+	require.NoErrorf(t, yaml.Unmarshal(content, &triggers), "failed to parse %s", name)
+	return triggers
+}
+
+// defaultBranch reads the repository's default branch out of scorecard.yml.
+func defaultBranch(t *testing.T) string {
+	t.Helper()
+
+	files := workflowFiles(t)
+	content, ok := files[scorecardWorkflow]
+	require.Truef(t, ok, "%s is missing; it is the source of truth for the default branch", scorecardWorkflow)
+
+	branches := parseTriggers(t, scorecardWorkflow, content).On.Push.Branches
+	require.Lenf(t, branches, 1, "%s should pin exactly one branch", scorecardWorkflow)
+
+	return branches[0]
+}
+
+// documentedBranchRe matches the README sentence naming the branch to target.
+var documentedBranchRe = regexp.MustCompile("default branch is `([^`]+)`")
+
+// TestReadmeDocumentsTheRealDefaultBranch is the regression test for the
+// README claiming `main` while every PR actually targets `master`.
+func TestReadmeDocumentsTheRealDefaultBranch(t *testing.T) {
+	want := defaultBranch(t)
+
+	matches := documentedBranchRe.FindStringSubmatch(readme(t))
+	require.Lenf(t, matches, 2,
+		"%s must state the default branch as: default branch is `<branch>`", readmeName)
+
+	assert.Equalf(t, want, matches[1],
+		"%s documents branch %q but %s pins %q; contributors branch and target from this line",
+		readmeName, matches[1], scorecardWorkflow, want)
+}
+
+// documentedLabelRe matches any PR label the README claims drives CI.
+var documentedLabelRe = regexp.MustCompile("`([a-z0-9][a-z0-9-]*)` label")
+
+// TestReadmeLabelsAreReadBySomeWorkflow is the regression test for the README
+// documenting a `trigger-integration-test` label that no workflow ever reads.
+func TestReadmeLabelsAreReadBySomeWorkflow(t *testing.T) {
+	files := workflowFiles(t)
+
+	for _, match := range documentedLabelRe.FindAllStringSubmatch(readme(t), -1) {
+		label := match[1]
+
+		t.Run(label, func(t *testing.T) {
+			for name, content := range files {
+				if strings.Contains(string(content), label) {
+					t.Logf("label %q is read by %s", label, name)
+					return
+				}
+			}
+			t.Errorf("%s documents the %q label as driving CI, but no workflow references it; "+
+				"either wire it up or stop documenting it", readmeName, label)
+		})
+	}
+}
+
+// workflowFileRe matches workflow file names mentioned in the README.
+var workflowFileRe = regexp.MustCompile("`([a-z0-9][a-z0-9._-]*\\.ya?ml)`")
+
+// TestReadmeReferencesExistingWorkflows keeps the README from pointing at
+// workflow files that were renamed or deleted.
+func TestReadmeReferencesExistingWorkflows(t *testing.T) {
+	files := workflowFiles(t)
+
+	for _, match := range workflowFileRe.FindAllStringSubmatch(readme(t), -1) {
+		name := match[1]
+
+		t.Run(name, func(t *testing.T) {
+			_, ok := files[name]
+			assert.Truef(t, ok, "%s references workflow %q, which does not exist in .github/workflows",
+				readmeName, name)
+		})
+	}
+}
+
+// TestWorkflowPrefixConventionHolds encodes the convention the README's
+// "Additional Information" section states: entrypoint workflows that call
+// another workflow carry a numeric prefix, and the reusable workflows they
+// call carry an alphabetic prefix. The README had this backwards. Asserting
+// the convention against the YAML means a future workflow that breaks it
+// fails here instead of quietly making the README wrong again.
+func TestWorkflowPrefixConventionHolds(t *testing.T) {
+	numericPrefix := regexp.MustCompile(`^[0-9]`)
+
+	for name, content := range workflowFiles(t) {
+		t.Run(name, func(t *testing.T) {
+			isReusable := parseTriggers(t, name, content).On.WorkflowCall.Kind != 0
+			isCaller := strings.Contains(string(content), "uses: ./.github/workflows/")
+
+			switch {
+			case isReusable:
+				assert.Falsef(t, numericPrefix.MatchString(name),
+					"%s is reusable (on.workflow_call) so it should carry an alphabetic prefix", name)
+			case isCaller:
+				assert.Truef(t, numericPrefix.MatchString(name),
+					"%s calls another workflow so it should carry a numeric prefix", name)
+			default:
+				// Standalone workflows (scorecard, comments) are outside the
+				// caller/reusable convention and are intentionally unconstrained.
+				t.Skipf("%s is standalone: neither reusable nor a caller", name)
+			}
+		})
+	}
+}

--- a/internal/ghworkflows/readme_test.go
+++ b/internal/ghworkflows/readme_test.go
@@ -189,6 +189,9 @@ func TestReadmeReferencesExistingWorkflows(t *testing.T) {
 // fails here instead of quietly making the README wrong again.
 func TestWorkflowPrefixConventionHolds(t *testing.T) {
 	numericPrefix := regexp.MustCompile(`^[0-9]`)
+	// Asserted positively rather than as "not numeric", so a name starting with
+	// punctuation or an underscore fails too instead of passing by default.
+	alphabeticPrefix := regexp.MustCompile(`^[A-Za-z]`)
 
 	for name, content := range workflowFiles(t) {
 		t.Run(name, func(t *testing.T) {
@@ -197,7 +200,7 @@ func TestWorkflowPrefixConventionHolds(t *testing.T) {
 
 			switch {
 			case isReusable:
-				assert.Falsef(t, numericPrefix.MatchString(name),
+				assert.Truef(t, alphabeticPrefix.MatchString(name),
 					"%s is reusable (on.workflow_call) so it should carry an alphabetic prefix", name)
 			case isCaller:
 				assert.Truef(t, numericPrefix.MatchString(name),


### PR DESCRIPTION
## Overview

`.github/workflows/README.md` is one of the first files a new contributor opens to work out which branch to target and what CI will do to their PR. It had drifted from the workflows sitting beside it, and the drift is the kind that only misleads the people least able to spot it.

The reported symptom was line 7: *"Kubescape's main branch is `main`, any PR will be opened against the main branch."* The default branch is `master` — `scorecard.yml:15` pins `branches: [ "master" ]`, and every recent PR targets `master`.

Correcting that line alone would have left the rest of the file wrong, so I checked every factual claim in it against the workflow definitions. Four more had drifted:

| Where | The README said | What the workflows do |
|---|---|---|
| Line 11 | PRs trigger "units, license, etc." | There is no license job. `a-pr-scanner.yaml` runs unit tests with `-race`, a separate `CGO_ENABLED=1` race run over `./core/cautils/...`, the `httphandler` module tests, a GoReleaser snapshot build, `smoke_testing/init.py`, and golangci-lint in `only-new-issues` mode. DCO and GitGuardian report as GitHub Apps. |
| Lines 15, 19 | A reviewer adds a `trigger-integration-test` label to run E2E, and merge is blocked on it | That label appears nowhere in the repository except those two lines. E2E is dispatched automatically by `00-pr-scanner.yaml` and gated only on the `wf-preparation` job finding organization secrets — no label, no approval gate. |
| Line 48 | "callers have the alphabetic prefix and the executes have the numeric prefix" | Inverted. `00-pr-scanner.yaml` (numeric) has `uses: ./.github/workflows/a-pr-scanner.yaml`; `a-pr-scanner.yaml` (alphabetic) is the one with `on: workflow_call`. |
| Release section | Tag `vA.B.C-rc.D`, CI strips the suffix to produce `vA.B.C` | `02-release.yaml`'s tag filter is `v[0-9]+.[0-9]+.[0-9]+`, which cannot match an `-rc` tag, and there is no suffix-stripping step. The last rc tag was `v3.0.46-rc.0` in December 2025; everything since has been `v4.0.x`. |

The release steps are now the ones `02-release.yaml` actually runs: GoReleaser build, system tests against a Kind cluster with a JUnit report, Cosign signing, Syft SBOM, build provenance attestation, publish to quay.io, and the krew-index bump.

I also made one thing explicit that the README previously implied the opposite of: **the E2E system tests are dispatched to a private repository and gated on organization secrets, so they are skipped on PRs from forks.** For an outside contributor the unit tests and the smoke test are the only automated verification available, which is worth knowing when deciding how much coverage to write. The old text suggested a maintainer could opt a PR into E2E with a label.

I deliberately left the release *cadence* wording ("every two weeks, bumping the minor version") alone. It doesn't match the recent tag history, but that is maintainer policy rather than a factual claim about the workflows, so it isn't mine to rewrite. Happy to update it if a maintainer says what it should be.

## Preventing the drift

Nothing linked this file to the workflows it describes, so it rotted silently. `internal/ghworkflows` is a small test-only package that asserts the README's claims against the YAML:

- the documented default branch must match the branch `scorecard.yml` pins
- any label the README says drives CI must be referenced by some workflow
- every workflow filename it mentions must exist
- the numeric/alphabetic prefix convention must hold, computed from `on: workflow_call` and `uses: ./.github/workflows/`

The branch assertion needs a source of truth that works offline and stays checked in; `scorecard.yml`'s `on.push.branches` is the only workflow that pins a branch by name, so it serves as the anchor. Standalone workflows that are neither reusable nor callers, like `scorecard.yml` and `comments.yaml`, are skipped by the prefix test rather than forced into the convention.

**No production code and no dependency changes.** The package contains only a `_test.go` file; `gopkg.in/yaml.v3` and `testify` were already direct dependencies, so `go.mod` and `go.sum` are untouched.

## Testing

Two of the assertions fail on `master` and pass here. On `master`, `TestReadmeDocumentsTheRealDefaultBranch` fails because the README does not state the branch in the asserted form, and `TestReadmeLabelsAreReadBySomeWorkflow/trigger-integration-test` fails with:

```
README.md documents the "trigger-integration-test" label as driving CI,
but no workflow references it; either wire it up or stop documenting it
```

To reproduce, check out the README from `master` and run the package:

```bash
git checkout master -- .github/workflows/README.md
go test ./internal/ghworkflows/...   # FAIL
git checkout HEAD -- .github/workflows/README.md
go test ./internal/ghworkflows/...   # ok
```

Also run: `go build ./...`, `go vet ./internal/...`, `gofmt -l internal/ghworkflows/` (clean), `go test -race ./internal/...`.

Worth flagging for reviewers: **`00-pr-scanner.yaml` has `**.md` in its `paths-ignore`**, and the only other file here is a `_test.go`, so this PR may not trigger the build workflow at all. The commands above are what stands in for it. The new test will first run in CI on the next code-touching PR.

## Related issues/PRs

Resolves #3116

Rebased on `6827c35f`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow documentation with the current default branch, pull request and GitHub App checks, documentation-only filtering, private-repository end-to-end testing, fork limitations, and merge requirements.
  * Expanded release documentation covering tag-triggered releases, artifact signing, SBOM and provenance generation, publishing, krew updates, manual dry runs, and workflow naming conventions.

* **Tests**
  * Added automated checks to ensure workflow documentation matches configured workflows, branches, labels, referenced workflows, and naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->