### PR TITLE
fix(hostsensor): return nil handler on initialization error

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 )
@@ -131,6 +132,19 @@ func TestListCRDResources(t *testing.T) {
 }
 
 func TestHostSensorHandlerLifecycleEdges(t *testing.T) {
+	sharedConfig := &rest.Config{
+		Host: "https://cluster.example.test",
+		ContentConfig: rest.ContentConfig{
+			AcceptContentTypes: "application/json",
+			ContentType:        "application/json",
+		},
+	}
+	originalConfig := k8sinterface.K8SConfig
+	k8sinterface.K8SConfig = sharedConfig
+	t.Cleanup(func() {
+		k8sinterface.K8SConfig = originalConfig
+	})
+
 	handler := &HostSensorHandler{}
 
 	assert.NoError(t, handler.TearDown())

--- a/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
 )
 
 func TestConvertCRDToEnvelope(t *testing.T) {
@@ -135,6 +138,14 @@ func TestHostSensorHandlerLifecycleEdges(t *testing.T) {
 	got, err := NewHostSensorHandler(nil, "")
 	require.Nil(t, got)
 	require.ErrorContains(t, err, "nil k8s interface received")
+
+	k8sObj := &k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewSimpleClientset(),
+		Context:          context.Background(),
+	}
+	got2, err2 := NewHostSensorHandler(k8sObj, "")
+	require.Nil(t, got2)
+	require.ErrorContains(t, err2, "failed to get nodes list: no nodes to scan")
 }
 
 func mustJSON(t *testing.T, value map[string]any) string {

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -65,7 +65,7 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 		if err == nil {
 			err = fmt.Errorf("no nodes to scan")
 		}
-		return hsh, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
+		return nil, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
 	}
 
 	return hsh, nil


### PR DESCRIPTION
## Overview

This PR fixes a Go API footgun in `NewHostSensorHandler` where a fully instantiated `HostSensorHandler` pointer was mistakenly returned alongside an error when zero nodes were found on the cluster.

It now returns `nil` alongside the error, strictly adhering to standard Go error-handling conventions and ensuring that a "zombie" handler built for a cluster with zero visible nodes can't leak into the caller's scope.

## Additional Information

While current callers inside the codebase correctly check the `err` variable first and safely discard the returned handler, returning a non-nil pointer with an error is highly dangerous. A future maintainer or external consumer of this package might follow the common pattern of `if handler != nil { handler.DoSomething() }` instead of strictly checking the error. This would lead to unpredictable downstream panics or silent failures.

## How to Test

A new unit test case has been added to `TestHostSensorHandlerLifecycleEdges` that explicitly passes a zero-node mock cluster into `NewHostSensorHandler`. It verifies that the returned handler is now strictly `nil` while the expected `"no nodes to scan"` error is emitted.

Here is the real test output showing the new regression test passing locally:

```text
=== RUN   TestHostSensorHandlerLifecycleEdges

--- PASS: TestHostSensorHandlerLifecycleEdges (0.00s)

=== RUN   TestInitAllowsEmptyCRDList

[info] Using CRD-based host sensor data collection (no deployment needed)

[warning] node-agent status: No OsReleaseFile CRDs found - node-agent may not be running or sensing yet

--- PASS: TestInitAllowsEmptyCRDList (0.00s)

=== RUN   TestConvertCRDToEnvelopeKeepsObjectMetadataName

--- PASS: TestConvertCRDToEnvelopeKeepsObjectMetadataName (0.00s)

=== RUN   TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig

--- PASS: TestNewHostSensorHandlerDoesNotMutateSharedK8sConfig (0.00s)

PASS

ok  	github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils	4.496s
```

## Related issues/PRs:

- Fixes  #3117

## Checklist before requesting a review

-  My code follows the style guidelines of this project
-  I have commented on my code, particularly in hard-to-understand areas
-  I have performed a self-review of my code
-  If it is a core feature, I have added thorough tests.
-  New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host sensor handler initialization when no nodes are available.
  * Prevented partially initialized handlers from being returned after validation errors.
  * Added coverage for this edge case to ensure consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->