### PR TITLE
fix(scan): validate minimum severity for subcommands

### DIFF
--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -80,6 +80,11 @@ func ValidateCommonScanFlags(cmd *cobra.Command, scanInfo *cautils.ScanInfo, sup
 			return err
 		}
 	}
+	if scanInfo.MinSeverity != "" {
+		if err := ValidateSeverity(scanInfo.MinSeverity); err != nil {
+			return err
+		}
+	}
 	f := cmd.Flags().Lookup("format")
 	if f == nil {
 		f = cmd.InheritedFlags().Lookup("format")

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -77,6 +77,7 @@ func TestValidateCommonScanFlags(t *testing.T) {
 	tests := []struct {
 		name          string
 		severity      string
+		minSeverity   string
 		format        string
 		formatChanged bool
 		expectedErr   string
@@ -84,6 +85,7 @@ func TestValidateCommonScanFlags(t *testing.T) {
 		{
 			name:          "Valid setup",
 			severity:      "High",
+			minSeverity:   "Medium",
 			format:        "json",
 			formatChanged: true,
 			expectedErr:   "",
@@ -91,6 +93,14 @@ func TestValidateCommonScanFlags(t *testing.T) {
 		{
 			name:          "Invalid severity",
 			severity:      "Extreme",
+			format:        "json",
+			formatChanged: true,
+			expectedErr:   "unknown severity",
+		},
+		{
+			name:          "Invalid minimum severity",
+			severity:      "High",
+			minSeverity:   "Extreme",
 			format:        "json",
 			formatChanged: true,
 			expectedErr:   "unknown severity",
@@ -115,6 +125,7 @@ func TestValidateCommonScanFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanInfo := &cautils.ScanInfo{
 				FailThresholdSeverity: tt.severity,
+				MinSeverity:           tt.minSeverity,
 				Format:                tt.format,
 			}
 


### PR DESCRIPTION
## Overview

`--min-severity` is a persistent scan flag, but its value is currently validated only in the bare `scan` command's `RunE`. The framework, control, workload, and image subcommands call `ValidateCommonScanFlags` instead, and that shared validator checks `--severity-threshold` but not `--min-severity`.

As a result, a value such as `--min-severity Extreme` is rejected by `kubescape scan` but silently accepted by the subcommands. The output severity parser treats the unknown value as its lowest rank, so the requested filter is not applied.

This change validates non-empty `MinSeverity` in `ValidateCommonScanFlags`, next to the existing severity-threshold validation. The regression test proves that a valid minimum severity remains accepted and an unknown value returns the existing `ErrUnknownSeverity` path.

## How was this tested?

- `go test ./cmd/shared -count=1`

## Checklist

- [x] The change uses the existing case-insensitive severity validator.
- [x] The regression test covers valid and invalid minimum severities.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan commands now reject unsupported minimum severity values with a clear validation error.
  * Valid severity settings continue to be accepted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->