### PR TITLE
fix(imagescan): use match metadata for severity gates

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -362,14 +362,18 @@ func enforceImageSeverityThresholds(imageScanData []cautils.ImageScanData, scanI
 	}
 
 	for _, data := range imageScanData {
-		if data.VulnerabilityProvider == nil {
-			continue
-		}
 		for m := range data.Matches.Enumerate() {
-			//nolint:staticcheck // deprecated but replacing it requires refactoring
-			metadata, err := data.VulnerabilityProvider.VulnerabilityMetadata(m.Vulnerability.Reference)
-			if err != nil {
-				continue
+			metadata := m.Vulnerability.Metadata
+			if metadata == nil || imagescan.ParseSeverity(metadata.Severity) == vulnerability.UnknownSeverity {
+				if data.VulnerabilityProvider == nil {
+					continue
+				}
+				var err error
+				//nolint:staticcheck // fallback for matches without a known embedded severity
+				metadata, err = data.VulnerabilityProvider.VulnerabilityMetadata(m.Vulnerability.Reference)
+				if err != nil {
+					continue
+				}
 			}
 
 			if imagescan.ParseSeverity(metadata.Severity) >= thresholdSeverity &&

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -749,6 +749,7 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 		name          string
 		threshold     string
 		matchSeverity string
+		metadata      *vulnerability.Metadata
 		fixState      vulnerability.FixState
 		onlyFixable   bool
 		expectedError bool
@@ -775,6 +776,27 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 			name:          "threshold exceeded",
 			threshold:     "high",
 			matchSeverity: "Critical",
+			expectedError: true,
+		},
+		{
+			name:          "empty embedded severity falls back to provider metadata",
+			threshold:     "high",
+			matchSeverity: "Critical",
+			metadata:      &vulnerability.Metadata{},
+			expectedError: true,
+		},
+		{
+			name:          "unrecognized embedded severity falls back to provider metadata",
+			threshold:     "high",
+			matchSeverity: "Critical",
+			metadata:      &vulnerability.Metadata{Severity: "important"},
+			expectedError: true,
+		},
+		{
+			name:          "explicit unknown embedded severity falls back to provider metadata",
+			threshold:     "high",
+			matchSeverity: "Critical",
+			metadata:      &vulnerability.Metadata{Severity: vulnerability.UnknownSeverity.String()},
 			expectedError: true,
 		},
 		{
@@ -820,6 +842,7 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 				matches.Add(match.Match{
 					Vulnerability: vulnerability.Vulnerability{
 						Reference: vulnerability.Reference{ID: "CVE-TEST"},
+						Metadata:  tt.metadata,
 						Fix:       vulnerability.Fix{State: tt.fixState},
 					},
 				})
@@ -840,4 +863,20 @@ func TestEnforceImageSeverityThresholds(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnforceImageSeverityThresholdsUsesEmbeddedMetadataWithoutProvider(t *testing.T) {
+	matches := match.NewMatches(match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: "CVE-TEST"},
+			Metadata:  &vulnerability.Metadata{Severity: vulnerability.CriticalSeverity.String()},
+		},
+	})
+
+	err := enforceImageSeverityThresholds(
+		[]cautils.ImageScanData{{Matches: matches}},
+		&cautils.ScanInfo{FailThresholdSeverity: "high"},
+	)
+
+	assert.EqualError(t, err, "image scan result exceeds severity threshold: high")
 }

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -265,10 +265,17 @@ func (s *Service) ExceedsSeverityThreshold(severity vulnerability.Severity, matc
 		return false
 	}
 	for m := range matches.Enumerate() {
-		//nolint:staticcheck // deprecated but replacing it requires refactoring
-		metadata, err := s.vp.VulnerabilityMetadata(m.Vulnerability.Reference)
-		if err != nil {
-			continue
+		metadata := m.Vulnerability.Metadata
+		if metadata == nil || vulnerability.ParseSeverity(metadata.Severity) == vulnerability.UnknownSeverity {
+			if s.vp == nil {
+				continue
+			}
+			var err error
+			//nolint:staticcheck // fallback for matches without a known embedded severity
+			metadata, err = s.vp.VulnerabilityMetadata(m.Vulnerability.Reference)
+			if err != nil {
+				continue
+			}
 		}
 
 		if vulnerability.ParseSeverity(metadata.Severity) < severity {

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -68,6 +68,12 @@ func makeThresholdTestMatchWithFixState(id string, state vulnerability.FixState)
 	return m
 }
 
+func makeThresholdTestMatchWithMetadata(id, severity string) match.Match {
+	m := makeThresholdTestMatch(id)
+	m.Vulnerability.Metadata = &vulnerability.Metadata{Severity: severity}
+	return m
+}
+
 type stubVulnerabilityProvider struct {
 	metadataByID map[string]*vulnerability.Metadata
 	errByID      map[string]error
@@ -128,6 +134,14 @@ func TestParseSeverity(t *testing.T) {
 	}{
 		{
 			name: "",
+			want: vulnerability.UnknownSeverity,
+		},
+		{
+			name: "unknown",
+			want: vulnerability.UnknownSeverity,
+		},
+		{
+			name: "important",
 			want: vulnerability.UnknownSeverity,
 		},
 		{
@@ -318,6 +332,42 @@ func TestExceedsSeverityThreshold(t *testing.T) {
 			),
 			onlyFixable: false,
 			want:        false,
+		},
+		{
+			name:      "embedded metadata gates when provider lookup fails",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithMetadata("CVE-error", vulnerability.CriticalSeverity.String()),
+			),
+			onlyFixable: false,
+			want:        true,
+		},
+		{
+			name:      "empty embedded severity falls back to provider metadata",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithMetadata("CVE-high", ""),
+			),
+			onlyFixable: false,
+			want:        true,
+		},
+		{
+			name:      "unrecognized embedded severity falls back to provider metadata",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithMetadata("CVE-high", "important"),
+			),
+			onlyFixable: false,
+			want:        true,
+		},
+		{
+			name:      "explicit unknown embedded severity falls back to provider metadata",
+			threshold: vulnerability.HighSeverity,
+			matches: match.NewMatches(
+				makeThresholdTestMatchWithMetadata("CVE-high", vulnerability.UnknownSeverity.String()),
+			),
+			onlyFixable: false,
+			want:        true,
 		},
 		{
 			name:      "onlyFixable ignores an unfixable CVE at or above threshold",


### PR DESCRIPTION
## Overview

Grype matches already carry vulnerability metadata, but both image severity gates ignored that metadata and queried the metadata provider again. In combined scans, the image scan service is closed before the command-level gate runs, so a known Critical finding could be skipped and the command could exit successfully.

This change uses a recognized severity attached to the match first. It falls back to the existing provider lookup when embedded metadata is absent, empty, unrecognized, or Unknown.

## Additional Information

- No exported API is added.
- The existing behavior from #2211 is preserved: if no usable embedded severity exists and provider lookup fails, the match is skipped.
- Known embedded metadata becomes the canonical source, matching the current Grype model.
- Focused tests cover nil providers, provider errors, invalid/empty metadata, Unknown severity, only-fixable filtering, and the combined-scan gate.

## How to Test

```sh
go test ./pkg/imagescan ./cmd/scan -count=1
go test -race ./pkg/imagescan -run '^TestExceedsSeverityThreshold$' -count=1
go test -race ./cmd/scan -run '^(TestEnforceImageSeverityThresholds|TestEnforceImageSeverityThresholdsUsesEmbeddedMetadataWithoutProvider)$' -count=1
go vet ./pkg/imagescan ./cmd/scan
```

## Related issues/PRs

- Resolved #3184
- Follow-up context: #2894
- Compatibility context: #2211

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added focused regression and edge-case tests
- [x] New and existing unit tests pass locally with my changes
- [x] All commits include the required DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image vulnerability severity filtering by using severity information embedded in scan results when available.
  - Added reliable fallback lookups when embedded severity is missing or unrecognized.
  - Prevented scan failures when no vulnerability provider is configured or a lookup cannot be completed.
  - Ensured vulnerabilities with known embedded severity are correctly evaluated against configured thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->