### PR TITLE
fix(core): stop TestGetDownloadReleasedPolicy failing on transient GitHub 5xx

### DIFF
--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -747,8 +747,6 @@ func TestGetDownloadReleasedPolicy(t *testing.T) {
 	ctx := context.Background()
 	downloadReleasedPolicy := getter.NewDownloadReleasedPolicy()
 
-	require.NoError(t, downloadReleasedPolicy.SetRegoObjects())
-
 	result, err := getDownloadReleasedPolicy(ctx, downloadReleasedPolicy)
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

`TestGetDownloadReleasedPolicy` in `core/core/initutils_test.go` called `require.NoError(t, downloadReleasedPolicy.SetRegoObjects())` before invoking the function under test, `getDownloadReleasedPolicy`. That function already tolerates a failed download by falling back to a cached policy set (`SetRegoObjectsWithFallback`), but the pre-check used the stricter, non-fallback `SetRegoObjects()` and asserted it must never fail. So the test was stricter than the code it exercises: any transient GitHub 5xx during CI failed the whole `pr-scanner` job, even though production code would have handled the same failure gracefully. The pre-check was also redundant, since it downloaded the same release a second time that `getDownloadReleasedPolicy` already downloads internally.

This PR drops that redundant pre-check, exactly as suggested in the linked issue. The test still asserts what its comment says ("getDownloadReleasedPolicy should always have a non-nil result"), now makes half the network calls, and — when GitHub genuinely is unavailable — exercises the cache-fallback branch instead of failing outright.

Note: the issue also flagged `TestReleasedPolicy` in `core/cautils/getter/downloadreleasedpolicy_test.go` as having similar (though not identical) exposure. That test is left untouched here; it's a separate, less mechanical change and out of scope for this fix.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

## How to Test

Run the affected test normally:

```
go test ./core/core/... -run TestGetDownloadReleasedPolicy -v
```

Reproduce the CI failure mode locally by forcing all outbound requests to fail, then confirm the fix goes down the cache-fallback path instead of failing:

```
HTTPS_PROXY=http://127.0.0.1:1 go test ./core/core/... -run TestGetDownloadReleasedPolicy -v
```

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

## Related issues/PRs:

* Resolved #3081

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a policy download test to run without preloaded configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->