### PR TITLE
test(diff): cover --fail-on-new and severity-threshold gating

### DIFF
--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -3,9 +3,21 @@ package diff
 import (
 	"testing"
 
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/stretchr/testify/assert"
 )
+
+// stubKubescape returns a configurable new-failure count from Diff so the
+// command's --fail-on-new gate can be exercised without real scan reports.
+type stubKubescape struct {
+	mocks.MockIKubescape
+	newFailures int
+}
+
+func (s *stubKubescape) Diff(_ *metav1.DiffInfo) (int, error) {
+	return s.newFailures, nil
+}
 
 func TestGetDiffCmd_FormatValidation(t *testing.T) {
 	tests := []struct {
@@ -29,6 +41,64 @@ func TestGetDiffCmd_FormatValidation(t *testing.T) {
 			err := diffCmd.Execute()
 			if tt.wantError {
 				assert.ErrorContains(t, err, "invalid format")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		newFailures int
+		wantErr     string
+	}{
+		{
+			name:        "fail-on-new with new failures and empty severity reports all",
+			args:        []string{"base.json", "head.json", "--fail-on-new"},
+			newFailures: 2,
+			wantErr:     `found 2 new failure(s) at or above severity threshold "all"`,
+		},
+		{
+			name:        "fail-on-new with new failures uses the given severity threshold",
+			args:        []string{"base.json", "head.json", "--fail-on-new", "--severity-threshold", "high"},
+			newFailures: 1,
+			wantErr:     `found 1 new failure(s) at or above severity threshold "high"`,
+		},
+		{
+			name:        "fail-on-new with no new failures succeeds",
+			args:        []string{"base.json", "head.json", "--fail-on-new"},
+			newFailures: 0,
+		},
+		{
+			name:        "new failures without fail-on-new succeed",
+			args:        []string{"base.json", "head.json"},
+			newFailures: 5,
+		},
+		{
+			name:    "invalid severity is rejected",
+			args:    []string{"base.json", "head.json", "--severity-threshold", "unknown"},
+			wantErr: "unknown severity",
+		},
+		{
+			name:        "valid severity without fail-on-new succeeds",
+			args:        []string{"base.json", "head.json", "--severity-threshold", "medium"},
+			newFailures: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diffCmd := GetDiffCmd(&stubKubescape{newFailures: tt.newFailures})
+			diffCmd.SilenceUsage = true
+			diffCmd.SilenceErrors = true
+			diffCmd.SetArgs(tt.args)
+
+			err := diffCmd.Execute()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
## Overview
`kubescape diff` already gates CI on `--fail-on-new` and `--severity-threshold`, but `cmd/diff` only tested format validation.
This PR adds `TestGetDiffCmd_FailOnNewAndSeverity` so those command-level behaviors stay covered:
- `--fail-on-new` fails when new findings exist, and succeeds when there are none
- new findings without `--fail-on-new` do not fail the command
- unknown `--severity-threshold` values are rejected
- an empty severity threshold is labeled `"all"` in the failure message
## How to Test
```bash
go test ./cmd/diff/ -count=1 -v
```
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for `--fail-on-new` behavior.
  * Added tests for severity thresholds, successful scans, and invalid severity values.
  * Preserved existing format validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->