### PR TITLE
fix(anonymizer): widen --hide pseudonym suffix past the 32-bit collision bound

### DIFF
--- a/core/pkg/anonymizer/mapping.go
+++ b/core/pkg/anonymizer/mapping.go
@@ -5,6 +5,22 @@ import (
 	"encoding/hex"
 )
 
+// pseudoIDHashLength is the number of hex characters of the SHA-256 digest
+// kept in a pseudo-ID suffix. 32 hex characters carry 128 bits, which puts a
+// collision beyond reach for any realistic report.
+//
+// This is deliberately not a short digest: the suffix is the only thing that
+// distinguishes one pseudonym from another, and transformSession (session.go)
+// re-keys AllResources, ResourcesResult and the rest of the session maps by
+// the transformed ID. Two distinct values sharing a suffix therefore do not
+// merely look alike in the report - they collapse into a single map entry,
+// silently dropping a resource. A 32-bit suffix reached that point at a
+// birthday bound of only ~2^16 distinct values, well inside the range a
+// single large cluster produces once names, namespaces, labels, annotations
+// and source paths are counted together - all of which share one suffix
+// space, because the hash is taken over the value alone (see GetOrCreate).
+const pseudoIDHashLength = 32
+
 type Mapping struct {
 	data map[string]string
 }
@@ -67,7 +83,7 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 	// this function exists to preserve. That combined trade-off needs an
 	// explicit decision, not a change made incidentally here.
 	hash := sha256.Sum256([]byte(value))
-	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:8]
+	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:pseudoIDHashLength]
 
 	m.data[key] = pseudo
 

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -85,6 +85,54 @@ func TestMapping_GetOrCreate_DeterministicAcrossInstances(t *testing.T) {
 		NewMapping().GetOrCreate("res", "same-value"))
 }
 
+// collidingNameA and collidingNameB are two distinct values whose SHA-256
+// digests share their first 8 hex characters (822ee169) and differ from the
+// 9th onwards. They were found by hashing sequential "payments-api-<n>" names
+// and stopping at the first repeated 8-character prefix - reachable after
+// ~90k names, which is the birthday bound for a 32-bit suffix and well inside
+// the number of distinct values one large cluster contributes.
+//
+// The pair is a fixed input, so these tests are deterministic: they do not
+// search for a collision at run time.
+const (
+	collidingNameA = "payments-api-55939"
+	collidingNameB = "payments-api-89940"
+)
+
+// TestMapping_GetOrCreate_TruncatedHashDoesNotCollide covers the case the
+// "different inputs should return different outputs" table entry above
+// asserts but cannot detect: that entry uses two arbitrary values, which
+// pass for any suffix width. This one uses a value pair chosen to collide in
+// the first 32 bits of the digest, so it fails whenever the suffix is
+// truncated that short, and passes only because the retained digest is wide
+// enough to separate them.
+func TestMapping_GetOrCreate_TruncatedHashDoesNotCollide(t *testing.T) {
+	mapping := NewMapping()
+
+	first := mapping.GetOrCreate("res", collidingNameA)
+	second := mapping.GetOrCreate("res", collidingNameB)
+
+	require.Equal(t,
+		pseudoIDSuffix(t, first, "res")[:8],
+		pseudoIDSuffix(t, second, "res")[:8],
+		"test fixture is stale: %q and %q must still collide in the first 32 bits, otherwise this test proves nothing", collidingNameA, collidingNameB)
+
+	assert.NotEqual(t, first, second,
+		"two distinct values must not share a pseudonym: the report cannot tell them apart, and session maps keyed by the pseudonym silently lose one of them")
+}
+
+// TestMapping_GetOrCreate_SuffixRetainsEnoughDigest pins the suffix width
+// itself. Without it, a future change could shorten the digest again and only
+// TestMapping_GetOrCreate_TruncatedHashDoesNotCollide would notice - and only
+// for the one collision the fixture happens to encode.
+func TestMapping_GetOrCreate_SuffixRetainsEnoughDigest(t *testing.T) {
+	suffix := pseudoIDSuffix(t, NewMapping().GetOrCreate("res", "any-value"), "res")
+
+	assert.Len(t, suffix, pseudoIDHashLength)
+	assert.GreaterOrEqual(t, len(suffix), 32,
+		"a suffix shorter than 128 bits brings collisions back within reach of a single large report")
+}
+
 func TestMapping_GetOrCreate_PrefixIsolationAcrossMultiplePrefixes(t *testing.T) {
 	mapping := NewMapping()
 

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -125,6 +125,61 @@ func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 	}
 }
 
+// TestTransformSession_CollidingNamesKeepDistinctResources covers what a
+// pseudonym collision costs at session level, which is more than a confusing
+// report: transformSession rebuilds AllResources and ResourcesResult keyed by
+// the *transformed* ID, so two resources whose names hash to the same
+// pseudonym overwrite each other and one disappears from the output
+// entirely - a scanned, failing workload that the report never mentions.
+//
+// collidingNameA and collidingNameB (mapping_test.go) collide in the first 32
+// bits of their SHA-256 digests, so this test fails whenever the pseudonym
+// suffix is truncated that short.
+func TestTransformSession_CollidingNamesKeepDistinctResources(t *testing.T) {
+	newPod := func(name string) workloadinterface.IMetadata {
+		return workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+		})
+	}
+
+	podA := newPod(collidingNameA)
+	podB := newPod(collidingNameB)
+
+	session := &cautils.OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			podA.GetID(): podA,
+			podB.GetID(): podB,
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			podA.GetID(): {ResourceID: podA.GetID()},
+			podB.GetID(): {ResourceID: podB.GetID()},
+		},
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	assert.Len(t, session.AllResources, 2,
+		"both pods were scanned, so both must still be present after anonymization")
+	assert.Len(t, session.ResourcesResult, 2,
+		"each pod must keep its own result entry after anonymization")
+
+	names := make(map[string]struct{}, len(session.AllResources))
+	for _, resource := range session.AllResources {
+		assert.NotContains(t, resource.GetName(), "payments-api",
+			"the real name must not survive anonymization")
+		names[resource.GetName()] = struct{}{}
+	}
+	assert.Len(t, names, 2, "the two pods must carry distinct pseudonyms")
+}
+
 func TestTransformSession_IDConsistencyAcrossMaps(t *testing.T) {
 	pod := workloadinterface.NewWorkloadObj(map[string]any{
 		"apiVersion": "v1",


### PR DESCRIPTION
## Overview

`Mapping.GetOrCreate` builds every `--hide` pseudonym as `<prefix>-<suffix>`, where the suffix is the **first 8 hex characters** of the SHA-256 digest — 32 bits:

```go
hash := sha256.Sum256([]byte(value))
pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:8]
```

**Current behavior.** 32 bits puts the birthday bound at roughly 2^16 distinct values. That is not a theoretical number for this function: because the digest is deliberately taken over the *value alone* (so the same raw value keeps the same suffix under different prefixes — the property pinned in #2687), resource names, namespaces, label values, annotation values, source paths and git metadata all share **one** 32-bit suffix space per report. A single large cluster reaches that range.

Once two values collide, the cost depends on the scan type:

* **Cluster scan — a resource is silently dropped.** `transformSession` rebuilds `AllResources`, `ResourcesResult`, `ResourceSource`, `ResourcesPrioritized` and `ResourceAttackTracks` keyed by the *transformed* ID. A cluster resource ID is `group/version/namespace/kind/name` with no per-file component, so two Pods in the same namespace whose names share a suffix produce the same key and one overwrites the other. A scanned, failing workload never appears in the report.
* **File/repo scan — pseudonyms become ambiguous.** `LocalWorkload` prefixes the ID with a per-path hash, so both resources survive, but they are printed under an identical pseudonym. The shared-suffix property the anonymizer uses to express references (a pod's `imagePullSecrets` pointing at a Secret) then also asserts a link between two unrelated resources.

**Expected behavior.** Two distinct values must never share a pseudonym; every scanned resource must survive anonymization.

**Root cause.** The truncation width at `core/pkg/anonymizer/mapping.go:70` — nothing else. This is separate from the unsalted-hash / cross-prefix trade-off already documented at length on `GetOrCreate`; that trade-off is about *guessability* of a pseudonym, this is about *distinctness*, and widening the suffix does not touch it.

**Fix.** Keep 32 hex characters (128 bits) instead of 8, behind a named `pseudoIDHashLength` constant with a comment recording why the width matters. The digest is still taken over the value alone, so cross-prefix referential integrity and determinism across runs are unchanged.

## Additional Information

Behavior deliberately left alone:

* Hashing `value` rather than `prefix+value` — unchanged, so the referential-integrity tests including `TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes` still pass.
* Determinism across separate runs/reports (documented in `docs/cli-reference.md`) — unchanged.
* Salting/HMAC — explicitly *not* addressed here; the existing comment says that trade-off needs its own decision, and this change does not pre-empt it.

Pseudonyms in report output get longer (`res-822ee169` → `res-822ee1698571dce2f24b74a1e0a9608e`). No code, test or doc asserts the old length; existing assertions check the `<prefix>-` form only.

## How to Test

The colliding pair used by the tests is fixed input, not a run-time search, so the tests are deterministic. `payments-api-55939` and `payments-api-89940` share the SHA-256 prefix `822ee169` and were found by hashing sequential names until the first repeated 8-character prefix (~90k names — the birthday bound being described above).

```bash
go test ./core/pkg/anonymizer/...
```

Three tests are added; all three fail on `master` and pass with this change:

* `TestMapping_GetOrCreate_TruncatedHashDoesNotCollide` — the two values must not map to the same pseudonym. The existing "different inputs should return different outputs" table entry cannot catch this: it uses two arbitrary values, which stay distinct at any suffix width.
* `TestTransformSession_CollidingNamesKeepDistinctResources` — end-to-end through `transformSession` with two Pods in one namespace; asserts both survive in `AllResources` and `ResourcesResult` with distinct pseudonyms. On `master` both maps come back with 1 entry instead of 2.
* `TestMapping_GetOrCreate_SuffixRetainsEnoughDigest` — pins the suffix width so a future change cannot shorten it back.

Reproducing the old behavior directly (set `pseudoIDHashLength = 8`) gives:

```
--- FAIL: TestMapping_GetOrCreate_TruncatedHashDoesNotCollide
        Error: Should not be: "res-822ee169"
--- FAIL: TestMapping_GetOrCreate_SuffixRetainsEnoughDigest
        Error: "8" is not greater than or equal to "32"
--- FAIL: TestTransformSession_CollidingNamesKeepDistinctResources
        Error: "map[/v1/ns-37a8eec1/Pod/res-822ee169:...]" should have 2 item(s), but has 1
        Messages: both pods were scanned, so both must still be present after anonymization
```

The ambiguity symptom is also visible through the CLI. Scanning two manifests named `payments-api-55939` and `payments-api-89940` with `--hide --format json`:

```
# before — one pseudonym for two different pods
/v1/ns-37a8eec1/Pod/res-822ee169
/v1/ns-37a8eec1/Pod/res-822ee169

# after — distinct pseudonyms (still sharing the collided first 32 bits)
/v1/ns-37a8eec1ce19687d132fe29051dca629/Pod/res-822ee1698571dce2f24b74a1e0a9608e
/v1/ns-37a8eec1ce19687d132fe29051dca629/Pod/res-822ee1690a187f758fd98a51b6abcc94
```

(Both rows are present in the "before" output because this is a file scan; the drop described above needs the cluster-scan ID form, which the `transformSession` test exercises.)

Validation run locally: `gofmt` clean, `go vet ./core/pkg/anonymizer/...`, `go build ./...`, `golangci-lint run` on the changed package (0 issues), `go test ./...` and `go test -race ./...` on the main module, and `go test ./...` in `httphandler/` — all pass.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymized identifier uniqueness by expanding pseudonym suffixes to 32 hexadecimal characters.
  * Prevented distinct resources from receiving the same anonymized name in collision scenarios.

* **Tests**
  * Added coverage for hash-prefix collisions and session transformations involving similarly named resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->