### PR TITLE
fix(resourcehandler): scan Terraform-only directories

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -29,6 +29,10 @@ import (
 var (
 	YAML_PREFIX = []string{"yaml", "yml"}
 	JSON_PREFIX = []string{"json"}
+
+	// ErrNoManifestFiles lets resource orchestrators defer this specific error
+	// while another supported loader examines the same input.
+	ErrNoManifestFiles = errors.New("no YAML or JSON manifest files found")
 )
 
 type FileFormat string
@@ -626,7 +630,7 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 		logger.L().Ctx(ctx).Warning("Continuing with manifest files found before a discovery error", helpers.Error(discoveryErr))
 	}
 	if len(files) == 0 {
-		return nil, nil, fmt.Errorf("no YAML or JSON manifest files found for input %q", input)
+		return nil, nil, fmt.Errorf("%w for input %q", ErrNoManifestFiles, input)
 	}
 
 	// skip the plain-YAML glob for the templates of charts the helm render already covered; a chart

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -38,6 +38,7 @@ func TestLoadResourcesFromFilesReturnsErrorForMissingInput(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, workloads)
+	assert.ErrorIs(t, err, ErrNoManifestFiles)
 	assert.Contains(t, err.Error(), "no YAML or JSON manifest files")
 	// The error formats the input with %q, which escapes the separators in a
 	// Windows path, so the raw path is not a substring of it.
@@ -51,7 +52,22 @@ func TestLoadResourcesFromFilesReturnsErrorForEmptyDirectory(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, workloads)
+	assert.ErrorIs(t, err, ErrNoManifestFiles)
+	assert.Equal(t, "no YAML or JSON manifest files found for input "+strconv.Quote(dir), err.Error())
 	assert.Contains(t, err.Error(), "no YAML or JSON manifest files")
+}
+
+func TestLoadResourcesFromFilesTerraformOnlyDirectoryKeepsPlainLoaderContract(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFixture(t, dir, "main.tf", `resource "null_resource" "example" {}`)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoManifestFiles)
+	assert.Nil(t, workloads)
+	assert.Empty(t, skips)
+	assert.Equal(t, "no YAML or JSON manifest files found for input "+strconv.Quote(dir), err.Error())
 }
 
 func TestLoadResourcesFromFilesReturnsJSONParseErrorWithPath(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -339,12 +340,22 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeResult.OwnedHelmChartDirectories...)
 	sourceToWorkloads, fileSkips, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
 	allSkips = append(allSkips, fileSkips...)
-	if err != nil {
+	filesErr := err
+	if err != nil && !errors.Is(err, cautils.ErrNoManifestFiles) {
 		return nil, nil, allSkips, err
 	}
 	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraform(ctx, path)
 	if err != nil {
 		return nil, nil, allSkips, err
+	}
+	if filesErr != nil {
+		terraformWorkloads := 0
+		for _, ws := range terraformSourceToWorkloads {
+			terraformWorkloads += len(ws)
+		}
+		if terraformWorkloads == 0 {
+			return nil, nil, allSkips, filesErr
+		}
 	}
 
 	// merge Terraform-derived workloads, same pattern as the Kustomize block below

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -850,6 +850,105 @@ func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testi
 	assert.Contains(t, err.Error(), "no scannable Kubernetes resources")
 }
 
+const terraformPodFixture = `
+resource "kubernetes_pod_v1" "example" {
+  metadata {
+    name      = "terraform-pod"
+    namespace = "default"
+  }
+  spec {
+    container {
+      name  = "pause"
+      image = "registry.k8s.io/pause:3.9"
+    }
+  }
+}
+`
+
+func writeTerraformFixture(t *testing.T, dir, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, "main.tf")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestGetResourcesFromPathLoadsTerraformOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTerraformFixture(t, dir, terraformPodFixture)
+
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.NoError(t, err)
+	assert.Empty(t, skips)
+	require.Len(t, workloads, 1)
+	assert.Equal(t, "Pod", workloads[0].GetKind())
+	assert.Equal(t, "terraform-pod", workloads[0].GetName())
+	source := sources[workloads[0].GetID()]
+	assert.Equal(t, "Terraform", source.FileType)
+	assert.Equal(t, filepath.Base(path), source.RelativePath)
+}
+
+func TestGetResourcesFromPathLoadsExplicitTerraformFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTerraformFixture(t, dir, terraformPodFixture)
+
+	_, workloads, _, err := getResourcesFromPath(context.Background(), path, cautils.HelmValueOptions{})
+
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+	assert.Equal(t, "terraform-pod", workloads[0].GetName())
+}
+
+func TestGetResourcesFromPathReturnsTerraformErrorForMalformedTerraformOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeTerraformFixture(t, dir, `resource "kubernetes_pod_v1" "broken" {`)
+
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.Error(t, err)
+	assert.Nil(t, sources)
+	assert.Nil(t, workloads)
+	assert.Empty(t, skips)
+	assert.Contains(t, err.Error(), "failed to render Terraform resources")
+	assert.NotContains(t, err.Error(), "no YAML or JSON manifest files")
+}
+
+func TestGetResourcesFromPathKeepsNoManifestErrorForUnsupportedTerraformOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeTerraformFixture(t, dir, `resource "null_resource" "example" {}`)
+
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cautils.ErrNoManifestFiles)
+	assert.Nil(t, sources)
+	assert.Nil(t, workloads)
+	assert.Empty(t, skips)
+}
+
+func TestGetResourcesFromPathLoadsMixedYamlAndTerraformDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeTerraformFixture(t, dir, terraformPodFixture)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yaml-config
+`), 0o600))
+
+	_, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+
+	require.NoError(t, err)
+	resources := map[string]bool{}
+	for _, workload := range workloads {
+		resources[workload.GetKind()+"/"+workload.GetName()] = true
+	}
+	assert.Equal(t, map[string]bool{
+		"ConfigMap/yaml-config": true,
+		"Pod/terraform-pod":     true,
+	}, resources)
+}
+
 func TestGetResourcesFromPathPropagatesKustomizeFailure(t *testing.T) {
 	dir := t.TempDir()
 	kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
## Overview

A Terraform-only directory currently stops at `LoadResourcesFromFiles`, so supported Terraform Kubernetes resources are never reached and malformed Terraform reports an unrelated YAML/JSON error.

`LoadResourcesFromFiles` now wraps its existing no-manifest text with an `errors.Is`-compatible sentinel while preserving the exact message and direct-caller behavior. `getResourcesFromPath` defers only that sentinel, invokes the Terraform loader, and suppresses the pending file error only when Terraform produced at least one actual workload. All other plain-file errors remain immediate, Terraform parser errors win, and unsupported Terraform-only input still fails.

Tests cover a supported Terraform-only directory, an explicit `.tf` file, malformed and unsupported Terraform-only directories, mixed YAML plus Terraform, empty/missing inputs, and a direct plain-loader call on a directory containing only unrelated Terraform.

## How was this tested?

- `go test ./core/cautils -run 'TestLoadResourcesFromFiles.*(EmptyDirectory|TerraformOnlyDirectory)' -count=1`
- `go test ./core/pkg/resourcehandler -run 'TestGetResourcesFromPath.*Terraform' -count=1`

## Related issues/PRs

Resolves #3134

## Checklist

- [x] The exported plain-loader contract and exact error text remain intact.
- [x] Regression and contract tests cover supported, unsupported, malformed, explicit, and mixed inputs.
- [x] The commit is signed off under DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading Terraform resources from directories and explicitly selected files.
  - Mixed directories can now load both Terraform and YAML/JSON resources together.

- **Bug Fixes**
  - Terraform resources load successfully even when no YAML or JSON manifests are present.
  - Improved handling of empty, missing, unsupported, or malformed inputs with clearer no-manifest and rendering errors.
  - Preserved accurate errors when inputs contain unsupported Terraform files or no loadable resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->