### PR TITLE
test(config): assert view flags are passed to ViewConfig

### DIFF
--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -1,11 +1,25 @@
 package config
 
 import (
+	"os"
 	"testing"
 
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v3/core/mocks"
 	"github.com/stretchr/testify/assert"
 )
+
+// capturingView records the ViewConfig passed to ViewCachedConfig so tests can
+// assert that command flags are wired through.
+type capturingView struct {
+	mocks.MockIKubescape
+	got *metav1.ViewConfig
+}
+
+func (c *capturingView) ViewCachedConfig(vc *metav1.ViewConfig) error {
+	c.got = vc
+	return nil
+}
 
 func TestGetViewCmd(t *testing.T) {
 	// Create a mock Kubescape interface
@@ -29,5 +43,39 @@ func TestGetViewCmd(t *testing.T) {
 	if assert.NotNil(t, includeEmptyFlag) {
 		assert.Equal(t, "false", includeEmptyFlag.DefValue)
 		assert.Equal(t, "Include empty values in the rendered output", includeEmptyFlag.Usage)
+	}
+}
+
+func TestGetViewCmd_RunEPassesFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantFormat string
+		wantEmpty  bool
+	}{
+		{name: "defaults", args: []string{}, wantFormat: "text", wantEmpty: false},
+		{name: "output json", args: []string{"--output", "json"}, wantFormat: "json", wantEmpty: false},
+		{name: "short output yaml", args: []string{"-o", "yaml"}, wantFormat: "yaml", wantEmpty: false},
+		{name: "include-empty", args: []string{"--include-empty"}, wantFormat: "text", wantEmpty: true},
+		{name: "json with include-empty short flags", args: []string{"-o", "json", "-e"}, wantFormat: "json", wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &capturingView{}
+			cmd := getViewCmd(ks)
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+			if !assert.NotNil(t, ks.got) {
+				return
+			}
+			assert.Equal(t, tt.wantFormat, ks.got.OutputFormat)
+			assert.Equal(t, tt.wantEmpty, ks.got.IncludeEmpty)
+			assert.Equal(t, os.Stdout, ks.got.Writer)
+		})
 	}
 }


### PR DESCRIPTION
## Overview

`kubescape config view` already forwards `--output` and `--include-empty` into `ViewConfig`, but the existing test only checked flag names, defaults, and usage text.

This PR adds `TestGetViewCmd_RunEPassesFlags` so `RunE` actually executes and those values are asserted on the `ViewConfig` passed to `ViewCachedConfig`:

- defaults → `text`, `include-empty=false`, writer `os.Stdout`
- `--output json` / `-o yaml`
- `--include-empty` and `-o json -e`

## How to Test

```bash
go test ./cmd/config/ -count=1 -v
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that configuration view options correctly pass output format, empty-value handling, and output destination settings across default, short, and long flag combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->