### PR TITLE
refactor(resourcehandler): count streaming namespaces in place

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -422,14 +422,19 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 
 	// allResources is resident.AllResources, which only ever holds
 	// cluster-scoped resources (see the partition loop above); namespaced
-	// resources live in namespaceBatches. Aggregate both before counting, and
-	// do it here, before namespaceBatches are drained into batchChan below.
-	countable := make(map[string]workloadinterface.IMetadata, len(allResources))
-	maps.Copy(countable, allResources)
+	// resources live in namespaceBatches. Count across both before the batches
+	// are drained below, without building a second whole-cluster map just for
+	// this report metadata. Count namespace batches first, then skip a resident
+	// entry when the same ID is already present in its namespace batch. This
+	// preserves the old merged-map deduplication for resources injected into the
+	// resident batch (for example SingleResourceScan and RBAC resources) without
+	// allocating a whole-cluster seen-ID set.
+	mapNamespaceToNumberOfResources := make(map[string]int)
 	for _, batch := range namespaceBatches {
-		maps.Copy(countable, batch.AllResources)
+		addNamespaceResourceCounts(ctx, batch.AllResources, mapNamespaceToNumberOfResources, nil)
 	}
-	setMapNamespaceToNumOfResources(ctx, countable, sessionObj)
+	addNamespaceResourceCounts(ctx, allResources, mapNamespaceToNumberOfResources, namespaceBatches)
+	sessionObj.SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources)
 	if len(cloudResources) > 0 {
 		if err := k8sHandler.collectCloudResources(ctx, sessionObj, allResources, ksResourceMap, cloudResources); err != nil {
 			cautils.SetInfoMapForResources(err.Error(), cloudResources, sessionObj.InfoMap)
@@ -672,9 +677,26 @@ func (k8sHandler *K8sResourceHandler) GetClusterAPIServerInfo(ctx context.Contex
 
 // set  namespaceToNumOfResources map in report
 func setMapNamespaceToNumOfResources(ctx context.Context, allResources map[string]workloadinterface.IMetadata, sessionObj *cautils.OPASessionObj) {
-
 	mapNamespaceToNumberOfResources := make(map[string]int)
-	for _, resource := range allResources {
+	addNamespaceResourceCounts(ctx, allResources, mapNamespaceToNumberOfResources, nil)
+	sessionObj.SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources)
+}
+
+// addNamespaceResourceCounts accumulates reportable top-level resources into
+// an existing namespace-count map. Keeping accumulation separate lets the
+// streaming collector count resident and namespace batches in place instead
+// of copying every resource into a temporary whole-cluster map. When
+// alreadyCounted is non-nil, a resource already present in its namespace batch
+// is skipped; callers with one already-unique map can pass nil.
+func addNamespaceResourceCounts(ctx context.Context, allResources map[string]workloadinterface.IMetadata, mapNamespaceToNumberOfResources map[string]int, alreadyCounted map[string]*cautils.ResourceBatch) {
+	for resourceID, resource := range allResources {
+		if alreadyCounted != nil {
+			if batch := alreadyCounted[resource.GetNamespace()]; batch != nil {
+				if _, counted := batch.AllResources[resourceID]; counted {
+					continue
+				}
+			}
+		}
 		if obj := workloadinterface.NewWorkloadObj(resource.GetObject()); obj != nil {
 			ownerReferences, err := obj.GetOwnerReferences()
 			if err == nil {
@@ -691,7 +713,6 @@ func setMapNamespaceToNumOfResources(ctx context.Context, allResources map[strin
 			}
 		}
 	}
-	sessionObj.SetMapNamespaceToNumberOfResources(mapNamespaceToNumberOfResources)
 }
 
 // queryFailure records a failed pull at query granularity (GVR + field selectors).

--- a/core/pkg/resourcehandler/namespace_resource_counts_test.go
+++ b/core/pkg/resourcehandler/namespace_resource_counts_test.go
@@ -1,0 +1,80 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestAddNamespaceResourceCounts_AccumulatesResourceSets(t *testing.T) {
+	counts := make(map[string]int)
+
+	addNamespaceResourceCounts(context.Background(), map[string]workloadinterface.IMetadata{
+		"deployment-a": newNamespaceCountResource("apps/v1", "Deployment", "deployment-a", "team-a"),
+	}, counts, nil)
+	addNamespaceResourceCounts(context.Background(), map[string]workloadinterface.IMetadata{
+		"service-a": newNamespaceCountResource("v1", "Service", "service-a", "team-a"),
+		"service-b": newNamespaceCountResource("v1", "Service", "service-b", "team-b"),
+	}, counts, nil)
+
+	assert.Equal(t, map[string]int{"team-a": 2, "team-b": 1}, counts)
+}
+
+func TestCollectAndStreamBatches_DeduplicatesSingleResourceNamespaceCount(t *testing.T) {
+	ctx := context.Background()
+	pods := testPodList("standalone-pod", "team-a")
+	handler := newHandlerWithReactor(t, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, pods, nil
+	})
+	scanInfo, session := streamingTestSession(ctx)
+	session.SingleResourceScan = workloadinterface.NewWorkloadObj(pods.Items[0].Object)
+
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 2)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		resourceResolver(defaultResourceResolver),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, session.Metadata.ContextMetadata.ClusterContextMetadata)
+	assert.Equal(t, map[string]int{"team-a": 1}, session.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
+
+	require.Len(t, batches, 2)
+	resident := <-batches
+	namespace := <-batches
+	resourceID := session.SingleResourceScan.GetID()
+	assert.Contains(t, resident.AllResources, resourceID)
+	assert.Contains(t, namespace.AllResources, resourceID)
+}
+
+func newNamespaceCountResource(apiVersion, kind, name, namespace string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	})
+}


### PR DESCRIPTION
## Overview

Relates to #3235. Follow-up to #2645.

Reduce an avoidable pre-first-batch allocation in the streaming Kubernetes collector.

`collectAndStreamBatches` previously copied every resident and namespaced resource reference into a temporary `countable` map solely to derive `MapNamespaceToNumberOfResources`. The collector already owns those objects in the resident/namespace batches, so this added a second O(N) map at the point where the full collected cluster is resident.

This change extracts the existing namespace-count accumulation logic and applies it directly to each resident/namespace resource map. Namespace batches are counted first; a resident resource is skipped only if the same resource ID is already present in its namespace batch. This preserves the former merged-map deduplication for `SingleResourceScan` and RBAC-injected overlaps without allocating a whole-cluster seen-ID set.

The report value and filtering rules are unchanged:

- resources present in both resident and namespace batches are counted once;
- only namespaced resources are counted;
- resources with owner references are excluded;
- `Job` remains excluded;
- eager collection still uses the same counting path.

This is a deliberately small Phase 0 step. It removes one O(N) temporary map; it does **not** claim to bound the collector or total process memory. Paged partition storage and downstream `AllResources` ownership require the linked design discussion.

## Test plan

- [x] `go test ./core/pkg/resourcehandler -run '^(TestSetMapNamespaceToNumOfResources|TestCollectAndStreamBatches_CountsNamespacedResourcesAcrossBatches|TestCollectAndStreamBatches_DeduplicatesSingleResourceNamespaceCount|TestAddNamespaceResourceCounts_AccumulatesResourceSets)$' -count=1`
- [x] Same targeted suite with `-race`
- [x] `go test ./core/pkg/resourcehandler -run '^$' -count=1` (package compile)
- [x] `go vet ./core/pkg/resourcehandler`
- [x] `git diff --check`

A full verbose package run was also attempted in this sandbox. It reached the pre-existing repository-path test `TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative` and then made no progress, so it was interrupted. All affected tests, the race run, package compilation, and vet pass.

## Compatibility

No API, output schema, ordering, or resource-filtering behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace resource counting across multiple resource sets.
  * Ensured resource totals are accumulated accurately for resident and per-namespace resources.

* **Tests**
  * Added coverage verifying that namespace counts remain accurate when combining multiple resource sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->