### PR TITLE
fix: prevent panic in getLastLineOfResource for empty yaml files

### DIFF
--- a/core/pkg/fixhandler/yamlhelper.go
+++ b/core/pkg/fixhandler/yamlhelper.go
@@ -202,7 +202,7 @@ func getLastLineOfResource(linesSlice *[]string, currentLine int) (int, error) {
 	}
 
 	lastLine := len(*linesSlice)
-	for lastLine >= 0 {
+	for lastLine > 0 {
 		if !isEmptyLineOrComment((*linesSlice)[lastLine-1]) {
 			lastLinesOfResources = append(lastLinesOfResources, lastLine)
 			break

--- a/core/pkg/fixhandler/yamlhelper_test.go
+++ b/core/pkg/fixhandler/yamlhelper_test.go
@@ -262,6 +262,20 @@ func TestAssignLastLine(t *testing.T) {
 	}
 }
 
+func TestGetLastLineOfResource_EmptyFile(t *testing.T) {
+	linesSlice := []string{
+		"# comment",
+		"",
+		" ",
+	}
+
+	_, err := getLastLineOfResource(&linesSlice, 1)
+
+	if err == nil {
+		t.Errorf("Expected an error for empty resource, but got none")
+	}
+}
+
 // returns the line number of the node at the given tracker position
 func TestGetNodeLine_ReturnsLineNumberOfNodeAtGivenTrackerPosition(t *testing.T) {
 	nodeList := []nodeInfo{


### PR DESCRIPTION
## Description
This PR fixes a bug in `getLastLineOfResource` that causes an index out of range panic when `kubescape fix` is run against a YAML file containing only comments or empty lines.

The function had an off-by-one loop condition (`lastLine >= 0` instead of `lastLine > 0`).

## Changes
- Fixed loop condition in `getLastLineOfResource` in `yamlhelper.go`
- Added `TestGetLastLineOfResource_EmptyFile` unit test to prevent regression

## Testing
- Verified `go test ./core/pkg/fixhandler/...` passes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of YAML files containing only comments or whitespace.
  * Prevented errors when processing resources with no meaningful content.

* **Tests**
  * Added coverage to verify appropriate error handling for empty YAML resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->