### PR TITLE
fix(output): keep combined renderers from mutating scan data

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -107,6 +107,11 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 }
 
 func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, jp *JsonPrinter) error {
+	// Finalize into the report owned by this renderer before adding image data.
+	// The same OPASessionObj is submitted after local output is written, so
+	// enriching opaSessionObj.Report here would make --format change the backend
+	// payload as a side effect.
+	finalizedReport := FinalizeResults(opaSessionObj)
 
 	if imageScanData != nil {
 		imageScanSummary, err := jp.convertToImageScanSummary(imageScanData)
@@ -114,15 +119,14 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 			logger.L().Error("failed to convert to image scan summary", helpers.Error(err))
 			return err
 		}
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.Images = imageScanSummary.Images
+		finalizedReport.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
+		finalizedReport.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
+		finalizedReport.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)
+		finalizedReport.SummaryDetails.Vulnerabilities.Images = imageScanSummary.Images
 	}
 
 	// Convert to PostureReportWithSeverity to add severity field to controls,
 	// extract specified labels from workloads, and attach scan coverage gaps.
-	finalizedReport := FinalizeResults(opaSessionObj)
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 	FilterBySeverity(reportWithSeverity, jp.minSeverity)
 

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -117,18 +117,21 @@ func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 }
 
 func printConfigurationsScanningYaml(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, yp *YamlPrinter) error {
+	// Add combined-scan data to this renderer's finalized report. Mutating the
+	// shared session here would also change the posture payload submitted after
+	// local output has finished.
+	finalizedReport := FinalizeResults(opaSessionObj)
 
 	if imageScanData != nil {
 		imageScanSummary := yp.convertToImageScanSummary(imageScanData)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)
-		opaSessionObj.Report.SummaryDetails.Vulnerabilities.Images = imageScanSummary.Images
+		finalizedReport.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
+		finalizedReport.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
+		finalizedReport.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)
+		finalizedReport.SummaryDetails.Vulnerabilities.Images = imageScanSummary.Images
 	}
 
 	// Convert to PostureReportWithSeverity to add severity field to controls,
 	// extract specified labels from workloads, and attach scan coverage gaps.
-	finalizedReport := FinalizeResults(opaSessionObj)
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 
 	r, err := yaml.Marshal(reportWithSeverity)

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -5,10 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
@@ -29,6 +34,36 @@ func (dr *DummyReporter) Submit(_ context.Context, _ *cautils.OPASessionObj) err
 func (dr *DummyReporter) SetTenantConfig(_ cautils.ITenantConfig) {}
 func (dr *DummyReporter) DisplayMessage()                         {}
 func (dr *DummyReporter) GetURL() string                          { return "" }
+
+type capturingReporter struct {
+	cves   []reportsummary.CVESummary
+	images []string
+}
+
+func (r *capturingReporter) Submit(_ context.Context, data *cautils.OPASessionObj) error {
+	r.cves = append([]reportsummary.CVESummary(nil), data.Report.SummaryDetails.Vulnerabilities.CVESummary...)
+	r.images = append([]string(nil), data.Report.SummaryDetails.Vulnerabilities.Images...)
+	return nil
+}
+func (r *capturingReporter) SetTenantConfig(_ cautils.ITenantConfig) {}
+func (r *capturingReporter) DisplayMessage()                         {}
+func (r *capturingReporter) GetURL() string                          { return "" }
+
+type combinedScanVulnerabilityProvider struct{}
+
+func (combinedScanVulnerabilityProvider) PackageSearchNames(grypepkg.Package) []string {
+	return nil
+}
+func (combinedScanVulnerabilityProvider) FindVulnerabilities(...vulnerability.Criteria) ([]vulnerability.Vulnerability, error) {
+	return nil, nil
+}
+func (combinedScanVulnerabilityProvider) VulnerabilityMetadata(ref vulnerability.Reference) (*vulnerability.Metadata, error) {
+	if ref.ID != "CVE-COMBINED" {
+		return nil, errors.New("metadata not found")
+	}
+	return &vulnerability.Metadata{ID: ref.ID, Severity: "High"}, nil
+}
+func (combinedScanVulnerabilityProvider) Close() error { return nil }
 
 type SpyPrinter struct {
 	ActionPrintCalls int
@@ -128,6 +163,63 @@ func TestResultsHandlerHandleResultsPrintsBeforeReturningScanError(t *testing.T)
 	require.ErrorIs(t, err, scanErr)
 	assert.Equal(t, 1, uiPrinter.ActionPrintCalls)
 	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
+}
+
+func TestCombinedJSONAndYAMLOutputDoesNotMutateSubmittedSession(t *testing.T) {
+	imageMatch := match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-COMBINED", Namespace: "nvd"},
+			Metadata:  &vulnerability.Metadata{ID: "CVE-COMBINED", Severity: "High"},
+		},
+		Package: grypepkg.Package{
+			ID:      grypepkg.ID("pkg-combined"),
+			Name:    "pkg-combined",
+			Version: "1.0.0",
+		},
+	}
+	imageData := []cautils.ImageScanData{{
+		Image:                 "combined:latest",
+		Matches:               match.NewMatches(imageMatch),
+		VulnerabilityProvider: combinedScanVulnerabilityProvider{},
+	}}
+
+	tests := []struct {
+		name      string
+		extension string
+		printer   func() printer.IPrinter
+	}{
+		{name: "json", extension: ".json", printer: func() printer.IPrinter { return printerv2.NewJsonPrinter("") }},
+		{name: "yaml", extension: ".yaml", printer: func() printer.IPrinter { return printerv2.NewYamlPrinter() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanData := &cautils.OPASessionObj{
+				Report:   &reporthandlingv2.PostureReport{},
+				Metadata: &reporthandlingv2.Metadata{},
+			}
+			reporter := &capturingReporter{}
+			outputPrinter := tt.printer()
+			outputPath := filepath.Join(t.TempDir(), "combined"+tt.extension)
+			outputPrinter.SetWriter(context.Background(), outputPath)
+
+			handler := NewResultsHandler(reporter, []printer.IPrinter{outputPrinter}, &SpyPrinter{})
+			handler.SetData(scanData)
+			handler.ImageScanData = imageData
+			scanInfo := &cautils.ScanInfo{}
+			scanInfo.Submit.SetBool(true)
+
+			require.NoError(t, handler.HandleResults(context.Background(), scanInfo))
+
+			output, err := os.ReadFile(outputPath)
+			require.NoError(t, err)
+			assert.Contains(t, string(output), "CVE-COMBINED", "combined local output lost image findings")
+			assert.Empty(t, reporter.cves, "local output changed the submitted posture summary")
+			assert.Empty(t, reporter.images, "local output changed the submitted posture summary")
+			assert.Empty(t, handler.GetData().Report.SummaryDetails.Vulnerabilities.CVESummary)
+			assert.Empty(t, handler.GetData().Report.SummaryDetails.Vulnerabilities.Images)
+		})
+	}
 }
 
 func TestValidatePrinter(t *testing.T) {


### PR DESCRIPTION
## Overview

Make the v2 JSON and YAML combined-scan renderers add image vulnerability data only to their finalized output report.

## Why this is a bug

`ResultsHandler` deliberately prints before it submits. Both combined renderers previously enriched `opaSessionObj.Report` in place, so choosing JSON or YAML changed the session later sent to the reporter. Output format therefore affected backend data rather than only representation.

## Fix

Finalize the posture report first, add the image vulnerability summary to that renderer-owned report, then apply severity, label, and coverage conversion. The shared `OPASessionObj` remains untouched.

## Validation

A table-driven regression exercises both JSON and YAML through the real `ResultsHandler` with submission enabled. It verifies that the local artifact contains `CVE-COMBINED` while the capturing reporter and `ResultsHandler.GetData()` see no injected CVE or image summary.

- `go test ./core/pkg/resultshandling -run '^TestCombinedJSONAndYAMLOutputDoesNotMutateSubmittedSession$' -count=1`

Fixes #3138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON and YAML scan reports to consistently include image vulnerability findings.
  * Prevented local report generation from altering submitted vulnerability summaries or image lists.
  * Ensured posture results are generated from the finalized report data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->