### PR TITLE
test(cel): assert every params.settings key a bundle policy reads is shipped

### DIFF
--- a/core/pkg/opaprocessor/cel/vapdata_test.go
+++ b/core/pkg/opaprocessor/cel/vapdata_test.go
@@ -3,11 +3,14 @@ package cel
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 // These tests guard the prerequisite the loader (loader.go) //go:embeds: the
@@ -49,4 +52,98 @@ func TestVapdataBasicControlConfiguration(t *testing.T) {
 	content := string(data)
 	assert.True(t, strings.Contains(content, "kind: ControlConfiguration"), "expected a ControlConfiguration document")
 	assert.Contains(t, content, "settings:")
+}
+
+// paramsSettingsRef matches a `params.settings.<key>` read in a CEL expression.
+// The bundle only ever uses the dot form today, but the index form is legal CEL
+// for the same lookup, so both are matched rather than trusting a convention
+// nothing enforces.
+var paramsSettingsRef = regexp.MustCompile(`params\.settings(?:\.(\w+)|\[['"]([^'"]+)['"]\])`)
+
+// knownMissingSettings are params.settings keys a bundle policy reads that the
+// shipped basic-control-configuration.yaml does not define. An entry here is a
+// live bug being tracked, not an accepted state, so each one carries the
+// consequence rather than a bare key name.
+//
+// Both files are vendored from cel-admission-library by `make sync-vap`, so
+// neither can be fixed in this repo: the fix ships in the library's own
+// basic-control-configuration.yaml and arrives here at the next pin bump, at
+// which point the entry below must be deleted and this test will say so.
+var knownMissingSettings = map[string]string{
+	"cloudProvider": "read by C-0020 (kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials). " +
+		"Only the library's test configuration sets it, which is why library CI does not catch it. " +
+		"CEL short-circuits, so the expression only reaches the key once a volume actually matches a sensitive path, " +
+		"meaning it errors on exactly the objects it should be flagging and a scan can never report a C-0020 violation.",
+}
+
+// TestBundleParamsSettingsAreShipped asserts every params.settings key a bundle
+// policy reads is defined in the shipped control configuration.
+//
+// A missing key is not a loud failure at runtime. The policy resolves params,
+// the lookup errors mid-expression, and the object lands in skipped, so the
+// control silently reports nothing on precisely the resources it exists to
+// catch. That is indistinguishable from "no violations found" in a scan result.
+//
+// This is cheapest to catch at a pin bump, when both files move together and
+// the diff is in front of you, which is why it lives beside the other vendored
+// bundle guards.
+func TestBundleParamsSettingsAreShipped(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	// Where each key is read, so a failure names the policy to look at rather
+	// than just the key.
+	readBy := map[string][]string{}
+	for name, vap := range catalog.byName {
+		var expressions []string
+		for _, v := range vap.Variables {
+			expressions = append(expressions, v.Expression)
+		}
+		for _, v := range vap.Validations {
+			expressions = append(expressions, v.Expression, v.MessageExpression)
+		}
+		for _, expression := range expressions {
+			for _, m := range paramsSettingsRef.FindAllStringSubmatch(expression, -1) {
+				key := m[1]
+				if key == "" {
+					key = m[2]
+				}
+				if !slices.Contains(readBy[key], name) {
+					readBy[key] = append(readBy[key], name)
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, readBy, "no params.settings reads found in the bundle; the extraction is broken, not the bundle")
+
+	data, err := os.ReadFile(filepath.Join(vapdataDir, "basic-control-configuration.yaml"))
+	require.NoError(t, err)
+	var config struct {
+		Settings map[string]any `json:"settings"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &config))
+	require.NotEmpty(t, config.Settings, "shipped control configuration has no settings block")
+
+	for key, policies := range readBy {
+		slices.Sort(policies)
+		_, shipped := config.Settings[key]
+		if reason, known := knownMissingSettings[key]; known {
+			assert.Falsef(t, shipped,
+				"params.settings.%s is now shipped in basic-control-configuration.yaml; "+
+					"delete its knownMissingSettings entry, the bug it tracks is fixed", key)
+			t.Logf("known gap: params.settings.%s, read by %s: %s", key, strings.Join(policies, ", "), reason)
+			continue
+		}
+		assert.Truef(t, shipped,
+			"policy %s reads params.settings.%s but the shipped basic-control-configuration.yaml does not define it. "+
+				"The lookup errors mid-expression and the object is skipped, so the control silently reports nothing "+
+				"on the resources it should flag. Fix it in cel-admission-library's basic-control-configuration.yaml, "+
+				"or add it to knownMissingSettings with the consequence spelled out if it is a gap being tracked.",
+			strings.Join(policies, ", "), key)
+	}
+
+	for key := range knownMissingSettings {
+		assert.Containsf(t, readBy, key,
+			"knownMissingSettings lists params.settings.%s but no bundle policy reads it any more; remove the entry", key)
+	}
 }


### PR DESCRIPTION
## Overview

I went looking for something else and found that C-0020 can never report a violation today.

It reads params.settings.cloudProvider, and that key is not in the shipped basic-control-configuration.yaml. Only the library's test config sets it, which is why library CI stays green. The part that makes it hard to notice is that CEL short-circuits, so the expression only reaches the key once a volume actually matches a sensitive path. It errors on exactly the objects it is supposed to be flagging, the object goes to skipped, and the scan result looks the same as "nothing found".

So this adds a test that pulls every params.settings key the embedded bundle reads and checks each one is actually shipped. 18 keys today, 17 fine, cloudProvider is the one. I put it in as a documented exemption rather than a failure, because both files are vendored by make sync-vap and the real fix belongs in the library config. When that ships, the test fails until the exemption is deleted, which is the reminder I want.

Part of #2001 and #2002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure all referenced configuration settings are included in the shipped control configuration.
  * Added checks to identify missing or outdated setting references.
  * Documented the known exception for the `cloudProvider` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->