### PR TITLE
fix(junit): disambiguate duplicate testcase names with control ID

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -288,7 +288,10 @@ func testsCases(results *cautils.OPASessionObj, controls reportsummary.IControls
 			continue
 		}
 		testCase.Name = control.GetName()
-		testCase.Classname = classname
+		// JUnit consumers identify a test by (classname, name); several controls
+		// share a display name, so fold the unique control ID into the classname
+		// to keep findings from colliding in CI reporters.
+		testCase.Classname = classname + "/" + cID
 
 		if control.GetStatus().IsFailed() {
 			resources := map[string]any{}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -669,6 +669,38 @@ func TestAggregateSuiteCounts(t *testing.T) {
 	}
 }
 
+func TestTestCases_UniqueClassnameForDuplicateNames(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+
+	const sharedName = "Minimize the admission of containers wishing to share the host process ID namespace"
+	controls := reportsummary.ControlSummaries{
+		"C-0194": {
+			ControlID:  "C-0194",
+			Name:       sharedName,
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusPassed},
+		},
+		"C-0214": {
+			ControlID:  "C-0214",
+			Name:       sharedName,
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		},
+	}
+
+	cases := testsCases(session, &controls, "AllControls")
+	require.Len(t, cases, 2)
+
+	seen := make(map[string]struct{}, len(cases))
+	for _, tc := range cases {
+		// JUnit consumers key a test by (classname, name); two same-named
+		// controls must not produce the same identity.
+		key := tc.Classname + "\x00" + tc.Name
+		require.NotContains(t, seen, key, "duplicate (classname, name) identity %q / %q", tc.Classname, tc.Name)
+		seen[key] = struct{}{}
+		assert.Equal(t, sharedName, tc.Name, "name must stay untouched")
+		assert.Contains(t, tc.Classname, "/C-", "classname must embed the control ID")
+	}
+}
+
 func TestTestCases_MissingControl(t *testing.T) {
 	session := cautils.NewOPASessionObjMock()
 	session.Report = &reporthandlingv2.PostureReport{

--- a/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
+++ b/core/pkg/resultshandling/printer/v2/testdata/junit_golden.xml
@@ -4,66 +4,66 @@
     <properties>
       <property name="complianceScore" value="73.25"></property>
     </properties>
-    <testcase classname="NSA" name="Exec into container">
+    <testcase classname="NSA/C-0002" name="Exec into container">
       <failure message="Exec into container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0002&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="API server insecure port is enabled"></testcase>
-    <testcase classname="NSA" name="Resource limits">
+    <testcase classname="NSA/C-0005" name="API server insecure port is enabled"></testcase>
+    <testcase classname="NSA/C-0009" name="Resource limits">
       <failure message="Resource limits failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0009&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Applications credentials in configuration files">
+    <testcase classname="NSA/C-0012" name="Applications credentials in configuration files">
       <skipped message="configuration: Control configurations are empty"></skipped>
     </testcase>
-    <testcase classname="NSA" name="Non-root containers">
+    <testcase classname="NSA/C-0013" name="Non-root containers">
       <failure message="Non-root containers failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0013&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Allow privilege escalation">
+    <testcase classname="NSA/C-0016" name="Allow privilege escalation">
       <failure message="Allow privilege escalation failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0016&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Immutable container filesystem">
+    <testcase classname="NSA/C-0017" name="Immutable container filesystem">
       <failure message="Immutable container filesystem failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0017&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Ingress and Egress blocked">
+    <testcase classname="NSA/C-0030" name="Ingress and Egress blocked">
       <failure message="Ingress and Egress blocked failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0030&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Automatic mapping of service account">
+    <testcase classname="NSA/C-0034" name="Automatic mapping of service account">
       <failure message="Automatic mapping of service account failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0034&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Cluster-admin binding">
+    <testcase classname="NSA/C-0035" name="Cluster-admin binding">
       <failure message="Cluster-admin binding failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0035&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Host PID/IPC privileges">
+    <testcase classname="NSA/C-0038" name="Host PID/IPC privileges">
       <failure message="Host PID/IPC privileges failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0038&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="HostNetwork access"></testcase>
-    <testcase classname="NSA" name="Container hostPort"></testcase>
-    <testcase classname="NSA" name="Insecure capabilities">
+    <testcase classname="NSA/C-0041" name="HostNetwork access"></testcase>
+    <testcase classname="NSA/C-0044" name="Container hostPort"></testcase>
+    <testcase classname="NSA/C-0046" name="Insecure capabilities">
       <failure message="Insecure capabilities failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0046&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Cluster internal networking">
+    <testcase classname="NSA/C-0054" name="Cluster internal networking">
       <failure message="Cluster internal networking failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0054&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Linux hardening">
+    <testcase classname="NSA/C-0055" name="Linux hardening">
       <failure message="Linux hardening failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0055&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Privileged container">
+    <testcase classname="NSA/C-0057" name="Privileged container">
       <failure message="Privileged container failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0057&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="CVE-2021-25741 - Using symlink for arbitrary host file system access."></testcase>
-    <testcase classname="NSA" name="CVE-2021-25742-nginx-ingress-snippet-annotation-vulnerability"></testcase>
-    <testcase classname="NSA" name="Secret/ETCD encryption enabled">
+    <testcase classname="NSA/C-0058" name="CVE-2021-25741 - Using symlink for arbitrary host file system access."></testcase>
+    <testcase classname="NSA/C-0059" name="CVE-2021-25742-nginx-ingress-snippet-annotation-vulnerability"></testcase>
+    <testcase classname="NSA/C-0066" name="Secret/ETCD encryption enabled">
       <failure message="Secret/ETCD encryption enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0066&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Audit logs enabled">
+    <testcase classname="NSA/C-0067" name="Audit logs enabled">
       <failure message="Audit logs enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0067&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="PSP enabled">
+    <testcase classname="NSA/C-0068" name="PSP enabled">
       <failure message="PSP enabled failed on 0 resource(s)" type="Control">Remediation: &#xA;More details: https://hub.armosec.io/docs/c-0068&#xA;&#xA;</failure>
     </testcase>
-    <testcase classname="NSA" name="Disable anonymous access to Kubelet service">
+    <testcase classname="NSA/C-0069" name="Disable anonymous access to Kubelet service">
       <skipped message="This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator"></skipped>
     </testcase>
-    <testcase classname="NSA" name="Enforce Kubelet client TLS authentication">
+    <testcase classname="NSA/C-0070" name="Enforce Kubelet client TLS authentication">
       <skipped message="This control requires the host-scanner capability. To activate the host scanner capability, proceed with the installation of the kubescape operator chart found here: https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-cloud-operator"></skipped>
     </testcase>
   </testsuite>


### PR DESCRIPTION
While chasing why some failing controls never surfaced in our GitLab CI JUnit reports, I traced it back to `testsCases` naming every testcase after the control's display name and giving every test in a suite the same classname. Fifteen controls in the rule library share a name with another control (a couple are three-way collisions), and JUnit consumers identify a test by the (classname, name) pair, so when two controls emit the same pair, reporters merge or drop one of them. That's a silent false negative: a failing control can disappear from the report, and when two survive there's no way to tell which control each testcase belongs to. This is #3007.

The control ID already exists as the loop's sort key, but the printer only uses it inside the failure text, buried in a `hub.armosec.io/docs/c-00xx` link, so a consumer has to regex it out of a sentence to recover it.

The fix folds the ID into the classname, so `classname="NSA"` becomes `classname="NSA/C-0034"`. That makes every (classname, name) pair unique without touching the name attribute, so anything tracking tests by name keeps working. I picked this over the alternatives deliberately: putting the ID in the name renames every testcase and breaks name-based filters and CI history, and a `<property>` is backward compatible but doesn't actually fix uniqueness.

Verification:
- `TestTestCases_UniqueClassnameForDuplicateNames` builds two same-named controls and asserts distinct (classname, name) identities, it fails on the old code and passes with the fix.
- Regenerated the JUnit golden fixture (`go test -run TestJunitGoldenFile -update-golden`); the only change is the classname gaining the /C-xxxx suffix.
- `go vet ./core/...` and `go build ./core/...` are clean, and the printer/v2 package passes its full 540-test suite.

One thing worth flagging for review: this changes the classname consumers see, so CI tooling that groups on the exact classname string (e.g. `NSA`) will now split by control. That's the intended effect, but the original issue explicitly noted this is a maintainer call, so I wanted to call it out.