### PR TITLE
feat(mcp): add scan_controls, scan_local_iac_controls, list_frameworks, and list_controls tools

### DIFF
--- a/cmd/mcpserver/control_scan.go
+++ b/cmd/mcpserver/control_scan.go
@@ -1,0 +1,20 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (ksServer *KubescapeMcpserver) ScanControls(ctx context.Context, namespace string, controlIDs []string) ([]byte, error) {
+	filtered := make([]string, 0, len(controlIDs))
+	for _, id := range controlIDs {
+		if id = strings.TrimSpace(id); id != "" {
+			filtered = append(filtered, id)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("at least one control ID is required")
+	}
+	return runControlScan(ctx, ksServer, namespace, filtered, "Control")
+}

--- a/cmd/mcpserver/control_scan_test.go
+++ b/cmd/mcpserver/control_scan_test.go
@@ -1,0 +1,32 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanControls_EmptyInput(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.ScanControls(context.Background(), "", []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one control ID")
+}
+
+func TestScanControls_WhitespaceOnlyIDs(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.ScanControls(context.Background(), "", []string{"  ", "\t", ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one control ID")
+}
+
+func TestScanControls_TrimsIDs(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.ScanControls(context.Background(), "", []string{" C-0012 ", "  C-0017"})
+	if err != nil {
+		assert.NotContains(t, err.Error(), "at least one control ID",
+			"trim should pass validation even if the scan itself fails due to no cluster")
+	}
+}

--- a/cmd/mcpserver/iac_scan_controls.go
+++ b/cmd/mcpserver/iac_scan_controls.go
@@ -1,0 +1,32 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/pkg/resourcehandler"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+)
+
+func (ksServer *KubescapeMcpserver) runIaCScanControls(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+	filtered := make([]string, 0, len(controlIDs))
+	for _, id := range controlIDs {
+		if id = strings.TrimSpace(id); id != "" {
+			filtered = append(filtered, id)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("at least one control ID is required")
+	}
+	if path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	policyIdentifiers := make([]cautils.PolicyIdentifier, len(filtered))
+	for i, id := range filtered {
+		policyIdentifiers[i] = cautils.PolicyIdentifier{Kind: apisv1.KindControl, Identifier: id}
+	}
+	fileHandler := resourcehandler.NewFileResourceHandler()
+	return runScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Control", false, fileHandler, []string{path}, nil)
+}

--- a/cmd/mcpserver/iac_scan_controls_test.go
+++ b/cmd/mcpserver/iac_scan_controls_test.go
@@ -1,0 +1,73 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+)
+
+func TestIaCScanControls_EmptyPath(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.runIaCScanControls(context.Background(), "", []string{"C-0012"})
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if !strings.Contains(err.Error(), "path is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIaCScanControls_EmptyControlIDs(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.runIaCScanControls(context.Background(), "/some/path", []string{})
+	if err == nil {
+		t.Fatal("expected error for empty control IDs")
+	}
+	if !strings.Contains(err.Error(), "at least one control ID") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIaCScanControls_WhitespaceIDs(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	_, err := srv.runIaCScanControls(context.Background(), "/some/path", []string{"  ", "\t"})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only IDs")
+	}
+	if !strings.Contains(err.Error(), "at least one control ID") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIaCScanControls_InvalidPath(t *testing.T) {
+	ksServer := &KubescapeMcpserver{
+		policyGetter: getter.NewDownloadReleasedPolicy(),
+	}
+	_, err := ksServer.runIaCScanControls(context.Background(), "/invalid/path/that/does/not/exist", []string{"C-0012"})
+	if err == nil {
+		t.Fatal("expected error when scanning invalid path")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") &&
+		!strings.Contains(err.Error(), "failed to collect") &&
+		!strings.Contains(err.Error(), "failed to load") {
+		t.Errorf("expected a file/resource collection error, got: %v", err)
+	}
+}
+
+func TestIaCScanControls_ValidPath(t *testing.T) {
+	ksServer := &KubescapeMcpserver{
+		policyGetter: getter.NewDownloadReleasedPolicy(),
+	}
+	_, _ = ksServer.policyGetter.SetRegoObjectsWithFallback()
+
+	respBytes, err := ksServer.runIaCScanControls(context.Background(), "testdata/privileged-pod.yaml", []string{"C-0017"})
+	if err != nil {
+		t.Fatalf("unexpected error scanning valid path: %v", err)
+	}
+	respStr := string(respBytes)
+	if !strings.Contains(respStr, `"total_failed":`) {
+		t.Errorf("expected scan response to include total_failed, got: %s", respStr)
+	}
+}

--- a/cmd/mcpserver/list_policies.go
+++ b/cmd/mcpserver/list_policies.go
@@ -1,0 +1,70 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/kubescape/v3/core/cautils/getter"
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+)
+
+func (ksServer *KubescapeMcpserver) ListFrameworks(ctx context.Context) ([]byte, error) {
+	pg := ksServer.policyGetter
+	if pg == nil {
+		pg = getter.NewDownloadReleasedPolicy()
+	}
+	names, err := pg.ListFrameworks()
+	if err != nil {
+		names = getter.NativeFrameworks
+	}
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+	return json.Marshal(sorted)
+}
+
+func (ksServer *KubescapeMcpserver) ListControls(ctx context.Context) ([]byte, error) {
+	pg := ksServer.policyGetter
+	if pg == nil {
+		pg = getter.NewDownloadReleasedPolicy()
+	}
+	pipes, err := pg.ListControls()
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]metav1.ControlListEntry, 0, len(pipes))
+	for _, pipe := range pipes {
+		entries = append(entries, parsePolicyPipe(pipe))
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].ID < entries[j].ID
+	})
+	return json.Marshal(entries)
+}
+
+func parsePolicyPipe(pipe string) metav1.ControlListEntry {
+	entry := metav1.ControlListEntry{Frameworks: []string{}}
+	if pipe == "" {
+		return entry
+	}
+	before, rest, ok := strings.Cut(pipe, "|")
+	if !ok {
+		entry.ID = pipe
+		return entry
+	}
+	entry.ID = before
+	last := strings.LastIndex(rest, "|")
+	if last == -1 {
+		entry.Name = rest
+		return entry
+	}
+	entry.Name = rest[:last]
+	for _, fw := range strings.Split(rest[last+1:], ",") {
+		if fw = strings.TrimSpace(fw); fw != "" {
+			entry.Frameworks = append(entry.Frameworks, fw)
+		}
+	}
+	return entry
+}

--- a/cmd/mcpserver/list_policies_test.go
+++ b/cmd/mcpserver/list_policies_test.go
@@ -1,0 +1,98 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePolicyPipe_Empty(t *testing.T) {
+	entry := parsePolicyPipe("")
+	assert.Equal(t, "", entry.ID)
+	assert.Equal(t, "", entry.Name)
+	assert.Empty(t, entry.Frameworks)
+}
+
+func TestParsePolicyPipe_IDOnly(t *testing.T) {
+	entry := parsePolicyPipe("C-0012")
+	assert.Equal(t, "C-0012", entry.ID)
+	assert.Equal(t, "", entry.Name)
+	assert.Empty(t, entry.Frameworks)
+}
+
+func TestParsePolicyPipe_IDAndName(t *testing.T) {
+	entry := parsePolicyPipe("C-0012|Applications credentials in configuration files")
+	assert.Equal(t, "C-0012", entry.ID)
+	assert.Equal(t, "Applications credentials in configuration files", entry.Name)
+	assert.Empty(t, entry.Frameworks)
+}
+
+func TestParsePolicyPipe_FullEntry(t *testing.T) {
+	entry := parsePolicyPipe("C-0012|Applications credentials in configuration files|nsa, mitre")
+	assert.Equal(t, "C-0012", entry.ID)
+	assert.Equal(t, "Applications credentials in configuration files", entry.Name)
+	assert.Equal(t, []string{"nsa", "mitre"}, entry.Frameworks)
+}
+
+func TestParsePolicyPipe_SingleFramework(t *testing.T) {
+	entry := parsePolicyPipe("C-0017|Immutable container filesystem|nsa")
+	assert.Equal(t, "C-0017", entry.ID)
+	assert.Equal(t, "Immutable container filesystem", entry.Name)
+	assert.Equal(t, []string{"nsa"}, entry.Frameworks)
+}
+
+func TestParsePolicyPipe_FrameworksWithSpaces(t *testing.T) {
+	entry := parsePolicyPipe("C-0030|Ingress and Egress blocked| nsa ,  mitre ")
+	assert.Equal(t, "C-0030", entry.ID)
+	assert.Equal(t, "Ingress and Egress blocked", entry.Name)
+	assert.Equal(t, []string{"nsa", "mitre"}, entry.Frameworks)
+}
+
+func TestListFrameworks_ReturnsJSON(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	data, err := srv.ListFrameworks(t.Context())
+	require.NoError(t, err)
+	var names []string
+	require.NoError(t, json.Unmarshal(data, &names), "output must be a JSON array of strings")
+	assert.NotEmpty(t, names, "should return at least the native frameworks on fallback")
+}
+
+func TestListControls_ReturnsJSON(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	data, err := srv.ListControls(t.Context())
+	if err != nil {
+		t.Skipf("skipping: could not download controls (no network?): %v", err)
+	}
+	var entries []metav1.ControlListEntry
+	require.NoError(t, json.Unmarshal(data, &entries), "output must be a JSON array of ControlListEntry")
+	for _, e := range entries {
+		assert.NotEmpty(t, e.ID, "every entry must have an ID")
+	}
+}
+
+func TestListFrameworks_IsSorted(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	data, err := srv.ListFrameworks(t.Context())
+	require.NoError(t, err)
+	var names []string
+	require.NoError(t, json.Unmarshal(data, &names))
+	for i := 1; i < len(names); i++ {
+		assert.LessOrEqual(t, names[i-1], names[i], "frameworks must be sorted")
+	}
+}
+
+func TestListControls_IsSorted(t *testing.T) {
+	srv := &KubescapeMcpserver{}
+	data, err := srv.ListControls(t.Context())
+	if err != nil {
+		t.Skipf("skipping: could not download controls (no network?): %v", err)
+	}
+	var entries []metav1.ControlListEntry
+	require.NoError(t, json.Unmarshal(data, &entries))
+	for i := 1; i < len(entries); i++ {
+		assert.LessOrEqual(t, entries[i-1].ID, entries[i].ID, "controls must be sorted by ID")
+	}
+}

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -402,6 +402,59 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 	return parsed, nil
 }
 
+// parseControlIDs extracts a list of trimmed, non-empty control IDs from an
+// argument value that may be either a comma-separated string or a JSON array
+// of strings. It returns a ToolResultError when the value is absent, has the
+// wrong type, or yields no valid IDs after trimming.
+func parseControlIDs(raw any, present bool) ([]string, *mcp.CallToolResult) {
+	if !present {
+		return nil, mcp.NewToolResultError("control_ids argument is required")
+	}
+	var ids []string
+	switch v := raw.(type) {
+	case string:
+		for _, id := range strings.Split(v, ",") {
+			if id = strings.TrimSpace(id); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, mcp.NewToolResultError("control_ids array elements must be strings")
+			}
+			if s = strings.TrimSpace(s); s != "" {
+				ids = append(ids, s)
+			}
+		}
+	default:
+		return nil, mcp.NewToolResultError("control_ids must be a comma-separated string or array")
+	}
+	if len(ids) == 0 {
+		return nil, mcp.NewToolResultError("control_ids must contain at least one control ID")
+	}
+	return ids, nil
+}
+
+// withControlIDsProperty adds control_ids to the tool schema as a required
+// property that accepts either a comma-separated string or an array of strings.
+func withControlIDsProperty(desc string) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		t.InputSchema.Properties["control_ids"] = map[string]any{
+			"anyOf": []any{
+				map[string]any{"type": "string"},
+				map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string"},
+				},
+			},
+			"description": desc,
+		}
+		t.InputSchema.Required = append(t.InputSchema.Required, "control_ids")
+	}
+}
+
 func (ksServer *KubescapeMcpserver) ReadResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 	uri := request.Params.URI
 
@@ -527,10 +580,6 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if namespace == "*" {
 			namespace = ""
 		}
-
-		if namespace == "*" {
-			namespace = ""
-		}
 		key := fmt.Sprintf("rbac_scan:%s", namespace)
 		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
 			return ksServer.RunRBACScan(scanCtx, namespace)
@@ -570,6 +619,31 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
+	case "scan_local_iac_controls":
+		path := ""
+		if p, ok := arguments["path"]; ok {
+			pStr, ok := p.(string)
+			if !ok {
+				return mcp.NewToolResultError("path argument must be a string"), nil
+			}
+			path = strings.TrimSpace(pStr)
+		}
+		if path == "" {
+			return mcp.NewToolResultError("path argument is required and cannot be empty"), nil
+		}
+		rawControlIDs, hasControlIDs := arguments["control_ids"]
+		controlIDs, toolErr := parseControlIDs(rawControlIDs, hasControlIDs)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		key := fmt.Sprintf("scan_local_iac_controls:%s:%s", url.QueryEscape(path), url.QueryEscape(strings.Join(controlIDs, ",")))
+		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
+			return ksServer.runIaCScanControls(scanCtx, path, controlIDs)
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to run IaC control scan: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "run_network_security_scan":
 		namespace := ""
 		if ns, ok := arguments["namespace"]; ok {
@@ -579,10 +653,6 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			}
 			namespace = nsStr
 		}
-		if namespace == "*" {
-			namespace = ""
-		}
-
 		if namespace == "*" {
 			namespace = ""
 		}
@@ -1053,10 +1123,6 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if namespace == "*" {
 			namespace = ""
 		}
-
-		if namespace == "*" {
-			namespace = ""
-		}
 		key := fmt.Sprintf("framework_scan:%s:%s", namespace, url.QueryEscape(frameworkNameStr))
 		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
 			return ksServer.RunFrameworkScan(scanCtx, namespace, frameworkNameStr)
@@ -1066,6 +1132,43 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
+	case "scan_controls":
+		namespace := ""
+		if ns, ok := arguments["namespace"]; ok {
+			nsStr, ok := ns.(string)
+			if !ok {
+				return mcp.NewToolResultError("namespace argument must be a string"), nil
+			}
+			namespace = nsStr
+		}
+		if namespace == "*" {
+			namespace = ""
+		}
+		rawControlIDs, hasControlIDs := arguments["control_ids"]
+		controlIDs, toolErr := parseControlIDs(rawControlIDs, hasControlIDs)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		key := fmt.Sprintf("control_scan:%s:%s", namespace, url.QueryEscape(strings.Join(controlIDs, ",")))
+		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
+			return ksServer.ScanControls(scanCtx, namespace, controlIDs)
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to run control scan: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(v.([]byte))), nil
+	case "list_frameworks":
+		result, err := ksServer.ListFrameworks(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list frameworks: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(result)), nil
+	case "list_controls":
+		result, err := ksServer.ListControls(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list controls: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(result)), nil
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -1103,6 +1206,9 @@ func mcpServerEntrypoint() error {
 	createNetworkScanningTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
+	createIaCControlScanningTool(ksServer)
+	createControlScanningTools(ksServer)
+	createPolicyListingTools(ksServer)
 
 	// Start the server
 	if err := server.ServeStdio(s); err != nil {
@@ -1165,6 +1271,44 @@ func createIaCScanningTools(ksServer *KubescapeMcpserver) {
 	)
 
 	ksServer.s.AddTool(iacScanTool, ksServer.toolHandler(iacScanTool.Name))
+}
+
+func createIaCControlScanningTool(ksServer *KubescapeMcpserver) {
+	iacControlScanTool := mcp.NewTool(
+		"scan_local_iac_controls",
+		mcp.WithDescription("Scan local Infrastructure-as-Code (Helm charts, Kustomize, YAML) for specific controls by control ID. Use list_controls to discover valid IDs. Prefer scan_local_iac when you want full framework coverage."),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Absolute or relative path to the local directory or file (e.g., /path/to/helm-chart or /path/to/manifest.yaml)"),
+		),
+		withControlIDsProperty("Control IDs to scan against: a comma-separated string (e.g. \"C-0012,C-0017\") or an array of strings (e.g. [\"C-0012\",\"C-0017\"]). At least one ID is required."),
+	)
+	ksServer.s.AddTool(iacControlScanTool, ksServer.toolHandler(iacControlScanTool.Name))
+}
+
+func createControlScanningTools(ksServer *KubescapeMcpserver) {
+	runControlScanTool := mcp.NewTool(
+		"scan_controls",
+		mcp.WithDescription("Run an on-demand, live security scan restricted to a given set of controls by control ID (e.g. C-0012, C-0017) and return the failed resources. Use list_controls to discover valid IDs first."),
+		withControlIDsProperty("Control IDs to scan: a comma-separated string (e.g. \"C-0012,C-0017\") or an array of strings (e.g. [\"C-0012\",\"C-0017\"]). At least one ID is required."),
+		mcp.WithString("namespace",
+			mcp.Description("Namespace to scope the scan (optional, defaults to cluster-wide if omitted)"),
+		),
+	)
+	ksServer.s.AddTool(runControlScanTool, ksServer.toolHandler(runControlScanTool.Name))
+}
+
+func createPolicyListingTools(ksServer *KubescapeMcpserver) {
+	listFrameworksTool := mcp.NewTool(
+		"list_frameworks",
+		mcp.WithDescription("List the names of all security frameworks available for scanning (e.g. nsa, mitre, cis-v1.23-t1.0.1). Use a returned name as the framework_name argument to run_framework_security_scan."),
+	)
+	listControlsTool := mcp.NewTool(
+		"list_controls",
+		mcp.WithDescription("List all available security controls with their IDs, names, and the frameworks they belong to. Use a returned ID as a control_ids value in scan_controls."),
+	)
+	ksServer.s.AddTool(listFrameworksTool, ksServer.toolHandler(listFrameworksTool.Name))
+	ksServer.s.AddTool(listControlsTool, ksServer.toolHandler(listControlsTool.Name))
 }
 
 func GetMCPServerCmd() *cobra.Command {

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -509,3 +509,97 @@ func TestGetK8sClient_RetriesAfterTransientLoadFailure(t *testing.T) {
 		t.Fatal("expected the connectivity latch to be cleared to true on successful retry")
 	}
 }
+
+func TestCallTool_ScanControls(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	tests := []struct {
+		name          string
+		arguments     map[string]any
+		wantErrString string
+	}{
+		{
+			name:          "missing control_ids",
+			arguments:     map[string]any{},
+			wantErrString: "control_ids argument is required",
+		},
+		{
+			name:          "control_ids wrong type",
+			arguments:     map[string]any{"control_ids": 42},
+			wantErrString: "control_ids must be a comma-separated string or array",
+		},
+		{
+			name:          "control_ids empty string",
+			arguments:     map[string]any{"control_ids": "  ,  "},
+			wantErrString: "control_ids must contain at least one control ID",
+		},
+		{
+			name:          "control_ids empty array",
+			arguments:     map[string]any{"control_ids": []interface{}{}},
+			wantErrString: "control_ids must contain at least one control ID",
+		},
+		{
+			name:          "namespace not a string",
+			arguments:     map[string]any{"control_ids": "C-0012", "namespace": 99},
+			wantErrString: "namespace argument must be a string",
+		},
+		{
+			name:          "control_ids mixed array rejects non-string element",
+			arguments:     map[string]any{"control_ids": []interface{}{"C-0012", 42}},
+			wantErrString: "control_ids array elements must be strings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ksServer.CallTool(t.Context(), "scan_controls", tt.arguments)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected tool error for %q, got success", tt.name)
+			}
+			text := result.Content[0].(mcp.TextContent).Text
+			if tt.wantErrString != "" && !containsSubstring(text, tt.wantErrString) {
+				t.Errorf("error %q does not contain %q", text, tt.wantErrString)
+			}
+		})
+	}
+}
+
+func TestCallTool_ScanControls_ArrayInput(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+	result, err := ksServer.CallTool(t.Context(), "scan_controls", map[string]any{
+		"control_ids": []interface{}{"C-0012", "C-0017"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if result.IsError {
+		text := result.Content[0].(mcp.TextContent).Text
+		if containsSubstring(text, "control_ids") {
+			t.Errorf("array input should pass argument validation but got control_ids error: %s", text)
+		}
+	}
+}
+
+func TestCallTool_ListingTools_UnknownToolFallthrough(t *testing.T) {
+
+	ksServer := &KubescapeMcpserver{}
+	_, err := ksServer.CallTool(t.Context(), "not_a_real_tool", map[string]any{})
+	if err == nil {
+		t.Fatal("expected Go error for unknown tool name")
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

The MCP server exposes framework, RBAC, network, and IaC scans but has no way to target specific controls by ID, scan local manifests against controls instead of a whole framework, or enumerate what frameworks and controls are available. An AI agent using the server has to guess valid framework names and control IDs - `run_framework_security_scan` fails silently on a misspelled name with no recovery path.

`runControlScan` in `scan_helper.go` already existed but was never wired to a tool. `ListFrameworks` and `ListControls` are exposed by the CLI (`kubescape list`) but not the MCP server. This change closes that gap with four new tools and a shared argument-parsing helper.

**New tools:**

- `scan_controls`: live cluster scan against specific control IDs (`"C-0012,C-0017"` or a JSON array), optional namespace scoping. Uses the existing `runControlScan` helper.
- `scan_local_iac_controls`: same control-level scan against local IaC files (YAML, Helm, Kustomize). Mirrors `scan_local_iac` which only accepts a framework name.
- `list_frameworks`: sorted JSON array of framework names. Uses the server's startup-cached `policyGetter`; falls back to `NativeFrameworks` offline.
- `list_controls`: sorted JSON array of `{id, name, frameworks}` so an agent can discover valid control IDs before calling `scan_controls`.

**Also fixed:** duplicate `if namespace == "*" { namespace = "" }` guard that appeared twice in each of the `run_rbac_security_scan`, `run_network_security_scan`, and `run_framework_security_scan` cases - the second check was unreachable dead code.

**Files changed:**
- `cmd/mcpserver/control_scan.go`: `ScanControls` wrapper with input validation
- `cmd/mcpserver/iac_scan_controls.go`: `runIaCScanControls` using `FileResourceHandler`
- `cmd/mcpserver/list_policies.go`: `ListFrameworks`, `ListControls`, `parsePolicyPipe`
- `cmd/mcpserver/mcpserver.go`: `parseControlIDs` helper, three new `createXxx` registration functions, five new `CallTool` cases, dead-code removal
- `cmd/mcpserver/control_scan_test.go`, `iac_scan_controls_test.go`, `list_policies_test.go`, `mcpserver_test.go`: tests for all new paths

**Tests run:**
- `TestCallTool_ScanControls`: missing ID, wrong type, empty string, empty array, namespace type error
- `TestIaCScanControls_EmptyPath`, `_EmptyControlIDs`, `_WhitespaceIDs`, `_InvalidPath`, `_ValidPath`
- `TestParsePolicyPipe_Empty`, `_IDOnly`, `_IDAndName`, `_FullEntry`, `_SingleFramework`, `_FrameworksWithSpaces`
- `TestListFrameworks_ReturnsJSON`, `TestListFrameworks_IsSorted`
- `TestListControls_ReturnsJSON`, `TestListControls_IsSorted` (auto-skipped if offline)
- `TestCallTool_ListingTools_UnknownToolFallthrough`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added control-focused scanning for live and local infrastructure-as-code resources.
  * Added validation and trimming for control IDs, including comma-separated and list inputs.
  * Added tools to list available frameworks and controls with sorted results.
  * Registered the new scanning and listing tools for use through the MCP server.

* **Bug Fixes**
  * Improved handling of empty, whitespace-only, invalid, and unknown tool inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->