### PR TITLE
fix(cautils): add cluster-context isolation helper for sequential multi-cluster scans

### DIFF
--- a/core/cautils/clustercontext.go
+++ b/core/cautils/clustercontext.go
@@ -1,0 +1,28 @@
+package cautils
+
+import (
+	"github.com/kubescape/k8s-interface/k8sinterface"
+)
+
+// EnterClusterContext switches the active kube context to targetContext and returns a
+// leave function that restores whatever context was active before this call.
+//
+// Callers running a sequence of single-cluster scans in one process (e.g. a fleet scan
+// over several kubeconfig contexts) must defer leave() immediately, before running the
+// scan against targetContext, not call it after the scan returns: a scan that errors,
+// panics, or returns early must still restore the previous context, and deferring before
+// the scan runs is what guarantees that regardless of how it exits.
+//
+// k8sinterface.SetClusterContextName invalidates the cached client config and connection
+// state for the previous context on any actual context change, and NewKubernetesApi
+// refreshes the API discovery snapshot from the live discovery client it is given, so
+// entering a new context here is enough for the next scan built against it (via
+// k8sinterface.NewKubernetesApi) to see that cluster's own config and resources rather
+// than a previous cluster's leftover state.
+func EnterClusterContext(targetContext string) (leave func()) {
+	previous := k8sinterface.GetContextName()
+	k8sinterface.SetClusterContextName(targetContext)
+	return func() {
+		k8sinterface.SetClusterContextName(previous)
+	}
+}

--- a/core/cautils/clustercontext_integration_test.go
+++ b/core/cautils/clustercontext_integration_test.go
@@ -39,10 +39,14 @@ func groundTruthKubeSystemUID(t *testing.T, contextName string) string {
 // discovery snapshot, or connection state left over from the first.
 //
 // Opt-in and skipped by default: needs `kind create cluster --name fleet-test-a` and
-// `--name fleet-test-b` already running (KUBESCAPE_INTEGRATION_KIND=1 to enable).
+// `--name fleet-test-b` already running, each with a distinct CRD applied (`foos.example.io`
+// on cluster A, `bars.example.io` on cluster B, both group example.io) so the discovery half
+// of the fix (#159/#160) is exercised as well as the client-config half (#158/#161) - the
+// typed CoreV1().Namespaces().Get call alone never touches the process-global resource map
+// InitializeMapResources builds. KUBESCAPE_INTEGRATION_KIND=1 to enable.
 func TestEnterClusterContext_TwoRealClusters(t *testing.T) {
 	if os.Getenv("KUBESCAPE_INTEGRATION_KIND") == "" {
-		t.Skip("set KUBESCAPE_INTEGRATION_KIND=1 with kind clusters fleet-test-a and fleet-test-b running to enable")
+		t.Skip("set KUBESCAPE_INTEGRATION_KIND=1 with kind clusters fleet-test-a and fleet-test-b running, each with its own CRD, to enable")
 	}
 
 	const contextA = "kind-fleet-test-a"
@@ -72,6 +76,8 @@ func TestEnterClusterContext_TwoRealClusters(t *testing.T) {
 	leaveA := EnterClusterContext(contextA)
 	gotUIDA := fetchKubeSystemUID(t)
 	require.Equal(t, wantUIDA, gotUIDA, "scan of context A did not observe cluster A")
+	requireResourceDiscoverable(t, "foos", true, "cluster A's own CRD must be discoverable")
+	requireResourceDiscoverable(t, "bars", false, "cluster B's CRD must not leak into cluster A's discovery mapping")
 	leaveA()
 
 	leaveB := EnterClusterContext(contextB)
@@ -79,7 +85,20 @@ func TestEnterClusterContext_TwoRealClusters(t *testing.T) {
 	require.Equal(t, wantUIDB, gotUIDB,
 		"scan of context B observed cluster A's data (uid=%s) instead of cluster B's (uid=%s) - "+
 			"this is the cross-cluster state leak the isolation fix exists to close", gotUIDA, wantUIDB)
+	requireResourceDiscoverable(t, "bars", true, "cluster B's own CRD must be discoverable")
+	requireResourceDiscoverable(t, "foos", false,
+		"cluster A's CRD is still in the discovery mapping after switching to cluster B - "+
+			"the resource-map half of the isolation fix (#159/#160) did not take effect")
 	leaveB()
+}
+
+// requireResourceDiscoverable asserts whether resource is present in k8sinterface's
+// process-global resource-group mapping, which InitializeMapResources rebuilds from the
+// active cluster's live discovery client each time k8sinterface.NewKubernetesApi runs.
+func requireResourceDiscoverable(t *testing.T, resource string, want bool, msgAndArgs ...interface{}) {
+	t.Helper()
+	_, ok := k8sinterface.GetSingleResourceFromGroupMapping(resource)
+	require.Equal(t, want, ok, msgAndArgs...)
 }
 
 // fetchKubeSystemUID reads kube-system's UID through the same k8sinterface.NewKubernetesApi

--- a/core/cautils/clustercontext_integration_test.go
+++ b/core/cautils/clustercontext_integration_test.go
@@ -1,0 +1,95 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// groundTruthKubeSystemUID builds a client directly from clientcmd for contextName,
+// bypassing k8sinterface entirely, and returns that cluster's kube-system namespace UID.
+// This is the independent reference the integration test below checks
+// EnterClusterContext + k8sinterface.NewKubernetesApi against: if it only compared two
+// k8sinterface-derived values against each other, a bug that made both wrong in the same
+// way (e.g. both stuck on a third, unrelated context) could still pass.
+func groundTruthKubeSystemUID(t *testing.T, contextName string) string {
+	t.Helper()
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: contextName}
+	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
+	require.NoError(t, err)
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err)
+
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), "kube-system", metav1.GetOptions{})
+	require.NoError(t, err)
+	return string(ns.UID)
+}
+
+// TestEnterClusterContext_TwoRealClusters is the two-kind-cluster regression case the
+// isolation fix exists for: scan two real clusters in a row, in one process, and confirm
+// the second scan actually observes the second cluster - not the first cluster's config,
+// discovery snapshot, or connection state left over from the first.
+//
+// Opt-in and skipped by default: needs `kind create cluster --name fleet-test-a` and
+// `--name fleet-test-b` already running (KUBESCAPE_INTEGRATION_KIND=1 to enable).
+func TestEnterClusterContext_TwoRealClusters(t *testing.T) {
+	if os.Getenv("KUBESCAPE_INTEGRATION_KIND") == "" {
+		t.Skip("set KUBESCAPE_INTEGRATION_KIND=1 with kind clusters fleet-test-a and fleet-test-b running to enable")
+	}
+
+	const contextA = "kind-fleet-test-a"
+	const contextB = "kind-fleet-test-b"
+
+	resetClusterContextState(t)
+	t.Cleanup(func() { resetClusterContextState(t) })
+
+	// Use the default kubeconfig location (where `kind` registers cluster contexts),
+	// regardless of what the environment's KUBECONFIG happens to be set to elsewhere in
+	// the test run.
+	oldKubeconfig, hadKubeconfig := os.LookupEnv("KUBECONFIG")
+	require.NoError(t, os.Unsetenv("KUBECONFIG"))
+	t.Cleanup(func() {
+		if hadKubeconfig {
+			_ = os.Setenv("KUBECONFIG", oldKubeconfig)
+		}
+	})
+
+	wantUIDA := groundTruthKubeSystemUID(t, contextA)
+	wantUIDB := groundTruthKubeSystemUID(t, contextB)
+	require.NotEqual(t, wantUIDA, wantUIDB, "test setup: the two kind clusters must be distinct")
+
+	// Simulate cmd/root.go's single startup call, same as every non-fleet invocation.
+	k8sinterface.SetClusterContextName(contextA)
+
+	leaveA := EnterClusterContext(contextA)
+	gotUIDA := fetchKubeSystemUID(t)
+	require.Equal(t, wantUIDA, gotUIDA, "scan of context A did not observe cluster A")
+	leaveA()
+
+	leaveB := EnterClusterContext(contextB)
+	gotUIDB := fetchKubeSystemUID(t)
+	require.Equal(t, wantUIDB, gotUIDB,
+		"scan of context B observed cluster A's data (uid=%s) instead of cluster B's (uid=%s) - "+
+			"this is the cross-cluster state leak the isolation fix exists to close", gotUIDA, wantUIDB)
+	leaveB()
+}
+
+// fetchKubeSystemUID reads kube-system's UID through the same k8sinterface.NewKubernetesApi
+// path core/core's scan setup (getKubernetesApi) uses, so this exercises the production
+// code the bug actually lives in rather than a client built specifically for the test.
+func fetchKubeSystemUID(t *testing.T) string {
+	t.Helper()
+	require.True(t, k8sinterface.IsConnectedToCluster())
+	k8sAPI := k8sinterface.NewKubernetesApi()
+	ns, err := k8sAPI.KubernetesClient.CoreV1().Namespaces().Get(context.Background(), "kube-system", metav1.GetOptions{})
+	require.NoError(t, err)
+	return string(ns.UID)
+}

--- a/core/cautils/clustercontext_test.go
+++ b/core/cautils/clustercontext_test.go
@@ -1,0 +1,78 @@
+package cautils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/require"
+)
+
+// resetClusterContextState clears the k8sinterface globals EnterClusterContext relies on,
+// so this test is independent of whatever ran before/after it in the same package.
+func resetClusterContextState(t *testing.T) {
+	t.Helper()
+	k8sinterface.SetClusterContextName("")
+	k8sinterface.K8SConfig = nil
+	k8sinterface.SetClientConfigAPI(nil)
+	k8sinterface.SetConnectedToCluster(true)
+}
+
+func TestEnterClusterContext_SwitchesAndRestores(t *testing.T) {
+	resetClusterContextState(t)
+	t.Cleanup(func() { resetClusterContextState(t) })
+
+	path := writeScanInfoMultiContextKubeconfig(t)
+	oldKubeconfig, hadKubeconfig := os.LookupEnv("KUBECONFIG")
+	require.NoError(t, os.Setenv("KUBECONFIG", path))
+	t.Cleanup(func() {
+		if hadKubeconfig {
+			_ = os.Setenv("KUBECONFIG", oldKubeconfig)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	})
+
+	// Simulate cmd/root.go's startup: the CLI's own single-cluster context, set once
+	// before any fleet-style iteration begins.
+	k8sinterface.SetClusterContextName("context-current")
+	require.True(t, k8sinterface.IsConnectedToCluster())
+	require.Equal(t, "https://current.example", k8sinterface.GetK8sConfig().Host)
+
+	leave := EnterClusterContext("context-selected")
+	require.Equal(t, "context-selected", k8sinterface.GetContextName())
+	require.True(t, k8sinterface.IsConnectedToCluster())
+	require.Equal(t, "https://selected.example", k8sinterface.GetK8sConfig().Host,
+		"EnterClusterContext did not switch to the target context's config")
+
+	leave()
+	require.Equal(t, "context-current", k8sinterface.GetContextName(),
+		"leave() did not restore the context that was active before EnterClusterContext")
+	require.True(t, k8sinterface.IsConnectedToCluster())
+	require.Equal(t, "https://current.example", k8sinterface.GetK8sConfig().Host,
+		"leave() restored the context name but not the config that goes with it")
+}
+
+// A scan against the entered context can fail partway; leave must still be able to run
+// from a deferred call regardless of what the scan itself did to state in between. This
+// only exercises that leave() is safe to call after arbitrary intervening
+// SetClusterContextName calls, not actual panic recovery (which is the caller's job).
+func TestEnterClusterContext_LeaveAfterInterveningContextChange(t *testing.T) {
+	resetClusterContextState(t)
+	t.Cleanup(func() { resetClusterContextState(t) })
+
+	path := writeScanInfoMultiContextKubeconfig(t)
+	require.NoError(t, os.Setenv("KUBECONFIG", path))
+	t.Cleanup(func() { _ = os.Unsetenv("KUBECONFIG") })
+
+	k8sinterface.SetClusterContextName("context-current")
+	leave := EnterClusterContext("context-selected")
+
+	// leave captured "context-current" as the context to restore at the moment
+	// EnterClusterContext was called, regardless of what happens to the active
+	// context afterward.
+	k8sinterface.SetClusterContextName("context-selected")
+
+	leave()
+	require.Equal(t, "context-current", k8sinterface.GetContextName())
+}

--- a/core/cautils/clustercontext_test.go
+++ b/core/cautils/clustercontext_test.go
@@ -2,11 +2,54 @@ package cautils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/require"
 )
+
+// writeThreeContextKubeconfig extends writeScanInfoMultiContextKubeconfig's two contexts
+// with a third, distinct one, so a test can exercise a genuine intervening context change
+// (switching to a context that differs from both the original and the entered one) rather
+// than a no-op switch back to a context that's already active.
+func writeThreeContextKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	contents := `apiVersion: v1
+kind: Config
+current-context: context-current
+clusters:
+- name: cluster-current
+  cluster:
+    server: https://current.example
+- name: cluster-selected
+  cluster:
+    server: https://selected.example
+- name: cluster-third
+  cluster:
+    server: https://third.example
+contexts:
+- name: context-current
+  context:
+    cluster: cluster-current
+    user: user
+- name: context-selected
+  context:
+    cluster: cluster-selected
+    user: user
+- name: context-third
+  context:
+    cluster: cluster-third
+    user: user
+users:
+- name: user
+  user:
+    token: test
+`
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
 
 // resetClusterContextState clears the k8sinterface globals EnterClusterContext relies on,
 // so this test is independent of whatever ran before/after it in the same package.
@@ -61,18 +104,29 @@ func TestEnterClusterContext_LeaveAfterInterveningContextChange(t *testing.T) {
 	resetClusterContextState(t)
 	t.Cleanup(func() { resetClusterContextState(t) })
 
-	path := writeScanInfoMultiContextKubeconfig(t)
+	path := writeThreeContextKubeconfig(t)
+	oldKubeconfig, hadKubeconfig := os.LookupEnv("KUBECONFIG")
 	require.NoError(t, os.Setenv("KUBECONFIG", path))
-	t.Cleanup(func() { _ = os.Unsetenv("KUBECONFIG") })
+	t.Cleanup(func() {
+		if hadKubeconfig {
+			_ = os.Setenv("KUBECONFIG", oldKubeconfig)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	})
 
 	k8sinterface.SetClusterContextName("context-current")
 	leave := EnterClusterContext("context-selected")
 
 	// leave captured "context-current" as the context to restore at the moment
-	// EnterClusterContext was called, regardless of what happens to the active
-	// context afterward.
-	k8sinterface.SetClusterContextName("context-selected")
+	// EnterClusterContext was called. Switch to a third, previously-untouched context
+	// before calling leave, so restoration is checked against a genuine intervening
+	// change rather than a no-op switch back to the context that was already active.
+	k8sinterface.SetClusterContextName("context-third")
+	require.Equal(t, "https://third.example", k8sinterface.GetK8sConfig().Host)
 
 	leave()
 	require.Equal(t, "context-current", k8sinterface.GetContextName())
+	require.Equal(t, "https://current.example", k8sinterface.GetK8sConfig().Host,
+		"leave() restored the context name but not the config that goes with it")
 }

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	github.com/moby/buildkit v0.29.0
 	github.com/open-policy-agent/opa v1.14.1
 	github.com/owenrumney/go-sarif/v2 v2.2.0
-	github.com/prometheus/common v0.67.5
 	github.com/project-copacetic/copacetic v0.10.0
+	github.com/prometheus/common v0.67.5
 	github.com/quay/claircore v1.5.35
 	github.com/schollz/progressbar/v3 v3.13.0
 	github.com/sergi/go-diff v1.4.0
@@ -95,11 +95,13 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/artifactregistry v1.20.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/container v1.46.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
+	cloud.google.com/go/longrunning v1.0.0 // indirect
 	cloud.google.com/go/monitoring v1.25.0 // indirect
 	cloud.google.com/go/storage v1.62.2 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
@@ -111,6 +113,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -623,3 +626,5 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
+
+replace github.com/kubescape/k8s-interface => github.com/doraem-on/k8s-interface v0.0.218-0.20260815050130-fa6fe1e9bc98

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ cloud.google.com/go v0.98.0/go.mod h1:ua6Ush4NALrHk5QXDWnjvZHN93OuF0HfuEPq9I1X0c
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
 cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
+cloud.google.com/go/artifactregistry v1.20.0 h1:j/XQiQfaeTyQeNj3HNk4iDFREVnY/fxkHIjsxpaDs8A=
+cloud.google.com/go/artifactregistry v1.20.0/go.mod h1:0G9wdbGyDFkvrYH+2AlQs9MuTJdbY8Vg45M8VjlI8rc=
 cloud.google.com/go/auth v0.20.0 h1:kXTssoVb4azsVDoUiF8KvxAqrsQcQtB53DcSgta74CA=
 cloud.google.com/go/auth v0.20.0/go.mod h1:942/yi/itH1SsmpyrbnTMDgGfdy2BUqIKyd0cyYLc5Q=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
@@ -116,14 +118,18 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthoriza
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0/go.mod h1:lPneRe3TwsoDRKY4O6YDLXHhEWrD+TIRa8XrV/3/fqw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1 h1:6A4M8smF+y8nM/DYsLNQz9n7n2ZGaEVqfz8ZWQirQkI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1/go.mod h1:WqyxV5S0VtXD2+2d6oPqOvyhGubCvzLCKSAKgQ004Uk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 h1:DWlwvVV5r/Wy1561nZ3wrpI1/vDIBRY/Wd1HWaRBZWA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0/go.mod h1:E7ltexgRDmeJ0fJWv0D/HLwY2xbDdN+uv+X2uZtOx3w=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0/go.mod h1:U5gpsREQZE6SLk1t/cFfc1eMhYAlYpEzvaYXuDfefy8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 h1:+1fJwTilk/X7inNqwREnYEOgFCdg8ut7GULxARDbu34=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0/go.mod h1:EGwSLlGqrrfYQhtCi9JcIkPQKl9WxsL6ZPJd+63Vy1A=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0/go.mod h1:s1tW/At+xHqjNFvWU4G0c0Qv33KOhvbGNj0RCTQDV8s=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 h1:MaKvxE6D0KkjOg6Wd9M00iqP5PR0kUxCfiezes4JweM=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0/go.mod h1:i2h9fsTFKZorh8RdV2IcSUf/Qj98GlTkrTvUbX/s8as=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
@@ -623,6 +629,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/doraem-on/k8s-interface v0.0.218-0.20260815050130-fa6fe1e9bc98 h1:0d+svgGitcFu+mmf24/KPMa/Npapl6fouyRMVxSHgNA=
+github.com/doraem-on/k8s-interface v0.0.218-0.20260815050130-fa6fe1e9bc98/go.mod h1:sOZm48DJn8QO1cWRbuNsPPsk0TxLzm13Ws85EkiH0X0=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 h1:2tV76y6Q9BB+NEBasnqvs7e49aEBFI8ejC89PSnWH+4=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
@@ -1208,8 +1216,6 @@ github.com/kubescape/go-git-url v0.0.31 h1:VZnvtdGLVc42cQaR7llQeGZz0PnOxcs+eDig2
 github.com/kubescape/go-git-url v0.0.31/go.mod h1:3ddc1HEflms1vMhD9owt/3FBES070UaYTUarcjx8jDk=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/k8s-interface v0.0.209 h1:icdBpzSZsfBE4HYmKPbJuxIMWnhIGkixocbIQT4If7k=
-github.com/kubescape/k8s-interface v0.0.209/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.303 h1:NGP2qeDhA52/GTTiwND0RR1xak+gJeJdxK1Ih4EtRHU=
 github.com/kubescape/opa-utils v0.0.303/go.mod h1:uBft9WOfZRwQBzrJNjHklMnZv7ipgChrMTUd3Eapi3Y=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=


### PR DESCRIPTION
Closes #3217

## Overview

`core/cautils/clustercontext.go` adds `EnterClusterContext(context)`, an enter/leave helper for callers that need to scan more than one cluster in a single process.

It switches to the target context and returns a `leave` function that restores whichever context was active before. `leave` is intended to be deferred immediately, before the scan runs, so that a scan that errors, panics, or returns early still restores the previous context.

This PR depends on `kubescape/k8s-interface#161` for the client-config state invalidation. Since that PR is not merged or tagged yet, `go.mod` currently points to it through a fork `replace` directive. This will be replaced with a normal `require` version bump once the upstream fix lands. `#160`, which covers the API-discovery cache, is already merged and included.

## Reason / Behaviour

Scanning two clusters sequentially in the same process is currently unsafe. `SetClusterContextName` alone does not reset the cached client configuration or discovery state, so a second scan can silently observe data from the first cluster.

This is the client-config/resource-map isolation prerequisite identified in `proposals/multi-cluster-fleet-posture-aggregation.md` §6.1. It is required before a sequential `scan fleet` command can reliably produce separate reports for each cluster.

The fleet command itself is not part of this PR.

## Testing

- Added two unit tests using a fake multi-context kubeconfig, with no live cluster required.
- Added an integration test using `KUBESCAPE_INTEGRATION_KIND=1`, skipped by default, against two real kind clusters.
- The integration test fails with an unpatched `k8s-interface` because the second cluster's scan returns the first cluster's `kube-system` UID, and passes with the cache invalidation fix.
- `go build ./...` passes.
- `go test ./core/...` passes.
- `go test ./cmd/...` passes.
- `golangci-lint run ./core/cautils/...` passes.

## Scope

This PR is purely additive. `EnterClusterContext` has no callers yet, and the existing single-cluster path in `cmd/root.go` remains unchanged.

This is a building block for safe multi-cluster scanning, not the fleet command itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable switching between Kubernetes cluster contexts, with automatic restoration of the previously active context.
  - Context restoration remains correct even when another context is selected in between.

- **Bug Fixes**
  - Improved sequential scans across multiple Kubernetes clusters to ensure each scan uses the correct cluster state.

- **Tests**
  - Added coverage for context switching, restoration behavior, and multi-cluster integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->