### PR TITLE
fix(rules): guard privilege-escalation RBAC rules with resourceNames

### DIFF
--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -20,7 +20,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named pods cannot be pointed at an arbitrary pod's ephemeral containers
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/attach-ephemeral-container-v1/raw.rego
+++ b/rules/attach-ephemeral-container-v1/raw.rego
@@ -19,6 +19,9 @@ deny contains msga if {
 
 	rule := role.rules[p]
 
+	# a rule restricted to named pods cannot be pointed at an arbitrary pod's ephemeral containers
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 

--- a/rules/attach-ephemeral-container-v1/test/resourcenames-empty/expected.json
+++ b/rules/attach-ephemeral-container-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-debugger-empty-resourcenames-sa can attach ephemeral containers to pods",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "debugger-empty-resourcenames-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "debugger-empty-resourcenames-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "ephemeral-debugger-empty-resourcenames"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "debugger-empty-resourcenames-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "ephemeral-debugger-empty-resourcenames" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["pods/ephemeralcontainers"], "verbs": ["patch"], "resourceNames": [] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/attach-ephemeral-container-v1/test/resourcenames-empty/input/clusterrole.yaml
+++ b/rules/attach-ephemeral-container-v1/test/resourcenames-empty/input/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ephemeral-debugger-empty-resourcenames
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]
+  resourceNames: []

--- a/rules/attach-ephemeral-container-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
+++ b/rules/attach-ephemeral-container-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: debugger-empty-resourcenames-crb
+subjects:
+- kind: ServiceAccount
+  name: debugger-empty-resourcenames-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ephemeral-debugger-empty-resourcenames
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/bind-roles-clusterroles-v1/raw.rego
+++ b/rules/bind-roles-clusterroles-v1/raw.rego
@@ -15,6 +15,10 @@ deny contains msga if {
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 	rule := role.rules[p]
+
+	# a rule restricted to named roles/clusterroles cannot be used to bind an arbitrary role/clusterrole
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])

--- a/rules/bind-roles-clusterroles-v1/raw.rego
+++ b/rules/bind-roles-clusterroles-v1/raw.rego
@@ -17,7 +17,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named roles/clusterroles cannot be used to bind an arbitrary role/clusterrole
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/expected.json
+++ b/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-binder-empty-resourcenames-sa can bind roles/clusterroles with rights they do not already hold",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "binder-empty-resourcenames-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "bind-roles-empty-resourcenames-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "bind-roles-empty-resourcenames"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "binder-empty-resourcenames-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "bind-roles-empty-resourcenames" },
+                        "rules": [
+                            { "apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterroles"], "verbs": ["bind"], "resourceNames": [] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrole.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bind-roles-empty-resourcenames
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["bind"]
+  resourceNames: []

--- a/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bind-roles-empty-resourcenames-crb
+subjects:
+- kind: ServiceAccount
+  name: binder-empty-resourcenames-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: bind-roles-empty-resourcenames
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/serviceaccount.yaml
+++ b/rules/bind-roles-clusterroles-v1/test/resourcenames-empty/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: binder-empty-resourcenames-sa
+  namespace: kube-system

--- a/rules/escalate-roles-clusterroles-v1/raw.rego
+++ b/rules/escalate-roles-clusterroles-v1/raw.rego
@@ -15,6 +15,10 @@ deny contains msga if {
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 	rule := role.rules[p]
+
+	# a rule restricted to named roles/clusterroles cannot be used to escalate to an arbitrary role/clusterrole
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])

--- a/rules/escalate-roles-clusterroles-v1/raw.rego
+++ b/rules/escalate-roles-clusterroles-v1/raw.rego
@@ -17,7 +17,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named roles/clusterroles cannot be used to escalate to an arbitrary role/clusterrole
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/expected.json
+++ b/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-escalator-empty-resourcenames-sa can escalate roles/clusterroles beyond their own permissions",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "escalator-empty-resourcenames-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "escalate-roles-empty-resourcenames-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "escalate-roles-empty-resourcenames"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "escalator-empty-resourcenames-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "escalate-roles-empty-resourcenames" },
+                        "rules": [
+                            { "apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterroles"], "verbs": ["escalate"], "resourceNames": [] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrole.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: escalate-roles-empty-resourcenames
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["escalate"]
+  resourceNames: []

--- a/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: escalate-roles-empty-resourcenames-crb
+subjects:
+- kind: ServiceAccount
+  name: escalator-empty-resourcenames-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: escalate-roles-empty-resourcenames
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/serviceaccount.yaml
+++ b/rules/escalate-roles-clusterroles-v1/test/resourcenames-empty/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: escalator-empty-resourcenames-sa
+  namespace: kube-system

--- a/rules/impersonate-users-groups-v1/raw.rego
+++ b/rules/impersonate-users-groups-v1/raw.rego
@@ -15,6 +15,10 @@ deny contains msga if {
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 	rule := role.rules[p]
+
+	# a rule restricted to named identities cannot be used to impersonate an arbitrary identity
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
@@ -57,6 +61,10 @@ deny contains msga if {
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 	rule := role.rules[p]
+
+	# a rule restricted to named identities cannot be used to impersonate an arbitrary identity
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])

--- a/rules/impersonate-users-groups-v1/raw.rego
+++ b/rules/impersonate-users-groups-v1/raw.rego
@@ -17,7 +17,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named identities cannot be used to impersonate an arbitrary identity
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
@@ -63,7 +64,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named identities cannot be used to impersonate an arbitrary identity
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/impersonate-users-groups-v1/test/resourcenames-empty/expected.json
+++ b/rules/impersonate-users-groups-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-impersonator-empty-resourcenames-sa can impersonate other identities and gain their RBAC rights",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "impersonator-empty-resourcenames-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "impersonate-empty-resourcenames-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "impersonate-all-empty-resourcenames"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "impersonator-empty-resourcenames-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "impersonate-all-empty-resourcenames" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["users"], "verbs": ["impersonate"], "resourceNames": [] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/clusterrole.yaml
+++ b/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-all-empty-resourcenames
+rules:
+- apiGroups: [""]
+  resources: ["users"]
+  verbs: ["impersonate"]
+  resourceNames: []

--- a/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
+++ b/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: impersonate-empty-resourcenames-crb
+subjects:
+- kind: ServiceAccount
+  name: impersonator-empty-resourcenames-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: impersonate-all-empty-resourcenames
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/serviceaccount.yaml
+++ b/rules/impersonate-users-groups-v1/test/resourcenames-empty/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: impersonator-empty-resourcenames-sa
+  namespace: kube-system

--- a/rules/node-proxy-access-v1/raw.rego
+++ b/rules/node-proxy-access-v1/raw.rego
@@ -15,6 +15,10 @@ deny contains msga if {
 	rolebinding.roleRef.name == role.metadata.name
 	is_same_namespace(role, rolebinding)
 	rule := role.rules[p]
+
+	# a rule restricted to named nodes cannot be pointed at an arbitrary node's proxy subresource
+	not rule.resourceNames
+
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])

--- a/rules/node-proxy-access-v1/raw.rego
+++ b/rules/node-proxy-access-v1/raw.rego
@@ -17,7 +17,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named nodes cannot be pointed at an arbitrary node's proxy subresource
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/node-proxy-access-v1/test/resourcenames-empty/expected.json
+++ b/rules/node-proxy-access-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,54 @@
+[
+    {
+        "alertMessage": "Subject: ServiceAccount-node-proxy-empty-resourcenames-sa can access the node proxy subresource and execute commands via kubelet",
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 8,
+        "alertObject": {
+            "externalObjects": {
+                "kind": "ServiceAccount",
+                "name": "node-proxy-empty-resourcenames-sa",
+                "namespace": "kube-system",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRoleBinding",
+                        "metadata": { "name": "node-proxy-access-empty-resourcenames-crb" },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "ClusterRole",
+                            "name": "node-proxy-access-empty-resourcenames"
+                        },
+                        "subjects": [
+                            { "kind": "ServiceAccount", "name": "node-proxy-empty-resourcenames-sa", "namespace": "kube-system" }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "ClusterRole",
+                        "metadata": { "name": "node-proxy-access-empty-resourcenames" },
+                        "rules": [
+                            { "apiGroups": [""], "resources": ["nodes/proxy"], "verbs": ["get"], "resourceNames": [] }
+                        ]
+                    }
+                ]
+            },
+            "k8sApiObjects": []
+        }
+    }
+]

--- a/rules/node-proxy-access-v1/test/resourcenames-empty/input/clusterrole.yaml
+++ b/rules/node-proxy-access-v1/test/resourcenames-empty/input/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-proxy-access-empty-resourcenames
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+  resourceNames: []

--- a/rules/node-proxy-access-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
+++ b/rules/node-proxy-access-v1/test/resourcenames-empty/input/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-proxy-access-empty-resourcenames-crb
+subjects:
+- kind: ServiceAccount
+  name: node-proxy-empty-resourcenames-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: node-proxy-access-empty-resourcenames
+  apiGroup: rbac.authorization.k8s.io

--- a/rules/node-proxy-access-v1/test/resourcenames-empty/input/serviceaccount.yaml
+++ b/rules/node-proxy-access-v1/test/resourcenames-empty/input/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-proxy-empty-resourcenames-sa
+  namespace: kube-system


### PR DESCRIPTION
## Summary
- `attach-ephemeral-container-v1`, `node-proxy-access-v1`, `bind-roles-clusterroles-v1`, `escalate-roles-clusterroles-v1`, and `impersonate-users-groups-v1` flag any Role/ClusterRole granting the relevant verb, even when the rule's `resourceNames` restricts it to one named object.
- Kubernetes RBAC honors `resourceNames` for these verbs, so a rule scoped to a single pod, node, role, or identity cannot actually reach arbitrary ones — the alert is overstated in that case.
- `modify-privileged-pods-v1` already carries this exact guard (`not rule.resourceNames`), added for the same reason ("a rule restricted to named pods cannot be pointed at an arbitrary privileged pod"). This applies the same guard to the other five rules, which share the identical role/rolebinding join pattern.

## Example
A ClusterRole like:
```yaml
rules:
- apiGroups: [""]
  resources: ["pods/ephemeralcontainers"]
  verbs: ["patch"]
  resourceNames: ["debug-pod"]
```
only lets the subject attach ephemeral containers to `debug-pod`, but before this fix `attach-ephemeral-container-v1` raised the same "can attach ephemeral containers to pods" alert as if the subject could target any pod.

## Files changed
- `rules/attach-ephemeral-container-v1/raw.rego`
- `rules/node-proxy-access-v1/raw.rego`
- `rules/bind-roles-clusterroles-v1/raw.rego`
- `rules/escalate-roles-clusterroles-v1/raw.rego`
- `rules/impersonate-users-groups-v1/raw.rego` (both `deny` blocks)

## Test plan
- [x] Verified functionally with the `open-policy-agent/opa/v1/rego` library (already a project dependency) against each rule's existing test fixtures under `rules/*/test/*/expected.json`: an unscoped rule still denies (no regression), and the same rule scoped with `resourceNames` no longer denies (bug fixed).
- [x] Sanity-checked the harness against the already-fixed `modify-privileged-pods-v1` sibling rule to confirm it reproduces known-correct behavior.
- [x] `go build ./...` / `go vet ./...` (no Go code touched by this change; confirms nothing else broke)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization analysis for ephemeral container attachments with resource-specific restrictions.
  * Reduced false-positive alerts for role bindings involving specifically named resources.
  * Improved escalation detection by correctly handling permissions limited to named resources.
  * Refined impersonation checks to distinguish broad permissions from named-resource permissions.
  * Reduced false positives for node proxy access when permissions target specific nodes or subresources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->