### PR TITLE
fix(core): close output writers when Scan fails

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -51,6 +51,24 @@ type componentInterfaces struct {
 	k8s               *k8sinterface.KubernetesApi
 }
 
+func (interfaces componentInterfaces) closePrinters() error {
+	var closeErr error
+	printers := append([]printer.IPrinter{interfaces.uiPrinter}, interfaces.outputPrinters...)
+	for _, configuredPrinter := range printers {
+		if configuredPrinter == nil {
+			continue
+		}
+		if closer, ok := configuredPrinter.(interface{ CloseWriter() error }); ok {
+			closeErr = errors.Join(closeErr, closer.CloseWriter())
+			continue
+		}
+		if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
+			closer.CloseWriter()
+		}
+	}
+	return closeErr
+}
+
 func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (componentInterfaces, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "setup interfaces")
 	defer span.End()
@@ -233,7 +251,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 // reused or another operation could run concurrently against it, since a
 // mid-operation ks.Context() read could observe a different deadline than
 // the one that started the operation, or an already-restored/canceled one.
-func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (scanResult *resultshandling.ResultsHandler, scanErr error) {
 	ctxInit, spanInit := otel.Tracer("").Start(ctx, "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
 
@@ -254,6 +272,16 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 		spanInit.End()
 		return nil, err
 	}
+	// Output printers open their writers during interface setup. Scan owns
+	// those writers until a successful return hands them to ResultsHandler.
+	printersOwnedByScan := true
+	defer func() {
+		if printersOwnedByScan {
+			if err := interfaces.closePrinters(); err != nil {
+				scanErr = errors.Join(scanErr, fmt.Errorf("close printers after scan failure: %w", err))
+			}
+		}
+	}()
 	interfaces.report.SetTenantConfig(interfaces.tenantConfig)
 
 	// remove host scanner components
@@ -346,6 +374,7 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 		if denied := result.Denied(); len(denied) > 0 {
 			return resultsHandling, fmt.Errorf("dry-run: %d required resource type(s) cannot be listed with the current credentials", len(denied))
 		}
+		printersOwnedByScan = false
 		return resultsHandling, nil
 	}
 
@@ -485,6 +514,7 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 		}
 	}
 
+	printersOwnedByScan = false
 	return resultsHandling, nil
 }
 

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -64,13 +64,7 @@ func closePrinters(printers ...printer.IPrinter) error {
 		if configuredPrinter == nil {
 			continue
 		}
-		if closer, ok := configuredPrinter.(interface{ CloseWriter() error }); ok {
-			closeErr = errors.Join(closeErr, closer.CloseWriter())
-			continue
-		}
-		if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
-			closer.CloseWriter()
-		}
+		closeErr = errors.Join(closeErr, resultshandling.ClosePrinter(configuredPrinter))
 	}
 	return closeErr
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -52,8 +52,14 @@ type componentInterfaces struct {
 }
 
 func (interfaces componentInterfaces) closePrinters() error {
-	var closeErr error
 	printers := append([]printer.IPrinter{interfaces.uiPrinter}, interfaces.outputPrinters...)
+	return closePrinters(printers...)
+}
+
+// closePrinters supports both printer close contracts while the migration to
+// error-returning CloseWriter methods is in progress.
+func closePrinters(printers ...printer.IPrinter) error {
+	var closeErr error
 	for _, configuredPrinter := range printers {
 		if configuredPrinter == nil {
 			continue
@@ -152,24 +158,15 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	containPrettyPrinter := false
 	outputPrinters := make([]printer.IPrinter, 0)
 	resolvedPaths := make(map[string]string)
-	// closeConfiguredPrinters closes already configured output printers upon setup failure.
-	closeConfiguredPrinters := func() error {
-		var closeErr error
-		for _, configuredPrinter := range outputPrinters {
-			if closer, ok := configuredPrinter.(interface{ CloseWriter() error }); ok {
-				if err := closer.CloseWriter(); err != nil {
-					closeErr = errors.Join(closeErr, err)
-				}
-			} else if closer, ok := configuredPrinter.(interface{ CloseWriter() }); ok {
-				closer.CloseWriter()
-			}
-		}
-		return closeErr
+	closeConfiguredPrinters := func(setupErr error, additional ...printer.IPrinter) error {
+		printersToClose := append([]printer.IPrinter(nil), outputPrinters...)
+		printersToClose = append(printersToClose, additional...)
+		return errors.Join(setupErr, closePrinters(printersToClose...))
 	}
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
-			return nil, errors.Join(err, closeConfiguredPrinters())
+			return nil, closeConfiguredPrinters(err)
 		}
 
 		if usesPrettyPrinter && containPrettyPrinter {
@@ -178,14 +175,16 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 
 		if path := resolvedOutputPath(format, scanInfo.Output); path != "" {
 			if existing, collision := resolvedPaths[path]; collision {
-				return nil, errors.Join(fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path), closeConfiguredPrinters())
+				setupErr := fmt.Errorf("output path collision: formats %q and %q both resolve to %q; specify distinct output paths or use format-specific file extensions", existing, format, path)
+				return nil, closeConfiguredPrinters(setupErr)
 			}
 			resolvedPaths[path] = format
 		}
 
 		printerHandler := resultshandling.NewPrinter(ctx, format, scanInfo, clusterName)
 		if err := printerHandler.SetWriter(ctx, scanInfo.Output); err != nil {
-			return nil, errors.Join(fmt.Errorf("configure %q output: %w", format, err), closeConfiguredPrinters())
+			setupErr := fmt.Errorf("configure %q output: %w", format, err)
+			return nil, closeConfiguredPrinters(setupErr, printerHandler)
 		}
 		outputPrinters = append(outputPrinters, printerHandler)
 

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -263,6 +264,51 @@ func TestGetOutputPrinters(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, outputPrinters)
 	assert.Equal(t, 3, len(outputPrinters))
+}
+
+func TestScanClosesOutputPrinterWhenPolicyLoadingFails(t *testing.T) {
+	if _, err := os.Stat("/proc/self/fd"); err != nil {
+		t.Skip("requires /proc/self/fd")
+	}
+
+	for _, formatVersion := range []string{"v1", "v2"} {
+		t.Run(formatVersion, func(t *testing.T) {
+			output := filepath.Join(t.TempDir(), "report.json")
+			missingPolicy := "missing-" + filepath.Base(t.TempDir())
+			scanInfo := &cautils.ScanInfo{
+				InputPatterns: []string{"../cautils/testdata/mixed_extensions/pod.yaml"},
+				UseFrom:       []string{filepath.Join(t.TempDir(), missingPolicy+".json")},
+				Format:        printer.JsonFormat,
+				FormatVersion: formatVersion,
+				Output:        output,
+				Local:         true,
+				FrameworkScan: true,
+				ScanType:      cautils.ScanTypeFramework,
+			}
+
+			results, err := NewKubescape(context.Background()).Scan(scanInfo, cautils.BuildPolicyIdentifiers([]string{missingPolicy}, apisv1.KindFramework))
+			require.Error(t, err)
+			require.NotNil(t, results, "policy loading must fail after the configured printer is attached to a result handler")
+			assertNoOpenFileDescriptor(t, output)
+			// Keep the returned handler (and its printer) reachable while inspecting
+			// /proc so an os.File finalizer cannot hide the leak under test.
+			runtime.KeepAlive(results)
+		})
+	}
+}
+
+func assertNoOpenFileDescriptor(t *testing.T, path string) {
+	t.Helper()
+	absPath, err := filepath.Abs(path)
+	require.NoError(t, err)
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err == nil {
+			assert.NotEqual(t, absPath, strings.TrimSuffix(target, " (deleted)"), "leaked output file descriptor %s", entry.Name())
+		}
+	}
 }
 
 func TestGetOutputPrintersReturnsExplicitSetupErrorsForEveryFormat(t *testing.T) {

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -366,6 +366,7 @@ func TestGetOutputPrintersClosesV1JSONWriterAfterLaterSetupFailure(t *testing.T)
 		Format:        printer.JsonFormat + "," + printer.GitLabSASTFormat,
 		FormatVersion: "v1",
 		Output:        output,
+		InputPatterns: []string{"manifest.yaml"},
 	}
 
 	outputPrinters, err := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -288,6 +288,7 @@ func TestScanClosesOutputPrinterWhenPolicyLoadingFails(t *testing.T) {
 
 			results, err := NewKubescape(context.Background()).Scan(scanInfo, cautils.BuildPolicyIdentifiers([]string{missingPolicy}, apisv1.KindFramework))
 			require.Error(t, err)
+			require.ErrorContains(t, err, missingPolicy)
 			require.NotNil(t, results, "policy loading must fail after the configured printer is attached to a result handler")
 			assertNoOpenFileDescriptor(t, output)
 			// Keep the returned handler (and its printer) reachable while inspecting
@@ -352,6 +353,26 @@ func TestGetOutputPrintersCollisionReturnsError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "output path collision")
+}
+
+func TestGetOutputPrintersClosesV1JSONWriterAfterLaterSetupFailure(t *testing.T) {
+	if _, err := os.Stat("/proc/self/fd"); err != nil {
+		t.Skip("requires /proc/self/fd")
+	}
+
+	output := filepath.Join(t.TempDir(), "report")
+	scanInfo := &cautils.ScanInfo{
+		ScanType:      cautils.ScanTypeControl,
+		Format:        printer.JsonFormat + "," + printer.GitLabSASTFormat,
+		FormatVersion: "v1",
+		Output:        output,
+	}
+
+	outputPrinters, err := GetOutputPrinters(scanInfo, context.Background(), "test-cluster")
+
+	require.ErrorContains(t, err, "output path collision")
+	assert.Nil(t, outputPrinters)
+	assertNoOpenFileDescriptor(t, output+printer.JsonOutputExt)
 }
 
 func TestResolvedOutputPath(t *testing.T) {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -297,7 +297,7 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 	}
 
 	rh.UiPrinter.PrintNextSteps()
-	if err := closePrinter(rh.UiPrinter); err != nil {
+	if err := ClosePrinter(rh.UiPrinter); err != nil {
 		printErr = errors.Join(printErr, fmt.Errorf("ui printer close: %w", err))
 	}
 
@@ -309,7 +309,7 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 		if rh.ScanData != nil {
 			p.Score(rh.GetComplianceScore())
 		}
-		if err := closePrinter(p); err != nil {
+		if err := ClosePrinter(p); err != nil {
 			printErr = errors.Join(printErr, fmt.Errorf("output printer %T close: %w", p, err))
 		}
 	}
@@ -408,11 +408,11 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	}
 }
 
-// closePrinter closes p's output writer if p implements an optional close
+// ClosePrinter closes p's output writer if p implements an optional close
 // contract, returning any error so callers can surface incomplete writes.
 // Printers migrated to return an error from CloseWriter are preferred; the
 // legacy void contract is still supported for backwards compatibility.
-func closePrinter(p printer.IPrinter) error {
+func ClosePrinter(p printer.IPrinter) error {
 	type errorCloser interface {
 		CloseWriter() error
 	}

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -853,12 +853,12 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 			require.NoError(t, setErr)
 
 			// 1. Initial close on active writer must succeed
-			closeErr := closePrinter(tt.printer)
+			closeErr := ClosePrinter(tt.printer)
 			assert.NoError(t, closeErr)
 
 			// 2. Subsequent close on already-closed writer must surface the underlying error
-			secondCloseErr := closePrinter(tt.printer)
-			assert.Error(t, secondCloseErr, "closePrinter must surface error on already-closed writer for %s", tt.name)
+			secondCloseErr := ClosePrinter(tt.printer)
+			assert.Error(t, secondCloseErr, "ClosePrinter must surface error on already-closed writer for %s", tt.name)
 		})
 	}
 }


### PR DESCRIPTION
## Overview

Output printers open their writers during `getInterfaces`, but until now they were closed only by `ResultsHandler.HandleResults`. If `Scan` failed after interface setup and before a successful return, normal callers skipped result handling and the output file descriptor remained open.

This change makes writer ownership explicit:

- `Scan` owns the configured UI/output printers while initialization and evaluation are in progress;
- a deferred cleanup closes them on every unsuccessful return (and during panic unwinding);
- successful normal and dry-run returns transfer ownership to the existing `ResultsHandler` lifecycle;
- cleanup errors are joined with the original scan error.

The cleanup helper accepts both `CloseWriter() error` and the legacy `CloseWriter()` contract, so it remains compatible whether #3215 lands before or after this PR.

## Regression coverage

The new test configures an explicit JSON output and forces local policy loading to fail after printer setup. For both v1 and v2 it verifies that:

- `Scan` returns the original failure and the partial handler;
- the handler remains reachable during the assertion;
- no descriptor in `/proc/self/fd` still targets the output file.

The test skips only on platforms without `/proc/self/fd`.

## How to test

Root module:

```bash
go test ./core/core -count=1
```

Nested HTTP-handler module:

```bash
cd httphandler
go test ./handlerequests/v1 -count=1
```

Both pass locally with Go 1.26.0.

## Related issues/PRs

- Resolves #3231
- Related lifecycle work: #2259, #3140, #3215

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have documented the writer ownership boundary
- [x] I have performed a self-review of the code
- [x] I have added regression coverage for both JSON format versions
- [x] Relevant root and nested-module tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Output files and UI writers are now properly closed when scans fail during policy loading or output setup.
  * Improved resource cleanup for dry-run and successful scans while preserving generated results.
  * Prevented file descriptor leaks during scan failures.
  * Cleanup errors are now reported alongside the original scan or setup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->