### PR TITLE
fix(mcpserver): detach new callers from canceled scans

### DIFF
--- a/cmd/mcpserver/concurrency_test.go
+++ b/cmd/mcpserver/concurrency_test.go
@@ -10,6 +10,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type doneObservedContext struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+func receiveWithin[T any](t *testing.T, ch <-chan T, event string) T {
+	t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case value := <-ch:
+		return value
+	case <-timer.C:
+		t.Fatalf("timed out waiting for %s", event)
+		var zero T
+		return zero
+	}
+}
+
 func TestDoScanChan_Deduplication(t *testing.T) {
 	ksServer := &KubescapeMcpserver{}
 	var runCount int
@@ -81,6 +106,72 @@ func TestDoScanChan_Cancellation(t *testing.T) {
 
 	// The background scan should still be running and finish cleanly
 	<-scanFinished
+}
+
+func TestDoScanChan_NewCallerDoesNotInheritCanceledGeneration(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	oldStarted := make(chan struct{})
+	oldCanceled := make(chan struct{})
+	releaseOld := make(chan struct{})
+	oldReturned := make(chan struct{})
+	firstDone := make(chan error, 1)
+	var releaseOldOnce sync.Once
+	releaseOldScan := func() {
+		releaseOldOnce.Do(func() { close(releaseOld) })
+	}
+	t.Cleanup(cancelFirst)
+	t.Cleanup(releaseOldScan)
+
+	go func() {
+		_, err := ksServer.doScanChan(firstCtx, "reused_key", func(scanCtx context.Context) (interface{}, error) {
+			close(oldStarted)
+			<-scanCtx.Done()
+			close(oldCanceled)
+			<-releaseOld
+			close(oldReturned)
+			return nil, scanCtx.Err()
+		})
+		firstDone <- err
+	}()
+
+	receiveWithin(t, oldStarted, "old scan to start")
+	cancelFirst()
+	assert.ErrorIs(t, receiveWithin(t, firstDone, "first caller to return"), context.Canceled)
+	receiveWithin(t, oldCanceled, "old scan to observe cancellation")
+
+	enteredSelect := make(chan struct{})
+	freshCtx := &doneObservedContext{
+		Context:  context.Background(),
+		observed: enteredSelect,
+	}
+	freshStarted := make(chan struct{})
+	freshDone := make(chan error, 1)
+	var freshResult interface{}
+	go func() {
+		var err error
+		freshResult, err = ksServer.doScanChan(freshCtx, "reused_key", func(context.Context) (interface{}, error) {
+			close(freshStarted)
+			return "fresh result", nil
+		})
+		freshDone <- err
+	}()
+
+	// Done is evaluated only after DoChan has either joined the old call or
+	// registered a new generation. Keep the old call alive until that point so
+	// this test exercises the singleflight cleanup window deterministically.
+	receiveWithin(t, enteredSelect, "fresh caller to register with singleflight")
+	releaseOldScan()
+
+	assert.NoError(t, receiveWithin(t, freshDone, "fresh caller to return"))
+	assert.Equal(t, "fresh result", freshResult)
+	select {
+	case <-freshStarted:
+	default:
+		t.Error("fresh scan function was not called")
+	}
+	receiveWithin(t, oldReturned, "old scan function to return")
 }
 
 func TestDoScanChan_ConcurrencyLimit(t *testing.T) {

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -73,10 +73,6 @@ func (ksServer *KubescapeMcpserver) getScanSem() *semaphore.Weighted {
 }
 
 // doScanChan executes a singleflight scan wrapped with context cancellation reference counting.
-// TODO: There is a narrow race condition here if the last waiter cancels and deletes the scanCtxs entry
-// while singleflight is still cleaning up its internal map. A new caller arriving in this tiny window
-// will create a fresh context but get attached to the dying singleflight call, receiving a spurious
-// cancellation error. This self-heals on retry.
 func (ksServer *KubescapeMcpserver) doScanChan(ctx context.Context, key string, scanFunc func(context.Context) (interface{}, error)) (interface{}, error) {
 	ksServer.scanCtxMu.Lock()
 	if ksServer.scanCtxs == nil {
@@ -101,6 +97,9 @@ func (ksServer *KubescapeMcpserver) doScanChan(ctx context.Context, key string, 
 		if state.count <= 0 {
 			state.cancel()
 			delete(ksServer.scanCtxs, key)
+			// Keep this inside scanCtxMu's critical section. Otherwise a new
+			// generation could be registered and then forgotten here.
+			ksServer.scanGroup.Forget(key)
 		}
 	}()
 


### PR DESCRIPTION
## Overview

This PR fixes the narrow cancellation race documented during the review of #3089.

After the last caller for a scan key cancels, `doScanChan` removes the corresponding `scanCtxs` entry immediately. The old scan can still be registered in `singleflight.Group` while its function unwinds. A new caller for the same key could therefore create a fresh context but attach to the old canceled call and receive a spurious `context.Canceled`.

The change calls `scanGroup.Forget(key)` when the final caller reference is released. It does so while `scanCtxMu` is still held, preventing a new generation from being registered between removal of the refcount state and retirement of the old singleflight generation.

The old scan is allowed to finish unwinding. `Forget` only ensures that future callers start a fresh generation.

## Regression test

`TestDoScanChan_NewCallerDoesNotInheritCanceledGeneration` forces the affected ordering with channels rather than scheduler timing:

1. Start an old scan and cancel its final caller.
2. Keep the old scan function alive after it observes cancellation.
3. Start a fresh caller with the same key.
4. Ensure the fresh caller has registered with singleflight.
5. Release the old scan.
6. Assert that the fresh scan function runs and returns its own result.

The test failed on the unmodified implementation with `context canceled`, a nil result, and zero executions of the fresh callback.

## How to Test

```shell
go test ./cmd/mcpserver -run '^TestDoScanChan_NewCallerDoesNotInheritCanceledGeneration$' -count=100
go test ./cmd/mcpserver -run '^TestDoScanChan_' -shuffle=on -count=20
go test ./cmd/mcpserver -count=1
go test -race ./cmd/mcpserver -run '^TestDoScanChan_' -count=10
go vet ./cmd/mcpserver
```

All commands pass locally with Go 1.26.6.

## Scope

This does not change:

- the global limit of two concurrent expensive scans;
- deduplication among callers in the same active generation;
- cancellation of a shared scan after its final caller leaves.

It only prevents a new generation from inheriting the result of an already canceled generation.

## Related issues/PRs

- Resolves #3175
- Follow-up to #3089
- Maintainer review context: https://github.com/kubescape/kubescape/pull/3089#discussion_r3776158145

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the lock-ordering requirement
- [x] I have performed a self-review and an independent adversarial review
- [x] I have added a deterministic regression test
- [x] New and existing MCP server unit tests pass locally
- [x] Race-enabled tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent scan handling so a new request can start a fresh scan after an earlier scan is canceled.
  * Prevented overlapping scan generations from interfering with one another when sharing the same request key.
  * Improved reliability when multiple callers wait for or leave an in-progress scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->