### PR TITLE
fix(results): preserve scan ID in posture reports

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -143,6 +143,15 @@ func TestActionPrintOmitsExceptionAuditWhenNil(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestActionPrintIncludesSessionIDAsReportGUID(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.SessionID = "scan-6f012842"
+
+	got := jsonPrinterOutput(t, session)
+
+	assert.Equal(t, "scan-6f012842", got["reportGUID"])
+}
+
 func jsonPrinterOutput(t *testing.T, session *cautils.OPASessionObj) map[string]any {
 	t.Helper()
 

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -61,6 +61,7 @@ type PostureReportWithSeverity struct {
 	ClusterCloudProvider string                            `json:"clusterCloudProvider"`
 	CustomerGUID         string                            `json:"customerGUID"`
 	ClusterName          string                            `json:"clusterName"`
+	ReportID             string                            `json:"reportGUID"`
 	SummaryDetails       SummaryDetailsWithSeverity        `json:"summaryDetails"`
 	Resources            []reporthandling.Resource         `json:"resources,omitempty"`
 	Attributes           []reportsummary.PostureAttributes `json:"attributes"`
@@ -188,6 +189,7 @@ func ConvertToPostureReportWithSeverityLabelsAndCoverage(report *reporthandlingv
 		ClusterCloudProvider: report.ClusterCloudProvider,
 		CustomerGUID:         report.CustomerGUID,
 		ClusterName:          report.ClusterName,
+		ReportID:             report.ReportID,
 		SummaryDetails: SummaryDetailsWithSeverity{
 			Controls:                  enrichedControls,
 			Status:                    report.SummaryDetails.Status,
@@ -265,6 +267,9 @@ func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureRepor
 	if data.Report.ClusterName == "" {
 		data.Report.ClusterName = cautils.AdoptClusterName(scanContextName(data))
 	}
+	if data.Report.ReportID == "" {
+		data.Report.ReportID = data.SessionID
+	}
 	report := reporthandlingv2.PostureReport{
 		SummaryDetails:       data.Report.SummaryDetails,
 		Metadata:             *data.Metadata,
@@ -273,6 +278,7 @@ func FinalizeResults(data *cautils.OPASessionObj) *reporthandlingv2.PostureRepor
 		Attributes:           data.Report.Attributes,
 		ClusterName:          data.Report.ClusterName,
 		CustomerGUID:         data.Report.CustomerGUID,
+		ReportID:             data.Report.ReportID,
 		ClusterCloudProvider: data.Report.ClusterCloudProvider,
 	}
 

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -1095,6 +1095,32 @@ func TestFinalizeResults_PreservesExistingGenerationTime(t *testing.T) {
 	assert.Equal(t, preset, session.Report.ReportGenerationTime)
 }
 
+func TestFinalizeResults_SetsReportIDFromSession(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.SessionID = "scan-6f012842"
+	require.Empty(t, session.Report.ReportID,
+		"precondition: the report has not been assigned an ID")
+
+	report := FinalizeResults(session)
+
+	require.NotNil(t, report)
+	assert.Equal(t, "scan-6f012842", report.ReportID)
+	assert.Equal(t, "scan-6f012842", session.Report.ReportID,
+		"FinalizeResults must write the ID back so every downstream consumer observes the same identity")
+}
+
+func TestFinalizeResults_PreservesExistingReportID(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.SessionID = "scan-new"
+	session.Report.ReportID = "report-preset"
+
+	report := FinalizeResults(session)
+
+	require.NotNil(t, report)
+	assert.Equal(t, "report-preset", report.ReportID)
+	assert.Equal(t, "report-preset", session.Report.ReportID)
+}
+
 // TestFinalizeResults_SetsClusterNameWhenEmpty is the regression test for
 // kubescape/kubescape#2856: JSON reports always had an empty clusterName
 // because nothing on the scan path ever assigned OPASessionObj.Report.ClusterName,


### PR DESCRIPTION
Fixes #3238

## Summary

Preserve the scan identifier as `reportGUID` across finalized and rendered posture reports.

- initialize an empty `OPASessionObj.Report.ReportID` from `OPASessionObj.SessionID`;
- copy `ReportID` into the finalized `reporthandlingv2.PostureReport`;
- carry `ReportID` through `PostureReportWithSeverity`, used by the JSON/YAML printers;
- preserve any report ID already supplied by the caller.

## Why

Every posture scan already gets an ID: `ScanInfo.Init` generates `ScanInfo.ScanID`, and `NewOPASessionObj` copies it into `SessionID`. `FinalizeResults` previously constructed a new report without that field. The v2 JSON/YAML output DTO independently omitted the field as well.

As a result, `GetResults` returned an empty `ReportID`, `ToJson` emitted an empty `reportGUID`, and CLI JSON/YAML omitted `reportGUID` entirely. Cloud submission was inconsistent because its reporter explicitly populated the field.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| empty session report ID | finalized `ReportID` is empty | finalized `ReportID == SessionID` |
| caller-provided report ID | dropped from finalized report | preserved unchanged |
| v2 JSON output | no `reportGUID` member | `reportGUID` contains the scan ID |

The fallback is conditional, so the existing RBAC path's independently generated report ID is not overwritten.

## Tests

Added:

- `TestFinalizeResults_SetsReportIDFromSession`
- `TestFinalizeResults_PreservesExistingReportID`
- `TestActionPrintIncludesSessionIDAsReportGUID`

The regression tests were checked against the previous implementation: finalization returned an empty ID, a preset report ID was omitted from the returned report, and the actual JSON printer output had no `reportGUID` key.

Validation on `master` base `8d468e32b6483506df988534783f205dfd997104`:

```bash
go test ./core/pkg/resultshandling/... -count=1

go test -race \
  ./core/pkg/resultshandling/printer/v2 \
  ./core/pkg/resultshandling \
  -run '^(TestFinalizeResults_(SetsReportIDFromSession|PreservesExistingReportID)|TestActionPrintIncludesSessionIDAsReportGUID|TestResultsHandler)' \
  -count=1

go test ./core/cautils ./core/core \
  -run '^(TestNewOPASessionObj|Test.*Report.*|TestFinalize.*)$' \
  -count=1

go vet ./core/pkg/resultshandling/printer/v2 ./core/pkg/resultshandling
git diff --check
```

All commands pass.

## Compatibility and scope

- No ID-generation behavior or public Go signature changes.
- The JSON/YAML change is additive and restores an existing canonical `PostureReport` field.
- Existing non-empty report IDs are preserved.
- Cloud submission behavior is unchanged.
- This change provides correlation only; it does not implement report signing, attestation, integrity verification, or provenance.

## Related work

- [#2931](https://github.com/kubescape/kubescape/pull/2931) fixes the synchronous HTTP envelope's ID; this fixes the ID inside the posture report artifact.
- [#2992](https://github.com/kubescape/kubescape/issues/2992) concerns cryptographic attestation and is orthogonal.
- [#2862](https://github.com/kubescape/kubescape/pull/2862) preserves the programmatic JSON shape but receives an empty ID from finalization; this supplies the value and fixes the CLI DTO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include a `reportGUID` identifier.
  * Existing report identifiers are preserved.
  * Reports without an identifier automatically use the session ID.

* **Bug Fixes**
  * Improved consistency of report identifiers in generated JSON output.

* **Tests**
  * Added coverage for identifier assignment, preservation, and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->