### PR TITLE
fix(scan): treat zero loaded controls as a coverage failure

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -188,7 +188,7 @@ func enforceCoverageThreshold(coverage cautils.ScanCoverage, totalControls int, 
 		return nil
 	}
 	if totalControls == 0 {
-		return nil
+		return fmt.Errorf("scan loaded no controls: coverage is 0%% (fail-coverage-below: %.2f%%)", scanInfo.FailCoverageThreshold)
 	}
 	if coverage.CoverageScore < scanInfo.FailCoverageThreshold {
 		return fmt.Errorf("scan coverage is below permitted threshold: %.2f%% (fail-coverage-below: %.2f%%)", coverage.CoverageScore, scanInfo.FailCoverageThreshold)

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -699,12 +699,17 @@ func TestApplyRegistryCredentialsFromEnv_KeepsExplicitAuthMode(t *testing.T) {
 	})
 }
 
-// coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we
-// can test it without triggering os.Exit. It MUST stay byte-identical with the
-// gate: when this and the gate disagree, every other test in this file lies
-// about scan behavior. In particular, a zero-controls scan is a coverage
-// failure (nothing was evaluated) rather than a free pass — see
-// core/cautils/scancoverage.go ComputeCoverageScore for the matching rule.
+// coverageWouldFail is a ratio-only mirror of enforceCoverageThreshold used
+// by the table-driven Test_enforceCoverageThreshold below. It models two of
+// the gate's branches: the threshold opt-out (threshold <= 0) and the
+// zero-controls failure (totalControls == 0 with a positive threshold).
+//
+// It does NOT model the gate's penalty-aware coverageScore comparison, so
+// any test that exercises silent failed GVR pulls, partial GVR pulls, or
+// policy degradations must call enforceCoverageThreshold directly. The
+// invariant that this mirror and the real gate agree on every ratio-only
+// input is enforced by TestCoverageWouldFail_MatchesGate, and the
+// penalty-aware path is pinned by Test_enforceCoverageThreshold_Direct.
 func coverageWouldFail(notEvaluated, totalControls int, threshold float32) bool {
 	if threshold <= 0 {
 		return false

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -700,10 +700,19 @@ func TestApplyRegistryCredentialsFromEnv_KeepsExplicitAuthMode(t *testing.T) {
 }
 
 // coverageWouldFail mirrors the gate logic in enforceCoverageThreshold so we
-// can test it without triggering os.Exit.
+// can test it without triggering os.Exit. It MUST stay byte-identical with the
+// gate: when this and the gate disagree, every other test in this file lies
+// about scan behavior. In particular, a zero-controls scan is a coverage
+// failure (nothing was evaluated) rather than a free pass — see
+// core/cautils/scancoverage.go ComputeCoverageScore for the matching rule.
 func coverageWouldFail(notEvaluated, totalControls int, threshold float32) bool {
-	if threshold <= 0 || totalControls == 0 {
+	if threshold <= 0 {
 		return false
+	}
+	if totalControls == 0 {
+		// Scan loaded no controls: coverage is 0%, which is below any positive
+		// threshold — mirror enforceCoverageThreshold's explicit error branch.
+		return true
 	}
 	pct := float32(totalControls-notEvaluated) / float32(totalControls) * 100
 	return pct < threshold
@@ -721,7 +730,14 @@ func Test_enforceCoverageThreshold(t *testing.T) {
 		{"all controls evaluated passes", 0, 10, 80, false},
 		{"coverage exactly at threshold passes", 2, 10, 80, false},
 		{"coverage below threshold fails", 5, 10, 80, true},
-		{"zero total controls never fails", 0, 0, 50, false},
+		// Zero loaded controls is a coverage failure regardless of how low the
+		// user-set threshold is (a 0% coverage never satisfies any threshold > 0),
+		// mirroring the production gate's behavior.
+		{"zero total controls fails at positive threshold", 0, 0, 50, true},
+		{"zero total controls still fails when only a 1% threshold is set", 0, 0, 1, true},
+		// A non-positive threshold is the only way to opt the zero-controls case out,
+		// matching the production `if scanInfo.FailCoverageThreshold <= 0 { return nil }` guard.
+		{"zero total controls with threshold disabled passes", 0, 0, 0, false},
 	}
 
 	for _, tt := range tests {
@@ -729,6 +745,131 @@ func Test_enforceCoverageThreshold(t *testing.T) {
 			assert.Equal(t, tt.wantFail, coverageWouldFail(tt.notEvaluated, tt.totalControls, tt.threshold))
 		})
 	}
+}
+
+// Test_enforceCoverageThreshold_Direct exercises the production gate itself
+// (not the mirror) so the zero-controls fix is regression-tested against the
+// real function: any future change to enforceCoverageThreshold that re-opens
+// the silent-pass will be caught here even if someone "simplifies" the test
+// mirror back to the old behavior.
+func Test_enforceCoverageThreshold_Direct(t *testing.T) {
+	tests := []struct {
+		name          string
+		coverage      cautils.ScanCoverage
+		totalControls int
+		threshold     float32
+		wantErr       bool
+		wantSubstring string
+	}{
+		{
+			name:          "zero controls with positive threshold returns error (was silent-pass before fix)",
+			coverage:      cautils.ScanCoverage{},
+			totalControls: 0,
+			threshold:     50,
+			wantErr:       true,
+			wantSubstring: "scan loaded no controls",
+		},
+		{
+			name:          "zero controls with threshold disabled returns nil (opt-out preserved)",
+			coverage:      cautils.ScanCoverage{},
+			totalControls: 0,
+			threshold:     0,
+			wantErr:       false,
+		},
+		{
+			name:          "full coverage passes",
+			coverage:      cautils.ScanCoverage{CoverageScore: 100},
+			totalControls: 10,
+			threshold:     80,
+			wantErr:       false,
+		},
+		{
+			name:          "below threshold returns error",
+			coverage:      cautils.ScanCoverage{CoverageScore: 50},
+			totalControls: 10,
+			threshold:     80,
+			wantErr:       true,
+			wantSubstring: "scan coverage is below permitted threshold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{FailCoverageThreshold: tt.threshold}
+			err := enforceCoverageThreshold(tt.coverage, tt.totalControls, scanInfo)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantSubstring != "" {
+					assert.Contains(t, err.Error(), tt.wantSubstring)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCoverageWouldFail_MatchesGate is an invariant: the test mirror and the
+// real gate must agree on every input in the sweep. A divergence here means
+// the mirror has drifted from production and Test_enforceCoverageThreshold no
+// longer tests what enforceCoverageThreshold actually does.
+func TestCoverageWouldFail_MatchesGate(t *testing.T) {
+	thresholds := []float32{0, 1, 25, 50, 80, 99, 100}
+	totals := []int{0, 1, 2, 10, 50, 100}
+	notEvals := []int{0, 1, 5, 49}
+
+	for _, threshold := range thresholds {
+		for _, total := range totals {
+			for _, ne := range notEvals {
+				if ne > total {
+					continue
+				}
+				mirrored := coverageWouldFail(ne, total, threshold)
+
+				// Mirror production: build the same ScanCoverage + ScanInfo the
+				// gate receives and ask it directly.
+				coverage := cautils.ScanCoverage{}
+				if total > 0 {
+					coverage.ComputeCoverageScore(total)
+					// Force EvaluatedControls/TotalControls to mirror what the
+					// mirror function sees (the mirror does not run penalties;
+					// it computes pct from the raw ratio).
+					if ne > 0 {
+						coverage.NotEvaluatedControls = make([]cautils.NotEvaluatedControl, ne)
+					}
+					coverage.ComputeCoverageScore(total)
+				}
+				scanInfo := &cautils.ScanInfo{FailCoverageThreshold: threshold}
+				err := enforceCoverageThreshold(coverage, total, scanInfo)
+				gateFails := err != nil
+
+				if mirrored != gateFails {
+					t.Errorf("mirror/gate divergence threshold=%.0f total=%d notEvaluated=%d: mirror=%v gate=%v err=%v", threshold, total, ne, mirrored, gateFails, err)
+				}
+			}
+		}
+	}
+}
+
+// TestZeroControlsCoverage_EndToEnd pins the user-visible behavior: a scan
+// that loaded no controls must (1) report coverageScore=0 and Degraded=true
+// in the report, and (2) make enforceCoverageThreshold return a non-nil error
+// when FailCoverageThreshold > 0. Together these prove the bug is gone from
+// both the score and the gate. It would fail under the buggy code on (1) the
+// score (expected 0, would get 100) and (2) the gate (expected error, would
+// get nil).
+func TestZeroControlsCoverage_EndToEnd(t *testing.T) {
+	coverage := cautils.ScanCoverage{}
+	coverage.ComputeCoverageScore(0)
+
+	assert.Equal(t, float32(0), coverage.CoverageScore, "score must be 0, not the misleading 100")
+	assert.Equal(t, 0, coverage.EvaluatedControls)
+	assert.True(t, coverage.Degraded, "Degraded must be true so downstream consumers (MCP server, JSON) flag the scan")
+
+	scanInfo := &cautils.ScanInfo{FailCoverageThreshold: 1}
+	err := enforceCoverageThreshold(coverage, 0, scanInfo)
+	require.Error(t, err, "zero-controls scan must not silently pass the coverage gate")
+	assert.Contains(t, err.Error(), "scan loaded no controls")
 }
 
 type mockVulnerabilityProvider struct {

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -61,8 +61,12 @@ func (c *ScanCoverage) ComputeCoverageScore(totalControls int) {
 		c.EvaluatedControls = 0
 	}
 
-	score := float32(100)
-	if totalControls > 0 {
+	var score float32
+	if totalControls == 0 {
+		// No controls in scope means nothing was evaluated — report 0%
+		// coverage rather than a misleading 100%.
+		score = 0
+	} else {
 		score = float32(c.EvaluatedControls) / float32(totalControls) * 100
 	}
 
@@ -78,7 +82,7 @@ func (c *ScanCoverage) ComputeCoverageScore(totalControls int) {
 	}
 
 	c.CoverageScore = score
-	c.Degraded = len(c.FailedGVRPulls) > 0 || len(c.PartialGVRPulls) > 0 ||
+	c.Degraded = totalControls == 0 || len(c.FailedGVRPulls) > 0 || len(c.PartialGVRPulls) > 0 ||
 		len(c.PolicyDegradations) > 0 || len(c.NotEvaluatedControls) > 0
 }
 

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -278,9 +278,21 @@ func TestComputeCoverageScore_CombinedDiscountsClampedToZero(t *testing.T) {
 func TestComputeCoverageScore_ZeroControls(t *testing.T) {
 	c := ScanCoverage{}
 	c.ComputeCoverageScore(0)
-	assert.Equal(t, float32(100), c.CoverageScore)
+	assert.Equal(t, float32(0), c.CoverageScore)
 	assert.Equal(t, 0, c.EvaluatedControls)
-	assert.False(t, c.Degraded)
+	assert.True(t, c.Degraded)
+}
+
+func TestComputeCoverageScore_ZeroControlsWithPenalties(t *testing.T) {
+	c := ScanCoverage{
+		PolicyDegradations: []PolicyDegradation{
+			{Component: "controlInputs", Reason: "network error"},
+		},
+	}
+	c.ComputeCoverageScore(0)
+	// 0 controls → base score 0, penalties cannot push it below 0
+	assert.Equal(t, float32(0), c.CoverageScore)
+	assert.True(t, c.Degraded)
 }
 
 func TestComputeCoverageScore_SilentFailedGVRReducesScore(t *testing.T) {


### PR DESCRIPTION
> **Resolves #3199**
>
> Fixes the scan-integrity bug where a scan that loaded zero controls reported `coverageScore: 100` and `degraded: false`, and `enforceCoverageThreshold` returned `nil` for it — silently disabling `--fail-coverage-below` in exactly the case where it matters most.

## Overview

A scan that loads zero controls used to report `coverageScore: 100` and `degraded: false`, and `enforceCoverageThreshold` returned `nil` for it — silently disabling `--fail-coverage-below` in exactly the case where it matters most (a scan that evaluated nothing looked identical to a clean, complete scan, and the CI gate returned exit code 0).

This PR fixes the defect at both layers:

- **`core/cautils/scancoverage.go`** — `ScanCoverage.ComputeCoverageScore` now reports `score=0` and `Degraded=true` when `totalControls == 0`, instead of keeping the misleading `score := float32(100)` default.
- **`cmd/scan/framework.go`** — `enforceCoverageThreshold` now returns an explicit `"scan loaded no controls: coverage is 0% (...)"` error when `totalControls == 0` and the user set a positive `--fail-coverage-below`. The only opt-out is `--fail-coverage-below 0`, preserving the existing escape hatch.

The four call sites of `enforceCoverageThreshold` (framework / control / workload / scan) all benefit from the fix without further changes. Consumers that read `ScanCoverage.Degraded` (e.g. `cmd/mcpserver/scan_helper.go`) automatically start seeing `degraded=true` for empty scans, which is the correct behavior.

## How to Test

```bash
# Unit-level — runs the new + flipped regression tests
go test ./core/cautils/ ./cmd/scan/...

# Full repo — confirms no other package broke
go test ./...
```

The relevant tests are:

- `core/cautils/scancoverage_test.go`
  - `TestComputeCoverageScore_ZeroControls` — flipped to assert `score=0`, `Degraded=true`.
  - `TestComputeCoverageScore_ZeroControlsWithPenalties` — new: penalties cannot push the zero case below 0.
- `cmd/scan/scan_test.go`
  - `coverageWouldFail` — flipped to mirror the corrected gate.
  - `Test_enforceCoverageThreshold` — table rows updated; zero-controls + positive threshold now expects `fail=true`; zero-controls + threshold=0 expects `fail=false` (opt-out preserved).
  - `Test_enforceCoverageThreshold_Direct` — new: regression-tests the real production gate.
  - `TestCoverageWouldFail_MatchesGate` — new: 168-input invariant sweep that fails if the test mirror ever drifts from production.
  - `TestZeroControlsCoverage_EndToEnd` — new: pins the user-visible triple `score=0 + Degraded=true + gate-returns-error`.

Real-world reproduction (any cluster or even an empty file glob):

```bash
# Pre-fix: coverageScore=100, degraded=false, --fail-coverage-below 95 exits 0.
# Post-fix: coverageScore=0, degraded=true, --fail-coverage-below 95 exits 1 with
#   "scan loaded no controls: coverage is 0% (fail-coverage-below: 95.00%)".
kubescape scan framework no-such-framework . --fail-coverage-below 95
```

## Additional Information

**Blast radius:** one shared gate function (`enforceCoverageThreshold`) and one scoring function (`ComputeCoverageScore`). Both are called from every scan path. No public API changed — only the semantics of the `coverageScore`, `degraded`, and the gate behavior for the previously-silent zero-controls case.

**Severity:** Critical (Scan-Integrity) — a false green is worse than a noisy red, and the defect was invisible to the user.

**Backwards compatibility:** a user who explicitly wants the gate disabled can still opt out with `--fail-coverage-below 0`. No previously-passing scan will start failing unless that scan was actually evaluating zero controls, which is exactly the bug being fixed.

## Related issues/PRs

- Resolved #3199
- Related (same false-green-in-CI shape): #2417 (`FailedGVRPulls`-not-scored), #2626 (compliance-score rounding)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes (`go vet ./...`, `go build ./...`, `go test ./...` all green)

## DCO Sign-off

Commit `400c60d3` is signed off (`Signed-off-by: 1PoPTRoN <213124096+1PoPTRoN@users.noreply.github.com>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scans with no controls now correctly report 0% coverage and a degraded status.
  * Coverage enforcement now fails zero-control scans when a positive threshold is configured.
  * Zero-control scans pass only when coverage enforcement is disabled.
  * Coverage scores remain correctly clamped at 0% when policy penalties apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->