### PR TITLE
fix(junit): include image findings in combined scans

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -138,6 +138,15 @@ func (jp *JunitPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 
 	if opaSessionObj != nil {
 		junitResult = testsSuites(opaSessionObj)
+		if len(imageScanData) > 0 {
+			imageResult := imageTestsSuites(imageScanData)
+			suiteIDOffset := len(junitResult.Suites)
+			for i := range imageResult.Suites {
+				imageResult.Suites[i].ID += suiteIDOffset
+			}
+			junitResult.Suites = append(junitResult.Suites, imageResult.Suites...)
+			junitResult.Tests, junitResult.Failures, junitResult.Errors = aggregateSuiteCounts(junitResult.Suites)
+		}
 	} else if len(imageScanData) > 0 {
 		junitResult = imageTestsSuites(imageScanData)
 	} else {

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
@@ -119,6 +122,75 @@ func TestTestSuites(t *testing.T) {
 	assert.Equal(t, listTestsSuite(results), junitTestSuites.Suites)
 	assert.Equal(t, results.Report.SummaryDetails.NumberOfControls().All(), junitTestSuites.Tests)
 	assert.Equal(t, "Kubescape Scanning", junitTestSuites.Name)
+}
+
+func TestJunitActionPrintCombinedScanIncludesPostureAndImages(t *testing.T) {
+	postureControlID := "C-COMBINED"
+	postureSession := cautils.NewOPASessionObjMock()
+	postureSession.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				postureControlID: {
+					ControlID:  postureControlID,
+					Name:       "Combined posture control",
+					Status:     apis.StatusFailed,
+					StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				},
+			},
+		},
+	}
+
+	imageMatch := func(id, severity string) match.Match {
+		return match.Match{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{ID: id, Namespace: "nvd"},
+				Metadata:  &vulnerability.Metadata{ID: id, Severity: severity},
+			},
+			Package: grypepkg.Package{
+				ID:      grypepkg.ID("pkg-" + id),
+				Name:    "pkg-" + id,
+				Version: "1.0.0",
+			},
+		}
+	}
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:   "combined:first",
+			Matches: match.NewMatches(imageMatch("CVE-COMBINED", "High")),
+		},
+		{
+			Image:   "combined:second",
+			Matches: match.NewMatches(imageMatch("CVE-COMBINED-SECOND", "Critical")),
+		},
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "combined.xml")
+	jp := NewJunitPrinter(false)
+	require.NoError(t, jp.SetWriter(context.Background(), outputPath))
+	require.NoError(t, jp.ActionPrint(context.Background(), postureSession, imageScanData))
+	require.NoError(t, jp.writer.Close())
+
+	raw, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var got JUnitTestSuites
+	require.NoError(t, xml.Unmarshal(raw, &got))
+	require.Len(t, got.Suites, 3)
+	assert.Equal(t, "Kubescape Scanning", got.Name)
+	assert.Equal(t, []string{"kubescape", "combined:first", "combined:second"}, []string{
+		got.Suites[0].Name,
+		got.Suites[1].Name,
+		got.Suites[2].Name,
+	})
+	assert.Equal(t, []int{0, 1, 2}, []int{got.Suites[0].ID, got.Suites[1].ID, got.Suites[2].ID})
+	assert.Equal(t, 1, got.Suites[0].Tests)
+	assert.Equal(t, 1, got.Suites[0].Failures)
+	assert.Equal(t, 3, got.Tests)
+	assert.Equal(t, 3, got.Failures)
+	assert.Zero(t, got.Errors)
+	assert.Contains(t, string(raw), "Combined posture control")
+	assert.Contains(t, string(raw), "CVE-COMBINED")
+	assert.Contains(t, string(raw), "CVE-COMBINED-SECOND")
 }
 
 func TestListTestSuites(t *testing.T) {


### PR DESCRIPTION
## Overview

Combined scans pass both posture results and image scan data to the JUnit printer. The printer previously selected the posture branch whenever a posture session existed, silently dropping every image finding from the XML.

This change appends the existing image suites after the posture suites, offsets their suite IDs, and recomputes the document-level Tests, Failures, and Errors totals across all suites.

## Additional Information

- Config-only and image-only JUnit output are unchanged.
- The XML schema and existing per-suite conversion logic are unchanged.
- The regression test renders and parses the real XML. It verifies one failed posture control plus two image CVEs, unique suite IDs, suite order, and aggregate counters.
- A mutation check confirmed that counting image suites without the posture suite makes the regression test fail.

## How to Test

```sh
go test ./core/pkg/resultshandling/printer/... -count=1
go test ./core/pkg/resultshandling/printer/v2 -run '^TestJunitActionPrintCombinedScanIncludesPostureAndImages$' -count=10
go test -race ./core/pkg/resultshandling/printer/v2 -run '^TestJunitActionPrintCombinedScanIncludesPostureAndImages$' -count=3
go vet ./core/pkg/resultshandling/printer/v2
```

## Related issues/PRs

- Resolved #3187
- Image-only JUnit support: #2786

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added a lifecycle-level regression test with non-zero results from both sources
- [x] New and existing unit tests pass locally with my changes
- [x] All commits include the required DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Combined JUnit reports now include both posture controls and image vulnerability results.
  - Image test suites use unique identifiers and accurate aggregate totals for tests, failures, and errors.

- **Tests**
  - Added coverage validating combined report structure, suite ordering, counts, failures, and vulnerability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->