### PR TITLE
fix(metrics): report latest resource counts

### DIFF
--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -22,38 +22,59 @@ var initOnce sync.Once
 var (
 	kubernetesResourcesCount metric.Int64UpDownCounter
 	workerNodesCount         metric.Int64UpDownCounter
+
+	// Resource collection reports absolute snapshots, while UpDownCounter.Add
+	// records changes. Retain the previous snapshots so repeated updates export
+	// the latest values without changing the existing instrument contract.
+	lastValueMu                  sync.Mutex
+	lastKubernetesResourcesCount int64
+	lastWorkerNodesCount         int64
 )
 
 // Init initializes the metrics
 func Init() {
 	initOnce.Do(func() {
-		var err error
 		meterProvider := otel.GetMeterProvider()
 		meter := meterProvider.Meter(METER_NAME)
 		metricName := func(name string) string {
 			return strings.Join([]string{METRIC_NAME_PREFIX, name}, "_")
 		}
 
-		if kubernetesResourcesCount, err = meter.Int64UpDownCounter(metricName("kubernetes_resources_count")); err != nil {
+		resourcesCounter, err := meter.Int64UpDownCounter(metricName("kubernetes_resources_count"))
+		if err != nil {
 			logger.L().Error("failed to register instrument", helpers.Error(err))
 		}
 
-		if workerNodesCount, err = meter.Int64UpDownCounter(metricName("worker_nodes_count")); err != nil {
+		workersCounter, err := meter.Int64UpDownCounter(metricName("worker_nodes_count"))
+		if err != nil {
 			logger.L().Error("failed to register instrument", helpers.Error(err))
 		}
+
+		lastValueMu.Lock()
+		kubernetesResourcesCount = resourcesCounter
+		workerNodesCount = workersCounter
+		lastValueMu.Unlock()
 	})
 }
 
 // UpdateKubernetesResourcesCount updates the kubernetes resources count metric
 func UpdateKubernetesResourcesCount(ctx context.Context, value int64) {
-	if kubernetesResourcesCount != nil {
-		kubernetesResourcesCount.Add(ctx, value)
-	}
+	updateCounter(ctx, &kubernetesResourcesCount, &lastKubernetesResourcesCount, value)
 }
 
 // UpdateWorkerNodesCount updates the worker nodes count metric
 func UpdateWorkerNodesCount(ctx context.Context, value int64) {
-	if workerNodesCount != nil {
-		workerNodesCount.Add(ctx, value)
+	updateCounter(ctx, &workerNodesCount, &lastWorkerNodesCount, value)
+}
+
+func updateCounter(ctx context.Context, counter *metric.Int64UpDownCounter, previous *int64, value int64) {
+	lastValueMu.Lock()
+	defer lastValueMu.Unlock()
+
+	if *counter == nil {
+		return
 	}
+
+	(*counter).Add(ctx, value-*previous)
+	*previous = value
 }

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -15,17 +15,27 @@ import (
 func resetMetricsForTest(t *testing.T) {
 	t.Helper()
 
+	lastValueMu.Lock()
 	savedKubernetesResourcesCount := kubernetesResourcesCount
 	savedWorkerNodesCount := workerNodesCount
-
-	initOnce = sync.Once{}
+	savedLastKubernetesResourcesCount := lastKubernetesResourcesCount
+	savedLastWorkerNodesCount := lastWorkerNodesCount
 	kubernetesResourcesCount = nil
 	workerNodesCount = nil
+	lastKubernetesResourcesCount = 0
+	lastWorkerNodesCount = 0
+	lastValueMu.Unlock()
+
+	initOnce = sync.Once{}
 
 	t.Cleanup(func() {
 		initOnce = sync.Once{}
+		lastValueMu.Lock()
 		kubernetesResourcesCount = savedKubernetesResourcesCount
 		workerNodesCount = savedWorkerNodesCount
+		lastKubernetesResourcesCount = savedLastKubernetesResourcesCount
+		lastWorkerNodesCount = savedLastWorkerNodesCount
+		lastValueMu.Unlock()
 	})
 }
 
@@ -54,7 +64,7 @@ func TestInit(t *testing.T) {
 	require.NotNil(t, workerNodesCount)
 }
 
-func TestInitRegistersCountersAndUpdatesValues(t *testing.T) {
+func TestUpdatesReportLatestValues(t *testing.T) {
 	resetMetricsForTest(t)
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
@@ -62,12 +72,76 @@ func TestInitRegistersCountersAndUpdatesValues(t *testing.T) {
 
 	Init()
 	UpdateKubernetesResourcesCount(context.Background(), 3)
-	UpdateKubernetesResourcesCount(context.Background(), 4)
 	UpdateWorkerNodesCount(context.Background(), 2)
 
 	got := collectMetricSums(t, reader)
+	assert.Equal(t, int64(3), got["kubescape_kubernetes_resources_count"])
+	assert.Equal(t, int64(2), got["kubescape_worker_nodes_count"])
 
-	assert.Equal(t, int64(7), got["kubescape_kubernetes_resources_count"])
+	UpdateKubernetesResourcesCount(context.Background(), 4)
+	UpdateWorkerNodesCount(context.Background(), 1)
+
+	got = collectMetricSums(t, reader)
+
+	assert.Equal(t, int64(4), got["kubescape_kubernetes_resources_count"])
+	assert.Equal(t, int64(1), got["kubescape_worker_nodes_count"])
+}
+
+func TestUpdatesRemainConsistentConcurrently(t *testing.T) {
+	resetMetricsForTest(t)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	setMeterProviderForTest(t, provider)
+	Init()
+
+	var wg sync.WaitGroup
+	for value := int64(1); value <= 32; value++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			UpdateKubernetesResourcesCount(context.Background(), value)
+			UpdateWorkerNodesCount(context.Background(), value)
+		}()
+	}
+	wg.Wait()
+
+	// Make the final observations deterministic after the concurrent updates.
+	UpdateKubernetesResourcesCount(context.Background(), 5)
+	UpdateWorkerNodesCount(context.Background(), 2)
+
+	got := collectMetricSums(t, reader)
+	assert.Equal(t, int64(5), got["kubescape_kubernetes_resources_count"])
+	assert.Equal(t, int64(2), got["kubescape_worker_nodes_count"])
+}
+
+func TestInitAndUpdatesRemainConsistentConcurrently(t *testing.T) {
+	resetMetricsForTest(t)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	setMeterProviderForTest(t, provider)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		for value := int64(1); value <= 256; value++ {
+			UpdateKubernetesResourcesCount(context.Background(), value)
+			UpdateWorkerNodesCount(context.Background(), value)
+		}
+		close(done)
+	}()
+
+	<-started
+	Init()
+	<-done
+
+	// Updates racing with initialization may be no-ops. A final observation
+	// after Init must still establish the exact exported values.
+	UpdateKubernetesResourcesCount(context.Background(), 5)
+	UpdateWorkerNodesCount(context.Background(), 2)
+
+	got := collectMetricSums(t, reader)
+	assert.Equal(t, int64(5), got["kubescape_kubernetes_resources_count"])
 	assert.Equal(t, int64(2), got["kubescape_worker_nodes_count"])
 }
 
@@ -90,13 +164,24 @@ func TestInitOnlyRegistersOnce(t *testing.T) {
 	assert.Empty(t, collectMetricSums(t, secondReader))
 }
 
-func TestUpdateBeforeInitDoesNotPanic(t *testing.T) {
+func TestUpdatesBeforeInitAreNoOps(t *testing.T) {
 	resetMetricsForTest(t)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	setMeterProviderForTest(t, provider)
 
 	assert.NotPanics(t, func() {
-		UpdateKubernetesResourcesCount(context.Background(), 1)
-		UpdateWorkerNodesCount(context.Background(), 1)
+		UpdateKubernetesResourcesCount(context.Background(), 100)
+		UpdateWorkerNodesCount(context.Background(), 100)
 	})
+
+	Init()
+	UpdateKubernetesResourcesCount(context.Background(), 3)
+	UpdateWorkerNodesCount(context.Background(), 2)
+
+	got := collectMetricSums(t, reader)
+	assert.Equal(t, int64(3), got["kubescape_kubernetes_resources_count"])
+	assert.Equal(t, int64(2), got["kubescape_worker_nodes_count"])
 }
 
 func TestUpdateKubernetesResourcesCount_NilCounter(t *testing.T) {


### PR DESCRIPTION
Fixes #3247.

## Overview

Kubescape's resource collectors pass absolute resource and worker-node counts to `core/metrics`, but the metrics package forwarded each value directly to `Int64UpDownCounter.Add`.

Because `Add` records a change, repeated scans accumulated every absolute snapshot. Observations of 3 followed by 4 were exported as 7, while worker-node observations of 2 followed by 1 were exported as 3.

This change retains the previous absolute observation for each instrument and records only the delta. A mutex makes the previous-value transition and synchronous metric update one ordered operation.

## Compatibility

The existing telemetry contract is preserved:

- metric names and meter scope are unchanged;
- instruments remain `Int64UpDownCounter`;
- exported aggregation remains a non-monotonic Sum;
- no attributes or additional time series are introduced.

An `ObservableGauge` would model an instantaneous value directly, but would change the exported data type. The delta approach fixes the values without requiring downstream consumers to migrate metric-type assumptions.

Updates before `Init` retain their no-op behavior. If no new observation is collected, the last successful value remains available.

## Tests

The OpenTelemetry `ManualReader` regression verifies:

- first observations are exported unchanged;
- a later increase replaces rather than accumulates the resource count;
- a later decrease lowers the worker-node count;
- concurrent updates are race-free and converge after a deterministic final observation;
- the existing Sum contract remains intact.

Commands run:

```bash
go test ./core/metrics -count=20
go test -race ./core/metrics -count=5
go vet ./core/metrics
go test ./core/pkg/resourcehandler -run '^$' -count=1
go test ./core/pkg/resourcehandler -run 'Test(GetResources_(SurfacesMissingGVRFailuresInInfoMap|FailsWhenAllQueriesFail|HostSensorInfoMapMerged)|CollectAndStreamBatches_(CleanSuccessHasNoFailureMetadata|CountsNamespacedResourcesAcrossBatches))$' -count=1
```

All commands pass.

The complete resourcehandler suite was attempted but stopped at the pre-existing repository-path test that hangs in this environment; the changed package, race suite, call-site compilation, and affected collector tests pass.

## Related work

- #1269 introduced these instruments.
- #2252 added initialization and accumulation tests but did not cover the absolute-snapshot call-site semantics.

## Checklist

- [x] External metric contract preserved
- [x] Increase/decrease regression covered
- [x] Concurrent updates covered under race detector
- [x] Changed package tests repeated
- [x] Call sites compile and targeted tests pass
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected resource and worker-node metrics so repeated updates no longer cause cumulative overcounting.
  - Metrics now accurately reflect changes from previously reported values.
  - Improved consistency when metrics are updated concurrently, providing more reliable monitoring data.
  - Updates received before metric initialization are safely ignored, preventing inconsistent readings.
  - Improved metric initialization and update handling to ensure values remain stable during simultaneous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->