### PR TITLE
feat: add PolicyReport/ClusterPolicyReport (wgpolicyk8s.io) output format

### DIFF
--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -414,7 +414,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json"
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json, policyreport"
 	assert.EqualError(t, err, errMessage)
 }
 

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -64,19 +64,20 @@ const (
 // than re-deriving it, so a format can never resolve to a path its printer
 // does not write. Every entry in AllFormats is covered.
 var FormatOutputExt = map[string]string{
-	PrettyFormat:      PrettyOutputExt,
-	JsonFormat:        JsonOutputExt,
-	JunitResultFormat: JunitOutputExt,
-	PrometheusFormat:  PrometheusOutputExt,
-	PdfFormat:         PdfOutputExt,
-	HtmlFormat:        HtmlOutputExt,
-	SARIFFormat:       SARIFOutputExt,
-	GitLabSASTFormat:  JsonOutputExt,
-	YamlFormat:        YamlOutputExt,
-	CsvFormat:         CsvOutputExt,
-	MarkdownFormat:    MarkdownOutputExt,
-	CycloneDXFormat:   CycloneDXOutputExt,
-	SPDXFormat:        SPDXOutputExt,
+	PrettyFormat:       PrettyOutputExt,
+	JsonFormat:         JsonOutputExt,
+	JunitResultFormat:  JunitOutputExt,
+	PrometheusFormat:   PrometheusOutputExt,
+	PdfFormat:          PdfOutputExt,
+	HtmlFormat:         HtmlOutputExt,
+	SARIFFormat:        SARIFOutputExt,
+	GitLabSASTFormat:   JsonOutputExt,
+	YamlFormat:         YamlOutputExt,
+	CsvFormat:          CsvOutputExt,
+	MarkdownFormat:     MarkdownOutputExt,
+	CycloneDXFormat:    CycloneDXOutputExt,
+	SPDXFormat:         SPDXOutputExt,
+	PolicyReportFormat: PolicyReportOutputExt,
 }
 
 type IPrinter interface {

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -15,23 +15,24 @@ import (
 var INDENT = "   "
 
 const (
-	PrettyFormat      string = "pretty-printer"
-	JsonFormat        string = "json"
-	JunitResultFormat string = "junit"
-	PrometheusFormat  string = "prometheus"
-	PdfFormat         string = "pdf"
-	HtmlFormat        string = "html"
-	SARIFFormat       string = "sarif"
-	GitLabSASTFormat  string = "gitlab-sast"
-	YamlFormat        string = "yaml"
-	CsvFormat         string = "csv"
-	MarkdownFormat    string = "markdown"
-	CycloneDXFormat   string = "cyclonedx-json"
-	SPDXFormat        string = "spdx-json"
+	PrettyFormat       string = "pretty-printer"
+	JsonFormat         string = "json"
+	JunitResultFormat  string = "junit"
+	PrometheusFormat   string = "prometheus"
+	PdfFormat          string = "pdf"
+	HtmlFormat         string = "html"
+	SARIFFormat        string = "sarif"
+	GitLabSASTFormat   string = "gitlab-sast"
+	YamlFormat         string = "yaml"
+	CsvFormat          string = "csv"
+	MarkdownFormat     string = "markdown"
+	CycloneDXFormat    string = "cyclonedx-json"
+	SPDXFormat         string = "spdx-json"
+	PolicyReportFormat string = "policyreport"
 )
 
 // AllFormats lists every output format kubescape can emit.
-var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat}
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat, PolicyReportFormat}
 
 // ImageFormats lists formats whose printers support image-scan data. CSV is
 // deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
@@ -43,18 +44,19 @@ var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, Prometheu
 var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CycloneDXFormat, SPDXFormat}
 
 const (
-	JsonOutputExt       = ".json"
-	JunitOutputExt      = ".xml"
-	SARIFOutputExt      = ".sarif"
-	HtmlOutputExt       = ".html"
-	PdfOutputExt        = ".pdf"
-	PrometheusOutputExt = ".txt"
-	PrettyOutputExt     = ".txt"
-	YamlOutputExt       = ".yaml"
-	CsvOutputExt        = ".csv"
-	MarkdownOutputExt   = ".md"
-	CycloneDXOutputExt  = ".cdx.json"
-	SPDXOutputExt       = ".spdx.json"
+	JsonOutputExt         = ".json"
+	JunitOutputExt        = ".xml"
+	SARIFOutputExt        = ".sarif"
+	HtmlOutputExt         = ".html"
+	PdfOutputExt          = ".pdf"
+	PrometheusOutputExt   = ".txt"
+	PrettyOutputExt       = ".txt"
+	YamlOutputExt         = ".yaml"
+	CsvOutputExt          = ".csv"
+	MarkdownOutputExt     = ".md"
+	CycloneDXOutputExt    = ".cdx.json"
+	SPDXOutputExt         = ".spdx.json"
+	PolicyReportOutputExt = ".yaml"
 )
 
 // FormatOutputExt maps a format to the extension its printer enforces in

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -29,6 +29,7 @@ const (
 
 	policyReportResultPass = "pass"
 	policyReportResultFail = "fail"
+	policyReportResultSkip = "skip"
 )
 
 var _ printer.IPrinter = &PolicyReportPrinter{}
@@ -178,8 +179,9 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 			policyResult := policyReportResultFail
 			if status.IsPassed() {
 				policyResult = policyReportResultPass
+			} else if status.IsSkipped() {
+				policyResult = policyReportResultSkip
 			}
-
 			severity := "Unknown"
 			message := ac.GetName()
 			if ctl := summaryControls.GetControl(reportsummary.EControlCriteriaID, ac.GetID()); ctl != nil {
@@ -204,9 +206,12 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 			})
 
 			s := summaries[namespace]
-			if policyResult == policyReportResultPass {
+			switch policyResult {
+			case policyReportResultPass:
 				s.Pass++
-			} else {
+			case policyReportResultSkip:
+				s.Skip++
+			default:
 				s.Fail++
 			}
 			summaries[namespace] = s

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -154,7 +155,14 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 	byNamespace := map[string][]policyReportResult{}
 	summaries := map[string]policyReportSummary{}
 
-	for resourceID, result := range opaSessionObj.ResourcesResult {
+	resourceIDs := make([]string, 0, len(opaSessionObj.ResourcesResult))
+	for resourceID := range opaSessionObj.ResourcesResult {
+		resourceIDs = append(resourceIDs, resourceID)
+	}
+	sort.Strings(resourceIDs)
+
+	for _, resourceID := range resourceIDs {
+		result := opaSessionObj.ResourcesResult[resourceID]
 		resourceData, ok := opaSessionObj.AllResources[resourceID]
 		if !ok {
 			continue
@@ -220,8 +228,15 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 
 	clusterName := scanContextName(opaSessionObj)
 
+	namespaces := make([]string, 0, len(byNamespace))
+	for namespace := range byNamespace {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+
 	reports := make([]policyReport, 0, len(byNamespace))
-	for namespace, results := range byNamespace {
+	for _, namespace := range namespaces {
+		results := byNamespace[namespace]
 		if namespace == "" {
 			reports = append(reports, policyReport{
 				APIVersion: policyReportAPIVersion,
@@ -254,6 +269,9 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 
 func policyReportName(clusterName, namespace string) string {
 	base := "kubescape"
+	if clusterName != "" {
+		base = base + "-" + clusterName
+	}
 	if namespace != "" {
 		base = base + "-" + namespace
 	}

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -101,11 +101,11 @@ func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string)
 		if ext != printer.YamlOutputExt && ext != ".yml" {
 			outputFile = outputFile + printer.YamlOutputExt
 		}
+		var err error
+		pp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
 	}
 	pp.writer = printer.GetWriter(ctx, outputFile)
-	if pp.writer == nil {
-		return fmt.Errorf("failed to open writer for PolicyReport output %q", outputFile)
-	}
 	return nil
 }
 

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -1,0 +1,298 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	policyReportOutputFile = "report"
+
+	policyReportAPIVersion  = "wgpolicyk8s.io/v1alpha2"
+	policyReportKind        = "PolicyReport"
+	clusterPolicyReportKind = "ClusterPolicyReport"
+
+	policyReportSource = "kubescape"
+
+	policyReportResultPass = "pass"
+	policyReportResultFail = "fail"
+)
+
+var _ printer.IPrinter = &PolicyReportPrinter{}
+
+type PolicyReportPrinter struct {
+	writer *os.File
+}
+
+type policyReport struct {
+	APIVersion string               `json:"apiVersion"`
+	Kind       string               `json:"kind"`
+	Metadata   policyReportMeta     `json:"metadata"`
+	Scope      *policyReportScope   `json:"scope,omitempty"`
+	Results    []policyReportResult `json:"results"`
+	Summary    policyReportSummary  `json:"summary"`
+}
+
+type policyReportMeta struct {
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+type policyReportScope struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+}
+
+type policyReportResult struct {
+	Source     string                    `json:"source"`
+	Policy     string                    `json:"policy"`
+	Rule       string                    `json:"rule,omitempty"`
+	Category   string                    `json:"category,omitempty"`
+	Severity   string                    `json:"severity,omitempty"`
+	Result     string                    `json:"result"`
+	Message    string                    `json:"message,omitempty"`
+	Timestamp  metav1.Time               `json:"timestamp,omitempty"`
+	Resources  []policyReportResourceRef `json:"resources,omitempty"`
+	Properties map[string]string         `json:"properties,omitempty"`
+}
+
+type policyReportResourceRef struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+type policyReportSummary struct {
+	Pass  int `json:"pass"`
+	Fail  int `json:"fail"`
+	Warn  int `json:"warn"`
+	Error int `json:"error"`
+	Skip  int `json:"skip"`
+}
+
+func NewPolicyReportPrinter() *PolicyReportPrinter {
+	return &PolicyReportPrinter{}
+}
+
+func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string) {
+	if outputFile != "" {
+		if strings.TrimSpace(outputFile) == "" {
+			outputFile = policyReportOutputFile
+		}
+		ext := filepath.Ext(strings.TrimSpace(outputFile))
+		if ext != printer.YamlOutputExt && ext != ".yml" {
+			outputFile = outputFile + printer.YamlOutputExt
+		}
+	}
+	pp.writer = printer.GetWriter(ctx, outputFile)
+}
+
+func (pp *PolicyReportPrinter) Score(score float32) {
+}
+
+func (pp *PolicyReportPrinter) PrintNextSteps() {
+}
+
+func (pp *PolicyReportPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	if opaSessionObj == nil {
+		return fmt.Errorf("failed to write results in PolicyReport format: no data provided")
+	}
+
+	reports := buildPolicyReports(opaSessionObj)
+	if len(reports) == 0 {
+		logger.L().Ctx(ctx).Warning("no results to report in PolicyReport format")
+	}
+
+	var out []byte
+	for i, report := range reports {
+		encoded, err := yaml.Marshal(report)
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to encode PolicyReport", helpers.Error(err))
+			return fmt.Errorf("failed to encode PolicyReport: %w", err)
+		}
+		if i > 0 {
+			out = append(out, []byte("---\n")...)
+		}
+		out = append(out, encoded...)
+	}
+
+	if _, err := pp.writer.Write(out); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write results in PolicyReport format", helpers.Error(err))
+		return fmt.Errorf("failed to write results in PolicyReport format: %w", err)
+	}
+
+	printer.LogOutputFile(pp.writer.Name())
+	return nil
+}
+
+func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
+	timestamp := opaSessionObj.Report.ReportGenerationTime
+	if timestamp.IsZero() {
+		timestamp = time.Now().UTC()
+	}
+	metaTime := metav1.NewTime(timestamp)
+
+	summaryControls := opaSessionObj.Report.SummaryDetails.Controls
+
+	byNamespace := map[string][]policyReportResult{}
+	summaries := map[string]policyReportSummary{}
+
+	for resourceID, result := range opaSessionObj.ResourcesResult {
+		resourceData, ok := opaSessionObj.AllResources[resourceID]
+		if !ok {
+			continue
+		}
+
+		ref := policyReportResourceRef{
+			APIVersion: resourceData.GetApiVersion(),
+			Kind:       resourceData.GetKind(),
+			Namespace:  resourceData.GetNamespace(),
+			Name:       resourceData.GetName(),
+		}
+		namespace := resourceData.GetNamespace()
+
+		for _, assocCtrl := range result.AssociatedControls {
+			ac := assocCtrl
+			status := ac.GetStatus(nil)
+
+			if status.Status() == "" {
+				continue
+			}
+
+			policyResult := policyReportResultFail
+			if status.IsPassed() {
+				policyResult = policyReportResultPass
+			}
+
+			severity := "Unknown"
+			message := ac.GetName()
+			if ctl := summaryControls.GetControl(reportsummary.EControlCriteriaID, ac.GetID()); ctl != nil {
+				severity = apis.ControlSeverityToString(ctl.GetScoreFactor())
+				if desc := ctl.GetDescription(); desc != "" {
+					message = desc
+				}
+			}
+
+			byNamespace[namespace] = append(byNamespace[namespace], policyReportResult{
+				Source:    policyReportSource,
+				Policy:    ac.GetID(),
+				Rule:      ac.GetName(),
+				Severity:  mapPolicyReportSeverity(severity),
+				Result:    policyResult,
+				Message:   message,
+				Timestamp: metaTime,
+				Resources: []policyReportResourceRef{ref},
+				Properties: map[string]string{
+					"controlURL": cautils.GetControlLink(ac.GetID()),
+				},
+			})
+
+			s := summaries[namespace]
+			if policyResult == policyReportResultPass {
+				s.Pass++
+			} else {
+				s.Fail++
+			}
+			summaries[namespace] = s
+		}
+	}
+
+	clusterName := scanContextName(opaSessionObj)
+
+	reports := make([]policyReport, 0, len(byNamespace))
+	for namespace, results := range byNamespace {
+		if namespace == "" {
+			reports = append(reports, policyReport{
+				APIVersion: policyReportAPIVersion,
+				Kind:       clusterPolicyReportKind,
+				Metadata: policyReportMeta{
+					Name:   policyReportName(clusterName, ""),
+					Labels: policyReportLabels(clusterName),
+				},
+				Scope:   policyReportClusterScope(clusterName),
+				Results: results,
+				Summary: summaries[namespace],
+			})
+			continue
+		}
+		reports = append(reports, policyReport{
+			APIVersion: policyReportAPIVersion,
+			Kind:       policyReportKind,
+			Metadata: policyReportMeta{
+				Name:      policyReportName(clusterName, namespace),
+				Namespace: namespace,
+				Labels:    policyReportLabels(clusterName),
+			},
+			Results: results,
+			Summary: summaries[namespace],
+		})
+	}
+
+	return reports
+}
+
+func policyReportName(clusterName, namespace string) string {
+	base := "kubescape"
+	if namespace != "" {
+		base = base + "-" + namespace
+	}
+	return base
+}
+
+func policyReportLabels(clusterName string) map[string]string {
+	labels := map[string]string{
+		"app.kubernetes.io/managed-by": policyReportSource,
+	}
+	if clusterName != "" {
+		labels["kubescape.io/cluster"] = clusterName
+	}
+	return labels
+}
+
+func policyReportClusterScope(clusterName string) *policyReportScope {
+	if clusterName == "" {
+		return nil
+	}
+	return &policyReportScope{
+		APIVersion: "v1",
+		Kind:       "Cluster",
+		Name:       clusterName,
+	}
+}
+
+func mapPolicyReportSeverity(severity string) string {
+	switch severity {
+	case apis.SeverityCriticalString:
+		return "critical"
+	case apis.SeverityHighString:
+		return "high"
+	case apis.SeverityMediumString:
+		return "medium"
+	case apis.SeverityLowString:
+		return "low"
+	default:
+		return "info"
+	}
+}
+
+func (pp *PolicyReportPrinter) CloseWriter() {
+	if pp.writer != nil && pp.writer != os.Stdout {
+		pp.writer.Close()
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -92,7 +92,7 @@ func NewPolicyReportPrinter() *PolicyReportPrinter {
 	return &PolicyReportPrinter{}
 }
 
-func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string) error {
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = policyReportOutputFile
@@ -103,6 +103,10 @@ func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string)
 		}
 	}
 	pp.writer = printer.GetWriter(ctx, outputFile)
+	if pp.writer == nil {
+		return fmt.Errorf("failed to open writer for PolicyReport output %q", outputFile)
+	}
+	return nil
 }
 
 func (pp *PolicyReportPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -219,6 +219,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewCycloneDXPrinter()
 	case printer.SPDXFormat:
 		return printerv2.NewSPDXPrinter()
+	case printer.PolicyReportFormat:
+		return printerv2.NewPolicyReportPrinter()
 	default:
 		if printFormat != printer.PrettyFormat {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Invalid format \"%s\", default format \"pretty-printer\" is applied", printFormat))
@@ -251,7 +253,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	}
 
 	switch printFormat {
-	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat:
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat, printer.PolicyReportFormat:
 		return false, nil
 	default:
 		return true, nil


### PR DESCRIPTION
## Overview

Adds a new `--format policyreport` output option that emits configuration-scan results as `PolicyReport` / `ClusterPolicyReport` CRDs, following the `wgpolicyk8s.io/v1alpha2` schema (now under the CNCF OpenReports umbrella). This lets Kubescape results be consumed by the broader Kubernetes policy-reporting ecosystem - tools like Policy Reporter - alongside other scanners such as Kyverno and Trivy, using a shared, standard format instead of a Kubescape-specific one.

Namespaced results are grouped into one `PolicyReport` per namespace; cluster-scoped resources are grouped into a single `ClusterPolicyReport`.

## Scope

v1 covers configuration-scan (control) results only. Vulnerability/image-scan results are intentionally out of scope for this PR - mapping CVEs into the PolicyReport schema is a separate design problem and is left as follow-up work.

## How to test

kubescape scan /path/to/manifests --format policyreport --output report.yaml
cat report.yaml

This writes one or more PolicyReport/ClusterPolicyReport YAML documents (multi-doc `---`-separated), one per namespace plus a cluster-scoped report where applicable.

## Related issues

* Refs #1645

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PolicyReport as a supported output format.
  - Added YAML export for namespace-scoped and cluster-scoped policy reports.
  - Reports include scan results, resource references, statuses, severities, metadata, summaries, timestamps, and control links.
  - Multiple reports can be exported as separate YAML documents.
  - PolicyReport output can be selected and validated alongside existing report formats.
  - Generated YAML reports include relevant labels and control references for improved integration with policy reporting workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->