### PR TITLE
feat(cel): evaluate VAP matchConditions offline instead of refusing the control

### DIFF
--- a/core/pkg/opaprocessor/cel/catalog_test.go
+++ b/core/pkg/opaprocessor/cel/catalog_test.go
@@ -61,10 +61,10 @@ func TestParamKindForPolicy(t *testing.T) {
 }
 
 // TestCatalogBypassesRequireSupported proves the metadata helpers answer for a
-// matchConditions-gated policy loadVAP refuses: deploying/binding such a policy
-// is valid (live admission evaluates the gate), so metadata questions about it
-// must not be blocked. Exercised via parseVAPBundle + lookup on an in-memory
-// bundle, since the vendored bundle ships no gated policies today.
+// policy loadVAP refuses: deploying/binding a namespaceSelector-narrowed policy
+// is valid (live admission has the namespace labels the scan lacks), so metadata
+// questions about it must not be blocked. Exercised via parseVAPBundle + lookup
+// on an in-memory bundle, since the vendored bundle ships no such policy today.
 func TestCatalogBypassesRequireSupported(t *testing.T) {
 	bundle := `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -73,9 +73,15 @@ metadata:
   labels:
     controlId: C-1001
 spec:
-  matchConditions:
-  - name: only-kube-system
-    expression: "object.metadata.namespace == 'kube-system'"
+  matchConstraints:
+    namespaceSelector:
+      matchLabels:
+        env: prod
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
   validations:
   - expression: "false"
 `
@@ -84,7 +90,7 @@ spec:
 
 	vap := catalog.byControl["C-1001"]
 	require.NotNil(t, vap)
-	require.Error(t, vap.requireSupported(), "the offline eval path refuses the gated policy")
+	require.Error(t, vap.requireSupported(), "the offline eval path refuses the narrowed policy")
 
 	// The name index still carries it, so name-keyed metadata stays answerable.
 	named := catalog.byName["kubescape-c-1001-gated"]

--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -48,7 +48,10 @@ func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, 
 	if err != nil {
 		return ControlEvaluation{}, err
 	}
-	matched, err := e.matchConditionsHold(ctx, vap.matchConditions, obj, namespaceObject, params, vap.Variables)
+	// namespaceObject is not threaded into the gate: admission evaluates
+	// matchConditions with it bound to null and only resolves the real Namespace
+	// for the validations below (see matchConditionsHold).
+	matched, err := e.matchConditionsHold(ctx, vap.matchConditions, obj, params, vap.Variables)
 	if err != nil {
 		return matchConditionsGate(vap, err), nil
 	}

--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -31,10 +31,11 @@ type ControlEvaluation struct {
 // via resolveParams, matching what a live binding's ParamRef would supply.
 //
 // A control the offline engine cannot honor with scan/admission parity (e.g.
-// one gated on matchConditions) is refused by loadVAP and surfaces here as an
-// error. The scanner maps that to a skipped status, never a silent pass. An
-// object outside the policy's matchConstraints returns Applicable=false rather
-// than an error, since it is a normal not-matched case, not a failure.
+// one narrowed by a namespaceSelector) is refused by loadVAP and surfaces here
+// as an error. The scanner maps that to a skipped status, never a silent pass.
+// An object outside the policy's matchConstraints returns Applicable=false
+// rather than an error, since it is a normal not-matched case, not a failure —
+// and so does an object a matchCondition gates out (see matchConditionsGate).
 func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, namespaceObject map[string]any) (ControlEvaluation, error) {
 	vap, err := loadVAP(controlID)
 	if err != nil {
@@ -47,9 +48,40 @@ func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, 
 	if err != nil {
 		return ControlEvaluation{}, err
 	}
+	matched, err := e.matchConditionsHold(ctx, vap.matchConditions, obj, namespaceObject, params, vap.Variables)
+	if err != nil {
+		return matchConditionsGate(vap, err), nil
+	}
+	if !matched {
+		return ControlEvaluation{Applicable: false}, nil
+	}
 	results, err := e.EvaluateOnObject(ctx, obj, namespaceObject, params, vap.Variables, vap.Validations)
 	if err != nil {
 		return ControlEvaluation{}, err
 	}
 	return ControlEvaluation{Applicable: true, Results: results, FailOnError: vap.failOnError()}, nil
+}
+
+// matchConditionsGate turns a matchCondition that did not reach a verdict into
+// the outcome admission would produce.
+//
+// Under failurePolicy Ignore the apiserver skips the whole policy, so the object
+// is simply not evaluated. Under Fail it denies the request, so we hand back one
+// errored result and let the scanner report the failure (it applies FailOnError
+// to expression errors exactly as it does for a validation).
+//
+// An offline-only failure — a gate that will not compile, an exhausted budget, a
+// cancelled scan — is not a verdict admission can reach, so failurePolicy does
+// not apply to it. It stays an unknown verdict either way, which is what the
+// scanner does with an error IsExpressionError rejects. The result carries no
+// Expression because the gate is not a validation; the error names the condition.
+func matchConditionsGate(vap *VAP, err error) ControlEvaluation {
+	if IsExpressionError(err) && !vap.failOnError() {
+		return ControlEvaluation{Applicable: false}
+	}
+	return ControlEvaluation{
+		Applicable:  true,
+		Results:     []ValidationResult{{Err: err}},
+		FailOnError: vap.failOnError(),
+	}
 }

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -53,11 +53,9 @@ type VAP struct {
 
 	// matchConditions gates whether a policy runs at all: at admission a policy
 	// whose matchConditions evaluate to false is skipped and none of its
-	// validations run. The offline engine does not evaluate them yet, so we keep
-	// them here only so loadVAP can refuse such a policy (see requireSupported)
-	// rather than run its validations unconditionally and emit violations live
-	// admission would never raise.
-	matchConditions []admissionregistrationv1.MatchCondition
+	// validations run. The evaluator honors the gate offline the same way (see
+	// matchConditionsHold), so a gated policy is scanned rather than refused.
+	matchConditions []MatchCondition
 
 	// paramKind mirrors spec.paramKind; nil when the policy declares no params.
 	paramKind *admissionregistrationv1.ParamKind
@@ -83,12 +81,11 @@ func (v *VAP) failOnError() bool {
 }
 
 // requireSupported reports whether the offline engine can honor this policy with
-// scan/admission parity. matchConditions is an admission-time gate we do not
-// evaluate yet; running a gated policy's validations unconditionally would emit
-// violations live admission never would, so we refuse the control instead. The
-// error maps to the same errored/skipped status a Rego eval error takes, never a
-// silent pass or a false violation. Removing a guard here is the seam for when
-// the evaluator learns to evaluate that gate.
+// scan/admission parity. A refusal maps to the same errored/skipped status a
+// Rego eval error takes, never a silent pass or a false violation. Removing a
+// guard here is the seam for when the evaluator learns to honor that input —
+// matchConditions came off this list once the evaluator could evaluate the gate
+// (see matchConditionsHold).
 //
 // A namespaceSelector is refused for a subtler reason. Its input is the
 // NAMESPACE's labels, and the scan only has those when some control's match
@@ -106,9 +103,6 @@ func (v *VAP) failOnError() bool {
 // objectSelector (the object's own labels) and a resource rule's operations
 // and resourceNames (the object's own name).
 func (v *VAP) requireSupported() error {
-	if len(v.matchConditions) > 0 {
-		return fmt.Errorf("control %q uses spec.matchConditions, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", v.ControlID)
-	}
 	if v.matchConstraints != nil && selectorNarrows(v.matchConstraints.NamespaceSelector) {
 		return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, whose input (namespace labels) the scan cannot guarantee to have; refusing it to preserve scan/admission parity", v.ControlID)
 	}
@@ -269,8 +263,8 @@ func indexUnique(index map[string]*VAP, duplicates map[string]struct{}, key stri
 
 // newVAP flattens a parsed policy into the evaluator's structs. The message and
 // messageExpression travel with each validation so the evaluator can resolve the
-// violation message the same way the apiserver does. matchConditions is carried
-// so loadVAP can refuse a gated policy (see requireSupported).
+// violation message the same way the apiserver does. matchConditions are carried
+// so the evaluator can honor the gate before running any validation.
 //
 // spec.matchConstraints is kept so the scan can scope evaluation to the kinds
 // the policy actually applies to (see appliesTo); without it a non-matching
@@ -287,10 +281,12 @@ func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 	vap := &VAP{
 		ControlID:        policy.Labels[controlIDLabel],
 		PolicyName:       policy.Name,
-		matchConditions:  policy.Spec.MatchConditions,
 		paramKind:        policy.Spec.ParamKind,
 		matchConstraints: policy.Spec.MatchConstraints,
 		failurePolicy:    failurePolicy,
+	}
+	for _, c := range policy.Spec.MatchConditions {
+		vap.matchConditions = append(vap.matchConditions, MatchCondition{Name: c.Name, Expression: c.Expression})
 	}
 	for _, v := range policy.Spec.Variables {
 		vap.Variables = append(vap.Variables, Variable{Name: v.Name, Expression: v.Expression})

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -189,11 +189,11 @@ func TestParseVAPBundleDuplicateName(t *testing.T) {
 	assert.Contains(t, catalog.byName, "kubescape-c-2000", "an unrelated name must still index")
 }
 
-// TestLoadVAPRefusesMatchConditions proves a policy with a matchConditions gate is
-// captured but refused, rather than having its validations run unconditionally.
-// Today's bundle ships none, but a future sync could, and running one offline
-// would emit violations live admission (which honors the gate) never would.
-func TestLoadVAPRefusesMatchConditions(t *testing.T) {
+// TestLoadVAPAcceptsMatchConditions proves a policy with a matchConditions gate
+// loads with its conditions captured, rather than being refused. The evaluator
+// honors the gate per object (see TestMatchConditions*), so refusing the control
+// outright would drop it from the scan for no reason.
+func TestLoadVAPAcceptsMatchConditions(t *testing.T) {
 	bundle := `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -212,11 +212,11 @@ spec:
 
 	vap := catalog.byControl["C-1001"]
 	require.NotNil(t, vap)
-	require.NotEmpty(t, vap.matchConditions, "matchConditions must be captured, not dropped")
+	require.Len(t, vap.matchConditions, 1, "matchConditions must be captured, not dropped")
+	assert.Equal(t, "only-kube-system", vap.matchConditions[0].Name)
+	assert.Equal(t, "object.metadata.namespace == 'kube-system'", vap.matchConditions[0].Expression)
 
-	err = vap.requireSupported()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "matchConditions")
+	assert.NoError(t, vap.requireSupported(), "a gated policy is evaluated, not refused")
 }
 
 // TestLoadVAPRefusesNarrowingSelectors pins which selector is refused and which

--- a/core/pkg/opaprocessor/cel/matchconditions.go
+++ b/core/pkg/opaprocessor/cel/matchconditions.go
@@ -1,0 +1,63 @@
+package cel
+
+import (
+	"context"
+	"fmt"
+)
+
+// MatchCondition is one entry from a VAP's spec.matchConditions: a CEL
+// expression gating whether the policy runs against an object at all. Name
+// labels the condition in the error a broken gate produces.
+type MatchCondition struct {
+	Name       string
+	Expression string
+}
+
+// matchConditionsHold reports whether every matchCondition admits the object.
+//
+// At admission a policy whose matchConditions do not all evaluate to true is
+// skipped and none of its validations run, so offline we must do the same:
+// running a gated policy's validations emits violations admission never raises.
+// Conditions evaluate in order and the first false one short-circuits, as the
+// apiserver does.
+//
+// The error return is the unknown case — a condition that would not compile or
+// failed to evaluate. Whether that denies the object or skips the policy depends
+// on failurePolicy, so the caller decides (see EvaluateControl).
+//
+// The gate gets its own budget and its own activation. Its own budget because
+// the apiserver's matcher runs on a fresh RuntimeCELCostBudget and discards the
+// remainder, so charging the validations for the gate would exhaust a scan where
+// admission is fine. Its own activation because variables memoize per
+// activation: sharing one would hand the validations variables the gate already
+// paid for, making the policy cheaper offline than at admission.
+func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchCondition, obj, namespaceObject map[string]any, params any, variables []Variable) (bool, error) {
+	if len(conditions) == 0 {
+		return true, nil
+	}
+
+	budget := newCostBudget(e.budgetLimit())
+	activation := e.activationFor(ctx, obj, namespaceObject, params, variables, budget)
+
+	for _, condition := range conditions {
+		// cel-go only notices a cancelled context every InterruptCheckFrequency
+		// steps within one expression, so without this a gate of cheap conditions
+		// runs to completion after Ctrl+C (same guard as EvaluateOnObject).
+		if err := ctx.Err(); err != nil {
+			return false, fmt.Errorf("matchCondition %q: evaluation stopped: %w", condition.Name, err)
+		}
+
+		out, err := e.evalExpression(ctx, condition.Expression, activation, budget)
+		if err != nil {
+			return false, fmt.Errorf("matchCondition %q: %w", condition.Name, err)
+		}
+		matched, ok := out.Value().(bool)
+		if !ok {
+			return false, &expressionError{fmt.Errorf("matchCondition %q must return bool, got %T", condition.Name, out.Value())}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/core/pkg/opaprocessor/cel/matchconditions.go
+++ b/core/pkg/opaprocessor/cel/matchconditions.go
@@ -2,7 +2,10 @@ package cel
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
 )
 
 // MatchCondition is one entry from a VAP's spec.matchConditions: a CEL
@@ -18,17 +21,33 @@ type MatchCondition struct {
 // At admission a policy whose matchConditions do not all evaluate to true is
 // skipped and none of its validations run, so offline we must do the same:
 // running a gated policy's validations emits violations admission never raises.
-// Conditions evaluate in order and the first false one short-circuits, as the
-// apiserver does.
 //
-// The error return is the unknown case — a condition that would not compile or
-// failed to evaluate. Whether that denies the object or skips the policy depends
-// on failurePolicy, so the caller decides (see EvaluateControl).
+// A false condition outranks a condition that errored, whatever order the two
+// appear in. The apiserver's matcher evaluates every condition, collects the
+// errors, and still returns not-matched the moment it sees a false one; only a
+// gate of trues and errors reaches failurePolicy (webhook/matchconditions
+// matcher.go, which the VAP path reuses). So an error is retained rather than
+// returned, and a later false discards it. Returning on the first error instead
+// would deny an object under failurePolicy Fail that admission simply skips.
+//
+// A false condition still short-circuits the conditions after it. Evaluating
+// them could only add errors that the false already outranks, and the gate's
+// budget is discarded either way, so the outcome is identical to the
+// apiserver's for less work.
+//
+// Cancellation and an exhausted budget are the exceptions: they are terminal,
+// because no later condition can still produce the false that would outrank
+// them. A compile error is not terminal, since the conditions after it are
+// unaffected and one of them may yet be false.
+//
+// The error return is the unknown case. Whether it denies the object or skips
+// the policy depends on failurePolicy, so the caller decides (see
+// matchConditionsGate).
 //
 // The gate gets its own budget and its own activation. Its own budget because
-// the apiserver's matcher runs on a fresh RuntimeCELCostBudget and discards the
-// remainder, so charging the validations for the gate would exhaust a scan where
-// admission is fine. Its own activation because variables memoize per
+// the apiserver's matcher runs on a fresh matchConditions budget and discards
+// the remainder, so charging the validations for the gate would exhaust a scan
+// where admission is fine. Its own activation because variables memoize per
 // activation: sharing one would hand the validations variables the gate already
 // paid for, making the policy cheaper offline than at admission.
 func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchCondition, obj, namespaceObject map[string]any, params any, variables []Variable) (bool, error) {
@@ -36,8 +55,12 @@ func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchC
 		return true, nil
 	}
 
-	budget := newCostBudget(e.budgetLimit())
+	budget := newCostBudget(e.matchConditionsBudgetLimit())
 	activation := e.activationFor(ctx, obj, namespaceObject, params, variables, budget)
+
+	// The first error we can still recover from, held until a false outranks it
+	// or the gate runs out of conditions.
+	var retained error
 
 	for _, condition := range conditions {
 		// cel-go only notices a cancelled context every InterruptCheckFrequency
@@ -49,15 +72,42 @@ func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchC
 
 		out, err := e.evalExpression(ctx, condition.Expression, activation, budget)
 		if err != nil {
-			return false, fmt.Errorf("matchCondition %q: %w", condition.Name, err)
+			if isContextError(ctx, err) || errors.Is(err, errOutOfBudget) {
+				return false, fmt.Errorf("matchCondition %q: %w", condition.Name, err)
+			}
+			if retained == nil {
+				retained = fmt.Errorf("matchCondition %q: %w", condition.Name, err)
+			}
+			continue
 		}
+
 		matched, ok := out.Value().(bool)
 		if !ok {
-			return false, &expressionError{fmt.Errorf("matchCondition %q must return bool, got %T", condition.Name, out.Value())}
+			if retained == nil {
+				retained = &expressionError{fmt.Errorf("matchCondition %q must return bool, got %T", condition.Name, out.Value())}
+			}
+			continue
 		}
 		if !matched {
 			return false, nil
 		}
 	}
+
+	if retained != nil {
+		return false, retained
+	}
 	return true, nil
+}
+
+// matchConditionsBudgetLimit is the cost budget one object's gate runs on. The
+// apiserver bills matchConditions to RuntimeCELCostBudgetMatchConditions, a
+// quarter of what it gives the validations, so metering the gate against the
+// validations' ceiling would let a gate pass offline that admission cuts off. A
+// WithCostBudget override still wins, so tests can reach the exhausted path
+// without writing an expensive condition.
+func (e *Evaluator) matchConditionsBudgetLimit() int64 {
+	if e.costBudget > 0 {
+		return e.costBudget
+	}
+	return celconfig.RuntimeCELCostBudgetMatchConditions
 }

--- a/core/pkg/opaprocessor/cel/matchconditions.go
+++ b/core/pkg/opaprocessor/cel/matchconditions.go
@@ -50,13 +50,24 @@ type MatchCondition struct {
 // where admission is fine. Its own activation because variables memoize per
 // activation: sharing one would hand the validations variables the gate already
 // paid for, making the policy cheaper offline than at admission.
-func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchCondition, obj, namespaceObject map[string]any, params any, variables []Variable) (bool, error) {
+//
+// namespaceObject is deliberately absent from the signature: the gate binds it
+// to null, never to the object's real Namespace, even when the scan captured
+// one. The apiserver's matcher passes a hardcoded nil namespace to ForInput
+// (webhook/matchconditions matcher.go), while the validations that follow get
+// the resolved Namespace, so at admission a matchCondition touching
+// namespaceObject always evaluates against null and errors into failurePolicy.
+// Binding the real namespace here would answer that condition offline instead
+// of reproducing the error, which is the scan/admission divergence this package
+// exists to avoid. params and variables ARE available to matchConditions at
+// admission (the shared CompositedCompiler), so those stay bound.
+func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchCondition, obj map[string]any, params any, variables []Variable) (bool, error) {
 	if len(conditions) == 0 {
 		return true, nil
 	}
 
 	budget := newCostBudget(e.matchConditionsBudgetLimit())
-	activation := e.activationFor(ctx, obj, namespaceObject, params, variables, budget)
+	activation := e.activationFor(ctx, obj, nil, params, variables, budget)
 
 	// The first error we can still recover from, held until a false outranks it
 	// or the gate runs out of conditions.

--- a/core/pkg/opaprocessor/cel/matchconditions_test.go
+++ b/core/pkg/opaprocessor/cel/matchconditions_test.go
@@ -1,0 +1,220 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedPod is the object the matchCondition tests gate on.
+func gatedPod() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "gated", "namespace": "prod"},
+		"spec":       map[string]any{"containers": []any{map[string]any{"name": "c", "image": "nginx"}}},
+	}
+}
+
+func cond(name, expr string) MatchCondition {
+	return MatchCondition{Name: name, Expression: expr}
+}
+
+// TestMatchConditionsHold pins the gate's verdicts: a policy runs only when every
+// condition is true, and the first false one short-circuits the rest.
+func TestMatchConditionsHold(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		conditions []MatchCondition
+		matched    bool
+	}{
+		{
+			name:       "no conditions match everything",
+			conditions: nil,
+			matched:    true,
+		},
+		{
+			name: "every condition true matches",
+			conditions: []MatchCondition{
+				cond("is-pod", "object.kind == 'Pod'"),
+				cond("is-prod", "object.metadata.namespace == 'prod'"),
+			},
+			matched: true,
+		},
+		{
+			name: "one false condition does not match",
+			conditions: []MatchCondition{
+				cond("is-pod", "object.kind == 'Pod'"),
+				cond("is-kube-system", "object.metadata.namespace == 'kube-system'"),
+			},
+			matched: false,
+		},
+		{
+			// The second condition selects a field that is absent, which errors
+			// when evaluated. A clean not-matched verdict therefore proves the
+			// first false condition short-circuited it, as the apiserver does.
+			name: "a false condition short-circuits the ones after it",
+			conditions: []MatchCondition{
+				cond("is-kube-system", "object.metadata.namespace == 'kube-system'"),
+				cond("would-error", "object.spec.nodeName == 'node-1'"),
+			},
+			matched: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.matched, matched)
+		})
+	}
+}
+
+// TestMatchConditionsHoldReadsPolicyInputs proves the gate evaluates against the
+// same bindings a validation gets, so a condition can narrow on any of them.
+func TestMatchConditionsHoldReadsPolicyInputs(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	namespaceObject := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   map[string]any{"name": "prod", "labels": map[string]any{"tier": "critical"}},
+	}
+	params := map[string]any{"settings": map[string]any{"gate": true}}
+	variables := []Variable{{Name: "isProd", Expression: "object.metadata.namespace == 'prod'"}}
+
+	conditions := []MatchCondition{
+		cond("via-variable", "variables.isProd"),
+		cond("via-params", "params.settings.gate"),
+		cond("via-request", "request.operation == 'CREATE'"),
+		cond("via-namespace", "namespaceObject.metadata.labels.tier == 'critical'"),
+	}
+
+	matched, err := e.matchConditionsHold(context.Background(), conditions, gatedPod(), namespaceObject, params, variables)
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+// TestMatchConditionsHoldErrors separates the errors failurePolicy governs from
+// the ones it must not. A condition the expression itself broke is a verdict
+// admission can reach; one that never compiled is offline-only.
+func TestMatchConditionsHoldErrors(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		condition       MatchCondition
+		expressionError bool
+	}{
+		{
+			name:            "a non-bool result is an expression error",
+			condition:       cond("not-bool", "object.metadata.name"),
+			expressionError: true,
+		},
+		{
+			name:            "selecting an absent field is an expression error",
+			condition:       cond("absent", "object.spec.nodeName == 'node-1'"),
+			expressionError: true,
+		},
+		{
+			// authorizer is deliberately not declared on the env, so a condition
+			// using it cannot compile. Admission never reaches this, so it must
+			// stay outside failurePolicy's reach.
+			name:            "an expression that will not compile is not an expression error",
+			condition:       cond("uncompilable", "authorizer.group('').resource('pods').check('list').allowed()"),
+			expressionError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{tc.condition}, gatedPod(), nil, nil, nil)
+			require.Error(t, err)
+			assert.False(t, matched)
+			assert.Contains(t, err.Error(), tc.condition.Name, "the error must name the condition")
+			assert.Equal(t, tc.expressionError, IsExpressionError(err))
+		})
+	}
+}
+
+// TestMatchConditionsHoldCancellation proves a cancelled scan stops the gate and
+// reports an unknown verdict rather than a not-matched one, which would silently
+// drop the resource from the results.
+func TestMatchConditionsHoldCancellation(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	matched, err := e.matchConditionsHold(ctx, []MatchCondition{cond("is-pod", "object.kind == 'Pod'")}, gatedPod(), nil, nil, nil)
+	require.Error(t, err)
+	assert.False(t, matched)
+	assert.False(t, IsExpressionError(err), "a cancelled scan is not a verdict failurePolicy governs")
+}
+
+// TestMatchConditionsHoldOwnBudget proves the gate does not spend the budget the
+// validations run on. The evaluator is capped so low that a single condition
+// exhausts it; the validations that follow must still reach clean verdicts, which
+// they only can on a budget of their own.
+func TestMatchConditionsHoldOwnBudget(t *testing.T) {
+	e, err := NewEvaluator(WithCostBudget(1))
+	require.NoError(t, err)
+
+	_, err = e.matchConditionsHold(context.Background(), []MatchCondition{
+		cond("is-prod", "object.metadata.namespace == 'prod'"),
+	}, gatedPod(), nil, nil, nil)
+	require.Error(t, err, "the gate must exhaust this budget for the test to mean anything")
+	assert.False(t, IsExpressionError(err))
+
+	results, err := e.EvaluateOnObject(context.Background(), gatedPod(), nil, nil, nil, []Validation{
+		{Expression: "true"},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Err, "the gate must not have spent the validations' budget")
+	assert.True(t, results[0].Passed)
+}
+
+// TestMatchConditionsGate maps a gate that reached no verdict onto the outcome
+// admission produces, which is the whole reason failurePolicy is carried.
+func TestMatchConditionsGate(t *testing.T) {
+	failing := &VAP{ControlID: "C-1001", failurePolicy: admissionregistrationv1.Fail}
+	ignoring := &VAP{ControlID: "C-1001", failurePolicy: admissionregistrationv1.Ignore}
+	exprErr := &expressionError{assert.AnError}
+
+	t.Run("failurePolicy Fail denies the object", func(t *testing.T) {
+		eval := matchConditionsGate(failing, exprErr)
+		assert.True(t, eval.Applicable)
+		assert.True(t, eval.FailOnError)
+		require.Len(t, eval.Results, 1)
+		assert.Equal(t, exprErr, eval.Results[0].Err)
+	})
+
+	t.Run("failurePolicy Ignore skips the policy", func(t *testing.T) {
+		eval := matchConditionsGate(ignoring, exprErr)
+		assert.False(t, eval.Applicable)
+		assert.Empty(t, eval.Results)
+	})
+
+	t.Run("an offline-only failure stays unknown under Ignore", func(t *testing.T) {
+		// Admission never reaches a compile error, so failurePolicy does not
+		// apply: the resource must surface as unknown, not be dropped as
+		// not-matched the way an Ignore'd expression error is.
+		eval := matchConditionsGate(ignoring, assert.AnError)
+		assert.True(t, eval.Applicable)
+		assert.False(t, eval.FailOnError)
+		require.Len(t, eval.Results, 1)
+		assert.Equal(t, assert.AnError, eval.Results[0].Err)
+	})
+}

--- a/core/pkg/opaprocessor/cel/matchconditions_test.go
+++ b/core/pkg/opaprocessor/cel/matchconditions_test.go
@@ -72,7 +72,7 @@ func TestMatchConditionsHold(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil, nil)
+			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.matched, matched)
 		})
@@ -114,7 +114,7 @@ func TestMatchConditionsHoldFalseOutranksError(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil, nil)
+			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil)
 			require.NoError(t, err, "a false condition outranks an error, so the gate is a clean not-matched")
 			assert.False(t, matched)
 		})
@@ -124,7 +124,7 @@ func TestMatchConditionsHoldFalseOutranksError(t *testing.T) {
 		matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{
 			cond("is-pod", "object.kind == 'Pod'"),
 			evalErrors,
-		}, gatedPod(), nil, nil, nil)
+		}, gatedPod(), nil, nil)
 		require.Error(t, err, "with no false condition the error is what failurePolicy acts on")
 		assert.False(t, matched)
 		assert.True(t, IsExpressionError(err))
@@ -133,16 +133,13 @@ func TestMatchConditionsHoldFalseOutranksError(t *testing.T) {
 }
 
 // TestMatchConditionsHoldReadsPolicyInputs proves the gate evaluates against the
-// same bindings a validation gets, so a condition can narrow on any of them.
+// bindings admission gives a matchCondition, so a condition can narrow on any of
+// them. namespaceObject is not among them - see
+// TestMatchConditionsHoldBindsNamespaceObjectNull.
 func TestMatchConditionsHoldReadsPolicyInputs(t *testing.T) {
 	e, err := NewEvaluator()
 	require.NoError(t, err)
 
-	namespaceObject := map[string]any{
-		"apiVersion": "v1",
-		"kind":       "Namespace",
-		"metadata":   map[string]any{"name": "prod", "labels": map[string]any{"tier": "critical"}},
-	}
 	params := map[string]any{"settings": map[string]any{"gate": true}}
 	variables := []Variable{{Name: "isProd", Expression: "object.metadata.namespace == 'prod'"}}
 
@@ -150,12 +147,35 @@ func TestMatchConditionsHoldReadsPolicyInputs(t *testing.T) {
 		cond("via-variable", "variables.isProd"),
 		cond("via-params", "params.settings.gate"),
 		cond("via-request", "request.operation == 'CREATE'"),
-		cond("via-namespace", "namespaceObject.metadata.labels.tier == 'critical'"),
 	}
 
-	matched, err := e.matchConditionsHold(context.Background(), conditions, gatedPod(), namespaceObject, params, variables)
+	matched, err := e.matchConditionsHold(context.Background(), conditions, gatedPod(), params, variables)
 	require.NoError(t, err)
 	assert.True(t, matched)
+}
+
+// TestMatchConditionsHoldBindsNamespaceObjectNull pins the one binding the gate
+// deliberately withholds. The apiserver's matcher evaluates matchConditions with
+// a hardcoded nil namespace even when the VAP dispatcher has already resolved
+// the real one for spec.validations, so at admission a condition reading
+// namespaceObject.* always errors into failurePolicy. Answering it offline from
+// the scan's real Namespace would pass a policy admission rejects, so the gate
+// must reproduce the error - and it must stay an expression error, since that is
+// the verdict failurePolicy governs.
+func TestMatchConditionsHoldBindsNamespaceObjectNull(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	// matchConditionsHold takes no namespaceObject at all, so a caller holding a
+	// real Namespace (EvaluateControl does, for the validations) has no way to
+	// reach the gate with it. The condition below therefore runs against null.
+	conditions := []MatchCondition{cond("via-namespace", "namespaceObject.metadata.labels.tier == 'critical'")}
+
+	matched, err := e.matchConditionsHold(context.Background(), conditions, gatedPod(), nil, nil)
+	require.Error(t, err, "namespaceObject is null at admission, so the condition errors rather than answering")
+	assert.False(t, matched)
+	assert.True(t, IsExpressionError(err), "the error is one failurePolicy governs, as at admission")
+	assert.Contains(t, err.Error(), "via-namespace")
 }
 
 // TestMatchConditionsHoldErrors separates the errors failurePolicy governs from
@@ -192,7 +212,7 @@ func TestMatchConditionsHoldErrors(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{tc.condition}, gatedPod(), nil, nil, nil)
+			matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{tc.condition}, gatedPod(), nil, nil)
 			require.Error(t, err)
 			assert.False(t, matched)
 			assert.Contains(t, err.Error(), tc.condition.Name, "the error must name the condition")
@@ -211,7 +231,7 @@ func TestMatchConditionsHoldCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	matched, err := e.matchConditionsHold(ctx, []MatchCondition{cond("is-pod", "object.kind == 'Pod'")}, gatedPod(), nil, nil, nil)
+	matched, err := e.matchConditionsHold(ctx, []MatchCondition{cond("is-pod", "object.kind == 'Pod'")}, gatedPod(), nil, nil)
 	require.Error(t, err)
 	assert.False(t, matched)
 	assert.False(t, IsExpressionError(err), "a cancelled scan is not a verdict failurePolicy governs")
@@ -231,7 +251,7 @@ func TestMatchConditionsHoldOwnBudget(t *testing.T) {
 	_, err = e.matchConditionsHold(context.Background(), []MatchCondition{
 		cond("is-prod", "object.metadata.namespace == 'prod'"),
 		cond("is-kube-system", "object.metadata.namespace == 'kube-system'"),
-	}, gatedPod(), nil, nil, nil)
+	}, gatedPod(), nil, nil)
 	require.Error(t, err, "the gate must exhaust this budget for the test to mean anything")
 	assert.False(t, IsExpressionError(err))
 

--- a/core/pkg/opaprocessor/cel/matchconditions_test.go
+++ b/core/pkg/opaprocessor/cel/matchconditions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,6 +77,59 @@ func TestMatchConditionsHold(t *testing.T) {
 			assert.Equal(t, tc.matched, matched)
 		})
 	}
+}
+
+// TestMatchConditionsHoldFalseOutranksError pins the apiserver's precedence: a
+// condition evaluating to false skips the policy whatever order it appears in
+// relative to a condition that errored, and only a gate of trues and errors
+// reaches failurePolicy. Returning on the first error instead would deny an
+// object under Fail that admission simply skips.
+func TestMatchConditionsHoldFalseOutranksError(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	isFalse := cond("is-kube-system", "object.metadata.namespace == 'kube-system'")
+	// Selects a field the object does not carry, so it errors at eval time.
+	evalErrors := cond("absent-field", "object.spec.nodeName == 'node-1'")
+	// authorizer is not declared on the env, so this cannot compile.
+	wontCompile := cond("uncompilable", "authorizer.group('').resource('pods').check('list').allowed()")
+
+	cases := []struct {
+		name       string
+		conditions []MatchCondition
+	}{
+		{
+			name:       "an eval error before a false one is discarded",
+			conditions: []MatchCondition{evalErrors, isFalse},
+		},
+		{
+			name:       "a compile error before a false one is discarded",
+			conditions: []MatchCondition{wontCompile, isFalse},
+		},
+		{
+			name:       "the false one still wins from further down the gate",
+			conditions: []MatchCondition{cond("is-pod", "object.kind == 'Pod'"), evalErrors, isFalse},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, err := e.matchConditionsHold(context.Background(), tc.conditions, gatedPod(), nil, nil, nil)
+			require.NoError(t, err, "a false condition outranks an error, so the gate is a clean not-matched")
+			assert.False(t, matched)
+		})
+	}
+
+	t.Run("trues and errors with no false still surface the error", func(t *testing.T) {
+		matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{
+			cond("is-pod", "object.kind == 'Pod'"),
+			evalErrors,
+		}, gatedPod(), nil, nil, nil)
+		require.Error(t, err, "with no false condition the error is what failurePolicy acts on")
+		assert.False(t, matched)
+		assert.True(t, IsExpressionError(err))
+		assert.Contains(t, err.Error(), evalErrors.Name)
+	})
 }
 
 // TestMatchConditionsHoldReadsPolicyInputs proves the gate evaluates against the
@@ -171,8 +225,12 @@ func TestMatchConditionsHoldOwnBudget(t *testing.T) {
 	e, err := NewEvaluator(WithCostBudget(1))
 	require.NoError(t, err)
 
+	// A false condition after the exhausted one must NOT rescue the gate: once
+	// the budget is gone nothing later can be trusted to have really evaluated,
+	// so an exhausted budget is terminal where an expression error is not.
 	_, err = e.matchConditionsHold(context.Background(), []MatchCondition{
 		cond("is-prod", "object.metadata.namespace == 'prod'"),
+		cond("is-kube-system", "object.metadata.namespace == 'kube-system'"),
 	}, gatedPod(), nil, nil, nil)
 	require.Error(t, err, "the gate must exhaust this budget for the test to mean anything")
 	assert.False(t, IsExpressionError(err))
@@ -184,6 +242,22 @@ func TestMatchConditionsHoldOwnBudget(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.NoError(t, results[0].Err, "the gate must not have spent the validations' budget")
 	assert.True(t, results[0].Passed)
+}
+
+// TestMatchConditionsBudgetLimit pins the gate to the budget the apiserver bills
+// matchConditions against, which is a quarter of the validations' ceiling.
+// Metering the gate against the larger one would let a gate run offline that
+// admission cuts off.
+func TestMatchConditionsBudgetLimit(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(celconfig.RuntimeCELCostBudgetMatchConditions), e.matchConditionsBudgetLimit())
+	assert.Less(t, e.matchConditionsBudgetLimit(), e.budgetLimit(), "the gate gets the smaller ceiling")
+
+	overridden, err := NewEvaluator(WithCostBudget(7))
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), overridden.matchConditionsBudgetLimit(), "an explicit override still wins")
 }
 
 // TestMatchConditionsGate maps a gate that reached no verdict onto the outcome

--- a/core/pkg/opaprocessor/cel/optionalfields_test.go
+++ b/core/pkg/opaprocessor/cel/optionalfields_test.go
@@ -116,9 +116,9 @@ func TestNoEvalErrorOnMinimalWorkloads(t *testing.T) {
 		for _, id := range bundleControlIDs {
 			ev, err := e.EvaluateControl(context.Background(), id, obj, nil)
 			if err != nil {
-				// The engine refuses policies it cannot honor offline (e.g.
-				// matchConditions); the scanner skips the whole rule, which is a
-				// separate, already-intentional path.
+				// The engine refuses policies it cannot honor offline (e.g. ones
+				// narrowed by a namespaceSelector); the scanner skips the whole
+				// rule, which is a separate, already-intentional path.
 				continue
 			}
 			if !ev.Applicable {


### PR DESCRIPTION
## Overview

Today the offline CEL engine refuses to load any ValidatingAdmissionPolicy that declares `spec.matchConditions`. The refusal happens in `loadVAP`, so the whole control is dropped from the scan for every resource, not just for the objects the gate would have excluded.

This PR evaluates the gate instead of refusing it. Conditions run in order and the first false one short circuits, matching the apiserver. An object the gate excludes comes back as not applicable, which is the same path an object outside `matchConstraints` already takes.

A condition that does not reach a verdict is mapped onto what admission would do with it. Under `failurePolicy: Ignore` the policy is skipped, and under `Fail` the object is denied. Failures that only exist offline, such as an expression that will not compile, an exhausted cost budget or a cancelled scan, stay unknown in both cases, since admission never reaches them.

The gate runs on its own cost budget and its own activation. The apiserver's matcher starts from a fresh `RuntimeCELCostBudget` and variables memoize per activation, so sharing either one would make a policy cost a different amount offline than it does at admission.

## Additional Information

The vendored bundle ships no gated policies at the moment, so no scan result changes today. The bundle is synced from cel-admission-library, and as things stand the first upstream policy to pick up a matchCondition would quietly take its control out of scan coverage.

`namespaceSelector` stays refused, for the reason already documented on `requireSupported`: its input is the namespace labels, which a scan cannot guarantee to have.

## How to Test

```
go test ./core/pkg/opaprocessor/...
```

New tests in `matchconditions_test.go` cover matching, short circuit ordering, the object/params/request/namespaceObject/variables bindings, error classification, cancellation and budget independence. Three existing tests that pinned the old refusal now point at `namespaceSelector`, which is still refused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CEL match conditions during offline policy evaluation.
  * Conditions are evaluated in order, with false conditions stopping further evaluation.
  * Match conditions can access policy inputs and honor configured failure policies.

* **Bug Fixes**
  * Improved handling of condition evaluation errors, cancellation, and invalid results.
  * Policies with supported match conditions are no longer incorrectly rejected.
  * Evaluation now correctly reports unsupported narrowing namespace selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->