### PR TITLE
fix(opaprocessor): add C-0261 to whole-cluster control fallback

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -48,6 +48,7 @@ const ControlAttributeRequiresWholeClusterInput = "requiresWholeClusterInput"
 // requiresWholeClusterInput attribute on them. Keep it in sync with the
 // regolibrary: remove an ID once its control carries the attribute.
 var wholeClusterControlIDsFallback = map[string]struct{}{
+	"C-0261": {}, // SA token auto-mount bound via RoleBinding/ClusterRoleBinding in another namespace
 	"C-0266": {}, // Exposure to internet via Gateway API or Istio Ingress (Gateway/Service/VirtualService across namespaces)
 	"C-0267": {}, // Workload with cluster takeover roles (RoleBinding -> ServiceAccount in another namespace)
 	"C-0272": {}, // Workload with administrative roles (RoleBinding -> ServiceAccount in another namespace)

--- a/core/pkg/opaprocessor/wholecluster_missing_control_test.go
+++ b/core/pkg/opaprocessor/wholecluster_missing_control_test.go
@@ -18,6 +18,8 @@ import (
 // any RoleBinding in the input, regardless of which namespace that RoleBinding
 // itself lives in. A RoleBinding legally binds a ServiceAccount subject from a
 // different namespace than its own metadata.namespace.
+//
+//nolint:gosec // G101: this is a Rego rule fixture, not a hardcoded credential
 const saTokenBindingRule = `package armo_builtins
 
 deny[msga] {

--- a/core/pkg/opaprocessor/wholecluster_missing_control_test.go
+++ b/core/pkg/opaprocessor/wholecluster_missing_control_test.go
@@ -1,0 +1,159 @@
+package opaprocessor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saTokenBindingRule mirrors the shape of C-0261's real has_service_account_binding
+// logic: it fails a Pod whose (default) ServiceAccount is named as a subject by
+// any RoleBinding in the input, regardless of which namespace that RoleBinding
+// itself lives in. A RoleBinding legally binds a ServiceAccount subject from a
+// different namespace than its own metadata.namespace.
+const saTokenBindingRule = `package armo_builtins
+
+deny[msga] {
+    pod := input[_]
+    pod.kind == "Pod"
+    sa := input[_]
+    sa.kind == "ServiceAccount"
+    sa.metadata.name == "default"
+    sa.metadata.namespace == pod.metadata.namespace
+
+    rb := input[_]
+    rb.kind == "RoleBinding"
+    subject := rb.subjects[_]
+    subject.kind == "ServiceAccount"
+    subject.name == sa.metadata.name
+    subject.namespace == sa.metadata.namespace
+
+    msga := {
+        "alertMessage": "pod's default service account is bound via a RoleBinding",
+        "packagename":  "armo_builtins",
+        "alertScore":   9,
+        "fixPaths":     [],
+        "failedPaths":  [],
+        "alertObject":  {"k8sApiObjects": [pod]},
+    }
+}
+`
+
+// saTokenBindingFixture places the workload and its ServiceAccount in ns-a, and
+// the RoleBinding that actually grants that ServiceAccount elevated access in
+// ns-b — the standard cross-namespace RBAC pattern C-0261 has to catch.
+func saTokenBindingFixture() (cautils.K8SResources, map[string]workloadinterface.IMetadata) {
+	raw := []string{
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ns-a"}}`,
+		`{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ns-b"}}`,
+		`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"app","namespace":"ns-a"},"spec":{"containers":[{"name":"app","image":"nginx"}]}}`,
+		`{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"name":"default","namespace":"ns-a"}}`,
+		`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"name":"grant","namespace":"ns-b"},"subjects":[{"kind":"ServiceAccount","name":"default","namespace":"ns-a"}],"roleRef":{"kind":"ClusterRole","name":"admin"}}`,
+	}
+
+	k8sResources := make(cautils.K8SResources)
+	allResources := make(map[string]workloadinterface.IMetadata, len(raw))
+	for _, item := range raw {
+		object := make(map[string]any)
+		if err := json.Unmarshal([]byte(item), &object); err != nil {
+			panic(err)
+		}
+		workload := workloadinterface.NewWorkloadObj(object)
+		allResources[workload.GetID()] = workload
+
+		var groupResource string
+		switch workload.GetKind() {
+		case "Namespace":
+			groupResource = "/v1/namespaces"
+		case "Pod":
+			groupResource = "/v1/pods"
+		case "ServiceAccount":
+			groupResource = "/v1/serviceaccounts"
+		case "RoleBinding":
+			groupResource = "rbac.authorization.k8s.io/v1/rolebindings"
+		}
+		k8sResources[groupResource] = append(k8sResources[groupResource], workload.GetID())
+	}
+	return k8sResources, allResources
+}
+
+func saTokenBindingControl(controlID string) reporthandling.Control {
+	control := reporthandling.Control{ControlID: controlID}
+	control.Name = "SA token bound via cross-namespace RoleBinding"
+	control.Rules = []reporthandling.PolicyRule{
+		{
+			Rule:         saTokenBindingRule,
+			RuleLanguage: reporthandling.RegoLanguage,
+			Match: []reporthandling.RuleMatchObjects{
+				{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod", "ServiceAccount"}},
+				{APIGroups: []string{"rbac.authorization.k8s.io"}, APIVersions: []string{"v1"}, Resources: []string{"RoleBinding"}},
+			},
+		},
+	}
+	control.Rules[0].Name = "sa-token-binding-rule"
+	return control
+}
+
+// TestControlRequiresWholeClusterInput_C0261 pins C-0261 in
+// wholeClusterControlIDsFallback: it has the same "workload/ServiceAccount +
+// RoleBinding, no resourcesAggregator" shape as C-0266/C-0267/C-0272, which are
+// already in the map.
+func TestControlRequiresWholeClusterInput_C0261(t *testing.T) {
+	control := &reporthandling.Control{ControlID: "C-0261"}
+	assert.True(t, controlRequiresWholeClusterInput(control),
+		"C-0261 (SA token auto-mount bound via cross-namespace RoleBinding) needs whole-cluster input, same as C-0266/C-0267/C-0272")
+}
+
+// TestProcess_C0261ShapedControlCatchesCrossNamespaceBinding verifies that a
+// control built with C-0261's real join shape reaches the same verdict
+// whether the cluster is evaluated as one scope or partitioned per namespace
+// (the eager large-cluster path): the RoleBinding that grants access lives in
+// a different namespace batch than the Pod/ServiceAccount it targets, so
+// without the whole-cluster deferral the partitioned pass would never see it.
+func TestProcess_C0261ShapedControlCatchesCrossNamespaceBinding(t *testing.T) {
+	control := saTokenBindingControl("C-0261")
+	policies := convertFrameworksToPolicies(
+		[]reporthandling.Framework{{Controls: []reporthandling.Control{control}}},
+		nil, reporthandling.ScopeCluster,
+	)
+
+	const podID = "/v1/ns-a/Pod/app"
+
+	newProcessor := func() *OPAProcessor {
+		k8sResources, allResources := saTokenBindingFixture()
+		sessionObj := cautils.NewOPASessionObjMock()
+		sessionObj.K8SResources = k8sResources
+		sessionObj.AllResources = allResources
+		opap := NewOPAProcessor(sessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+		opap.AllPolicies = policies
+		return opap
+	}
+
+	t.Run("single scope", func(t *testing.T) {
+		t.Setenv("LARGE_CLUSTER_SIZE", "100000")
+		opap := newProcessor()
+		require.NoError(t, opap.Process(context.Background(), policies, nil))
+		require.Contains(t, opap.ResourcesResult, podID)
+		singleResult := opap.ResourcesResult[podID]
+		assert.True(t, singleResult.GetStatus(nil).IsFailed(),
+			"a single input holds both namespaces, so the RoleBinding join fires")
+	})
+
+	t.Run("partitioned eager", func(t *testing.T) {
+		t.Setenv("LARGE_CLUSTER_SIZE", "1")
+		opap := newProcessor()
+		require.Greater(t, len(opap.evaluationScopes()), 1, "fixture must be split into per-namespace scopes")
+		require.NoError(t, opap.Process(context.Background(), policies, nil))
+		require.Contains(t, opap.ResourcesResult, podID)
+		partitionedResult := opap.ResourcesResult[podID]
+		assert.True(t, partitionedResult.GetStatus(nil).IsFailed(),
+			"whole-cluster control must be evaluated once after the scopes merge, so the cross-namespace binding is still caught")
+	})
+}


### PR DESCRIPTION
## Overview

This is the fix for #3144.

#3080 introduced `wholeClusterControlIDsFallback` in `core/pkg/opaprocessor/processorhandler.go` to defer a control to a single whole-cluster evaluation pass when its rule joins objects that can live in different namespace batches. Regolibrary doesn't ship the `requiresWholeClusterInput` attribute on any control yet, so that static map is currently the only thing deciding which controls get the whole-cluster pass:

```go
var wholeClusterControlIDsFallback = map[string]struct{}{
	"C-0266": {}, // Exposure to internet via Gateway API or Istio Ingress (Gateway/Service/VirtualService across namespaces)
	"C-0267": {}, // Workload with cluster takeover roles (RoleBinding -> ServiceAccount in another namespace)
	"C-0272": {}, // Workload with administrative roles (RoleBinding -> ServiceAccount in another namespace)
}
```

C-0261 (`satokenmounted`, "SA token is automatically mounted") has the exact same shape as these three: its regolibrary rule matches `Pod, ServiceAccount, RoleBinding, ClusterRoleBinding, Deployment, ReplicaSet, DaemonSet, StatefulSet, Job, CronJob` with no `resourcesAggregator` attribute, and its `has_service_account_binding` function scans every RoleBinding/ClusterRoleBinding in the input for a subject matching the ServiceAccount, regardless of the binding's own namespace:

```rego
has_service_account_binding(service_account) if {
	role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
	role_binding := role_bindings[_]
	role_binding.subjects[_].name == service_account.metadata.name
	role_binding.subjects[_].namespace == service_account.metadata.namespace
	role_binding.subjects[_].kind == "ServiceAccount"
}
```

A RoleBinding can legally bind a ServiceAccount subject from a different namespace than its own. When a scan is namespace-bucketed (large cluster) or streamed, and that RoleBinding lands in a different batch than the workload it grants access to, this never matches, and a workload running with its service account token auto-mounted and bound to elevated permissions from another namespace passes silently. C-0261 carries `alertScore: 9`, one of the highest in the shipped set.

The fix is one line, matching the pattern the existing three entries already use:

```go
// before
var wholeClusterControlIDsFallback = map[string]struct{}{
	"C-0266": {}, // Exposure to internet via Gateway API or Istio Ingress (Gateway/Service/VirtualService across namespaces)
	"C-0267": {}, // Workload with cluster takeover roles (RoleBinding -> ServiceAccount in another namespace)
	"C-0272": {}, // Workload with administrative roles (RoleBinding -> ServiceAccount in another namespace)
}

// after
var wholeClusterControlIDsFallback = map[string]struct{}{
	"C-0261": {}, // SA token auto-mount bound via RoleBinding/ClusterRoleBinding in another namespace
	"C-0266": {}, // Exposure to internet via Gateway API or Istio Ingress (Gateway/Service/VirtualService across namespaces)
	"C-0267": {}, // Workload with cluster takeover roles (RoleBinding -> ServiceAccount in another namespace)
	"C-0272": {}, // Workload with administrative roles (RoleBinding -> ServiceAccount in another namespace)
}
```

This makes the existing, correct machinery in `controlRequiresWholeClusterInput` and `splitWholeClusterControls` take over, no other change is needed there.

## Test

Added `core/pkg/opaprocessor/wholecluster_missing_control_test.go`, following the same style as `processorhandler_parity_test.go` from #3080:

- `TestControlRequiresWholeClusterInput_C0261` pins C-0261 in the fallback map, mirroring the existing `TestControlRequiresWholeClusterInput`'s fallback case for C-0267.
- `TestProcess_C0261ShapedControlCatchesCrossNamespaceBinding` runs `Process()` end to end with a rule that mirrors C-0261's real `has_service_account_binding` logic, against a fixture with the workload/ServiceAccount in `ns-a` and the RoleBinding that actually grants access in `ns-b`. Both `single scope` and `partitioned eager` (forcing `LARGE_CLUSTER_SIZE=1`, the real large-cluster path) now catch the misconfiguration, the same parity guarantee `TestWholeClusterControlParityAcrossPaths` already checks for the attribute-based mechanism.

Reverting the one-line fix and re-running both tests fails them exactly as expected (`Should be true` on the map lookup, and the partitioned-eager subtest no longer catching the binding), confirming they're genuine regression guards and not tautologies.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation of control C-0261 across the entire cluster.
  * Cross-namespace bindings are now detected consistently during standard and partitioned evaluations.

* **Tests**
  * Added coverage confirming whole-cluster evaluation and cross-namespace detection for C-0261.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->