### PR TITLE
fix(hostsensor): emit error when CRD list is empty but nodes exist

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -16,23 +16,25 @@ import (
 )
 
 // getCRDResources retrieves resources from CRDs and converts them to HostSensorDataEnvelope format
-func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType k8shostsensor.HostSensorResource) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType k8shostsensor.HostSensorResource) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	pluralName := k8shostsensor.MapResourceToPlural(resourceType)
 	if pluralName == "" {
-		return nil, fmt.Errorf("unsupported resource type: %s", resourceType)
+		return nil, 0, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
 
 	clusterName := k8sinterface.GetContextName()
 	// Try loading from cache first
 	if cachedEnvelopes, err := loadFromCache(clusterName, resourceType.String()); err == nil {
-		return cachedEnvelopes, nil
+		return cachedEnvelopes, len(cachedEnvelopes), nil
 	} else if !os.IsNotExist(err) {
 		logger.L().Warning("Failed to load cache, proceeding to fetch", helpers.Error(err))
 	}
 
 	// List CRD resources and process them page by page
 	result := make([]hostsensor.HostSensorDataEnvelope, 0)
+	totalItems := 0
 	err := hsh.listCRDResources(ctx, pluralName, resourceType.String(), func(items []unstructured.Unstructured) error {
+		totalItems += len(items)
 		for _, item := range items {
 			envelope, err := hsh.convertCRDToEnvelope(item, resourceType)
 			if err != nil {
@@ -52,7 +54,7 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 			helpers.String("kind", resourceType.String()),
 			helpers.String("plural", pluralName),
 			helpers.Error(err))
-		return nil, err
+		return nil, 0, err
 	}
 
 	logger.L().Ctx(ctx).Info("Retrieved resources from CRDs",
@@ -64,7 +66,7 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 		logger.L().Warning("Failed to save to cache", helpers.Error(err))
 	}
 
-	return result, nil
+	return result, totalItems, nil
 }
 
 // convertCRDToEnvelope converts a CRD unstructured object to HostSensorDataEnvelope
@@ -124,52 +126,52 @@ func (hsh *HostSensorHandler) convertCRDToEnvelope(item unstructured.Unstructure
 }
 
 // getOsReleaseFile returns the list of osRelease metadata from CRDs.
-func (hsh *HostSensorHandler) getOsReleaseFile(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getOsReleaseFile(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.OsReleaseFile)
 }
 
 // getKernelVersion returns the list of kernelVersion metadata from CRDs.
-func (hsh *HostSensorHandler) getKernelVersion(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getKernelVersion(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KernelVersion)
 }
 
 // getLinuxSecurityHardeningStatus returns the list of LinuxSecurityHardeningStatus metadata from CRDs.
-func (hsh *HostSensorHandler) getLinuxSecurityHardeningStatus(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getLinuxSecurityHardeningStatus(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.LinuxSecurityHardeningStatus)
 }
 
 // getOpenPortsList returns the list of open ports from CRDs.
-func (hsh *HostSensorHandler) getOpenPortsList(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getOpenPortsList(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.OpenPortsList)
 }
 
 // getKernelVariables returns the list of Linux Kernel variables from CRDs.
-func (hsh *HostSensorHandler) getKernelVariables(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getKernelVariables(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.LinuxKernelVariables)
 }
 
 // getKubeletInfo returns the list of kubelet metadata from CRDs.
-func (hsh *HostSensorHandler) getKubeletInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getKubeletInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KubeletInfo)
 }
 
 // getKubeProxyInfo returns the list of kubeProxy metadata from CRDs.
-func (hsh *HostSensorHandler) getKubeProxyInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getKubeProxyInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KubeProxyInfo)
 }
 
 // getControlPlaneInfo returns the list of controlPlaneInfo metadata from CRDs.
-func (hsh *HostSensorHandler) getControlPlaneInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getControlPlaneInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.ControlPlaneInfo)
 }
 
 // getCloudProviderInfo returns the list of cloudProviderInfo metadata from CRDs.
-func (hsh *HostSensorHandler) getCloudProviderInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getCloudProviderInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.CloudProviderInfo)
 }
 
 // getCNIInfo returns the list of CNI metadata from CRDs.
-func (hsh *HostSensorHandler) getCNIInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, error) {
+func (hsh *HostSensorHandler) getCNIInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.CNIInfo)
 }
 
@@ -201,7 +203,7 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 
 	var hasCloudProvider bool
 	// We first query CloudProviderInfo to determine if we should skip ControlPlaneInfo
-	cloudProviderData, err := hsh.getCloudProviderInfo(ctx)
+	cloudProviderData, _, err := hsh.getCloudProviderInfo(ctx)
 	if err != nil {
 		addInfoToMap(k8shostsensor.CloudProviderInfo, infoMap, err)
 		logger.L().Ctx(ctx).Warning("Failed to get CloudProviderInfo from CRD", helpers.Error(err))
@@ -214,7 +216,7 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 
 	for _, toPin := range []struct {
 		Resource k8shostsensor.HostSensorResource
-		Query    func(context.Context) ([]hostsensor.HostSensorDataEnvelope, error)
+		Query    func(context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error)
 	}{
 		// queries to CRDs
 		{
@@ -262,13 +264,13 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 			continue
 		}
 
-		kcData, err := k8sInfo.Query(ctx)
+		kcData, rawCount, err := k8sInfo.Query(ctx)
 		if err != nil {
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Failed to get resource from CRD",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
-		} else if len(kcData) == 0 && hsh.nodeCount > 0 {
+		} else if rawCount == 0 && hsh.nodeCount > 0 {
 			err = fmt.Errorf("node-agent didn't report any %s for %d nodes", k8sInfo.Resource.String(), hsh.nodeCount)
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Zero CRD items found",

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -268,6 +268,12 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 			logger.L().Ctx(ctx).Warning("Failed to get resource from CRD",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
+		} else if len(kcData) == 0 && hsh.nodeCount > 0 {
+			err = fmt.Errorf("node-agent didn't report any %s for %d nodes", k8sInfo.Resource.String(), hsh.nodeCount)
+			addInfoToMap(k8sInfo.Resource, infoMap, err)
+			logger.L().Ctx(ctx).Warning("Zero CRD items found",
+				helpers.String("resource", k8sInfo.Resource.String()),
+				helpers.Error(err))
 		}
 
 		if len(kcData) > 0 {

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -193,6 +193,20 @@ func TestCollectResources_RecordsQueryErrors(t *testing.T) {
 	assert.Len(t, infoMap, 2)
 }
 
+func TestCollectResources_RecordsZeroItemsErrors(t *testing.T) {
+	client := newCRDDynamicClient(t)
+	// Empty client with no CRD items created, but simulate 1 node existing
+	hsh := &HostSensorHandler{dynamicClient: client, nodeCount: 1}
+
+	res, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, res)
+	// It should record an error for every collected resource type since nodeCount is 1 but lists are empty.
+	// K8sInfo slices have 9-10 elements.
+	assert.Greater(t, len(infoMap), 0, "should record errors for missing CRD items when nodes exist")
+}
+
 func hasKind(envelopes []hostsensor.HostSensorDataEnvelope, kind k8shostsensor.HostSensorResource) bool {
 	for _, e := range envelopes {
 		if e.GetKind() == kind.String() {

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -3,9 +3,11 @@ package hostsensorutils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	k8shostsensor "github.com/kubescape/k8s-interface/hostsensor"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,7 +85,7 @@ func newCRDDynamicClient(t *testing.T, items ...*unstructured.Unstructured) *fak
 func TestGetCRDResources_UnsupportedResourceType(t *testing.T) {
 	hsh := &HostSensorHandler{}
 
-	got, err := hsh.getCRDResources(context.Background(), k8shostsensor.KubeletConfiguration)
+	got, _, err := hsh.getCRDResources(context.Background(), k8shostsensor.KubeletConfiguration)
 
 	require.Nil(t, got)
 	require.ErrorContains(t, err, "unsupported resource type")
@@ -111,7 +113,7 @@ func TestCRDResourceGetters(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		query func(context.Context) ([]hostsensor.HostSensorDataEnvelope, error)
+		query func(context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error)
 	}{
 		{"OsReleaseFile", hsh.getOsReleaseFile},
 		{"KernelVersion", hsh.getKernelVersion},
@@ -127,7 +129,7 @@ func TestCRDResourceGetters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.query(ctx)
+			got, _, err := tt.query(ctx)
 			require.NoError(t, err)
 			require.Len(t, got, 1)
 			assert.Equal(t, "node-1", got[0].GetName())
@@ -202,9 +204,25 @@ func TestCollectResources_RecordsZeroItemsErrors(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, res)
-	// It should record an error for every collected resource type since nodeCount is 1 but lists are empty.
-	// K8sInfo slices have 9-10 elements.
-	assert.Greater(t, len(infoMap), 0, "should record errors for missing CRD items when nodes exist")
+	assert.Len(t, infoMap, 9)
+	for _, resource := range []k8shostsensor.HostSensorResource{
+		k8shostsensor.OsReleaseFile,
+		k8shostsensor.KernelVersion,
+		k8shostsensor.LinuxSecurityHardeningStatus,
+		k8shostsensor.OpenPortsList,
+		k8shostsensor.LinuxKernelVariables,
+		k8shostsensor.KubeletInfo,
+		k8shostsensor.KubeProxyInfo,
+		k8shostsensor.CNIInfo,
+		k8shostsensor.ControlPlaneInfo,
+	} {
+		expectedErr := fmt.Sprintf("node-agent didn't report any %s for 1 nodes", resource.String())
+		group, version := k8sinterface.SplitApiVersion(k8shostsensor.MapHostSensorResourceToApiGroup(resource))
+		for _, r := range k8sinterface.ResourceGroupToString(group, version, resource.String()) {
+			assert.Contains(t, infoMap, r)
+			assert.Equal(t, expectedErr, infoMap[r].InnerInfo)
+		}
+	}
 }
 
 func hasKind(envelopes []hostsensor.HostSensorDataEnvelope, kind k8shostsensor.HostSensorResource) bool {

--- a/core/pkg/hostsensorutils/hostsensorcrdshandler.go
+++ b/core/pkg/hostsensorutils/hostsensorcrdshandler.go
@@ -29,6 +29,7 @@ const (
 type HostSensorHandler struct {
 	k8sObj        *k8sinterface.KubernetesApi
 	dynamicClient dynamic.Interface
+	nodeCount     int
 }
 
 // NewHostSensorHandler builds a new CRD-based host sensor handler.
@@ -58,12 +59,14 @@ func NewHostSensorHandler(k8sObj *k8sinterface.KubernetesApi, _ string) (*HostSe
 	}
 
 	// Verify we can access nodes (basic sanity check)
-	if nodeList, err := k8sObj.KubernetesClient.CoreV1().Nodes().List(k8sObj.Context, metav1.ListOptions{}); err != nil || len(nodeList.Items) == 0 {
+	nodeList, err := k8sObj.KubernetesClient.CoreV1().Nodes().List(k8sObj.Context, metav1.ListOptions{})
+	if err != nil || len(nodeList.Items) == 0 {
 		if err == nil {
 			err = fmt.Errorf("no nodes to scan")
 		}
 		return nil, fmt.Errorf("in NewHostSensorHandler, failed to get nodes list: %w", err)
 	}
+	hsh.nodeCount = len(nodeList.Items)
 
 	return hsh, nil
 }


### PR DESCRIPTION
## Overview
Fixes #3171 
`getCRDResources()` returns `(empty slice, nil error)` whenever the CRD list is empty. This treats a `node-agent` outage as "nothing to report" rather than an error, which can give false assurance. This PR cross-checks the resource count against the number of active nodes and reports an error whenever a resource type returns no results while nodes exist.

## Changes

- Modified `HostSensorHandler` in `hostsensorcrdshandler.go` to track the number of active nodes.
- Updated `CollectResources` in `hostsensorcollectcrds.go` to return an error (`node-agent didn't report any %s for %d nodes`) when a CRD API request returns 0 results while there are active nodes.
- Added `TestCollectResources_RecordsZeroItemsErrors` to verify that `infoMap` records errors when CRD resources are completely missing for existing nodes.

Fixes #ISSUE_ID

## Test Logs

    === RUN   TestCollectResources_RecordsZeroItemsErrors
    [warning] Zero CRD items found. resource: KernelVersion; error: node-agent didn't report any KernelVersion for 1 nodes
    [warning] Zero CRD items found. resource: LinuxSecurityHardeningStatus; error: node-agent didn't report any LinuxSecurityHardeningStatus for 1 nodes
    [warning] Zero CRD items found. resource: OpenPortsList; error: node-agent didn't report any OpenPortsList for 1 nodes
    [warning] Zero CRD items found. resource: LinuxKernelVariables; error: node-agent didn't report any LinuxKernelVariables for 1 nodes
    [warning] Zero CRD items found. resource: KubeletInfo; error: node-agent didn't report any KubeletInfo for 1 nodes
    [warning] Zero CRD items found. resource: KubeProxyInfo; error: node-agent didn't report any KubeProxyInfo for 1 nodes
    [warning] Zero CRD items found. resource: CNIInfo; error: node-agent didn't report any CNIInfo for 1 nodes
    [warning] Zero CRD items found. resource: ControlPlaneInfo; error: node-agent didn't report any ControlPlaneInfo for 1 nodes
    --- PASS: TestCollectResources_RecordsZeroItemsErrors (0.00s)
    PASS
    ok  github.com/kubescape/kubescape/v3/core/pkg/hostsensorutils  4.514s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved host sensor diagnostics when expected Kubernetes resources are missing.
- Reports clearer errors and warnings when no custom resources are found despite registered Kubernetes nodes.
- Preserves raw resource counts to better detect incomplete or empty scan results.
- Retains errors from Kubernetes node listing and empty-result responses.

## Tests

- Added coverage for missing resources, empty results, and mismatched node counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->