### PR TITLE
fix(terraform): map sysctl blocks to Kubernetes sysctls

### DIFF
--- a/core/cautils/terraform_test.go
+++ b/core/cautils/terraform_test.go
@@ -2,12 +2,52 @@ package cautils
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTerraformDirectory_GetWorkloads_MapsSysctls(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.tf")
+	require.NoError(t, os.WriteFile(path, []byte(`
+resource "kubernetes_pod_v1" "example" {
+  metadata {
+    name      = "sysctl-test"
+    namespace = "default"
+  }
+  spec {
+    security_context {
+      sysctl {
+        name  = "net.ipv4.ip_local_port_range"
+        value = "1024 65535"
+      }
+    }
+    container {
+      name  = "pause"
+      image = "registry.k8s.io/pause:3.9"
+    }
+  }
+}
+`), 0o600))
+
+	workloads, errs := NewTerraformDirectory(dir).GetWorkloads(dir)
+	require.Empty(t, errs)
+	require.Len(t, workloads[path], 1)
+
+	obj := workloads[path][0].GetObject()
+	spec := obj["spec"].(map[string]interface{})
+	securityContext := spec["securityContext"].(map[string]interface{})
+	assert.NotContains(t, securityContext, "sysctl")
+	sysctls, ok := securityContext["sysctls"].([]interface{})
+	require.True(t, ok, "securityContext.sysctls must be an array")
+	require.Len(t, sysctls, 1)
+	assert.Equal(t, "net.ipv4.ip_local_port_range", sysctls[0].(map[string]interface{})["name"])
+}
 
 func TestTerraformDirectory_GetWorkloads(t *testing.T) {
 	td := NewTerraformDirectory("testdata/terraform")

--- a/core/cautils/terraform_typed.go
+++ b/core/cautils/terraform_typed.go
@@ -61,6 +61,7 @@ var pluralOverrides = map[string]string{
 	"match_expressions":     "matchExpressions",
 	"volume_claim_template": "volumeClaimTemplates",
 	"http_header":           "httpHeaders",
+	"sysctl":                "sysctls",
 }
 
 // repeatableBlocks lists HCL block labels that always encode as a JSON array,
@@ -71,6 +72,7 @@ var repeatableBlocks = map[string]bool{
 	"env": true, "env_from": true, "port": true, "toleration": true,
 	"host_alias": true, "rule": true, "subject": true, "image_pull_secrets": true,
 	"match_expressions": true, "volume_claim_template": true, "http_header": true,
+	"sysctl": true,
 }
 
 // resourceMetaAttributes are Terraform meta-argument attributes valid on any


### PR DESCRIPTION
## Overview

A supported `kubernetes_pod_v1` `security_context { sysctl { ... } }` is currently converted to `securityContext.sysctl` as an object. Kubernetes expects `securityContext.sysctls` as an array. The generated resource therefore has the wrong shape, and controls reading `spec.securityContext.sysctls` cannot inspect the configured value.

This adds the provider mapping `sysctl -> sysctls` and marks `sysctl` blocks repeatable, including when only one block is present. The test converts a real typed Pod fixture and pins the Kubernetes field name, array type, and value.

## How was this tested?

- `go test ./core/cautils -run '^TestTerraformDirectory_GetWorkloads_MapsSysctls$' -count=1`
- `go test ./core/cautils -count=1`

## Checklist

- [x] The change uses the typed converter's existing mapping mechanism.
- [x] A regression test covers the supported Terraform Pod input.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Terraform workload parsing so Kubernetes sysctl settings are represented using the standard plural `securityContext.sysctls` field.
  * Ensured sysctl configurations are consistently handled as an array, including when only one setting is present.

* **Tests**
  * Added coverage verifying sysctl mappings in parsed Terraform workload manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->