### PR TITLE
fix(ksinit): resolve the kubeconfig home directory with os.UserHomeDir

### DIFF
--- a/pkg/ksinit/ksinit.go
+++ b/pkg/ksinit/ksinit.go
@@ -18,10 +18,19 @@ func CreateKsObjectConnection(namespace string, maxElapsedTime time.Duration) (s
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
 		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
-		home := os.Getenv("HOME")
-		kubeconfigPath := filepath.Join(home, ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
+		// os.UserHomeDir resolves USERPROFILE on Windows (where HOME is
+		// normally not set at all) and reports an error when there is no home
+		// directory to resolve. Reading os.Getenv("HOME") instead left the
+		// home path empty, so filepath.Join produced the relative path
+		// ".kube/config" and the lookup silently became relative to the
+		// current working directory. Skip the file-based lookup entirely when
+		// there is no home directory and fall back to the in-cluster
+		// configuration, as before.
+		home, homeErr := os.UserHomeDir()
+		if homeErr == nil {
+			cfg, err = clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
+		}
+		if homeErr != nil || err != nil {
 			cfg, err = rest.InClusterConfig()
 		}
 	}

--- a/pkg/ksinit/ksinit_test.go
+++ b/pkg/ksinit/ksinit_test.go
@@ -56,10 +56,64 @@ func TestCreateKsObjectConnectionReturnsKubeconfigErrors(t *testing.T) {
 }
 
 func TestCreateKsObjectConnectionSuccess(t *testing.T) {
-	validKubeconfig := `apiVersion: v1
+	configPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(configPath, []byte(kubeconfigForServer("https://127.0.0.1:6443")), 0600))
+	t.Setenv("KUBECONFIG", configPath)
+
+	got, err := CreateKsObjectConnection("default", time.Second)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+// TestCreateKsObjectConnectionUsesHomeKubeconfig covers the default lookup:
+// with no KUBECONFIG set, the kubeconfig under the home directory is used.
+func TestCreateKsObjectConnectionUsesHomeKubeconfig(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".kube"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".kube", "config"), []byte(kubeconfigForServer("https://127.0.0.1:6443")), 0600))
+
+	t.Setenv("KUBECONFIG", "")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	got, err := CreateKsObjectConnection("default", time.Second)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "127.0.0.1:6443", got.RESTClient().Get().URL().Host)
+}
+
+// TestCreateKsObjectConnectionIgnoresWorkingDirectoryKubeconfig guards against
+// resolving the home kubeconfig to the relative path ".kube/config" when the
+// home directory is unknown (HOME unset on unix, and never set on Windows).
+// That made the lookup relative to the current working directory, so a
+// kubeconfig dropped next to the scanned files was silently used to reach an
+// arbitrary API server. Without a home directory the in-cluster configuration
+// is the only remaining source.
+func TestCreateKsObjectConnectionIgnoresWorkingDirectoryKubeconfig(t *testing.T) {
+	workdir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workdir, ".kube"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, ".kube", "config"), []byte(kubeconfigForServer("https://untrusted.example:6443")), 0600))
+	t.Chdir(workdir)
+
+	t.Setenv("KUBECONFIG", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	got, err := CreateKsObjectConnection("default", time.Second)
+
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "KUBERNETES_SERVICE_HOST")
+}
+
+func kubeconfigForServer(server string) string {
+	return `apiVersion: v1
 clusters:
 - cluster:
-    server: https://127.0.0.1:6443
+    server: ` + server + `
   name: test-cluster
 contexts:
 - context:
@@ -72,13 +126,4 @@ preferences: {}
 users:
 - name: test-user
   user: {}`
-
-	configPath := filepath.Join(t.TempDir(), "kubeconfig")
-	require.NoError(t, os.WriteFile(configPath, []byte(validKubeconfig), 0600))
-	t.Setenv("KUBECONFIG", configPath)
-
-	got, err := CreateKsObjectConnection("default", time.Second)
-
-	require.NoError(t, err)
-	require.NotNil(t, got)
 }


### PR DESCRIPTION
## Overview

`CreateKsObjectConnection` in `pkg/ksinit/ksinit.go` is the shared kubeconfig resolver used by `kubescape mcpserver` (`cmd/mcpserver/storage.go`) and the HTTP API server (`httphandler/main.go`). When no `KUBECONFIG` is set, it resolved the home kubeconfig like this:

```go
home := os.Getenv("HOME")
kubeconfigPath := filepath.Join(home, ".kube", "config")
cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
if err != nil {
    cfg, err = rest.InClusterConfig()
}
```

**Problem.** `os.Getenv("HOME")` returns `""` when `HOME` is unset. `filepath.Join("", ".kube", "config")` then yields the *relative* path `.kube/config`, which is resolved against the process working directory. If a `.kube/config` happens to exist in the directory kubescape was started from, it is loaded silently and successfully, and the client connects to the API server named in that file using the credentials it carries.

This is not purely theoretical. `HOME` is normally not set on Windows at all — where the home directory lives in `USERPROFILE` — so this is the default lookup on that platform rather than an edge case, and kubescape ships Windows binaries. It can also occur under systemd units and some service-account contexts on unix. The defect stayed hidden because the relative file usually does not exist, in which case the in-cluster fallback took over; it only manifests when a kubeconfig is present in the working directory, and then it succeeds rather than erroring. Since kubescape is commonly run from inside a checked-out repository, a `.kube/config` committed to that tree lands on this path.

**Expected behavior.** Resolve the home directory with `os.UserHomeDir()`, which reads `USERPROFILE` on Windows and returns an explicit error when no home directory can be determined. When there is no home directory, skip the file-based lookup entirely and fall back to the in-cluster configuration as before. A kubeconfig in the current working directory is never consulted.

**Actual behavior before this change.** With a `.kube/config` pointing at `https://untrusted.example:6443` in the working directory, and `HOME`, `KUBECONFIG` and `KUBERNETES_SERVICE_*` unset:

```
connected to API server: untrusted.example:6443
```

After the change, under identical conditions:

```
error: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```

## Root cause

`os.Getenv` cannot distinguish "no home directory" from "home directory is the empty string", and `filepath.Join` builds a relative path from the empty string without complaint. The existing `if err != nil { rest.InClusterConfig() }` fallback only triggers when the relative read *fails*, so a working-directory kubeconfig is used instead of being rejected.

## Fix

```go
home, homeErr := os.UserHomeDir()
if homeErr == nil {
    cfg, err = clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
}
if homeErr != nil || err != nil {
    cfg, err = rest.InClusterConfig()
}
```

No input can now produce a relative path reaching `BuildConfigFromFlags`. Routing the no-home case to the in-cluster fallback, rather than returning the `os.UserHomeDir` error, is deliberate: `httphandler` runs in-cluster where `HOME` may legitimately be unset, and failing hard there would be a regression.

## Regression test

Added to `pkg/ksinit/ksinit_test.go`:

- **`TestCreateKsObjectConnectionIgnoresWorkingDirectoryKubeconfig`** — plants a decoy `.kube/config` in a temporary working directory (`t.Chdir`), clears `HOME`, `USERPROFILE`, `KUBECONFIG` and `KUBERNETES_SERVICE_*`, and asserts that no client is built. **This test fails on the pre-fix implementation** (a client is returned, pointed at the decoy's server) **and passes after the fix.** It asserts on the in-cluster error, so it also confirms the fallback is still reached.
- **`TestCreateKsObjectConnectionUsesHomeKubeconfig`** — positive coverage the package previously lacked: with `HOME` set, the resolved client must point at the home kubeconfig's server. This prevents the guard above from being satisfied by over-correcting. It passes both before and after the change.

The inline kubeconfig fixture was extracted into a `kubeconfigForServer(server)` helper now shared by three tests.

## Validation

Run locally and passing:

- `go build ./...` for `linux/amd64` and `GOOS=windows GOARCH=amd64`
- `go vet ./pkg/ksinit/...` for both platforms
- `go test -race -count=1 ./pkg/ksinit/...`
- `go test -race -count=1 ./cmd/mcpserver/...`
- `cd httphandler && go build ./... && go test ./...` — all 5 packages pass
- `gofmt -l pkg/ksinit/` — clean
- `golangci-lint run --timeout 10m ./pkg/ksinit/...` using the repository `.golangci.yml` — 0 issues
- `go test -count=1 ./...` on the main module — 51 packages pass

One **pre-existing, unrelated failure**: `TestExcludeFilesUnderDirectories` in `core/pkg/resourcehandler` fails on macOS. It fails identically on an unmodified tree and does not involve `pkg/ksinit`.

Behavior on unaffected paths was compared before and after and is identical: `KUBECONFIG` set explicitly, `HOME` set with a home kubeconfig present, and `HOME` set with the home kubeconfig missing (in-cluster fallback).

Not run locally: the goreleaser cross-platform release build, `smoke_testing/init.py`, and the system-test dispatch in `00-pr_scanner.yaml` (requires repository secrets). Cross-compilation for Windows and both module test suites were run as the closest local equivalents.

## CI / E2E impact

Based on `.github/workflows/a-pr-scanner.yaml`, CI runs `go test -race ./...`, the `httphandler` module tests, a goreleaser cross-platform build, python smoke tests, and `golangci-lint`. The corresponding local checks listed above pass; CI itself has not been run for this change.

The E2E and system tests drive `kubescape scan`, which does not use `pkg/ksinit` — the only consumers are `mcpserver` and `httphandler`.

In-cluster behavior is preserved: a pod with `HOME` unset previously reached `rest.InClusterConfig()` after a failed relative-path read and now reaches it directly, with the same result and one fewer spurious file stat.

The new test uses `t.Chdir`, which requires Go >= 1.24; `go.mod` declares `go 1.26.0` and CI selects the toolchain via `go-version-file: go.mod`.

## Compatibility

- `KUBECONFIG` precedence unchanged.
- Home kubeconfig location (`$HOME/.kube/config`, now `%USERPROFILE%\.kube\config` on Windows) unchanged.
- In-cluster fallback preserved, including its ordering.
- No public API, configuration, flag, or generated-file changes.

## Files changed

```
pkg/ksinit/ksinit.go
pkg/ksinit/ksinit_test.go
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved kubeconfig discovery by using the user’s home directory.
  - Prevented unintended use of a `.kube/config` file in the current working directory when no home directory is available.
  - Falls back to in-cluster configuration when home-directory lookup is unavailable or unsuccessful.

- **Tests**
  - Added coverage for home-directory kubeconfig loading and in-cluster fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->