### PR TITLE
fix(core): report cached exceptions as degraded

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -199,7 +199,7 @@ func downloadConfigInputs(ctx context.Context, downloadInfo *metav1.DownloadInfo
 
 func downloadExceptions(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]string, error) {
 	tenant := tenantConfigFunc(ctx, downloadInfo.AccountID, downloadInfo.AccessKey, "", "", kubernetesAPIFunc())
-	exceptionsGetter, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
+	exceptionsGetter, _, err := exceptionsGetterFunc(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -430,8 +430,8 @@ func withConfigInputsGetter(t *testing.T, g getter.IControlsInputsGetter, err er
 func withExceptionsGetter(t *testing.T, g getter.IExceptionsGetter, err error) {
 	t.Helper()
 	orig := exceptionsGetterFunc
-	exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, error) {
-		return g, err
+	exceptionsGetterFunc = func(context.Context, string, string, *getter.DownloadReleasedPolicy, bool) (getter.IExceptionsGetter, bool, error) {
+		return g, false, err
 	}
 	t.Cleanup(func() { exceptionsGetterFunc = orig })
 }

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -53,19 +53,27 @@ func getExceptionsK8sClient(ctx context.Context) client.Client {
 	return k8sClient
 }
 
-func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IExceptionsGetter, error) {
+type releasedExceptionsGetter interface {
+	getter.IExceptionsGetter
+	SetRegoObjectsWithFallback() (bool, error)
+}
+
+// getExceptionsGetter returns the selected getter and whether an online
+// GitHub source degraded to the bundled cache. Explicit local/air-gapped
+// sources are intentional selections and therefore do not count as fallback.
+func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IExceptionsGetter, bool, error) {
 	var primary getter.IExceptionsGetter
 
 	if useExceptions != "" {
 		// load exceptions from file
 		primary = getter.NewLoadPolicy([]string{useExceptions})
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
 	}
 	if airGapped {
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
@@ -74,24 +82,31 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIAdapter()
 		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
+		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
 	}
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
-	if fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback(); err != nil {
+	return getReleasedExceptionsGetter(ctx, downloadReleasedPolicy)
+}
+
+// getReleasedExceptionsGetter reports whether the GitHub release could not be
+// fetched and the bundled local cache is being used instead. The caller must
+// preserve that signal because cached exceptions can change scan findings.
+func getReleasedExceptionsGetter(ctx context.Context, downloadReleasedPolicy releasedExceptionsGetter) (getter.IExceptionsGetter, bool, error) {
+	var primary getter.IExceptionsGetter = downloadReleasedPolicy
+	fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback()
+	if err != nil {
 		// pinned version: hard error, do not silently serve cached exceptions
-		return nil, err
-	} else if fallback { // if failed to pull exceptions, fallback to cache
+		return nil, false, err
+	}
+	if fallback { // if failed to pull exceptions, fallback to cache
 		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading exceptions from cache")
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
-		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
 	}
-	primary = downloadReleasedPolicy
 	k8sClient := getExceptionsK8sClient(ctx)
-	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), nil
+	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), fallback, nil
 
 }
 

--- a/core/core/initutils_test.go
+++ b/core/core/initutils_test.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -135,11 +137,59 @@ func TestGetExceptionsGetter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy, false)
+			got, _, err := getExceptionsGetter(tt.args.ctx, tt.args.useExceptions, tt.args.accountID, tt.args.downloadReleasedPolicy, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, reflect.TypeOf(got).String())
 		})
 	}
+}
+
+type releasedExceptionsGetterStub struct {
+	fallback bool
+	err      error
+}
+
+func (s *releasedExceptionsGetterStub) SetRegoObjectsWithFallback() (bool, error) {
+	return s.fallback, s.err
+}
+
+func (s *releasedExceptionsGetterStub) GetExceptions(context.Context, string) ([]armotypes.PostureExceptionPolicy, error) {
+	return nil, nil
+}
+
+func TestGetReleasedExceptionsGetterReportsCacheFallback(t *testing.T) {
+	t.Run("fresh release", func(t *testing.T) {
+		got, fromCache, err := getReleasedExceptionsGetter(context.Background(), &releasedExceptionsGetterStub{})
+		require.NoError(t, err)
+		assert.False(t, fromCache)
+		assert.Equal(t, "*getter.MergedExceptionsGetter", reflect.TypeOf(got).String())
+	})
+
+	t.Run("local cache fallback", func(t *testing.T) {
+		originalStore := getter.DefaultLocalStore
+		getter.DefaultLocalStore = t.TempDir()
+		t.Cleanup(func() { getter.DefaultLocalStore = originalStore })
+
+		want := []armotypes.PostureExceptionPolicy{{PortalBase: armotypes.PortalBase{Name: "cached-exception"}}}
+		require.NoError(t, getter.SaveInFile(want, getter.GetDefaultPath(cautils.LocalExceptionsFilename)))
+
+		got, fromCache, err := getReleasedExceptionsGetter(context.Background(), &releasedExceptionsGetterStub{fallback: true})
+		require.NoError(t, err)
+		assert.True(t, fromCache)
+		assert.Equal(t, "*getter.MergedExceptionsGetter", reflect.TypeOf(got).String())
+
+		loaded, err := got.GetExceptions(context.Background(), "cluster")
+		require.NoError(t, err)
+		assert.Equal(t, want, loaded)
+	})
+
+	t.Run("hard error", func(t *testing.T) {
+		wantErr := errors.New("release unavailable")
+		got, fromCache, err := getReleasedExceptionsGetter(context.Background(), &releasedExceptionsGetterStub{err: wantErr})
+		require.ErrorIs(t, err, wantErr)
+		assert.False(t, fromCache)
+		assert.Nil(t, got)
+	})
 }
 
 func TestGettersAirGappedUseCache(t *testing.T) {
@@ -155,8 +205,9 @@ func TestGettersAirGappedUseCache(t *testing.T) {
 			attackTracksGetter, err := getAttackTracksGetter(ctx, "", accountID, nil, true)
 			assert.NoError(t, err)
 			assert.Equal(t, "*getter.LoadPolicy", reflect.TypeOf(attackTracksGetter).String())
-			exceptionsGetter, err := getExceptionsGetter(ctx, "", accountID, nil, true)
+			exceptionsGetter, fromCache, err := getExceptionsGetter(ctx, "", accountID, nil, true)
 			assert.NoError(t, err)
+			assert.False(t, fromCache)
 			assert.Equal(t, "*getter.MergedExceptionsGetter", reflect.TypeOf(exceptionsGetter).String())
 		})
 	}
@@ -778,8 +829,9 @@ func TestPinnedVersionGettersReturnHardError(t *testing.T) {
 	})
 
 	t.Run("getExceptionsGetter", func(t *testing.T) {
-		g, err := getExceptionsGetter(ctx, "", "", newPinned(), false)
+		g, fromCache, err := getExceptionsGetter(ctx, "", "", newPinned(), false)
 		require.Error(t, err)
+		require.False(t, fromCache)
 		require.Nil(t, g)
 	})
 

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -176,7 +176,7 @@ func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]s
 	tenant := cautils.GetTenantConfig(ctx, listPolicies.AccountID, listPolicies.AccessKey, "", "", getKubernetesApi())
 
 	var exceptionsNames []string
-	ksCloudAPI, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
+	ksCloudAPI, _, err := getExceptionsGetter(ctx, "", tenant.GetAccountID(), nil, false)
 	if err != nil {
 		return exceptionsNames, err
 	}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -254,7 +254,8 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 		spanInit.End()
 		return nil, err
 	}
-	getters.ExceptionsGetter, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	var exceptionsFromCache bool
+	getters.ExceptionsGetter, exceptionsFromCache, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
 	if err != nil {
 		spanInit.End()
 		return nil, err
@@ -284,6 +285,9 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 	if controlInputsFromCache {
 		scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: "failed to fetch from GitHub, loaded from local cache"})
+	}
+	if exceptionsFromCache {
+		scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "exceptions", Reason: "failed to fetch from GitHub, loaded from local cache"})
 	}
 	spanPolicies.End()
 


### PR DESCRIPTION
Fixes #3240.

## Overview

When the regolibrary GitHub release cannot be fetched, Kubescape can continue by loading `exceptions.json` from its local artifact store. That fallback previously discarded the `fallback=true` signal returned by `SetRegoObjectsWithFallback`.

Because the local file can load successfully, `PolicyHandler` sees no error and records no `PolicyDegradation`. The loaded exceptions are nevertheless applied and may suppress findings. An otherwise complete scan could therefore report `coverageScore: 100`, `degraded: false`, and pass degradation/coverage gates.

This change preserves the fallback signal and records it through the existing scan-coverage contract.

## Changes

- Extend the internal `getExceptionsGetter` result with a `fromCache` boolean.
- Add a small `releasedExceptionsGetter` interface so success, fallback, and hard-error behavior are tested without network access.
- Preserve `fallback=true` only for an automatic GitHub-release-to-local-cache transition.
- Return `fromCache=false` for explicit local, intentional air-gapped, account-backed, and successfully loaded GitHub sources.
- Append an `exceptions` `PolicyDegradation` after policy collection.
- Keep pinned-version failures as hard errors.
- Adapt list/download callers, which do not construct scan coverage.

The existing OPA/result paths carry the degradation into `ScanCoverage`, apply the existing policy-input penalty, and expose it to degradation and coverage gates.

## Regression coverage

The deterministic tests cover:

- fresh release: `fromCache=false`;
- fallback: `fromCache=true`;
- the fallback actually reading a sentinel exception from an isolated `exceptions.json`;
- hard errors returning no getter and `fromCache=false`;
- intentional air-gapped input returning `fromCache=false`;
- pinned-version failures remaining hard errors.

## How to test

```text
go test ./core/core -count=1
go test ./cmd/scan -count=1
go test -race ./core/core -run '^TestGetReleasedExceptionsGetterReportsCacheFallback$' -count=1
git diff --check
```

All commands pass locally.

## Scope and compatibility

No exported API changes. Existing fallback and exception-matching behavior remain intact; the change makes the automatic fallback visible in scan metadata.

`POLICIES_CACHE_TTL` defaults to `0`. Source provenance across an explicitly enabled cross-request cache is a separate cache-isolation concern and is intentionally not claimed here.

## Related work

- #2384 and #2395 cover exception getter errors rather than a successful local-cache fallback.
- #2513 covers the analogous control-input fallback.
- #2458 defines intentional air-gapped source selection.

## Checklist

- [x] Bounded internal change; no exported API change
- [x] Deterministic, network-independent regression coverage
- [x] Full core and command tests pass
- [x] Targeted race test passes
- [x] DCO sign-off included