### PR TITLE
fix(mcpserver): return marshal errors from get_configuration_drift

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -40,6 +40,9 @@ var setConnectedToCluster = k8sinterface.SetConnectedToCluster
 
 var newK8sClient = k8sinterface.NewKubernetesApi
 
+// jsonMarshal is a package-level var so tests can inject marshal failures.
+var jsonMarshal = json.Marshal
+
 type scanCtxState struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -1012,14 +1015,20 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to get workload manifest: %v", err)), nil
 		}
-		rawManifest, _ = json.Marshal(workloadObj)
+		rawManifest, err = jsonMarshal(workloadObj)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal workload manifest: %v", err)), nil
+		}
 
 		containerName := ""
 		if profile.GetLabels() != nil {
 			containerName = profile.GetLabels()["kubescape.io/workload-container-name"]
 		}
 		fixes := fixhandler.DetectProfileDrift(rawManifest, profile, workloadKindStr, containerName, 0)
-		fixesJson, _ := json.MarshalIndent(fixes, "", "  ")
+		fixesJson, err := json.MarshalIndent(fixes, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal drift result: %v", err)), nil
+		}
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -6,14 +6,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	storagefake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
 
@@ -227,4 +230,38 @@ func TestReadResourceWithFakeClient(t *testing.T) {
 			require.ElementsMatch(t, test.wantIDs, ids)
 		})
 	}
+}
+
+func TestGetConfigurationDrift_MarshalErrorIsToolError(t *testing.T) {
+	orig := jsonMarshal
+	t.Cleanup(func() { jsonMarshal = orig })
+	jsonMarshal = func(any) ([]byte, error) {
+		return nil, fmt.Errorf("marshal boom")
+	}
+
+	profile := &storagev1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-profile", Namespace: "default"},
+	}
+	ksClient := storagefake.NewClientset(profile)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "default"},
+	}
+	ksServer := &KubescapeMcpserver{
+		ksClient: ksClient.SpdxV1beta1(),
+		k8sClient: &k8sinterface.KubernetesApi{
+			KubernetesClient: fake.NewClientset(pod),
+		},
+	}
+
+	result, err := ksServer.CallTool(context.Background(), "get_configuration_drift", map[string]any{
+		"profile_name":  "nginx-profile",
+		"workload_name": "nginx",
+		"workload_kind": "pod",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	text := toolResultText(t, result)
+	assert.Contains(t, text, "failed to marshal workload manifest")
+	assert.Contains(t, text, "marshal boom")
 }


### PR DESCRIPTION
## Overview
`get_configuration_drift` ignored marshal errors and returned `"null"` as if there was no drift. It now returns an MCP tool error instead.
## How to Test
go test ./cmd/mcpserver -run TestGetConfigurationDrift_MarshalErrorIsToolError

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration drift checks now clearly report errors when workload or drift-result data cannot be serialized.
  * Users receive both a descriptive error message and the underlying serialization details.

* **Tests**
  * Added coverage to verify serialization failures are returned as tool errors without interrupting the MCP call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->