### PR TITLE
fix(version): propagate text output errors

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -40,10 +40,14 @@ func GetVersionCmd(ks meta.IKubescape, version, commit, date string) *cobra.Comm
 				v := versioncheck.NewIVersionCheckHandler(ks.Context())
 				_ = v.CheckLatestVersion(ks.Context(), versioncheck.NewVersionCheckRequest("", version, "", "", "version", nil))
 
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Your current version is: %s\n", version)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Build commit: %s\n", commit)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Build date: %s\n", date)
-				return nil
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Your current version is: %s\n", version); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Build commit: %s\n", commit); err != nil {
+					return err
+				}
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "Build date: %s\n", date)
+				return err
 			default:
 				return fmt.Errorf("unsupported format %q, supported: text, json", outputFormat)
 			}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"testing"
 
@@ -12,6 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
 
 func TestGetVersionCmd_TextOutput(t *testing.T) {
 	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
@@ -126,4 +135,16 @@ func TestGetVersionCmd_InvalidFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "yaml")
+}
+
+func TestGetVersionCmd_TextWriterError(t *testing.T) {
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+
+	wantErr := errors.New("write failed")
+	ks := core.NewKubescape(context.Background())
+	cmd := GetVersionCmd(ks, "v3.0.0", "abc123", "2026-08-13")
+	cmd.SetOut(errorWriter{err: wantErr})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, wantErr)
 }


### PR DESCRIPTION
## Overview

`kubescape version` writes three lines in text mode, but currently discards every `fmt.Fprintf` error and returns success even when stdout fails. This can leave callers with truncated output and a zero exit status. The JSON path already propagates its encoder error.

This change returns an error from each text write. A regression test installs a writer that returns a sentinel error and verifies that Cobra propagates it. Successful output is unchanged.

## How was this tested?

- `go test ./cmd/version -count=1`

## Checklist

- [x] The change fixes a reproducible current failure rather than changing output policy.
- [x] A regression test covers the failing writer path.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version command output now reports errors encountered while writing version, commit, or date information.
  - Prevents successful results from being returned when output cannot be written.

- **Tests**
  - Added coverage to verify that output-writing errors are correctly propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->