### PR TITLE
fix(imagescan): reject invalid exception target regexes

### DIFF
--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -64,8 +64,38 @@ func GetImageExceptionsFromFile(filePath string) ([]VulnerabilitiesIgnorePolicy,
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling exceptions file: %w", err)
 	}
+	if err := validateImageExceptionTargetRegexes(policies); err != nil {
+		return nil, fmt.Errorf("error validating exceptions file: %w", err)
+	}
 
 	return policies, nil
+}
+
+func validateImageExceptionTargetRegexes(policies []VulnerabilitiesIgnorePolicy) error {
+	for policyIndex := range policies {
+		policyName := policies[policyIndex].Metadata.Name
+		if policyName == "" {
+			policyName = fmt.Sprintf("#%d", policyIndex)
+		}
+		for targetIndex := range policies[policyIndex].Targets {
+			attributes := policies[policyIndex].Targets[targetIndex].Attributes
+			fields := []struct {
+				name  string
+				value string
+			}{
+				{name: "registry", value: attributes.Registry},
+				{name: "organization", value: attributes.Organization},
+				{name: "imageName", value: attributes.ImageName},
+				{name: "imageTag", value: attributes.ImageTag},
+			}
+			for _, field := range fields {
+				if _, err := regexp.Compile(field.value); err != nil {
+					return fmt.Errorf("image exception policy %q target %d field %s contains an invalid regular expression: %w", policyName, targetIndex, field.name, err)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // This function will identify the registry, organization and image tag from the image name

--- a/core/core/image_scan_test.go
+++ b/core/core/image_scan_test.go
@@ -1,14 +1,18 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"sort"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetImageExceptionsFromFile(t *testing.T) {
@@ -101,6 +105,51 @@ func TestGetImageExceptionsFromFile(t *testing.T) {
 			policies, err := GetImageExceptionsFromFile(tt.filePath)
 			assert.Equal(t, tt.expectedPolicies, policies)
 			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestGetImageExceptionsFromFileRejectsInvalidTargetRegex(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*Attributes)
+	}{
+		{name: "registry", set: func(a *Attributes) { a.Registry = "[" }},
+		{name: "organization", set: func(a *Attributes) { a.Organization = "[" }},
+		{name: "imageName", set: func(a *Attributes) { a.ImageName = "[" }},
+		{name: "imageTag", set: func(a *Attributes) { a.ImageTag = "[" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := Attributes{
+				Registry:     ".*",
+				Organization: ".*",
+				ImageName:    ".*",
+				ImageTag:     ".*",
+			}
+			tt.set(&attributes)
+
+			policies := []VulnerabilitiesIgnorePolicy{
+				{
+					Metadata: Metadata{Name: "invalid-pattern"},
+					Kind:     "VulnerabilitiesIgnorePolicy",
+					Targets: []Target{
+						{DesignatorType: "Attributes", Attributes: attributes},
+					},
+				},
+			}
+			data, err := json.Marshal(policies)
+			require.NoError(t, err)
+
+			path := filepath.Join(t.TempDir(), "exceptions.json")
+			require.NoError(t, os.WriteFile(path, data, 0o600))
+
+			got, err := GetImageExceptionsFromFile(path)
+			require.Error(t, err)
+			assert.Nil(t, got)
+			assert.ErrorContains(t, err, `policy "invalid-pattern" target 0 field `+tt.name)
+			assert.ErrorContains(t, err, "invalid regular expression")
 		})
 	}
 }


### PR DESCRIPTION
## Overview

Image exception target fields are regular expressions, but exception loading currently validates only file I/O and JSON. Target patterns are compiled lazily during matching. If an invalid pattern is reached, the matcher logs the compile error and returns false; short-circuit evaluation can also leave invalid later fields unchecked for a particular image. In neither case does loading fail.

This change validates every target field when the exception file is loaded and returns a contextual error before scanning starts.

## Additional Information

- Validation covers `registry`, `organization`, `imageName`, and `imageTag`.
- Errors include the policy name/index, target index, field name, and wrapped regexp parser error.
- Validation order is deterministic.
- The JSON schema and matching behavior for valid patterns are unchanged; malformed patterns now fail fast.
- Empty or omitted fields remain valid and keep their existing match-all behavior.

## How to Test

```sh
go test ./core/core -run '^TestGetImageExceptionsFromFile(RejectsInvalidTargetRegex)?$' -count=10
go test -race ./core/core -run '^TestGetImageExceptionsFromFile(RejectsInvalidTargetRegex)?$' -count=1
```

## Related issues/PRs

- Resolved #3186
- Regex target support: #1568

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added focused loader tests for all four target fields
- [x] New and existing unit tests pass locally with my changes
- [x] All commits include the required DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for registry, organization, image name, and image tag patterns in image exception policies.
  * Invalid patterns now produce clear errors identifying the affected policy, target, and field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->