### PR TITLE
fix(scan): keep CRD policy clients target-scoped

### DIFF
--- a/core/cautils/getter/crdcontrolinputs.go
+++ b/core/cautils/getter/crdcontrolinputs.go
@@ -43,9 +43,17 @@ func NewCRDControlInputs() (*CRDControlInputs, error) {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
-	return &CRDControlInputs{
-		client: dynamicClient,
-	}, nil
+	return NewCRDControlInputsWithClient(dynamicClient)
+}
+
+// NewCRDControlInputsWithClient creates a control-input getter from the dynamic
+// client already selected for the scan target.
+func NewCRDControlInputsWithClient(dynamicClient dynamic.Interface) (*CRDControlInputs, error) {
+	if dynamicClient == nil {
+		return nil, fmt.Errorf("kubernetes dynamic client is nil")
+	}
+
+	return &CRDControlInputs{client: dynamicClient}, nil
 }
 
 // GetControlsInputs retrieves control inputs from the ControlInput CRD.

--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -67,6 +67,17 @@ func NewCRDExceptionsGetter(k8sClient client.Client) *CRDExceptionsGetter {
 	return getter
 }
 
+// NewCRDExceptionsGetterWithClients creates a CRD-backed exceptions getter from
+// clients that belong to the same scan target. Callers that already resolved a
+// Kubernetes target should use this constructor instead of consulting the
+// process-global Kubernetes configuration again.
+func NewCRDExceptionsGetterWithClients(dynamicClient dynamic.Interface, k8sClient client.Client) *CRDExceptionsGetter {
+	return &CRDExceptionsGetter{
+		client:    dynamicClient,
+		k8sClient: k8sClient,
+	}
+}
+
 func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]armotypes.PostureExceptionPolicy, error) {
 	if g == nil || g.client == nil {
 		return []armotypes.PostureExceptionPolicy{}, nil

--- a/core/core/crd_target_client_test.go
+++ b/core/core/crd_target_client_test.go
@@ -1,0 +1,166 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/dynamic"
+	restclient "k8s.io/client-go/rest"
+)
+
+func TestCRDPolicyGettersUseScanTargetClient(t *testing.T) {
+	var globalRequests atomic.Int64
+	globalServer := newCRDPolicyAPIServer(t, "global", &globalRequests)
+	defer globalServer.Close()
+
+	var targetRequests atomic.Int64
+	targetServer := newCRDPolicyAPIServer(t, "target", &targetRequests)
+	defer targetServer.Close()
+
+	previousConfig := k8sinterface.K8SConfig
+	previousConnected := k8sinterface.IsConnectedToCluster()
+	k8sinterface.K8SConfig = &restclient.Config{Host: globalServer.URL}
+	k8sinterface.SetConnectedToCluster(true)
+	t.Cleanup(func() {
+		k8sinterface.K8SConfig = previousConfig
+		k8sinterface.SetConnectedToCluster(previousConnected)
+	})
+
+	targetConfig := &restclient.Config{Host: targetServer.URL}
+	targetDynamic, err := dynamic.NewForConfig(targetConfig)
+	require.NoError(t, err)
+	target := &k8sinterface.KubernetesApi{
+		DynamicClient: targetDynamic,
+		K8SConfig:     targetConfig,
+	}
+
+	controlInputsGetter, fromCache, err := getConfigInputsGetterForTarget(
+		context.Background(), "", "", nil, true, false, target,
+	)
+	require.NoError(t, err)
+	assert.False(t, fromCache)
+	controlInputs, err := controlInputsGetter.GetControlsInputs(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"target"}, controlInputs["source"])
+
+	exceptionsPath := filepath.Join(t.TempDir(), "exceptions.json")
+	require.NoError(t, os.WriteFile(exceptionsPath, []byte("[]"), 0o600))
+	exceptionsGetter, exceptionsFromCache, err := getExceptionsGetterForTarget(
+		context.Background(), exceptionsPath, "", nil, false, target,
+	)
+	require.NoError(t, err)
+	assert.False(t, exceptionsFromCache)
+	exceptions, err := exceptionsGetter.GetExceptions(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, exceptions, 1)
+	assert.Equal(t, "target-exception/C-0001", exceptions[0].Name)
+	require.Len(t, exceptions[0].Resources, 1)
+	assert.Equal(t, "target-ns", exceptions[0].Resources[0].Attributes["namespace"])
+
+	assert.Zero(t, globalRequests.Load(), "CRD policy reads must not consult the process-global API server")
+	assert.Positive(t, targetRequests.Load())
+}
+
+func newCRDPolicyAPIServer(t *testing.T, source string, requests *atomic.Int64) *httptest.Server {
+	t.Helper()
+
+	writeJSON := func(w http.ResponseWriter, value any) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(value); err != nil {
+			t.Errorf("encode fake Kubernetes API response: %v", err)
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch r.URL.Path {
+		case "/api":
+			writeJSON(w, map[string]any{
+				"apiVersion": "v1",
+				"kind":       "APIVersions",
+				"versions":   []string{"v1"},
+			})
+		case "/apis":
+			writeJSON(w, map[string]any{
+				"apiVersion": "v1",
+				"kind":       "APIGroupList",
+				"groups":     []any{},
+			})
+		case "/api/v1":
+			writeJSON(w, map[string]any{
+				"apiVersion":   "v1",
+				"kind":         "APIResourceList",
+				"groupVersion": "v1",
+				"resources": []map[string]any{{
+					"name":         "namespaces",
+					"singularName": "namespace",
+					"namespaced":   false,
+					"kind":         "Namespace",
+					"verbs":        []string{"get", "list"},
+				}},
+			})
+		case "/api/v1/namespaces":
+			writeJSON(w, map[string]any{
+				"apiVersion": "v1",
+				"kind":       "NamespaceList",
+				"items": []map[string]any{{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]any{
+						"name":   source + "-ns",
+						"labels": map[string]string{"source": source},
+					},
+				}},
+			})
+		case "/apis/kubescape.io/v1/controlinputs/default":
+			writeJSON(w, map[string]any{
+				"apiVersion": "kubescape.io/v1",
+				"kind":       "ControlInput",
+				"metadata":   map[string]any{"name": "default"},
+				"spec": map[string]any{
+					"controls": map[string]any{"source": []string{source}},
+				},
+			})
+		case "/apis/kubescape.io/v1beta1/securityexceptions":
+			writeJSON(w, map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "SecurityExceptionList",
+				"items":      []any{},
+			})
+		case "/apis/kubescape.io/v1beta1/clustersecurityexceptions":
+			writeJSON(w, map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "ClusterSecurityExceptionList",
+				"items": []map[string]any{{
+					"apiVersion": "kubescape.io/v1beta1",
+					"kind":       "ClusterSecurityException",
+					"metadata": map[string]any{
+						"name": source + "-exception",
+					},
+					"spec": map[string]any{
+						"match": map[string]any{
+							"namespaceSelector": map[string]any{
+								"matchLabels": map[string]string{"source": source},
+							},
+						},
+						"posture": []map[string]any{{
+							"controlID": "C-0001",
+							"action":    "ignore",
+						}},
+					},
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	restclient "k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,11 +33,16 @@ func getKubernetesApi() *k8sinterface.KubernetesApi {
 	return k8sinterface.NewKubernetesApi()
 }
 
-func getExceptionsK8sClient(ctx context.Context) client.Client {
-	if !k8sinterface.IsConnectedToCluster() {
-		return nil
+func getExceptionsK8sClient(ctx context.Context, target *k8sinterface.KubernetesApi) client.Client {
+	var config *restclient.Config
+	if target != nil {
+		config = target.K8SConfig
+	} else {
+		if !k8sinterface.IsConnectedToCluster() {
+			return nil
+		}
+		config = k8sinterface.GetK8sConfig()
 	}
-	config := k8sinterface.GetK8sConfig()
 	if config == nil {
 		return nil
 	}
@@ -58,22 +64,32 @@ type releasedExceptionsGetter interface {
 	SetRegoObjectsWithFallback() (bool, error)
 }
 
+func newCRDExceptionsGetter(ctx context.Context, target *k8sinterface.KubernetesApi) *getter.CRDExceptionsGetter {
+	k8sClient := getExceptionsK8sClient(ctx, target)
+	if target != nil {
+		return getter.NewCRDExceptionsGetterWithClients(target.DynamicClient, k8sClient)
+	}
+	return getter.NewCRDExceptionsGetter(k8sClient)
+}
+
 // getExceptionsGetter returns the selected getter and whether an online
 // GitHub source degraded to the bundled cache. Explicit local/air-gapped
 // sources are intentional selections and therefore do not count as fallback.
 func getExceptionsGetter(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool) (getter.IExceptionsGetter, bool, error) {
+	return getExceptionsGetterForTarget(ctx, useExceptions, accountID, downloadReleasedPolicy, airGapped, nil)
+}
+
+func getExceptionsGetterForTarget(ctx context.Context, useExceptions string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, airGapped bool, target *k8sinterface.KubernetesApi) (getter.IExceptionsGetter, bool, error) {
 	var primary getter.IExceptionsGetter
 
 	if useExceptions != "" {
 		// load exceptions from file
 		primary = getter.NewLoadPolicy([]string{useExceptions})
-		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
+		return getter.NewMergedExceptionsGetter(primary, newCRDExceptionsGetter(ctx, target)), false, nil
 	}
 	if airGapped {
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
-		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
+		return getter.NewMergedExceptionsGetter(primary, newCRDExceptionsGetter(ctx, target)), false, nil
 	}
 	if accountID != "" {
 		if downloadReleasedPolicy != nil && downloadReleasedPolicy.IsVersionPinned() {
@@ -81,20 +97,23 @@ func getExceptionsGetter(ctx context.Context, useExceptions string, accountID st
 		}
 		// download exceptions from Kubescape Cloud backend
 		primary = getter.GetKSCloudAPIAdapter()
-		k8sClient := getExceptionsK8sClient(ctx)
-		return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), false, nil
+		return getter.NewMergedExceptionsGetter(primary, newCRDExceptionsGetter(ctx, target)), false, nil
 	}
 	// download exceptions from GitHub
 	if downloadReleasedPolicy == nil {
 		downloadReleasedPolicy = getter.NewDownloadReleasedPolicy()
 	}
-	return getReleasedExceptionsGetter(ctx, downloadReleasedPolicy)
+	return getReleasedExceptionsGetterForTarget(ctx, downloadReleasedPolicy, target)
 }
 
 // getReleasedExceptionsGetter reports whether the GitHub release could not be
 // fetched and the bundled local cache is being used instead. The caller must
 // preserve that signal because cached exceptions can change scan findings.
 func getReleasedExceptionsGetter(ctx context.Context, downloadReleasedPolicy releasedExceptionsGetter) (getter.IExceptionsGetter, bool, error) {
+	return getReleasedExceptionsGetterForTarget(ctx, downloadReleasedPolicy, nil)
+}
+
+func getReleasedExceptionsGetterForTarget(ctx context.Context, downloadReleasedPolicy releasedExceptionsGetter, target *k8sinterface.KubernetesApi) (getter.IExceptionsGetter, bool, error) {
 	var primary getter.IExceptionsGetter = downloadReleasedPolicy
 	fallback, err := downloadReleasedPolicy.SetRegoObjectsWithFallback()
 	if err != nil {
@@ -105,9 +124,7 @@ func getReleasedExceptionsGetter(ctx context.Context, downloadReleasedPolicy rel
 		logger.L().Ctx(ctx).Warning("failed to get exceptions from github release, loading exceptions from cache")
 		primary = getter.NewLoadPolicy([]string{getter.GetDefaultPath(cautils.LocalExceptionsFilename)})
 	}
-	k8sClient := getExceptionsK8sClient(ctx)
-	return getter.NewMergedExceptionsGetter(primary, getter.NewCRDExceptionsGetter(k8sClient)), fallback, nil
-
+	return getter.NewMergedExceptionsGetter(primary, newCRDExceptionsGetter(ctx, target)), fallback, nil
 }
 
 func getRBACHandler(tenantConfig cautils.ITenantConfig, k8s *k8sinterface.KubernetesApi, submit bool) *cautils.RBACObjects {
@@ -316,6 +333,10 @@ func getPolicyGetter(ctx context.Context, loadPoliciesFromFile []string, account
 // whether the inputs are served from the local cache fallback (GitHub download
 // failed) rather than fetched fresh, so the caller can record a PolicyDegradation.
 func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool) (getter.IControlsInputsGetter, bool, error) {
+	return getConfigInputsGetterForTarget(ctx, ControlsInputs, accountID, downloadReleasedPolicy, useCRD, airGapped, nil)
+}
+
+func getConfigInputsGetterForTarget(ctx context.Context, ControlsInputs string, accountID string, downloadReleasedPolicy *getter.DownloadReleasedPolicy, useCRD bool, airGapped bool, target *k8sinterface.KubernetesApi) (getter.IControlsInputsGetter, bool, error) {
 	if len(ControlsInputs) > 0 {
 		return getter.NewLoadPolicy([]string{ControlsInputs}), false, nil
 	}
@@ -332,7 +353,14 @@ func getConfigInputsGetter(ctx context.Context, ControlsInputs string, accountID
 
 	// Try to read control inputs from the ControlInput CRD in-cluster (live cluster scans only)
 	if useCRD {
-		if crdInputs, err := getter.NewCRDControlInputs(); err == nil {
+		var crdInputs *getter.CRDControlInputs
+		var err error
+		if target != nil {
+			crdInputs, err = getter.NewCRDControlInputsWithClient(target.DynamicClient)
+		} else {
+			crdInputs, err = getter.NewCRDControlInputs()
+		}
+		if err == nil {
 			if _, crdErr := crdInputs.GetControlsInputs(ctx, ""); crdErr == nil {
 				logger.L().Ctx(ctx).Info("using ControlInput CRD for control configuration")
 				return crdInputs, false, nil

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -253,13 +253,13 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 		return nil, err
 	}
 	var controlInputsFromCache bool
-	getters.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetter(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped)
+	getters.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetterForTarget(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped, interfaces.k8s)
 	if err != nil {
 		spanInit.End()
 		return nil, err
 	}
 	var exceptionsFromCache bool
-	getters.ExceptionsGetter, exceptionsFromCache, err = getExceptionsGetter(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+	getters.ExceptionsGetter, exceptionsFromCache, err = getExceptionsGetterForTarget(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped, interfaces.k8s)
 	if err != nil {
 		spanInit.End()
 		return nil, err


### PR DESCRIPTION
Fixes #3261.

## Overview

Keep CRD-backed policy reads on the same Kubernetes target that `Scan` already resolved for resource collection.

Previously, ControlInput and SecurityException initialization discarded `componentInterfaces.k8s` and rebuilt clients from process-global Kubernetes configuration. The exceptions path performed two independent global lookups: one for its dynamic CRD client and another for its controller-runtime namespace client. A scan could therefore evaluate resources and CRD policy data from different configuration snapshots.

In the normal serialized CLI path, the materialized target and global configuration initially refer to the same endpoint, so this is behavior-preserving while that state remains stable. The correction removes the latent second client-selection path when a concrete target already exists; it does not claim the default CLI changes global state during every scan.

## What changed

- add `NewCRDControlInputsWithClient` for callers that already own a dynamic client;
- add `NewCRDExceptionsGetterWithClients` for a coherent dynamic/controller-runtime client pair;
- preserve the existing exported constructors as compatibility wrappers;
- add internal target-aware initialization wrappers without changing existing helper signatures;
- pass the `KubernetesApi` already stored in `componentInterfaces` from `Scan`;
- build namespace-selector resolution from `target.K8SConfig` and perform CRD reads through `target.DynamicClient`;
- preserve the exceptions release-to-cache fallback signal and its PolicyDegradation handling from merged #3241.

## Regression coverage

`TestCRDPolicyGettersUseScanTargetClient` uses two independent `httptest` Kubernetes API servers:

- the process-global endpoint returns `global` ControlInput, SecurityException, and Namespace data;
- the injected scan target returns corresponding `target` data.

The test verifies the target ControlInput value, the target exception, and target namespace-selector resolution. It also asserts that the global server receives exactly zero requests and that the explicit-file path does not report a cache fallback.

Existing #3241 regressions verify that the legacy and target-aware integration retain the three-result `(getter, fromCache, error)` contract and degradation signal.

## Compatibility and scope

- Existing exported constructor signatures remain available.
- Existing internal helper signatures remain available through nil-target wrappers.
- File scans and callers without a resolved target keep the current compatibility path.
- Policy merge, fallback/degradation, matching, scoring, report schemas, and output formats are unchanged.
- No command or context-switching behavior is added.

## Validation

After rebasing onto `master` at `685eab2b0cbb5fbf9840d7f4ec2e3f4b400264d9`:

```bash
go test ./core/cautils/getter ./core/core \
  -run '^(TestCRDPolicyGettersUseScanTargetClient|TestGetExceptionsGetter|TestGetReleasedExceptionsGetterReportsCacheFallback|TestGettersAirGappedUseCache|TestPinnedVersionGettersReturnHardError)$' \
  -count=1

go test -race ./core/core \
  -run '^TestCRDPolicyGettersUseScanTargetClient$' \
  -count=1

go vet ./core/cautils/getter ./core/core
git diff --check
```

All commands pass. The complete getter and core packages also passed on the immediately preceding rebase; the later upstream changes applied cleanly and the current-base targeted, race, and vet checks above were rerun.

## Related work

- #2702 addresses synchronization while lazily loading global Kubernetes configuration; this PR removes later global reads from the target-aware CRD policy path.
- #2772 / #2775 address context propagation and are orthogonal to client selection.
- Merged #3218 handles global configuration invalidation before target construction. This PR only reuses the target object after construction and does not alter context selection.
- Merged #3241 records release-to-cache exception fallback. This rebase preserves its three-result helper contract and threads that signal through the target-aware path.

## Checklist

- [x] Single-scan client-coherence fix only
- [x] Backward-compatible exported constructors and helper wrappers
- [x] Two-endpoint regression covers both CRD sources and namespace resolution
- [x] Cache-fallback degradation contract preserved
- [x] Normal, race, vet, and diff checks pass on current master
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scanning a specified Kubernetes cluster target.
  * Control inputs and security exceptions now load from the selected cluster when available.
  * Default cluster behavior remains supported when no target is provided.

* **Bug Fixes**
  * Improved reliability in multi-cluster environments by ensuring scans use data from the intended cluster.
  * Prevented cluster-specific policy settings from being read from the wrong Kubernetes environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->