### PR TITLE
perf(printer): dedupe image scan summary in O(N) via a shared helper

### DIFF
--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -7,7 +7,6 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -168,29 +167,6 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 	}
 
 	return resourceTableView
-}
-
-// buildImageScanSummary aggregates CVE, package-score, and severity data for an image scan report (#2782)
-func buildImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.ImageScanSummary {
-	imageScanSummary := &imageprinter.ImageScanSummary{
-		CVEs:                  []imageprinter.CVE{},
-		PackageScores:         map[string]*imageprinter.PackageScore{},
-		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
-	}
-
-	for i := range imageScanData {
-		if !slices.Contains(imageScanSummary.Images, imageScanData[i].Image) {
-			imageScanSummary.Images = append(imageScanSummary.Images, imageScanData[i].Image)
-		}
-
-		cves := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
-		imageScanSummary.CVEs = append(imageScanSummary.CVEs, cves...)
-
-		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
-		setSeverityToSummaryMap(cves, imageScanSummary.MapsSeverityToSummary)
-	}
-
-	return imageScanSummary
 }
 
 func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary, resource workloadinterface.IMetadata) ResourceControlResult {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/anchore/clio"
@@ -65,29 +64,6 @@ func (jp *JsonPrinter) Score(score float32) {
 	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 
 }
-func (jp *JsonPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) (*imageprinter.ImageScanSummary, error) {
-	imageScanSummary := imageprinter.ImageScanSummary{
-		CVEs:                  []imageprinter.CVE{},
-		PackageScores:         map[string]*imageprinter.PackageScore{},
-		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
-	}
-
-	for i := range imageScanData {
-		if !slices.Contains(imageScanSummary.Images, imageScanData[i].Image) {
-			imageScanSummary.Images = append(imageScanSummary.Images, imageScanData[i].Image)
-		}
-
-		CVEs := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
-		imageScanSummary.CVEs = append(imageScanSummary.CVEs, CVEs...)
-
-		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
-
-		setSeverityToSummaryMap(CVEs, imageScanSummary.MapsSeverityToSummary)
-	}
-
-	return &imageScanSummary, nil
-}
-
 func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var err error
 
@@ -121,11 +97,7 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 	finalizedReport := FinalizeResults(opaSessionObj)
 
 	if imageScanData != nil {
-		imageScanSummary, err := jp.convertToImageScanSummary(imageScanData)
-		if err != nil {
-			logger.L().Error("failed to convert to image scan summary", helpers.Error(err))
-			return err
-		}
+		imageScanSummary := buildImageScanSummary(imageScanData)
 		finalizedReport.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
 		finalizedReport.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
 		finalizedReport.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -13,13 +13,10 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/jwalton/gchalk"
-	"github.com/kubescape/go-logger"
-	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter"
-	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -76,37 +73,8 @@ func (pp *PrettyPrinter) PrintNextSteps() {
 	pp.mainPrinter.PrintNextSteps()
 }
 
-// convertToImageScanSummary takes a list of image scan data and converts it to a single image scan summary
-func (pp *PrettyPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) (*imageprinter.ImageScanSummary, error) {
-	imageScanSummary := imageprinter.ImageScanSummary{
-		CVEs:                  []imageprinter.CVE{},
-		PackageScores:         map[string]*imageprinter.PackageScore{},
-		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
-	}
-
-	for i := range imageScanData {
-		if !slices.Contains(imageScanSummary.Images, imageScanData[i].Image) {
-			imageScanSummary.Images = append(imageScanSummary.Images, imageScanData[i].Image)
-		}
-
-		CVEs := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
-		imageScanSummary.CVEs = append(imageScanSummary.CVEs, CVEs...)
-
-		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
-
-		setSeverityToSummaryMap(CVEs, imageScanSummary.MapsSeverityToSummary)
-	}
-
-	return &imageScanSummary, nil
-}
-
 func (pp *PrettyPrinter) PrintImageScan(imageScanData []cautils.ImageScanData) error {
-	imageScanSummary, err := pp.convertToImageScanSummary(imageScanData)
-	if err != nil {
-		logger.L().Error("failed to convert to image scan summary", helpers.Error(err))
-		return fmt.Errorf("failed to convert to image scan summary: %w", err)
-	}
-	pp.mainPrinter.PrintImageScanning(imageScanSummary)
+	pp.mainPrinter.PrintImageScanning(buildImageScanSummary(imageScanData))
 	return nil
 }
 

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -420,3 +420,33 @@ func extractCVEs(matches match.Matches, image string) []imageprinter.CVE {
 	}
 	return CVEs
 }
+
+// buildImageScanSummary aggregates per-image scan data into the summary every
+// output format consumes. The image list is deduplicated with a set so this is
+// O(N) in the number of images; the printer-local copies this replaces used
+// slices.Contains and were O(N^2) on large image sets.
+func buildImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.ImageScanSummary {
+	imageScanSummary := &imageprinter.ImageScanSummary{
+		CVEs:                  []imageprinter.CVE{},
+		PackageScores:         map[string]*imageprinter.PackageScore{},
+		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
+	}
+
+	seenImages := make(map[string]struct{}, len(imageScanData))
+	for i := range imageScanData {
+		image := imageScanData[i].Image
+		if _, seen := seenImages[image]; !seen {
+			seenImages[image] = struct{}{}
+			imageScanSummary.Images = append(imageScanSummary.Images, image)
+		}
+
+		cves := extractCVEs(imageScanData[i].Matches, image)
+		imageScanSummary.CVEs = append(imageScanSummary.CVEs, cves...)
+
+		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
+
+		setSeverityToSummaryMap(cves, imageScanSummary.MapsSeverityToSummary)
+	}
+
+	return imageScanSummary
+}

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/anchore/clio"
@@ -16,7 +15,6 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
-	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"sigs.k8s.io/yaml"
 )
 
@@ -65,29 +63,6 @@ func (yp *YamlPrinter) Score(score float32) {
 	fmt.Fprintf(os.Stderr, "\nOverall compliance-score (100- Excellent, 0- All failed): %d\n", cautils.ComplianceScoreToInt(score))
 }
 
-func (yp *YamlPrinter) convertToImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.ImageScanSummary {
-	imageScanSummary := imageprinter.ImageScanSummary{
-		CVEs:                  []imageprinter.CVE{},
-		PackageScores:         map[string]*imageprinter.PackageScore{},
-		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
-	}
-
-	for i := range imageScanData {
-		if !slices.Contains(imageScanSummary.Images, imageScanData[i].Image) {
-			imageScanSummary.Images = append(imageScanSummary.Images, imageScanData[i].Image)
-		}
-
-		CVEs := extractCVEs(imageScanData[i].Matches, imageScanData[i].Image)
-		imageScanSummary.CVEs = append(imageScanSummary.CVEs, CVEs...)
-
-		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)
-
-		setSeverityToSummaryMap(CVEs, imageScanSummary.MapsSeverityToSummary)
-	}
-
-	return &imageScanSummary
-}
-
 func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
 	var err error
 
@@ -130,7 +105,7 @@ func printConfigurationsScanningYaml(opaSessionObj *cautils.OPASessionObj, image
 	finalizedReport := FinalizeResults(opaSessionObj)
 
 	if imageScanData != nil {
-		imageScanSummary := yp.convertToImageScanSummary(imageScanData)
+		imageScanSummary := buildImageScanSummary(imageScanData)
 		finalizedReport.SummaryDetails.Vulnerabilities.MapsSeverityToSummary = convertToReportSummary(imageScanSummary.MapsSeverityToSummary)
 		finalizedReport.SummaryDetails.Vulnerabilities.CVESummary = convertToCVESummary(imageScanSummary.CVEs)
 		finalizedReport.SummaryDetails.Vulnerabilities.PackageScores = convertToPackageScores(imageScanSummary.PackageScores)


### PR DESCRIPTION
Noticed the four output printers (json, yaml, html, pretty) each carried their own copy of the same image-scan-summary builder, and every copy deduped the image list with `slices.Contains(summary.Images, image)` inside the loop. That's O(N^2) on the number of distinct images. On a cluster scan with `--scan-images` that N can climb into the hundreds or thousands, so we were burning a few hundred thousand redundant string comparisons just to build the `images` list for the report.

This collapses all four copies into one `buildImageScanSummary` in utils.go and swaps the `slices.Contains` scan for a `map[string]struct{}` seen-set, so the whole pass is O(N). As a bonus it deletes three duplicate ~15-line loops (net -79 lines) and drops the vestigial always-nil `error` return that json and pretty were threading through, since the builder can't actually fail.

No behavior change intended. The summary shape is identical, image ordering stays first-seen (the seen-set only answers "have I emitted this yet"), and the empty-slice semantics for `CVEs` are preserved so the JSON output doesn't flip between `[]` and `null`.

Verified locally with `go test ./core/...` (all passing) and `go vet ./core/...` (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized image scan summary generation across supported report formats.
  * Image summaries now consolidate duplicate image entries and aggregate CVE counts, package scores, and severity totals.
  * Removed obsolete conversion and error-handling paths, simplifying report generation and improving consistency across HTML, JSON, YAML, and pretty-printed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->