### PR TITLE
fix(reporter): make posture report chunking deterministic

### DIFF
--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -143,7 +144,15 @@ func (report *ReportEventReceiver) sendResources(ctx context.Context, opaSession
 }
 
 func (report *ReportEventReceiver) setResults(ctx context.Context, reportObj *reporthandlingv2.PostureReport, results map[string]resourcesresults.Result, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, prioritizedResources map[string]prioritization.PrioritizedResource, counter, reportCounter *int) error {
-	for _, v := range results {
+	// Chunk boundaries depend on iteration order, so keep the input order stable.
+	resourceIDs := make([]string, 0, len(results))
+	for resourceID := range results {
+		resourceIDs = append(resourceIDs, resourceID)
+	}
+	sort.Strings(resourceIDs)
+
+	for _, resultID := range resourceIDs {
+		v := results[resultID]
 		// set result.RawResource
 		resourceID := v.GetResourceID()
 		if _, ok := allResources[resourceID]; !ok {
@@ -196,7 +205,15 @@ func (report *ReportEventReceiver) setResults(ctx context.Context, reportObj *re
 }
 
 func (report *ReportEventReceiver) setResources(ctx context.Context, reportObj *reporthandlingv2.PostureReport, allResources map[string]workloadinterface.IMetadata, resourcesSource map[string]reporthandling.Source, results map[string]resourcesresults.Result, counter, reportCounter *int) error {
-	for resourceID, v := range allResources {
+	// Chunk boundaries depend on iteration order, so keep the input order stable.
+	resourceIDs := make([]string, 0, len(allResources))
+	for resourceID := range allResources {
+		resourceIDs = append(resourceIDs, resourceID)
+	}
+	sort.Strings(resourceIDs)
+
+	for _, resourceID := range resourceIDs {
+		v := allResources[resourceID]
 		/*
 
 			// process only resources which have no result because these resources will be sent on the result object

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"os"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -11,8 +12,10 @@ import (
 	v1 "github.com/kubescape/backend/pkg/client/v1"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/prettylogger"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,6 +174,53 @@ func TestPrepareReport(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestReportChunksUseStableResourceOrder(t *testing.T) {
+	resources := []workloadinterface.IMetadata{
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "zeta"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "alpha"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "kappa"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "beta"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "theta"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "delta"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "eta"}}),
+		workloadinterface.NewWorkloadObj(map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "gamma"}}),
+	}
+
+	allResources := make(map[string]workloadinterface.IMetadata, len(resources))
+	results := make(map[string]resourcesresults.Result, len(resources))
+	expectedResourceIDs := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		resourceID := resource.GetID()
+		allResources[resourceID] = resource
+		results[resourceID] = resourcesresults.Result{ResourceID: resourceID}
+		expectedResourceIDs = append(expectedResourceIDs, resourceID)
+	}
+	sort.Strings(expectedResourceIDs)
+
+	receiver := &ReportEventReceiver{}
+	// Repeat to guard against a randomized map iteration coincidentally matching
+	// the canonical order once.
+	for i := 0; i < 64; i++ {
+		reportObj := &reporthandlingv2.PostureReport{}
+		counter, reportCounter := 0, 0
+
+		require.NoError(t, receiver.setResources(context.Background(), reportObj, allResources, nil, results, &counter, &reportCounter))
+		require.NoError(t, receiver.setResults(context.Background(), reportObj, results, allResources, nil, nil, &counter, &reportCounter))
+
+		gotResources := make([]string, 0, len(reportObj.Resources))
+		for _, resource := range reportObj.Resources {
+			gotResources = append(gotResources, resource.ResourceID)
+		}
+		gotResults := make([]string, 0, len(reportObj.Results))
+		for _, result := range reportObj.Results {
+			gotResults = append(gotResults, result.ResourceID)
+		}
+
+		require.Equalf(t, expectedResourceIDs, gotResources, "resources iteration %d", i)
+		require.Equalf(t, expectedResourceIDs, gotResults, "results iteration %d", i)
+	}
 }
 
 func TestSubmit(t *testing.T) {


### PR DESCRIPTION
## Overview

`ReportEventReceiver` previously ranged directly over the resource and result maps while applying the 2 MiB report-size threshold. Since Go map order is unspecified, identical scan data could be assigned to different `reportNumber` chunks across runs.

This change sorts resource IDs before the existing serialization and packing logic in both paths:

- `setResources`
- `setResults`

No report schema, size threshold, error handling, or submission behavior changes. The tradeoff is `O(n log n)` sorting and `O(n)` temporary key storage per collection.

## Regression coverage

The test builds resource and result maps in deliberately non-canonical insertion order, invokes both reporter paths 64 times, and verifies that every generated sequence uses the same resource-ID order.

This covers both map iteration sites and distinguishes this path from #2773, which canonicalized finalized printer output rather than cloud-submission pagination.

## How to test

```bash
go test ./core/pkg/resultshandling/reporter/v2 -count=1
go test -race ./core/pkg/resultshandling/reporter/v2 -run 'TestReportChunksUseStableResourceOrder' -count=1
```

Both commands pass locally with Go 1.26.0.

## Related issues/PRs

- Resolves #3229
- Related: #2773

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have documented why canonical ordering is required
- [x] I have performed a self-review of the code
- [x] I have added regression coverage for both affected paths
- [x] New and existing package tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured report resources and results are consistently processed in a stable order.
  * Made report chunking and submission deterministic, improving repeatability across executions.

* **Tests**
  * Added coverage verifying that reports maintain the same resource order across repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->