### PR TITLE
fix(update): make version-check handler injectable for unit tests

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -26,6 +26,16 @@ var updateCmdExamples = fmt.Sprintf(`
   %[1]s update
 `, cautils.ExecName())
 
+// newVersionCheckHandler is the seam used by GetUpdateCmd so unit tests can
+// substitute a mock without changing runtime behaviour. The update command
+// intentionally does NOT use versioncheck.NewIVersionCheckHandler: that
+// constructor returns a no-op mock when KS_SKIP_UPDATE_CHECK is set, which is a
+// scan/deploy knob ("don't phone home during scans") and must not disable the
+// one command whose purpose is checking for a release.
+var newVersionCheckHandler = func() versioncheck.IVersionCheckHandler {
+	return versioncheck.NewVersionCheckHandler()
+}
+
 func GetUpdateCmd(ks meta.IKubescape) *cobra.Command {
 	updateCmd := &cobra.Command{
 		Use:     "update",
@@ -33,7 +43,7 @@ func GetUpdateCmd(ks meta.IKubescape) *cobra.Command {
 		Long:    ``,
 		Example: updateCmdExamples,
 		RunE: func(_ *cobra.Command, args []string) error {
-			v := versioncheck.NewVersionCheckHandler()
+			v := newVersionCheckHandler()
 			versionCheckRequest := versioncheck.NewVersionCheckRequest("", versioncheck.BuildNumber, "", "", "update", nil)
 			if err := v.CheckLatestVersion(ks.Context(), versionCheckRequest); err != nil {
 				return err

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -2,17 +2,144 @@ package update
 
 import (
 	"context"
+	"errors"
+	"io"
+	"os"
 	"testing"
 
-	"github.com/kubescape/kubescape/v3/core/core"
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/meta"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// stubKubescape is a minimal IKubescape used by update command tests. RunE only
+// needs Context(); the remaining methods exist solely to satisfy the interface.
+type stubKubescape struct {
+	ctx context.Context
+}
+
+func (s *stubKubescape) Context() context.Context { return s.ctx }
+func (s *stubKubescape) SetContext(ctx context.Context) {
+	s.ctx = ctx
+}
+func (s *stubKubescape) Scan(*cautils.ScanInfo, []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return nil, nil
+}
+func (s *stubKubescape) List(*metav1.ListPolicies) (*metav1.ListResult, error) {
+	return nil, nil
+}
+func (s *stubKubescape) Download(*metav1.DownloadInfo) (*metav1.DownloadResult, error) {
+	return nil, nil
+}
+func (s *stubKubescape) SetCachedConfig(*metav1.SetConfig) error   { return nil }
+func (s *stubKubescape) ViewCachedConfig(*metav1.ViewConfig) error { return nil }
+func (s *stubKubescape) DeleteCachedConfig(*metav1.DeleteConfig) error {
+	return nil
+}
+func (s *stubKubescape) Fix(*metav1.FixInfo) error { return nil }
+func (s *stubKubescape) Diff(*metav1.DiffInfo) (int, error) {
+	return 0, nil
+}
+func (s *stubKubescape) Patch(*metav1.PatchInfo, *cautils.ScanInfo) (bool, error) {
+	return false, nil
+}
+func (s *stubKubescape) ScanImage(*metav1.ImageScanInfo, *cautils.ScanInfo) (bool, error) {
+	return false, nil
+}
+
+var _ meta.IKubescape = (*stubKubescape)(nil)
+
+type stubVersionCheckHandler struct {
+	latest string
+	err    error
+}
+
+func (s *stubVersionCheckHandler) CheckLatestVersion(_ context.Context, _ *versioncheck.VersionCheckRequest) error {
+	versioncheck.LatestReleaseVersion = s.latest
+	return s.err
+}
+
+func withVersionCheckHandler(t *testing.T, handler versioncheck.IVersionCheckHandler) {
+	t.Helper()
+	original := newVersionCheckHandler
+	newVersionCheckHandler = func() versioncheck.IVersionCheckHandler { return handler }
+	t.Cleanup(func() {
+		newVersionCheckHandler = original
+	})
+}
+
+func withVersionGlobals(t *testing.T, buildNumber, latestRelease string) {
+	t.Helper()
+	origBuild := versioncheck.BuildNumber
+	origLatest := versioncheck.LatestReleaseVersion
+	versioncheck.BuildNumber = buildNumber
+	versioncheck.LatestReleaseVersion = latestRelease
+	t.Cleanup(func() {
+		versioncheck.BuildNumber = origBuild
+		versioncheck.LatestReleaseVersion = origLatest
+	})
+}
+
 func TestGetUpdateCmd(t *testing.T) {
-	ks := core.NewKubescape(context.Background())
-	cmd := GetUpdateCmd(ks)
-	assert.NotNil(t, cmd)
+	withVersionCheckHandler(t, versioncheck.NewVersionCheckHandlerMock())
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
 
 	err := cmd.RunE(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+}
+
+func TestGetUpdateCmd_CheckLatestVersionError(t *testing.T) {
+	wantErr := errors.New("version lookup failed")
+	withVersionCheckHandler(t, &stubVersionCheckHandler{err: wantErr})
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
+
+	err := cmd.RunE(cmd, []string{})
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestGetUpdateCmd_ReportsAvailableUpdate(t *testing.T) {
+	withVersionCheckHandler(t, &stubVersionCheckHandler{latest: "v3.1.0"})
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	assert.NoError(t, cmd.RunE(cmd, []string{}))
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v3.1.0", versioncheck.LatestReleaseVersion)
+	assert.Contains(t, string(out), "Version v3.1.0 is available.")
+}
+
+func TestUpdateCommandDoesNotHonorSkipUpdateCheckEnv(t *testing.T) {
+	// KS_SKIP_UPDATE_CHECK must not turn the update command into a no-op.
+	// NewIVersionCheckHandler would return VersionCheckHandlerMock here; the
+	// update seam must keep constructing the real VersionCheckHandler.
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+	t.Setenv("KUBESCAPE_SKIP_UPDATE_CHECK", "true")
+
+	handler := newVersionCheckHandler()
+	_, isReal := handler.(*versioncheck.VersionCheckHandler)
+	_, isMock := handler.(*versioncheck.VersionCheckHandlerMock)
+
+	assert.True(t, isReal, "update command must use the real version-check handler at runtime")
+	assert.False(t, isMock, "update command must not use the skip-check mock when KS_SKIP_UPDATE_CHECK is set")
 }


### PR DESCRIPTION
## Summary
- Add a package-level `newVersionCheckHandler` seam in `cmd/update` so unit tests can inject a mock version-check handler
- Update `TestGetUpdateCmd` to use the mock (no live network call)
- Add regression coverage for error propagation, available-update messaging, and `KS_SKIP_UPDATE_CHECK` semantics

## Why
`TestGetUpdateCmd` previously executed `RunE`, which called `versioncheck.NewVersionCheckHandler()` and hit the live release endpoint. That made the unit test depend on network/external availability and flake in CI (#2716).

We intentionally do **not** switch to `NewIVersionCheckHandler`: that constructor returns a no-op mock when `KS_SKIP_UPDATE_CHECK` is set. That env var is a scan/deploy knob (“don’t check during scans”), not a switch to disable the one command whose purpose is checking for a release.

## Test plan
- [x] `go test ./cmd/update -count=1 -v`
- [x] Confirm `TestUpdateCommandDoesNotHonorSkipUpdateCheckEnv` keeps the real handler when `KS_SKIP_UPDATE_CHECK=true`
- [ ] CI green on this branch

Fixes #2716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update-check error handling and reporting when a newer version is available.
  * Ensured update checks continue to run correctly even when skip-update environment settings are present.
  * Preserved the existing update command behavior while making version checks more reliable.

* **Tests**
  * Added coverage for update-check failures, available updates, and skip-update behavior.
  * Expanded validation of update results and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->