### PR TITLE
fix(reporter): clean up generated credentials on all early returns

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -42,6 +42,7 @@ type ReportEventReceiver struct {
 	reportID           string
 	submitContext      SubmitContext
 	accountIdGenerated bool
+	firstChunkSent     bool
 }
 
 func NewReportEventReceiver(tenantConfig cautils.ITenantConfig, reportID string, submitContext SubmitContext, client *client.KSCloudAPI) *ReportEventReceiver {
@@ -69,6 +70,16 @@ func (report *ReportEventReceiver) Submit(ctx context.Context, opaSessionObj *ca
 		getter.SetKSCloudAPIConnector(report.client)
 		logger.L().Debug("generated account ID", helpers.String("account ID", accountID))
 	}
+
+	defer func() {
+		// Clean up generated credentials if no chunks were successfully sent
+		// This handles early returns (e.g., missing cluster name, context cancellation)
+		if report.accountIdGenerated && !report.firstChunkSent {
+			if err := report.tenantConfig.DeleteCredentials(); err != nil {
+				logger.L().Error("failed to delete generated credentials after report submission failed or returned early", helpers.Error(err))
+			}
+		}
+	}()
 
 	if opaSessionObj.Metadata.ScanMetadata.ScanningTarget == reporthandlingv2.Cluster && report.GetClusterName() == "" {
 		logger.L().Ctx(ctx).Error("failed to publish results because the cluster name is Unknown. If you are scanning YAML files the results are not submitted to the Kubescape SaaS")
@@ -263,16 +274,9 @@ func (report *ReportEventReceiver) sendReport(ctx context.Context, postureReport
 
 	strResponse, err := report.client.SubmitReport(postureReport)
 	if err != nil {
-		// in case of error, we need to revert the generated account ID
-		// otherwise the next run will fail using a non existing account ID
-		if report.accountIdGenerated {
-			if err := report.tenantConfig.DeleteCredentials(); err != nil {
-				logger.L().Error("failed to delete generated credentials after report submission failed", helpers.Error(err))
-			}
-		}
-
 		return fmt.Errorf("%w:%s", err, strResponse)
 	}
+	report.firstChunkSent = true
 
 	// message is taken only from last report
 	if strResponse != "" && isLastReport {

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
@@ -234,6 +234,72 @@ func TestSubmit(t *testing.T) {
 		require.ErrorContains(t, err, "scan canceled")
 	})
 
+	t.Run("should clean up generated credentials on early cancellation", func(t *testing.T) {
+		ksCloud, err := v1.NewKSCloudAPI(
+			srv.Root(),
+			srv.Root(),
+			"",
+			"",
+			v1.WithHTTPClient(hijackedClient(t, srv)))
+		require.NoError(t, err)
+
+		tenantMock := &TenantConfigMock{
+			clusterName: "test",
+			accountID:   "", // Empty to force generation
+			accessKey:   accessKey,
+		}
+
+		reporter := NewReportEventReceiver(
+			tenantMock,
+			"cbabd56f-bac6-416a-836b-b815ef347647",
+			SubmitContextScan,
+			ksCloud,
+		)
+
+		opaSession := mockOPASessionObj(t)
+
+		// Create a context that is already canceled
+		canceledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = reporter.Submit(canceledCtx, opaSession)
+		require.ErrorContains(t, err, "scan canceled")
+
+		// Since it was cancelled before sending any chunks, it should have deleted the credentials
+		assert.Empty(t, tenantMock.GetAccountID())
+	})
+
+	t.Run("should clean up generated credentials on missing cluster name", func(t *testing.T) {
+		ksCloud, err := v1.NewKSCloudAPI(
+			srv.Root(),
+			srv.Root(),
+			"",
+			"",
+			v1.WithHTTPClient(hijackedClient(t, srv)))
+		require.NoError(t, err)
+
+		tenantMock := &TenantConfigMock{
+			clusterName: "", // Missing to trigger early return
+			accountID:   "", // Empty to force generation
+			accessKey:   accessKey,
+		}
+
+		reporter := NewReportEventReceiver(
+			tenantMock,
+			"cbabd56f-bac6-416a-836b-b815ef347647",
+			SubmitContextScan,
+			ksCloud,
+		)
+
+		opaSession := mockOPASessionObj(t)
+
+		err = reporter.Submit(context.Background(), opaSession)
+		require.NoError(t, err) // It returns nil on missing cluster name
+
+		// Should have deleted the generated credentials
+		assert.Empty(t, tenantMock.GetAccountID())
+	})
+
 	t.Run("should generate new account if account is empty", func(t *testing.T) {
 		ksCloud, err := v1.NewKSCloudAPI(
 			srv.Root(),


### PR DESCRIPTION
## Overview
Fixes #3179
This PR fixes a credential leak where early returns in `Submit()`—such as an empty cluster name or context cancellation—could bypass cleanup of newly generated account IDs. This caused subsequent scans to reuse an unregistered account ID instead of generating a valid one.

## Changes

- Removed the isolated `DeleteCredentials()` cleanup logic from `sendReport()`.
- Added `firstChunkSent` tracking to `ReportEventReceiver` to determine whether any chunk was successfully submitted to the backend.
- Added deferred credential cleanup in `Submit()` so that any exit path cleans up newly generated credentials when no chunk was successfully sent.
- Added unit tests covering early cancellation and missing cluster name scenarios.

## Test Logs

    === RUN   TestSubmit
    === RUN   TestSubmit/should_submit_simple_report
    === RUN   TestSubmit/should_abort_on_context_cancellation
    === RUN   TestSubmit/should_clean_up_generated_credentials_on_early_cancellation
    === RUN   TestSubmit/should_clean_up_generated_credentials_on_missing_cluster_name
    [error] failed to publish results because the cluster name is Unknown.
    === RUN   TestSubmit/should_generate_new_account_if_account_is_empty
    === RUN   TestSubmit/should_warn_when_no_cluster_name
    --- PASS: TestSubmit (0.11s)

    PASS

    ok  github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2  1.558s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary generated credentials when report submission is canceled or exits before sending data.
  * Prevented credentials from being removed prematurely after submission errors when report data was successfully sent.

* **Tests**
  * Added coverage for credential cleanup during canceled submissions and submissions missing required cluster information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->