### PR TITLE
fix(cel): resolve CRD resource plurals the kind guess cannot reach

### DIFF
--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -1,6 +1,8 @@
 package cel
 
 import (
+	"strings"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,10 +88,14 @@ func objectSelectorMatches(selector *metav1.LabelSelector, obj map[string]any) b
 	return sel.Matches(labels.Set(objLabels))
 }
 
-// objectGVR guesses an object's GroupVersionResource from its apiVersion and
-// kind. Offline there is no discovery or RESTMapper, so we use apimachinery's
-// standard kind->resource guess (lower-case and pluralize), which is correct
-// for every kind the bundle's policies constrain.
+// resourcePluralAnnotation lets an object declare the plural its CRD actually
+// registers, for a plural the kind->resource guess cannot reach.
+const resourcePluralAnnotation = "kubescape.io/resource-plural"
+
+// objectGVR resolves an object's GroupVersionResource from its apiVersion and
+// kind. Offline there is no discovery or RESTMapper, so the plural comes from
+// the resource-plural annotation when the object carries one, and otherwise
+// from apimachinery's kind->resource guess (lower-case and pluralize).
 func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 	apiVersion, _ := obj["apiVersion"].(string)
 	kind, _ := obj["kind"].(string)
@@ -100,8 +106,22 @@ func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
 	if err != nil {
 		return schema.GroupVersionResource{}, false
 	}
+	if plural, ok := annotatedPlural(obj); ok {
+		return gv.WithResource(plural), true
+	}
 	gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
 	return gvr, true
+}
+
+// annotatedPlural reads the resource-plural hint off the object. A missing,
+// blank or non-string-map annotation set leaves the guess in charge.
+func annotatedPlural(obj map[string]any) (string, bool) {
+	annotations, found, err := unstructured.NestedStringMap(obj, "metadata", "annotations")
+	if err != nil || !found {
+		return "", false
+	}
+	plural := strings.TrimSpace(annotations[resourcePluralAnnotation])
+	return plural, plural != ""
 }
 
 func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource, name string) bool {
@@ -164,11 +184,34 @@ func matchesValue(allowed []string, want string) bool {
 // matchesResource is matchesValue for resources, also accepting the "*/*"
 // subresource wildcard. A "resource/subresource" entry never matches a bare
 // resource, which is correct: the scan does not evaluate subresources.
+//
+// A rule resource differing from the object's only in separators still matches:
+// a CRD may register "worker-pools" for kind WorkerPool, which the guess renders
+// "workerpools". Dropping that object would be silent — the policy evaluates
+// against nothing and the control reads as clean. A plural further from the
+// guess than that still needs the resource-plural annotation.
 func matchesResource(allowed []string, want string) bool {
 	for _, a := range allowed {
 		if a == "*" || a == "*/*" || a == want {
 			return true
 		}
 	}
+	if want == "" {
+		return false
+	}
+	normalized := normalizePlural(want)
+	for _, a := range allowed {
+		if normalizePlural(a) == normalized {
+			return true
+		}
+	}
 	return false
+}
+
+// pluralSeparators strips the separators a CRD plural may carry, so
+// "worker-pools" and the guessed "workerpools" compare equal.
+var pluralSeparators = strings.NewReplacer("-", "", "_", "")
+
+func normalizePlural(resource string) string {
+	return pluralSeparators.Replace(strings.ToLower(resource))
 }

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -57,6 +57,60 @@ func TestVAPAppliesTo(t *testing.T) {
 	}
 }
 
+// annotated returns obj carrying the resource-plural hint.
+func annotated(o map[string]any, plural string) map[string]any {
+	o["metadata"].(map[string]any)["annotations"] = map[string]any{resourcePluralAnnotation: plural}
+	return o
+}
+
+// TestVAPAppliesToCRDPlural covers the plurals the kind->resource guess does not
+// produce. A CRD registers spec.names.plural itself, so a policy constraining
+// "worker-pools" would be silently dropped by an exact compare against the
+// guessed "workerpools": the control evaluates against nothing and reads clean.
+func TestVAPAppliesToCRDPlural(t *testing.T) {
+	const apiVersion = "agentsubstrate.google.com/v1"
+	workerPool := func() map[string]any { return obj(apiVersion, "WorkerPool") }
+
+	cases := []struct {
+		name      string
+		resources []string
+		obj       map[string]any
+		want      bool
+	}{
+		{"hyphenated plural matches the guess", []string{"worker-pools"}, workerPool(), true},
+		{"underscored plural matches the guess", []string{"worker_pools"}, workerPool(), true},
+		{"guessed plural still matches exactly", []string{"workerpools"}, workerPool(), true},
+		{"annotation resolves a plural the guess cannot reach", []string{"wpools"}, annotated(workerPool(), "wpools"), true},
+		{"annotated plural matches a separated rule", []string{"worker-pools"}, annotated(workerPool(), "workerpools"), true},
+		{"unreachable plural without the annotation is out of scope", []string{"wpools"}, workerPool(), false},
+		{"blank annotation falls back to the guess", []string{"workerpools"}, annotated(workerPool(), "  "), true},
+		{"an unrelated resource is still out of scope", []string{"actortemplates"}, workerPool(), false},
+		{"a subresource rule never matches the bare resource", []string{"worker-pools/status"}, workerPool(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := vapWithConstraints(rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, tc.resources))
+			assert.Equal(t, tc.want, v.appliesTo(tc.obj))
+		})
+	}
+
+	t.Run("exclusion honors the same plural resolution", func(t *testing.T) {
+		v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{rule([]string{"*"}, []string{"*"}, []string{"*"})},
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, []string{"worker-pools"})},
+		}}
+		assert.False(t, v.appliesTo(workerPool()))
+		assert.True(t, v.appliesTo(obj(apiVersion, "ActorTemplate")))
+	})
+
+	t.Run("annotations that are not a string map fall back to the guess", func(t *testing.T) {
+		o := workerPool()
+		o["metadata"].(map[string]any)["annotations"] = map[string]any{resourcePluralAnnotation: 42}
+		v := vapWithConstraints(rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, []string{"workerpools"}))
+		assert.True(t, v.appliesTo(o))
+	})
+}
+
 func TestVAPAppliesToWildcards(t *testing.T) {
 	any := vapWithConstraints(rule([]string{"*"}, []string{"*"}, []string{"*"}))
 	assert.True(t, any.appliesTo(obj("v1", "Pod")))
@@ -129,7 +183,7 @@ func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
 						kind, ok := canonicalKinds[res]
 						require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
 						assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
-							"policy %q constrains %q but appliesTo rejects a %s %s; UnsafeGuessKindToResource likely mis-guessed the plural", name, res, apiVersion, kind)
+							"policy %q constrains %q but appliesTo rejects a %s %s; annotate scanned %s objects with %s=%q if the guess cannot reach that plural", name, res, apiVersion, kind, kind, resourcePluralAnnotation, res)
 					}
 				}
 			}

--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -97,7 +97,7 @@ func stubRequest(obj map[string]any) map[string]any {
 }
 
 // resourcePlural is the plural resource name for request.resource, taken from
-// the same objectGVR guess appliesTo scopes with. Sharing the guess is the
+// the same objectGVR resolution appliesTo scopes with. Sharing it is the
 // point: a policy that narrows by resource can do it through matchConstraints
 // or by reading request.resource.resource, and the two must agree.
 //

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -122,6 +122,15 @@ func TestStubRequestResourcePlural(t *testing.T) {
 			want: "actortemplates",
 		},
 		{
+			name: "resource-plural annotation overrides the guess",
+			obj: map[string]any{
+				"apiVersion": "agentsubstrate.google.com/v1",
+				"kind":       "WorkerPool",
+				"metadata":   map[string]any{"annotations": map[string]any{"kubescape.io/resource-plural": "worker-pools"}},
+			},
+			want: "worker-pools",
+		},
+		{
 			name: "undeterminable kind stays empty",
 			obj:  map[string]any{"apiVersion": "v1"},
 			want: "",


### PR DESCRIPTION
Closes #2780

### Overview

Offline there is no discovery or RESTMapper, so `objectGVR` derives an object's plural resource name with `meta.UnsafeGuessKindToResource`. That guess holds for the built-in kinds the bundle constrains today, but a CRD declares its own `spec.names.plural`, and `IsDNS1035Label` lets that plural carry separators. A policy constraining `worker-pools` is then compared against a guessed `workerpools`, `resourceRuleMatches` returns false, and the object is dropped before evaluation.

The failure is silent, which is the part worth fixing. The scan does not error, the policy just evaluates against zero objects, and the control renders exactly like one that passed. This is the same class of gap as #2001, where a non matching kind was recorded as a pass the cluster never made.

### What changed

`matchesResource` keeps its exact compare and adds a separator insensitive one behind it, so a rule resource that differs from the object's only in `-` or `_` still matches. Wildcards and the subresource rule are untouched, and a `resource/subresource` entry still never matches a bare resource since the separator stripping leaves the slash in place. Exclude rules go through the same predicate, so inclusion and exclusion stay symmetric.

For a plural further from the guess than separators, an object can carry `kubescape.io/resource-plural` and `objectGVR` uses it verbatim instead of guessing. A missing, blank, or non string map annotation set leaves the guess in charge, so nothing changes for the manifests people scan today. The hint resolves inside `objectGVR`, which means it flows into `request.resource.resource` through `resourcePlural` as well, and scoping and the stubbed request keep agreeing the way `TestStubRequestResourceMatchesScoping` pins them to.

### Tests

`TestVAPAppliesToCRDPlural` covers hyphenated and underscored plurals, the annotation override, a plural the guess cannot reach with and without the hint, exclusion symmetry, the subresource rule, and the two fallback paths. `TestStubRequestResourcePlural` gains the annotation case. `TestVAPAppliesToCoversEveryBundleKind` is unchanged apart from its failure message, which now points at the annotation as the way out when a synced policy brings in a plural the guess misses.

Verified with `go build ./...`, `go vet ./core/pkg/opaprocessor/...` and `go test ./core/pkg/opaprocessor/...`, all green. The new cases fail on master without the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resource recognition for custom resources using the `kubescape.io/resource-plural` annotation.
  * Resource matching now handles differences in capitalization, hyphens, and underscores.
  * Added fallback behavior when an annotation is missing or invalid.

* **Bug Fixes**
  * Improved policy and validation coverage for custom resource definitions and subresources.
  * Added clearer guidance when a resource cannot be matched automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->