### PR TITLE
fix(core): pin policy handler during collection

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -199,6 +199,14 @@ func fileExtForFormat(format string) string {
 	return printer.PrettyOutputExt
 }
 
+// collectPolicies pins the shared handler for exactly as long as its caches are
+// in use, so an idle registry sweep cannot close them during collection.
+func collectPolicies(ctx context.Context, clusterName string, policyIdentifiers []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (*cautils.OPASessionObj, error) {
+	policyHandler, release := policyhandler.NewPolicyHandlerWithRelease(clusterName)
+	defer release()
+	return policyHandler.CollectPolicies(ctx, policyIdentifiers, scanInfo, getters)
+}
+
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
 	ctxInit, spanInit := otel.Tracer("").Start(ks.Context(), "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
@@ -276,8 +284,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 
 	// ===================== policies =====================
 	ctxPolicies, spanPolicies := otel.Tracer("").Start(ctxInit, "policies")
-	policyHandler := policyhandler.NewPolicyHandler(interfaces.tenantConfig.GetContextName())
-	scanData, err := policyHandler.CollectPolicies(ctxPolicies, policyIdentifiers, scanInfo, &getters)
+	scanData, err := collectPolicies(ctxPolicies, interfaces.tenantConfig.GetContextName(), policyIdentifiers, scanInfo, &getters)
 	if err != nil {
 		spanInit.End()
 		return resultsHandling, err

--- a/core/core/scan_policyhandler_lifecycle_test.go
+++ b/core/core/scan_policyhandler_lifecycle_test.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	"github.com/kubescape/kubescape/v3/core/mocks"
+	"github.com/kubescape/kubescape/v3/core/pkg/policyhandler"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingPolicyGetter struct {
+	started chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+var policyHandlerLifecycleTestID atomic.Uint64
+
+func (g *blockingPolicyGetter) GetFramework(string) (*reporthandling.Framework, error) {
+	if g.calls.Add(1) == 1 {
+		close(g.started)
+		<-g.release
+	}
+	return mocks.MockFramework_0006_0013(), nil
+}
+
+func (g *blockingPolicyGetter) GetFrameworks() ([]reporthandling.Framework, error) {
+	return nil, nil
+}
+
+func (g *blockingPolicyGetter) GetControl(string) (*reporthandling.Control, error) {
+	return nil, nil
+}
+
+func (g *blockingPolicyGetter) ListFrameworks() ([]string, error) { return nil, nil }
+
+func (g *blockingPolicyGetter) ListControls() ([]string, error) { return nil, nil }
+
+type emptyExceptionsGetter struct{}
+
+func (emptyExceptionsGetter) GetExceptions(context.Context, string) ([]armotypes.PostureExceptionPolicy, error) {
+	return nil, nil
+}
+
+type emptyControlInputsGetter struct{}
+
+func (emptyControlInputsGetter) GetControlsInputs(context.Context, string) (map[string][]string, error) {
+	return map[string][]string{"test-control": {"test-value"}}, nil
+}
+
+// TestCollectPoliciesKeepsSharedHandlerAliveUntilReturn reproduces the lifecycle
+// race from the production scan path. A policy download stays in flight past
+// the registry idle window while another access triggers a sweep. The
+// completed download must remain cached on the original handler.
+func TestCollectPoliciesKeepsSharedHandlerAliveUntilReturn(t *testing.T) {
+	t.Setenv(policyhandler.PoliciesCacheTtlEnvVar, "100ms")
+
+	oldStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	t.Cleanup(func() { getter.DefaultLocalStore = oldStore })
+
+	policyGetter := &blockingPolicyGetter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	getters := &cautils.Getters{
+		PolicyGetter:         policyGetter,
+		ExceptionsGetter:     emptyExceptionsGetter{},
+		ControlsInputsGetter: emptyControlInputsGetter{},
+	}
+	identifiers := []cautils.PolicyIdentifier{{Identifier: "framework-0006-0013", Kind: "Framework"}}
+	scanInfo := &cautils.ScanInfo{}
+	testID := policyHandlerLifecycleTestID.Add(1)
+	clusterName := fmt.Sprintf("%s-active-%d", t.Name(), testID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := collectPolicies(context.Background(), clusterName, identifiers, scanInfo, getters)
+		done <- err
+	}()
+
+	select {
+	case <-policyGetter.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("policy getter did not start")
+	}
+
+	// Make the registry entry old enough for the next access to sweep it while
+	// the policy getter is still in flight unless collection owns a reference.
+	time.Sleep(200 * time.Millisecond)
+	policyhandler.NewPolicyHandler(clusterName)
+	close(policyGetter.release)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("policy collection did not finish")
+	}
+
+	_, err := collectPolicies(context.Background(), clusterName, identifiers, scanInfo, getters)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), policyGetter.calls.Load(), "the completed download should remain cached on the same live handler")
+}


### PR DESCRIPTION
Fixes #3249.

## Problem

`Scan` used `NewPolicyHandler`, so the registry considered its entry unreferenced while `CollectPolicies` was still using the handler's caches. Once the effective idle window elapsed, another registry access could sweep the entry and call `Close()` during a slow policy download.

The caches remain panic-safe after `Close`, but they cannot serve values again. A download that finishes on the detached handler is therefore lost to the shared cache and the next scan repeats the remote work.

## Change

- Route the production policy-loading call through a small `collectPolicies` helper.
- Acquire the shared handler with `NewPolicyHandlerWithRelease` and defer release.
- Scope the reference to `CollectPolicies` only, rather than retaining it through resource collection and evaluation.
- Add a bounded regression that blocks a fake policy getter past the idle window, triggers a same-key sweep, and verifies the completed policy remains cached.

Before the fix, the regression fails with two getter calls. After the fix, the second collection hits the original live handler and the getter is called once.

No scan result, cache key, TTL, or public API semantics change.

## Verification

```text
go test ./core/core -run '^TestCollectPoliciesKeepsSharedHandlerAliveUntilReturn$' -count=10
go test -race ./core/core -run '^TestCollectPoliciesKeepsSharedHandlerAliveUntilReturn$' -count=3
go test ./core/core ./core/pkg/policyhandler
go vet ./core/core ./core/pkg/policyhandler
git diff --check
```

All commands pass. The full core package run completed in approximately 57 seconds.

## Scope

This patch fixes registry/cache lifecycle and duplicate policy I/O. It does not claim current result corruption or a panic. The reference is intentionally released immediately after policy collection so later scan phases do not block normal idle eviction.

## Related work

- #2909 introduced the registry and release-aware API.
- #2899 removed per-request mutable getter state.
- #2004 is the earlier singleton/isolation problem and is distinct.

The missing production acquisition was also noted in an unresolved review thread on merged #2909; this PR completes that follow-up.

## Checklist

- [x] Reference released on every return path
- [x] Pin scope limited to active cache use
- [x] Deterministic production-helper regression
- [x] Repeated and race suites pass
- [x] Full affected packages and vet pass
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy collection reliability during scans.
  * Prevented active policy downloads from being interrupted by registry cleanup.
  * Ensured subsequent policy collections can reuse completed downloads without unnecessary repetition.

* **Tests**
  * Added coverage for policy-handler lifecycle and caching behavior during in-progress downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->