### PR TITLE
fix(policyhandler): bypass shared cache for local policies

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -152,20 +152,25 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 // getScanPolicies - get policies from cache or downloads them. The function returns an error if the policies could not be downloaded.
 func (policyHandler *PolicyHandler) getScanPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, getters *cautils.Getters) ([]reporthandling.Framework, error) {
 	policyIdentifiersSlice := policyIdentifierToSlice(policyIdentifier)
-	// check if policies are cached atomically
-	if entry, exist := policyHandler.cachedPolicies.Get(); exist {
-		// check if the cached policies match the requested policy identifiers
-		if cautils.StringSlicesAreEqual(entry.identifiers, policyIdentifiersSlice) {
-			logger.L().Info("Using cached policies")
-			return deepCopyPolicies(entry.frameworks)
-		}
+	_, isLocalPolicy := getters.PolicyGetter.(*getter.LoadPolicy)
+	// Explicit local policy sources are request-scoped inputs. They must not be
+	// shadowed by, or replace, a shared cache entry for the same identifiers.
+	if !isLocalPolicy {
+		// check if policies are cached atomically
+		if entry, exist := policyHandler.cachedPolicies.Get(); exist {
+			// check if the cached policies match the requested policy identifiers
+			if cautils.StringSlicesAreEqual(entry.identifiers, policyIdentifiersSlice) {
+				logger.L().Info("Using cached policies")
+				return deepCopyPolicies(entry.frameworks)
+			}
 
-		logger.L().Debug("Cached policies are not the same as the requested policies")
-		policyHandler.cachedPolicies.Invalidate()
+			logger.L().Debug("Cached policies are not the same as the requested policies")
+			policyHandler.cachedPolicies.Invalidate()
+		}
 	}
 
 	policies, err := policyHandler.downloadScanPolicies(ctx, policyIdentifier, getters)
-	if err == nil {
+	if err == nil && !isLocalPolicy {
 		policyHandler.cachedPolicies.Set(cachedPoliciesEntry{
 			identifiers: policyIdentifiersSlice,
 			frameworks:  policies,

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -2,6 +2,7 @@ package policyhandler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -280,6 +281,49 @@ func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
 	files, err := os.ReadDir(cacheDir)
 	assert.NoError(t, err)
 	assert.Empty(t, files)
+}
+
+func TestGetScanPolicies_LocalSourceBypassesSharedCache(t *testing.T) {
+	t.Setenv(PoliciesCacheTtlEnvVar, "1h")
+	policyHandler := NewRequestScopedPolicyHandler("local-source-cluster")
+	defer policyHandler.Close()
+
+	policyIdent := []cautils.PolicyIdentifier{{Identifier: FrameworkName, Kind: "Framework"}}
+	remoteGetters := &cautils.Getters{PolicyGetter: &PolicyGetterMock{}}
+
+	remotePolicies, err := policyHandler.getScanPolicies(context.Background(), policyIdent, remoteGetters)
+	require.NoError(t, err)
+	require.NotEmpty(t, remotePolicies)
+
+	localFramework := reporthandling.Framework{
+		PortalBase: armotypes.PortalBase{Name: FrameworkName},
+		Controls: []reporthandling.Control{
+			{
+				PortalBase: armotypes.PortalBase{Name: "local override"},
+				ControlID:  "local-control",
+			},
+		},
+	}
+	localBytes, err := json.Marshal(localFramework)
+	require.NoError(t, err)
+	localPath := filepath.Join(t.TempDir(), "framework.json")
+	require.NoError(t, os.WriteFile(localPath, localBytes, 0o600))
+
+	localGetters := &cautils.Getters{PolicyGetter: getter.NewLoadPolicy([]string{localPath})}
+	localPolicies, err := policyHandler.getScanPolicies(context.Background(), policyIdent, localGetters)
+	require.NoError(t, err)
+	require.Len(t, localPolicies, 1)
+	require.Len(t, localPolicies[0].Controls, 1)
+	assert.Equal(t, "local-control", localPolicies[0].Controls[0].ControlID,
+		"an explicit local source must not be shadowed by a warm shared cache entry")
+
+	remotePoliciesAgain, err := policyHandler.getScanPolicies(context.Background(), policyIdent, remoteGetters)
+	require.NoError(t, err)
+	require.Len(t, remotePoliciesAgain, len(remotePolicies))
+	require.NotEmpty(t, remotePoliciesAgain[0].Controls)
+	assert.Equal(t, remotePolicies[0].Controls[0].ControlID, remotePoliciesAgain[0].Controls[0].ControlID,
+		"a local request must not replace the shared remote-policy cache")
+	assert.NotEqual(t, "local-control", remotePoliciesAgain[0].Controls[0].ControlID)
 }
 
 type ControlsInputsGetterEmptyMock struct{}


### PR DESCRIPTION
## Overview

Fixes #3233.

When `POLICIES_CACHE_TTL` is enabled, `getScanPolicies` currently looks up a shared cache entry before honoring the request's `PolicyGetter`. Because that entry is keyed only by policy identifiers, a warm remote framework can silently shadow an explicitly supplied local framework with the same name.

This change treats `*getter.LoadPolicy` as request-scoped input:

- skip shared in-memory cache reads for local policy getters;
- do not write local policy results into the shared in-memory cache;
- leave an existing remote cache entry intact.

Remote-only cache behavior is unchanged. This also aligns the in-memory path with the existing disk-cache rule in #2463: explicit local policies are not shared cache material.

## Why this shape

Invalidating the cache before a local request would make the local file win, but it would unnecessarily discard a valid remote entry. Including only a generic source flag in the cache key would still make request-scoped file contents stale during the TTL. Bypassing shared caching for `LoadPolicy` preserves explicit-source semantics and keeps the change bounded.

## Test plan

- [x] A warm remote entry cannot shadow a same-named local framework.
- [x] The local result contains the sentinel local control.
- [x] The local request does not replace the warm remote entry.
- [x] Existing policy-handler package tests pass.
- [x] Targeted regression passes under the race detector.

Commands run:

```text
go test ./core/pkg/policyhandler -run '^TestGetScanPolicies_LocalSourceBypassesSharedCache$' -count=1
go test ./core/pkg/policyhandler -count=1
go test -race ./core/pkg/policyhandler -run '^TestGetScanPolicies_LocalSourceBypassesSharedCache$' -count=1
```

## Compatibility

No public API or default cache setting changes. The only behavioral change is that an explicit local policy getter is authoritative for its request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local scan policies now load correctly without being overridden by shared cached policies.
  * Remote policy cache contents remain consistent when local policies are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->