### PR TITLE
fix: validate layers and vulnerabilities in ScanResultReport

### DIFF
--- a/core/pkg/containerscan/datastructuresmethods.go
+++ b/core/pkg/containerscan/datastructuresmethods.go
@@ -30,7 +30,42 @@ func (scanresult *ScanResultReport) Validate() bool {
 		return false
 	}
 
-	//TODO validate layers & vuls
+	if scanresult.Layers == nil {
+		return false
+	}
+
+	type vulnerabilityKey struct {
+		Name               string
+		RelatedPackageName string
+		PackageVersion     string
+	}
+	layerHashes := make(map[string]bool)
+
+	for _, layer := range scanresult.Layers {
+		if layer.LayerHash != "" {
+			if layerHashes[layer.LayerHash] {
+				return false
+			}
+			layerHashes[layer.LayerHash] = true
+		}
+
+		vulnKeys := make(map[vulnerabilityKey]bool)
+
+		for _, vul := range layer.Vulnerabilities {
+			if vul.Name == "" {
+				return false
+			}
+			key := vulnerabilityKey{
+				Name:               vul.Name,
+				RelatedPackageName: vul.RelatedPackageName,
+				PackageVersion:     vul.PackageVersion,
+			}
+			if vulnKeys[key] {
+				return false
+			}
+			vulnKeys[key] = true
+		}
+	}
 
 	return true
 }

--- a/core/pkg/containerscan/datastructuresmethods_test.go
+++ b/core/pkg/containerscan/datastructuresmethods_test.go
@@ -7,6 +7,18 @@ import (
 )
 
 func TestScanResultReportValidate(t *testing.T) {
+	validLayers := LayersList{
+		{
+			LayerHash: "ddd",
+			Vulnerabilities: VulnerabilitiesList{
+				{Name: "CVE-2024-1234", Severity: HighSeverity},
+			},
+			Packages: LinuxPkgs{
+				{PackageName: "coreutils", PackageVersion: "1.0.0"},
+			},
+		},
+	}
+
 	tests := []struct {
 		name     string
 		in       ScanResultReport
@@ -24,6 +36,7 @@ func TestScanResultReportValidate(t *testing.T) {
 				ImgHash:      "aaa",
 				ImgTag:       "bbb",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: false,
 		},
@@ -34,36 +47,40 @@ func TestScanResultReportValidate(t *testing.T) {
 				ImgHash:      "",
 				ImgTag:       "",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: false,
 		},
 		{
-			name: "report with empty ImageHash and non-empty ImgTag should return true",
+			name: "report with empty ImgHash and non-empty ImgTag should return true",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "",
 				ImgTag:       "bbb",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: true,
 		},
 		{
-			name: "report with non-empty ImageHash and empty ImgTag should return true",
+			name: "report with non-empty ImgHash and empty ImgTag should return true",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
 				ImgTag:       "",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: true,
 		},
 		{
-			name: "report with non-empty ImageHash and non-empty ImgTag should return true",
+			name: "report with non-empty ImgHash and non-empty ImgTag should return true",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
 				ImgTag:       "ccc",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: true,
 		},
@@ -74,6 +91,7 @@ func TestScanResultReportValidate(t *testing.T) {
 				ImgHash:      "bbb",
 				ImgTag:       "ccc",
 				Timestamp:    0,
+				Layers:       validLayers,
 			},
 			expected: false,
 		},
@@ -84,6 +102,7 @@ func TestScanResultReportValidate(t *testing.T) {
 				ImgHash:      "bbb",
 				ImgTag:       "ccc",
 				Timestamp:    -1,
+				Layers:       validLayers,
 			},
 			expected: false,
 		},
@@ -94,24 +113,48 @@ func TestScanResultReportValidate(t *testing.T) {
 				ImgHash:      "bbb",
 				ImgTag:       "ccc",
 				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: true,
 		},
 		{
-			name: "report with layer missing LayerHash should return true (layers not validated yet)",
+			name: "report with nil layers should return false",
+			in: ScanResultReport{
+				CustomerGUID: "aaa",
+				ImgHash:      "bbb",
+				ImgTag:       "ccc",
+				Timestamp:    1,
+				Layers:       nil,
+			},
+			expected: false,
+		},
+		{
+			name: "report with empty but non-nil layers should return true",
+			in: ScanResultReport{
+				CustomerGUID: "aaa",
+				ImgHash:      "bbb",
+				ImgTag:       "ccc",
+				Timestamp:    1,
+				Layers:       LayersList{},
+			},
+			expected: true,
+		},
+		{
+			name: "report with duplicate layer hashes should return false",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
 				ImgTag:       "ccc",
 				Timestamp:    1,
 				Layers: LayersList{
-					{LayerHash: ""},
+					{LayerHash: "duplicate-hash"},
+					{LayerHash: "duplicate-hash"},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
-			name: "report with vulnerability missing Name and Severity should return true (vulnerabilities not validated yet)",
+			name: "report with vulnerability missing Name should return false",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
@@ -126,10 +169,10 @@ func TestScanResultReportValidate(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
-			name: "fully populated report should return true",
+			name: "report with duplicate vulnerability should return false",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
@@ -139,13 +182,49 @@ func TestScanResultReportValidate(t *testing.T) {
 					{
 						LayerHash: "ddd",
 						Vulnerabilities: VulnerabilitiesList{
-							{Name: "CVE-2024-1234", Severity: HighSeverity},
-						},
-						Packages: LinuxPkgs{
-							{PackageName: "coreutils", PackageVersion: "1.0.0"},
+							{Name: "CVE-2024-1234", RelatedPackageName: "pkgA", PackageVersion: "1.0"},
+							{Name: "CVE-2024-1234", RelatedPackageName: "pkgA", PackageVersion: "1.0"},
 						},
 					},
 				},
+			},
+			expected: false,
+		},
+		{
+			name: "same vulnerability in different packages should return true",
+			in: ScanResultReport{
+				CustomerGUID: "aaa",
+				ImgHash:      "bbb",
+				ImgTag:       "ccc",
+				Timestamp:    1,
+				Layers: LayersList{
+					{
+						LayerHash: "ddd",
+						Vulnerabilities: VulnerabilitiesList{
+							{
+								Name:               "CVE-2024-1234",
+								RelatedPackageName: "pkgA",
+								PackageVersion:     "1.0",
+							},
+							{
+								Name:               "CVE-2024-1234",
+								RelatedPackageName: "pkgB",
+								PackageVersion:     "2.0",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "fully populated report should return true",
+			in: ScanResultReport{
+				CustomerGUID: "aaa",
+				ImgHash:      "bbb",
+				ImgTag:       "ccc",
+				Timestamp:    1,
+				Layers:       validLayers,
 			},
 			expected: true,
 		},

--- a/core/pkg/containerscan/datastructuresmethods_test.go
+++ b/core/pkg/containerscan/datastructuresmethods_test.go
@@ -191,7 +191,34 @@ func TestScanResultReportValidate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "same vulnerability in different packages should return true",
+			name: "same vulnerability and package with different versions should return true",
+			in: ScanResultReport{
+				CustomerGUID: "aaa",
+				ImgHash:      "bbb",
+				ImgTag:       "ccc",
+				Timestamp:    1,
+				Layers: LayersList{
+					{
+						LayerHash: "ddd",
+						Vulnerabilities: VulnerabilitiesList{
+							{
+								Name:               "CVE-2024-1234",
+								RelatedPackageName: "pkgA",
+								PackageVersion:     "1.0",
+							},
+							{
+								Name:               "CVE-2024-1234",
+								RelatedPackageName: "pkgA",
+								PackageVersion:     "2.0",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "same vulnerability and version in different packages should return true",
 			in: ScanResultReport{
 				CustomerGUID: "aaa",
 				ImgHash:      "bbb",
@@ -209,7 +236,7 @@ func TestScanResultReportValidate(t *testing.T) {
 							{
 								Name:               "CVE-2024-1234",
 								RelatedPackageName: "pkgB",
-								PackageVersion:     "2.0",
+								PackageVersion:     "1.0",
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

Completes the layer and vulnerability validation in `ScanResultReport.Validate()`.

### Changes

* Reject scan results with nil `Layers`.
* Detect duplicate non-empty layer hashes.
* Reject vulnerabilities with an empty name.
* Detect duplicate vulnerabilities within a layer using vulnerability name, related package name, and package version.
* Added test coverage for the new validation cases while preserving the existing validation behavior.

### Tests

* `go test -v -run TestScanResultReportValidate ./core/pkg/containerscan`
* `go test ./core/pkg/containerscan`
* `go test -race ./core/pkg/containerscan`
* `git diff --check`

All of the above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scan report validation to reject incomplete or inconsistent results.
  - Reports now flag missing layers, duplicate layer identifiers, vulnerabilities without names, and duplicate vulnerability entries.
  - Valid reports containing distinct layers and vulnerabilities continue to be accepted.

- **Tests**
  - Expanded validation coverage for empty reports, duplicate data, missing fields, and valid populated reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->