### PR TITLE
fix(opaprocessor): redact ConfigMap binaryData

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -364,6 +364,7 @@ func removeConfigMapData(workload workloadinterface.IWorkload) {
 	workload.RemoveAnnotation("kubectl.kubernetes.io/last-applied-configuration")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "metadata", "managedFields")
 	overrideSensitiveData(workload)
+	overrideMapField(workload, "binaryData")
 }
 
 func overrideSensitiveData(workload workloadinterface.IWorkload) {

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -100,9 +100,9 @@ func TestRemoveData(t *testing.T) {
 			},
 		},
 		{
-			name: "remove configMap data",
+			name: "remove configMap data and binaryData",
 			args: args{
-				w: `{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "example-configmap", "namespace": "default", "annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{}"}}, "data": {"exampleKey": "exampleValue"}}`,
+				w: `{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "example-configmap", "namespace": "default", "annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{}"}}, "data": {"exampleKey": "exampleValue"}, "binaryData": {"example.bin": "dGVzdA=="}}`,
 			},
 		},
 	}
@@ -135,6 +135,14 @@ func TestRemoveData(t *testing.T) {
 				assert.True(t, ok)
 				for key := range stringData {
 					assert.Equalf(t, "XXXXXX", stringData[key], "stringData[%q] was not redacted", key)
+				}
+			}
+
+			if bd, ok := workloadinterface.InspectMap(workload.GetObject(), "binaryData"); ok {
+				binaryData, ok := bd.(map[string]any)
+				assert.True(t, ok)
+				for key := range binaryData {
+					assert.Equalf(t, "XXXXXX", binaryData[key], "binaryData[%q] was not redacted", key)
 				}
 			}
 


### PR DESCRIPTION
## Overview

Kubescape already replaces every value in `ConfigMap.data` before the raw object is retained in scan results, but leaves values in the standard sibling field `ConfigMap.binaryData` untouched. For example, a `private.key` value remains present in the result as its original base64 string.

This change applies the existing map-value redaction helper to `binaryData` as well. Keys and object structure remain unchanged; only values are replaced with `XXXXXX`, matching the established `data` behavior.

## How was this tested?

- `go test ./core/pkg/opaprocessor -run '^TestRemoveData$' -count=1`
- `go test ./core/pkg/opaprocessor -count=1`

The regression fixture contains both `data` and `binaryData` and verifies that values in both maps are redacted.

## Related work

#2757 addressed the analogous `Secret.stringData` omission.

## Checklist

- [x] The change reuses the existing redaction contract and helper.
- [x] A regression test covers the standard `binaryData` field.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ConfigMap binary data is now redacted alongside other sensitive configuration values.
  * Redacted values consistently appear as `XXXXXX`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->