### PR TITLE
fix(scan): reject invalid persistent flag values

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -64,6 +64,15 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Example: scanCmdExamples,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// runs for the bare scan command and all subcommands (framework, control, workload, image)
+			if scanInfo.FormatVersion != "v1" && scanInfo.FormatVersion != "v2" {
+				return fmt.Errorf("invalid --format-version %q: supported versions are v1 and v2", scanInfo.FormatVersion)
+			}
+			if scanInfo.ScanTimeout < 0 {
+				return fmt.Errorf("invalid --scan-timeout %s: must be zero or positive", scanInfo.ScanTimeout)
+			}
+			if scanInfo.ControlTimeout < 0 {
+				return fmt.Errorf("invalid --control-timeout %s: must be zero or positive", scanInfo.ControlTimeout)
+			}
 			if strings.Contains(scanInfo.ControlsVersion, "/") {
 				return fmt.Errorf(
 					"invalid --controls-version %q: must be a regolibrary release tag and cannot contain '/'",

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -418,6 +418,49 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	assert.EqualError(t, err, errMessage)
 }
 
+type scanCallCounter struct {
+	mocks.MockIKubescape
+	calls int
+}
+
+func (m *scanCallCounter) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandlingpkg.ResultsHandler, error) {
+	m.calls++
+	return nil, errors.New("scan reached")
+}
+
+func TestGetScanCommand_PersistentFlagValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCalls int
+		wantError string
+	}{
+		{name: "rejects unsupported format version", args: []string{"--format-version=v3"}, wantError: "invalid --format-version"},
+		{name: "format version is case sensitive", args: []string{"--format-version=V2"}, wantError: "invalid --format-version"},
+		{name: "rejects empty format version", args: []string{"--format-version="}, wantError: "invalid --format-version"},
+		{name: "rejects negative scan timeout", args: []string{"--scan-timeout=-1s"}, wantError: "invalid --scan-timeout"},
+		{name: "rejects negative control timeout", args: []string{"--control-timeout=-1s"}, wantError: "invalid --control-timeout"},
+		{name: "accepts defaults", wantCalls: 1, wantError: "scan reached"},
+		{name: "accepts format version v1", args: []string{"--format-version=v1"}, wantCalls: 1, wantError: "scan reached"},
+		{name: "accepts format version v2", args: []string{"--format-version=v2"}, wantCalls: 1, wantError: "scan reached"},
+		{name: "accepts zero timeouts", args: []string{"--scan-timeout=0", "--control-timeout=0"}, wantCalls: 1, wantError: "scan reached"},
+		{name: "accepts positive timeouts", args: []string{"--scan-timeout=2s", "--control-timeout=1s"}, wantCalls: 1, wantError: "scan reached"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &scanCallCounter{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			require.ErrorContains(t, err, tt.wantError)
+			assert.Equal(t, tt.wantCalls, ks.calls)
+		})
+	}
+}
+
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)


### PR DESCRIPTION
## Overview

Three persistent scan flags currently accept values outside their documented domains and still start a scan:

- `--format-version` documents only `v1` and `v2`, but values such as `v3`, `V2`, and an explicit empty value are accepted. The JSON printer then falls through to v2 behavior while report metadata can retain the unsupported value.
- Negative `--scan-timeout` values are parsed successfully and treated like a disabled timeout because the runtime applies a deadline only when the value is positive.
- Negative `--control-timeout` values likewise disable the per-control limit even though zero is the documented disabled value.

This change rejects those values in the parent scan command's `PersistentPreRunE`, before any bare scan or scan subcommand reaches `Scan`. The regression matrix executes the real Cobra command: five invalid cases must make zero scan calls, while the default, v1, v2, zero-timeout, and positive-timeout cases must still reach the scan exactly once.

## How was this tested?

- `go test ./cmd/scan -count=1`

## Checklist

- [x] Validation covers the bare command and inherited scan subcommands.
- [x] Existing valid defaults and documented values remain accepted.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for scan format versions and timeout values before scanning begins.
  * Unsupported format versions and negative timeout values now return clear error messages.

* **Tests**
  * Added coverage for valid defaults, supported versions, zero and positive timeouts, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->