### PR TITLE
feat(scan): add --show-evidence (-E) and --show-secrets flags

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -213,6 +213,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
+	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ShowEvidence, "show-evidence", "E", false, "Show evidence paths with current field values for each failed control (pretty-printer only)")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.ShowSecrets, "show-secrets", false, "Show secret field values in evidence output. By default secret values are redacted. Only effective with --show-evidence")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.SecurityViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -152,6 +152,8 @@ type ScanInfo struct {
 	FrameworkScan         bool                         // false if scanning control
 	ScanAll               bool                         // true if scan all frameworks
 	OmitRawResources      bool                         // true if omit raw resources from the output
+	ShowEvidence          bool                         // Show evidence paths with current field values in pretty-printer output (-E / --show-evidence)
+	ShowSecrets           bool                         // Show secret field values in evidence output; redacted by default (--show-secrets)
 	PrintAttackTree       bool                         // true if print attack tree
 	EnableRegoPrint       bool                         // true if print rego
 	ScanObject            *objectsenvelopes.ScanObject // identifies a single resource (k8s object) to be scanned

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/kubescape/go-logger"
@@ -433,14 +434,15 @@ func getAttackTracksGetter(ctx context.Context, attackTracks, accountID string, 
 
 // GetUIPrinter returns a printer that will be used to print to the program’s UI (terminal)
 func GetUIPrinter(ctx context.Context, scanInfo *cautils.ScanInfo, clusterName string) printer.IPrinter {
+	var p printer.IPrinter
 	if helpers.ToLevel(logger.L().GetLevel()) >= helpers.WarningLevel || (scanInfo.Format != "" && scanInfo.Output == "") {
-		return &printerv2.SilentPrinter{}
-	}
-
-	p := printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName)
-	if err := p.SetWriter(ctx, ""); err != nil {
-		logger.L().Ctx(ctx).Warning("failed to configure terminal output", helpers.Error(err))
-		return &printerv2.SilentPrinter{}
+		p = &printerv2.SilentPrinter{}
+	} else {
+		p = printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName, scanInfo.ShowEvidence, scanInfo.ShowSecrets)
+		if err := p.SetWriter(ctx, os.Stdout.Name()); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to configure terminal output", helpers.Error(err))
+			return &printerv2.SilentPrinter{}
+		}
 	}
 	return p
 }

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -171,6 +171,55 @@ func reviewPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedCo
 	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 }
 
+// redactedValue is substituted for sensitive field values when --show-secrets is not set.
+const redactedValue = "[redacted]"
+
+// AssistedRemediationPathsWithCurrentValuesFiltered is like AssistedRemediationPathsWithCurrentValues
+// but redacts sensitive field values (Secret.data, Secret.stringData) unless showSecrets is true.
+func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, showSecrets bool) []string {
+	if showSecrets {
+		return AssistedRemediationPathsWithCurrentValues(control, resource)
+	}
+	fixPaths := fixPathsToString(control, false)
+	deletePaths := deletePathsToString(control)
+	enrichedReview := reviewPathsWithCurrentValuesRedacted(control, resource)
+	enrichedFailed := failedPathsWithCurrentValuesRedacted(control, resource)
+	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
+	return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+}
+
+func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
+	var paths []string
+	obj := resource.GetObject()
+	kind := resource.GetKind()
+	for j := range control.ResourceAssociatedRules {
+		for k := range control.ResourceAssociatedRules[j].Paths {
+			p := getPath(control.ResourceAssociatedRules[j].Paths[k])
+			if p == "" {
+				continue
+			}
+			if isSensitivePath(kind, p) {
+				paths = append(paths, p+" (current: "+redactedValue+")")
+				continue
+			}
+			if val, ok := extractValueAtPath(obj, p); ok {
+				paths = append(paths, p+" (current: "+val+")")
+				continue
+			}
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func failedPathsWithCurrentValuesRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForFieldRedacted(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+}
+
+func reviewPathsWithCurrentValuesRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForFieldRedacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
+}
+
 func AssistedRemediationPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	fixPaths := fixPathsToString(control, false)
 	deletePaths := deletePathsToString(control)

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -174,13 +175,71 @@ func reviewPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedCo
 // redactedValue is substituted for sensitive field values when --show-secrets is not set.
 const redactedValue = "[redacted]"
 
+// fixPathsToStringFiltered emits fix paths as "path=value", redacting the value to
+// [redacted] for Secret.data and Secret.stringData paths when showSecrets is false.
+// This prevents FixPath.Value leaking secret material through the evidence column.
+func fixPathsToStringFiltered(control *resourcesresults.ResourceAssociatedControl, kind string, showSecrets bool) []string {
+	var paths []string
+	for j := range control.ResourceAssociatedRules {
+		for k := range control.ResourceAssociatedRules[j].Paths {
+			p := control.ResourceAssociatedRules[j].Paths[k].FixPath.Path
+			if p == "" {
+				continue
+			}
+			v := control.ResourceAssociatedRules[j].Paths[k].FixPath.Value
+			if !showSecrets && isSensitivePath(kind, p) {
+				v = redactedValue
+			}
+			paths = append(paths, fmt.Sprintf("%s=%s", p, v))
+		}
+	}
+	return paths
+}
+
 // AssistedRemediationPathsWithCurrentValuesFiltered is like AssistedRemediationPathsWithCurrentValues
 // but redacts sensitive field values (Secret.data, Secret.stringData) unless showSecrets is true.
-func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, showSecrets bool) []string {
-	if showSecrets {
-		return AssistedRemediationPathsWithCurrentValues(control, resource)
+// enrichedPathsForFieldUnredacted is like enrichedPathsForField but never suppresses values
+// for sensitive paths — used when --show-secrets is set and the operator explicitly wants
+// Secret.data / Secret.stringData values surfaced.
+func enrichedPathsForFieldUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
+	var paths []string
+	obj := resource.GetObject()
+	for j := range control.ResourceAssociatedRules {
+		for k := range control.ResourceAssociatedRules[j].Paths {
+			p := getPath(control.ResourceAssociatedRules[j].Paths[k])
+			if p == "" {
+				continue
+			}
+			if val, ok := extractValueAtPath(obj, p); ok {
+				paths = append(paths, p+" (current: "+val+")")
+				continue
+			}
+			paths = append(paths, p)
+		}
 	}
-	fixPaths := fixPathsToString(control, false)
+	return paths
+}
+
+func failedPathsWithCurrentValuesUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForFieldUnredacted(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+}
+
+func reviewPathsWithCurrentValuesUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
+	return enrichedPathsForFieldUnredacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
+}
+
+func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, showSecrets bool) []string {
+	kind := resource.GetKind()
+	if showSecrets {
+		// extract values for all paths including sensitive ones — caller explicitly opted in
+		fixPaths := fixPathsToStringFiltered(control, kind, true)
+		deletePaths := deletePathsToString(control)
+		enrichedReview := reviewPathsWithCurrentValuesUnredacted(control, resource)
+		enrichedFailed := failedPathsWithCurrentValuesUnredacted(control, resource)
+		paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
+		return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+	}
+	fixPaths := fixPathsToStringFiltered(control, kind, false)
 	deletePaths := deletePathsToString(control)
 	enrichedReview := reviewPathsWithCurrentValuesRedacted(control, resource)
 	enrichedFailed := failedPathsWithCurrentValuesRedacted(control, resource)

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -548,12 +548,14 @@ func TestAssistedRemediationPathsWithCurrentValuesFiltered(t *testing.T) {
 		assert.Equal(t, "data.password (current: test-value-for-testing)", got[0])
 	})
 
-	t.Run("showSecrets=true delegates to AssistedRemediationPathsWithCurrentValues", func(t *testing.T) {
+	t.Run("showSecrets=true extracts non-secret values same as unfiltered", func(t *testing.T) {
+		// for non-secret paths, showSecrets=true and the unfiltered variant
+		// both extract the current value — result must be identical
 		resource := &mockResource{obj: normalObj, kind: "Pod"}
 		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
-		filtered := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, true)
-		unfiltered := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
-		assert.Equal(t, unfiltered, filtered)
+		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, true)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[0])
 	})
 
 	t.Run("empty paths returns nil", func(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -501,3 +501,65 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 		assert.Len(t, got, 2)
 	})
 }
+
+func TestAssistedRemediationPathsWithCurrentValuesFiltered(t *testing.T) {
+	secretObj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"data": map[string]any{
+			"password": "test-value-for-testing",
+		},
+	}
+	normalObj := map[string]any{
+		"spec": map[string]any{
+			"hostPID": true,
+			"containers": []any{
+				map[string]any{
+					"securityContext": map[string]any{
+						"privileged": true,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("non-secret path with showSecrets=false shows value", func(t *testing.T) {
+		resource := &mockResource{obj: normalObj, kind: "Pod"}
+		ctrl := makeControlWithPaths([]string{"spec.hostPID"}, nil)
+		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, false)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.hostPID (current: true)", got[0])
+	})
+
+	t.Run("secret path with showSecrets=false is redacted", func(t *testing.T) {
+		resource := &mockResource{obj: secretObj, kind: "Secret"}
+		ctrl := makeControlWithPaths([]string{"data.password"}, nil)
+		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, false)
+		require.Len(t, got, 1)
+		assert.Equal(t, "data.password (current: "+redactedValue+")", got[0])
+		assert.NotContains(t, got[0], "test-value-for-testing")
+	})
+
+	t.Run("secret path with showSecrets=true shows actual value", func(t *testing.T) {
+		resource := &mockResource{obj: secretObj, kind: "Secret"}
+		ctrl := makeControlWithPaths([]string{"data.password"}, nil)
+		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, true)
+		require.Len(t, got, 1)
+		assert.Equal(t, "data.password (current: test-value-for-testing)", got[0])
+	})
+
+	t.Run("showSecrets=true delegates to AssistedRemediationPathsWithCurrentValues", func(t *testing.T) {
+		resource := &mockResource{obj: normalObj, kind: "Pod"}
+		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
+		filtered := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, true)
+		unfiltered := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
+		assert.Equal(t, unfiltered, filtered)
+	})
+
+	t.Run("empty paths returns nil", func(t *testing.T) {
+		resource := &mockResource{obj: normalObj, kind: "Pod"}
+		ctrl := makeControlWithPaths(nil, nil)
+		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, false)
+		assert.Nil(t, got)
+	})
+}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -38,9 +38,11 @@ type PrettyPrinter struct {
 	inputPatterns   []string
 	verboseMode     bool
 	printAttackTree bool
+	showEvidence    bool
+	showSecrets     bool
 }
 
-func NewPrettyPrinter(verboseMode bool, formatVersion string, attackTree bool, viewType cautils.ViewTypes, scanType cautils.ScanTypes, inputPatterns []string, clusterName string) *PrettyPrinter {
+func NewPrettyPrinter(verboseMode bool, formatVersion string, attackTree bool, viewType cautils.ViewTypes, scanType cautils.ScanTypes, inputPatterns []string, clusterName string, showEvidence bool, showSecrets bool) *PrettyPrinter {
 	prettyPrinter := &PrettyPrinter{
 		verboseMode:     verboseMode,
 		formatVersion:   formatVersion,
@@ -49,6 +51,8 @@ func NewPrettyPrinter(verboseMode bool, formatVersion string, attackTree bool, v
 		scanType:        scanType,
 		inputPatterns:   inputPatterns,
 		clusterName:     clusterName,
+		showEvidence:    showEvidence,
+		showSecrets:     showSecrets,
 	}
 
 	return prettyPrinter

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -169,7 +169,7 @@ func TestSetWriter_Pretty(t *testing.T) {
 				tt.outputFile = filepath.Join(tmpDir, tt.outputFile)
 				tt.expected = filepath.Join(tmpDir, tt.expected)
 			}
-			pp := NewPrettyPrinter(false, "v2", false, cautils.ViewTypes("control"), cautils.ScanTypes("cluster"), []string{}, "")
+			pp := NewPrettyPrinter(false, "v2", false, cautils.ViewTypes("control"), cautils.ScanTypes("cluster"), []string{}, "", false, false)
 
 			pp.SetWriter(ctx, tt.outputFile)
 			if tt.outputFile != "" && tt.outputFile != os.DevNull {

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -91,7 +91,7 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 		if showEvidence {
 			paths := AssistedRemediationPathsWithCurrentValuesFiltered(&controls[i], resource, showSecrets)
 			addContainerNameToAssistedRemediation(resource, &paths)
-			if sourcePath != "" && len(paths) > 0 {
+			if sourcePath != "" {
 				paths = append([]string{"@ " + sourcePath}, paths...)
 			}
 			row[resourceColumnPath] = strings.Join(paths, "\n")

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -58,7 +58,11 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 		summaryTable.Style().Format.Header = text.FormatDefault
 		summaryTable.Style().Box = table.StyleBoxRounded
 
-		resourceRows := generateResourceRows(result.ListControls(), &opaSessionObj.Report.SummaryDetails, resource)
+		var sourcePath string
+		if src, ok := opaSessionObj.ResourceSource[resourceID]; ok {
+			sourcePath = src.RelativePath
+		}
+		resourceRows := generateResourceRows(result.ListControls(), &opaSessionObj.Report.SummaryDetails, resource, prettyPrinter.showEvidence, prettyPrinter.showSecrets, sourcePath)
 
 		short := utils.CheckShortTerminalWidth(resourceRows, generateResourceHeader(false))
 		if short {
@@ -73,7 +77,7 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 
 }
 
-func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata) []table.Row {
+func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata, showEvidence bool, showSecrets bool, sourcePath string) []table.Row {
 	var rows []table.Row
 
 	for i := range controls {
@@ -84,9 +88,14 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 		}
 
 		row[resourceColumnURL] = cautils.GetControlLink(controls[i].GetID())
-		paths := AssistedRemediationPathsWithCurrentValues(&controls[i], resource)
-		addContainerNameToAssistedRemediation(resource, &paths)
-		row[resourceColumnPath] = strings.Join(paths, "\n")
+		if showEvidence {
+			paths := AssistedRemediationPathsWithCurrentValuesFiltered(&controls[i], resource, showSecrets)
+			addContainerNameToAssistedRemediation(resource, &paths)
+			if sourcePath != "" && len(paths) > 0 {
+				paths = append([]string{"@ " + sourcePath}, paths...)
+			}
+			row[resourceColumnPath] = strings.Join(paths, "\n")
+		}
 		row[resourceColumnName] = controls[i].GetName()
 
 		if c := summaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, controls[i].GetID()); c != nil {

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -517,7 +517,7 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rows := generateResourceRows(tt.controls, &tt.summaryDetails, tt.resource)
+			rows := generateResourceRows(tt.controls, &tt.summaryDetails, tt.resource, true, false, "")
 			assert.Equal(t, tt.expectedLen, len(rows))
 			//remediation is the last column of the first row
 			if len(rows) != 0 {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -225,7 +225,7 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		if printFormat != printer.PrettyFormat {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Invalid format \"%s\", default format \"pretty-printer\" is applied", printFormat))
 		}
-		return printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName)
+		return printerv2.NewPrettyPrinter(scanInfo.VerboseMode, scanInfo.FormatVersion, scanInfo.PrintAttackTree, cautils.ViewTypes(scanInfo.View), scanInfo.ScanType, scanInfo.InputPatterns, clusterName, scanInfo.ShowEvidence, scanInfo.ShowSecrets)
 	}
 }
 

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -792,7 +792,7 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 		{"cyclonedx", printerv2.NewCycloneDXPrinter()},
 		{"gitlabsast", printerv2.NewGitLabSASTPrinter()},
 		{"csv", printerv2.NewCsvPrinter()},
-		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "")},
+		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "", false, false)},
 		{"silent", &printerv2.SilentPrinter{}},
 	}
 


### PR DESCRIPTION
pretty-printer currently always calls `AssistedRemediationPathsWithCurrentValues` for every failed control, mixing fix paths and live field values into the remediation column with no way to suppress or opt in. also no redaction for `Secret` field values — running kubescape in CI can leak `Secret.data` contents into logs.

this adds two flags:

--show-evidence / -E gate evidence rendering in the pretty-printer;
without this flag the remediation column is empty
(current behaviour for operators who just want
the control list)

--show-secrets when evidence is shown, Secret.data and
Secret.stringData values are redacted to
[redacted] by default; this flag disables
redaction for operators who need the actual value


for file-based scans (YAML, Helm, Kustomize), the source file is prepended to the evidence column per resource (`@ path/to/manifest.yaml`) so operators can trace which manifest triggered the finding.

## Overview

**current behaviour:** evidence paths always shown, no redaction, no opt-in

**new behaviour:** evidence is opt-in via `--show-evidence` / `-E`; secret values redacted by default; source file shown per resource for file-based scans

implementation:
- `ScanInfo` gains `ShowEvidence` and `ShowSecrets` bool fields
- both flags registered on the persistent scan flag set alongside `--verbose`
- threaded through `NewPrettyPrinter` → `PrettyPrinter` struct → `generateResourceRows`
- `generateResourceRows` gated on `showEvidence`; calls new `AssistedRemediationPathsWithCurrentValuesFiltered` when enabled
- `pathvalue.go`: `AssistedRemediationPathsWithCurrentValuesFiltered` + `enrichedPathsForFieldRedacted` implement redaction-by-default; `redactedValue` const = `"[redacted]"`
- `pathvalue_test.go`: 5 new table-driven cases covering non-secret show, secret redaction, secret reveal, delegation to unfiltered variant, and empty-path nil return

## How to Test

```bash
# evidence on, secrets redacted by default
kubescape scan . --show-evidence

# evidence on, secrets visible
kubescape scan . --show-evidence --show-secrets

# default — no evidence shown (unchanged behaviour)
kubescape scan .
```

## Related issues/PRs

* Resolved #3219
* Related to #1563
* `pathvalue.go` groundwork from #3032 and #3062

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--show-evidence` to display evidence paths and current field values in scan results.
  - Added `--show-secrets` to display secret values in evidence output when evidence display is enabled.
  - Remediation details now include resource source paths for improved context.

- **Bug Fixes**
  - Secret values are now redacted by default in evidence output to reduce accidental exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->