### PR TITLE
feat(vapreconcile): discover the served VAP API version instead of assuming v1

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -194,16 +194,30 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	}
 
 	if scanInfo.GetScanningContext() == cautils.ContextCluster {
-		policies, bindings, err := vapreconcile.Collect(ctx, k8sHandler.k8s)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("failed to collect VAP resources", helpers.Error(err))
-		} else {
-			sessionObj.VAPPolicies = policies
-			sessionObj.VAPBindings = bindings
-		}
+		k8sHandler.collectVAPResources(ctx, sessionObj)
 	}
 
 	return k8sResourcesMap, allResources, ksResourceMap, excludedRulesMap, nil
+}
+
+// collectVAPResources records the cluster's admission enforcement state on the
+// session. Clusters that do not serve the VAP API are skipped without a warning,
+// since having no policies to reconcile is not a scan failure.
+func (k8sHandler *K8sResourceHandler) collectVAPResources(ctx context.Context, sessionObj *cautils.OPASessionObj) {
+	if k8sHandler.k8s == nil {
+		return
+	}
+
+	policies, bindings, err := vapreconcile.Collect(ctx, k8sHandler.k8s)
+	switch {
+	case errors.Is(err, vapreconcile.ErrUnsupported):
+		logger.L().Debug("skipping VAP reconciliation, cluster does not serve the API")
+	case err != nil:
+		logger.L().Ctx(ctx).Warning("failed to collect VAP resources", helpers.Error(err))
+	default:
+		sessionObj.VAPPolicies = policies
+		sessionObj.VAPBindings = bindings
+	}
 }
 
 func (k8sHandler *K8sResourceHandler) GetCloudProvider() string {
@@ -436,14 +450,8 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		}
 	}
 
-	if scanInfo.GetScanningContext() == cautils.ContextCluster && k8sHandler.k8s != nil {
-		policies, bindings, err := vapreconcile.Collect(ctx, k8sHandler.k8s)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("failed to collect VAP resources", helpers.Error(err))
-		} else {
-			sessionObj.VAPPolicies = policies
-			sessionObj.VAPBindings = bindings
-		}
+	if scanInfo.GetScanningContext() == cautils.ContextCluster {
+		k8sHandler.collectVAPResources(ctx, sessionObj)
 	}
 
 	for groupResource, ids := range ksResourceMap {

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -2,43 +2,113 @@ package vapreconcile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 )
 
-var (
-	vapGVR = schema.GroupVersionResource{
-		Group:    "admissionregistration.k8s.io",
-		Version:  "v1",
-		Resource: "validatingadmissionpolicies",
-	}
-	vapbGVR = schema.GroupVersionResource{
-		Group:    "admissionregistration.k8s.io",
-		Version:  "v1",
-		Resource: "validatingadmissionpolicybindings",
-	}
+const (
+	vapGroup           = "admissionregistration.k8s.io"
+	vapResource        = "validatingadmissionpolicies"
+	vapBindingResource = "validatingadmissionpolicybindings"
 )
+
+// vapVersions lists the served versions of the VAP API in preference order:
+// v1 since Kubernetes 1.30, v1beta1 since 1.28, v1alpha1 since 1.26.
+var vapVersions = []string{"v1", "v1beta1", "v1alpha1"}
+
+// ErrUnsupported reports a cluster that serves no version of the VAP API, so
+// there is no enforcement state to reconcile.
+var ErrUnsupported = errors.New("cluster does not serve ValidatingAdmissionPolicy resources")
 
 // Collect lists ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
-// resources from the live cluster. Both resource types are cluster-scoped so no
-// namespace selector is needed.
+// resources from the live cluster, using whichever version of the API the
+// cluster serves. Both resource types are cluster-scoped so no namespace
+// selector is needed. Clusters without the API return ErrUnsupported.
 func Collect(ctx context.Context, k8s *k8sinterface.KubernetesApi) ([]unstructured.Unstructured, []unstructured.Unstructured, error) {
-	vapList, err := k8s.DynamicClient.Resource(vapGVR).List(ctx, metav1.ListOptions{})
+	version, err := resolveVersion(k8s.DiscoveryClient)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list ValidatingAdmissionPolicies: %w", err)
+		return nil, nil, err
 	}
 
-	vapbList, err := k8s.DynamicClient.Resource(vapbGVR).List(ctx, metav1.ListOptions{})
+	policies, err := list(ctx, k8s.DynamicClient, version, vapResource)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list ValidatingAdmissionPolicyBindings: %w", err)
+		return nil, nil, err
+	}
+	bindings, err := list(ctx, k8s.DynamicClient, version, vapBindingResource)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return vapList.Items, vapbList.Items, nil
+	return policies, bindings, nil
+}
+
+// resolveVersion returns the first VAP version the cluster both advertises and
+// serves both resources for. Without a discovery client the newest version is
+// assumed, which is what the API server routing did before discovery existed.
+func resolveVersion(client discovery.DiscoveryInterface) (string, error) {
+	if client == nil {
+		return vapVersions[0], nil
+	}
+
+	for _, version := range vapVersions {
+		gv := schema.GroupVersion{Group: vapGroup, Version: version}
+		resources, err := client.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", fmt.Errorf("failed to discover %s: %w", gv.String(), err)
+		}
+		if serves(resources, vapResource, vapBindingResource) {
+			return version, nil
+		}
+	}
+
+	return "", ErrUnsupported
+}
+
+// serves reports whether the API resource list carries every named resource.
+func serves(resources *metav1.APIResourceList, names ...string) bool {
+	if resources == nil {
+		return false
+	}
+
+	served := make(map[string]struct{}, len(resources.APIResources))
+	for _, resource := range resources.APIResources {
+		served[resource.Name] = struct{}{}
+	}
+	for _, name := range names {
+		if _, ok := served[name]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// list pulls every object of one cluster-scoped VAP resource. A resource that
+// discovery advertised but the API server does not route is reported as
+// unsupported rather than as a scan failure.
+func list(ctx context.Context, client dynamic.Interface, version, resource string) ([]unstructured.Unstructured, error) {
+	gvr := schema.GroupVersionResource{Group: vapGroup, Version: version, Resource: resource}
+	listed, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, ErrUnsupported
+		}
+		return nil, fmt.Errorf("failed to list %s: %w", gvr.String(), err)
+	}
+
+	return listed.Items, nil
 }
 
 // BuildIndex builds a map of controlId -> VAPEnforcementStatus by reading the

--- a/core/pkg/vapreconcile/reconcile_test.go
+++ b/core/pkg/vapreconcile/reconcile_test.go
@@ -1,11 +1,20 @@
 package vapreconcile
 
 import (
+	"context"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func makeVAP(name, controlID string) unstructured.Unstructured {
@@ -36,6 +45,125 @@ func toInterfaceSlice(ss []string) []any {
 		out[i] = s
 	}
 	return out
+}
+
+// discoveryServing returns a discovery client advertising the VAP API on every
+// given version, plus the webhook resources every supported cluster serves.
+func discoveryServing(versions ...string) *discoveryfake.FakeDiscovery {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	for _, version := range versions {
+		client.Resources = append(client.Resources, &metav1.APIResourceList{
+			GroupVersion: vapGroup + "/" + version,
+			APIResources: []metav1.APIResource{
+				{Name: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration"},
+				{Name: vapResource, Kind: "ValidatingAdmissionPolicy"},
+				{Name: vapBindingResource, Kind: "ValidatingAdmissionPolicyBinding"},
+			},
+		})
+	}
+	return client
+}
+
+// dynamicServing returns a dynamic client holding the given objects under the
+// VAP resources of one version.
+func dynamicServing(version string, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: vapGroup, Version: version, Resource: vapResource}:        "ValidatingAdmissionPolicyList",
+		{Group: vapGroup, Version: version, Resource: vapBindingResource}: "ValidatingAdmissionPolicyBindingList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+}
+
+func servedVAP(version, name, controlID string) *unstructured.Unstructured {
+	vap := makeVAP(name, controlID)
+	vap.SetAPIVersion(vapGroup + "/" + version)
+	vap.SetKind("ValidatingAdmissionPolicy")
+	return &vap
+}
+
+func TestResolveVersion_PrefersNewestServedVersion(t *testing.T) {
+	version, err := resolveVersion(discoveryServing("v1", "v1beta1", "v1alpha1"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version)
+}
+
+func TestResolveVersion_FallsBackToOlderVersions(t *testing.T) {
+	for _, served := range []string{"v1beta1", "v1alpha1"} {
+		t.Run(served, func(t *testing.T) {
+			version, err := resolveVersion(discoveryServing(served))
+
+			require.NoError(t, err)
+			assert.Equal(t, served, version)
+		})
+	}
+}
+
+func TestResolveVersion_GroupWithoutPolicyResources(t *testing.T) {
+	// pre-1.26 clusters serve the group for webhook configurations only
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{{
+		GroupVersion: vapGroup + "/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration"},
+		},
+	}}
+
+	_, err := resolveVersion(client)
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestResolveVersion_BindingsNotServed(t *testing.T) {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{{
+		GroupVersion: vapGroup + "/v1",
+		APIResources: []metav1.APIResource{{Name: vapResource, Kind: "ValidatingAdmissionPolicy"}},
+	}}
+
+	_, err := resolveVersion(client)
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestResolveVersion_NoGroupAtAll(t *testing.T) {
+	_, err := resolveVersion(&discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}})
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestResolveVersion_WithoutDiscoveryClient(t *testing.T) {
+	version, err := resolveVersion(nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version)
+}
+
+func TestCollect_ReadsFromServedVersion(t *testing.T) {
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: discoveryServing("v1beta1"),
+		DynamicClient:   dynamicServing("v1beta1", servedVAP("v1beta1", "kubescape-c-0041", "C-0041")),
+	}
+
+	policies, bindings, err := Collect(context.Background(), k8s)
+
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "kubescape-c-0041", policies[0].GetName())
+	assert.Empty(t, bindings)
+}
+
+func TestCollect_UnsupportedClusterIsNotAFailure(t *testing.T) {
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}},
+		DynamicClient:   dynamicServing("v1"),
+	}
+
+	policies, bindings, err := Collect(context.Background(), k8s)
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+	assert.Nil(t, policies)
+	assert.Nil(t, bindings)
 }
 
 func TestBuildIndex_BoundDeny(t *testing.T) {


### PR DESCRIPTION
Closes #2879

### Overview

`Collect` pins both list calls to `admissionregistration.k8s.io/v1`. That group version predates VAPs by a long way, since the webhook configurations live there too, so on a cluster below 1.30 the group resolves and the resource does not. The list fails, every cluster scan logs a VAP warning, and the enforcement state a 1.28 or 1.29 cluster is actually holding under `v1beta1` never gets read. Controls that are bound and denying in that cluster render with no enforcement information at all, which looks exactly like a cluster running no policies.

The two outcomes also need telling apart. A cluster that serves no VAP API has nothing to reconcile and should stay quiet about it, while a cluster that does serve it and still fails the list is a real problem worth warning on.

### What changed

`resolveVersion` asks discovery for the group version and takes the first entry in `vapVersions` that serves both policies and bindings, ordered `v1`, `v1beta1`, `v1alpha1` to follow v1 in 1.30, v1beta1 in 1.28 and v1alpha1 in 1.26. Checking both resources is the part that matters, because the group on older clusters carries webhook configurations only and version presence on its own says nothing about VAPs. Picking up a future version is one entry in that slice.

`ErrUnsupported` carries the not served case back to the caller, and a `NotFound` from the list maps onto it as well, which covers discovery and API server routing disagreeing. Everything else keeps its error, wrapped with the GVR being read so the message names the resource and version that failed. A nil discovery client still assumes `v1`, so the callers that build a `KubernetesApi` without one behave as they did.

Both call sites in `k8sresources.go` held the same collect and log block, one guarding `k8s` for nil and the other not. They now share `collectVAPResources`, which does the nil check in one place, logs an unsupported cluster at debug, and warns only on a genuine failure.

### Tests

`TestResolveVersion_*` cover the version preference, the fallback to each older version, a group serving webhook configurations only, bindings missing while policies are served, an empty group list, and the nil discovery client. `TestCollect_ReadsFromServedVersion` pulls a policy through the `v1beta1` fallback, and `TestCollect_UnsupportedClusterIsNotAFailure` pins the sentinel so the skip path cannot regress into a warning.

Verified with `go build ./...`, `go vet ./...` and `go test ./core/... ./cmd/... ./pkg/...`, all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection of ValidatingAdmissionPolicies across supported Kubernetes API versions.
  * Clusters without a compatible policy API are now skipped without disrupting scans.
  * Collection failures are handled more reliably while successful policy and binding data continues to be recorded.

* **Tests**
  * Added coverage for API version selection, fallback behavior, unsupported clusters, and resource collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->