### PR TITLE
fix(cel): honor matchConstraints rule scope when scoping offline VAP evaluation

### DIFF
--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -20,7 +20,7 @@ import (
 //
 // Matching covers everything on matchConstraints whose input the scanned
 // object itself carries: the resource rules (apiGroups/apiVersions/resources,
-// each rule's operations and resourceNames, honoring "*" and
+// each rule's operations, scope and resourceNames, honoring "*" and
 // excludeResourceRules) and the objectSelector, which matches the object's own
 // labels. The scan models every resource as a fresh CREATE (see stub.go), so a
 // rule that fires only on other operations does not match here either. The one
@@ -39,10 +39,11 @@ func (v *VAP) appliesTo(obj map[string]any) bool {
 		return true // kind undeterminable; let evaluation proceed (it will error and skip)
 	}
 	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+	target := scopedObject{gvr: gvr, name: name, namespaced: isNamespaced(obj)}
 
 	included := false
 	for i := range v.matchConstraints.ResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], gvr, name) {
+		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], target) {
 			included = true
 			break
 		}
@@ -51,7 +52,7 @@ func (v *VAP) appliesTo(obj map[string]any) bool {
 		return false
 	}
 	for i := range v.matchConstraints.ExcludeResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], gvr, name) {
+		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], target) {
 			return false
 		}
 	}
@@ -124,12 +125,39 @@ func annotatedPlural(obj map[string]any) (string, bool) {
 	return plural, plural != ""
 }
 
-func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, gvr schema.GroupVersionResource, name string) bool {
+// scopedObject is what appliesTo reads off the scanned object once and matches
+// every resource rule against, so adding a rule field to honor costs one field
+// here rather than another parameter on every call.
+type scopedObject struct {
+	gvr        schema.GroupVersionResource
+	name       string
+	namespaced bool
+}
+
+func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, target scopedObject) bool {
 	return matchesOperation(rule.Operations) &&
-		matchesValue(rule.APIGroups, gvr.Group) &&
-		matchesValue(rule.APIVersions, gvr.Version) &&
-		matchesResource(rule.Resources, gvr.Resource) &&
-		matchesName(rule.ResourceNames, name)
+		matchesScope(rule.Scope, target.namespaced) &&
+		matchesValue(rule.APIGroups, target.gvr.Group) &&
+		matchesValue(rule.APIVersions, target.gvr.Version) &&
+		matchesResource(rule.Resources, target.gvr.Resource) &&
+		matchesName(rule.ResourceNames, target.name)
+}
+
+// matchesScope reports whether the rule's scope admits the object. nil and "*"
+// are the API default and admit everything.
+//
+// Only a Cluster rule narrows anything offline: an object carrying a namespace
+// is proven namespaced, and admission would not hand it to that rule. The
+// reverse is not provable — the apiserver defaults metadata.namespace before
+// admission, so an absent one does not make the object cluster-scoped — which
+// is why a Namespaced rule matches regardless, the same widening appliesTo
+// applies to an undeterminable kind. Exclude rules get this symmetrically: a
+// Cluster-scoped exclusion does not exempt an object we know is namespaced.
+func matchesScope(scope *admissionregistrationv1.ScopeType, namespaced bool) bool {
+	if scope == nil || *scope != admissionregistrationv1.ClusterScope {
+		return true
+	}
+	return !namespaced
 }
 
 // matchesName reports whether the rule's resourceNames admit the object's

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -250,6 +250,76 @@ func TestVAPAppliesToOperations(t *testing.T) {
 	})
 }
 
+// withScope returns a copy of the rule constrained to the given scope.
+func withScope(r admissionregistrationv1.NamedRuleWithOperations, scope admissionregistrationv1.ScopeType) admissionregistrationv1.NamedRuleWithOperations {
+	r.Scope = &scope
+	return r
+}
+
+// inNamespace returns a copy of the object placed in a namespace, which is what
+// proves it namespaced offline.
+func inNamespace(o map[string]any, namespace string) map[string]any {
+	meta, _ := o["metadata"].(map[string]any)
+	placed := make(map[string]any, len(meta))
+	for k, v := range meta {
+		placed[k] = v
+	}
+	placed["namespace"] = namespace
+
+	out := make(map[string]any, len(o))
+	for k, v := range o {
+		out[k] = v
+	}
+	out["metadata"] = placed
+	return out
+}
+
+// TestVAPAppliesToScope pins the scope side of rule matching. A Cluster rule is
+// the only one that narrows offline: an object carrying a namespace is proven
+// namespaced, so admission would never hand it to that rule. An absent
+// namespace proves nothing (the apiserver defaults it before admission), so
+// every other combination stays matched.
+func TestVAPAppliesToScope(t *testing.T) {
+	pods := rule([]string{""}, []string{"v1"}, []string{"pods"})
+
+	cases := []struct {
+		name      string
+		scope     *admissionregistrationv1.ScopeType
+		namespace string
+		want      bool
+	}{
+		{"unset scope matches a namespaced object", nil, "prod", true},
+		{"unset scope matches an object with no namespace", nil, "", true},
+		{"wildcard scope matches a namespaced object", scopePtr(admissionregistrationv1.AllScopes), "prod", true},
+		{"Namespaced scope matches a namespaced object", scopePtr(admissionregistrationv1.NamespacedScope), "prod", true},
+		{"Namespaced scope still matches when the namespace is absent", scopePtr(admissionregistrationv1.NamespacedScope), "", true},
+		{"Cluster scope does not match a namespaced object", scopePtr(admissionregistrationv1.ClusterScope), "prod", false},
+		{"Cluster scope matches when the namespace is absent", scopePtr(admissionregistrationv1.ClusterScope), "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := pods
+			r.Scope = tc.scope
+			o := obj("v1", "Pod")
+			if tc.namespace != "" {
+				o = inNamespace(o, tc.namespace)
+			}
+			assert.Equal(t, tc.want, vapWithConstraints(r).appliesTo(o))
+		})
+	}
+
+	t.Run("a Cluster-scoped exclusion does not exempt a namespaced object", func(t *testing.T) {
+		v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{pods},
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{withScope(pods, admissionregistrationv1.ClusterScope)},
+		}}
+		assert.True(t, v.appliesTo(inNamespace(obj("v1", "Pod"), "prod")),
+			"the exclusion only covers cluster-scoped objects, so a namespaced one is still matched")
+	})
+}
+
+func scopePtr(s admissionregistrationv1.ScopeType) *admissionregistrationv1.ScopeType { return &s }
+
 // TestBundleControlRulesAllMatchModeledCreate is the safety case for honoring
 // operations, and it is the assertion the kind sweep cannot make: that sweep
 // skips subresources, which is exactly where the bundle's non-CREATE rules
@@ -295,6 +365,8 @@ func TestBundleUsesNoUnevaluatedScoping(t *testing.T) {
 		for _, rr := range rules {
 			assert.Emptyf(t, rr.ResourceNames,
 				"policy %q now uses resourceNames: appliesTo matches it against metadata.name, so confirm the scanned manifests carry the names it expects", name)
+			assert.Truef(t, rr.Scope == nil || *rr.Scope == admissionregistrationv1.AllScopes,
+				"policy %q now scopes a rule to %v: appliesTo narrows a Cluster rule by the object's namespace, so confirm that matches the policy's intent", name, rr.Scope)
 		}
 	}
 }


### PR DESCRIPTION
## Overview

The offline VAP scope matcher honors every field of a `matchConstraints` resource rule except `scope`. `resourceRuleMatches` checks `apiGroups`, `apiVersions`, `resources`, `operations` and `resourceNames`, but `rule.Scope` is never read, so a rule scoped to `Cluster` matches namespaced objects offline that live admission would never hand it.

That is a silent scan/admission parity break, which is the exact thing `appliesTo` exists to prevent. The object is evaluated, its validations self guard by kind and pass, and the scan records a pass the cluster never made. An out of scope resource is only Debug logged, so there is no signal in the output either way.

This PR evaluates the scope instead of ignoring it. `matchesScope` narrows only where the manifest actually proves something. An object carrying a namespace is provably namespaced, so a `Cluster` rule does not match it. The reverse is not provable, because the apiserver defaults `metadata.namespace` before admission and an absent one therefore does not make an object cluster scoped, so a `Namespaced` rule still matches. That is the same widening `appliesTo` already applies to an undeterminable kind, where evaluating and surfacing a result beats dropping a resource silently.

Exclude rules get this symmetrically, the same way `matchesOperation` already does. A `Cluster` scoped exclusion no longer exempts an object we know is namespaced.

## Additional Information

The three object derived inputs are now bundled into a `scopedObject` struct that `appliesTo` reads once, rather than threaded through as separate parameters. Honoring the next rule field costs one field there instead of another argument at every call site.

The vendored bundle sets no `scope` on any rule today, so no shipped control changes behaviour. The bundle is synced from cel-admission-library, so `TestBundleUsesNoUnevaluatedScoping` gained a matching assertion, following the pattern already used there for `objectSelector`, `namespaceSelector` and `resourceNames`. A `make sync-vap` that introduces a scoped rule fails that test rather than quietly relying on handling no real policy has exercised.

## How to Test

```
go test ./core/pkg/opaprocessor/...
```

`TestVAPAppliesToScope` in `scope_test.go` covers the scope matrix, an unset scope, the `*` wildcard, `Namespaced` and `Cluster` against both a namespaced object and one with no namespace, plus the `Cluster` scoped exclusion case.

Both of the assertions that pin the new narrowing fail if `matchesScope` is stubbed back to always returning true, so they cover the reported behaviour rather than restating the implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Offline policy matching now correctly respects whether resources are namespaced or cluster-scoped.
  * Resource and exclusion rules provide more accurate results when scope information is available.
  * Cluster-scoped rules are excluded from matching known namespaced resources.

* **Tests**
  * Added coverage for unset, wildcard, namespaced, and cluster scope matching.
  * Added safeguards validating scope usage across policy rules.
  * Added checks to ensure namespace information is preserved during matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->