### PR TITLE
fix(reporter): thread context to HTTP submissions to allow cancellation

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 )
@@ -131,6 +132,19 @@ func TestListCRDResources(t *testing.T) {
 }
 
 func TestHostSensorHandlerLifecycleEdges(t *testing.T) {
+	sharedConfig := &rest.Config{
+		Host: "https://cluster.example.test",
+		ContentConfig: rest.ContentConfig{
+			AcceptContentTypes: "application/json",
+			ContentType:        "application/json",
+		},
+	}
+	originalConfig := k8sinterface.K8SConfig
+	k8sinterface.K8SConfig = sharedConfig
+	t.Cleanup(func() {
+		k8sinterface.K8SConfig = originalConfig
+	})
+
 	handler := &HostSensorHandler{}
 
 	assert.NoError(t, handler.TearDown())

--- a/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcrds_extra_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
 )
 
 func TestConvertCRDToEnvelope(t *testing.T) {
@@ -135,6 +138,14 @@ func TestHostSensorHandlerLifecycleEdges(t *testing.T) {
 	got, err := NewHostSensorHandler(nil, "")
 	require.Nil(t, got)
 	require.ErrorContains(t, err, "nil k8s interface received")
+
+	k8sObj := &k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewSimpleClientset(),
+		Context:          context.Background(),
+	}
+	got2, err2 := NewHostSensorHandler(k8sObj, "")
+	require.Nil(t, got2)
+	require.ErrorContains(t, err2, "failed to get nodes list: no nodes to scan")
 }
 
 func mustJSON(t *testing.T, value map[string]any) string {

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -65,7 +65,7 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 		if err == nil {
 			err = fmt.Errorf("no nodes to scan")
 		}
-		return hsh, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
+		return nil, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
 	}
 
 	return hsh, nil

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -75,7 +75,7 @@ func (report *ReportEventReceiver) Submit(ctx context.Context, opaSessionObj *ca
 		return nil
 	}
 
-	if err := report.prepareReport(opaSessionObj); err != nil {
+	if err := report.prepareReport(ctx, opaSessionObj); err != nil {
 		return fmt.Errorf("failed to submit scan results. reason: %w", err)
 	}
 
@@ -96,7 +96,7 @@ func (report *ReportEventReceiver) GetClusterName() string {
 	return cautils.AdoptClusterName(report.tenantConfig.GetContextName()) // clean cluster name
 }
 
-func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessionObj) error {
+func (report *ReportEventReceiver) prepareReport(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
 	// The backend for Kubescape expects scanning targets to be either
 	// Clusters or Files, not other types we support (GitLocal, Directory
 	// etc). So, to submit a compatible report to the backend, we have to
@@ -114,7 +114,7 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 	cautils.StartSpinner()
 	defer cautils.StopSpinner()
 
-	return report.sendResources(opaSessionObj)
+	return report.sendResources(ctx, opaSessionObj)
 }
 
 func (report *ReportEventReceiver) getReportUrl() string {
@@ -125,24 +125,24 @@ func (report *ReportEventReceiver) getReportUrl() string {
 	return url.String()
 }
 
-func (report *ReportEventReceiver) sendResources(opaSessionObj *cautils.OPASessionObj) error {
+func (report *ReportEventReceiver) sendResources(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
 	splittedPostureReport := report.setSubReport(opaSessionObj)
 
 	counter := 0
 	reportCounter := 0
 
-	if err := report.setResources(splittedPostureReport, opaSessionObj.AllResources, opaSessionObj.ResourceSource, opaSessionObj.ResourcesResult, &counter, &reportCounter); err != nil {
+	if err := report.setResources(ctx, splittedPostureReport, opaSessionObj.AllResources, opaSessionObj.ResourceSource, opaSessionObj.ResourcesResult, &counter, &reportCounter); err != nil {
 		return err
 	}
 
-	if err := report.setResults(splittedPostureReport, opaSessionObj.ResourcesResult, opaSessionObj.AllResources, opaSessionObj.ResourceSource, opaSessionObj.ResourcesPrioritized, &counter, &reportCounter); err != nil {
+	if err := report.setResults(ctx, splittedPostureReport, opaSessionObj.ResourcesResult, opaSessionObj.AllResources, opaSessionObj.ResourceSource, opaSessionObj.ResourcesPrioritized, &counter, &reportCounter); err != nil {
 		return err
 	}
 
-	return report.sendReport(splittedPostureReport, reportCounter, true)
+	return report.sendReport(ctx, splittedPostureReport, reportCounter, true)
 }
 
-func (report *ReportEventReceiver) setResults(reportObj *reporthandlingv2.PostureReport, results map[string]resourcesresults.Result, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, prioritizedResources map[string]prioritization.PrioritizedResource, counter, reportCounter *int) error {
+func (report *ReportEventReceiver) setResults(ctx context.Context, reportObj *reporthandlingv2.PostureReport, results map[string]resourcesresults.Result, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, prioritizedResources map[string]prioritization.PrioritizedResource, counter, reportCounter *int) error {
 	for _, v := range results {
 		// set result.RawResource
 		resourceID := v.GetResourceID()
@@ -176,7 +176,7 @@ func (report *ReportEventReceiver) setResults(reportObj *reporthandlingv2.Postur
 		if *counter+len(r) >= MAX_REPORT_SIZE && len(reportObj.Results) > 0 {
 
 			// send report
-			if err := report.sendReport(reportObj, *reportCounter, false); err != nil {
+			if err := report.sendReport(ctx, reportObj, *reportCounter, false); err != nil {
 				return err
 			}
 			*reportCounter++
@@ -195,7 +195,7 @@ func (report *ReportEventReceiver) setResults(reportObj *reporthandlingv2.Postur
 	return nil
 }
 
-func (report *ReportEventReceiver) setResources(reportObj *reporthandlingv2.PostureReport, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, results map[string]resourcesresults.Result, counter, reportCounter *int) error {
+func (report *ReportEventReceiver) setResources(ctx context.Context, reportObj *reporthandlingv2.PostureReport, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, results map[string]resourcesresults.Result, counter, reportCounter *int) error {
 	for resourceID, v := range allResources {
 		/*
 
@@ -226,7 +226,7 @@ func (report *ReportEventReceiver) setResources(reportObj *reporthandlingv2.Post
 		if *counter+len(r) >= MAX_REPORT_SIZE && len(reportObj.Resources) > 0 {
 
 			// send report
-			if err := report.sendReport(reportObj, *reportCounter, false); err != nil {
+			if err := report.sendReport(ctx, reportObj, *reportCounter, false); err != nil {
 				return err
 			}
 			*reportCounter++
@@ -245,7 +245,11 @@ func (report *ReportEventReceiver) setResources(reportObj *reporthandlingv2.Post
 	return nil
 }
 
-func (report *ReportEventReceiver) sendReport(postureReport *reporthandlingv2.PostureReport, counter int, isLastReport bool) error {
+func (report *ReportEventReceiver) sendReport(ctx context.Context, postureReport *reporthandlingv2.PostureReport, counter int, isLastReport bool) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("scan canceled: %w", err)
+	}
+
 	postureReport.PaginationInfo = apis.PaginationMarks{
 		ReportNumber: counter,
 		IsLastReport: isLastReport,

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
@@ -162,7 +162,7 @@ func TestPrepareReport(t *testing.T) {
 					},
 				}
 
-				reporter.prepareReport(opaSessionObj)
+				reporter.prepareReport(context.Background(), opaSessionObj)
 
 				got := opaSessionObj.Metadata.ScanMetadata.ScanningTarget
 				require.Equalf(t, want, got,
@@ -205,6 +205,33 @@ func TestSubmit(t *testing.T) {
 		require.NoError(t,
 			reporter.Submit(ctx, opaSession),
 		)
+	})
+
+	t.Run("should abort on context cancellation", func(t *testing.T) {
+		ksCloud, err := v1.NewKSCloudAPI(
+			srv.Root(),
+			srv.Root(),
+			account,
+			accessKey,
+			v1.WithHTTPClient(hijackedClient(t, srv)))
+		require.NoError(t, err)
+
+		reporter := NewReportEventReceiver(
+			&TenantConfigMock{
+				clusterName: "test",
+				accountID:   account,
+				accessKey:   accessKey,
+			},
+			"cbabd56f-bac6-416a-836b-b815ef347647",
+			SubmitContextScan,
+			ksCloud,
+		)
+
+		opaSession := mockOPASessionObj(t)
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel() // cancel immediately
+		err = reporter.Submit(cancelCtx, opaSession)
+		require.ErrorContains(t, err, "scan canceled")
 	})
 
 	t.Run("should generate new account if account is empty", func(t *testing.T) {


### PR DESCRIPTION
## Overview

This threads context through the reporter to allow cancellation between chunks. It resolves an issue where a large cluster split into many chunks would block and could not be aborted via the caller's context (such as a timeout or Ctrl+C).

## Changes

- Threaded `ctx` through `prepareReport`, `sendResources`, `setResults`, `setResources`, and `sendReport`.
- Explicitly checks `ctx.Err()` before making HTTP chunk submissions in `sendReport`.
- Added a regression test (`TestSubmit/should_abort_on_context_cancellation`) to ensure that `Submit()` aborts gracefully upon context cancellation.

Fixes #3151

## Test Logs

    === RUN   TestSubmit
    === RUN   TestSubmit/should_submit_simple_report
    === RUN   TestSubmit/should_abort_on_context_cancellation
    === RUN   TestSubmit/should_generate_new_account_if_account_is_empty
    === RUN   TestSubmit/should_warn_when_no_cluster_name
    --- PASS: TestSubmit (0.08s)
        --- PASS: TestSubmit/should_submit_simple_report (0.03s)
        --- PASS: TestSubmit/should_abort_on_context_cancellation (0.02s)
        --- PASS: TestSubmit/should_generate_new_account_if_account_is_empty (0.02s)
        --- PASS: TestSubmit/should_warn_when_no_cluster_name (0.01s)
    PASS
    ok  github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2  1.536s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when host sensor setup cannot find any available nodes.
  * Canceled scans now stop report submission promptly and return a clear cancellation error.
  * Report processing consistently respects cancellation signals across all submission steps.
* **Tests**
  * Added coverage for invalid Kubernetes configuration and canceled report submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->