### PR TITLE
fix(http): handle JSON marshal errors in responseToBytes

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -322,7 +322,11 @@ func writeScanErrorToFile(err error, scanID string) (e error) {
 
 // responseToBytes convert response object to bytes
 func responseToBytes(res *utilsmetav1.Response) []byte {
-	b, _ := json.Marshal(res)
+	b, err := json.Marshal(res)
+	if err != nil {
+		logger.L().Error("failed to marshal response", helpers.Error(err))
+		return []byte(`{"response":"internal error: failed to marshal response","type":"error"}`)
+	}
 	return b
 }
 

--- a/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -40,12 +41,28 @@ func TestEnvHelpers(t *testing.T) {
 }
 
 func TestResponseToBytes(t *testing.T) {
-	got := responseToBytes(&utilsmetav1.Response{
-		Type:     "done",
-		Response: "ok",
+	t.Run("valid response marshals successfully", func(t *testing.T) {
+		got := responseToBytes(&utilsmetav1.Response{
+			Type:     "done",
+			Response: "ok",
+		})
+
+		assert.JSONEq(t, `{"id":"","type":"done","response":"ok"}`, string(got))
 	})
 
-	assert.JSONEq(t, `{"id":"","type":"done","response":"ok"}`, string(got))
+	t.Run("marshal error returns fallback JSON", func(t *testing.T) {
+		// A channel cannot be marshaled to JSON, triggering the error path.
+		got := responseToBytes(&utilsmetav1.Response{
+			Response: make(chan int),
+		})
+
+		assert.NotEmpty(t, got)
+
+		var decoded utilsmetav1.Response
+		err := json.Unmarshal(got, &decoded)
+		assert.NoError(t, err)
+		assert.Contains(t, decoded.Response, "failed to marshal response")
+	})
 }
 
 func TestWriteScanErrorToFile(t *testing.T) {


### PR DESCRIPTION
## Summary
closed - #3188 
- `responseToBytes` silently ignored `json.Marshal` errors, returning `nil` to clients when marshaling failed
- Now logs the error and returns a fallback JSON error body so clients always receive a valid, parseable response
- Extended `TestResponseToBytes` with a marshal-error subtest that passes a channel (unmarshallable type) and asserts the fallback JSON is returned

## Files changed
- `httphandler/handlerequests/v1/requestshandlerutils.go` — handle marshal error in `responseToBytes`
- `httphandler/handlerequests/v1/requestshandlerutils_extra_test.go` — add marshal-error subtest

## Test plan
- [x] `cd httphandler && go test ./handlerequests/v1 -run TestResponseToBytes -v`
- [x] `cd httphandler && go test ./handlerequests/v1 -v` (full package)
<img width="665" height="190" alt="image" src="https://github.com/user-attachments/assets/aa9a0f81-79b6-4f98-b3fd-23e789934135" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when generating JSON responses.
  - Returns a clear internal-error response if response data cannot be serialized, instead of potentially returning incomplete data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->