### PR TITLE
feat(sarif): resolve each FailedPath to its own relatedLocation

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -117,15 +118,18 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 		})
 }
 
-// addResult adds a result of checking a rule to the scan run based on the given control summary
-func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) *sarif.Result {
+// addResult adds a result of checking a rule to the scan run based on the given control summary.
+// failedPathLocations, when non-empty, adds one relatedLocation per resolved FailedPath so each
+// field that actually caused the failure gets its own precise location in the manifest, distinct
+// from the single primary location (which points at the fix, not necessarily at every failed field).
+func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, failedPathLocations map[string]locationresolver.Location) *sarif.Result {
 	msg := ctl.GetDescription()
 	if resource != nil {
 		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
 			msg += "\n\nAffected fields:\n" + strings.Join(paths, "\n")
 		}
 	}
-	return scanRun.CreateResultForRule(ctl.GetID()).
+	result := scanRun.CreateResultForRule(ctl.GetID()).
 		WithMessage(sarif.NewTextMessage(msg)).
 		WithLocations([]*sarif.Location{
 			sarif.NewLocationWithPhysicalLocation(
@@ -137,6 +141,69 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 				),
 			),
 		})
+
+	// Sort for deterministic output - map iteration order is randomized and this feeds
+	// directly into the written SARIF file.
+	paths := make([]string, 0, len(failedPathLocations))
+	for p := range failedPathLocations {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		loc := failedPathLocations[p]
+		result.AddRelatedLocation(
+			sarif.NewLocation().
+				WithMessage(sarif.NewTextMessage(p)).
+				WithPhysicalLocation(
+					sarif.NewPhysicalLocation().
+						WithArtifactLocation(
+							sarif.NewSimpleArtifactLocation(filepath),
+						).WithRegion(
+						sarif.NewRegion().WithStartLine(loc.Line).WithStartColumn(loc.Column),
+					),
+				),
+		)
+	}
+
+	return result
+}
+
+// resolveFailedPathLocations resolves each of ac's FailedPaths to its location in the source
+// manifest, using the same locationResolver already built for the fix location. Unlike
+// resolveFixLocation, which returns one location for the highest-priority remediation path, this
+// resolves every FailedPath independently so each field that actually caused the failure can get
+// its own precise location instead of all sharing the fix location. A path that doesn't resolve
+// (unknown docIndex, or ResolveLocation finding nothing) is omitted rather than defaulted to line
+// 1 - a relatedLocation with a fabricated line number would be worse than no relatedLocation at all.
+func resolveFailedPathLocations(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) map[string]locationresolver.Location {
+	if locationResolver == nil {
+		return nil
+	}
+	docIndex, ok := getDocIndex(opaSessionObj, resourceID)
+	if !ok {
+		return nil
+	}
+
+	var locations map[string]locationresolver.Location
+	for i := range ac.ResourceAssociatedRules {
+		for _, p := range ac.ResourceAssociatedRules[i].Paths {
+			if p.FailedPath == "" {
+				continue
+			}
+			if _, seen := locations[p.FailedPath]; seen {
+				continue
+			}
+			location, err := locationResolver.ResolveLocation(p.FailedPath, docIndex)
+			if err != nil || location.Line == 0 {
+				continue
+			}
+			if locations == nil {
+				locations = make(map[string]locationresolver.Location)
+			}
+			locations[p.FailedPath] = location
+		}
+	}
+	return locations
 }
 
 func (sp *SARIFPrinter) printImageScan(scanResults cautils.ImageScanData) error {
@@ -259,9 +326,10 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 					continue
 				}
 				location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
+				failedPathLocations := resolveFailedPathLocations(opaSessionObj, locationResolver, &ac, resource.resourceID)
 				sp.addRule(run, ctl)
 				rsrc := opaSessionObj.AllResources[resource.resourceID]
-				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc)
+				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc, failedPathLocations)
 				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
 			}
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -915,6 +915,152 @@ spec:
 		"all findings must not collapse to line 1 for absolute-path file scans")
 }
 
+// TestPrintConfigurationScan_FailedPathGetsRelatedLocation is a regression test for evidence
+// locations: a control's FailedPath previously had no location of its own in SARIF output - only
+// the (possibly different) FixPath got the primary Locations entry. This asserts the FailedPath
+// now resolves to its own relatedLocations entry, pointing at the actual line the failing field
+// lives on, independent of where the fix would apply.
+func TestPrintConfigurationScan_FailedPathGetsRelatedLocation(t *testing.T) {
+	const (
+		imageLine      = 12
+		privilegedLine = 13
+	)
+
+	manifestDir := t.TempDir()
+	manifestPath := filepath.Join(manifestDir, "deploy.yaml")
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata: {name: demo, namespace: default}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: demo}}
+  template:
+    metadata: {labels: {app: demo}}
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.23
+        securityContext: {privileged: true}
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath("deploy.yaml:0")
+
+	controlID := "C-0001"
+	// FixPath targets a different field (image) than FailedPath (privileged), so their
+	// resolved locations diverge - the test would pass by coincidence if they matched.
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "privileged-container",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{
+						FailedPath: "spec.template.spec.containers[0].securityContext.privileged",
+						FixPath: armotypes.FixPath{
+							Path:  "spec.template.spec.containers[0].image",
+							Value: "nginx:1.25",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{
+			ScanningTarget: reporthandlingv2.File,
+		},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			FileContextMetadata: &reporthandlingv2.FileContextMetadata{
+				FilePath: manifestPath,
+			},
+		},
+	}
+	session.ResourcesResult[resourceID] = resourcesresults.Result{
+		ResourceID:         resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {
+			Path:         manifestDir,
+			RelativePath: "deploy.yaml",
+			FileType:     reporthandling.SourceTypeYaml,
+		},
+	}
+	session.AllResources[resourceID] = lw
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				controlID: reportsummary.ControlSummary{
+					ControlID:   controlID,
+					Name:        "Privileged container",
+					Description: "Do not run privileged containers",
+					Remediation: "Set privileged to false",
+					ScoreFactor: 8.0,
+				},
+			},
+		},
+	}
+
+	tmp, err := os.CreateTemp("", "sarif-related-location-*.sarif")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	otherWD := t.TempDir()
+	require.NoError(t, os.Chdir(otherWD))
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 1)
+	require.Len(t, report.Runs[0].Results, 1)
+
+	result := report.Runs[0].Results[0]
+
+	// Primary location follows the fix path (image), as before this change.
+	require.NotEmpty(t, result.Locations)
+	require.NotNil(t, result.Locations[0].PhysicalLocation.Region)
+	assert.Equal(t, imageLine, *result.Locations[0].PhysicalLocation.Region.StartLine,
+		"primary location should still resolve to the FixPath's line")
+
+	// The FailedPath now gets its own relatedLocations entry, at its own line.
+	require.Len(t, result.RelatedLocations, 1)
+	relatedLoc := result.RelatedLocations[0]
+	require.NotNil(t, relatedLoc.PhysicalLocation)
+	require.NotNil(t, relatedLoc.PhysicalLocation.Region)
+	assert.Equal(t, privilegedLine, *relatedLoc.PhysicalLocation.Region.StartLine,
+		"relatedLocations must resolve the FailedPath to its own line, distinct from the fix location")
+	require.NotNil(t, relatedLoc.Message)
+	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", *relatedLoc.Message.Text)
+}
+
 // TestPrintImageScan_WriterIsNonSeekablePipe is a regression test for image
 // SARIF output hanging when the destination is a pipe (e.g. stdout in a Unix
 // pipeline). printImageScan used to render the report to sp.writer, then


### PR DESCRIPTION
## Summary
- A SARIF result's primary `Location` was resolved from only the highest-priority remediation path (`resolveFixLocation` picks the first of fixPaths/deletePaths/reviewPaths/failedPaths via `AssistedRemediationPathsToString`) - so when a control's `FixPath` and `FailedPath` point at different fields, the SARIF location shown was the fix target, not necessarily the field that actually caused the failure. A reviewer clicking through from a code-scanning alert would land on the wrong line for anything other than simple one-field controls.
- Add `resolveFailedPathLocations`, which resolves every `FailedPath` on a control independently using the same `FixPathLocationResolver` already built per-manifest for the primary location, and wire the results into the SARIF result as `relatedLocations` (one per resolved path, each carrying the path itself as its message so a reader can tell which field each location corresponds to).
- The primary `Location` is unchanged - this is additive, since `relatedLocations` is exactly what the SARIF spec provides for "other locations relevant to this result."
- A path that can't be resolved (unknown doc index, or the location resolver finding nothing) is silently omitted rather than defaulted to line 1, since a `relatedLocation` pointing at a fabricated line would be actively misleading. The existing `resolveFixLocation` default-to-line-1 behavior for the primary location is unchanged.

## Test plan
- [x] `go test ./core/pkg/resultshandling/...` (full existing suite, including `TestPrintConfigurationScan_FileScanResolvesLineNumbers`, passes unchanged)
- [x] `go vet ./core/pkg/resultshandling/printer/v2/...`
- [x] `gofmt -l` clean
- [x] `go build ./...`
- [x] Added `TestPrintConfigurationScan_FailedPathGetsRelatedLocation`: a control whose `FixPath` and `FailedPath` target different fields, asserting the primary location still resolves to the fix line while `relatedLocations` independently resolves to the failed field's own line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF reports now include resolvable failed paths as related locations.
  * Related locations are sorted consistently, while unresolved or duplicate paths are excluded.
  * The primary fix path remains correctly identified, including when scans run from different working directories.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->