### PR TITLE
fix(printer): render map/slice values in AssistedRemediation evidence

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -43,10 +43,13 @@ func splitPath(path string) []pathSegment {
 	return segments
 }
 
-// anyToString converts a scalar value to its string representation.
+// anyToString converts a value to its string representation.
 // It handles all numeric types that may appear in JSON-decoded or
-// programmatically-constructed Kubernetes objects.
-// Maps and slices return ("", false).
+// programmatically-constructed Kubernetes objects. Maps and slices are
+// rendered as compact JSON rather than dropped, so a failing path whose
+// value is an object or array (e.g. a container's full securityContext, an
+// env var list) still surfaces something instead of falling back to the
+// bare path with no value at all.
 func anyToString(v any) (string, bool) {
 	switch val := v.(type) {
 	case nil:
@@ -77,6 +80,12 @@ func anyToString(v any) (string, bool) {
 		return strconv.FormatUint(val, 10), true
 	case json.Number:
 		return val.String(), true
+	case map[string]any, []any:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
 	default:
 		return "", false
 	}

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -113,8 +113,12 @@ func TestAnyToString(t *testing.T) {
 		{name: "uint64", input: uint64(65535), want: "65535", wantOK: true},
 		{name: "json.Number integer", input: json.Number("3"), want: "3", wantOK: true},
 		{name: "json.Number float", input: json.Number("1.5"), want: "1.5", wantOK: true},
-		{name: "map (complex)", input: map[string]any{"k": "v"}, want: "", wantOK: false},
-		{name: "slice (complex)", input: []any{"a"}, want: "", wantOK: false},
+		{name: "map renders as compact JSON", input: map[string]any{"k": "v"}, want: `{"k":"v"}`, wantOK: true},
+		{name: "map with multiple keys is sorted", input: map[string]any{"b": 1, "a": 2}, want: `{"a":2,"b":1}`, wantOK: true},
+		{name: "empty map renders as {}", input: map[string]any{}, want: "{}", wantOK: true},
+		{name: "slice renders as compact JSON", input: []any{"a"}, want: `["a"]`, wantOK: true},
+		{name: "slice of maps", input: []any{map[string]any{"name": "x"}}, want: `[{"name":"x"}]`, wantOK: true},
+		{name: "empty slice renders as []", input: []any{}, want: "[]", wantOK: true},
 	}
 
 	for _, tc := range cases {
@@ -151,6 +155,10 @@ func TestExtractValueAtPath(t *testing.T) {
 							"memory": "128Mi",
 							"cpu":    float64(500),
 						},
+					},
+					"ports": []any{
+						map[string]any{"containerPort": float64(8080)},
+						map[string]any{"containerPort": float64(9090)},
 					},
 				},
 				map[string]any{
@@ -249,10 +257,22 @@ func TestExtractValueAtPath(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "map value returns false",
+			name:   "map value renders as compact JSON",
 			path:   "spec.securityContext",
-			want:   "",
-			wantOK: false,
+			want:   `{"runAsNonRoot":true}`,
+			wantOK: true,
+		},
+		{
+			name:   "nested map value renders as compact JSON",
+			path:   "spec.containers[0].securityContext",
+			want:   `{"allowPrivilegeEscalation":false,"privileged":true}`,
+			wantOK: true,
+		},
+		{
+			name:   "slice value renders as compact JSON",
+			path:   "spec.containers[0].ports",
+			want:   `[{"containerPort":8080},{"containerPort":9090}]`,
+			wantOK: true,
 		},
 		{
 			name:   "empty path",
@@ -450,6 +470,29 @@ func TestFailedPathsWithCurrentValues(t *testing.T) {
 		ctrl := makeControlWithPaths(nil, nil)
 		got := failedPathsWithCurrentValues(ctrl, resource)
 		assert.Nil(t, got)
+	})
+
+	t.Run("object-valued path is rendered as JSON instead of falling back to bare path", func(t *testing.T) {
+		objResource := &mockResource{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"securityContext": map[string]any{
+								"privileged": true,
+								"capabilities": map[string]any{
+									"add": []any{"SYS_ADMIN"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext"}, nil)
+		got := failedPathsWithCurrentValues(ctrl, objResource)
+		require.Len(t, got, 1)
+		assert.Equal(t, `spec.containers[0].securityContext (current: {"capabilities":{"add":["SYS_ADMIN"]},"privileged":true})`, got[0])
 	})
 }
 


### PR DESCRIPTION
## Summary
- `anyToString()` (added in #2882) only handled scalars and returned `("", false)` for `map[string]any` and `[]any`, so `extractValueAtPath()` silently dropped any failed/review path whose value was an object or array - e.g. a control failing on a container's whole `securityContext` block or its `ports` list showed only the bare path with no `(current: ...)` annotation, even though the value was already sitting in the captured resource object.
- Render map and slice values as compact JSON instead of dropping them, matching how scalar values are already surfaced. Existing scalar behavior is unchanged.

## Test plan
- [x] `go test ./core/pkg/resultshandling/printer/v2/...`
- [x] `go vet ./core/pkg/resultshandling/printer/v2/...`
- [x] `gofmt -l` clean
- [x] `go build ./...`
- [x] Extended `TestAnyToString` and `TestExtractValueAtPath` with map/slice/nested cases, and added a case to `TestFailedPathsWithCurrentValues` showing the full enrichment output for an object-valued path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Object and list values are now displayed as compact JSON.
  * Nested structures and empty collections are rendered consistently.
  * Path results containing object values now show their serialized contents, including when a path lookup fails.

* **Bug Fixes**
  * Improved handling of complex result values during path extraction and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->