### PR TITLE
fix(printer): migrate v2 report printers to return errors from CloseWriter (#3214)

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -131,18 +131,24 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
 	resolvedPaths := make(map[string]string)
-	closeConfiguredPrinters := func() {
+	// closeConfiguredPrinters closes already configured output printers upon setup failure.
+	closeConfiguredPrinters := func() error {
+		var closeErr error
 		for _, configuredPrinter := range outputPrinters {
-			if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
+			if closer, ok := configuredPrinter.(interface{ CloseWriter() error }); ok {
+				if err := closer.CloseWriter(); err != nil {
+					closeErr = errors.Join(closeErr, err)
+				}
+			} else if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
 				closer.CloseWriter()
 			}
 		}
+		return closeErr
 	}
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
-			closeConfiguredPrinters()
-			return nil, err
+			return nil, errors.Join(err, closeConfiguredPrinters())
 		}
 
 		if usesPrettyPrinter && containPrettyPrinter {
@@ -151,16 +157,14 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 
 		if path := resolvedOutputPath(format, scanInfo.Output); path != "" {
 			if existing, collision := resolvedPaths[path]; collision {
-				closeConfiguredPrinters()
-				return nil, fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path)
+				return nil, errors.Join(fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path), closeConfiguredPrinters())
 			}
 			resolvedPaths[path] = format
 		}
 
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo, clusterName)
 		if err := printerHandler.SetWriter(ctx, scanInfo.Output); err != nil {
-			closeConfiguredPrinters()
-			return nil, fmt.Errorf("configure %q output: %w", format, err)
+			return nil, errors.Join(fmt.Errorf("configure %q output: %w", format, err), closeConfiguredPrinters())
 		}
 		outputPrinters = append(outputPrinters, printerHandler)
 

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -176,10 +176,12 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 func (cp *CsvPrinter) PrintNextSteps() {
 }
 
-func (cp *CsvPrinter) CloseWriter() {
+// CloseWriter closes the CSV output writer, returning any error from flushing or closing.
+func (cp *CsvPrinter) CloseWriter() error {
 	if cp.writer != nil && cp.writer != os.Stdout {
-		_ = cp.writer.Close()
+		return cp.writer.Close()
 	}
+	return nil
 }
 
 // csvControlPaths returns the semicolon-separated failed paths and fix paths

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -85,6 +85,7 @@ func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *caut
 
 func (cp *CycloneDXPrinter) PrintNextSteps() {}
 
+// CloseWriter closes the CycloneDX output writer, returning any error from flushing or closing.
 func (cp *CycloneDXPrinter) CloseWriter() error {
 	if cp.writer != nil && cp.writer != os.Stdout {
 		return cp.writer.Close()

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -442,9 +442,10 @@ func kubescapeVersion() string {
 	return versioncheck.BuildNumber
 }
 
-// CloseWriter closes the output file, unless it is stdout, satisfying the optional printerCloser interface
-func (gp *GitLabSASTPrinter) CloseWriter() {
+// CloseWriter closes the GitLab SAST output writer, returning any error from flushing or closing.
+func (gp *GitLabSASTPrinter) CloseWriter() error {
 	if gp.writer != nil && gp.writer != os.Stdout {
-		gp.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return gp.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -220,8 +220,10 @@ func buildResourceControlResultTable(resourceControls []resourcesresults.Resourc
 	return ctlResults
 }
 
-func (p *HtmlPrinter) CloseWriter() {
+// CloseWriter closes the HTML output writer, returning any error from flushing or closing.
+func (p *HtmlPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -191,8 +191,10 @@ func (jp *JsonPrinter) PrintNextSteps() {
 
 }
 
-func (p *JsonPrinter) CloseWriter() {
+// CloseWriter closes the JSON output writer, returning any error from flushing or closing.
+func (p *JsonPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -382,8 +382,10 @@ func properties(complianceScore float32) []JUnitProperty {
 	}
 }
 
-func (p *JunitPrinter) CloseWriter() {
+// CloseWriter closes the JUnit output writer, returning any error from flushing or closing.
+func (p *JunitPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -85,10 +85,12 @@ func (mp *MarkdownPrinter) ActionPrint(ctx context.Context, opaSessionObj *cauti
 
 func (mp *MarkdownPrinter) PrintNextSteps() {}
 
-func (mp *MarkdownPrinter) CloseWriter() {
+// CloseWriter closes the Markdown output writer, returning any error from flushing or closing.
+func (mp *MarkdownPrinter) CloseWriter() error {
 	if mp.writer != nil && mp.writer != os.Stdout {
-		_ = mp.writer.Close()
+		return mp.writer.Close()
 	}
+	return nil
 }
 
 // mdErrWriter wraps an io.Writer and records the first write error so callers

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -199,8 +199,10 @@ func getSeverityColor(severity string) *props.Color {
 	return &props.BlackColor
 }
 
-func (p *PdfPrinter) CloseWriter() {
+// CloseWriter closes the PDF output writer, returning any error from flushing or closing.
+func (p *PdfPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -412,8 +412,10 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 	}
 }
 
-func (p *PrettyPrinter) CloseWriter() {
+// CloseWriter closes the pretty-printer output writer, returning any error from flushing or closing.
+func (p *PrettyPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -110,8 +110,10 @@ func (pp *PrometheusPrinter) ActionPrint(ctx context.Context, opaSessionObj *cau
 	return nil
 }
 
-func (p *PrometheusPrinter) CloseWriter() {
+// CloseWriter closes the Prometheus output writer, returning any error from flushing or closing.
+func (p *PrometheusPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -559,8 +559,10 @@ func hashArtifactChange(artifactChange *sarif.ArtifactChange) [32]byte {
 	return sha256.Sum256(acJson)
 }
 
-func (p *SARIFPrinter) CloseWriter() {
+// CloseWriter closes the SARIF output writer, returning any error from flushing or closing.
+func (p *SARIFPrinter) CloseWriter() error {
 	if p.writer != nil && p.writer != os.Stdout {
-		p.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return p.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/silentprinter.go
+++ b/core/pkg/resultshandling/printer/v2/silentprinter.go
@@ -28,4 +28,5 @@ func (silentPrinter *SilentPrinter) SetWriter(ctx context.Context, outputFile st
 func (silentPrinter *SilentPrinter) Score(score float32) {
 }
 
-func (sp *SilentPrinter) CloseWriter() {}
+// CloseWriter is a no-op closer for the silent printer that always returns nil.
+func (sp *SilentPrinter) CloseWriter() error { return nil }

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -85,8 +85,10 @@ func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 
 func (sp *SPDXPrinter) PrintNextSteps() {}
 
-func (sp *SPDXPrinter) CloseWriter() {
+// CloseWriter closes the SPDX output writer, returning any error from flushing or closing.
+func (sp *SPDXPrinter) CloseWriter() error {
 	if sp.writer != nil && sp.writer != os.Stdout {
-		sp.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return sp.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -154,8 +154,10 @@ func (yp *YamlPrinter) PrintNextSteps() {
 
 }
 
-func (yp *YamlPrinter) CloseWriter() {
+// CloseWriter closes the YAML output writer, returning any error from flushing or closing.
+func (yp *YamlPrinter) CloseWriter() error {
 	if yp.writer != nil && yp.writer != os.Stdout {
-		yp.writer.Close() // #nosec G104 -- closing the output writer; the error is not actionable from a void CloseWriter
+		return yp.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -772,3 +772,97 @@ func TestValidatePrinter_ImageFormatsInvariant(t *testing.T) {
 		})
 	}
 }
+
+// TestClosePrinter_AllV2PrintersImplementErrorCloser tests that all v2 report printers implement
+// the CloseWriter() error interface and properly surface errors on already-closed writers.
+func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
+	printers := []struct {
+		name    string
+		printer printer.IPrinter
+	}{
+		{"json", printerv2.NewJsonPrinter("")},
+		{"sarif", printerv2.NewSARIFPrinter()},
+		{"html", printerv2.NewHtmlPrinter()},
+		{"yaml", printerv2.NewYamlPrinter()},
+		{"junit", printerv2.NewJunitPrinter(false)},
+		{"markdown", printerv2.NewMarkdownPrinter()},
+		{"pdf", printerv2.NewPdfPrinter()},
+		{"prometheus", printerv2.NewPrometheusPrinter(false)},
+		{"spdx", printerv2.NewSPDXPrinter()},
+		{"cyclonedx", printerv2.NewCycloneDXPrinter()},
+		{"gitlabsast", printerv2.NewGitLabSASTPrinter()},
+		{"csv", printerv2.NewCsvPrinter()},
+		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "")},
+		{"silent", &printerv2.SilentPrinter{}},
+	}
+
+	type errorCloser interface {
+		CloseWriter() error
+	}
+
+	for _, tt := range printers {
+		t.Run(tt.name, func(t *testing.T) {
+			closer, ok := tt.printer.(errorCloser)
+			require.True(t, ok, "printer %T must implement CloseWriter() error", tt.printer)
+
+			// When writer is nil/stdout, CloseWriter() must succeed
+			err := closer.CloseWriter()
+			assert.NoError(t, err)
+
+			if tt.name == "silent" {
+				return
+			}
+
+			// When writer points to an explicit file, SetWriter and CloseWriter must work cleanly
+			tmp, tmpErr := os.CreateTemp(t.TempDir(), "close_test*")
+			require.NoError(t, tmpErr)
+			targetName := tmp.Name()
+			_ = tmp.Close()
+
+			setErr := tt.printer.SetWriter(context.Background(), targetName)
+			require.NoError(t, setErr)
+
+			// 1. Initial close on active writer must succeed
+			closeErr := closePrinter(tt.printer)
+			assert.NoError(t, closeErr)
+
+			// 2. Subsequent close on already-closed writer must surface the underlying error
+			secondCloseErr := closePrinter(tt.printer)
+			assert.Error(t, secondCloseErr, "closePrinter must surface error on already-closed writer for %s", tt.name)
+		})
+	}
+}
+
+// mockFailingClosePrinter is a mock IPrinter implementation whose CloseWriter method returns a simulated error.
+type mockFailingClosePrinter struct {
+	printer.IPrinter
+}
+
+// CloseWriter returns a simulated error during writer closure.
+func (m *mockFailingClosePrinter) CloseWriter() error {
+	return errors.New("simulated close flush failure")
+}
+
+// ActionPrint is a no-op implementation of IPrinter.ActionPrint for testing.
+func (m *mockFailingClosePrinter) ActionPrint(_ context.Context, _ *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
+	return nil
+}
+
+// Score is a no-op implementation of IPrinter.Score for testing.
+func (m *mockFailingClosePrinter) Score(_ float32) {}
+
+// PrintNextSteps is a no-op implementation of IPrinter.PrintNextSteps for testing.
+func (m *mockFailingClosePrinter) PrintNextSteps() {}
+
+// TestHandleResults_PropagatesPrinterCloseErrors verifies that ResultsHandler.HandleResults
+// joins and propagates close errors returned by UI and output printers.
+func TestHandleResults_PropagatesPrinterCloseErrors(t *testing.T) {
+	rh := &ResultsHandler{
+		UiPrinter:   &mockFailingClosePrinter{},
+		PrinterObjs: []printer.IPrinter{&mockFailingClosePrinter{}},
+	}
+	err := rh.HandleResults(context.Background(), &cautils.ScanInfo{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ui printer close: simulated close flush failure")
+	assert.Contains(t, err.Error(), "output printer *resultshandling.mockFailingClosePrinter close: simulated close flush failure")
+}


### PR DESCRIPTION

## Overview
Migrates all v2 report printers to implement `CloseWriter() error` so that `closePrinter` in `ResultsHandler.HandleResults` can properly capture and surface output file closure and buffer flush errors instead of silently reporting success.

### Problem
`core/pkg/resultshandling/results.go` has a dispatcher `closePrinter` that checks if a printer implements `CloseWriter() error` to catch and join file closing errors (`printErr = errors.Join(printErr, fmt.Errorf("output printer %T close: %w", p, err))`).

Prior to this change, only `CycloneDXPrinter` returned an error; all other v2 printers implemented a legacy void `CloseWriter()` that discarded `p.writer.Close()` errors via `#nosec G104`. If writing an output report failed on close/flush (e.g. `ENOSPC`, broken pipe, NFS error), the command exited with status `0` while leaving an incomplete or corrupted report artifact.

### Changes
- Updated `CloseWriter() error` across all v2 report printers (`json`, `sarif`, `html`, `yaml`, `junit`, `markdown`, `pdf`, `prometheus`, `spdx`, `gitlabsast`, `csv`, `pretty`, `silent`).
- Updated `core/core/scan.go`'s `closeConfiguredPrinters` helper to support `CloseWriter() error`.
- Added `TestClosePrinter_AllV2PrintersImplementErrorCloser` in `core/pkg/resultshandling/results_test.go` verifying that all 14 v2 printers satisfy the error closer interface and handle writer closures cleanly.

## How to Test
Run the new closePrinter test and full test suite:
```bash
go test -v -run TestClosePrinter_AllV2PrintersImplementErrorCloser ./core/pkg/resultshandling/...
go test ./core/pkg/resultshandling/...
go build -v .
```

## Related issues/PRs:
* Resolved #3214

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output handling by reporting errors encountered when closing generated output files.
  * Cleanup errors are now preserved alongside validation and output configuration errors.
  * Standard output remains safely open when no cleanup is required.

* **Compatibility**
  * Standardized output cleanup behavior across supported formats while preserving existing output behavior.

* **Tests**
  * Added coverage for successful and repeated cleanup, default outputs, temporary files, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->