### PR TITLE
fix(anonymizer): stop a Windows drive letter from masking sourcePath

### DIFF
--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -292,7 +292,7 @@ func transformResourceObjectSourcePath(resource workloadinterface.IMetadata, tra
 // src-xxxx:12).
 func transformSourcePath(sourcePath string, transformer Transformer) (string, error) {
 
-	lastColon := strings.LastIndex(sourcePath, ":")
+	lastColon := lastSourcePathColon(sourcePath)
 	if lastColon == -1 {
 		return transformValue(transformer, "src", sourcePath)
 	}
@@ -310,6 +310,30 @@ func transformSourcePath(sourcePath string, transformer Transformer) (string, er
 	}
 
 	return transformedPath + linePart, nil
+}
+
+// lastSourcePathColon returns the index of the colon separating a
+// sourcePath's file path from its trailing document-index suffix (for
+// example the ":12" in "src-xxxx:12"), or -1 if there is none. A leading
+// Windows drive letter (for example "C:\...") is skipped so it is never
+// mistaken for that separator, which would otherwise leave everything past
+// the drive letter untransformed.
+func lastSourcePathColon(sourcePath string) int {
+	searchFrom := 0
+	if len(sourcePath) >= 2 && sourcePath[1] == ':' && isASCIILetter(sourcePath[0]) {
+		searchFrom = 2
+	}
+
+	idx := strings.LastIndex(sourcePath[searchFrom:], ":")
+	if idx == -1 {
+		return -1
+	}
+
+	return idx + searchFrom
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 // transformAnnotationNodes recursively traverses unstructured resource

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -1232,3 +1232,56 @@ func TestTransformSourcePath_EncryptionTransformer(t *testing.T) {
 		decryptedPath,
 	)
 }
+
+func TestTransformSourcePath_WindowsDriveLetterNoLineSuffix(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	// A bare Windows path has no trailing ":<index>" suffix, so its only
+	// colon is the drive letter's. That colon must not be mistaken for a
+	// line-number separator, or everything past "C" leaks in cleartext.
+	transformed, err := transformSourcePath(
+		`C:\Users\alice\manifests\payment.yaml`,
+		transformer,
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, transformed, `Users\alice`)
+	assert.Contains(t, transformed, "ENC[AES256_GCM,")
+
+	decryptedPath, err := reportcrypto.DecryptString(transformed, dek)
+	require.NoError(t, err)
+
+	assert.Equal(t, `C:\Users\alice\manifests\payment.yaml`, decryptedPath)
+}
+
+func TestTransformSourcePath_WindowsDriveLetterWithLineSuffix(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	transformer := NewEncryptionTransformer(dek)
+
+	transformed, err := transformSourcePath(
+		`C:\Users\alice\manifests\payment.yaml:7`,
+		transformer,
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, transformed, `Users\alice`)
+
+	lastColon := strings.LastIndex(transformed, ":")
+	require.NotEqual(t, -1, lastColon)
+
+	encryptedPath := transformed[:lastColon]
+	linePart := transformed[lastColon:]
+
+	assert.Contains(t, encryptedPath, "ENC[AES256_GCM,")
+	assert.Equal(t, ":7", linePart)
+
+	decryptedPath, err := reportcrypto.DecryptString(encryptedPath, dek)
+	require.NoError(t, err)
+
+	assert.Equal(t, `C:\Users\alice\manifests\payment.yaml`, decryptedPath)
+}


### PR DESCRIPTION
## Summary
- `transformSourcePath` (used by `kubescape scan --anonymize` / encrypted reports) splits a resource's `sourcePath` on the *last* colon to separate the file path from its optional trailing document index, e.g. `src.yaml:12`.
- When `sourcePath` has no index suffix, a Windows absolute path's drive letter (e.g. `C:\Users\alice\deploy.yaml`) is the only colon in the string, so it was mistaken for that separator.
- Only `"C"` was passed to the transformer/encryptor; the rest of the real path — usernames, project layout, filenames — was reattached and left in the "anonymized"/encrypted report untouched, defeating the privacy feature for paths produced without a trailing index. `core/cautils/kustomizedirectory.go` and `core/cautils/helmchart.go` both call `lw.SetPath` with a bare path and no `:<index>` suffix, so this is reachable from real scans (Kustomize directories, Helm charts) on Windows.
- This mirrors a bug class already fixed elsewhere in this codebase: `fixhandler.getFilePathAndIndex` and `sarifprinter.go` both explicitly strip a Windows volume name before searching for the trailing colon, with comments documenting the same drive-letter hazard. `core/pkg/anonymizer/session.go` was missed when that fix was applied.

## Fix
A leading drive letter (`X:` at the start of the string) is now recognized and skipped before searching for the trailing document-index colon, so a bare Windows path with no index suffix is transformed/encrypted in full instead of leaking everything past the drive letter.

## Files changed
- `core/pkg/anonymizer/session.go`
- `core/pkg/anonymizer/session_test.go` — added `TestTransformSourcePath_WindowsDriveLetterNoLineSuffix` and `TestTransformSourcePath_WindowsDriveLetterWithLineSuffix`

## Test plan
- [x] Confirmed `TestTransformSourcePath_WindowsDriveLetterNoLineSuffix` fails against the pre-fix code (leaks `Users\alice` in cleartext) and passes after the fix.
- [x] `go test ./core/pkg/anonymizer/... -race -v`
- [x] `go test ./...` (full module)
- [x] `go build ./...` / `go vet ./...`
- [x] `golangci-lint run ./core/pkg/anonymizer/...` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed source-path encryption for Windows paths containing drive letters.
  * Preserved trailing line-number suffixes, such as `:7`, during encryption and decryption.

* **Tests**
  * Added coverage for Windows paths with and without line-number suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->