### PR TITLE
fix(streaming): report complete resource telemetry

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -307,6 +307,22 @@ func streamingResourceScope(obj workloadinterface.IMetadata, namespaced *bool) s
 	return cautils.ClusterScope
 }
 
+// streamingKubernetesResourceCount returns the number of unique Kubernetes
+// resources retained across the resident and namespace batches. A single
+// resource scan may add an object to resident that was already collected in a
+// namespace batch, so resident IDs are excluded from the namespace count.
+func streamingKubernetesResourceCount(resident *cautils.ResourceBatch, namespaceBatches map[string]*cautils.ResourceBatch) int {
+	count := len(resident.AllResources)
+	for _, batch := range namespaceBatches {
+		for id := range batch.AllResources {
+			if _, alreadyCounted := resident.AllResources[id]; !alreadyCounted {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // collectAndStreamBatches pulls every queryable GVR exactly once, partitions
 // the results into a single resident batch (cluster-scoped and external
 // resources) and one batch per namespace, then streams the resident batch
@@ -406,6 +422,21 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		addSingleResourceToResourceMaps(resident.K8SResources, allResources, sessionObj.SingleResourceScan, resolver)
 	}
 
+	// Match the eager collector's metric timing: report the complete Kubernetes
+	// resource snapshot before adding host, RBAC, or cloud resources. Resource
+	// telemetry is independent of the worker-node LIST and must survive a node
+	// permission or transport failure.
+	metrics.UpdateKubernetesResourcesCount(ctx, int64(streamingKubernetesResourceCount(resident, namespaceBatches)))
+	if k8sHandler.k8s != nil {
+		numberOfWorkerNodes, err := k8sHandler.pullWorkerNodesNumber(ctx)
+		if err != nil {
+			logger.L().Debug("failed to collect worker nodes number", helpers.Error(err))
+		} else {
+			sessionObj.SetNumberOfWorkerNodes(numberOfWorkerNodes)
+			metrics.UpdateWorkerNodesCount(ctx, int64(numberOfWorkerNodes))
+		}
+	}
+
 	hostResources := cautils.MapHostResources(ksResourceMap)
 	// check that controls use host sensor resources
 	if len(hostResources) > 0 {
@@ -475,17 +506,6 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 	// concurrent write against that read. ProcessWithStreaming copies the
 	// resident batch into the processor (sessionObj) after receiving it, so the
 	// maps still land on the session by the time downstream stages run.
-
-	if k8sHandler.k8s != nil {
-		numberOfWorkerNodes, err := k8sHandler.pullWorkerNodesNumber(ctx)
-		if err != nil {
-			logger.L().Debug("failed to collect worker nodes number", helpers.Error(err))
-		} else {
-			sessionObj.SetNumberOfWorkerNodes(numberOfWorkerNodes)
-			metrics.UpdateKubernetesResourcesCount(ctx, int64(len(allResources)))
-			metrics.UpdateWorkerNodesCount(ctx, int64(numberOfWorkerNodes))
-		}
-	}
 
 	// Stream resident batch first.
 	select {

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -6,13 +6,18 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v3/core/metrics"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -273,6 +278,74 @@ func TestCollectAndStreamBatches_CountsNamespacedResourcesAcrossBatches(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, session.Metadata.ContextMetadata.ClusterContextMetadata)
 	assert.Equal(t, map[string]int{"ns-a": 2}, session.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
+}
+
+func TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails(t *testing.T) {
+	previousProvider := otel.GetMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	metrics.Init()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(previousProvider)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	ctx := context.Background()
+	twoPods := &unstructured.UnstructuredList{
+		Object: map[string]any{"apiVersion": "v1", "kind": "PodList"},
+		Items: []unstructured.Unstructured{
+			{Object: map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "a", "namespace": "ns-a"}}},
+			{Object: map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "b", "namespace": "ns-b"}}},
+		},
+	}
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, twoPods, nil
+	})
+	client, ok := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	require.True(t, ok)
+	client.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden: cannot list nodes")
+	})
+
+	scanInfo, session := streamingTestSession(ctx)
+	namespaced := true
+	const podsGVR = "/v1/pods"
+	queryable := QueryableResources{
+		podsGVR: {
+			GroupVersionResourceTriplet: podsGVR,
+			Namespaced:                  &namespaced,
+		},
+	}
+	batches := make(chan *cautils.ResourceBatch, 3)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		nil,
+	)
+
+	require.NoError(t, err)
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != "kubescape_kubernetes_resources_count" {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			assert.Equal(t, int64(2), sum.DataPoints[0].Value)
+			return
+		}
+	}
+	t.Fatal("kubescape_kubernetes_resources_count was not recorded")
 }
 
 func TestCollectAndStreamBatches_RecordsPartialSelectorFailure(t *testing.T) {

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -280,6 +280,20 @@ func TestCollectAndStreamBatches_CountsNamespacedResourcesAcrossBatches(t *testi
 	assert.Equal(t, map[string]int{"ns-a": 2}, session.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources)
 }
 
+func TestStreamingKubernetesResourceCount_DeduplicatesResidentOverlap(t *testing.T) {
+	resident := cautils.NewResourceBatch(cautils.ClusterScope)
+	resident.AllResources["resident-only"] = nil
+	resident.AllResources["shared"] = nil
+
+	namespaced := cautils.NewResourceBatch("team-a")
+	namespaced.AllResources["namespaced-only"] = nil
+	namespaced.AllResources["shared"] = nil
+
+	assert.Equal(t, 3, streamingKubernetesResourceCount(resident, map[string]*cautils.ResourceBatch{
+		"team-a": namespaced,
+	}))
+}
+
 func TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails(t *testing.T) {
 	previousProvider := otel.GetMeterProvider()
 	reader := sdkmetric.NewManualReader()


### PR DESCRIPTION
Fixes #3259.

## Overview

A streaming scan currently supplies an incomplete Kubernetes resource snapshot to OpenTelemetry:

- `allResources` aliases the resident batch, so `len(allResources)` omits every object held in a namespace batch;
- the resource update is nested inside the successful worker-node LIST branch, so a Node RBAC or transport failure suppresses an otherwise valid resource observation;
- the update happens after host/RBAC/cloud collection, rather than at the eager collector's Kubernetes-snapshot boundary.

This change makes the streaming producer follow the eager collector's single-scan contract.

## What changed

- Count unique Kubernetes resource IDs across the resident batch and every namespace batch after single-resource injection.
- Exclude an ID already present in the resident batch, preserving single-resource-scan deduplication without allocating another O(N) set.
- Record the Kubernetes resource snapshot before host, RBAC, and cloud resources are added.
- Make resource telemetry independent of worker-node collection.
- Keep worker-node telemetry best-effort: it is still updated only after a successful Node LIST.

## Compatibility and scope

The telemetry schema is unchanged:

- metric names and meter scope are unchanged;
- instrument types and aggregation shape are unchanged;
- attributes and time-series cardinality are unchanged;
- scan evaluation, report schemas, and output formats are unchanged.

This PR fixes only the value and occurrence of the observation produced by one streaming scan. It does not change streaming batch orchestration, namespace selection, progress reporting, or report aggregation.

Merged #3248 prevents successive absolute snapshots from accumulating across repeated scans. This PR is complementary: it ensures that the streaming call site supplies a complete single-scan snapshot, including when the independent Node LIST fails. The branch is rebased onto #3248 and the combined behavior is covered by the current-base tests below.

## Regression coverage

`TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails` uses the OpenTelemetry SDK `ManualReader` with:

- two namespaced Pods retained in separate namespace batches;
- a deterministic `forbidden: cannot list nodes` response;
- a successful streaming collection;
- an exported Kubernetes resource count of `2`.

Before the production fix, the test fails with:

```text
kubescape_kubernetes_resources_count was not recorded
```

`TestStreamingKubernetesResourceCount_DeduplicatesResidentOverlap` separately verifies that an ID present in both the resident and namespace batches is counted once.

## Validation

After rebasing onto `master` at `355e4432bdf7feec15df902c265a4dbec8f3bb87`:

```bash
go test ./core/pkg/resourcehandler \
  -run '^(TestStreamingKubernetesResourceCount_DeduplicatesResidentOverlap|TestCollectAndStreamBatches_(CountsNamespacedResourcesAcrossBatches|ReportsAllKubernetesResourcesWhenNodeCountFails|CleanSuccessHasNoFailureMetadata|RecordsPartialSelectorFailure))$' \
  -count=1

go test -race ./core/pkg/resourcehandler \
  -run '^(TestStreamingKubernetesResourceCount_DeduplicatesResidentOverlap|TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails)$' \
  -count=1

go test ./core/pkg/resourcehandler -count=1 -skip '^TestGetResourcesFromPath'
go vet ./core/pkg/resourcehandler
git diff --check
```

All commands pass. The unfiltered package run remains unsuitable in this restricted workspace because the pre-existing `TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative` launches a git subprocess that can wait on unavailable repository/network behavior; excluding that unrelated path-test family, the complete package passes.

## Related work / duplicate check

- #2808 / #2809 fixes report namespace metadata and host-sensor parity, not the OpenTelemetry resource snapshot. The current metric placement originated in #2809.
- #2796 / #2797 covers the overlapping host-sensor/report issue.
- Merged #3247 / #3248 fixes repeated-scan accumulation, not this single-scan producer bug.
- #2645 introduced the streaming collector.
- Merged #3235 / #3236 removes a temporary whole-cluster map used for namespace report metadata. This branch is rebased on that change and preserves its independent report-counting behavior.

## Checklist

- [x] Single-scan streaming behavior only
- [x] No public API or report-schema change
- [x] No metric schema or cardinality change
- [x] Node failure, namespaced resources, and overlap deduplication covered
- [x] Rebased and validated with merged #3236 and #3248
- [x] Normal, race, full affected package (with unrelated path-test exclusion), vet, and diff checks pass
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes resource metrics to count overlapping resources only once.
  * Ensured total Kubernetes resource metrics remain available even when worker-node collection fails.
  * Resource metric collection now operates independently from worker-node data gathering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->