### PR TITLE
fix(containerscan): make IsRCE classification case-insensitive

### DIFF
--- a/core/pkg/containerscan/datastructuresmethods.go
+++ b/core/pkg/containerscan/datastructuresmethods.go
@@ -1,10 +1,17 @@
 package containerscan
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/armosec/armoapi-go/identifiers"
 )
+
+// rceAcronymRe matches the standalone "RCE" acronym case-insensitively. The
+// word boundaries are what keep it from matching the substring inside unrelated
+// words such as "source", "force" or "resource", which would otherwise flood
+// the RCE tally with false positives on almost every vulnerability description.
+var rceAcronymRe = regexp.MustCompile(`(?i)\brce\b`)
 
 // GetPackagesNames retrieves the names of all the packages stored in the Packages field of the ScanResultLayer object and returns them as a slice of strings.
 func (layer *ScanResultLayer) GetPackagesNames() []string {
@@ -39,7 +46,7 @@ func (scanresult *ScanResultReport) Validate() bool {
 func (v *Vulnerability) IsRCE() bool {
 	desc := strings.ToLower(v.Description)
 
-	isRCE := strings.Contains(v.Description, "RCE")
+	isRCE := rceAcronymRe.MatchString(v.Description)
 
 	return isRCE || strings.Contains(desc, "remote code execution") || strings.Contains(desc, "remote command execution") || strings.Contains(desc, "arbitrary code") || strings.Contains(desc, "code execution") || strings.Contains(desc, "code injection") || strings.Contains(desc, "command injection") || strings.Contains(desc, "inject arbitrary commands")
 }

--- a/core/pkg/containerscan/datastructuresmethods_test.go
+++ b/core/pkg/containerscan/datastructuresmethods_test.go
@@ -158,3 +158,74 @@ func TestScanResultReportValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestVulnerabilityIsRCE(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		expected    bool
+	}{
+		{
+			name:        "uppercase acronym",
+			description: "a flaw allows an attacker to achieve RCE",
+			expected:    true,
+		},
+		{
+			name:        "lowercase acronym",
+			description: "a flaw allows an attacker to achieve rce",
+			expected:    true,
+		},
+		{
+			name:        "mixed-case acronym",
+			description: "a flaw allows an attacker to achieve Rce",
+			expected:    true,
+		},
+		{
+			name:        "acronym adjacent to punctuation",
+			description: "this is an RCE-vulnerability affecting the product",
+			expected:    true,
+		},
+		{
+			name:        "expanded phrase is still detected",
+			description: "allows arbitrary code execution in the context of the host",
+			expected:    true,
+		},
+		{
+			name:        "command injection phrase is still detected",
+			description: "allows command injection via crafted arguments",
+			expected:    true,
+		},
+		{
+			name:        "source substring is not a false positive",
+			description: "the source code of the affected component is available",
+			expected:    false,
+		},
+		{
+			name:        "resource substring is not a false positive",
+			description: "an unauthenticated user may access the affected resource",
+			expected:    false,
+		},
+		{
+			name:        "force substring is not a false positive",
+			description: "the update may force a restart of the service",
+			expected:    false,
+		},
+		{
+			name:        "commerce substring is not a false positive",
+			description: "information disclosure in the commerce component",
+			expected:    false,
+		},
+		{
+			name:        "no RCE keywords",
+			description: "a denial of service vulnerability exists in the parser",
+			expected:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			vul := Vulnerability{Description: test.description}
+			assert.Equal(t, test.expected, vul.IsRCE())
+		})
+	}
+}


### PR DESCRIPTION
Small but real one here.

`Vulnerability.IsRCE()` decides whether a CVE gets counted in the RCE tally that shows up in the image-scan severity summary. The way it's written today, the acronym check runs against the raw, case-sensitive description (`strings.Contains(v.Description, "RCE")`) while every other keyword check runs against a lowercased copy. So a description that spells the acronym `rce` or `Rce`, which upstream CVE/NVD text does all the time, quietly falls through and the vuln is reported as not-RCE. That under-counts a metric people actually look at when they're triaging an image.

Fixing it naively would have been a trap, and I wanted to flag it: switching to `strings.Contains(desc, "rce")` is a regression, because `rce` is a substring of `source`, `force`, `resource`, `commerce` and a bunch of other words that show up in essentially every description. That would have flooded the RCE count with false positives instead of fixing the false negative. So the fix matches the standalone acronym with a case-insensitive, word-bounded regex, `(?i)\brce\b`, which catches `RCE`, `rce`, `Rce` (and things like `RCE-vulnerability`) while leaving `source`/`resource`/`force` alone. The word boundaries also quietly fix a pre-existing false positive where uppercase `FORCE`/`SOURCE` used to match the old raw `"RCE"` check.

I added a table-driven test covering the casing variants plus a set of `source`/`force`/`resource`/`commerce` negatives so this can't regress in either direction.

Verified locally with `go test ./core/pkg/containerscan/...` (all passing) and `go vet ./core/...` (clean).

Closes #3142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of remote code execution vulnerabilities regardless of capitalization.
  * Correctly recognizes standalone “RCE” references next to punctuation.
  * Prevents false positives when “RCE” appears within unrelated words.
  * Expanded recognition of code-execution and command-injection descriptions.

* **Tests**
  * Added coverage for valid detections, case variations, punctuation, false positives, and unrelated descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->