### PR TITLE
fix(reporter): split report before first result exceeds limit

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -173,7 +173,7 @@ func (report *ReportEventReceiver) setResults(reportObj *reporthandlingv2.Postur
 			continue
 		}
 
-		if *counter+len(r) >= MAX_REPORT_SIZE && len(reportObj.Results) > 0 {
+		if *counter+len(r) >= MAX_REPORT_SIZE && (len(reportObj.Results) > 0 || len(reportObj.Resources) > 0) {
 
 			// send report
 			if err := report.sendReport(reportObj, *reportCounter, false); err != nil {

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver_boundary_test.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver_boundary_test.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ func TestSubmitSplitsBeforeFirstResultExceedsReportLimit(t *testing.T) {
 	var (
 		mu        sync.Mutex
 		bodySizes []int
+		reports   []reporthandlingv2.PostureReport
 	)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -30,9 +32,15 @@ func TestSubmitSplitsBeforeFirstResultExceedsReportLimit(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		var capturedReport reporthandlingv2.PostureReport
+		if err := json.Unmarshal(body, &capturedReport); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 
 		mu.Lock()
 		bodySizes = append(bodySizes, len(body))
+		reports = append(reports, capturedReport)
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))
@@ -97,6 +105,11 @@ func TestSubmitSplitsBeforeFirstResultExceedsReportLimit(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.Len(t, bodySizes, 2, "resources must be flushed before the first result is appended")
+	require.Len(t, reports, 2)
+	require.Len(t, reports[0].Resources, 2)
+	require.Empty(t, reports[0].Results)
+	require.Empty(t, reports[1].Resources)
+	require.Len(t, reports[1].Results, 1)
 	for _, size := range bodySizes {
 		require.Less(t, size, MAX_REPORT_SIZE, "submitted request exceeded the report-size limit")
 	}

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver_boundary_test.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver_boundary_test.go
@@ -1,0 +1,103 @@
+package reporter
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	v1 "github.com/kubescape/backend/pkg/client/v1"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitSplitsBeforeFirstResultExceedsReportLimit(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		bodySizes []int
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		mu.Lock()
+		bodySizes = append(bodySizes, len(body))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	server := &testServer{Server: httptest.NewUnstartedServer(handler)}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	const (
+		accountID = "00000000-0000-0000-0000-000000000001"
+		accessKey = "00000000-0000-0000-0000-000000000002"
+	)
+	cloudAPI, err := v1.NewKSCloudAPI(
+		server.Root(),
+		server.Root(),
+		accountID,
+		accessKey,
+		v1.WithHTTPClient(hijackedClient(t, server)),
+	)
+	require.NoError(t, err)
+
+	resources := make(map[string]workloadinterface.IMetadata, 2)
+	for _, name := range []string{"first", "second"} {
+		resource := workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			// Each individual ConfigMap stays below Kubernetes' 1 MiB limit.
+			"data": map[string]any{"payload": strings.Repeat("x", 850*1024)},
+		})
+		resources[resource.GetID()] = resource
+	}
+
+	var resultResourceID string
+	for resourceID := range resources {
+		resultResourceID = resourceID
+		break
+	}
+	session := &cautils.OPASessionObj{
+		AllResources: resources,
+		ResourcesResult: map[string]resourcesresults.Result{
+			resultResourceID: {ResourceID: resultResourceID},
+		},
+		ResourceSource: map[string]reporthandling.Source{},
+		Report:         &reporthandlingv2.PostureReport{},
+		Metadata: &reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{ScanningTarget: reporthandlingv2.File},
+		},
+	}
+
+	reporter := NewReportEventReceiver(
+		&TenantConfigMock{accountID: accountID, accessKey: accessKey},
+		"cbabd56f-bac6-416a-836b-b815ef347647",
+		SubmitContextScan,
+		cloudAPI,
+	)
+	require.NoError(t, reporter.Submit(context.Background(), session))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodySizes, 2, "resources must be flushed before the first result is appended")
+	for _, size := range bodySizes {
+		require.Less(t, size, MAX_REPORT_SIZE, "submitted request exceeded the report-size limit")
+	}
+}


### PR DESCRIPTION
## Overview

Fix the v2 reporter's resource-to-result chunk boundary. `setResults` now treats pending resources as content when deciding whether an incoming result would cross `MAX_REPORT_SIZE`.

## Why this is a bug

`setResources` and `setResults` share one byte counter and one `PostureReport`. Before this change, `setResults` only flushed an oversized pending chunk if `Results` was already non-empty. A chunk containing only `Resources` therefore accepted the first result even when that result pushed the serialized payload beyond the documented 2 MiB limit.

## Validation

The regression test uses the real TLS submission path with two valid 850 KiB ConfigMaps and one result embedding a raw resource. It asserts that the boundary is split into two requests and every submitted body is below `MAX_REPORT_SIZE`. On the parent revision, the same fixture produces one 2,612,734-byte request.

- `go test ./core/pkg/resultshandling/reporter/v2 -run '^TestSubmitSplitsBeforeFirstResultExceedsReportLimit$' -count=1`

## Scope

One condition changes. Existing behavior for an individually oversized first item is unchanged; the fix only flushes an already non-empty mixed resource/result chunk.

Fixes #3136.

Supersedes closed/unmerged #2152.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report batching so submissions are sent before exceeding the maximum report size, including when resources are present before the first result.
  * Prevented oversized report requests in boundary cases.

* **Tests**
  * Added coverage confirming large resource and result payloads are split into separate, size-compliant requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->