### PR TITLE
fix(cache): preserve rolling fallback across pinned scans

### DIFF
--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -52,6 +52,15 @@ func (drp *DownloadReleasedPolicy) IsVersionPinned() bool {
 	return drp.version != ""
 }
 
+// ShouldPersistPolicyArtifacts reports whether policies fetched by this getter
+// may be published to Kubescape's shared, unversioned disk fallback. A pinned
+// release must not replace that fallback because the flat cache path does not
+// record release provenance; doing so would let a later unpinned fallback
+// silently evaluate the pinned release.
+func (drp *DownloadReleasedPolicy) ShouldPersistPolicyArtifacts() bool {
+	return !drp.IsVersionPinned()
+}
+
 // SetRegoObjectsWithFallback downloads the policy objects and reports whether
 // the caller should fall back to the bundled cache on failure.
 //

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -183,6 +183,24 @@ func TestNewDownloadReleasedPolicyWithVersion(t *testing.T) {
 	})
 }
 
+func TestDownloadReleasedPolicyArtifactPersistence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rolling release may refresh the shared fallback", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicy()
+		require.True(t, p.ShouldPersistPolicyArtifacts())
+	})
+
+	t.Run("pinned release must not replace the unversioned fallback", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("v2.0.301")
+		require.False(t, p.ShouldPersistPolicyArtifacts())
+	})
+}
+
 func TestSetRegoObjectsWithFallback(t *testing.T) {
 	t.Parallel()
 

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -57,6 +57,12 @@ func NewLoadPolicy(filePaths []string) *LoadPolicy {
 	}
 }
 
+// ShouldPersistPolicyArtifacts prevents explicit local inputs from being
+// republished into Kubescape's shared disk fallback.
+func (lp *LoadPolicy) ShouldPersistPolicyArtifacts() bool {
+	return false
+}
+
 // GetControl returns a control from the policy file.
 func (lp *LoadPolicy) GetControl(controlID string) (*reporthandling.Control, error) {
 	if controlID == "" {

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -25,6 +25,10 @@ type cachedPoliciesEntry struct {
 	frameworks  []reporthandling.Framework
 }
 
+type policyArtifactPersistence interface {
+	ShouldPersistPolicyArtifacts() bool
+}
+
 // PolicyHandler
 type PolicyHandler struct {
 	clusterName         string
@@ -196,7 +200,10 @@ func deepCopyPolicies(src []reporthandling.Framework) ([]reporthandling.Framewor
 
 func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, getters *cautils.Getters) ([]reporthandling.Framework, error) {
 	frameworks := []reporthandling.Framework{}
-	_, isLocalPolicy := getters.PolicyGetter.(*getter.LoadPolicy)
+	persistPolicyArtifacts := true
+	if persistence, ok := getters.PolicyGetter.(policyArtifactPersistence); ok {
+		persistPolicyArtifacts = persistence.ShouldPersistPolicyArtifacts()
+	}
 
 	switch getScanKind(policyIdentifier) {
 	case apisv1.KindFramework: // Download frameworks
@@ -211,8 +218,8 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedFramework != nil {
 				frameworks = append(frameworks, *receivedFramework)
-				if isLocalPolicy {
-					continue // skip caching for local files
+				if !persistPolicyArtifacts {
+					continue
 				}
 				cache, err := getter.PolicyCachePath(rule.Identifier)
 				if err != nil {
@@ -236,8 +243,8 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 			}
 			if receivedControl != nil {
 				f.Controls = append(f.Controls, *receivedControl)
-				if isLocalPolicy {
-					continue // skip caching for local files
+				if !persistPolicyArtifacts {
+					continue
 				}
 				cache, err := getter.PolicyCachePath(policy.Identifier)
 				if err != nil {

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -33,6 +33,11 @@ var (
 type ExceptionsGetterMock struct{}
 type ControlsInputsGetterMock struct{}
 type PolicyGetterMock struct{}
+type nonPersistentPolicyGetterMock struct{ PolicyGetterMock }
+
+func (mock *nonPersistentPolicyGetterMock) ShouldPersistPolicyArtifacts() bool {
+	return false
+}
 
 func (mock *ExceptionsGetterMock) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	return CachedExceptions, nil
@@ -324,6 +329,32 @@ func TestGetScanPolicies_LocalSourceBypassesSharedCache(t *testing.T) {
 	assert.Equal(t, remotePolicies[0].Controls[0].ControlID, remotePoliciesAgain[0].Controls[0].ControlID,
 		"a local request must not replace the shared remote-policy cache")
 	assert.NotEqual(t, "local-control", remotePoliciesAgain[0].Controls[0].ControlID)
+}
+
+func TestDownloadScanPolicies_NonPersistentSourcePreservesSharedFallback(t *testing.T) {
+	cacheDir := t.TempDir()
+	originalLocalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = cacheDir
+	t.Cleanup(func() { getter.DefaultLocalStore = originalLocalStore })
+
+	cachePath, err := getter.PolicyCachePath(FrameworkName)
+	require.NoError(t, err)
+	rollingFallback := []byte(`{"name":"rolling-fallback","controls":[{"controlID":"rolling-control"}]}`)
+	require.NoError(t, os.WriteFile(cachePath, rollingFallback, 0o600))
+
+	policyHandler := NewRequestScopedPolicyHandler("non-persistent-policy-source")
+	t.Cleanup(policyHandler.Close)
+	getters := &cautils.Getters{PolicyGetter: &nonPersistentPolicyGetterMock{}}
+	policyIdent := []cautils.PolicyIdentifier{{Identifier: FrameworkName, Kind: "Framework"}}
+
+	frameworks, err := policyHandler.downloadScanPolicies(context.Background(), policyIdent, getters)
+	require.NoError(t, err)
+	require.NotEmpty(t, frameworks, "the requested policy must still be returned to the current scan")
+
+	after, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	require.Equal(t, rollingFallback, after,
+		"a source without cache provenance must not replace the shared rolling fallback")
 }
 
 type ControlsInputsGetterEmptyMock struct{}

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -39,6 +39,10 @@ func (mock *nonPersistentPolicyGetterMock) ShouldPersistPolicyArtifacts() bool {
 	return false
 }
 
+func (mock *nonPersistentPolicyGetterMock) GetControl(name string) (*reporthandling.Control, error) {
+	return &reporthandling.Control{ControlID: name}, nil
+}
+
 func (mock *ExceptionsGetterMock) GetExceptions(ctx context.Context, clusterName string) ([]armotypes.PostureExceptionPolicy, error) {
 	return CachedExceptions, nil
 }
@@ -355,6 +359,25 @@ func TestDownloadScanPolicies_NonPersistentSourcePreservesSharedFallback(t *test
 	require.NoError(t, err)
 	require.Equal(t, rollingFallback, after,
 		"a source without cache provenance must not replace the shared rolling fallback")
+
+	const controlID = "control-from-non-persistent-source"
+	controlCachePath, err := getter.PolicyCachePath(controlID)
+	require.NoError(t, err)
+	rollingControlFallback := []byte(`{"controlID":"rolling-control"}`)
+	require.NoError(t, os.WriteFile(controlCachePath, rollingControlFallback, 0o600))
+
+	controlIdentifiers := []cautils.PolicyIdentifier{{Identifier: controlID, Kind: "Control"}}
+	controlFrameworks, err := policyHandler.downloadScanPolicies(context.Background(), controlIdentifiers, getters)
+	require.NoError(t, err)
+	require.Len(t, controlFrameworks, 1)
+	require.Len(t, controlFrameworks[0].Controls, 1)
+	require.Equal(t, controlID, controlFrameworks[0].Controls[0].ControlID,
+		"the requested control must still be returned to the current scan")
+
+	controlAfter, err := os.ReadFile(controlCachePath)
+	require.NoError(t, err)
+	require.Equal(t, rollingControlFallback, controlAfter,
+		"a non-persistent control source must not replace the shared rolling fallback")
 }
 
 type ControlsInputsGetterEmptyMock struct{}


### PR DESCRIPTION
Fixes #3253.

## Overview

Pinned regolibrary policies were written to the same flat `~/.kubescape/<identifier>.json` paths used by rolling-release fallback. A successful `--controls-version` scan could therefore replace the rolling fallback; if a later unpinned download failed, Kubescape silently evaluated the pinned revision from disk.

This change introduces a small source-owned persistence contract:

- rolling `DownloadReleasedPolicy` results remain eligible for disk persistence;
- pinned `DownloadReleasedPolicy` results are used by the current scan but are not published into the unversioned fallback;
- `LoadPolicy` keeps its existing non-persistent behavior through the same contract;
- policy getters without the optional contract keep the existing persist-by-default behavior.

Both framework and individual-control download paths honor the contract.

## Why this shape

The existing cache filename contains no source or release identity, so it cannot safely represent a pinned artifact as a rolling fallback. Adding a versioned offline cache would also require a version-aware read path, migration behavior, cleanup rules, and CLI semantics.

Pinned download failures already return a hard error instead of falling back. This bounded fix preserves that contract and prevents provenance loss without creating a new offline-pinning feature.

## Regression coverage

The policy-handler regression seeds known-good rolling fallback artifacts, downloads different content from a non-persistent source, and verifies both sides of the contract for frameworks and individual controls:

1. the requested framework/control is returned to the current scan;
2. the existing rolling fallback remains byte-for-byte unchanged.

Constructor-level tests verify that rolling and pinned `DownloadReleasedPolicy` instances select the correct persistence behavior.

The control-path case was added in response to review feedback so both write branches in `downloadScanPolicies` are covered directly.

## Validation

After rebasing onto `master` at `355e4432bdf7feec15df902c265a4dbec8f3bb87`:

```bash
go test ./core/cautils/getter ./core/pkg/policyhandler -count=1

go test -race ./core/cautils/getter ./core/pkg/policyhandler \
  -run '^(TestDownloadScanPolicies_NonPersistentSourcePreservesSharedFallback|TestDownloadReleasedPolicyArtifactPersistence)$' \
  -count=1

go vet ./core/cautils/getter ./core/pkg/policyhandler
git diff --check
```

All commands pass with Go 1.26.0.

## Compatibility

- No CLI, report schema, or cache-read behavior changes.
- Rolling downloads and getters that do not opt out retain the current persistence behavior.
- Explicit local policy inputs remain non-persistent.
- Merged #3234's in-memory local-source bypass remains intact; the current branch is rebased on it and the corresponding regression still passes.

## Related issues/PRs

- #2494, #2498, and #2515 introduced/versioned pinned policy selection.
- Merged #3233 / #3234 fixes in-memory local-policy cache isolation.
- This PR fixes the independent on-disk release-provenance boundary.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the provenance-sensitive behavior
- [x] I have performed a self-review of the change
- [x] Framework and control write paths have deterministic regression coverage
- [x] New and existing affected-package tests pass normally and under the race detector
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pinned release policies from overwriting shared fallback policy caches.
  * Locally supplied policies are no longer persisted to shared caches.
  * Preserved existing fallback policies when downloads come from non-persistent sources.
  * Unpinned release policies continue to be eligible for caching.
  * Ensured current policy downloads remain available without replacing reusable fallback policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->