### PR TITLE
fix(ci): restore valid YAML in dependabot.yaml and guard it

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,19 +1,19 @@
 # Dependabot configuration
-#https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-   - package-ecosystem: "gomod"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
 
-    - package-ecosystem: "gomod"
+  - package-ecosystem: "gomod"
     directory: "/httphandler"
     schedule:
       interval: "weekly"
 
-    - package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/repo-hygiene.yaml
+++ b/.github/workflows/repo-hygiene.yaml
@@ -1,0 +1,35 @@
+name: repo-hygiene
+permissions:
+  contents: read
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    # 00-pr-scanner.yaml skips a PR whose every file matches its paths-ignore
+    # list, and ".github/dependabot.yaml" matches two entries there ("**.yaml"
+    # and ".github/*"). A PR touching only that file therefore runs no checks
+    # at all, which is how an invalid config disabled Dependabot for three
+    # months. This workflow uses `paths` - an allow-list - to cover exactly the
+    # blind spot the other workflow's deny-list leaves open.
+    paths:
+      - ".github/**"
+      - "internal/ghworkflows/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-config:
+    name: validate repository configuration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        name: Installing go
+        with:
+          go-version-file: go.mod
+
+      - name: Validate workflow and Dependabot configuration
+        run: go test -v ./internal/ghworkflows/...

--- a/internal/ghworkflows/dependabot_test.go
+++ b/internal/ghworkflows/dependabot_test.go
@@ -1,0 +1,215 @@
+// Package ghworkflows holds repository-hygiene tests: assertions over the
+// configuration files under .github that nothing else checks, and that fail
+// silently when they are wrong.
+//
+// Deliberately test-only. These guards add no production surface.
+package ghworkflows
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// These tests guard .github/dependabot.yaml, which drives the only automated
+// CVE patching this repository has.
+//
+// A malformed config fails somewhere no contributor looks: GitHub disables
+// version updates for the repository and leaves the last successful run
+// standing, so the dependency graph keeps looking healthy while nothing is
+// patched. Commit 7218a904 ("ci: fix indentation in dependabot.yaml") replaced
+// valid 2-space indentation with invalid 3/4-space and stopped Dependabot dead
+// for roughly three months across ~300 modules, Grype, OPA and client-go among
+// them. Nothing failed, because nothing was checking.
+//
+// Syntax is only half the exposure. A config that parses but has quietly lost
+// an entry - the same file was broken and repaired twice before in one day -
+// fails just as silently, so TestDependabotCoversEveryGoModule asserts
+// coverage against the go.mod files actually on disk rather than a hardcoded
+// list. Adding a third module is then covered automatically.
+//
+// Deliberately test-only: this is a repository-hygiene guard, so it adds no
+// production surface.
+const (
+	dependabotConfigName = "dependabot.yaml"
+
+	// gomodEcosystem and actionsEcosystem are Dependabot's identifiers for the
+	// two ecosystems this repository ships: the Go modules themselves, and the
+	// SHA-pinned actions under .github/workflows.
+	gomodEcosystem   = "gomod"
+	actionsEcosystem = "github-actions"
+
+	// dependabotSchemaVersion is the only value Dependabot accepts.
+	dependabotSchemaVersion = 2
+)
+
+// dependabotUpdate is the subset of an `updates` entry these tests assert on.
+// Unknown keys are tolerated on purpose: Dependabot supports many optional
+// options (groups, ignore, open-pull-requests-limit), and a strict decoder
+// would turn adopting one of them into a spurious failure here.
+type dependabotUpdate struct {
+	PackageEcosystem string `yaml:"package-ecosystem"`
+	Directory        string `yaml:"directory"`
+	Schedule         struct {
+		Interval string `yaml:"interval"`
+	} `yaml:"schedule"`
+}
+
+type dependabotConfig struct {
+	Version int                `yaml:"version"`
+	Updates []dependabotUpdate `yaml:"updates"`
+}
+
+// repoRoot resolves the repository root from this test's own location so the
+// tests do not depend on the working directory `go test` is invoked from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	// internal/ghworkflows -> repository root
+	return filepath.Join(testutils.CurrentDir(), "..", "..")
+}
+
+func dependabotConfigPath(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(repoRoot(t), ".github", dependabotConfigName)
+}
+
+// loadDependabotConfig reads and parses the config, surfacing the parser's own
+// message on failure. This is the assertion 7218a904 would have tripped.
+func loadDependabotConfig(t *testing.T) dependabotConfig {
+	t.Helper()
+
+	configPath := dependabotConfigPath(t)
+	content, err := os.ReadFile(configPath)
+	require.NoErrorf(t, err, "cannot read %s", configPath)
+
+	var config dependabotConfig
+	require.NoErrorf(t, yaml.Unmarshal(content, &config),
+		"%s is not valid YAML; GitHub disables version updates for a config it cannot parse, "+
+			"and reports that nowhere a contributor will see it", configPath)
+
+	return config
+}
+
+// normalizeDirectory renders a configured `directory` in the same form
+// goModuleDirectories produces, so "/httphandler", "httphandler" and
+// "/httphandler/" all compare equal.
+func normalizeDirectory(directory string) string {
+	return path.Join("/", filepath.ToSlash(directory))
+}
+
+// goModuleDirectories returns the Dependabot `directory` value for every Go
+// module in the repository, discovered from the go.mod files on disk so that a
+// module added later is covered without editing this test.
+func goModuleDirectories(t *testing.T) []string {
+	t.Helper()
+
+	root := repoRoot(t)
+	var directories []string
+
+	err := filepath.WalkDir(root, func(currentPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			// Skip trees that never hold a module Dependabot should track: VCS
+			// metadata, vendored copies, and fixtures that may carry their own
+			// go.mod purely as test input.
+			switch entry.Name() {
+			case ".git", "vendor", "testdata", "node_modules":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() != "go.mod" {
+			return nil
+		}
+
+		relative, err := filepath.Rel(root, filepath.Dir(currentPath))
+		if err != nil {
+			return err
+		}
+		directories = append(directories, normalizeDirectory(relative))
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, directories, "no go.mod found; the walk is looking in the wrong place")
+
+	sort.Strings(directories)
+	return directories
+}
+
+// TestDependabotConfigIsValid is the direct regression test for 7218a904: the
+// config must parse, and must carry the fields Dependabot requires before it
+// will schedule anything.
+func TestDependabotConfigIsValid(t *testing.T) {
+	config := loadDependabotConfig(t)
+
+	require.Equalf(t, dependabotSchemaVersion, config.Version,
+		"Dependabot only accepts version %d", dependabotSchemaVersion)
+	require.NotEmpty(t, config.Updates,
+		"an empty updates list disables Dependabot as completely as a parse error does")
+
+	for i, update := range config.Updates {
+		t.Run(fmt.Sprintf("updates[%d]", i), func(t *testing.T) {
+			assert.NotEmpty(t, update.PackageEcosystem, "package-ecosystem is required")
+			assert.NotEmpty(t, update.Directory, "directory is required")
+			assert.NotEmptyf(t, update.Schedule.Interval,
+				"schedule.interval is required; the %q entry would never run without it",
+				update.PackageEcosystem)
+		})
+	}
+}
+
+// TestDependabotCoversEveryGoModule catches the silent half of this failure
+// mode: a config that parses but no longer covers every module. This repository
+// ships two (the root module and httphandler, which has its own go.mod and its
+// own dependency set), and only CI tests the second one today.
+func TestDependabotCoversEveryGoModule(t *testing.T) {
+	config := loadDependabotConfig(t)
+
+	tracked := make(map[string]struct{}, len(config.Updates))
+	for _, update := range config.Updates {
+		if update.PackageEcosystem == gomodEcosystem {
+			tracked[normalizeDirectory(update.Directory)] = struct{}{}
+		}
+	}
+
+	for _, directory := range goModuleDirectories(t) {
+		t.Run(directory, func(t *testing.T) {
+			_, ok := tracked[directory]
+			assert.Truef(t, ok,
+				"a go.mod exists at %s but no %q entry in .github/%s covers it, "+
+					"so its dependencies receive no automated CVE patches",
+				directory, gomodEcosystem, dependabotConfigName)
+		})
+	}
+}
+
+// TestDependabotTracksGitHubActions guards the supply chain of CI itself: every
+// action in .github/workflows is pinned to a commit SHA, so nothing moves them
+// off a vulnerable revision unless Dependabot is watching this ecosystem.
+func TestDependabotTracksGitHubActions(t *testing.T) {
+	config := loadDependabotConfig(t)
+
+	for _, update := range config.Updates {
+		if update.PackageEcosystem == actionsEcosystem {
+			return
+		}
+	}
+
+	t.Errorf("no %q entry in .github/%s; the workflows pin actions by commit SHA, "+
+		"so without it a pinned action stays on a vulnerable revision indefinitely",
+		actionsEcosystem, dependabotConfigName)
+}


### PR DESCRIPTION
## Overview

`.github/dependabot.yaml` has not parsed since 7218a904 (2026-05-16), so Dependabot has opened no update PRs for 80 days. The commit that broke it is titled "ci: fix indentation in dependabot.yaml" — it replaced 2-space list indentation with 3-space markers and 4-space child keys, which is a syntax error, not a style change: `directory` ends up less indented than the `package-ecosystem` key that opened the mapping, so it can neither continue that mapping nor start a new list item.

This restores the indentation from 234582c6 (the last revision that parsed) and adds guards so the same failure cannot recur silently.

## Additional Information

Three changes:

- `.github/dependabot.yaml` — indentation restored. Both Psych (the parser `dependabot-core` uses) and `gopkg.in/yaml.v3` accept it again.
- `internal/ghworkflows/dependabot_test.go` — asserts the config parses and carries the fields Dependabot requires. The module-coverage test derives its expectations from the `go.mod` files on disk rather than a hardcoded list, so it also catches the silent variant (valid YAML that has quietly lost an entry), and a third module added later is covered without editing the test.
- `.github/workflows/repo-hygiene.yaml` — runs those tests on `.github/**` changes. This is why the breakage survived three months: `00-pr-scanner.yaml` filters on a `paths-ignore` deny-list that matches `.github/dependabot.yaml` twice (`**.yaml` and `.github/*`), so the commit that broke it changed only ignored files and ran no checks at all. A guard sitting behind that deny-list would miss the same class of commit again.

Note: `internal/ghworkflows` is also introduced by #3118. The two are independent and merge in either order — I verified they compile together, since the local `repoRoot` variable there legally shadows the package-level function here — but whoever merges second may want to drop the duplicate package doc comment.

## How to Test

```
# guard fails on the original bug
git show 7218a904:.github/dependabot.yaml > .github/dependabot.yaml
go test ./internal/ghworkflows/...
# FAIL: yaml: line 5: did not find expected '-' indicator

# and on the silent variant (valid YAML, httphandler entry dropped)
go test -run TestDependabotCoversEveryGoModule ./internal/ghworkflows/...

# passes on the fix
git checkout .github/dependabot.yaml
go test -race ./internal/ghworkflows/...
```

Verified from a clean clone of this branch: `go test -race ./internal/...`, `CGO_ENABLED=1 go test -race ./core/cautils/...`, and builds of both the root and `httphandler` modules all pass.

## Related issues/PRs:

* Resolved #3127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected repository update configuration for Go modules and GitHub Actions.
  * Added automated checks to validate repository configuration changes.
* **Tests**
  * Added validation for update configuration structure and required fields.
  * Added coverage checks to ensure all Go modules and GitHub Actions are tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->