### PR TITLE
fix(diff): propagate output errors

### DIFF
--- a/core/core/diff.go
+++ b/core/core/diff.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -11,15 +12,21 @@ import (
 )
 
 // Diff writes the diff between the two scan reports and returns the number of new failures at or above the severity threshold; the caller decides whether to exit 1.
-func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (int, error) {
+func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (newFailures int, err error) {
 	cs, err := diff.Compute(diffInfo.BaseFile, diffInfo.HeadFile)
 	if err != nil {
 		return 0, err
 	}
 
-	w := printer.GetWriter(context.Background(), diffInfo.Output)
-	if w != os.Stdout {
-		defer w.Close()
+	w := os.Stdout
+	if diffInfo.Output != "" {
+		w, err = printer.GetWriterNoFallback(diffInfo.Output)
+		if err != nil {
+			return 0, fmt.Errorf("opening diff output: %w", err)
+		}
+		defer func() {
+			err = closeDiffOutput(w, err)
+		}()
 	}
 
 	switch diffInfo.Format {
@@ -32,8 +39,17 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (int, error) {
 			return 0, fmt.Errorf("writing YAML diff: %w", err)
 		}
 	default:
-		diff.PrintPretty(w, cs)
+		if err := diff.PrintPretty(w, cs); err != nil {
+			return 0, fmt.Errorf("writing pretty diff: %w", err)
+		}
 	}
 
 	return len(diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)), nil
+}
+
+func closeDiffOutput(closer io.Closer, err error) error {
+	if closeErr := closer.Close(); closeErr != nil {
+		return errors.Join(err, fmt.Errorf("closing diff output: %w", closeErr))
+	}
+	return err
 }

--- a/core/core/diff_test.go
+++ b/core/core/diff_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingCloser struct {
+	err error
+}
+
+func (c failingCloser) Close() error {
+	return c.err
+}
 
 // writeReport writes raw scan-report JSON to a temp file and returns its path.
 func writeReport(t *testing.T, json string) string {
@@ -102,4 +111,53 @@ func TestDiff_PrettyFormatWritesOutput(t *testing.T) {
 	data, err := os.ReadFile(out)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "New failures")
+}
+
+func TestDiff_ExplicitOutputSetupFailureIsReturned(t *testing.T) {
+	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+	head := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o600))
+
+	ks := NewKubescape(context.Background())
+	_, err := ks.Diff(&metav1.DiffInfo{
+		BaseFile: base,
+		HeadFile: head,
+		Format:   "pretty-printer",
+		Output:   filepath.Join(blocker, "diff.out"),
+	})
+	require.ErrorContains(t, err, "opening diff output")
+}
+
+func TestDiff_PrettyWriteFailureIsReturned(t *testing.T) {
+	if _, err := os.Stat("/dev/full"); err != nil {
+		t.Skip("requires /dev/full")
+	}
+
+	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+	head := writeReport(t, `{
+		"results":[{"resourceID":"res1","controls":[
+			{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}}
+		]}],
+		"summaryDetails":{"controls":{"C-HIGH":{"scoreFactor":7.0}}}
+	}`)
+
+	ks := NewKubescape(context.Background())
+	_, err := ks.Diff(&metav1.DiffInfo{
+		BaseFile: base,
+		HeadFile: head,
+		Format:   "pretty-printer",
+		Output:   "/dev/full",
+	})
+	require.ErrorContains(t, err, "writing pretty diff")
+}
+
+func TestCloseDiffOutput_JoinsCloseError(t *testing.T) {
+	writeErr := errors.New("write failed")
+	closeErr := errors.New("close failed")
+
+	err := closeDiffOutput(failingCloser{err: closeErr}, writeErr)
+	require.ErrorIs(t, err, writeErr)
+	require.ErrorIs(t, err, closeErr)
 }

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -3,6 +3,7 @@ package diff
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
 
 func writeTempReport(t *testing.T, r scanReport) string {
 	t.Helper()
@@ -369,6 +378,30 @@ func TestPrintYAML(t *testing.T) {
 	assert.Contains(t, yamlStr, "resourceID: path-123/api/v1/Pod/demo")
 	assert.Contains(t, yamlStr, "controlID: C-0057")
 	assert.Contains(t, yamlStr, "controlName: Privileged container")
+}
+
+func TestPrintPretty_ReturnsWriteError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	err := PrintPretty(failingWriter{err: wantErr}, &ChangeSet{
+		New: []ControlChange{{ControlID: "C-001"}},
+	})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestPrintPretty_WritesExpectedOutput(t *testing.T) {
+	cs := &ChangeSet{
+		New: []ControlChange{{
+			ResourceID:  "resource",
+			ControlID:   "C-001",
+			ControlName: "Control",
+			Severity:    "High",
+		}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, PrintPretty(&buf, cs))
+	assert.Contains(t, buf.String(), "New failures")
+	assert.Contains(t, buf.String(), "Summary: 1 new, 0 resolved, 0 unchanged")
 }
 
 func TestCompute_OutputOrderIsDeterministic(t *testing.T) {

--- a/core/pkg/resultshandling/diff/printer.go
+++ b/core/pkg/resultshandling/diff/printer.go
@@ -10,26 +10,38 @@ import (
 )
 
 // PrintPretty writes a human-readable diff summary to w.
-func PrintPretty(w io.Writer, cs *ChangeSet) {
-	printSection(w, "New failures", cs.New, "+")
-	printSection(w, "Resolved", cs.Resolved, "-")
+func PrintPretty(w io.Writer, cs *ChangeSet) error {
+	if err := printSection(w, "New failures", cs.New, "+"); err != nil {
+		return err
+	}
+	if err := printSection(w, "Resolved", cs.Resolved, "-"); err != nil {
+		return err
+	}
 	if len(cs.Unchanged) > 0 {
-		printSection(w, "Still failing (unchanged)", cs.Unchanged, " ")
+		if err := printSection(w, "Still failing (unchanged)", cs.Unchanged, " "); err != nil {
+			return err
+		}
 	}
 
-	fmt.Fprintf(w, "\nSummary: %d new, %d resolved, %d unchanged\n",
+	_, err := fmt.Fprintf(w, "\nSummary: %d new, %d resolved, %d unchanged\n",
 		len(cs.New), len(cs.Resolved), len(cs.Unchanged))
+	return err
 }
 
-func printSection(w io.Writer, title string, changes []ControlChange, prefix string) {
+func printSection(w io.Writer, title string, changes []ControlChange, prefix string) error {
 	if len(changes) == 0 {
-		return
+		return nil
 	}
-	fmt.Fprintf(w, "\n%s (%d)\n%s\n", title, len(changes), strings.Repeat("-", len(title)+10))
+	if _, err := fmt.Fprintf(w, "\n%s (%d)\n%s\n", title, len(changes), strings.Repeat("-", len(title)+10)); err != nil {
+		return err
+	}
 	for _, c := range changes {
-		fmt.Fprintf(w, "%s [%s] %s (%s)\n    Resource: %s\n",
-			prefix, c.Severity, c.ControlName, c.ControlID, c.ResourceID)
+		if _, err := fmt.Fprintf(w, "%s [%s] %s (%s)\n    Resource: %s\n",
+			prefix, c.Severity, c.ControlName, c.ControlID, c.ResourceID); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // PrintJSON writes the ChangeSet as JSON to w.


### PR DESCRIPTION
## Overview

The diff command could report success after failing to create an explicitly requested output file because the generic writer helper fell back to stdout. Its pretty renderer also ignored every write error, and output close errors were not returned.

This change makes explicit diff output strict, returns pretty-render write failures, and joins close failures with any existing render error so neither error is lost.

## Additional Information

- Output omitted by the user still writes to stdout and stdout is never closed.
- JSON and YAML rendering behavior is unchanged.
- Only explicit output paths use `GetWriterNoFallback`, consistent with the output contract introduced in #3140.
- Tests cover output setup failure, deterministic pretty write failure, normal pretty output, close failure, and simultaneous write/close failures.

## How to Test

```sh
go test -p 1 ./core/pkg/resultshandling/diff ./cmd/diff ./core/core -count=1
go test -race ./core/pkg/resultshandling/diff -run 'TestPrintPretty_' -count=20
go vet ./core/pkg/resultshandling/diff ./cmd/diff ./core/core
```

## Related issues/PRs

- Resolved #3185
- Related output error contract: #3140

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added focused failure-path and success-path tests
- [x] New and existing unit tests pass locally with my changes
- [x] All commits include the required DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when generating diff output.
  * Reported failures when output cannot be opened, written, or closed.
  * Preserved and surfaced errors from formatted diff summaries.
  * Stopped output generation after the first rendering failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->