### PR TITLE
fix(decrypt): restore complete encrypted reports

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -1,22 +1,17 @@
 package decrypt
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
-	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
-	"github.com/kubescape/opa-utils/reporthandling"
-	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
-	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/spf13/cobra"
 )
 
 var decryptCmdExamples = `
   # The key is used as raw bytes and must be exactly 32 characters long.
   # Note: openssl rand -base64 32 (44 chars) and openssl rand -hex 32 (64 chars)
-  # are NOT valid — they exceed 32 bytes once passed through as raw text.
+  # are NOT valid because they exceed 32 bytes when passed as raw text.
   export KUBESCAPE_MASTER_KEY="01234567890123456789012345678901"
 
   # Decrypt an encrypted report
@@ -29,303 +24,30 @@ var decryptCmdExamples = `
 func GetDecryptCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "decrypt <report.json>",
-		Short: "Decrypt report metadata encrypted with kubescape scan --encrypt",
-		Long: `Decrypt report metadata using the KUBESCAPE_MASTER_KEY
-environment variable.
+		Short: "Decrypt a report produced by kubescape scan --encrypt",
+		Long: `Decrypt all encrypted report fields using KUBESCAPE_MASTER_KEY.
 
-The decrypted report is written to standard output and can be redirected
-to a file.`,
+The command restores metadata, resources, result raw resources, resource
+labels, and resource ID references. The decrypted report is written to
+standard output and can be redirected to a file.`,
 		Example: decryptCmdExamples,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			data, err := os.ReadFile(args[0])
 			if err != nil {
-				return fmt.Errorf(
-					"failed to read report %q: %w",
-					args[0],
-					err,
-				)
+				return fmt.Errorf("failed to read report %q: %w", args[0], err)
 			}
 
-			var report map[string]json.RawMessage
-
-			if err := json.Unmarshal(
-				data,
-				&report,
-			); err != nil {
-				return fmt.Errorf(
-					"failed to parse report: %w",
-					err,
-				)
-			}
-
-			metadataRaw, ok := report["metadata"]
-			if !ok {
-				return fmt.Errorf(
-					"report metadata not found",
-				)
-			}
-
-			var metadata reporthandlingv2.Metadata
-
-			if err := json.Unmarshal(
-				metadataRaw,
-				&metadata,
-			); err != nil {
-				return fmt.Errorf(
-					"failed to parse metadata: %w",
-					err,
-				)
-			}
-
-			dek, err := reportcrypto.DecryptMetadataFromEnv(
-				&metadata,
-			)
+			decrypted, err := reportcrypto.DecryptReportFromEnv(data)
 			if err != nil {
 				return err
 			}
 
-			defer func() {
-				for i := range dek {
-					dek[i] = 0
-				}
-			}()
-
-			updatedMetadata, err := json.Marshal(
-				metadata,
-			)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to marshal metadata: %w",
-					err,
-				)
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(decrypted)); err != nil {
+				return fmt.Errorf("failed to write decrypted report: %w", err)
 			}
 
-			report["metadata"] = updatedMetadata
-			resourcesRaw, ok := report["resources"]
-			if ok {
-				var resources []map[string]json.RawMessage
-
-				if err := json.Unmarshal(
-					resourcesRaw,
-					&resources,
-				); err != nil {
-					return fmt.Errorf(
-						"failed to parse resources: %w",
-						err,
-					)
-				}
-
-				idMapping := make(map[string]string)
-
-				for i := range resources {
-
-					var oldID string
-
-					if rawID, ok := resources[i]["resourceID"]; ok {
-						if err := json.Unmarshal(rawID, &oldID); err != nil {
-							return fmt.Errorf(
-								"failed to parse resourceID: %w",
-								err,
-							)
-						}
-					}
-
-					objectRaw, ok := resources[i]["object"]
-					if ok {
-						resource, err := workloadinterface.NewWorkload(
-							objectRaw,
-						)
-						if err != nil {
-							return fmt.Errorf(
-								"failed to parse resource object: %w",
-								err,
-							)
-						}
-						if err := reportcrypto.DecryptResourceMetadata(resource, dek); err != nil {
-							return err
-						}
-
-						if err := reportcrypto.DecryptResourceLabels(resource, dek); err != nil {
-							return err
-						}
-
-						if err := reportcrypto.DecryptResourceAnnotations(resource, dek); err != nil {
-							return err
-						}
-
-						if err := reportcrypto.DecryptResourceObjectSourcePath(resource, dek); err != nil {
-							return err
-						}
-
-						if err := reportcrypto.DecryptContainerMetadata(resource, dek); err != nil {
-							return err
-						}
-
-						newID := resource.GetID()
-						if oldID != "" {
-							idMapping[oldID] = newID
-						}
-
-						updatedID, err := json.Marshal(newID)
-						if err != nil {
-							return fmt.Errorf(
-								"failed to marshal resourceID: %w",
-								err,
-							)
-						}
-
-						resources[i]["resourceID"] = updatedID
-
-						updatedObject, err := json.Marshal(
-							resource.GetWorkload(),
-						)
-						if err != nil {
-							return fmt.Errorf(
-								"failed to marshal resource object: %w",
-								err,
-							)
-						}
-
-						resources[i]["object"] = updatedObject
-					}
-
-					sourceRaw, ok := resources[i]["source"]
-					if !ok {
-						continue
-					}
-
-					var source reporthandling.Source
-
-					if err := json.Unmarshal(
-						sourceRaw,
-						&source,
-					); err != nil {
-						return fmt.Errorf(
-							"failed to parse resource source: %w",
-							err,
-						)
-					}
-
-					if err := reportcrypto.DecryptResourceSource(
-						&source,
-						dek,
-					); err != nil {
-						return err
-					}
-
-					updatedSource, err := json.Marshal(
-						source,
-					)
-					if err != nil {
-						return fmt.Errorf(
-							"failed to marshal resource source: %w",
-							err,
-						)
-					}
-
-					resources[i]["source"] = updatedSource
-				}
-
-				updatedResources, err := json.Marshal(
-					resources,
-				)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to marshal resources: %w",
-						err,
-					)
-				}
-
-				report["resources"] = updatedResources
-				resultsRaw, ok := report["results"]
-				if ok {
-					var results []resourcesresults.Result
-					if err := json.Unmarshal(
-						resultsRaw,
-						&results,
-					); err != nil {
-						return fmt.Errorf(
-							"failed to parse results: %w",
-							err,
-						)
-					}
-
-					remapResults(results, idMapping)
-					updatedResults, err := json.Marshal(
-						results,
-					)
-					if err != nil {
-						return fmt.Errorf(
-							"failed to marshal results: %w",
-							err,
-						)
-					}
-
-					report["results"] = updatedResults
-				}
-			}
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "  ")
-
-			return encoder.Encode(report)
+			return nil
 		},
 	}
-}
-
-// remapResults restores all resource ID references that were rewritten
-// during encryption so they remain consistent with the decrypted resources.
-func remapResults(results []resourcesresults.Result, idMapping map[string]string) {
-	for i := range results {
-		results[i].ResourceID = remapResourceID(
-			results[i].ResourceID,
-			idMapping,
-		)
-
-		if results[i].PrioritizedResource != nil {
-			results[i].PrioritizedResource.ResourceID =
-				remapResourceID(
-					results[i].PrioritizedResource.ResourceID,
-					idMapping,
-				)
-		}
-
-		for controlIndex := range results[i].AssociatedControls {
-			for ruleIndex := range results[i].AssociatedControls[controlIndex].ResourceAssociatedRules {
-
-				rule := &results[i].AssociatedControls[controlIndex].ResourceAssociatedRules[ruleIndex]
-
-				for pathIndex := range rule.Paths {
-					rule.Paths[pathIndex].ResourceID =
-						remapResourceID(
-							rule.Paths[pathIndex].ResourceID,
-							idMapping,
-						)
-				}
-
-				for relatedIndex := range rule.RelatedResourcesIDs {
-					rule.RelatedResourcesIDs[relatedIndex] =
-						remapResourceID(
-							rule.RelatedResourcesIDs[relatedIndex],
-							idMapping,
-						)
-				}
-			}
-		}
-	}
-}
-
-// remapResourceID restores a resource ID if it was rewritten during
-// encryption. Unknown IDs are returned unchanged.
-func remapResourceID(
-	id string,
-	idMapping map[string]string,
-) string {
-
-	if mappedID, ok := idMapping[id]; ok {
-		return mappedID
-	}
-
-	return id
 }

--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -23,8 +23,9 @@ var decryptCmdExamples = `
 
 func GetDecryptCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "decrypt <report.json>",
-		Short: "Decrypt a report produced by kubescape scan --encrypt",
+		Use:          "decrypt <report.json>",
+		Short:        "Decrypt a report produced by kubescape scan --encrypt",
+		SilenceUsage: true,
 		Long: `Decrypt all encrypted report fields using KUBESCAPE_MASTER_KEY.
 
 The command restores metadata, resources, result raw resources, resource

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -3,6 +3,7 @@ package decrypt
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 
@@ -10,6 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
 
 func TestDecryptCommand(t *testing.T) {
 	tests := []struct {
@@ -155,7 +164,9 @@ func TestDecryptCommand(t *testing.T) {
 
 			report := map[string]any{
 				"resourceLabels": map[string]any{
-					"team": "platform",
+					"resource-1": map[string]any{
+						"team": encryptedLabel,
+					},
 				},
 				"scanCoverage": map[string]any{
 					"all": true,
@@ -237,6 +248,17 @@ func TestDecryptCommand(t *testing.T) {
 				"results": []map[string]any{
 					{
 						"resourceID": "resource-1",
+						"rawResource": map[string]any{
+							"resourceID": "resource-1",
+							"object": map[string]any{
+								"apiVersion": "apps/v1",
+								"kind":       "Deployment",
+								"metadata": map[string]any{
+									"name":      encryptedName,
+									"namespace": encryptedNamespace,
+								},
+							},
+						},
 						"prioritizedResource": map[string]any{
 							"resourceID": "resource-1",
 						},
@@ -291,35 +313,15 @@ func TestDecryptCommand(t *testing.T) {
 				string(masterKey),
 			)
 
-			oldStdout := os.Stdout
-
-			r, w, err := os.Pipe()
-			require.NoError(t, err)
-
-			os.Stdout = w
-
-			defer func() {
-				os.Stdout = oldStdout
-			}()
-
-			defer func() {
-				_ = w.Close()
-			}()
-
 			cmd := GetDecryptCommand()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
 
 			err = cmd.RunE(
 				cmd,
 				[]string{tmp.Name()},
 			)
 
-			require.NoError(t, err)
-
-			require.NoError(t, w.Close())
-
-			var buf bytes.Buffer
-
-			_, err = buf.ReadFrom(r)
 			require.NoError(t, err)
 
 			var output map[string]any
@@ -370,6 +372,14 @@ func TestDecryptCommand(t *testing.T) {
 			result, ok := results[0].(map[string]any)
 			require.True(t, ok, "result should be an object")
 			assert.Equal(t, resourceID, result["resourceID"])
+
+			rawResource, ok := result["rawResource"].(map[string]any)
+			require.True(t, ok, "rawResource should be an object")
+			assert.Equal(t, resourceID, rawResource["resourceID"])
+			rawObject := rawResource["object"].(map[string]any)
+			rawMetadata := rawObject["metadata"].(map[string]any)
+			assert.Equal(t, "nginx-deployment", rawMetadata["name"])
+			assert.Equal(t, "production", rawMetadata["namespace"])
 
 			prioritized, ok := result["prioritizedResource"].(map[string]any)
 			require.True(t, ok, "prioritizedResource should be an object")
@@ -487,6 +497,55 @@ func TestDecryptCommand(t *testing.T) {
 
 			require.Len(t, related, 1)
 			assert.Equal(t, resourceID, related[0])
+
+			resourceLabels := output["resourceLabels"].(map[string]any)
+			restoredLabels, ok := resourceLabels[resourceID].(map[string]any)
+			require.True(t, ok, "resourceLabels should use the restored resource ID")
+			assert.Equal(t, "backend", restoredLabels["team"])
 		})
 	}
+}
+
+func TestDecryptCommandReturnsReadError(t *testing.T) {
+	cmd := GetDecryptCommand()
+	err := cmd.RunE(cmd, []string{"/path/that/does/not/exist/report.json"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read report")
+	assert.Contains(t, err.Error(), "report.json")
+}
+
+func TestDecryptCommandReturnsWriteError(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+	masterKey := []byte("12345678901234567890123456789012")
+	wrappedDEK, err := reportcrypto.WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	report := map[string]any{
+		"metadata": map[string]any{
+			"encryptionMetadata": map[string]any{
+				"encryptedDEK": wrappedDEK,
+			},
+		},
+	}
+	data, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	tmp, err := os.CreateTemp("", "encrypted-write-error-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	t.Setenv("KUBESCAPE_MASTER_KEY", string(masterKey))
+	wantErr := errors.New("output unavailable")
+	cmd := GetDecryptCommand()
+	cmd.SetOut(failingWriter{err: wantErr})
+
+	err = cmd.RunE(cmd, []string{tmp.Name()})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "failed to write decrypted report")
 }

--- a/cmd/decrypt/decrypt_test.go
+++ b/cmd/decrypt/decrypt_test.go
@@ -20,6 +20,10 @@ func (w failingWriter) Write(_ []byte) (int, error) {
 	return 0, w.err
 }
 
+func TestDecryptCommandSilencesUsageForRuntimeErrors(t *testing.T) {
+	assert.True(t, GetDecryptCommand().SilenceUsage)
+}
+
 func TestDecryptCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -22,11 +22,8 @@ func applyWithTransformer(
 		return nil
 	}
 
-	mapping := NewMapping()
-
 	if err := transformSession(
 		resultsHandler.ScanData,
-		mapping,
 		transformer,
 	); err != nil {
 		return err

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -22,8 +22,11 @@ func applyWithTransformer(
 		return nil
 	}
 
+	mapping := NewMapping()
+
 	if err := transformSession(
 		resultsHandler.ScanData,
+		mapping,
 		transformer,
 	); err != nil {
 		return err

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -17,7 +17,7 @@ import (
 // transformSession applies the supplied Transformer to sensitive resource
 // identifiers and metadata while preserving referential integrity across
 // the full OPA session.
-func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transformer Transformer) error {
+func transformSession(session *cautils.OPASessionObj, transformer Transformer) error {
 	if session == nil {
 		return nil
 	}
@@ -65,7 +65,10 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 
 	newResourcesResult := make(map[string]resourcesresults.Result, len(session.ResourcesResult))
 	for oldID, result := range session.ResourcesResult {
-		newID := resolveMappedID(mapping, idMapping, oldID, "ref")
+		newID, err := resolveMappedID(transformer, idMapping, oldID, "ref")
+		if err != nil {
+			return err
+		}
 		result.ResourceID = newID
 
 		if result.PrioritizedResource != nil {
@@ -77,21 +80,29 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 				rule := &result.AssociatedControls[controlIndex].ResourceAssociatedRules[ruleIndex]
 
 				for pathIndex := range rule.Paths {
-					rule.Paths[pathIndex].ResourceID = resolveMappedID(
-						mapping,
+					mappedID, err := resolveMappedID(
+						transformer,
 						idMapping,
 						rule.Paths[pathIndex].ResourceID,
 						"ref",
 					)
+					if err != nil {
+						return err
+					}
+					rule.Paths[pathIndex].ResourceID = mappedID
 				}
 
 				for relatedIndex := range rule.RelatedResourcesIDs {
-					rule.RelatedResourcesIDs[relatedIndex] = resolveMappedID(
-						mapping,
+					mappedID, err := resolveMappedID(
+						transformer,
 						idMapping,
 						rule.RelatedResourcesIDs[relatedIndex],
 						"ref",
 					)
+					if err != nil {
+						return err
+					}
+					rule.RelatedResourcesIDs[relatedIndex] = mappedID
 				}
 			}
 		}
@@ -103,7 +114,10 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 	newResourceSource := make(map[string]reporthandling.Source, len(session.ResourceSource))
 
 	for oldID, source := range session.ResourceSource {
-		newID := resolveMappedID(mapping, idMapping, oldID, "ref")
+		newID, err := resolveMappedID(transformer, idMapping, oldID, "ref")
+		if err != nil {
+			return err
+		}
 
 		if err := transformResourceSource(
 			&source,
@@ -118,7 +132,10 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 
 	newResourcesPrioritized := make(map[string]prioritization.PrioritizedResource, len(session.ResourcesPrioritized))
 	for oldID, prioritized := range session.ResourcesPrioritized {
-		newID := resolveMappedID(mapping, idMapping, oldID, "ref")
+		newID, err := resolveMappedID(transformer, idMapping, oldID, "ref")
+		if err != nil {
+			return err
+		}
 		prioritized.ResourceID = newID
 		newResourcesPrioritized[newID] = prioritized
 	}
@@ -126,7 +143,10 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 
 	newResourceAttackTracks := make(map[string]v1alpha1.IAttackTrack, len(session.ResourceAttackTracks))
 	for oldID, attackTrack := range session.ResourceAttackTracks {
-		newID := resolveMappedID(mapping, idMapping, oldID, "ref")
+		newID, err := resolveMappedID(transformer, idMapping, oldID, "ref")
+		if err != nil {
+			return err
+		}
 		newResourceAttackTracks[newID] = attackTrack
 	}
 	session.ResourceAttackTracks = newResourceAttackTracks
@@ -156,12 +176,15 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 			remappedResourceIDs.Clear()
 
 			for oldID, status := range originalResourceIDs {
-				newID := resolveMappedID(
-					mapping,
+				newID, err := resolveMappedID(
+					transformer,
 					idMapping,
 					oldID,
 					"ref",
 				)
+				if err != nil {
+					return err
+				}
 
 				remappedResourceIDs.Append(
 					status,
@@ -178,15 +201,24 @@ func transformSession(session *cautils.OPASessionObj, mapping *Mapping, transfor
 
 // resolveMappedID preserves referential integrity when IDs are rewritten during
 // anonymization, ensuring cross-references remain valid.
-func resolveMappedID(mapping *Mapping, idMapping map[string]string, originalID, prefix string) string {
+func resolveMappedID(transformer Transformer, idMapping map[string]string, originalID, prefix string) (string, error) {
 
 	// Exact match (most common case)
 	if mappedID, ok := idMapping[originalID]; ok {
-		return mappedID
+		return mappedID, nil
 	}
 
-	// Fallback for IDs that are not backed by a resource object.
-	return mapping.GetOrCreate(prefix, originalID)
+	// IDs that are not backed by a resource object still need the active
+	// transformation. In encrypted reports this keeps the fallback reversible;
+	// in hidden reports the mapping transformer retains deterministic aliases.
+	// Cache the fallback so every reference to the same missing resource uses
+	// one value even when the transformer uses randomized encryption.
+	mappedID, err := transformer.Transform(prefix, originalID)
+	if err != nil {
+		return "", err
+	}
+	idMapping[originalID] = mappedID
+	return mappedID, nil
 }
 
 // transformResourceLabels applies the supplied Transformer to labels

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -17,7 +17,7 @@ import (
 // transformSession applies the supplied Transformer to sensitive resource
 // identifiers and metadata while preserving referential integrity across
 // the full OPA session.
-func transformSession(session *cautils.OPASessionObj, transformer Transformer) error {
+func transformSession(session *cautils.OPASessionObj, _ *Mapping, transformer Transformer) error {
 	if session == nil {
 		return nil
 	}

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -117,7 +117,7 @@ func TestResolveMappedIDReturnsFallbackTransformationError(t *testing.T) {
 func TestTransformSession_NilSession(t *testing.T) {
 	require.NoError(
 		t,
-		transformSession(nil, NewMappingTransformer()),
+		transformSession(nil, NewMapping(), NewMappingTransformer()),
 	)
 }
 
@@ -141,7 +141,7 @@ func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
 	}
 
-	err := transformSession(session, NewMappingTransformer())
+	err := transformSession(session, NewMapping(), NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, resource := range session.AllResources {
@@ -230,7 +230,7 @@ func TestTransformSession_IDConsistencyAcrossMaps(t *testing.T) {
 		},
 	}
 
-	err := transformSession(session, NewMappingTransformer())
+	err := transformSession(session, NewMapping(), NewMappingTransformer())
 	require.NoError(t, err)
 
 	var newID string
@@ -404,7 +404,7 @@ func TestTransformSession_LabelHandling(t *testing.T) {
 				LabelsToCopy:         test.labelsToCopy,
 			}
 
-			err := transformSession(session, NewMappingTransformer())
+			err := transformSession(session, NewMapping(), NewMappingTransformer())
 			require.NoError(t, err)
 
 			for _, resource := range session.AllResources {
@@ -588,7 +588,7 @@ func TestTransformSession_Annotations(t *testing.T) {
 			}
 
 			assert.NotPanics(t, func() {
-				err := transformSession(session, NewMappingTransformer())
+				err := transformSession(session, NewMapping(), NewMappingTransformer())
 				require.NoError(t, err)
 			})
 
@@ -656,7 +656,7 @@ func TestTransformSession_RepoContextMetadata(t *testing.T) {
 		},
 	}
 
-	err := transformSession(session, NewMappingTransformer())
+	err := transformSession(session, NewMapping(), NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, repo := range []*reporthandlingv2.RepoContextMetadata{
@@ -989,6 +989,7 @@ func TestTransformSession_ResourceSourceEncryption(
 
 	err = transformSession(
 		session,
+		NewMapping(),
 		NewEncryptionTransformer(dek),
 	)
 	require.NoError(t, err)

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -76,19 +76,48 @@ func TestResolveMappedID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapping := NewMapping()
-			result := resolveMappedID(mapping, test.idMapping, test.original, "ref")
+			result, err := resolveMappedID(NewMappingTransformer(), test.idMapping, test.original, "ref")
+			require.NoError(t, err)
 			test.validate(t, result)
 		})
 	}
 }
 
-func TestTransformSession_NilSession(t *testing.T) {
-	mapping := NewMapping()
+func TestResolveMappedIDEncryptionFallbackIsReversible(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
 
+	original := "apps/v1/production/Deployment/payments-api"
+	idMapping := map[string]string{}
+	transformed, err := resolveMappedID(
+		NewEncryptionTransformer(dek),
+		idMapping,
+		original,
+		"ref",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, transformed, "ENC[AES256_GCM,")
+	assert.NotContains(t, transformed, "ref-")
+
+	restored, err := reportcrypto.DecryptString(transformed, dek)
+	require.NoError(t, err)
+	assert.Equal(t, original, restored)
+
+	repeated, err := resolveMappedID(NewEncryptionTransformer(dek), idMapping, original, "ref")
+	require.NoError(t, err)
+	assert.Equal(t, transformed, repeated)
+}
+
+func TestResolveMappedIDReturnsFallbackTransformationError(t *testing.T) {
+	_, err := resolveMappedID(&failingTransformer{}, map[string]string{}, "unknown-id", "ref")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transform failed")
+}
+
+func TestTransformSession_NilSession(t *testing.T) {
 	require.NoError(
 		t,
-		transformSession(nil, mapping, NewMappingTransformer()),
+		transformSession(nil, NewMappingTransformer()),
 	)
 }
 
@@ -112,9 +141,7 @@ func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
 	}
 
-	mapping := NewMapping()
-
-	err := transformSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, resource := range session.AllResources {
@@ -203,8 +230,7 @@ func TestTransformSession_IDConsistencyAcrossMaps(t *testing.T) {
 		},
 	}
 
-	mapping := NewMapping()
-	err := transformSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, NewMappingTransformer())
 	require.NoError(t, err)
 
 	var newID string
@@ -378,8 +404,7 @@ func TestTransformSession_LabelHandling(t *testing.T) {
 				LabelsToCopy:         test.labelsToCopy,
 			}
 
-			mapping := NewMapping()
-			err := transformSession(session, mapping, NewMappingTransformer())
+			err := transformSession(session, NewMappingTransformer())
 			require.NoError(t, err)
 
 			for _, resource := range session.AllResources {
@@ -562,10 +587,8 @@ func TestTransformSession_Annotations(t *testing.T) {
 				ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
 			}
 
-			mapping := NewMapping()
-
 			assert.NotPanics(t, func() {
-				err := transformSession(session, mapping, NewMappingTransformer())
+				err := transformSession(session, NewMappingTransformer())
 				require.NoError(t, err)
 			})
 
@@ -633,8 +656,7 @@ func TestTransformSession_RepoContextMetadata(t *testing.T) {
 		},
 	}
 
-	mapping := NewMapping()
-	err := transformSession(session, mapping, NewMappingTransformer())
+	err := transformSession(session, NewMappingTransformer())
 	require.NoError(t, err)
 
 	for _, repo := range []*reporthandlingv2.RepoContextMetadata{
@@ -967,7 +989,6 @@ func TestTransformSession_ResourceSourceEncryption(
 
 	err = transformSession(
 		session,
-		NewMapping(),
 		NewEncryptionTransformer(dek),
 	)
 	require.NoError(t, err)

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -80,6 +80,19 @@ func DecryptRepoContextMetadata(
 		}
 	}()
 
+	return decryptRepoContextMetadata(metadata, dek)
+}
+
+// decryptRepoContextMetadata performs the repository metadata portion
+// of report decryption with an already unwrapped data-encryption key. Keeping
+// this internal avoids unwrapping the same key twice during whole-report
+// decryption while the exported helper retains its existing master-key API.
+func decryptRepoContextMetadata(metadata *reporthandlingv2.Metadata, dek []byte) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata is nil")
+	}
+	var err error
+
 	repoMetadata :=
 		metadata.ContextMetadata.RepoContextMetadata
 

--- a/core/pkg/reportcrypto/decrypt_env.go
+++ b/core/pkg/reportcrypto/decrypt_env.go
@@ -27,10 +27,7 @@ func DecryptMetadataFromEnv(
 		return nil, err
 	}
 
-	if err := DecryptRepoContextMetadata(
-		metadata,
-		masterKey,
-	); err != nil {
+	if err := decryptRepoContextMetadata(metadata, dek); err != nil {
 		for i := range dek {
 			dek[i] = 0
 		}

--- a/core/pkg/reportcrypto/report.go
+++ b/core/pkg/reportcrypto/report.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -62,7 +63,14 @@ func DecryptReport(data, masterKey []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if err := decryptor.remapResources(); err != nil {
+		return nil, err
+	}
+
 	if err := decryptor.decryptResourceLabels(); err != nil {
+		return nil, err
+	}
+	if err := decryptor.validateNoEncryptedValues(); err != nil {
 		return nil, err
 	}
 
@@ -86,6 +94,8 @@ func DecryptReportFromEnv(data []byte) ([]byte, error) {
 	return DecryptReport(data, masterKey)
 }
 
+// decryptMetadata unwraps the report DEK and restores repository metadata
+// while retaining fields that are unknown to this Kubescape version.
 func (d *reportDecryptor) decryptMetadata() error {
 	metadataRaw, ok := d.report["metadata"]
 	if !ok || isJSONNull(metadataRaw) {
@@ -137,6 +147,8 @@ func (d *reportDecryptor) decryptMetadata() error {
 	return nil
 }
 
+// decryptResources restores resource objects and records every resource ID
+// mapping that can be derived from a complete Kubernetes object.
 func (d *reportDecryptor) decryptResources() error {
 	resourcesRaw, ok := d.report["resources"]
 	if !ok || isJSONNull(resourcesRaw) {
@@ -168,6 +180,8 @@ func (d *reportDecryptor) decryptResources() error {
 	return nil
 }
 
+// decryptResults restores all raw resource copies before remapping result
+// references, ensuring mappings discovered later in the section are visible.
 func (d *reportDecryptor) decryptResults() error {
 	resultsRaw, ok := d.report["results"]
 	if !ok || isJSONNull(resultsRaw) {
@@ -220,6 +234,8 @@ func (d *reportDecryptor) decryptResults() error {
 	return nil
 }
 
+// decryptResource restores one resource copy. Objectless and malformed
+// resources keep their original ID until the report-wide remap pass.
 func (d *reportDecryptor) decryptResource(resource rawObject, context string) (string, string, error) {
 	oldID, _, err := optionalString(resource, "resourceID", context+".resourceID")
 	if err != nil {
@@ -231,7 +247,7 @@ func (d *reportDecryptor) decryptResource(resource rawObject, context string) (s
 		if err := d.decryptSource(resource, context); err != nil {
 			return "", "", err
 		}
-		return oldID, d.remapResourceID(oldID), nil
+		return oldID, "", nil
 	}
 
 	workload, err := workloadinterface.NewWorkload(objectRaw)
@@ -255,12 +271,19 @@ func (d *reportDecryptor) decryptResource(resource rawObject, context string) (s
 		return "", "", fmt.Errorf("failed to decrypt %s containers: %w", context, err)
 	}
 
-	newID := workload.GetID()
 	updatedObject, err := json.Marshal(workload.GetWorkload())
 	if err != nil {
 		return "", "", fmt.Errorf("failed to marshal %s.object: %w", context, err)
 	}
 	resource["object"] = updatedObject
+	if !hasUsableWorkloadID(workload) {
+		if err := d.decryptSource(resource, context); err != nil {
+			return "", "", err
+		}
+		return oldID, "", nil
+	}
+
+	newID := workload.GetID()
 
 	if oldID != "" || newID != "" {
 		resource["resourceID"], err = json.Marshal(newID)
@@ -276,6 +299,7 @@ func (d *reportDecryptor) decryptResource(resource rawObject, context string) (s
 	return oldID, newID, nil
 }
 
+// decryptSource restores a resource source without discarding unknown fields.
 func (d *reportDecryptor) decryptSource(resource rawObject, context string) error {
 	sourceRaw, ok := resource["source"]
 	if !ok || isJSONNull(sourceRaw) {
@@ -315,6 +339,8 @@ func (d *reportDecryptor) decryptSource(resource rawObject, context string) erro
 	return nil
 }
 
+// recordResourceID adds an observed encrypted-to-plaintext ID relationship and
+// rejects contradictory copies of the same resource.
 func (d *reportDecryptor) recordResourceID(oldID, newID, context string) error {
 	if oldID == "" || newID == "" || oldID == newID {
 		return nil
@@ -327,6 +353,7 @@ func (d *reportDecryptor) recordResourceID(oldID, newID, context string) error {
 	return nil
 }
 
+// remapResult rewrites every resource ID reference reachable from one result.
 func (d *reportDecryptor) remapResult(result rawObject, resultIndex int) error {
 	context := fmt.Sprintf("results[%d]", resultIndex)
 	if err := d.remapStringField(result, "resourceID", context+".resourceID"); err != nil {
@@ -402,6 +429,33 @@ func (d *reportDecryptor) remapResult(result rawObject, resultIndex int) error {
 	return nil
 }
 
+// remapResources gives objectless resource entries a final remap after result
+// raw resources have populated the report-wide ID mapping.
+func (d *reportDecryptor) remapResources() error {
+	resourcesRaw, ok := d.report["resources"]
+	if !ok || isJSONNull(resourcesRaw) {
+		return nil
+	}
+
+	resources, err := decodeObjectArray(resourcesRaw, "resources")
+	if err != nil {
+		return err
+	}
+	for i := range resources {
+		context := fmt.Sprintf("resources[%d].resourceID", i)
+		if err := d.remapStringField(resources[i], "resourceID", context); err != nil {
+			return err
+		}
+	}
+
+	d.report["resources"], err = json.Marshal(resources)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resources: %w", err)
+	}
+	return nil
+}
+
+// remapRule restores resource IDs in rule paths and related-resource lists.
 func (d *reportDecryptor) remapRule(rule rawObject, context string) error {
 	pathsRaw, ok := rule["paths"]
 	if ok && !isJSONNull(pathsRaw) {
@@ -430,7 +484,14 @@ func (d *reportDecryptor) remapRule(rule rawObject, context string) error {
 		return fmt.Errorf("failed to parse %s.relatedResourcesIDs: %w", context, err)
 	}
 	for i := range related {
-		related[i] = d.remapResourceID(related[i])
+		restored, err := d.remapResourceID(
+			related[i],
+			fmt.Sprintf("%s.relatedResourcesIDs[%d]", context, i),
+		)
+		if err != nil {
+			return err
+		}
+		related[i] = restored
 	}
 	updatedRelated, err := json.Marshal(related)
 	if err != nil {
@@ -441,6 +502,8 @@ func (d *reportDecryptor) remapRule(rule rawObject, context string) error {
 	return nil
 }
 
+// decryptResourceLabels restores copied label values and moves each label set
+// under the corresponding plaintext resource ID.
 func (d *reportDecryptor) decryptResourceLabels() error {
 	labelsRaw, ok := d.report["resourceLabels"]
 	if !ok || isJSONNull(labelsRaw) {
@@ -478,7 +541,10 @@ func (d *reportDecryptor) decryptResourceLabels() error {
 			}
 		}
 
-		newID := d.remapResourceID(oldID)
+		newID, err := d.remapResourceID(oldID, context)
+		if err != nil {
+			return err
+		}
 		if existingRaw, exists := decryptedLabels[newID]; exists {
 			existing, err := decodeObject(existingRaw, fmt.Sprintf("resourceLabels[%q]", newID))
 			if err != nil {
@@ -506,25 +572,147 @@ func (d *reportDecryptor) decryptResourceLabels() error {
 	return nil
 }
 
+// remapStringField restores an optional string field containing a resource ID.
 func (d *reportDecryptor) remapStringField(object rawObject, field, context string) error {
 	value, ok, err := optionalString(object, field, context)
 	if err != nil || !ok {
 		return err
 	}
-	object[field], err = json.Marshal(d.remapResourceID(value))
+	value, err = d.remapResourceID(value, context)
+	if err != nil {
+		return err
+	}
+	object[field], err = json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s: %w", context, err)
 	}
 	return nil
 }
 
-func (d *reportDecryptor) remapResourceID(id string) string {
+// remapResourceID resolves an observed ID mapping or decrypts ciphertext
+// envelopes embedded directly in a resource ID.
+func (d *reportDecryptor) remapResourceID(id, context string) (string, error) {
 	if mapped, ok := d.idMapping[id]; ok {
-		return mapped
+		return mapped, nil
 	}
-	return id
+
+	restored, err := decryptEmbeddedCiphertexts(id, d.dek)
+	if err != nil {
+		return "", fmt.Errorf("failed to restore %s: %w", context, err)
+	}
+	if isIrreversibleResourceID(restored) {
+		return "", fmt.Errorf("cannot restore %s: irreversible resource ID pseudonym %q", context, restored)
+	}
+	return restored, nil
 }
 
+// decryptEmbeddedCiphertexts decrypts complete ENC envelopes without splitting
+// the surrounding resource ID, since base64 ciphertext may itself contain '/'.
+func decryptEmbeddedCiphertexts(value string, dek []byte) (string, error) {
+	if !strings.Contains(value, prefix) {
+		return value, nil
+	}
+
+	var restored strings.Builder
+	remainder := value
+	for {
+		start := strings.Index(remainder, prefix)
+		if start < 0 {
+			restored.WriteString(remainder)
+			break
+		}
+
+		restored.WriteString(remainder[:start])
+		payloadStart := start + len(prefix)
+		endOffset := strings.Index(remainder[payloadStart:], suffix)
+		if endOffset < 0 {
+			return "", fmt.Errorf("unterminated encrypted resource ID envelope")
+		}
+		end := payloadStart + endOffset + len(suffix)
+		envelope := remainder[start:end]
+		plaintext, err := DecryptString(envelope, dek)
+		if err != nil {
+			return "", fmt.Errorf("failed to decrypt embedded resource ID envelope: %w", err)
+		}
+		restored.WriteString(plaintext)
+		remainder = remainder[end:]
+	}
+
+	return restored.String(), nil
+}
+
+// isIrreversibleResourceID reports whether an ID uses the legacy one-way
+// ref-<hash> fallback that cannot be restored during decryption.
+func isIrreversibleResourceID(id string) bool {
+	if len(id) != len("ref-")+8 || !strings.HasPrefix(id, "ref-") {
+		return false
+	}
+	for _, character := range id[len("ref-"):] {
+		if !strings.ContainsRune("0123456789abcdef", character) {
+			return false
+		}
+	}
+	return true
+}
+
+// hasUsableWorkloadID guards against degenerate IDs such as "////" produced by
+// malformed or non-Kubernetes JSON objects.
+func hasUsableWorkloadID(workload workloadinterface.IMetadata) bool {
+	return workload != nil &&
+		strings.TrimSpace(workload.GetApiVersion()) != "" &&
+		strings.TrimSpace(workload.GetKind()) != "" &&
+		strings.TrimSpace(workload.GetName()) != ""
+}
+
+// validateNoEncryptedValues fails closed if any ciphertext remains outside the
+// intentionally wrapped DEK after all supported fields have been restored.
+func (d *reportDecryptor) validateNoEncryptedValues() error {
+	data, err := json.Marshal(d.report)
+	if err != nil {
+		return fmt.Errorf("failed to validate decrypted report: %w", err)
+	}
+
+	var report any
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("failed to validate decrypted report: %w", err)
+	}
+	if path, found := findEncryptedValue(report, "report"); found {
+		return fmt.Errorf("encrypted value remains at %s", path)
+	}
+	return nil
+}
+
+// findEncryptedValue recursively returns the path of the first ciphertext
+// envelope while exempting the wrapped DEK required by report metadata.
+func findEncryptedValue(value any, path string) (string, bool) {
+	if path == "report.metadata.encryptionMetadata.encryptedDEK" {
+		return "", false
+	}
+
+	switch current := value.(type) {
+	case map[string]any:
+		for key, child := range current {
+			if encryptedPath, found := findEncryptedValue(child, path+"."+key); found {
+				return encryptedPath, true
+			}
+		}
+	case []any:
+		for i, child := range current {
+			childPath := fmt.Sprintf("%s[%d]", path, i)
+			if encryptedPath, found := findEncryptedValue(child, childPath); found {
+				return encryptedPath, true
+			}
+		}
+	case string:
+		if strings.Contains(current, prefix) {
+			return path, true
+		}
+	}
+
+	return "", false
+}
+
+// optionalString decodes a nullable optional string field with path context.
 func optionalString(object rawObject, field, context string) (string, bool, error) {
 	raw, ok := object[field]
 	if !ok || isJSONNull(raw) {
@@ -537,6 +725,7 @@ func optionalString(object rawObject, field, context string) (string, bool, erro
 	return value, true, nil
 }
 
+// optionalObject decodes a nullable optional object field with path context.
 func optionalObject(parent rawObject, field, context string) (rawObject, bool, error) {
 	raw, ok := parent[field]
 	if !ok || isJSONNull(raw) {
@@ -549,6 +738,7 @@ func optionalObject(parent rawObject, field, context string) (rawObject, bool, e
 	return object, true, nil
 }
 
+// decodeObject parses a JSON object while rejecting null and non-object values.
 func decodeObject(data []byte, context string) (rawObject, error) {
 	var object rawObject
 	if err := json.Unmarshal(data, &object); err != nil {
@@ -560,6 +750,7 @@ func decodeObject(data []byte, context string) (rawObject, error) {
 	return object, nil
 }
 
+// decodeObjectArray parses a JSON array whose elements must be objects.
 func decodeObjectArray(data []byte, context string) ([]rawObject, error) {
 	var objects []rawObject
 	if err := json.Unmarshal(data, &objects); err != nil {
@@ -568,6 +759,11 @@ func decodeObjectArray(data []byte, context string) ([]rawObject, error) {
 	return objects, nil
 }
 
+// mergeKnownObject recursively overlays known object fields onto the original
+// object. Arrays and scalars are replaced rather than merged element by
+// element, which matches the currently supported string-array metadata and
+// source fields. Unknown fields inside future arrays of objects would not be
+// preserved by this helper.
 func mergeKnownObject(original, known rawObject, context string) (rawObject, error) {
 	for key, knownValue := range known {
 		originalValue, exists := original[key]
@@ -598,10 +794,14 @@ func mergeKnownObject(original, known rawObject, context string) (rawObject, err
 	return original, nil
 }
 
+// isJSONNull reports whether raw JSON contains a null value with optional
+// surrounding whitespace.
 func isJSONNull(data []byte) bool {
 	return bytes.Equal(bytes.TrimSpace(data), []byte("null"))
 }
 
+// zeroBytes overwrites sensitive key material before its backing slice is
+// released.
 func zeroBytes(data []byte) {
 	for i := range data {
 		data[i] = 0

--- a/core/pkg/reportcrypto/report.go
+++ b/core/pkg/reportcrypto/report.go
@@ -676,7 +676,7 @@ func (d *reportDecryptor) validateNoEncryptedValues() error {
 	if err := json.Unmarshal(data, &report); err != nil {
 		return fmt.Errorf("failed to validate decrypted report: %w", err)
 	}
-	if path, found := findEncryptedValue(report, "report"); found {
+	if path, found := findEncryptedValue(report, nil); found {
 		return fmt.Errorf("encrypted value remains at %s", path)
 	}
 	return nil
@@ -684,32 +684,64 @@ func (d *reportDecryptor) validateNoEncryptedValues() error {
 
 // findEncryptedValue recursively returns the path of the first ciphertext
 // envelope while exempting the wrapped DEK required by report metadata.
-func findEncryptedValue(value any, path string) (string, bool) {
-	if path == "report.metadata.encryptionMetadata.encryptedDEK" {
+func findEncryptedValue(value any, path []any) (string, bool) {
+	if isWrappedDEKPath(path) {
 		return "", false
 	}
 
 	switch current := value.(type) {
 	case map[string]any:
 		for key, child := range current {
-			if encryptedPath, found := findEncryptedValue(child, path+"."+key); found {
+			childPath := append(append([]any(nil), path...), key)
+			if encryptedPath, found := findEncryptedValue(child, childPath); found {
 				return encryptedPath, true
 			}
 		}
 	case []any:
 		for i, child := range current {
-			childPath := fmt.Sprintf("%s[%d]", path, i)
+			childPath := append(append([]any(nil), path...), i)
 			if encryptedPath, found := findEncryptedValue(child, childPath); found {
 				return encryptedPath, true
 			}
 		}
 	case string:
 		if strings.Contains(current, prefix) {
-			return path, true
+			return formatReportPath(path), true
 		}
 	}
 
 	return "", false
+}
+
+// isWrappedDEKPath matches the one allowed ciphertext location by structural
+// JSON segments so dotted object keys cannot forge the exemption.
+func isWrappedDEKPath(path []any) bool {
+	if len(path) != 3 {
+		return false
+	}
+	metadata, metadataOK := path[0].(string)
+	encryptionMetadata, encryptionMetadataOK := path[1].(string)
+	encryptedDEK, encryptedDEKOK := path[2].(string)
+	return metadataOK && encryptionMetadataOK && encryptedDEKOK &&
+		metadata == "metadata" &&
+		encryptionMetadata == "encryptionMetadata" &&
+		encryptedDEK == "encryptedDEK"
+}
+
+// formatReportPath renders structural path segments without treating dots in
+// JSON keys as nesting separators.
+func formatReportPath(path []any) string {
+	var formatted strings.Builder
+	formatted.WriteString("report")
+	for _, segment := range path {
+		switch segment := segment.(type) {
+		case string:
+			fmt.Fprintf(&formatted, "[%q]", segment)
+		case int:
+			fmt.Fprintf(&formatted, "[%d]", segment)
+		}
+	}
+	return formatted.String()
 }
 
 // optionalString decodes a nullable optional string field with path context.

--- a/core/pkg/reportcrypto/report.go
+++ b/core/pkg/reportcrypto/report.go
@@ -1,0 +1,609 @@
+package reportcrypto
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+// rawObject keeps report fields as raw JSON so decrypting a report does not
+// discard fields introduced by a newer Kubescape or backend version.
+type rawObject map[string]json.RawMessage
+
+// reportDecryptor owns the data-encryption key and the relationship between
+// encrypted resource IDs and the IDs reconstructed from decrypted resources.
+// A single instance is used for the complete report so every cross-reference
+// is rewritten consistently.
+type reportDecryptor struct {
+	dek       []byte
+	idMapping map[string]string
+	masterKey []byte
+	report    rawObject
+}
+
+// DecryptReport restores all fields encrypted by anonymizer.ApplyEncrypted.
+//
+// The operation is transactional from the caller's perspective. The input is
+// parsed and transformed entirely in memory, and bytes are returned only when
+// every encrypted field has been restored successfully. JSON fields unknown to
+// this Kubescape version are preserved.
+func DecryptReport(data, masterKey []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("report is empty")
+	}
+
+	report, err := decodeObject(data, "report")
+	if err != nil {
+		return nil, err
+	}
+
+	decryptor := &reportDecryptor{
+		idMapping: make(map[string]string),
+		masterKey: masterKey,
+		report:    report,
+	}
+	defer func() {
+		zeroBytes(decryptor.dek)
+	}()
+
+	if err := decryptor.decryptMetadata(); err != nil {
+		return nil, err
+	}
+
+	if err := decryptor.decryptResources(); err != nil {
+		return nil, err
+	}
+
+	if err := decryptor.decryptResults(); err != nil {
+		return nil, err
+	}
+
+	if err := decryptor.decryptResourceLabels(); err != nil {
+		return nil, err
+	}
+
+	decrypted, err := json.MarshalIndent(decryptor.report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal decrypted report: %w", err)
+	}
+
+	return decrypted, nil
+}
+
+// DecryptReportFromEnv restores a report using KUBESCAPE_MASTER_KEY.
+func DecryptReportFromEnv(data []byte) ([]byte, error) {
+	masterKey, err := GetMasterKeyFromEnv("decryption")
+	if err != nil {
+		return nil, err
+	}
+
+	defer zeroBytes(masterKey)
+
+	return DecryptReport(data, masterKey)
+}
+
+func (d *reportDecryptor) decryptMetadata() error {
+	metadataRaw, ok := d.report["metadata"]
+	if !ok || isJSONNull(metadataRaw) {
+		return fmt.Errorf("report metadata not found")
+	}
+
+	var metadata reporthandlingv2.Metadata
+	if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+		return fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	dek, err := DEKFromMetadata(&metadata, d.masterKey)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt report data key: %w", err)
+	}
+	d.dek = dek
+
+	if err := decryptRepoContextMetadata(&metadata, d.dek); err != nil {
+		return fmt.Errorf("failed to decrypt report metadata: %w", err)
+	}
+
+	// Marshal the known metadata shape, then recursively merge it into the
+	// original raw object. This updates decrypted values while retaining fields
+	// from future report schemas, including unknown fields inside lastCommit.
+	knownMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	original, err := decodeObject(metadataRaw, "metadata")
+	if err != nil {
+		return err
+	}
+	known, err := decodeObject(knownMetadata, "metadata")
+	if err != nil {
+		return err
+	}
+
+	merged, err := mergeKnownObject(original, known, "metadata")
+	if err != nil {
+		return err
+	}
+
+	d.report["metadata"], err = json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) decryptResources() error {
+	resourcesRaw, ok := d.report["resources"]
+	if !ok || isJSONNull(resourcesRaw) {
+		return nil
+	}
+
+	resources, err := decodeObjectArray(resourcesRaw, "resources")
+	if err != nil {
+		return err
+	}
+
+	for i := range resources {
+		context := fmt.Sprintf("resources[%d]", i)
+		oldID, newID, err := d.decryptResource(resources[i], context)
+		if err != nil {
+			return err
+		}
+
+		if err := d.recordResourceID(oldID, newID, context); err != nil {
+			return err
+		}
+	}
+
+	d.report["resources"], err = json.Marshal(resources)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resources: %w", err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) decryptResults() error {
+	resultsRaw, ok := d.report["results"]
+	if !ok || isJSONNull(resultsRaw) {
+		return nil
+	}
+
+	results, err := decodeObjectArray(resultsRaw, "results")
+	if err != nil {
+		return err
+	}
+
+	// Raw resources may be the only resource copies in reports emitted by the
+	// chunked reporter. Decrypt them first so their IDs are available when all
+	// result references are remapped in the second pass.
+	for i := range results {
+		context := fmt.Sprintf("results[%d].rawResource", i)
+		rawResource, ok, err := optionalObject(results[i], "rawResource", context)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+
+		oldID, newID, err := d.decryptResource(rawResource, context)
+		if err != nil {
+			return err
+		}
+		if err := d.recordResourceID(oldID, newID, context); err != nil {
+			return err
+		}
+
+		results[i]["rawResource"], err = json.Marshal(rawResource)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s: %w", context, err)
+		}
+	}
+
+	for i := range results {
+		if err := d.remapResult(results[i], i); err != nil {
+			return err
+		}
+	}
+
+	d.report["results"], err = json.Marshal(results)
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) decryptResource(resource rawObject, context string) (string, string, error) {
+	oldID, _, err := optionalString(resource, "resourceID", context+".resourceID")
+	if err != nil {
+		return "", "", err
+	}
+
+	objectRaw, hasObject := resource["object"]
+	if !hasObject || isJSONNull(objectRaw) {
+		if err := d.decryptSource(resource, context); err != nil {
+			return "", "", err
+		}
+		return oldID, d.remapResourceID(oldID), nil
+	}
+
+	workload, err := workloadinterface.NewWorkload(objectRaw)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse %s.object: %w", context, err)
+	}
+
+	if err := DecryptResourceMetadata(workload, d.dek); err != nil {
+		return "", "", fmt.Errorf("failed to decrypt %s metadata: %w", context, err)
+	}
+	if err := DecryptResourceLabels(workload, d.dek); err != nil {
+		return "", "", fmt.Errorf("failed to decrypt %s labels: %w", context, err)
+	}
+	if err := DecryptResourceAnnotations(workload, d.dek); err != nil {
+		return "", "", fmt.Errorf("failed to decrypt %s annotations: %w", context, err)
+	}
+	if err := DecryptResourceObjectSourcePath(workload, d.dek); err != nil {
+		return "", "", fmt.Errorf("failed to decrypt %s sourcePath: %w", context, err)
+	}
+	if err := DecryptContainerMetadata(workload, d.dek); err != nil {
+		return "", "", fmt.Errorf("failed to decrypt %s containers: %w", context, err)
+	}
+
+	newID := workload.GetID()
+	updatedObject, err := json.Marshal(workload.GetWorkload())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal %s.object: %w", context, err)
+	}
+	resource["object"] = updatedObject
+
+	if oldID != "" || newID != "" {
+		resource["resourceID"], err = json.Marshal(newID)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to marshal %s.resourceID: %w", context, err)
+		}
+	}
+
+	if err := d.decryptSource(resource, context); err != nil {
+		return "", "", err
+	}
+
+	return oldID, newID, nil
+}
+
+func (d *reportDecryptor) decryptSource(resource rawObject, context string) error {
+	sourceRaw, ok := resource["source"]
+	if !ok || isJSONNull(sourceRaw) {
+		return nil
+	}
+
+	var source reporthandling.Source
+	if err := json.Unmarshal(sourceRaw, &source); err != nil {
+		return fmt.Errorf("failed to parse %s.source: %w", context, err)
+	}
+	if err := DecryptResourceSource(&source, d.dek); err != nil {
+		return fmt.Errorf("failed to decrypt %s.source: %w", context, err)
+	}
+
+	knownSource, err := json.Marshal(source)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s.source: %w", context, err)
+	}
+	original, err := decodeObject(sourceRaw, context+".source")
+	if err != nil {
+		return err
+	}
+	known, err := decodeObject(knownSource, context+".source")
+	if err != nil {
+		return err
+	}
+	merged, err := mergeKnownObject(original, known, context+".source")
+	if err != nil {
+		return err
+	}
+
+	resource["source"], err = json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s.source: %w", context, err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) recordResourceID(oldID, newID, context string) error {
+	if oldID == "" || newID == "" || oldID == newID {
+		return nil
+	}
+
+	if existing, ok := d.idMapping[oldID]; ok && existing != newID {
+		return fmt.Errorf("%s maps resource ID %q to %q, already mapped to %q", context, oldID, newID, existing)
+	}
+	d.idMapping[oldID] = newID
+	return nil
+}
+
+func (d *reportDecryptor) remapResult(result rawObject, resultIndex int) error {
+	context := fmt.Sprintf("results[%d]", resultIndex)
+	if err := d.remapStringField(result, "resourceID", context+".resourceID"); err != nil {
+		return err
+	}
+
+	prioritized, ok, err := optionalObject(result, "prioritizedResource", context+".prioritizedResource")
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := d.remapStringField(prioritized, "resourceID", context+".prioritizedResource.resourceID"); err != nil {
+			return err
+		}
+		result["prioritizedResource"], err = json.Marshal(prioritized)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s.prioritizedResource: %w", context, err)
+		}
+	}
+
+	rawResource, ok, err := optionalObject(result, "rawResource", context+".rawResource")
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := d.remapStringField(rawResource, "resourceID", context+".rawResource.resourceID"); err != nil {
+			return err
+		}
+		result["rawResource"], err = json.Marshal(rawResource)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s.rawResource: %w", context, err)
+		}
+	}
+
+	controlsRaw, ok := result["controls"]
+	if !ok || isJSONNull(controlsRaw) {
+		return nil
+	}
+	controls, err := decodeObjectArray(controlsRaw, context+".controls")
+	if err != nil {
+		return err
+	}
+
+	for controlIndex := range controls {
+		controlContext := fmt.Sprintf("%s.controls[%d]", context, controlIndex)
+		rulesRaw, ok := controls[controlIndex]["rules"]
+		if !ok || isJSONNull(rulesRaw) {
+			continue
+		}
+		rules, err := decodeObjectArray(rulesRaw, controlContext+".rules")
+		if err != nil {
+			return err
+		}
+
+		for ruleIndex := range rules {
+			ruleContext := fmt.Sprintf("%s.rules[%d]", controlContext, ruleIndex)
+			if err := d.remapRule(rules[ruleIndex], ruleContext); err != nil {
+				return err
+			}
+		}
+
+		controls[controlIndex]["rules"], err = json.Marshal(rules)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s.rules: %w", controlContext, err)
+		}
+	}
+
+	result["controls"], err = json.Marshal(controls)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s.controls: %w", context, err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) remapRule(rule rawObject, context string) error {
+	pathsRaw, ok := rule["paths"]
+	if ok && !isJSONNull(pathsRaw) {
+		paths, err := decodeObjectArray(pathsRaw, context+".paths")
+		if err != nil {
+			return err
+		}
+		for pathIndex := range paths {
+			pathContext := fmt.Sprintf("%s.paths[%d].resourceID", context, pathIndex)
+			if err := d.remapStringField(paths[pathIndex], "resourceID", pathContext); err != nil {
+				return err
+			}
+		}
+		rule["paths"], err = json.Marshal(paths)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s.paths: %w", context, err)
+		}
+	}
+
+	relatedRaw, ok := rule["relatedResourcesIDs"]
+	if !ok || isJSONNull(relatedRaw) {
+		return nil
+	}
+	var related []string
+	if err := json.Unmarshal(relatedRaw, &related); err != nil {
+		return fmt.Errorf("failed to parse %s.relatedResourcesIDs: %w", context, err)
+	}
+	for i := range related {
+		related[i] = d.remapResourceID(related[i])
+	}
+	updatedRelated, err := json.Marshal(related)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s.relatedResourcesIDs: %w", context, err)
+	}
+	rule["relatedResourcesIDs"] = updatedRelated
+
+	return nil
+}
+
+func (d *reportDecryptor) decryptResourceLabels() error {
+	labelsRaw, ok := d.report["resourceLabels"]
+	if !ok || isJSONNull(labelsRaw) {
+		return nil
+	}
+
+	labelsByResource, err := decodeObject(labelsRaw, "resourceLabels")
+	if err != nil {
+		return err
+	}
+	decryptedLabels := make(rawObject, len(labelsByResource))
+
+	for oldID, rawLabels := range labelsByResource {
+		context := fmt.Sprintf("resourceLabels[%q]", oldID)
+		labels, err := decodeObject(rawLabels, context)
+		if err != nil {
+			return err
+		}
+
+		for key, rawValue := range labels {
+			if isJSONNull(rawValue) {
+				continue
+			}
+			var value string
+			if err := json.Unmarshal(rawValue, &value); err != nil {
+				return fmt.Errorf("failed to parse %s[%q]: %w", context, key, err)
+			}
+			value, err = decryptIfEncrypted(value, d.dek)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt %s[%q]: %w", context, key, err)
+			}
+			labels[key], err = json.Marshal(value)
+			if err != nil {
+				return fmt.Errorf("failed to marshal %s[%q]: %w", context, key, err)
+			}
+		}
+
+		newID := d.remapResourceID(oldID)
+		if existingRaw, exists := decryptedLabels[newID]; exists {
+			existing, err := decodeObject(existingRaw, fmt.Sprintf("resourceLabels[%q]", newID))
+			if err != nil {
+				return err
+			}
+			for key, value := range labels {
+				if existingValue, ok := existing[key]; ok && !bytes.Equal(existingValue, value) {
+					return fmt.Errorf("resourceLabels entries restored to resource ID %q with conflicting value for label %q", newID, key)
+				}
+				existing[key] = value
+			}
+			labels = existing
+		}
+		decryptedLabels[newID], err = json.Marshal(labels)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s: %w", context, err)
+		}
+	}
+
+	d.report["resourceLabels"], err = json.Marshal(decryptedLabels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resourceLabels: %w", err)
+	}
+
+	return nil
+}
+
+func (d *reportDecryptor) remapStringField(object rawObject, field, context string) error {
+	value, ok, err := optionalString(object, field, context)
+	if err != nil || !ok {
+		return err
+	}
+	object[field], err = json.Marshal(d.remapResourceID(value))
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", context, err)
+	}
+	return nil
+}
+
+func (d *reportDecryptor) remapResourceID(id string) string {
+	if mapped, ok := d.idMapping[id]; ok {
+		return mapped
+	}
+	return id
+}
+
+func optionalString(object rawObject, field, context string) (string, bool, error) {
+	raw, ok := object[field]
+	if !ok || isJSONNull(raw) {
+		return "", false, nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false, fmt.Errorf("failed to parse %s: %w", context, err)
+	}
+	return value, true, nil
+}
+
+func optionalObject(parent rawObject, field, context string) (rawObject, bool, error) {
+	raw, ok := parent[field]
+	if !ok || isJSONNull(raw) {
+		return nil, false, nil
+	}
+	object, err := decodeObject(raw, context)
+	if err != nil {
+		return nil, false, err
+	}
+	return object, true, nil
+}
+
+func decodeObject(data []byte, context string) (rawObject, error) {
+	var object rawObject
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", context, err)
+	}
+	if object == nil {
+		return nil, fmt.Errorf("failed to parse %s: expected an object", context)
+	}
+	return object, nil
+}
+
+func decodeObjectArray(data []byte, context string) ([]rawObject, error) {
+	var objects []rawObject
+	if err := json.Unmarshal(data, &objects); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", context, err)
+	}
+	return objects, nil
+}
+
+func mergeKnownObject(original, known rawObject, context string) (rawObject, error) {
+	for key, knownValue := range known {
+		originalValue, exists := original[key]
+		if !exists || isJSONNull(originalValue) || isJSONNull(knownValue) {
+			original[key] = knownValue
+			continue
+		}
+
+		var originalObject rawObject
+		var knownObject rawObject
+		originalObjectErr := json.Unmarshal(originalValue, &originalObject)
+		knownObjectErr := json.Unmarshal(knownValue, &knownObject)
+		if originalObjectErr != nil || knownObjectErr != nil || originalObject == nil || knownObject == nil {
+			original[key] = knownValue
+			continue
+		}
+
+		merged, err := mergeKnownObject(originalObject, knownObject, context+"."+key)
+		if err != nil {
+			return nil, err
+		}
+		original[key], err = json.Marshal(merged)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal %s.%s: %w", context, key, err)
+		}
+	}
+
+	return original, nil
+}
+
+func isJSONNull(data []byte) bool {
+	return bytes.Equal(bytes.TrimSpace(data), []byte("null"))
+}
+
+func zeroBytes(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
+}

--- a/core/pkg/reportcrypto/report_roundtrip_test.go
+++ b/core/pkg/reportcrypto/report_roundtrip_test.go
@@ -1,0 +1,165 @@
+package reportcrypto_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/anonymizer"
+	"github.com/kubescape/kubescape/v3/core/pkg/reportcrypto"
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncryptedReportProducerConsumerRoundTrip protects the contract between
+// anonymizer.ApplyEncrypted, ResultsHandler.ToJson, and DecryptReport. Unit
+// fixtures cover individual JSON shapes; this test ensures the real producer
+// and consumer continue to agree on transformed IDs and copied labels.
+func TestEncryptedReportProducerConsumerRoundTrip(t *testing.T) {
+	const masterKey = "01234567890123456789012345678901"
+
+	workload, err := workloadinterface.NewWorkload([]byte(`{
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"sourcePath": "/workspace/manifests/checkout.yaml:18",
+		"metadata": {
+			"name": "checkout",
+			"namespace": "production",
+			"labels": {
+				"team": "payments",
+				"environment": "production"
+			},
+			"annotations": {
+				"owner": "payments-on-call"
+			}
+		},
+		"spec": {
+			"template": {
+				"spec": {
+					"serviceAccountName": "checkout-service-account",
+					"imagePullSecrets": [{"name": "private-registry"}],
+					"containers": [{
+						"name": "checkout-api",
+						"image": "registry.example.com/checkout:v2",
+						"env": [{"name": "TOKEN", "value": "sensitive-value"}]
+					}]
+				}
+			}
+		}
+	}`))
+	require.NoError(t, err)
+	originalID := workload.GetID()
+
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			RepoContextMetadata: &reporthandlingv2.RepoContextMetadata{
+				Provider:      "github",
+				Repo:          "kubescape",
+				Owner:         "kubescape",
+				Branch:        "main",
+				DefaultBranch: "main",
+				RemoteURL:     "https://github.com/kubescape/kubescape.git",
+				LocalRootPath: "/workspace/kubescape",
+				LastCommit: reporthandling.LastCommit{
+					Hash:           "0123456789abcdef",
+					CommitterName:  "Kubescape Maintainer",
+					CommitterEmail: "maintainer@example.com",
+					Message:        "update checkout deployment",
+				},
+			},
+		},
+	}
+
+	result := resourcesresults.Result{
+		ResourceID: originalID,
+		PrioritizedResource: &prioritization.PrioritizedResource{
+			ResourceID: originalID,
+		},
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0010",
+				Name:      "Container Resources",
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{
+						Name:                "Resource limits",
+						RelatedResourcesIDs: []string{originalID},
+					},
+				},
+			},
+		},
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			originalID: workload,
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			originalID: result,
+		},
+		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
+			originalID: *result.PrioritizedResource,
+		},
+		ResourceSource: map[string]reporthandling.Source{
+			originalID: {
+				Path:         "/workspace/manifests/checkout.yaml",
+				RelativePath: "manifests/checkout.yaml",
+			},
+		},
+		Metadata:     metadata,
+		Report:       &reporthandlingv2.PostureReport{},
+		LabelsToCopy: []string{"team"},
+	}
+
+	handler := &resultshandling.ResultsHandler{ScanData: session}
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+	require.NoError(t, anonymizer.ApplyEncrypted(handler, dek, []byte(masterKey)))
+
+	encryptedJSON, err := handler.ToJson()
+	require.NoError(t, err)
+	assert.Contains(t, string(encryptedJSON), "ENC[AES256_GCM,")
+	assert.NotContains(t, string(encryptedJSON), `"name":"checkout"`)
+
+	decryptedJSON, err := reportcrypto.DecryptReport(encryptedJSON, []byte(masterKey))
+	require.NoError(t, err)
+
+	var report map[string]any
+	require.NoError(t, json.Unmarshal(decryptedJSON, &report))
+	resources := report["resources"].([]any)
+	require.Len(t, resources, 1)
+	resource := resources[0].(map[string]any)
+	assert.Equal(t, originalID, resource["resourceID"])
+	object := resource["object"].(map[string]any)
+	objectMetadata := object["metadata"].(map[string]any)
+	assert.Equal(t, "checkout", objectMetadata["name"])
+	assert.Equal(t, "production", objectMetadata["namespace"])
+	assert.Equal(t, "/workspace/manifests/checkout.yaml:18", object["sourcePath"])
+
+	results := report["results"].([]any)
+	require.Len(t, results, 1)
+	decryptedResult := results[0].(map[string]any)
+	assert.Equal(t, originalID, decryptedResult["resourceID"])
+	prioritized := decryptedResult["prioritizedResource"].(map[string]any)
+	assert.Equal(t, originalID, prioritized["resourceID"])
+	controls := decryptedResult["controls"].([]any)
+	rules := controls[0].(map[string]any)["rules"].([]any)
+	related := rules[0].(map[string]any)["relatedResourcesIDs"].([]any)
+	assert.Equal(t, originalID, related[0])
+
+	labelsByResource := report["resourceLabels"].(map[string]any)
+	require.Contains(t, labelsByResource, originalID)
+	labels := labelsByResource[originalID].(map[string]any)
+	assert.Equal(t, "payments", labels["team"])
+
+	decryptedMetadata := report["metadata"].(map[string]any)
+	target := decryptedMetadata["targetMetadata"].(map[string]any)
+	repository := target["gitRepoContextMetadata"].(map[string]any)
+	assert.Equal(t, "kubescape", repository["repo"])
+	assert.Equal(t, "https://github.com/kubescape/kubescape.git", repository["remoteURL"])
+}

--- a/core/pkg/reportcrypto/report_roundtrip_test.go
+++ b/core/pkg/reportcrypto/report_roundtrip_test.go
@@ -124,7 +124,13 @@ func TestEncryptedReportProducerConsumerRoundTrip(t *testing.T) {
 	encryptedJSON, err := handler.ToJson()
 	require.NoError(t, err)
 	assert.Contains(t, string(encryptedJSON), "ENC[AES256_GCM,")
-	assert.NotContains(t, string(encryptedJSON), `"name":"checkout"`)
+	var encryptedReport map[string]any
+	require.NoError(t, json.Unmarshal(encryptedJSON, &encryptedReport))
+	encryptedResources := encryptedReport["resources"].([]any)
+	encryptedObject := encryptedResources[0].(map[string]any)["object"].(map[string]any)
+	encryptedName := encryptedObject["metadata"].(map[string]any)["name"].(string)
+	assert.NotEqual(t, "checkout", encryptedName)
+	assert.Contains(t, encryptedName, "ENC[AES256_GCM,")
 
 	decryptedJSON, err := reportcrypto.DecryptReport(encryptedJSON, []byte(masterKey))
 	require.NoError(t, err)
@@ -162,4 +168,98 @@ func TestEncryptedReportProducerConsumerRoundTrip(t *testing.T) {
 	repository := target["gitRepoContextMetadata"].(map[string]any)
 	assert.Equal(t, "kubescape", repository["repo"])
 	assert.Equal(t, "https://github.com/kubescape/kubescape.git", repository["remoteURL"])
+}
+
+func TestEncryptedReportRoundTripWithoutRawResources(t *testing.T) {
+	const masterKey = "01234567890123456789012345678901"
+
+	workload, err := workloadinterface.NewWorkload([]byte(`{
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"metadata": {
+			"name": "checkout",
+			"namespace": "production",
+			"labels": {"team": "payments"}
+		},
+		"spec": {
+			"template": {
+				"spec": {
+					"containers": [{"name": "api", "image": "checkout:v2"}]
+				}
+			}
+		}
+	}`))
+	require.NoError(t, err)
+	originalID := workload.GetID()
+	relatedID := "apps/v1/production/Deployment/payments-worker"
+
+	result := resourcesresults.Result{
+		ResourceID: originalID,
+		PrioritizedResource: &prioritization.PrioritizedResource{
+			ResourceID: originalID,
+		},
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0010",
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{
+						Name:                "Related workload",
+						RelatedResourcesIDs: []string{relatedID},
+					},
+				},
+			},
+		},
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			originalID: workload,
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			originalID: result,
+		},
+		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
+			originalID: *result.PrioritizedResource,
+		},
+		ResourceSource:   map[string]reporthandling.Source{},
+		Metadata:         &reporthandlingv2.Metadata{},
+		Report:           &reporthandlingv2.PostureReport{},
+		LabelsToCopy:     []string{"team"},
+		OmitRawResources: true,
+	}
+
+	handler := &resultshandling.ResultsHandler{ScanData: session}
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+	require.NoError(t, anonymizer.ApplyEncrypted(handler, dek, []byte(masterKey)))
+
+	encryptedJSON, err := handler.ToJson()
+	require.NoError(t, err)
+	var encryptedReport map[string]any
+	require.NoError(t, json.Unmarshal(encryptedJSON, &encryptedReport))
+	assert.NotContains(t, encryptedReport, "resources")
+	encryptedResult := encryptedReport["results"].([]any)[0].(map[string]any)
+	encryptedID := encryptedResult["resourceID"].(string)
+	assert.Contains(t, encryptedID, "ENC[AES256_GCM,")
+	controls := encryptedResult["controls"].([]any)
+	rules := controls[0].(map[string]any)["rules"].([]any)
+	encryptedRelatedID := rules[0].(map[string]any)["relatedResourcesIDs"].([]any)[0].(string)
+	assert.Contains(t, encryptedRelatedID, "ENC[AES256_GCM,")
+	assert.NotContains(t, encryptedRelatedID, "ref-")
+
+	decryptedJSON, err := reportcrypto.DecryptReport(encryptedJSON, []byte(masterKey))
+	require.NoError(t, err)
+	var report map[string]any
+	require.NoError(t, json.Unmarshal(decryptedJSON, &report))
+	assert.NotContains(t, report, "resources")
+	decryptedResult := report["results"].([]any)[0].(map[string]any)
+	assert.Equal(t, originalID, decryptedResult["resourceID"])
+	prioritized := decryptedResult["prioritizedResource"].(map[string]any)
+	assert.Equal(t, originalID, prioritized["resourceID"])
+	controls = decryptedResult["controls"].([]any)
+	rules = controls[0].(map[string]any)["rules"].([]any)
+	related := rules[0].(map[string]any)["relatedResourcesIDs"].([]any)
+	assert.Equal(t, relatedID, related[0])
+	labels := report["resourceLabels"].(map[string]any)
+	assert.Equal(t, "payments", labels[originalID].(map[string]any)["team"])
 }

--- a/core/pkg/reportcrypto/report_test.go
+++ b/core/pkg/reportcrypto/report_test.go
@@ -1,0 +1,855 @@
+package reportcrypto
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testMasterKey    = "01234567890123456789012345678901"
+	testMasterKeyEnv = "KUBESCAPE_MASTER_KEY"
+)
+
+type encryptedReportFixture struct {
+	data               []byte
+	dek                []byte
+	encryptedID        string
+	decryptedID        string
+	encryptedName      string
+	encryptedNamespace string
+	encryptedLabel     string
+}
+
+func TestDecryptReportRestoresEveryReportCopy(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	report := decodeTestObject(t, decrypted)
+	assert.Equal(t, "keep-at-top-level", report["futureReportField"])
+	assert.Equal(t, true, report["scanCoverage"].(map[string]any)["degraded"])
+
+	metadata := requireTestObject(t, report, "metadata")
+	assert.Equal(t, "keep-in-metadata", metadata["futureMetadataField"])
+	target := requireTestObject(t, metadata, "targetMetadata")
+	repository := requireTestObject(t, target, "gitRepoContextMetadata")
+	assert.Equal(t, "kubescape", repository["repo"])
+	assert.Equal(t, "kubescape", repository["owner"])
+	assert.Equal(t, "fix/report-roundtrip", repository["branch"])
+	assert.Equal(t, "main", repository["defaultBranch"])
+	assert.Equal(t, "https://github.com/kubescape/kubescape.git", repository["remoteURL"])
+	assert.Equal(t, "/workspace/kubescape", repository["localRootPath"])
+	assert.Equal(t, "keep-in-repository", repository["futureRepositoryField"])
+	commit := requireTestObject(t, repository, "lastCommit")
+	assert.Equal(t, "0123456789abcdef", commit["hash"])
+	assert.Equal(t, "Kubescape Maintainer", commit["committerName"])
+	assert.Equal(t, "maintainer@example.com", commit["committerEmail"])
+	assert.Equal(t, "fix encrypted report decryption", commit["message"])
+	assert.Equal(t, "keep-in-commit", commit["futureCommitField"])
+
+	resources := requireTestArray(t, report, "resources")
+	require.Len(t, resources, 1)
+	resource := resources[0].(map[string]any)
+	assertDecryptedResource(t, resource, fixture.decryptedID)
+	assert.Equal(t, "keep-on-resource", resource["futureResourceField"])
+	assert.Equal(t, "keep-in-source", requireTestObject(t, resource, "source")["futureSourceField"])
+
+	results := requireTestArray(t, report, "results")
+	require.Len(t, results, 1)
+	result := results[0].(map[string]any)
+	assert.Equal(t, fixture.decryptedID, result["resourceID"])
+	assert.Equal(t, "keep-on-result", result["futureResultField"])
+
+	rawResource := requireTestObject(t, result, "rawResource")
+	assertDecryptedResource(t, rawResource, fixture.decryptedID)
+	assert.Equal(t, "keep-on-raw-resource", rawResource["futureRawResourceField"])
+
+	prioritized := requireTestObject(t, result, "prioritizedResource")
+	assert.Equal(t, fixture.decryptedID, prioritized["resourceID"])
+	assert.Equal(t, "keep-on-priority", prioritized["futurePriorityField"])
+
+	controls := requireTestArray(t, result, "controls")
+	require.Len(t, controls, 1)
+	control := controls[0].(map[string]any)
+	assert.Equal(t, "keep-on-control", control["futureControlField"])
+	rules := requireTestArray(t, control, "rules")
+	require.Len(t, rules, 1)
+	rule := rules[0].(map[string]any)
+	assert.Equal(t, "keep-on-rule", rule["futureRuleField"])
+	paths := requireTestArray(t, rule, "paths")
+	require.Len(t, paths, 2)
+	assert.Equal(t, fixture.decryptedID, paths[0].(map[string]any)["resourceID"])
+	assert.Equal(t, "unmapped-resource", paths[1].(map[string]any)["resourceID"])
+	related := requireTestArray(t, rule, "relatedResourcesIDs")
+	assert.Equal(t, []any{fixture.decryptedID, "unmapped-resource"}, related)
+
+	resourceLabels := requireTestObject(t, report, "resourceLabels")
+	require.NotContains(t, resourceLabels, fixture.encryptedID)
+	labels := requireTestObject(t, resourceLabels, fixture.decryptedID)
+	assert.Equal(t, "backend", labels["team"])
+	assert.Equal(t, "payments", labels["app.kubernetes.io/name"])
+}
+
+func TestDecryptReportSupportsRawResourceOnlyReports(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, false, true)
+
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	report := decodeTestObject(t, decrypted)
+	assert.NotContains(t, report, "resources")
+
+	results := requireTestArray(t, report, "results")
+	require.Len(t, results, 1)
+	result := results[0].(map[string]any)
+	assert.Equal(t, fixture.decryptedID, result["resourceID"])
+	assertDecryptedResource(t, requireTestObject(t, result, "rawResource"), fixture.decryptedID)
+
+	labels := requireTestObject(t, report, "resourceLabels")
+	assert.Contains(t, labels, fixture.decryptedID)
+	assert.NotContains(t, labels, fixture.encryptedID)
+}
+
+func TestDecryptReportSupportsResourceListOnlyReports(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, false)
+
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	report := decodeTestObject(t, decrypted)
+	resources := requireTestArray(t, report, "resources")
+	require.Len(t, resources, 1)
+	assertDecryptedResource(t, resources[0].(map[string]any), fixture.decryptedID)
+
+	results := requireTestArray(t, report, "results")
+	require.Len(t, results, 1)
+	result := results[0].(map[string]any)
+	assert.NotContains(t, result, "rawResource")
+	assert.Equal(t, fixture.decryptedID, result["resourceID"])
+}
+
+func TestDecryptReportLeavesPlaintextFieldsUntouched(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+
+	resources := requireTestArray(t, report, "resources")
+	resource := resources[0].(map[string]any)
+	object := requireTestObject(t, resource, "object")
+	metadata := requireTestObject(t, object, "metadata")
+	labels := requireTestObject(t, metadata, "labels")
+	labels["plaintext"] = "  keep surrounding whitespace  "
+	annotations := requireTestObject(t, metadata, "annotations")
+	annotations["multiline"] = "line one\nline two\n"
+
+	fixture.data = mustMarshalTestJSON(t, report)
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	outputResource := requireTestArray(t, output, "resources")[0].(map[string]any)
+	outputObject := requireTestObject(t, outputResource, "object")
+	outputMetadata := requireTestObject(t, outputObject, "metadata")
+	assert.Equal(t, "  keep surrounding whitespace  ", requireTestObject(t, outputMetadata, "labels")["plaintext"])
+	assert.Equal(t, "line one\nline two\n", requireTestObject(t, outputMetadata, "annotations")["multiline"])
+}
+
+func TestDecryptReportPreservesNullOptionalSections(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+
+	resources := requireTestArray(t, report, "resources")
+	resources[0].(map[string]any)["source"] = nil
+	results := requireTestArray(t, report, "results")
+	result := results[0].(map[string]any)
+	result["prioritizedResource"] = nil
+	result["controls"] = nil
+	result["rawResource"].(map[string]any)["source"] = nil
+	report["resourceLabels"] = nil
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	outputResource := requireTestArray(t, output, "resources")[0].(map[string]any)
+	assert.Nil(t, outputResource["source"])
+	outputResult := requireTestArray(t, output, "results")[0].(map[string]any)
+	assert.Nil(t, outputResult["prioritizedResource"])
+	assert.Nil(t, outputResult["controls"])
+	assert.Nil(t, outputResult["rawResource"].(map[string]any)["source"])
+	assert.Nil(t, output["resourceLabels"])
+}
+
+func TestDecryptReportHandlesMissingOptionalSections(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	delete(report, "resources")
+	delete(report, "results")
+	delete(report, "resourceLabels")
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	assert.NotContains(t, output, "resources")
+	assert.NotContains(t, output, "results")
+	assert.NotContains(t, output, "resourceLabels")
+	metadata := requireTestObject(t, output, "metadata")
+	repository := requireTestObject(t, requireTestObject(t, metadata, "targetMetadata"), "gitRepoContextMetadata")
+	assert.Equal(t, "kubescape", repository["repo"])
+}
+
+func TestDecryptReportRejectsIncorrectMasterKey(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+
+	_, err := DecryptReport(fixture.data, []byte("abcdefghijklmnopqrstuvwxyzABCDEF"))
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "decrypt")
+}
+
+func TestDecryptReportRejectsTamperedCiphertext(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	resources := requireTestArray(t, report, "resources")
+	object := requireTestObject(t, resources[0].(map[string]any), "object")
+	metadata := requireTestObject(t, object, "metadata")
+	metadata["name"] = fixture.encryptedName[:len(fixture.encryptedName)-2] + "AA"
+
+	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resources[0]")
+	assert.Contains(t, err.Error(), "metadata")
+}
+
+func TestDecryptReportSupportsMultipleEncryptedAliasesForResource(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, false)
+	report := decodeTestObject(t, fixture.data)
+	resources := requireTestArray(t, report, "resources")
+
+	duplicate := deepCopyTestObject(t, resources[0].(map[string]any))
+	duplicate["resourceID"] = "different-encrypted-id"
+	report["resources"] = append(resources, duplicate)
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	decryptedResources := requireTestArray(t, output, "resources")
+	require.Len(t, decryptedResources, 2)
+	assert.Equal(t, fixture.decryptedID, decryptedResources[0].(map[string]any)["resourceID"])
+	assert.Equal(t, fixture.decryptedID, decryptedResources[1].(map[string]any)["resourceID"])
+}
+
+func TestDecryptReportRejectsResourceLabelCollisions(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	labels := requireTestObject(t, report, "resourceLabels")
+	labels[fixture.decryptedID] = map[string]any{"team": "plaintext"}
+
+	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting value")
+}
+
+func TestDecryptReportMergesLabelsFromResourceAliases(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	labels := requireTestObject(t, report, "resourceLabels")
+	labels[fixture.decryptedID] = map[string]any{"cost-center": "security"}
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	labelsByResource := requireTestObject(t, output, "resourceLabels")
+	restored := requireTestObject(t, labelsByResource, fixture.decryptedID)
+	assert.Equal(t, "backend", restored["team"])
+	assert.Equal(t, "payments", restored["app.kubernetes.io/name"])
+	assert.Equal(t, "security", restored["cost-center"])
+}
+
+func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+
+	tests := []struct {
+		name        string
+		mutate      func(map[string]any)
+		wantError   string
+		wantContext string
+	}{
+		{
+			name: "empty report",
+			mutate: func(report map[string]any) {
+				for key := range report {
+					delete(report, key)
+				}
+			},
+			wantError: "metadata not found",
+		},
+		{
+			name: "null metadata",
+			mutate: func(report map[string]any) {
+				report["metadata"] = nil
+			},
+			wantError: "metadata not found",
+		},
+		{
+			name: "metadata array",
+			mutate: func(report map[string]any) {
+				report["metadata"] = []any{}
+			},
+			wantError: "failed to parse metadata",
+		},
+		{
+			name: "resources object",
+			mutate: func(report map[string]any) {
+				report["resources"] = map[string]any{}
+			},
+			wantError: "failed to parse resources",
+		},
+		{
+			name: "resource scalar",
+			mutate: func(report map[string]any) {
+				report["resources"] = []any{"not-an-object"}
+			},
+			wantError: "failed to parse resources",
+		},
+		{
+			name: "resource ID number",
+			mutate: func(report map[string]any) {
+				resources := requireTestArray(t, report, "resources")
+				resources[0].(map[string]any)["resourceID"] = 42
+			},
+			wantError:   "failed to parse",
+			wantContext: "resources[0].resourceID",
+		},
+		{
+			name: "resource object scalar",
+			mutate: func(report map[string]any) {
+				resources := requireTestArray(t, report, "resources")
+				resources[0].(map[string]any)["object"] = "not-a-workload"
+			},
+			wantError:   "failed to parse",
+			wantContext: "resources[0].object",
+		},
+		{
+			name: "resource source scalar",
+			mutate: func(report map[string]any) {
+				resources := requireTestArray(t, report, "resources")
+				resources[0].(map[string]any)["source"] = "not-a-source"
+			},
+			wantError:   "failed to parse",
+			wantContext: "resources[0].source",
+		},
+		{
+			name: "results object",
+			mutate: func(report map[string]any) {
+				report["results"] = map[string]any{}
+			},
+			wantError: "failed to parse results",
+		},
+		{
+			name: "result ID number",
+			mutate: func(report map[string]any) {
+				results := requireTestArray(t, report, "results")
+				results[0].(map[string]any)["resourceID"] = 42
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].resourceID",
+		},
+		{
+			name: "raw resource array",
+			mutate: func(report map[string]any) {
+				results := requireTestArray(t, report, "results")
+				results[0].(map[string]any)["rawResource"] = []any{}
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].rawResource",
+		},
+		{
+			name: "prioritized resource array",
+			mutate: func(report map[string]any) {
+				results := requireTestArray(t, report, "results")
+				results[0].(map[string]any)["prioritizedResource"] = []any{}
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].prioritizedResource",
+		},
+		{
+			name: "controls object",
+			mutate: func(report map[string]any) {
+				results := requireTestArray(t, report, "results")
+				results[0].(map[string]any)["controls"] = map[string]any{}
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].controls",
+		},
+		{
+			name: "rules scalar",
+			mutate: func(report map[string]any) {
+				result := requireTestArray(t, report, "results")[0].(map[string]any)
+				control := requireTestArray(t, result, "controls")[0].(map[string]any)
+				control["rules"] = "not-rules"
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].controls[0].rules",
+		},
+		{
+			name: "paths object",
+			mutate: func(report map[string]any) {
+				result := requireTestArray(t, report, "results")[0].(map[string]any)
+				control := requireTestArray(t, result, "controls")[0].(map[string]any)
+				rule := requireTestArray(t, control, "rules")[0].(map[string]any)
+				rule["paths"] = map[string]any{}
+			},
+			wantError:   "failed to parse",
+			wantContext: "results[0].controls[0].rules[0].paths",
+		},
+		{
+			name: "related resource IDs contain number",
+			mutate: func(report map[string]any) {
+				result := requireTestArray(t, report, "results")[0].(map[string]any)
+				control := requireTestArray(t, result, "controls")[0].(map[string]any)
+				rule := requireTestArray(t, control, "rules")[0].(map[string]any)
+				rule["relatedResourcesIDs"] = []any{42}
+			},
+			wantError:   "failed to parse",
+			wantContext: "relatedResourcesIDs",
+		},
+		{
+			name: "resource labels array",
+			mutate: func(report map[string]any) {
+				report["resourceLabels"] = []any{}
+			},
+			wantError: "failed to parse resourceLabels",
+		},
+		{
+			name: "resource label set scalar",
+			mutate: func(report map[string]any) {
+				labels := requireTestObject(t, report, "resourceLabels")
+				labels[fixture.encryptedID] = "not-labels"
+			},
+			wantError:   "failed to parse",
+			wantContext: "resourceLabels",
+		},
+		{
+			name: "resource label value number",
+			mutate: func(report map[string]any) {
+				labels := requireTestObject(t, report, "resourceLabels")
+				labels[fixture.encryptedID].(map[string]any)["team"] = 42
+			},
+			wantError:   "failed to parse",
+			wantContext: "team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := decodeTestObject(t, fixture.data)
+			tt.mutate(report)
+
+			_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+			if tt.wantContext != "" {
+				assert.Contains(t, err.Error(), tt.wantContext)
+			}
+		})
+	}
+}
+
+func TestDecryptReportRejectsInvalidTopLevelJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		wantError string
+	}{
+		{name: "empty", data: "", wantError: "report is empty"},
+		{name: "whitespace", data: " \n\t", wantError: "report is empty"},
+		{name: "truncated", data: `{`, wantError: "failed to parse report"},
+		{name: "array", data: `[]`, wantError: "failed to parse report"},
+		{name: "null", data: `null`, wantError: "expected an object"},
+		{name: "string", data: `"report"`, wantError: "failed to parse report"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecryptReport([]byte(tt.data), []byte(testMasterKey))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestDecryptReportFromEnv(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	t.Setenv(testMasterKeyEnv, testMasterKey)
+
+	decrypted, err := DecryptReportFromEnv(fixture.data)
+	require.NoError(t, err)
+	report := decodeTestObject(t, decrypted)
+	assert.Equal(t, fixture.decryptedID, requireTestArray(t, report, "results")[0].(map[string]any)["resourceID"])
+}
+
+func TestDecryptReportFromEnvRequiresKey(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	t.Setenv(testMasterKeyEnv, "")
+
+	_, err := DecryptReportFromEnv(fixture.data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testMasterKeyEnv)
+}
+
+func newEncryptedReportFixture(t *testing.T, includeResources, includeRawResource bool) encryptedReportFixture {
+	t.Helper()
+
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+	encrypt := func(value string) string {
+		t.Helper()
+		encrypted, err := EncryptString(value, dek)
+		require.NoError(t, err)
+		return encrypted
+	}
+
+	encryptedName := encrypt("payments-api")
+	encryptedNamespace := encrypt("production")
+	encryptedLabel := encrypt("backend")
+	encryptedApplicationLabel := encrypt("payments")
+	encryptedAnnotation := encrypt("platform-team")
+	encryptedNestedAnnotation := encrypt("pod-template-owner")
+	encryptedSourcePath := encrypt("/workspace/kubescape/manifests/payments.yaml")
+	encryptedContainerName := encrypt("api")
+	encryptedInitContainerName := encrypt("migrate")
+	encryptedEphemeralContainerName := encrypt("debugger")
+	encryptedImage := encrypt("registry.example.com/payments:v1.2.3")
+	encryptedInitImage := encrypt("registry.example.com/migrate:v4")
+	encryptedEphemeralImage := encrypt("registry.example.com/debug:v2")
+	encryptedEnvValue := encrypt("postgres://user:secret@database:5432/payments")
+	encryptedSecretRef := encrypt("payments-database")
+	encryptedConfigMapRef := encrypt("payments-settings")
+	encryptedEnvFromSecret := encrypt("payments-runtime")
+	encryptedEnvFromConfigMap := encrypt("payments-environment")
+	encryptedImagePullSecret := encrypt("private-registry")
+	encryptedServiceAccount := encrypt("payments-service-account")
+
+	object := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"sourcePath": encryptedSourcePath + ":37",
+		"futureObjectField": map[string]any{
+			"enabled": true,
+		},
+		"metadata": map[string]any{
+			"name":      encryptedName,
+			"namespace": encryptedNamespace,
+			"labels": map[string]any{
+				"team":                   encryptedLabel,
+				"app.kubernetes.io/name": encryptedApplicationLabel,
+				"plaintext":              "leave-me-alone",
+			},
+			"annotations": map[string]any{
+				"owner":     encryptedAnnotation,
+				"plaintext": "leave-this-too",
+			},
+		},
+		"spec": map[string]any{
+			"replicas":           2,
+			"serviceAccountName": encryptedServiceAccount,
+			"imagePullSecrets": []any{
+				map[string]any{"name": encryptedImagePullSecret},
+			},
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"owner": encryptedNestedAnnotation,
+					},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  encryptedContainerName,
+							"image": encryptedImage,
+							"env": []any{
+								map[string]any{
+									"name":  "DATABASE_URL",
+									"value": encryptedEnvValue,
+								},
+								map[string]any{
+									"name": "PASSWORD",
+									"valueFrom": map[string]any{
+										"secretKeyRef": map[string]any{
+											"name": encryptedSecretRef,
+											"key":  "password",
+										},
+									},
+								},
+								map[string]any{
+									"name": "LOG_LEVEL",
+									"valueFrom": map[string]any{
+										"configMapKeyRef": map[string]any{
+											"name": encryptedConfigMapRef,
+											"key":  "level",
+										},
+									},
+								},
+							},
+							"envFrom": []any{
+								map[string]any{
+									"secretRef": map[string]any{"name": encryptedEnvFromSecret},
+								},
+								map[string]any{
+									"configMapRef": map[string]any{"name": encryptedEnvFromConfigMap},
+								},
+							},
+						},
+					},
+					"initContainers": []any{
+						map[string]any{
+							"name":  encryptedInitContainerName,
+							"image": encryptedInitImage,
+						},
+					},
+					"ephemeralContainers": []any{
+						map[string]any{
+							"name":  encryptedEphemeralContainerName,
+							"image": encryptedEphemeralImage,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	workloadBytes := mustMarshalTestJSON(t, object)
+	workload, err := workloadinterface.NewWorkload(workloadBytes)
+	require.NoError(t, err)
+	encryptedID := workload.GetID()
+	decryptedID := "apps/v1/production/Deployment/payments-api"
+
+	source := map[string]any{
+		"path":                   encrypt("/workspace/kubescape/manifests/payments.yaml"),
+		"relativePath":           encrypt("manifests/payments.yaml"),
+		"helmPath":               encrypt("charts/payments"),
+		"helmChartName":          encrypt("payments"),
+		"helmTemplateFile":       encrypt("templates/deployment.yaml"),
+		"helmValuesPaths":        []any{encrypt("values.yaml"), encrypt("values/production.yaml")},
+		"kustomizeDirectoryName": encrypt("overlays/production"),
+		"futureSourceField":      "keep-in-source",
+		"lastCommit": map[string]any{
+			"hash":           encrypt("fedcba9876543210"),
+			"committerName":  encrypt("Source Author"),
+			"committerEmail": encrypt("source@example.com"),
+			"message":        encrypt("update payments manifest"),
+			"futureField":    "keep-in-source-commit",
+		},
+	}
+
+	resource := map[string]any{
+		"resourceID":          encryptedID,
+		"object":              object,
+		"source":              source,
+		"futureResourceField": "keep-on-resource",
+	}
+	rawResource := deepCopyTestObject(t, resource)
+	rawResource["futureRawResourceField"] = "keep-on-raw-resource"
+
+	wrappedDEK, err := WrapDEK(dek, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	result := map[string]any{
+		"resourceID": encryptedID,
+		"prioritizedResource": map[string]any{
+			"resourceID":          encryptedID,
+			"severity":            4,
+			"futurePriorityField": "keep-on-priority",
+		},
+		"controls": []any{
+			map[string]any{
+				"controlID":          "C-0010",
+				"name":               "Container Resources",
+				"futureControlField": "keep-on-control",
+				"rules": []any{
+					map[string]any{
+						"name":            "Resource limits",
+						"futureRuleField": "keep-on-rule",
+						"paths": []any{
+							map[string]any{"resourceID": encryptedID, "failedPath": "spec.template.spec.containers[0]"},
+							map[string]any{"resourceID": "unmapped-resource", "failedPath": "metadata"},
+						},
+						"relatedResourcesIDs": []any{encryptedID, "unmapped-resource"},
+					},
+				},
+			},
+		},
+		"futureResultField": "keep-on-result",
+	}
+	if includeRawResource {
+		result["rawResource"] = rawResource
+	}
+
+	report := map[string]any{
+		"generationTime": "2026-08-14T12:00:00Z",
+		"metadata": map[string]any{
+			"targetMetadata": map[string]any{
+				"gitRepoContextMetadata": map[string]any{
+					"provider":              "github",
+					"repo":                  encrypt("kubescape"),
+					"owner":                 encrypt("kubescape"),
+					"branch":                encrypt("fix/report-roundtrip"),
+					"defaultBranch":         encrypt("main"),
+					"remoteURL":             encrypt("https://github.com/kubescape/kubescape.git"),
+					"localRootPath":         encrypt("/workspace/kubescape"),
+					"futureRepositoryField": "keep-in-repository",
+					"lastCommit": map[string]any{
+						"hash":              encrypt("0123456789abcdef"),
+						"committerName":     encrypt("Kubescape Maintainer"),
+						"committerEmail":    encrypt("maintainer@example.com"),
+						"message":           encrypt("fix encrypted report decryption"),
+						"futureCommitField": "keep-in-commit",
+					},
+				},
+			},
+			"encryptionMetadata": map[string]any{
+				"version":      "v1",
+				"dekAlgorithm": "AES256_GCM",
+				"kekAlgorithm": "AES256_GCM",
+				"encryptedDEK": wrappedDEK,
+			},
+			"futureMetadataField": "keep-in-metadata",
+		},
+		"results": []any{result},
+		"resourceLabels": map[string]any{
+			encryptedID: map[string]any{
+				"team":                   encryptedLabel,
+				"app.kubernetes.io/name": encryptedApplicationLabel,
+			},
+		},
+		"scanCoverage": map[string]any{
+			"degraded": true,
+		},
+		"futureReportField": "keep-at-top-level",
+	}
+	if includeResources {
+		report["resources"] = []any{resource}
+	}
+
+	return encryptedReportFixture{
+		data:               mustMarshalTestJSON(t, report),
+		dek:                dek,
+		encryptedID:        encryptedID,
+		decryptedID:        decryptedID,
+		encryptedName:      encryptedName,
+		encryptedNamespace: encryptedNamespace,
+		encryptedLabel:     encryptedLabel,
+	}
+}
+
+func assertDecryptedResource(t *testing.T, resource map[string]any, expectedID string) {
+	t.Helper()
+
+	assert.Equal(t, expectedID, resource["resourceID"])
+	object := requireTestObject(t, resource, "object")
+	assert.Equal(t, "/workspace/kubescape/manifests/payments.yaml:37", object["sourcePath"])
+	assert.Equal(t, true, requireTestObject(t, object, "futureObjectField")["enabled"])
+
+	metadata := requireTestObject(t, object, "metadata")
+	assert.Equal(t, "payments-api", metadata["name"])
+	assert.Equal(t, "production", metadata["namespace"])
+	labels := requireTestObject(t, metadata, "labels")
+	assert.Equal(t, "backend", labels["team"])
+	assert.Equal(t, "payments", labels["app.kubernetes.io/name"])
+	assert.Equal(t, "leave-me-alone", labels["plaintext"])
+	annotations := requireTestObject(t, metadata, "annotations")
+	assert.Equal(t, "platform-team", annotations["owner"])
+	assert.Equal(t, "leave-this-too", annotations["plaintext"])
+
+	spec := requireTestObject(t, object, "spec")
+	assert.Equal(t, "payments-service-account", spec["serviceAccountName"])
+	pullSecrets := requireTestArray(t, spec, "imagePullSecrets")
+	assert.Equal(t, "private-registry", pullSecrets[0].(map[string]any)["name"])
+
+	template := requireTestObject(t, spec, "template")
+	templateMetadata := requireTestObject(t, template, "metadata")
+	assert.Equal(t, "pod-template-owner", requireTestObject(t, templateMetadata, "annotations")["owner"])
+	podSpec := requireTestObject(t, template, "spec")
+	containers := requireTestArray(t, podSpec, "containers")
+	container := containers[0].(map[string]any)
+	assert.Equal(t, "api", container["name"])
+	assert.Equal(t, "registry.example.com/payments:v1.2.3", container["image"])
+	env := requireTestArray(t, container, "env")
+	assert.Equal(t, "postgres://user:secret@database:5432/payments", env[0].(map[string]any)["value"])
+	secretValueFrom := requireTestObject(t, env[1].(map[string]any), "valueFrom")
+	assert.Equal(t, "payments-database", requireTestObject(t, secretValueFrom, "secretKeyRef")["name"])
+	configValueFrom := requireTestObject(t, env[2].(map[string]any), "valueFrom")
+	assert.Equal(t, "payments-settings", requireTestObject(t, configValueFrom, "configMapKeyRef")["name"])
+	envFrom := requireTestArray(t, container, "envFrom")
+	assert.Equal(t, "payments-runtime", requireTestObject(t, envFrom[0].(map[string]any), "secretRef")["name"])
+	assert.Equal(t, "payments-environment", requireTestObject(t, envFrom[1].(map[string]any), "configMapRef")["name"])
+
+	initContainers := requireTestArray(t, podSpec, "initContainers")
+	assert.Equal(t, "migrate", initContainers[0].(map[string]any)["name"])
+	assert.Equal(t, "registry.example.com/migrate:v4", initContainers[0].(map[string]any)["image"])
+	ephemeralContainers := requireTestArray(t, podSpec, "ephemeralContainers")
+	assert.Equal(t, "debugger", ephemeralContainers[0].(map[string]any)["name"])
+	assert.Equal(t, "registry.example.com/debug:v2", ephemeralContainers[0].(map[string]any)["image"])
+
+	source := requireTestObject(t, resource, "source")
+	assert.Equal(t, "/workspace/kubescape/manifests/payments.yaml", source["path"])
+	assert.Equal(t, "manifests/payments.yaml", source["relativePath"])
+	assert.Equal(t, "charts/payments", source["helmPath"])
+	assert.Equal(t, "payments", source["helmChartName"])
+	assert.Equal(t, "templates/deployment.yaml", source["helmTemplateFile"])
+	assert.Equal(t, []any{"values.yaml", "values/production.yaml"}, source["helmValuesPaths"])
+	assert.Equal(t, "overlays/production", source["kustomizeDirectoryName"])
+	assert.Equal(t, "keep-in-source", source["futureSourceField"])
+	sourceCommit := requireTestObject(t, source, "lastCommit")
+	assert.Equal(t, "fedcba9876543210", sourceCommit["hash"])
+	assert.Equal(t, "Source Author", sourceCommit["committerName"])
+	assert.Equal(t, "source@example.com", sourceCommit["committerEmail"])
+	assert.Equal(t, "update payments manifest", sourceCommit["message"])
+	assert.Equal(t, "keep-in-source-commit", sourceCommit["futureField"])
+}
+
+func decodeTestObject(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(data, &object))
+	require.NotNil(t, object)
+	return object
+}
+
+func requireTestObject(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := parent[key]
+	require.True(t, ok, "%s should be present", key)
+	object, ok := value.(map[string]any)
+	require.True(t, ok, "%s should be an object, got %T", key, value)
+	return object
+}
+
+func requireTestArray(t *testing.T, parent map[string]any, key string) []any {
+	t.Helper()
+	value, ok := parent[key]
+	require.True(t, ok, "%s should be present", key)
+	array, ok := value.([]any)
+	require.True(t, ok, "%s should be an array, got %T", key, value)
+	return array
+}
+
+func mustMarshalTestJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
+}
+
+func deepCopyTestObject(t *testing.T, object map[string]any) map[string]any {
+	t.Helper()
+	return decodeTestObject(t, mustMarshalTestJSON(t, object))
+}

--- a/core/pkg/reportcrypto/report_test.go
+++ b/core/pkg/reportcrypto/report_test.go
@@ -204,6 +204,114 @@ func TestDecryptReportHandlesMissingOptionalSections(t *testing.T) {
 	assert.Equal(t, "kubescape", repository["repo"])
 }
 
+func TestDecryptReportRestoresIDsWithoutResourceObjects(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, false, false)
+
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	report := decodeTestObject(t, decrypted)
+	result := requireTestArray(t, report, "results")[0].(map[string]any)
+	assert.Equal(t, fixture.decryptedID, result["resourceID"])
+	prioritized := requireTestObject(t, result, "prioritizedResource")
+	assert.Equal(t, fixture.decryptedID, prioritized["resourceID"])
+	labels := requireTestObject(t, report, "resourceLabels")
+	assert.Contains(t, labels, fixture.decryptedID)
+	assert.NotContains(t, labels, fixture.encryptedID)
+}
+
+func TestDecryptReportRemapsObjectlessResourceAfterRawResource(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	resource := requireTestArray(t, report, "resources")[0].(map[string]any)
+	delete(resource, "object")
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	resource = requireTestArray(t, output, "resources")[0].(map[string]any)
+	assert.Equal(t, fixture.decryptedID, resource["resourceID"])
+	assert.NotContains(t, resource, "object")
+}
+
+func TestDecryptReportDoesNotClobberIDForMalformedObject(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, false)
+	report := decodeTestObject(t, fixture.data)
+	resource := requireTestArray(t, report, "resources")[0].(map[string]any)
+	resource["resourceID"] = "apps/v1/prod/Deployment/checkout"
+	resource["object"] = map[string]any{"foo": "bar"}
+	delete(report, "results")
+	delete(report, "resourceLabels")
+
+	decrypted, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.NoError(t, err)
+
+	output := decodeTestObject(t, decrypted)
+	resource = requireTestArray(t, output, "resources")[0].(map[string]any)
+	assert.Equal(t, "apps/v1/prod/Deployment/checkout", resource["resourceID"])
+	assert.NotEqual(t, "////", resource["resourceID"])
+}
+
+func TestDecryptReportRejectsIrreversibleResourceIDPseudonyms(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, false, false)
+	report := decodeTestObject(t, fixture.data)
+	result := requireTestArray(t, report, "results")[0].(map[string]any)
+	result["resourceID"] = "ref-0123abcd"
+	delete(report, "resourceLabels")
+
+	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "irreversible resource ID pseudonym")
+	assert.Contains(t, err.Error(), "results[0].resourceID")
+}
+
+func TestDecryptReportRejectsLeftoverCiphertext(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+	report := decodeTestObject(t, fixture.data)
+	report["futureEncryptedField"] = fixture.encryptedLabel
+
+	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encrypted value remains")
+	assert.Contains(t, err.Error(), "futureEncryptedField")
+}
+
+func TestDecryptReportAllowsWrappedDEKToRemain(t *testing.T) {
+	fixture := newEncryptedReportFixture(t, true, true)
+
+	decrypted, err := DecryptReport(fixture.data, []byte(testMasterKey))
+	require.NoError(t, err)
+
+	report := decodeTestObject(t, decrypted)
+	metadata := requireTestObject(t, report, "metadata")
+	encryptionMetadata := requireTestObject(t, metadata, "encryptionMetadata")
+	assert.Contains(t, encryptionMetadata["encryptedDEK"], "ENC[AES256_GCM,")
+}
+
+func TestDecryptEmbeddedCiphertextsHandlesSlashesInsideEnvelopes(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	var encryptedNamespace string
+	for i := 0; i < 256; i++ {
+		encryptedNamespace, err = EncryptString("production", dek)
+		require.NoError(t, err)
+		if strings.Contains(encryptedNamespace, "/") {
+			break
+		}
+	}
+	require.Contains(t, encryptedNamespace, "/", "test requires base64 ciphertext containing a slash")
+
+	encryptedName, err := EncryptString("checkout", dek)
+	require.NoError(t, err)
+	encryptedID := "apps/v1/" + encryptedNamespace + "/Deployment/" + encryptedName
+
+	restored, err := decryptEmbeddedCiphertexts(encryptedID, dek)
+	require.NoError(t, err)
+	assert.Equal(t, "apps/v1/production/Deployment/checkout", restored)
+}
+
 func TestDecryptReportRejectsIncorrectMasterKey(t *testing.T) {
 	fixture := newEncryptedReportFixture(t, true, true)
 
@@ -218,7 +326,14 @@ func TestDecryptReportRejectsTamperedCiphertext(t *testing.T) {
 	resources := requireTestArray(t, report, "resources")
 	object := requireTestObject(t, resources[0].(map[string]any), "object")
 	metadata := requireTestObject(t, object, "metadata")
-	metadata["name"] = fixture.encryptedName[:len(fixture.encryptedName)-2] + "AA"
+	tampered := []byte(fixture.encryptedName)
+	last := len(tampered) - 1
+	if tampered[last] == 'A' {
+		tampered[last] = 'B'
+	} else {
+		tampered[last] = 'A'
+	}
+	metadata["name"] = string(tampered)
 
 	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
 	require.Error(t, err)
@@ -278,13 +393,13 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		mutate      func(map[string]any)
+		mutate      func(*testing.T, map[string]any)
 		wantError   string
 		wantContext string
 	}{
 		{
 			name: "empty report",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				for key := range report {
 					delete(report, key)
 				}
@@ -293,35 +408,35 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "null metadata",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["metadata"] = nil
 			},
 			wantError: "metadata not found",
 		},
 		{
 			name: "metadata array",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["metadata"] = []any{}
 			},
 			wantError: "failed to parse metadata",
 		},
 		{
 			name: "resources object",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["resources"] = map[string]any{}
 			},
 			wantError: "failed to parse resources",
 		},
 		{
 			name: "resource scalar",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["resources"] = []any{"not-an-object"}
 			},
 			wantError: "failed to parse resources",
 		},
 		{
 			name: "resource ID number",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				resources := requireTestArray(t, report, "resources")
 				resources[0].(map[string]any)["resourceID"] = 42
 			},
@@ -330,7 +445,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "resource object scalar",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				resources := requireTestArray(t, report, "resources")
 				resources[0].(map[string]any)["object"] = "not-a-workload"
 			},
@@ -339,7 +454,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "resource source scalar",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				resources := requireTestArray(t, report, "resources")
 				resources[0].(map[string]any)["source"] = "not-a-source"
 			},
@@ -348,14 +463,14 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "results object",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["results"] = map[string]any{}
 			},
 			wantError: "failed to parse results",
 		},
 		{
 			name: "result ID number",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				results := requireTestArray(t, report, "results")
 				results[0].(map[string]any)["resourceID"] = 42
 			},
@@ -364,7 +479,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "raw resource array",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				results := requireTestArray(t, report, "results")
 				results[0].(map[string]any)["rawResource"] = []any{}
 			},
@@ -373,7 +488,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "prioritized resource array",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				results := requireTestArray(t, report, "results")
 				results[0].(map[string]any)["prioritizedResource"] = []any{}
 			},
@@ -382,7 +497,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "controls object",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				results := requireTestArray(t, report, "results")
 				results[0].(map[string]any)["controls"] = map[string]any{}
 			},
@@ -391,7 +506,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "rules scalar",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				result := requireTestArray(t, report, "results")[0].(map[string]any)
 				control := requireTestArray(t, result, "controls")[0].(map[string]any)
 				control["rules"] = "not-rules"
@@ -401,7 +516,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "paths object",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				result := requireTestArray(t, report, "results")[0].(map[string]any)
 				control := requireTestArray(t, result, "controls")[0].(map[string]any)
 				rule := requireTestArray(t, control, "rules")[0].(map[string]any)
@@ -412,7 +527,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "related resource IDs contain number",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				result := requireTestArray(t, report, "results")[0].(map[string]any)
 				control := requireTestArray(t, result, "controls")[0].(map[string]any)
 				rule := requireTestArray(t, control, "rules")[0].(map[string]any)
@@ -423,14 +538,14 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "resource labels array",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				report["resourceLabels"] = []any{}
 			},
 			wantError: "failed to parse resourceLabels",
 		},
 		{
 			name: "resource label set scalar",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				labels := requireTestObject(t, report, "resourceLabels")
 				labels[fixture.encryptedID] = "not-labels"
 			},
@@ -439,7 +554,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 		},
 		{
 			name: "resource label value number",
-			mutate: func(report map[string]any) {
+			mutate: func(t *testing.T, report map[string]any) {
 				labels := requireTestObject(t, report, "resourceLabels")
 				labels[fixture.encryptedID].(map[string]any)["team"] = 42
 			},
@@ -451,7 +566,7 @@ func TestDecryptReportValidationErrorsIncludeFieldContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			report := decodeTestObject(t, fixture.data)
-			tt.mutate(report)
+			tt.mutate(t, report)
 
 			_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
 			require.Error(t, err)

--- a/core/pkg/reportcrypto/report_test.go
+++ b/core/pkg/reportcrypto/report_test.go
@@ -268,13 +268,34 @@ func TestDecryptReportRejectsIrreversibleResourceIDPseudonyms(t *testing.T) {
 
 func TestDecryptReportRejectsLeftoverCiphertext(t *testing.T) {
 	fixture := newEncryptedReportFixture(t, true, true)
-	report := decodeTestObject(t, fixture.data)
-	report["futureEncryptedField"] = fixture.encryptedLabel
+	tests := []struct {
+		name  string
+		field string
+		value any
+	}{
+		{
+			name:  "unknown field",
+			field: "futureEncryptedField",
+			value: fixture.encryptedLabel,
+		},
+		{
+			name:  "dotted key cannot forge wrapped DEK path",
+			field: "metadata.encryptionMetadata.encryptedDEK",
+			value: map[string]any{"ciphertext": fixture.encryptedLabel},
+		},
+	}
 
-	_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "encrypted value remains")
-	assert.Contains(t, err.Error(), "futureEncryptedField")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := decodeTestObject(t, fixture.data)
+			report[tt.field] = tt.value
+
+			_, err := DecryptReport(mustMarshalTestJSON(t, report), []byte(testMasterKey))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "encrypted value remains")
+			assert.Contains(t, err.Error(), tt.field)
+		})
+	}
 }
 
 func TestDecryptReportAllowsWrappedDEKToRemain(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -473,11 +473,15 @@ kubescape decrypt <report-file>
 Decrypts a JSON report that was protected with `kubescape scan --encrypt`.
 The command restores encrypted repository metadata, Kubernetes resource
 metadata, source paths, container fields, copied resource labels, raw resource
-copies in results, and every resource ID reference that Kubescape rewrote
-during encryption.
+copies in results, and recoverable resource ID references. If ciphertext or an
+irreversible legacy resource ID remains, decryption fails instead of returning
+a partially restored report.
 
 Only fields encrypted by `kubescape scan --encrypt` are restored.
 Metadata pseudonymized with `--hide` cannot be recovered by `kubescape decrypt`.
+Older encrypted reports may contain `ref-<hash>` resource IDs that were written
+with a one-way mapping. Those IDs cannot be recovered, so the command reports
+an error rather than silently treating the report as fully decrypted.
 
 ### Flags
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -470,10 +470,13 @@ kubescape decrypt <report-file>
 
 ### Description
 
-Decrypts report metadata that was protected with
-`kubescape scan --encrypt`.
+Decrypts a JSON report that was protected with `kubescape scan --encrypt`.
+The command restores encrypted repository metadata, Kubernetes resource
+metadata, source paths, container fields, copied resource labels, raw resource
+copies in results, and every resource ID reference that Kubescape rewrote
+during encryption.
 
-Only metadata encrypted by `kubescape scan --encrypt` is restored.
+Only fields encrypted by `kubescape scan --encrypt` are restored.
 Metadata pseudonymized with `--hide` cannot be recovered by `kubescape decrypt`.
 
 ### Flags
@@ -497,7 +500,7 @@ kubescape decrypt encrypted-report.json
 kubescape decrypt encrypted-report.json > decrypted-report.json
 ```
 
-> `kubescape decrypt` restores metadata encrypted by
+> `kubescape decrypt` restores report fields encrypted by
 > `kubescape scan --encrypt`. It does not reverse
 > deterministic pseudonymization produced by `--hide`.
 


### PR DESCRIPTION
## Brief

`kubescape decrypt` was only restoring part of an encrypted scan report.

The resources stored in the top-level `resources` collection were decrypted correctly, but other copies of the same data were left untouched. This affected:

- `results[].rawResource`
- `resourceLabels` keys and values
- prioritized resource IDs
- rule path resource IDs
- related resource IDs
- reports that only contain raw resources inside results

As a result, a decrypted report could contain a plaintext resource in one section and an encrypted copy of the same resource in another section. Resource labels could also remain indexed by the old encrypted resource ID, which made them impossible to associate with the restored resource.

## Relevancy

Consumers expect `kubescape decrypt` to return a usable and internally consistent report.

Partially decrypted reports can break:

- report ingestion and indexing
- resource-to-result correlation
- copied label lookups
- prioritization workflows
- integrations that consume `rawResource`
- auditing workflows that expect the original Kubernetes metadata

This is especially important for chunked or backend-facing reports where the result's raw resource may be the only complete copy of the Kubernetes object.

## Backward compatibility

Plaintext values are left unchanged.

Unknown top-level and nested report fields are preserved. This prevents the decrypt command from silently deleting fields added by newer report schemas or backend extensions.

Reports that omit optional sections such as resources, results, raw resources, labels, controls, or sources continue to work.

## Testing

The test coverage includes:

- a real `ApplyEncrypted` to `ResultsHandler.ToJson` to `DecryptReport` round trip
- top-level resource decryption
- raw-resource-only reports
- resource-list-only reports
- copied resource labels
- resource ID remapping across all supported result references
- container and environment metadata
- repository and source metadata
- unknown-field preservation
- plaintext compatibility
- null and missing optional sections
- encrypted alias handling
- conflicting label detection
- malformed JSON structures
- incorrect master keys
- tampered ciphertext
- CLI read failures
- CLI write failures

Commands run:

```bash
go test ./core/pkg/reportcrypto ./cmd/decrypt ./core/pkg/anonymizer ./core/pkg/resultshandling -count=1
go test -race ./core/pkg/reportcrypto ./cmd/decrypt -count=1
go vet ./core/pkg/reportcrypto ./cmd/decrypt
git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `kubescape decrypt` now restores supported encrypted report data, including resource metadata, paths, container fields, labels, raw resource copies, and recoverable resource IDs.
  - Related resource references and nested report identifiers are restored automatically.
  - Plaintext and unknown report fields are preserved during decryption.

- **Bug Fixes**
  - Added clearer errors for unreadable reports, failed output, invalid keys, tampered data, leftover ciphertext, and irreversible pseudonymous IDs.

- **Documentation**
  - Expanded CLI documentation with decryption coverage and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->