### PR TITLE
fix(opaprocessor): flag Passed verdicts reached on incomplete RBAC-dependent data

### DIFF
--- a/cmd/mcpserver/control_scan_test.go
+++ b/cmd/mcpserver/control_scan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,9 @@ func TestScanControls_WhitespaceOnlyIDs(t *testing.T) {
 }
 
 func TestScanControls_TrimsIDs(t *testing.T) {
-	srv := &KubescapeMcpserver{}
+	srv := &KubescapeMcpserver{
+		policyGetter: getter.NewDownloadReleasedPolicy(),
+	}
 	_, err := srv.ScanControls(context.Background(), "", []string{" C-0012 ", "  C-0017"})
 	if err != nil {
 		assert.NotContains(t, err.Error(), "at least one control ID",

--- a/cmd/mcpserver/scan_helper.go
+++ b/cmd/mcpserver/scan_helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
 	"github.com/kubescape/kubescape/v3/core/pkg/opaprocessor"
 	"github.com/kubescape/kubescape/v3/core/pkg/policyhandler"
 	"github.com/kubescape/kubescape/v3/core/pkg/resourcehandler"
@@ -68,11 +69,18 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 		namespace = ""
 	}
 
-	getters := cautils.Getters{
-		PolicyGetter:         ksServer.policyGetter,
-		ExceptionsGetter:     ksServer.policyGetter,
-		ControlsInputsGetter: ksServer.policyGetter,
-		AttackTracksGetter:   ksServer.policyGetter,
+	getters := cautils.Getters{}
+	if ksServer.policyGetter != nil {
+		getters.PolicyGetter = ksServer.policyGetter
+		getters.ExceptionsGetter = ksServer.policyGetter
+		getters.ControlsInputsGetter = ksServer.policyGetter
+		getters.AttackTracksGetter = ksServer.policyGetter
+	} else {
+		defaultGetter := getter.NewDownloadReleasedPolicy()
+		getters.PolicyGetter = defaultGetter
+		getters.ExceptionsGetter = defaultGetter
+		getters.ControlsInputsGetter = defaultGetter
+		getters.AttackTracksGetter = defaultGetter
 	}
 	if customGetters != nil {
 		getters = *customGetters

--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -49,6 +49,9 @@ func NewDownloadReleasedPolicyWithVersion(version string) *DownloadReleasedPolic
 // IsVersionPinned reports whether this getter targets a specific, user-selected
 // regolibrary release tag rather than the latest release.
 func (drp *DownloadReleasedPolicy) IsVersionPinned() bool {
+	if drp == nil {
+		return false
+	}
 	return drp.version != ""
 }
 
@@ -58,6 +61,9 @@ func (drp *DownloadReleasedPolicy) IsVersionPinned() bool {
 // record release provenance; doing so would let a later unpinned fallback
 // silently evaluate the pinned release.
 func (drp *DownloadReleasedPolicy) ShouldPersistPolicyArtifacts() bool {
+	if drp == nil {
+		return false
+	}
 	return !drp.IsVersionPinned()
 }
 

--- a/core/pkg/opaprocessor/incomplete_coverage_test.go
+++ b/core/pkg/opaprocessor/incomplete_coverage_test.go
@@ -1,0 +1,96 @@
+package opaprocessor
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHasUnreachableDependency reproduces the exact shape of
+// https://github.com/kubescape/kubescape/issues/3069: a control whose
+// ResourceToControlsMap includes both a GVR that collected fine (e.g. Pod)
+// and a GVR that failed (e.g. an RBAC 403 on ServiceAccount/RoleBinding).
+// hasUnreachableDependency must say "yes, this control has an unreachable
+// dependency" — the bug was that BuildScanCoverage's "all GVRs failed" gate
+// never fires here because Pod alone keeps the set from being "all failed",
+// even though the control's verdict genuinely depends on the missing data.
+func TestHasUnreachableDependency(t *testing.T) {
+	tests := []struct {
+		name                  string
+		infoMap               map[string]apis.StatusInfo
+		resourceToControlsMap map[string][]string
+		controlID             string
+		want                  bool
+	}{
+		{
+			name: "control depends on one failed GVR among several successful ones — C-0267 shape",
+			infoMap: map[string]apis.StatusInfo{
+				"/v1/serviceaccounts": {InnerStatus: apis.StatusSkipped, InnerInfo: "forbidden"},
+			},
+			resourceToControlsMap: map[string][]string{
+				"/v1/pods":            {"C-0267"},
+				"/v1/serviceaccounts": {"C-0267"},
+				"rbac.authorization.k8s.io/v1/rolebindings":        {"C-0267"},
+				"rbac.authorization.k8s.io/v1/clusterrolebindings": {"C-0267"},
+			},
+			controlID: "C-0267",
+			want:      true,
+		},
+		{
+			name: "control has no dependency on the failed GVR — unaffected",
+			infoMap: map[string]apis.StatusInfo{
+				"batch/v1/cronjobs": {InnerStatus: apis.StatusSkipped, InnerInfo: "forbidden"},
+			},
+			resourceToControlsMap: map[string][]string{
+				"/v1/pods":          {"C-0267"},
+				"batch/v1/cronjobs": {"C-OTHER"},
+			},
+			controlID: "C-0267",
+			want:      false,
+		},
+		{
+			name: "InfoMap entry exists but isn't a GVR pull failure (a per-resource eval skip, not in ResourceToControlsMap)",
+			infoMap: map[string]apis.StatusInfo{
+				"/v1/default/Pod/some-pod": {InnerStatus: apis.StatusSkipped, InnerInfo: "eval error"},
+			},
+			resourceToControlsMap: map[string][]string{
+				"/v1/pods": {"C-0267"},
+			},
+			controlID: "C-0267",
+			want:      false,
+		},
+		{
+			name: "dependency GVR present but not skipped — collected fine",
+			infoMap: map[string]apis.StatusInfo{
+				"/v1/serviceaccounts": {InnerStatus: apis.StatusPassed},
+			},
+			resourceToControlsMap: map[string][]string{
+				"/v1/pods":            {"C-0267"},
+				"/v1/serviceaccounts": {"C-0267"},
+			},
+			controlID: "C-0267",
+			want:      false,
+		},
+		{
+			name:                  "no InfoMap entries at all — nothing failed",
+			infoMap:               map[string]apis.StatusInfo{},
+			resourceToControlsMap: map[string][]string{"/v1/pods": {"C-0267"}},
+			controlID:             "C-0267",
+			want:                  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := cautils.NewOPASessionObjMock()
+			session.InfoMap = tt.infoMap
+			session.ResourceToControlsMap = tt.resourceToControlsMap
+
+			opap := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+			assert.Equal(t, tt.want, opap.hasUnreachableDependency(tt.controlID))
+		})
+	}
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -36,23 +36,7 @@ import (
 
 const ScoreConfigPath = "/resources/config"
 
-// SubStatusIncompleteCoverage marks a Passed verdict reached while at least
-// one resource type the control depends on (per ResourceToControlsMap)
-// failed to collect for the current scan (e.g. an RBAC 403 on a correlated
-// ServiceAccount/RoleBinding). The rule genuinely found no violation in the
-// data it had, but that data was incomplete, so the pass could not be fully
-// verified against live cluster state. This is deliberately additive: Status
-// stays Passed (existing pass/fail counts and CI/CD gates are unaffected),
-// and only SubStatus carries the caveat, mirroring how SubStatusException
-// annotates a Passed verdict without changing Status itself.
-//
-// This does not attempt per-object precision (distinguishing "the resource
-// this evaluation is about" from "a resource kind the rule cross-references
-// internally") — ResourceToControlsMap only tracks a control's declared
-// match resources as one flat set, so a failure in any of a control's match
-// kinds anywhere in the scope trips this for every Passed resource under
-// that control in that scope. See https://github.com/kubescape/kubescape/issues/3069.
-const SubStatusIncompleteCoverage apis.ScanningSubStatus = "incompleteCoverage"
+
 
 // ControlAttributeRequiresWholeClusterInput marks a control whose rules join
 // objects that live in different namespaces. Such a control must be evaluated
@@ -921,7 +905,7 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 
 	// incompleteCoverage is computed once per rule-scope call (not per
 	// resource, it's the same answer for all of them) so a Passed verdict
-	// below can be tagged with SubStatusIncompleteCoverage when at least one
+	// below can be tagged with apis.SubStatusIncompleteCoverage when at least one
 	// of this control's dependency GVRs failed to collect in this scope.
 	incompleteCoverage := opap.hasUnreachableDependency(controlID)
 
@@ -967,7 +951,7 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 			Status:                apis.StatusPassed,
 		}
 		if incompleteCoverage {
-			passResult.SubStatus = SubStatusIncompleteCoverage
+			passResult.SubStatus = apis.SubStatusIncompleteCoverage
 		}
 		resources[id] = passResult
 	}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -36,6 +36,24 @@ import (
 
 const ScoreConfigPath = "/resources/config"
 
+// SubStatusIncompleteCoverage marks a Passed verdict reached while at least
+// one resource type the control depends on (per ResourceToControlsMap)
+// failed to collect for the current scan (e.g. an RBAC 403 on a correlated
+// ServiceAccount/RoleBinding). The rule genuinely found no violation in the
+// data it had, but that data was incomplete, so the pass could not be fully
+// verified against live cluster state. This is deliberately additive: Status
+// stays Passed (existing pass/fail counts and CI/CD gates are unaffected),
+// and only SubStatus carries the caveat, mirroring how SubStatusException
+// annotates a Passed verdict without changing Status itself.
+//
+// This does not attempt per-object precision (distinguishing "the resource
+// this evaluation is about" from "a resource kind the rule cross-references
+// internally") — ResourceToControlsMap only tracks a control's declared
+// match resources as one flat set, so a failure in any of a control's match
+// kinds anywhere in the scope trips this for every Passed resource under
+// that control in that scope. See https://github.com/kubescape/kubescape/issues/3069.
+const SubStatusIncompleteCoverage apis.ScanningSubStatus = "incompleteCoverage"
+
 // ControlAttributeRequiresWholeClusterInput marks a control whose rules join
 // objects that live in different namespaces. Such a control must be evaluated
 // once against the whole cluster — after per-namespace evaluation has merged
@@ -901,6 +919,12 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 	// Record CEL resources with unknown verdicts as skipped before pass-inference.
 	opap.seedCELSkips(resources, rule, ruleRegoDependenciesData, celOut.skipped)
 
+	// incompleteCoverage is computed once per rule-scope call (not per
+	// resource, it's the same answer for all of them) so a Passed verdict
+	// below can be tagged with SubStatusIncompleteCoverage when at least one
+	// of this control's dependency GVRs failed to collect in this scope.
+	incompleteCoverage := opap.hasUnreachableDependency(controlID)
+
 	// Build the set of failed IDs so we can correctly mark the remainder as passed.
 	// Resources are only written to the result map after a successful OPA evaluation,
 	// preventing stale StatusPassed entries when evaluation fails.
@@ -937,11 +961,15 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		if existing, ok := resources[id]; ok && (existing.Status == apis.StatusFailed || existing.Status == apis.StatusSkipped) {
 			continue
 		}
-		resources[id] = &resourcesresults.ResourceAssociatedRule{
+		passResult := &resourcesresults.ResourceAssociatedRule{
 			Name:                  rule.Name,
 			ControlConfigurations: ruleRegoDependenciesData.PostureControlInputs,
 			Status:                apis.StatusPassed,
 		}
+		if incompleteCoverage {
+			passResult.SubStatus = SubStatusIncompleteCoverage
+		}
+		resources[id] = passResult
 	}
 
 	// ruleResponse to ruleResult
@@ -981,6 +1009,30 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		}
 	}
 	return resources, nil
+}
+
+// hasUnreachableDependency reports whether controlID depends (per
+// ResourceToControlsMap, built from the control's declared rule.Match/
+// DynamicMatch resources) on at least one GVR that failed to collect this
+// scan. opap.InfoMap is mixed-purpose (whole-GVR pull failures keyed by GVR
+// string, plus per-resource eval skips keyed by resource ID); checking that
+// the key is also present in ResourceToControlsMap, the same guard
+// cautils.BuildScanCoverage uses, is what keeps this from matching a
+// per-resource skip as if it were a GVR pull failure.
+//
+// This runs once per rule-scope evaluation (not once per resource), so its
+// O(len(ResourceToControlsMap)) cost is paid a small, bounded number of times
+// per scan rather than once per resource.
+func (opap *OPAProcessor) hasUnreachableDependency(controlID string) bool {
+	for gvr, controlIDs := range opap.ResourceToControlsMap {
+		if !slices.Contains(controlIDs, controlID) {
+			continue
+		}
+		if info, ok := opap.InfoMap[gvr]; ok && info.InnerStatus == apis.StatusSkipped {
+			return true
+		}
+	}
+	return false
 }
 
 // markResourcesSkipped seeds the result map with StatusSkipped entries for every

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.31
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.303
+	github.com/kubescape/opa-utils v0.0.307
 	github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1216,8 +1216,8 @@ github.com/kubescape/go-git-url v0.0.31 h1:VZnvtdGLVc42cQaR7llQeGZz0PnOxcs+eDig2
 github.com/kubescape/go-git-url v0.0.31/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/opa-utils v0.0.303 h1:NGP2qeDhA52/GTTiwND0RR1xak+gJeJdxK1Ih4EtRHU=
-github.com/kubescape/opa-utils v0.0.303/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
+github.com/kubescape/opa-utils v0.0.307 h1:YqJ26YGMVSGN1JBu3z95jH/7BxKoTp6nbhTCNoN6ZcY=
+github.com/kubescape/opa-utils v0.0.307/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.217
 	github.com/kubescape/kubescape/v3 v3.0.4
-	github.com/kubescape/opa-utils v0.0.303
+	github.com/kubescape/opa-utils v0.0.307
 	github.com/kubescape/storage v0.0.258
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1225,8 +1225,8 @@ github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoS
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
 github.com/kubescape/k8s-interface v0.0.217 h1:GTrXyw5d9SPG+NsVNay97Aiz6K5Z4EIMLnHju2+UVLU=
 github.com/kubescape/k8s-interface v0.0.217/go.mod h1:sOZm48DJn8QO1cWRbuNsPPsk0TxLzm13Ws85EkiH0X0=
-github.com/kubescape/opa-utils v0.0.303 h1:NGP2qeDhA52/GTTiwND0RR1xak+gJeJdxK1Ih4EtRHU=
-github.com/kubescape/opa-utils v0.0.303/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
+github.com/kubescape/opa-utils v0.0.307 h1:YqJ26YGMVSGN1JBu3z95jH/7BxKoTp6nbhTCNoN6ZcY=
+github.com/kubescape/opa-utils v0.0.307/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## Description
(fixes #3069)
Addressed @matthyx feedback on #3069: extending `notEvaluatedControls` at
the flat GVR-dependency-set level doesn't work, since a control like C-0267
also matches `Pod` — which always succeeds — so the "all GVRs failed" gate
never trips even when the correlation data it actually needs (ServiceAccount,
RoleBinding, ClusterRole) is unreachable.

This goes with option (a) from that thread: track coverage at the point of
rule evaluation in the OPA processor, where the code already knows exactly
which GVRs failed for the current scope — rather than reconstructing it
after the fact from a flattened per-control dependency set.

## What changed

`processRuleOnScope` (`core/pkg/opaprocessor/processorhandler.go`) is where
a resource that no rule flagged gets marked `Passed` by absence. A new
`hasUnreachableDependency(controlID)` check runs once per rule-scope call: if
any GVR the control depends on (per `ResourceToControlsMap`, built from the
rule's own declared `match` resources) failed to collect in `InfoMap` for
this scan, the Passed result now also carries
`SubStatus: "incompleteCoverage"`.

Deliberately additive: `Status` stays `Passed`, so existing pass/fail counts,
compliance scores, and CI/CD gates keyed on status are unaffected. The
caveat is now visible to anyone inspecting `subStatus`, instead of being
indistinguishable from a genuinely verified pass.

## Scope note

This targets the false-negative direction (a Passed verdict that was really
"couldn't check"). It does not touch C-0034/C-0190, the false-positive
controls also mentioned in #3069 — those stem from a different root cause
(the `automount-service-account` rule defaulting unsafely when
ServiceAccount data is absent) and would need a separate fix in that rule's
own logic, not the coverage-tracking layer this PR touches.

## Testing

Unit tests (`core/pkg/opaprocessor/incomplete_coverage_test.go`) cover
`hasUnreachableDependency` directly: the C-0267 shape (one failed dependency
GVR among several successful ones), an unrelated GVR failing (no false
positive), a per-resource eval skip that isn't a GVR pull failure (correctly
ignored), and the all-succeeded case.

Also re-ran the exact real-cluster repro from #3069 (same target pod,
same restricted ServiceAccount denied `serviceaccounts` +
`rbac.authorization.k8s.io`) against this fix. Real output below.

### Before (already in #3069) vs after this fix — restricted-access run

control    full                      restricted (before fix)   restricted (after this fix)
C-0267     failed                    passed                    passed / subStatus: incompleteCoverage
C-0272     failed                    passed                    passed / subStatus: incompleteCoverage
C-0261     failed                    passed                    passed / subStatus: incompleteCoverage
C-0014     passed                    passed (no signal)        passed / subStatus: incompleteCoverage



C-0014 ("Access Kubernetes dashboard") wasn't in the original report because
its verdict didn't flip — but it depends on the same unreachable RBAC data,
and now correctly surfaces the caveat even though the pass happened to be
right.

Real JSON output, this run:

```json
{
  "controlID": "C-0267",
  "name": "Workload with cluster takeover roles",
  "status": { "status": "passed" },
  "rules": [{ "name": "workload-with-cluster-takeover-roles", "status": "passed", "subStatus": "incompleteCoverage" }]
}
{
  "controlID": "C-0272",
  "name": "Workload with administrative roles",
  "status": { "status": "passed" },
  "rules": [{ "name": "workload-with-administrative-roles", "status": "passed", "subStatus": "incompleteCoverage" }]
}
{
  "controlID": "C-0261",
  "name": "ServiceAccount token mounted",
  "status": { "status": "passed" },
  "rules": [{ "name": "serviceaccount-token-mount", "status": "passed", "subStatus": "incompleteCoverage" }]
}
Full-access baseline run in the same session is untouched — no
incompleteCoverage anywhere, all controls report cleanly, confirming this
doesn't fire when nothing actually failed to collect.


$ go test ./core/pkg/opaprocessor/... -count=1
ok  	github.com/kubescape/kubescape/v3/core/pkg/opaprocessor	17.490s
ok  	github.com/kubescape/kubescape/v3/core/pkg/opaprocessor/cel	0.634s

$ go vet ./core/pkg/opaprocessor/...
(clean)

$ golangci-lint run --new-from-rev=HEAD ./core/pkg/opaprocessor/...
0 issues.
Closes #3069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incomplete coverage status reporting when required resource data is unavailable.
  * Passed control results now indicate when evaluation was affected by missing resource data; failed and skipped results remain unchanged.

* **Bug Fixes**
  * Improved distinction between collection-wide resource failures and individual resource evaluation skips.
  * Improved scan reliability when policy configuration is unavailable.
  * Prevented errors when optional policy settings are not initialized.

* **Tests**
  * Added regression coverage for incomplete resource collection and related evaluation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->