### PR TITLE
fix(core): return finalized data with OPA errors

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -347,6 +347,9 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 		reportResults.ControlTimeout = scanInfo.ControlTimeout
 		if err = reportResults.ProcessRulesListener(ctxOpa, cautils.NewProgressHandler("")); err != nil {
 			logger.L().Ctx(ctxOpa).Error("failed to process rules", helpers.Error(err))
+			// The eager listener finalizes its accumulated results before returning
+			// an error. Streaming errors can return before that invariant holds.
+			resultsHandling.SetData(scanData)
 			return resultsHandling, fmt.Errorf("%w", err)
 		}
 	}

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -15,12 +16,75 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v3/pkg/imagescan"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/version"
 )
+
+func TestScan_ReturnsFinalizedPartialDataOnOPAError(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "pod.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: partial-result-probe
+  namespace: default
+`), 0o600))
+
+	rule := reporthandling.PolicyRule{
+		Rule:         "package armo_builtins\nthis is not valid rego at all {{{",
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"Pod"},
+		}},
+	}
+	rule.Name = "broken-rule"
+	control := reporthandling.Control{ControlID: "C-BROKEN", BaseScore: 5, Rules: []reporthandling.PolicyRule{rule}}
+	control.Name = "broken-control"
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{control}}
+	framework.Name = "broken-framework"
+	frameworkBytes, err := json.Marshal(framework)
+	require.NoError(t, err)
+	frameworkPath := filepath.Join(dir, "framework.json")
+	require.NoError(t, os.WriteFile(frameworkPath, frameworkBytes, 0o600))
+	controlsInputsPath := filepath.Join(dir, "controls-inputs.json")
+	require.NoError(t, os.WriteFile(controlsInputsPath, []byte(`{"probe":["value"]}`), 0o600))
+	exceptionsPath := filepath.Join(dir, "exceptions.json")
+	require.NoError(t, os.WriteFile(exceptionsPath, []byte(`[]`), 0o600))
+	attackTracksPath := filepath.Join(dir, "attack-tracks.json")
+	require.NoError(t, os.WriteFile(attackTracksPath, []byte(`[]`), 0o600))
+
+	scanInfo := &cautils.ScanInfo{
+		UseFrom:          []string{frameworkPath},
+		ControlsInputs:   controlsInputsPath,
+		UseExceptions:    exceptionsPath,
+		AttackTracks:     attackTracksPath,
+		InputPatterns:    []string{manifestPath},
+		Local:            true,
+		FrameworkScan:    true,
+		ScanType:         cautils.ScanTypeFramework,
+		OmitRawResources: true,
+	}
+	scanInfo.Submit.SetBool(false)
+
+	results, err := NewKubescape(context.Background()).Scan(scanInfo, []cautils.PolicyIdentifier{{
+		Identifier: framework.Name,
+		Kind:       apisv1.KindFramework,
+	}})
+
+	require.ErrorContains(t, err, "broken-rule")
+	require.NotNil(t, results)
+	require.NotNil(t, results.GetData(), "the finalized partial session must remain available alongside the scan error")
+	require.Len(t, results.GetData().ResourcesResult, 1)
+	controlSummary := results.GetData().Report.SummaryDetails.Controls[control.ControlID]
+	assert.Equal(t, apis.StatusSkipped, controlSummary.GetStatus().Status())
+}
 
 type recordingImageScanService struct {
 	image              string

--- a/core/pkg/opaprocessor/processorhandler_partial_results_test.go
+++ b/core/pkg/opaprocessor/processorhandler_partial_results_test.go
@@ -1,0 +1,57 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ProcessRulesListener deliberately finalizes the eager session even when a
+// rule fails. Kubescape.Scan relies on this invariant before exposing the
+// session alongside the processing error.
+func TestProcessRulesListener_FinalizesPartialResultsBeforeReturningError(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "pod",
+			"namespace": "default",
+		},
+	})
+	rule := reporthandling.PolicyRule{
+		Rule:         "package armo_builtins\nthis is not valid rego at all {{{",
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"Pod"},
+		}},
+	}
+	rule.Name = "broken-rule"
+	control := reporthandling.Control{ControlID: "C-BROKEN", BaseScore: 5, Rules: []reporthandling.PolicyRule{rule}}
+	control.Name = "broken-control"
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{control}}
+	framework.Name = "broken-framework"
+
+	session := cautils.NewOPASessionObjMock()
+	session.Policies = []reporthandling.Framework{framework}
+	session.K8SResources = cautils.K8SResources{"/v1/pods": {pod.GetID()}}
+	session.AllResources[pod.GetID()] = pod
+	processor := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+
+	err := processor.ProcessRulesListener(context.Background(), nil)
+
+	require.ErrorContains(t, err, "broken-rule")
+	require.Len(t, session.ResourcesResult, 1)
+	controlSummary := session.Report.SummaryDetails.Controls[control.ControlID]
+	assert.Equal(t, apis.StatusSkipped, controlSummary.GetStatus().Status())
+	assert.Equal(t, 1, session.Report.SummaryDetails.NumberOfResources().Skipped())
+	assert.Equal(t, 1, session.ScanCoverage.TotalControls)
+}


### PR DESCRIPTION
## Brief

Preserve the finalized eager posture session when OPA rule processing returns an error.

`ProcessRulesListener` already aggregates successful and skipped resource results, rebuilds the summary, and calculates the available scores before returning its processing error. `Kubescape.Scan` returned before attaching that session to the non-nil `ResultsHandler`, so library callers received the error but `results.GetData()` was nil.

## Change

- Attach `scanData` to the result handler only in the eager `ProcessRulesListener` error branch.
- Keep returning the original error.
- Add an end-to-end offline file-scan regression with a real local framework, local manifest, and syntactically invalid Rego rule.
- Add a direct processor test that fixes the eager listener's error-finalization invariant.

The tests verify that the caller receives both the error and a finalized session containing one skipped resource result and a skipped control summary.

## Scope and compatibility

- No success-path behavior changes.
- No command exit-code changes.
- No automatic printing, persistence, or submission of partial results.
- No change to streaming errors. `ProcessWithStreaming` can return before finalization, so exposing those sessions requires a separate design.
- The `Scan` signature and error wrapping remain unchanged.

Fixes #3242.

## Validation

```bash
go test ./core/core \
  -run '^TestScan_ReturnsFinalizedPartialDataOnOPAError$' \
  -count=3

go test ./core/pkg/opaprocessor \
  -run '^TestProcessRulesListener_FinalizesPartialResultsBeforeReturningError$' \
  -count=3

go test -race ./core/core ./core/pkg/opaprocessor \
  -run '^(TestScan_ReturnsFinalizedPartialDataOnOPAError|TestProcessRulesListener_FinalizesPartialResultsBeforeReturningError)$' \
  -count=1

go test ./core/core -count=1
go test ./core/pkg/opaprocessor -count=1
git diff --check
```

All commands pass.

The end-to-end regression was also run against the previous implementation and failed because `results.GetData()` was nil.

## Related work

- #1987 and #1992 established fail-closed OPA evaluation and skipped-result preservation.
- The #1992 review identified this still-fatal caller boundary as a remaining loss point.
- #2813/#2814 cover streaming cancellation and are intentionally outside this patch.
- #2960/#2965 cover partial image-scan output, not posture/OPA results.

## Checklist

- [x] Original processing error is preserved
- [x] Only an already-finalized eager session is exposed
- [x] Streaming behavior is unchanged
- [x] End-to-end and invariant regression tests added
- [x] Package and race suites pass
- [x] DCO sign-off included