### PR TITLE
fix(cautils): make config serialization non-mutating

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -60,15 +60,7 @@ type ConfigObj struct {
 
 // Config - convert ConfigObj to config file
 func (co *ConfigObj) Config() []byte {
-
-	// remove cluster name before saving to file
-	clusterName := co.ClusterName
-	co.ClusterName = ""
-
-	b, err := json.MarshalIndent(co, "", "  ") // #nosec G117 -- config persists the cloud access key by design; secret handled as a credential
-
-	co.ClusterName = clusterName
-
+	b, err := marshalConfigObj(co)
 	if err == nil {
 		return b
 	}
@@ -370,14 +362,13 @@ var configMarshal = func(v any) ([]byte, error) {
 	return json.MarshalIndent(v, "", "  ") //nolint:gosec,nolintlint // G117: AccessKey is intentionally persisted to the local config file
 }
 
-// marshalConfigObj serializes co for persistence, stripping ClusterName
-// (runtime-only, must not be saved) before marshaling and restoring it after.
+// marshalConfigObj serializes co for persistence, stripping ClusterName from a
+// snapshot because it is runtime-only and must not be saved. Serializing the
+// snapshot keeps the shared runtime config unchanged for concurrent readers.
 func marshalConfigObj(co *ConfigObj) ([]byte, error) {
-	clusterName := co.ClusterName
-	co.ClusterName = ""
-	b, err := configMarshal(co)
-	co.ClusterName = clusterName
-	return b, err
+	snapshot := *co
+	snapshot.ClusterName = ""
+	return configMarshal(&snapshot)
 }
 
 func updateConfigFile(configObj *ConfigObj) error {

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -47,6 +47,52 @@ func TestConfig(t *testing.T) {
 
 }
 
+func TestConfigConcurrentSerializationDoesNotMutateSource(t *testing.T) {
+	co := mockConfigObj()
+
+	originalMarshal := configMarshal
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	var calls int
+	configMarshal = func(v any) ([]byte, error) {
+		calls++
+		switch calls {
+		case 1:
+			close(firstEntered)
+			<-releaseFirst
+		case 2:
+			close(secondEntered)
+			<-releaseSecond
+		}
+		return json.MarshalIndent(v, "", "  ") // #nosec G117 -- test fixture contains no real credential
+	}
+	t.Cleanup(func() { configMarshal = originalMarshal })
+
+	firstResult := make(chan []byte, 1)
+	go func() { firstResult <- co.Config() }()
+	<-firstEntered
+
+	secondResult := make(chan []byte, 1)
+	go func() { secondResult <- co.Config() }()
+	<-secondEntered
+
+	assert.Equal(t, "ddd", co.ClusterName, "serialization must not expose a temporary empty runtime identity")
+
+	close(releaseFirst)
+	firstJSON := <-firstResult
+	close(releaseSecond)
+	secondJSON := <-secondResult
+
+	assert.Equal(t, "ddd", co.ClusterName, "concurrent serialization must not change the source config")
+	for _, data := range [][]byte{firstJSON, secondJSON} {
+		var persisted map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &persisted))
+		assert.NotContains(t, persisted, "clusterName", "clusterName must remain absent from persisted config")
+	}
+}
+
 func TestITenantConfig(t *testing.T) {
 	var lc ITenantConfig
 	var c ITenantConfig


### PR DESCRIPTION
## Overview

Config serialization currently removes the runtime-only `ClusterName` by clearing the field on the shared `ConfigObj`, marshaling it, and restoring it afterwards. Concurrent serialization or a concurrent runtime reader can observe that temporary mutation; two overlapping serializations can also restore the empty value last and leave the in-memory identity corrupted.

This change makes serialization non-mutating:

- copy `ConfigObj` by value;
- clear `ClusterName` only on the snapshot;
- route both `ConfigObj.Config()` and persisted config writes through the same helper.

The persisted JSON contract is unchanged: `clusterName` remains omitted.

## Regression coverage

The new test controls two overlapping marshal calls. With the previous mutate/restore implementation, the second call captures an already-empty cluster name and restores it last. The test verifies that:

- the source object's cluster name remains available while both calls are in flight;
- it is still intact after both calls complete;
- both serialized outputs omit the `clusterName` key.

## How to test

```bash
go test ./core/cautils -count=1
go test -race ./core/cautils -run 'TestConfigConcurrentSerializationDoesNotMutateSource' -count=1
```

Both commands pass locally with Go 1.26.0.

## Related issues/PRs

- Resolves #3227
- Follow-up to #2766; that PR fixed marshal-error propagation but intentionally retained the mutate/restore behavior.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the concurrency-relevant behavior
- [x] I have performed a self-review of the code
- [x] I have added deterministic regression coverage
- [x] New and existing package tests pass locally