### PR TITLE
feat(imagescan): add native GitLab vulnerability adaptor

### DIFF
--- a/pkg/imagescan/gitlab_adaptor.go
+++ b/pkg/imagescan/gitlab_adaptor.go
@@ -1,0 +1,484 @@
+package imagescan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+)
+
+// GitlabAPI defines the interface for GitLab GraphQL interactions to enable mocking
+type GitlabAPI interface {
+	DoGraphQL(ctx context.Context, query string, variables map[string]interface{}) ([]byte, error)
+}
+
+type gitlabAPIWrapper struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+func (w *gitlabAPIWrapper) DoGraphQL(ctx context.Context, query string, variables map[string]interface{}) ([]byte, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"query":     query,
+		"variables": variables,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.baseURL+"/api/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+w.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := string(bodyBytes)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return nil, fmt.Errorf("gitlab graphql api returned status %d: %s", resp.StatusCode, snippet)
+	}
+
+	return bodyBytes, nil
+}
+
+// GitlabAdaptor implements IContainerImageVulnerabilityAdaptor for GitLab Container Registry.
+type GitlabAdaptor struct {
+	client GitlabAPI
+}
+
+// NewGitlabAdaptor creates a new GitLab adaptor instance.
+func NewGitlabAdaptor() *GitlabAdaptor {
+	return &GitlabAdaptor{}
+}
+
+// Login authenticates with GitLab GraphQL API.
+func (a *GitlabAdaptor) Login(ctx context.Context, registry string, credentials RegistryCredentials) error {
+	if credentials.Token == "" {
+		return fmt.Errorf("gitlab adaptor requires a personal or project access token; username/password is not supported for the GraphQL API")
+	}
+
+	registry = strings.TrimRight(registry, "/")
+	host := strings.TrimPrefix(strings.TrimPrefix(registry, "https://"), "http://")
+	scheme := "https"
+	if strings.HasPrefix(registry, "http://") {
+		scheme = "http"
+	}
+
+	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+
+	wrapper := &gitlabAPIWrapper{
+		baseURL:    baseURL,
+		token:      credentials.Token,
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+
+	data, err := wrapper.DoGraphQL(ctx, `query { currentUser { username } }`, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect to gitlab graphql api at %s: %w", wrapper.baseURL, err)
+	}
+
+	var loginResp struct {
+		Data struct {
+			CurrentUser *struct {
+				Username string `json:"username"`
+			} `json:"currentUser"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+
+	if err := json.Unmarshal(data, &loginResp); err != nil {
+		return fmt.Errorf("failed to parse login response: %w", err)
+	}
+
+	if len(loginResp.Errors) > 0 {
+		return fmt.Errorf("graphql error during login: %s", loginResp.Errors[0].Message)
+	}
+
+	if loginResp.Data.CurrentUser == nil || loginResp.Data.CurrentUser.Username == "" {
+		return fmt.Errorf("invalid token or insufficient scopes (currentUser is null)")
+	}
+
+	a.client = wrapper
+	return nil
+}
+
+// DescribeAdaptor provides a string description of the adaptor for help purposes.
+func (a *GitlabAdaptor) DescribeAdaptor() string {
+	return "GitLab Container Registry Vulnerability Adaptor"
+}
+
+// splitGitLabProjectPath splits a repository string into the project's GraphQL
+// fullPath and the trailing container image name.
+func splitGitLabProjectPath(repo string) (string, string, error) {
+	repo = strings.TrimPrefix(repo, "/")
+	if strings.Count(repo, "/") < 2 {
+		return "", "", fmt.Errorf("invalid gitlab repository format: expected at least group/project/image, got %s", repo)
+	}
+	idx := strings.LastIndex(repo, "/")
+	if idx <= 0 || idx == len(repo)-1 {
+		return "", "", fmt.Errorf("invalid gitlab repository format: expected at least group/project/image, got %s", repo)
+	}
+	return repo[:idx], repo[idx+1:], nil
+}
+
+// normalizeGitLabSeverity maps GitLab severity to Kubescape severity strings
+func normalizeGitLabSeverity(severity string) string {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL":
+		return "Critical"
+	case "HIGH":
+		return "High"
+	case "MEDIUM":
+		return "Medium"
+	case "LOW":
+		return "Low"
+	case "INFO":
+		return "Negligible"
+	default:
+		return "Unknown"
+	}
+}
+
+type gitlabVulnerabilityNode struct {
+	Title       string `json:"title"`
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Location    struct {
+		Image string `json:"image"`
+	} `json:"location"`
+	Links []struct {
+		URL string `json:"url"`
+	} `json:"links"`
+}
+
+type gitlabGraphQLResponse struct {
+	Data struct {
+		Project *struct {
+			Vulnerabilities struct {
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+				Nodes []gitlabVulnerabilityNode `json:"nodes"`
+			} `json:"vulnerabilities"`
+		} `json:"project"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type scanCacheEntry struct {
+	isAvailable bool
+	err         error
+}
+
+// GetImagesScanStatus retrieves the scan status for a list of image identifiers.
+func (a *GitlabAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageScanStatus, error) {
+	if a.client == nil {
+		return nil, fmt.Errorf("gitlab client not initialized, call login first")
+	}
+
+	var statuses []ContainerImageScanStatus
+	var aggErr error
+	cache := make(map[string]scanCacheEntry)
+
+	for _, imageID := range imageIDs {
+		status := ContainerImageScanStatus{
+			ImageID:         imageID,
+			IsScanAvailable: false,
+			IsBomAvailable:  false,
+		}
+
+		fullPath, _, err := splitGitLabProjectPath(imageID.Repository)
+		if err != nil {
+			fetchErr := fmt.Errorf("failed to parse gitlab path: %w", err)
+			logger.L().Warning("skipping image scan status due to format error", helpers.Error(fetchErr))
+			aggErr = errors.Join(aggErr, fetchErr)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		if entry, ok := cache[fullPath]; ok {
+			status.IsScanAvailable = entry.isAvailable
+			if entry.err != nil {
+				aggErr = errors.Join(aggErr, entry.err)
+			}
+			statuses = append(statuses, status)
+			continue
+		}
+
+		query := `
+			query($fullPath: ID!) {
+				project(fullPath: $fullPath) {
+					vulnerabilities(reportType: [CONTAINER_SCANNING], first: 1) {
+						nodes {
+							title
+						}
+					}
+				}
+			}
+		`
+
+		variables := map[string]interface{}{
+			"fullPath": fullPath,
+		}
+
+		data, err := a.client.DoGraphQL(ctx, query, variables)
+		if err != nil {
+			fetchErr := fmt.Errorf("failed to query scan status for repository %s: %w", fullPath, err)
+			logger.L().Warning("skipping image scan status due to api error", helpers.Error(fetchErr))
+			cache[fullPath] = scanCacheEntry{isAvailable: false, err: fetchErr}
+			aggErr = errors.Join(aggErr, fetchErr)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		var resp gitlabGraphQLResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			fetchErr := fmt.Errorf("failed to parse scan status payload: %w", err)
+			logger.L().Warning("skipping image scan status due to payload error", helpers.Error(fetchErr))
+			cache[fullPath] = scanCacheEntry{isAvailable: false, err: fetchErr}
+			aggErr = errors.Join(aggErr, fetchErr)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		if len(resp.Errors) > 0 {
+			fetchErr := fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+			logger.L().Warning("skipping image scan status due to graphql error", helpers.Error(fetchErr))
+			cache[fullPath] = scanCacheEntry{isAvailable: false, err: fetchErr}
+			aggErr = errors.Join(aggErr, fetchErr)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		if resp.Data.Project == nil {
+			fetchErr := fmt.Errorf("project not found or permission denied (project is null)")
+			logger.L().Warning("skipping image scan status due to missing project", helpers.Error(fetchErr))
+			cache[fullPath] = scanCacheEntry{isAvailable: false, err: fetchErr}
+			aggErr = errors.Join(aggErr, fetchErr)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		cache[fullPath] = scanCacheEntry{isAvailable: true, err: nil}
+		status.IsScanAvailable = true
+		statuses = append(statuses, status)
+	}
+
+	return statuses, aggErr
+}
+
+type vulnCacheEntry struct {
+	nodes []gitlabVulnerabilityNode
+	err   error
+}
+
+// imageMatches provides a boundary-safe match for the image location.
+func imageMatches(locationImage string, imageID ContainerImageIdentifier) bool {
+	if imageID.Hash != "" {
+		expectedSuffix := imageID.Repository + "@" + imageID.Hash
+		if strings.HasSuffix(locationImage, expectedSuffix) || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
+			return true
+		}
+	}
+
+	if imageID.Tag != "" {
+		expectedSuffix := imageID.Repository + ":" + imageID.Tag
+		if strings.HasSuffix(locationImage, expectedSuffix) || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetImagesVulnerabilities retrieves the vulnerability reports for a list of image identifiers.
+func (a *GitlabAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageVulnerabilityReport, error) {
+	if a.client == nil {
+		return nil, fmt.Errorf("gitlab client not initialized, call login first")
+	}
+
+	var reports []ContainerImageVulnerabilityReport
+	var aggErr error
+	cache := make(map[string]vulnCacheEntry)
+
+	for _, imageID := range imageIDs {
+		report := ContainerImageVulnerabilityReport{
+			ImageID:         imageID,
+			Vulnerabilities: []Vulnerability{},
+		}
+
+		fullPath, _, err := splitGitLabProjectPath(imageID.Repository)
+		if err != nil {
+			fetchErr := fmt.Errorf("failed to parse gitlab path: %w", err)
+			logger.L().Warning("skipping image vulnerabilities due to format error", helpers.Error(fetchErr))
+			aggErr = errors.Join(aggErr, fetchErr)
+			reports = append(reports, report)
+			continue
+		}
+
+		var projectNodes []gitlabVulnerabilityNode
+
+		if entry, ok := cache[fullPath]; ok {
+			projectNodes = entry.nodes
+			if entry.err != nil {
+				aggErr = errors.Join(aggErr, entry.err)
+			}
+		} else {
+			query := `
+				query($fullPath: ID!, $after: String) {
+					project(fullPath: $fullPath) {
+						vulnerabilities(reportType: [CONTAINER_SCANNING], after: $after) {
+							pageInfo {
+								hasNextPage
+								endCursor
+							}
+							nodes {
+								title
+								severity
+								description
+								location {
+									... on VulnerabilityLocationContainerScanning {
+										image
+									}
+								}
+								links {
+									url
+								}
+							}
+						}
+					}
+				}
+			`
+
+			var afterCursor string
+			hasNextPage := true
+			var fetchErr error
+
+			for hasNextPage {
+				variables := map[string]interface{}{
+					"fullPath": fullPath,
+				}
+				if afterCursor != "" {
+					variables["after"] = afterCursor
+				}
+
+				data, err := a.client.DoGraphQL(ctx, query, variables)
+				if err != nil {
+					fetchErr = fmt.Errorf("failed to query vulnerabilities for repository %s: %w", fullPath, err)
+					logger.L().Warning("skipping image vulnerabilities due to api error", helpers.Error(fetchErr))
+					break
+				}
+
+				var resp gitlabGraphQLResponse
+				if err := json.Unmarshal(data, &resp); err != nil {
+					fetchErr = fmt.Errorf("failed to parse vulnerability payload: %w", err)
+					logger.L().Warning("failed to parse vulnerability payload", helpers.Error(fetchErr))
+					break
+				}
+
+				if len(resp.Errors) > 0 {
+					fetchErr = fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+					logger.L().Warning("failed to fetch vulnerabilities due to graphql error", helpers.Error(fetchErr))
+					break
+				}
+
+				if resp.Data.Project == nil {
+					fetchErr = fmt.Errorf("project not found or permission denied (project is null)")
+					logger.L().Warning("failed to fetch vulnerabilities due to missing project", helpers.Error(fetchErr))
+					break
+				}
+
+				projectNodes = append(projectNodes, resp.Data.Project.Vulnerabilities.Nodes...)
+
+				hasNextPage = resp.Data.Project.Vulnerabilities.PageInfo.HasNextPage
+				afterCursor = resp.Data.Project.Vulnerabilities.PageInfo.EndCursor
+			}
+
+			cache[fullPath] = vulnCacheEntry{nodes: projectNodes, err: fetchErr}
+			if fetchErr != nil {
+				aggErr = errors.Join(aggErr, fetchErr)
+			}
+		}
+
+		for _, node := range projectNodes {
+			if !imageMatches(node.Location.Image, imageID) {
+				if imageID.Tag == "" && imageID.Hash != "" && strings.Contains(node.Location.Image, imageID.Repository) {
+					logger.L().Debug("skipped vulnerability because gitlab location lacked matching digest (API limitation?)", helpers.String("image", node.Location.Image), helpers.String("digest", imageID.Hash))
+				}
+				continue
+			}
+
+			var links []string
+			for _, l := range node.Links {
+				links = append(links, l.URL)
+			}
+
+			vuln := Vulnerability{
+				ID:          node.Title,
+				Severity:    normalizeGitLabSeverity(node.Severity),
+				Description: node.Description,
+				Links:       links,
+			}
+			report.Vulnerabilities = append(report.Vulnerabilities, vuln)
+		}
+
+		reports = append(reports, report)
+	}
+
+	return reports, aggErr
+}
+
+// GetImagesInformation retrieves the BOM and manifest information for a list of image identifiers.
+// Note: The GitLab GraphQL API does not expose SBOM data, so this always returns an empty BOM.
+func (a *GitlabAdaptor) GetImagesInformation(ctx context.Context, imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error) {
+	if a.client == nil {
+		return nil, fmt.Errorf("gitlab client not initialized, call login first")
+	}
+
+	var infos []ContainerImageInformation
+
+	for _, imageID := range imageIDs {
+		info := ContainerImageInformation{
+			ImageID: imageID,
+			Bom:     []string{},
+		}
+		infos = append(infos, info)
+	}
+
+	return infos, nil
+}
+
+// Destroy cleans up any persistent resources used by the adaptor.
+func (a *GitlabAdaptor) Destroy() error {
+	return nil
+}

--- a/pkg/imagescan/gitlab_adaptor_test.go
+++ b/pkg/imagescan/gitlab_adaptor_test.go
@@ -1,0 +1,392 @@
+package imagescan
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockGitlabAPI struct {
+	responses map[string][]byte
+	errors    map[string]error
+	callCount map[string]int
+}
+
+func (m *mockGitlabAPI) DoGraphQL(ctx context.Context, query string, variables map[string]interface{}) ([]byte, error) {
+	if m.callCount == nil {
+		m.callCount = make(map[string]int)
+	}
+
+	fullPath, ok := variables["fullPath"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing fullPath variable")
+	}
+
+	key := fullPath
+	if after, ok := variables["after"].(string); ok && after != "" {
+		key += "_" + after
+	}
+
+	m.callCount[key]++
+
+	if err, ok := m.errors[key]; ok {
+		return nil, err
+	}
+	if resp, ok := m.responses[key]; ok {
+		return resp, nil
+	}
+	return nil, fmt.Errorf("mock key not found: %s", key)
+}
+
+func TestGitlabAdaptor_DescribeAdaptor(t *testing.T) {
+	adaptor := NewGitlabAdaptor()
+	assert.Equal(t, "GitLab Container Registry Vulnerability Adaptor", adaptor.DescribeAdaptor())
+}
+
+func TestGitlabAdaptor_Login(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/graphql" {
+			auth := r.Header.Get("Authorization")
+			if auth == "Bearer badtoken" {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("unauthorized body test snippet"))
+				return
+			}
+			if auth == "Bearer nulluser" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"data":{"currentUser":null}}`))
+				return
+			}
+			if auth == "Bearer grapherror" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"errors":[{"message":"Forbidden"}]}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{"currentUser":{"username":"testuser"}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name        string
+		registry    string
+		credentials RegistryCredentials
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "valid registry format and auth",
+			registry:    server.URL + "/", // Test trailing slash removal
+			credentials: RegistryCredentials{Token: "goodtoken"},
+			wantErr:     false,
+		},
+		{
+			name:        "auth failure with truncated body",
+			registry:    server.URL,
+			credentials: RegistryCredentials{Token: "badtoken"},
+			wantErr:     true,
+			errMsg:      "unauthorized body test snippet",
+		},
+		{
+			name:        "null current user",
+			registry:    server.URL,
+			credentials: RegistryCredentials{Token: "nulluser"},
+			wantErr:     true,
+			errMsg:      "invalid token or insufficient scopes",
+		},
+		{
+			name:        "graphql error during login",
+			registry:    server.URL,
+			credentials: RegistryCredentials{Token: "grapherror"},
+			wantErr:     true,
+			errMsg:      "graphql error during login: Forbidden",
+		},
+		{
+			name:        "missing token",
+			registry:    server.URL,
+			credentials: RegistryCredentials{Username: "test", Password: "password"},
+			wantErr:     true,
+			errMsg:      "requires a personal or project access token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adaptor := NewGitlabAdaptor()
+			err := adaptor.Login(context.Background(), tt.registry, tt.credentials)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSplitGitLabProjectPath(t *testing.T) {
+	tests := []struct {
+		repo             string
+		expectedFullPath string
+		expectedImage    string
+		wantErr          bool
+	}{
+		{"my-group/my-project/my-image", "my-group/my-project", "my-image", false},
+		{"my-group/subgroup/my-project/my-image", "my-group/subgroup/my-project", "my-image", false},
+		{"my-group", "", "", true},          // Missing slash
+		{"/my-image", "", "", true},         // Invalid leading slash making fullPath empty
+		{"my-group/my-image", "", "", true}, // Only one slash, fails 'at least group/project/image'
+		{"/my-group/my-project/my-image", "my-group/my-project", "my-image", false}, // leading slash valid if rest is ok
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.repo, func(t *testing.T) {
+			fullPath, imageName, err := splitGitLabProjectPath(tt.repo)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedFullPath, fullPath)
+				assert.Equal(t, tt.expectedImage, imageName)
+			}
+		})
+	}
+}
+
+func TestGitlabAdaptor_GetImagesScanStatus(t *testing.T) {
+	mockAPI := &mockGitlabAPI{
+		responses: map[string][]byte{
+			"my-group/my-project": []byte(`{
+				"data": {
+					"project": {
+						"vulnerabilities": {
+							"nodes": [
+								{ "title": "CVE-2023-1234" }
+							]
+						}
+					}
+				}
+			}`),
+			"my-group/empty-project": []byte(`{
+				"data": {
+					"project": {
+						"vulnerabilities": {
+							"nodes": []
+						}
+					}
+				}
+			}`),
+			"my-group/null-project": []byte(`{
+				"data": {
+					"project": null
+				}
+			}`),
+			"my-group/error-project": []byte(`{
+				"errors": [
+					{ "message": "Project not found" }
+				]
+			}`),
+			"my-group/malformed-project": []byte(`{ malformed json }`),
+		},
+		errors: map[string]error{
+			"my-group/api-error-project": fmt.Errorf("api error"),
+		},
+	}
+
+	adaptor := NewGitlabAdaptor()
+	adaptor.client = mockAPI
+
+	imageIDs := []ContainerImageIdentifier{
+		{Repository: "my-group/my-project/my-image", Hash: "sha256:123"},
+		{Repository: "my-group/my-project/my-image2", Hash: "sha256:456"}, // Will test caching since it's the same project
+		{Repository: "my-group/empty-project/my-image", Hash: "sha256:456"},
+		{Repository: "my-group/null-project/my-image", Hash: "sha256:789"}, // Null project
+		{Repository: "my-group/error-project/my-image", Hash: "sha256:789"},
+		{Repository: "my-group/api-error-project/my-image", Hash: "sha256:000"},
+		{Repository: "invalidformat", Hash: "sha256:111"},
+		{Repository: "my-group/malformed-project/my-image", Hash: "sha256:999"},
+	}
+
+	statuses, err := adaptor.GetImagesScanStatus(context.Background(), imageIDs)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid gitlab repository format")
+	assert.Contains(t, err.Error(), "graphql error: Project not found")
+	assert.Contains(t, err.Error(), "project not found or permission denied")
+	assert.Contains(t, err.Error(), "api error")
+	assert.Contains(t, err.Error(), "failed to parse scan status payload")
+
+	assert.Len(t, statuses, 8)
+
+	assert.True(t, statuses[0].IsScanAvailable)  // Found nodes
+	assert.True(t, statuses[1].IsScanAvailable)  // Found nodes (cached!)
+	assert.True(t, statuses[2].IsScanAvailable)  // Empty nodes but no GraphQL error means scanned
+	assert.False(t, statuses[3].IsScanAvailable) // Null Project
+	assert.False(t, statuses[4].IsScanAvailable) // GraphQL Error
+	assert.False(t, statuses[5].IsScanAvailable) // API Error
+	assert.False(t, statuses[6].IsScanAvailable) // Format Error
+	assert.False(t, statuses[7].IsScanAvailable) // Malformed JSON
+
+	// Verify caching - 'my-group/my-project' should only have 1 call
+	assert.Equal(t, 1, mockAPI.callCount["my-group/my-project"])
+}
+
+func TestGitlabAdaptor_GetImagesVulnerabilities(t *testing.T) {
+	mockAPI := &mockGitlabAPI{
+		responses: map[string][]byte{
+			"my-group/my-project": []byte(`{
+				"data": {
+					"project": {
+						"vulnerabilities": {
+							"pageInfo": {
+								"hasNextPage": true,
+								"endCursor": "cursor123"
+							},
+							"nodes": [
+								{
+									"title": "CVE-2023-1234",
+									"severity": "High",
+									"description": "Test vulnerability",
+									"location": {
+										"image": "registry.gitlab.com/my-group/my-project/app:latest"
+									}
+								},
+								{
+									"title": "CVE-2023-5678",
+									"severity": "Low",
+									"description": "App Backend vulnerability",
+									"location": {
+										"image": "registry.gitlab.com/my-group/my-project/app-backend:latest"
+									}
+								},
+								{
+									"title": "CVE-2023-0000",
+									"severity": "Critical",
+									"description": "Digest vulnerability",
+									"location": {
+										"image": "registry.gitlab.com/my-group/my-project/app@sha256:112233"
+									}
+								}
+							]
+						}
+					}
+				}
+			}`),
+			"my-group/my-project_cursor123": []byte(`{
+				"data": {
+					"project": {
+						"vulnerabilities": {
+							"pageInfo": {
+								"hasNextPage": false,
+								"endCursor": ""
+							},
+							"nodes": [
+								{
+									"title": "CVE-2023-9999",
+									"severity": "Critical",
+									"description": "Page 2 vuln",
+									"location": {
+										"image": "registry.gitlab.com/my-group/my-project/app:latest"
+									}
+								}
+							]
+						}
+					}
+				}
+			}`),
+		},
+	}
+
+	adaptor := NewGitlabAdaptor()
+	adaptor.client = mockAPI
+
+	// Test case 1: Boundary matching. 'app' should NOT match 'app-backend'
+	imageIDs := []ContainerImageIdentifier{
+		{Repository: "my-group/my-project/app", Tag: "latest"},
+		{Repository: "my-group/my-project/app", Tag: "latest"}, // Second one tests cache
+	}
+
+	reports, err := adaptor.GetImagesVulnerabilities(context.Background(), imageIDs)
+
+	assert.NoError(t, err)
+	assert.Len(t, reports, 2)
+	assert.Len(t, reports[0].Vulnerabilities, 2) // One from page 1, one from page 2. Excludes app-backend!
+
+	vuln1 := reports[0].Vulnerabilities[0]
+	assert.Equal(t, "CVE-2023-1234", vuln1.ID)
+	assert.Equal(t, "High", vuln1.Severity)
+
+	vuln2 := reports[0].Vulnerabilities[1]
+	assert.Equal(t, "CVE-2023-9999", vuln2.ID)
+	assert.Equal(t, "Critical", vuln2.Severity)
+
+	// Verify caching - 'my-group/my-project' should only have 1 call for base and 1 for paginated
+	assert.Equal(t, 1, mockAPI.callCount["my-group/my-project"])
+	assert.Equal(t, 1, mockAPI.callCount["my-group/my-project_cursor123"])
+
+	// Test case 2: Digest matching priority
+	imageIDsHash := []ContainerImageIdentifier{
+		{Repository: "my-group/my-project/app", Hash: "sha256:112233"},
+	}
+
+	reportsHash, err := adaptor.GetImagesVulnerabilities(context.Background(), imageIDsHash)
+	assert.NoError(t, err)
+	assert.Len(t, reportsHash, 1)
+	assert.Len(t, reportsHash[0].Vulnerabilities, 1) // Should only match the digest vulnerability!
+
+	vulnDigest := reportsHash[0].Vulnerabilities[0]
+	assert.Equal(t, "CVE-2023-0000", vulnDigest.ID)
+
+	// Test case 3: Unmatched digest (simulate API limitation)
+	imageIDsUnmatched := []ContainerImageIdentifier{
+		{Repository: "my-group/my-project/app", Hash: "sha256:unknown"},
+	}
+
+	reportsUnmatched, err := adaptor.GetImagesVulnerabilities(context.Background(), imageIDsUnmatched)
+	assert.NoError(t, err)
+	assert.Len(t, reportsUnmatched, 1)
+	assert.Len(t, reportsUnmatched[0].Vulnerabilities, 0) // Should match nothing because the digest isn't present
+}
+
+func TestNormalizeGitlabSeverity(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"CRITICAL", "Critical"},
+		{"critical", "Critical"},
+		{"HIGH", "High"},
+		{"MEDIUM", "Medium"},
+		{"LOW", "Low"},
+		{"INFO", "Negligible"},
+		{"unknown", "Unknown"},
+		{"invalid", "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeGitLabSeverity(tt.input))
+		})
+	}
+}
+
+func TestGitlabAdaptor_GetImagesInformation(t *testing.T) {
+	adaptor := NewGitlabAdaptor()
+	adaptor.client = &mockGitlabAPI{}
+
+	infos, err := adaptor.GetImagesInformation(context.Background(), []ContainerImageIdentifier{{}})
+	assert.NoError(t, err)
+	assert.Len(t, infos, 1)
+}
+
+func TestGitlabAdaptor_Destroy(t *testing.T) {
+	adaptor := NewGitlabAdaptor()
+	assert.NoError(t, adaptor.Destroy())
+}


### PR DESCRIPTION
## Overview
This PR introduces `GitlabAdaptor`, a native implementation of the `IContainerImageVulnerabilityAdaptor` interface for the GitLab Container Registry. 

It allows Kubescape to fetch vulnerability data server-side via the GitLab API, preventing the need to pull the full image blob locally for scanning.

## Additional Information

> * This adaptor strictly uses the GitLab **GraphQL API** (via `POST /api/graphql`), as the REST endpoint for vulnerability findings is officially deprecated.
> * The API requires Bearer authentication, so the `Login` method expects a Personal or Project Access Token to be passed. It validates the token up-front by hitting the `currentUser` GraphQL query.
> * GitLab group paths can nest infinitely. To handle this, `splitGitLabProjectPath` mathematically splits on the *last* slash of the repository path to correctly isolate the project's `fullPath`.
> * The GraphQL API returns vulnerabilities for the entire project, so the adaptor actively filters the returned nodes client-side to ensure vulnerabilities strictly match the requested image name.
> * Error propagation explicitly handles both network failures and embedded GraphQL errors (which return HTTP 200) by checking the `errors` array in the JSON response.

## How to Test
> 1. Run the local test suite to verify the mock GraphQL interactions: `go test -v ./pkg/imagescan -run TestGitlab`

## Related issues/PRs:
* Resolved #3204 

## Checklist before requesting a review



- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for scanning images in the GitLab Container Registry.
  * Added authentication with personal or project access tokens.
  * Added scan availability status and vulnerability reporting.
  * Added image and tag filtering with normalized severity levels.
  * Added support for repositories with nested paths and aggregated image-level errors.

* **Bug Fixes**
  * Improved handling of authentication failures, unavailable scans, and malformed scan responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->