### PR TITLE
fix(output): return explicit output setup errors

### DIFF
--- a/cmd/scan/explicit_image_threshold_test.go
+++ b/cmd/scan/explicit_image_threshold_test.go
@@ -19,9 +19,9 @@ type explicitThresholdPrinter struct{}
 func (explicitThresholdPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
 	return nil
 }
-func (explicitThresholdPrinter) PrintNextSteps()                   {}
-func (explicitThresholdPrinter) Score(float32)                     {}
-func (explicitThresholdPrinter) SetWriter(context.Context, string) {}
+func (explicitThresholdPrinter) PrintNextSteps()                         {}
+func (explicitThresholdPrinter) Score(float32)                           {}
+func (explicitThresholdPrinter) SetWriter(context.Context, string) error { return nil }
 
 type explicitThresholdProvider struct {
 	severity string

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -25,8 +25,8 @@ func (noOpWorkloadPrinter) PrintNextSteps() {}
 func (noOpWorkloadPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
 	return nil
 }
-func (noOpWorkloadPrinter) SetWriter(context.Context, string) {}
-func (noOpWorkloadPrinter) Score(float32)                     {}
+func (noOpWorkloadPrinter) SetWriter(context.Context, string) error { return nil }
+func (noOpWorkloadPrinter) Score(float32)                           {}
 
 type workloadScanCaptureKubescape struct {
 	mocks.MockIKubescape
@@ -549,8 +549,8 @@ func (p *fakePrinter) PrintNextSteps() {}
 func (p *fakePrinter) ActionPrint(ctx context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
 	return nil
 }
-func (p *fakePrinter) SetWriter(ctx context.Context, _ string) {}
-func (p *fakePrinter) Score(_ float32)                         {}
+func (p *fakePrinter) SetWriter(ctx context.Context, _ string) error { return nil }
+func (p *fakePrinter) Score(_ float32)                               {}
 
 type recordingKubescape struct {
 	mocks.MockIKubescape

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"errors"
-	"os"
 
 	"github.com/google/uuid"
 	"github.com/kubescape/go-logger"
@@ -419,20 +418,15 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 
 // GetUIPrinter returns a printer that will be used to print to the program’s UI (terminal)
 func GetUIPrinter(ctx context.Context, scanInfo *cautils.ScanInfo, clusterName string) printer.IPrinter {
-	var p printer.IPrinter
-	if helpers.ToLevel(logger.L().GetLevel()) >= helpers.WarningLevel {
-		p = &printerv2.SilentPrinter{}
-	} else {
-		p = printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName)
-
-		// Since the UI of the program is a CLI (Stdout), it means that it should always print to Stdout
-		if scanInfo.Format != "" && scanInfo.Output == "" {
-			p.SetWriter(ctx, os.DevNull)
-		} else {
-			p.SetWriter(ctx, os.Stdout.Name())
-		}
+	if helpers.ToLevel(logger.L().GetLevel()) >= helpers.WarningLevel || (scanInfo.Format != "" && scanInfo.Output == "") {
+		return &printerv2.SilentPrinter{}
 	}
 
+	p := printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName)
+	if err := p.SetWriter(ctx, ""); err != nil {
+		logger.L().Ctx(ctx).Warning("failed to configure terminal output", helpers.Error(err))
+		return &printerv2.SilentPrinter{}
+	}
 	return p
 }
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -131,9 +131,17 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
 	resolvedPaths := make(map[string]string)
+	closeConfiguredPrinters := func() {
+		for _, configuredPrinter := range outputPrinters {
+			if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
+				closer.CloseWriter()
+			}
+		}
+	}
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
+			closeConfiguredPrinters()
 			return nil, err
 		}
 
@@ -143,13 +151,17 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 
 		if path := resolvedOutputPath(format, scanInfo.Output); path != "" {
 			if existing, collision := resolvedPaths[path]; collision {
+				closeConfiguredPrinters()
 				return nil, fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path)
 			}
 			resolvedPaths[path] = format
 		}
 
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo, clusterName)
-		printerHandler.SetWriter(ctx, scanInfo.Output)
+		if err := printerHandler.SetWriter(ctx, scanInfo.Output); err != nil {
+			closeConfiguredPrinters()
+			return nil, fmt.Errorf("configure %q output: %w", format, err)
+		}
 		outputPrinters = append(outputPrinters, printerHandler)
 
 		if usesPrettyPrinter {

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -3,7 +3,9 @@ package core
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,6 +131,36 @@ func TestGetOutputPrinters(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, outputPrinters)
 	assert.Equal(t, 3, len(outputPrinters))
+}
+
+func TestGetOutputPrintersReturnsExplicitSetupErrorsForEveryFormat(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("block"), 0o600))
+	requestedOutput := filepath.Join(blocker, "report")
+
+	for _, format := range printer.AllFormats {
+		t.Run(format, func(t *testing.T) {
+			scanType := cautils.ScanTypeControl
+			if format == printer.CycloneDXFormat || format == printer.SPDXFormat {
+				scanType = cautils.ScanTypeImage
+			}
+			scanInfo := &cautils.ScanInfo{
+				ScanType:      scanType,
+				Format:        format,
+				Output:        requestedOutput,
+				InputPatterns: []string{dir},
+			}
+
+			outputPrinters, err := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
+
+			require.Error(t, err)
+			assert.Nil(t, outputPrinters)
+			assert.Contains(t, err.Error(), "configure \""+format+"\" output")
+			assert.True(t, strings.Contains(err.Error(), "create output directory") || strings.Contains(err.Error(), "open output file"))
+			assert.NoFileExists(t, resolvedOutputPath(format, requestedOutput))
+		})
+	}
 }
 
 func TestGetOutputPrintersCollisionReturnsError(t *testing.T) {

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -80,7 +80,7 @@ var FormatOutputExt = map[string]string{
 type IPrinter interface {
 	PrintNextSteps()
 	ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error
-	SetWriter(ctx context.Context, outputFile string)
+	SetWriter(ctx context.Context, outputFile string) error
 	Score(score float32)
 }
 
@@ -105,6 +105,20 @@ func GetWriter(ctx context.Context, outputFile string) *os.File {
 	}
 	return os.Stdout
 
+}
+
+// GetWriterNoFallback opens an explicitly requested output path. Unlike the
+// legacy helpers, it never redirects an error to stdout or a temporary file:
+// callers can return the setup failure before a scan starts.
+func GetWriterNoFallback(outputFile string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(outputFile), outputDirPerm); err != nil {
+		return nil, fmt.Errorf("create output directory for %q: %w", outputFile, err)
+	}
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return nil, fmt.Errorf("open output file %q: %w", outputFile, err)
+	}
+	return f, nil
 }
 
 // GetWriterNoStdoutFallback opens outputFile for writing for formats whose

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -143,6 +143,20 @@ func TestGetWriter_CreateFailsFallsBackToStdout(t *testing.T) {
 	assert.Same(t, os.Stdout, f)
 }
 
+func TestGetWriterNoFallback_ReturnsExplicitSetupError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	target := filepath.Join(blocker, "report.json")
+
+	f, err := GetWriterNoFallback(target)
+
+	require.Error(t, err)
+	assert.Nil(t, f)
+	assert.ErrorContains(t, err, "create output directory")
+	assert.NoFileExists(t, target)
+}
+
 func TestGetWriterNoStdoutFallback_ValidFileName(t *testing.T) {
 	ctx := context.Background()
 	target := filepath.Join(t.TempDir(), "nested", "report.pdf")

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -27,7 +27,8 @@ func NewJsonPrinter() *JsonPrinter {
 	return &JsonPrinter{}
 }
 
-func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = jsonOutputFile
@@ -36,7 +37,13 @@ func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string
 			outputFile = outputFile + jsonOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		jsonPrinter.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	jsonPrinter.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (jsonPrinter *JsonPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -31,7 +31,8 @@ func NewCsvPrinter() *CsvPrinter {
 	return &CsvPrinter{}
 }
 
-func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = csvOutputFile
@@ -41,7 +42,13 @@ func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.CsvOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		cp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	cp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (cp *CsvPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -28,7 +28,8 @@ func NewCycloneDXPrinter() *CycloneDXPrinter {
 	return &CycloneDXPrinter{}
 }
 
-func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = cyclonedxOutputFile
@@ -37,7 +38,13 @@ func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.CycloneDXOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		cp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	cp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 // Score is a no-op: HandleResults only calls Score when opaSessionObj != nil

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -128,7 +128,8 @@ func (gp *GitLabSASTPrinter) Score(score float32) {
 }
 
 // SetWriter opens outputFile for writing, defaulting the name and forcing a .json extension
-func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = gitLabSASTOutputFile
@@ -137,7 +138,13 @@ func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.JsonOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		gp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	gp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 // PrintNextSteps is a no-op: machine-readable output carries no human-facing guidance

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -47,7 +47,8 @@ func NewHtmlPrinter() *HtmlPrinter {
 	return &HtmlPrinter{}
 }
 
-func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	outputFile = strings.TrimSpace(outputFile)
 	if outputFile == "" {
 		// Raw HTML markup must never fall back to stdout on a TTY.
@@ -57,9 +58,14 @@ func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) {
 	} else if filepath.Ext(outputFile) != printer.HtmlOutputExt {
 		outputFile = outputFile + printer.HtmlOutputExt
 	}
-	// HTML must never fall back to stdout on file-create errors either
-	// (e.g. read-only cwd) — use the no-stdout-fallback helper.
+	if explicitOutput {
+		var err error
+		hp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
+	// Preserve the temp-file fallback for the implicit HTML destination.
 	hp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+printer.HtmlOutputExt)
+	return nil
 }
 
 func (hp *HtmlPrinter) PrintNextSteps() {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -35,7 +35,8 @@ func NewJsonPrinter(minSeverity string) *JsonPrinter {
 	return &JsonPrinter{minSeverity: minSeverity}
 }
 
-func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = jsonOutputFile
@@ -44,7 +45,13 @@ func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.JsonOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		jp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	jp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (jp *JsonPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -99,7 +99,8 @@ func NewJunitPrinter(verbose bool) *JunitPrinter {
 	}
 }
 
-func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = junitOutputFile
@@ -108,7 +109,13 @@ func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.JunitOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		jp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	jp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (jp *JunitPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -32,7 +32,8 @@ func NewMarkdownPrinter() *MarkdownPrinter {
 	return &MarkdownPrinter{}
 }
 
-func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	outputFile = strings.TrimSpace(outputFile)
 	if outputFile == "" {
 		outputFile = markdownOutputFile + printer.MarkdownOutputExt
@@ -41,7 +42,13 @@ func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) {
 	} else if filepath.Ext(outputFile) != printer.MarkdownOutputExt {
 		outputFile = outputFile + printer.MarkdownOutputExt
 	}
+	if explicitOutput {
+		var err error
+		mp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	mp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, markdownTempPattern)
+	return nil
 }
 
 func (mp *MarkdownPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -162,12 +162,17 @@ func TestMarkdownPrinter_PrintNextSteps(t *testing.T) {
 	assert.NotPanics(t, func() { mp.PrintNextSteps() })
 }
 
-func TestMarkdownPrinter_SetWriter_NoStdoutFallback(t *testing.T) {
+func TestMarkdownPrinter_SetWriter_ReturnsExplicitSetupError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	target := filepath.Join(blocker, "report.md")
 	mp := NewMarkdownPrinter()
-	mp.SetWriter(context.TODO(), "/nonexistent-kubescape-dir/bad.md")
-	require.NotNil(t, mp.writer)
-	assert.NotEqual(t, os.Stdout, mp.writer, "SetWriter must never assign os.Stdout")
-	mp.CloseWriter()
+	err := mp.SetWriter(context.TODO(), target)
+
+	require.Error(t, err)
+	assert.Nil(t, mp.writer)
+	assert.NoFileExists(t, target)
 }
 
 func TestMarkdownPrinter_ActionPrint_NilSession(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -35,7 +35,8 @@ func NewPdfPrinter() *PdfPrinter {
 	return &PdfPrinter{}
 }
 
-func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	outputFile = strings.TrimSpace(outputFile)
 	if outputFile == "" {
 		// Binary PDF must never fall back to stdout: it corrupts TTYs and
@@ -46,10 +47,15 @@ func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) {
 	} else if filepath.Ext(outputFile) != printer.PdfOutputExt {
 		outputFile = outputFile + printer.PdfOutputExt
 	}
-	// PDF must never fall back to stdout on file-create errors either
-	// (e.g. read-only cwd) — use the no-stdout-fallback helper, which
-	// falls back to a temp file rather than corrupting the TTY.
+	if explicitOutput {
+		var err error
+		pp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
+	// The implicit PDF destination must never fall back to stdout. Preserve
+	// the existing temp-file fallback if the default path cannot be opened.
 	pp.writer = printer.GetWriterNoStdoutFallback(ctx, outputFile, "kubescape-report-*"+printer.PdfOutputExt)
+	return nil
 }
 
 func (pp *PdfPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -192,13 +192,14 @@ func (pp *PrettyPrinter) printHeader(opaSessionObj *cautils.OPASessionObj) {
 
 }
 
-func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) error {
 	if outputFile == os.Stdout.Name() {
 		pp.writer = printer.GetWriter(ctx, "")
 		pp.SetMainPrinter()
-		return
+		return nil
 	}
 
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		outputFile = strings.TrimSpace(outputFile)
 		if outputFile == "" {
@@ -210,8 +211,17 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) {
 		}
 	}
 
-	pp.writer = printer.GetWriter(ctx, outputFile)
+	if explicitOutput {
+		writer, err := printer.GetWriterNoFallback(outputFile)
+		if err != nil {
+			return err
+		}
+		pp.writer = writer
+	} else {
+		pp.writer = printer.GetWriter(ctx, outputFile)
+	}
 	pp.SetMainPrinter()
+	return nil
 }
 
 func (pp *PrettyPrinter) Score(_ float32) {

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -37,7 +37,8 @@ func (pp *PrometheusPrinter) PrintNextSteps() {
 
 }
 
-func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		outputFile = strings.TrimSpace(outputFile)
 		if outputFile == "" {
@@ -47,7 +48,13 @@ func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.PrometheusOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		pp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	pp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (pp *PrometheusPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -78,7 +78,8 @@ func NewSARIFPrinter() *SARIFPrinter {
 func (sp *SARIFPrinter) Score(score float32) {
 }
 
-func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = sarifOutputFile
@@ -87,7 +88,13 @@ func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.SARIFOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		sp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	sp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 // addRule adds a rule description to the scan run based on the given control summary

--- a/core/pkg/resultshandling/printer/v2/silentprinter.go
+++ b/core/pkg/resultshandling/printer/v2/silentprinter.go
@@ -21,7 +21,8 @@ func (silentPrinter *SilentPrinter) ActionPrint(ctx context.Context, opaSessionO
 	return nil
 }
 
-func (silentPrinter *SilentPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (silentPrinter *SilentPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	return nil
 }
 
 func (silentPrinter *SilentPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -28,7 +28,8 @@ func NewSPDXPrinter() *SPDXPrinter {
 	return &SPDXPrinter{}
 }
 
-func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = spdxOutputFile
@@ -37,7 +38,13 @@ func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.SPDXOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		sp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	sp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 // Score is a no-op: HandleResults only calls Score when opaSessionObj != nil

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -34,7 +34,8 @@ func NewYamlPrinter() *YamlPrinter {
 	return &YamlPrinter{}
 }
 
-func (yp *YamlPrinter) SetWriter(ctx context.Context, outputFile string) {
+func (yp *YamlPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	explicitOutput := outputFile != ""
 	if outputFile != "" {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = yamlOutputFile
@@ -44,7 +45,13 @@ func (yp *YamlPrinter) SetWriter(ctx context.Context, outputFile string) {
 			outputFile = outputFile + printer.YamlOutputExt
 		}
 	}
+	if explicitOutput {
+		var err error
+		yp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
 	yp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
 }
 
 func (yp *YamlPrinter) Score(score float32) {

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -36,8 +36,8 @@ type SpyPrinter struct {
 	ActionPrintErr   error
 }
 
-func (sp *SpyPrinter) SetWriter(_ context.Context, _ string) {}
-func (sp *SpyPrinter) PrintNextSteps()                       {}
+func (sp *SpyPrinter) SetWriter(_ context.Context, _ string) error { return nil }
+func (sp *SpyPrinter) PrintNextSteps()                             {}
 func (sp *SpyPrinter) ActionPrint(_ context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
 	sp.ActionPrintCalls += 1
 	return sp.ActionPrintErr

--- a/httphandler/handlerequests/v1/http_result_format_lifecycle_test.go
+++ b/httphandler/handlerequests/v1/http_result_format_lifecycle_test.go
@@ -26,18 +26,18 @@ type artifactPrinter struct {
 	content []byte
 }
 
-func (p *artifactPrinter) SetWriter(context.Context, string) {}
-func (p *artifactPrinter) PrintNextSteps()                   {}
-func (p *artifactPrinter) Score(float32)                     {}
+func (p *artifactPrinter) SetWriter(context.Context, string) error { return nil }
+func (p *artifactPrinter) PrintNextSteps()                         {}
+func (p *artifactPrinter) Score(float32)                           {}
 func (p *artifactPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
 	return os.WriteFile(p.path, p.content, 0o600)
 }
 
 type noOpPrinter struct{}
 
-func (*noOpPrinter) SetWriter(context.Context, string) {}
-func (*noOpPrinter) PrintNextSteps()                   {}
-func (*noOpPrinter) Score(float32)                     {}
+func (*noOpPrinter) SetWriter(context.Context, string) error { return nil }
+func (*noOpPrinter) PrintNextSteps()                         {}
+func (*noOpPrinter) Score(float32)                           {}
 func (*noOpPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
 	return nil
 }


### PR DESCRIPTION
## Overview

Follow up on #2904 by propagating failures that occur while configuring an explicitly requested output path.

#2908 made `ActionPrint`/rendering failures observable, but writer setup still returned no error. If `--output` could not be created, text/machine formats fell back to stdout and document formats fell back to a default or temporary file. Kubescape could therefore exit successfully without creating the artifact the user requested.

## Reproduction on current master

Create a regular file and request an output path beneath it, for example `<tmp>/blocker/report` where `<tmp>/blocker` is a file. For every supported format, the requested parent cannot be created. Current master logs a warning, returns setup success, and writes elsewhere; no requested artifact exists.

## Changes

- Make `IPrinter.SetWriter` return an error.
- Use a no-fallback opener whenever `--output` is explicit, so directory/open failures reach `GetOutputPrinters` with format and path context.
- Preserve existing implicit behavior when `--output` is omitted: machine/text formats may use stdout, while PDF/HTML/Markdown keep their safe default/temp-file behavior.
- Close writers configured earlier if a later format fails setup or collides. An earlier file may remain, but its descriptor is not leaked.
- Represent a suppressed terminal UI with `SilentPrinter` instead of configuring a pretty printer against a discard path; if terminal setup ever fails, fall back safely to `SilentPrinter` rather than retaining a nil writer.

## Validation

- A matrix covers every entry in `printer.AllFormats` with a deterministic regular-file parent failure and asserts a contextual setup error plus no requested artifact.
- Focused tests cover the strict opener and Markdown's explicit-path behavior.
- Existing implicit destination tests remain intact.
- Relevant result-handling, scan, and HTTP-handler compile/test checks pass.

## Known limitation

Multi-format setup is not transactional: if an earlier format opened successfully and a later format fails, the earlier empty artifact can remain. The writer is closed. Removing already-created user files automatically would be more surprising and is outside this focused fix.

Follow-up to #2904.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicit output paths now report file and directory setup errors instead of silently falling back to another destination.
  - Scan operations provide format-specific output configuration errors and clean up partially initialized outputs.
  - Default output behavior remains unchanged when no explicit destination is provided.

- **Tests**
  - Added coverage confirming errors are returned, no incomplete output files are created, and resources are cleaned up after setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->