### PR TITLE
test: fix macOS CI by evaluating TempDir symlinks in excludeFilesUnde…

### DIFF
--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -956,7 +956,8 @@ metadata:
 // files, survive. The containment check is directory-aware, so a root located
 // just above the scan tree must not swallow unrelated inputs.
 func TestExcludeFilesUnderDirectories(t *testing.T) {
-	root := t.TempDir()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	appDir := filepath.Join(root, "app")
 	nestedDir := filepath.Join(appDir, "config", "base")
 	require.NoError(t, os.MkdirAll(nestedDir, 0o750))

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -197,7 +197,7 @@ func TestCountNamespaces_AppliesNamespaceFilters(t *testing.T) {
 	ns := func(name string) *corev1.Namespace {
 		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	}
-	//nolint:staticcheck // deprecated but fine for this test
+
 	client := fakeclientset.NewSimpleClientset(ns("default"), ns("kube-system"), ns("prod-a"), ns("prod-b"))
 	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{KubernetesClient: client}}
 

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -48,7 +48,7 @@ var (
 		ImageVulnerabilities: {"armo.vuln.images/v1", "image.vulnscan.com/v1"}}
 	MapResourceToApiGroupCloud = map[string][]string{
 		ClusterDescribe:         {"container.googleapis.com/v1", "eks.amazonaws.com/v1", "management.azure.com/v1"},
-		DescribeRepositories:    {"eks.amazonaws.com/v1"}, //TODO - add google and azure when they are supported
+		DescribeRepositories:    {"eks.amazonaws.com/v1"},                            //TODO - add google and azure when they are supported
 		ListEntitiesForPolicies: {"eks.amazonaws.com/v1", "management.azure.com/v1"}, //TODO - add google when it is supported
 	}
 )


### PR DESCRIPTION
## Overview

This PR fixes a regression in `TestExcludeFilesUnderDirectories` introduced by recent file loader changes, which causes the cross-platform GitHub Action to fail on macOS runners.

On macOS, `t.TempDir()` returns a symlink under `/var` to `/private/var`. The new physical directory exclusion logic successfully evaluates the target directories to their physical paths (`/private/var`). However, because the test injects non-existent mock file paths into the `sources` map, `filepath.EvalSymlinks` fails on them with `os.ErrNotExist`, forcing them to fall back to their unresolved `/var` lexical strings. This string mismatch breaks the `IsUnderAnyDir` path exclusion check.

By explicitly resolving `t.TempDir()` in the test setup via `filepath.EvalSymlinks(t.TempDir())`, both the target directories and the mock file paths are guaranteed to share the exact same physical path prefix, restoring the test on macOS.

*(This PR also includes a quick auto-fix for some unrelated **`gofmt`** and **`nolintlint`** lint errors that recently crept into **`core/pkg/resourcehandler`** to ensure the CI passes).*

## Additional Information

> None.

## How to Test

1. Run `go test -v ./core/pkg/resourcehandler -run TestExcludeFilesUnderDirectories` on a macOS machine. Before this PR, it fails. With this PR, it passes.
2. Verify that the GitHub Actions cross-platform build (specifically the macOS runner) passes successfully.

## Examples/Screenshots

**Before:**

```text
filesloader_test.go:973: 

        	Error Trace:	/Users/runner/work/kubescape/kubescape/core/pkg/resourcehandler/filesloader_test.go:973

        	Error:      	map[string][]workloadinterface.IMetadata{".../app-docs/policy.yaml":..., ".../app/config/base/deployment.yaml":..., ".../app/service.yaml":..., ".../standalone.yaml":...} should not contain ".../app/config/base/deployment.yaml"

        	Test:       	TestExcludeFilesUnderDirectories

        	Messages:   	a file nested below the directory must be excluded

--- FAIL: TestExcludeFilesUnderDirectories (0.00s)
```

**After:**

```text
=== RUN   TestExcludeFilesUnderDirectories

--- PASS: TestExcludeFilesUnderDirectories (0.00s)

PASS
```

## Related issues/PRs:

- Fixes #3123

## Checklist before requesting a review

-  My code follows the style guidelines of this project
-  I have commented on my code, particularly in hard-to-understand areas
-  I have performed a self-review of my code
-  If it is a core feature, I have added thorough tests.
-  New and existing unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved filesystem path handling in resource exclusion tests.
  * Removed an obsolete static analysis suppression from namespace-counting tests.

* **Style**
  * Tidied spacing around an internal TODO comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->