### PR TITLE
fix(patch): read registry credentials from the environment

### DIFF
--- a/cmd/patch/README.md
+++ b/cmd/patch/README.md
@@ -49,8 +49,8 @@ The patch command can be run in 2 ways:
 | --timeout      | Timeout for the patching process                       | No       | 5m                                  |
 | --ignore-errors| Ignore errors during patching                          | No       | false                               |
 | --push         | Push the patched image to the source registry          | No       | false                               |
-| -u, --username | Username for the image registry login                  | No       |                                     |
-| -p, --password | Password for the image registry login                  | No       |                                     |
+| -u, --username | Username for the image registry login (falls back to `$KUBESCAPE_REGISTRY_USERNAME`) | No       |                                     |
+| -p, --password | Password for the image registry login (falls back to `$KUBESCAPE_REGISTRY_PASSWORD`) | No       |                                     |
 | -f, --format   | Output file format.                                    | No       |                                     |
 | -o, --output   | Output file. Print output to file and not stdout       | No       |                                     |
 | -v, --verbose  | Display full report. Default to false                  | No       |                                     |
@@ -145,6 +145,18 @@ Pass `--push` to push the patched image to the source registry instead. Credenti
 ```bash
 kubescape patch -i myregistry.example.com/team/app:1.2.3 --push
 ```
+
+### Registry credentials from the environment
+
+A password passed as `--password` is visible to every other user on the host via `ps` and `/proc/<pid>/cmdline`, and is recorded in your shell history. To keep it off the command line, set `KUBESCAPE_REGISTRY_USERNAME` / `KUBESCAPE_REGISTRY_PASSWORD` instead — `kubescape patch` uses them whenever the matching flag is omitted (the same variables `kubescape scan image` already honours):
+
+```bash
+export KUBESCAPE_REGISTRY_USERNAME=<registry-username>
+export KUBESCAPE_REGISTRY_PASSWORD=<registry-password>
+kubescape patch -i myregistry.example.com/team/app:1.2.3 --push
+```
+
+A flag given on the command line always takes precedence over the environment, so existing `--username` / `--password` invocations are unaffected.
 
 > **Note:** when used with `--push`, BuildKit uploads the patched image directly to the registry; the image is not necessarily added to your local Docker image store in that mode. Pass `--push` only if you have push access to the source registry — otherwise you will see an `insufficient_scope: authorization failed` error.
 

--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -3,6 +3,7 @@ package patch
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			applyRegistryCredentialsFromEnv(cmd, &patchInfo)
+
 			if f := cmd.Flags().Lookup("format"); f != nil && f.Changed && scanInfo.Format == "" {
 				return fmt.Errorf("format cannot be empty, supported formats: %s", strings.Join(shared.ImageScanFormats, ", "))
 			}
@@ -82,8 +85,9 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 	patchCmd.PersistentFlags().StringVar(&patchInfo.OutputMode, "output-mode", "docker", "Output mode for the patched image (docker, image, oci, local)")
 	patchCmd.PersistentFlags().StringVar(&patchInfo.OutputPath, "output-path", "", "Destination path for oci or local output mode")
 
-	patchCmd.PersistentFlags().StringVarP(&patchInfo.Username, "username", "u", "", "Username for registry login")
-	patchCmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "Password for registry login")
+	patchCmd.PersistentFlags().StringVarP(&patchInfo.Username, "username", "u", "", "Username for registry login [$"+shared.RegistryUsernameEnvVar+"]")
+	// Note: no backticks in the usage string - pflag reads a backquoted word as the flag's value placeholder.
+	patchCmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "Password for registry login. Prefer the environment variable: a flag value is visible in ps and shell history [$"+shared.RegistryPasswordEnvVar+"]")
 
 	patchCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "",
 		fmt.Sprintf("Output file format. Supported formats: %s", strings.Join(shared.ImageScanFormats, ", ")))
@@ -95,6 +99,31 @@ func GetPatchCmd(ks meta.IKubescape) *cobra.Command {
 	patchCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 
 	return patchCmd
+}
+
+// applyRegistryCredentialsFromEnv fills the registry credentials from
+// KUBESCAPE_REGISTRY_USERNAME/KUBESCAPE_REGISTRY_PASSWORD when the corresponding flag
+// was not given on the command line, so a registry password never has to be typed as a
+// `--password` argument - where it is visible in `ps`, /proc/<pid>/cmdline and shell
+// history. `kubescape scan image` already honours these variables (see
+// applyRegistryCredentialsFromEnv in cmd/scan/scan.go); `patch` authenticates against
+// the same registries with the same -u/-p flags, so it accepts them too.
+//
+// An explicitly set flag always wins, including when it is set to an empty value: that
+// is an explicit request for no credential and must not be overridden by the
+// environment. `patch` has no token flag, so only the username/password pair is
+// resolved here.
+func applyRegistryCredentialsFromEnv(cmd *cobra.Command, patchInfo *metav1.PatchInfo) {
+	if patchInfo == nil {
+		return
+	}
+
+	if !shared.RegistryCredentialFlagChanged(cmd, "username") && patchInfo.Username == "" {
+		patchInfo.Username = os.Getenv(shared.RegistryUsernameEnvVar)
+	}
+	if !shared.RegistryCredentialFlagChanged(cmd, "password") && patchInfo.Password == "" {
+		patchInfo.Password = os.Getenv(shared.RegistryPasswordEnvVar)
+	}
 }
 
 // validateImagePatchInfo validates the image patch info for the `patch` command

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -149,6 +150,139 @@ func TestPatchCmd_OutputModeFlags(t *testing.T) {
 	outputModeFlag2 := cmd2.PersistentFlags().Lookup("output-mode")
 	assert.True(t, outputModeFlag2.Changed)
 	assert.Equal(t, "image", outputModeFlag2.Value.String())
+}
+
+// registryFixtureValue assembles credential-looking test values from parts so no
+// literal password string appears in the source (which trips secret scanners).
+func registryFixtureValue(parts ...string) string {
+	return strings.Join(parts, "-")
+}
+
+// TestPatchCmd_RegistryCredentialsFromEnv verifies `kubescape patch` picks up registry
+// credentials from KUBESCAPE_REGISTRY_USERNAME/KUBESCAPE_REGISTRY_PASSWORD when the
+// corresponding flags are omitted, so a registry password never has to be typed on the
+// command line - where it is visible in `ps`, /proc/<pid>/cmdline and shell history.
+// `kubescape scan image` already honours these variables (cmd/scan/scan.go); patch
+// authenticates against the same registries with the same -u/-p flags.
+func TestPatchCmd_RegistryCredentialsFromEnv(t *testing.T) {
+	envUser := registryFixtureValue("env", "user")
+	envCredential := registryFixtureValue("env", "credential")
+
+	t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+	t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+
+	cmd := GetPatchCmd(&mocks.MockIKubescape{})
+	cmd.SetArgs([]string{"--image", "nginx:1.23"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, envUser, cmd.PersistentFlags().Lookup("username").Value.String(),
+		"--username omitted: the username must come from KUBESCAPE_REGISTRY_USERNAME")
+	assert.Equal(t, envCredential, cmd.PersistentFlags().Lookup("password").Value.String(),
+		"--password omitted: the password must come from KUBESCAPE_REGISTRY_PASSWORD")
+}
+
+// TestPatchCmd_RegistryCredentialFlagsBeatEnv verifies flags still win end-to-end, so
+// the environment fallback cannot silently swap the credentials of an existing
+// `kubescape patch -u ... -p ...` invocation.
+func TestPatchCmd_RegistryCredentialFlagsBeatEnv(t *testing.T) {
+	flagUser := registryFixtureValue("flag", "user")
+	flagCredential := registryFixtureValue("flag", "credential")
+
+	t.Setenv("KUBESCAPE_REGISTRY_USERNAME", registryFixtureValue("env", "user"))
+	t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", registryFixtureValue("env", "credential"))
+
+	cmd := GetPatchCmd(&mocks.MockIKubescape{})
+	cmd.SetArgs([]string{"--image", "nginx:1.23", "--username", flagUser, "--password", flagCredential})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, flagUser, cmd.PersistentFlags().Lookup("username").Value.String())
+	assert.Equal(t, flagCredential, cmd.PersistentFlags().Lookup("password").Value.String())
+}
+
+func Test_applyRegistryCredentialsFromEnv(t *testing.T) {
+	envUser := registryFixtureValue("env", "user")
+	envCredential := registryFixtureValue("env", "credential")
+	flagUser := registryFixtureValue("flag", "user")
+	flagCredential := registryFixtureValue("flag", "credential")
+
+	// newPatchCmd builds a command with the same credential flags patch registers,
+	// bound to the returned PatchInfo.
+	newPatchCmd := func() (*cobra.Command, *metav1.PatchInfo) {
+		patchInfo := &metav1.PatchInfo{}
+		cmd := &cobra.Command{Use: "patch"}
+		cmd.PersistentFlags().StringVarP(&patchInfo.Username, "username", "u", "", "")
+		cmd.PersistentFlags().StringVarP(&patchInfo.Password, "password", "p", "", "")
+		return cmd, patchInfo
+	}
+
+	t.Run("both credentials come from the environment when no flag is given", func(t *testing.T) {
+		t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+		t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+
+		cmd, patchInfo := newPatchCmd()
+		applyRegistryCredentialsFromEnv(cmd, patchInfo)
+
+		assert.Equal(t, envUser, patchInfo.Username)
+		assert.Equal(t, envCredential, patchInfo.Password)
+	})
+
+	t.Run("flags take precedence over the environment", func(t *testing.T) {
+		t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+		t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+
+		cmd, patchInfo := newPatchCmd()
+		require.NoError(t, cmd.PersistentFlags().Set("username", flagUser))
+		require.NoError(t, cmd.PersistentFlags().Set("password", flagCredential))
+
+		applyRegistryCredentialsFromEnv(cmd, patchInfo)
+
+		assert.Equal(t, flagUser, patchInfo.Username)
+		assert.Equal(t, flagCredential, patchInfo.Password)
+	})
+
+	t.Run("username flag pairs with password from the environment", func(t *testing.T) {
+		t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+		t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+
+		cmd, patchInfo := newPatchCmd()
+		require.NoError(t, cmd.PersistentFlags().Set("username", flagUser))
+
+		applyRegistryCredentialsFromEnv(cmd, patchInfo)
+
+		assert.Equal(t, flagUser, patchInfo.Username)
+		assert.Equal(t, envCredential, patchInfo.Password,
+			"passing only --username is the intended way to keep the password off the command line")
+	})
+
+	t.Run("explicitly empty flag is not overridden by the environment", func(t *testing.T) {
+		t.Setenv("KUBESCAPE_REGISTRY_USERNAME", envUser)
+		t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", envCredential)
+
+		cmd, patchInfo := newPatchCmd()
+		require.NoError(t, cmd.PersistentFlags().Set("username", ""))
+		require.NoError(t, cmd.PersistentFlags().Set("password", ""))
+
+		applyRegistryCredentialsFromEnv(cmd, patchInfo)
+
+		assert.Empty(t, patchInfo.Username, `--username "" is an explicit request for no credential`)
+		assert.Empty(t, patchInfo.Password, `--password "" is an explicit request for no credential`)
+	})
+
+	t.Run("credentials stay empty when neither flag nor environment is set", func(t *testing.T) {
+		t.Setenv("KUBESCAPE_REGISTRY_USERNAME", "")
+		t.Setenv("KUBESCAPE_REGISTRY_PASSWORD", "")
+
+		cmd, patchInfo := newPatchCmd()
+		applyRegistryCredentialsFromEnv(cmd, patchInfo)
+
+		assert.Empty(t, patchInfo.Username)
+		assert.Empty(t, patchInfo.Password)
+	})
+
+	t.Run("nil patch info is a no-op", func(t *testing.T) {
+		cmd, _ := newPatchCmd()
+		assert.NotPanics(t, func() { applyRegistryCredentialsFromEnv(cmd, nil) })
+	})
 }
 
 func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var scanCmdExamples = fmt.Sprintf(`
@@ -268,33 +267,19 @@ func applyRegistryCredentialsFromEnv(cmd *cobra.Command, scanInfo *cautils.ScanI
 	if scanInfo == nil {
 		return
 	}
-	usernameFlagChanged := registryCredentialFlagChanged(cmd, "registry-username", "username")
-	passwordFlagChanged := registryCredentialFlagChanged(cmd, "registry-password", "password")
-	tokenFlagChanged := registryCredentialFlagChanged(cmd, "registry-token")
+	usernameFlagChanged := shared.RegistryCredentialFlagChanged(cmd, "registry-username", "username")
+	passwordFlagChanged := shared.RegistryCredentialFlagChanged(cmd, "registry-password", "password")
+	tokenFlagChanged := shared.RegistryCredentialFlagChanged(cmd, "registry-token")
 
 	if !tokenFlagChanged && !usernameFlagChanged && scanInfo.RegistryUsername == "" {
-		scanInfo.RegistryUsername = os.Getenv("KUBESCAPE_REGISTRY_USERNAME")
+		scanInfo.RegistryUsername = os.Getenv(shared.RegistryUsernameEnvVar)
 	}
 	if !tokenFlagChanged && !passwordFlagChanged && scanInfo.RegistryPassword == "" {
-		scanInfo.RegistryPassword = os.Getenv("KUBESCAPE_REGISTRY_PASSWORD")
+		scanInfo.RegistryPassword = os.Getenv(shared.RegistryPasswordEnvVar)
 	}
 	if !tokenFlagChanged && !usernameFlagChanged && !passwordFlagChanged && scanInfo.RegistryToken == "" {
-		scanInfo.RegistryToken = os.Getenv("KUBESCAPE_REGISTRY_TOKEN")
+		scanInfo.RegistryToken = os.Getenv(shared.RegistryTokenEnvVar)
 	}
-}
-
-func registryCredentialFlagChanged(cmd *cobra.Command, names ...string) bool {
-	if cmd == nil {
-		return false
-	}
-	for _, name := range names {
-		for _, flags := range []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.InheritedFlags()} {
-			if flag := flags.Lookup(name); flag != nil && flag.Changed {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) []cautils.PolicyIdentifier {

--- a/cmd/shared/registry_credentials.go
+++ b/cmd/shared/registry_credentials.go
@@ -1,0 +1,36 @@
+package shared
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Environment variables that supply registry credentials when the corresponding
+// flags are omitted, so a password never has to appear on the command line -
+// where it is visible in `ps`, /proc/<pid>/cmdline and shell history.
+// gosec's G101 matches on the identifier name alone, so a constant naming the
+// password/token variable trips it even though the value is an environment variable
+// name and not a credential.
+const (
+	RegistryUsernameEnvVar = "KUBESCAPE_REGISTRY_USERNAME"
+	RegistryPasswordEnvVar = "KUBESCAPE_REGISTRY_PASSWORD" //nolint:gosec // G101 false positive: env var name, not a credential
+	RegistryTokenEnvVar    = "KUBESCAPE_REGISTRY_TOKEN"    //nolint:gosec // G101 false positive: env var name, not a credential
+)
+
+// RegistryCredentialFlagChanged reports whether any of the named registry credential
+// flags was explicitly set on the command line. Callers use it to tell "flag omitted"
+// (fall back to the environment) apart from "flag set to an empty value" (an explicit
+// request for no credential, which must not be overridden by the environment).
+func RegistryCredentialFlagChanged(cmd *cobra.Command, names ...string) bool {
+	if cmd == nil {
+		return false
+	}
+	for _, name := range names {
+		for _, flags := range []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.InheritedFlags()} {
+			if flag := flags.Lookup(name); flag != nil && flag.Changed {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -245,6 +245,14 @@ Ensure your kubeconfig user has sufficient permissions. At minimum, you need rea
 
    For `kubescape scan --scan-images`, also pass `--registry-authority myregistry.io` so the credentials are only used for that registry.
 
+   `kubescape patch` reads `KUBESCAPE_REGISTRY_USERNAME` / `KUBESCAPE_REGISTRY_PASSWORD` too (it has no token flag). Prefer them over `--password`, which is visible to other users on the host via `ps` and is written to your shell history:
+
+   ```bash
+   export KUBESCAPE_REGISTRY_USERNAME=<registry-username>
+   export KUBESCAPE_REGISTRY_PASSWORD=<registry-password>
+   kubescape patch --image myregistry.io/myimage:tag
+   ```
+
 ### Vulnerability database outdated
 
 **Symptom:** Known CVEs are not being detected.


### PR DESCRIPTION
## Overview

Fixes the repository-audit finding `#6` — **"Registry password accepted as plaintext CLI flag in `patch`"** (Medium):

> `cmd/patch/patch.go` defines `--password`/`-p` as a plain string flag for registry auth. Passwords passed via CLI flags are visible in shell history, `ps`, and `/proc/<pid>/cmdline`.
>
> *Suggested fix: support reading the password from an env var (e.g. `KUBESCAPE_REGISTRY_PASSWORD`) or prompt interactively (masked) when `--password` is omitted.*

**Current behavior:** `kubescape patch` accepts registry credentials *only* as `--username`/`--password`. There is no way to keep the password off the command line, where it is readable by every other user on the host via `ps` / `/proc/<pid>/cmdline` and is written to shell history.

This is specifically a gap rather than a project-wide design choice: `kubescape scan image` **already** resolves `KUBESCAPE_REGISTRY_USERNAME` / `KUBESCAPE_REGISTRY_PASSWORD` / `KUBESCAPE_REGISTRY_TOKEN` (`applyRegistryCredentialsFromEnv` in `cmd/scan/scan.go`, added in #2696), and those variables are documented in `docs/troubleshooting.md`. `patch` authenticates against the same registries with the same `-u`/`-p` flags, but ignored them.

**New behavior:** `kubescape patch` resolves the username and password from `KUBESCAPE_REGISTRY_USERNAME` / `KUBESCAPE_REGISTRY_PASSWORD` when the corresponding flag is omitted, so the password never has to appear on the command line.

```bash
export KUBESCAPE_REGISTRY_USERNAME=<registry-username>
export KUBESCAPE_REGISTRY_PASSWORD=<registry-password>
kubescape patch --image myregistry.io/myimage:tag
```

## Additional Information

**Root cause.** `GetPatchCmd` binds `--username`/`--password` straight into `PatchInfo` and `RunE` passes them to `ks.Patch` unchanged (`core/core/patch.go` builds `imagescan.RegistryCredentials` from them). Nothing in the `patch` path ever consulted the environment, so the flags were the only input channel.

**Fix.** `applyRegistryCredentialsFromEnv` in `cmd/patch/patch.go`, called at the top of `RunE`, fills each credential from its environment variable only when the matching flag was not set.

**Precedence** matches `scan image`, so existing invocations are unaffected:

| `--password` | `KUBESCAPE_REGISTRY_PASSWORD` | Result |
| --- | --- | --- |
| given | set | flag wins |
| given | unset | flag |
| omitted | set | environment |
| omitted | unset | empty (unauthenticated, as before) |
| `--password ""` | set | empty — an explicitly empty flag is a deliberate request for no credential and is not overridden |

Notes:
- `patch` has no token flag, so only the username/password pair is resolved.
- Partial credentials were already ignored downstream (`imagescan.RegistryCredentials.hasAuth()` requires both username *and* password), so the fallback introduces no new failure mode.
- The flag-changed lookup that was private to `cmd/scan` moves to `cmd/shared/registry_credentials.go` so both commands share one implementation and one set of env var names. `scan`'s behavior is unchanged — its existing `TestApplyRegistryCredentialsFromEnv*` tests pass untouched.
- The `-p` help text now names the variable and warns that a flag value is visible in `ps`. (No backticks in that usage string — pflag reads a backquoted word as the flag's value placeholder.)
- Docs updated: `cmd/patch/README.md` and `docs/troubleshooting.md`.

## How to Test

Automated — `go test ./cmd/patch/ ./cmd/scan/ ./cmd/shared/`:

- `TestPatchCmd_RegistryCredentialsFromEnv` — end-to-end through `cmd.Execute()`; **fails on master**, passes here. This is the regression test for the finding.
- `TestPatchCmd_RegistryCredentialFlagsBeatEnv` — flags still win end-to-end.
- `Test_applyRegistryCredentialsFromEnv` — env fallback, flag precedence, `--username` + password-from-env, explicitly-empty flag, neither source set, nil-safety.

Manual, against a real authenticated registry (this is what was actually run):

```bash
# local registry requiring basic auth, image present ONLY there
htpasswd -Bbn ksuser <password> > auth/htpasswd
docker run -d --name ks-reg -p 5001:5000 -v "$PWD/auth:/auth" \
  -e REGISTRY_AUTH=htpasswd -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2
# push localhost:5001/test/alpine:3.19, then delete every local copy
# and point DOCKER_CONFIG at an empty dir so no ambient credentials apply

export KUBESCAPE_REGISTRY_USERNAME=ksuser KUBESCAPE_REGISTRY_PASSWORD=<password>
kubescape patch --image localhost:5001/test/alpine:3.19
```

**Before (master):** the environment is ignored and the pull is rejected —

```
Error: errors occurred attempting to resolve 'localhost:5001/test/alpine:3.19':
  - docker: pull failed: ... pull access denied ... no basic auth credentials
  - oci-registry: failed to get image descriptor from registry:
      GET http://localhost:5001/v2/test/alpine/manifests/3.19: UNAUTHORIZED: authentication required
```

**After (this branch):** the credentials are picked up and the full patch flow completes, with no password on the command line —

```
Scanning image: localhost:5001/test/alpine:3.19
Successfully scanned image: localhost:5001/test/alpine:3.19
Patching image...
Patched image successfully. Loaded locally: localhost:5001/test/alpine:3.19-patched
Successfully re-scanned image: localhost:5001/test/alpine:3.19-patched
```

Also verified on the built binary:

- `-u ksuser -p <password>` with **no** env set — still works (backward compatible).
- No credentials at all — still fails closed with `UNAUTHORIZED`.
- Env set **and** `-p ""` — fails closed, confirming the explicit-empty-flag rule.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

CI checks run locally: `go build ./...`, `go vet ./cmd/...`, `gofmt`, `go test -race` on the changed packages, `go test ./cmd/...`, `golangci-lint run` (clean — the `//nolint:gosec` on the two env var name constants suppresses a G101 false positive, since G101 matches on the identifier name alone), and the CI smoke suite `python3 smoke_testing/init.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry credentials for patch operations can now be supplied through environment variables.
  * Explicit command-line credentials take precedence, including intentionally empty values.
  * Credential handling is consistent across patch and scan commands.

* **Documentation**
  * Added guidance for environment-based authentication, flag precedence, password visibility, and troubleshooting image patch commands.

* **Tests**
  * Added coverage for credential fallbacks, precedence, mixed credentials, empty values, and missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->