### PR TITLE
fix(scan): reject trailing JSON manifest data

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -842,6 +843,18 @@ func readJsonFile(jsonFile []byte) (workloads []workloadinterface.IMetadata, err
 	decoder.UseNumber()
 	if err := decoder.Decode(&jsonObj); err != nil {
 		return workloads, err
+	}
+
+	// A manifest file must contain exactly one top-level JSON value. Decoder.Decode
+	// intentionally stops after the first value, so without this EOF check a file
+	// containing a valid manifest followed by another value or malformed trailing
+	// data is accepted and the unscanned suffix is silently ignored.
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return workloads, errors.New("multiple top-level JSON values are not supported; use a JSON array or Kubernetes List")
+		}
+		return workloads, fmt.Errorf("invalid trailing JSON data: %w", err)
 	}
 
 	if convertErr := convertJsonToWorkload(jsonObj, &workloads); convertErr != nil {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -49,6 +49,21 @@ func TestLoadResourcesFromFiles(t *testing.T) {
 	}
 }
 
+func TestLoadResourcesFromFiles_RejectsTrailingJSONInExplicitFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifests.json")
+	data := []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"first"}}
+{"apiVersion":"v1","kind":"Service","metadata":{"name":"second"}}`)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	workloads, skipped, err := LoadResourcesFromFiles(context.Background(), path, filepath.Dir(path), nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "multiple top-level JSON values")
+	assert.Empty(t, workloads)
+	require.Len(t, skipped, 1)
+	assert.Equal(t, path, skipped[0].Path)
+}
+
 func TestLoadResourcesFromFiles_SupportsMixedCaseExtensions(t *testing.T) {
 	o, _ := os.Getwd()
 	testDir := filepath.Join(o, "testdata", "mixed_extensions")
@@ -1031,6 +1046,25 @@ func TestReadJsonFile(t *testing.T) {
 			content:   `{not valid json`,
 			wantCount: 0,
 			wantErr:   true,
+		},
+		{
+			name: "concatenated JSON objects are rejected instead of scanning only the first",
+			content: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"first"}}
+				{"apiVersion":"v1","kind":"Service","metadata":{"name":"ignored-before-fix"}}`,
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "valid manifest followed by malformed data is rejected",
+			content:   `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"first"}} trailing`,
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name: "trailing whitespace remains valid",
+			content: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"whitespace"}}
+				   `,
+			wantCount: 1,
 		},
 		{
 			name:      "empty JSON object (no kind) returns no workloads",


### PR DESCRIPTION
Fixes #3263.

## Overview

Reject unread data after the first top-level JSON manifest value.

`readJsonFile` previously called `json.Decoder.Decode` once and immediately converted the decoded object. Because `Decode` stops after one complete value, a second object or malformed suffix was silently omitted while the first object was returned as successfully loaded scan input.

## Change

After the first decode, perform one additional decode into `json.RawMessage` and require `io.EOF`:

- EOF accepts trailing whitespace;
- a successful second decode reports multiple top-level values and points users to a JSON array or Kubernetes List;
- any other decoder error reports malformed trailing JSON data.

The check happens before converting the first value, so a partially read file cannot be returned as successful input.

## Regression coverage

Added parser cases for:

- two concatenated Kubernetes objects;
- one valid object followed by malformed bytes;
- one valid object followed only by whitespace.

An end-to-end `LoadResourcesFromFiles` test uses an explicitly requested file containing a Pod followed by a Service and verifies:

- an error containing `multiple top-level JSON values` is returned;
- no partial workload is returned;
- the file path is present in the skipped-manifest record.

The base implementation fails this regression because it returns the first Pod with no error.

## Compatibility and scope

- JSON arrays remain supported.
- Kubernetes `List` and typed-list envelopes remain supported.
- Number handling remains on `UseNumber`.
- YAML loading is unchanged.
- Cluster scans, policy evaluation, output schemas, and command flags are unchanged.
- This is a local single-scan input-integrity fix.

## Validation

After rebasing onto `master` at `355e4432bdf7feec15df902c265a4dbec8f3bb87`:

```bash
go test ./core/cautils \
  -run '^(TestReadJsonFile|TestLoadResourcesFromFiles_RejectsTrailingJSONInExplicitFile)$' \
  -count=1

go test -race ./core/cautils \
  -run '^(TestReadJsonFile|TestLoadResourcesFromFiles_RejectsTrailingJSONInExplicitFile)$' \
  -count=1

go test ./core/cautils -count=1 -timeout=5m
go vet ./core/cautils
git diff --check
```

All commands pass on the current base.

## Related work

- #2546 propagates parser failures to explicit-file callers; this PR makes the previously invisible suffix a parser failure.
- #2820 covers arrays and Kubernetes List envelopes, which remain valid multi-object JSON shapes.

## Checklist

- [x] Deterministic base-fail regression
- [x] No partial first object returned on invalid input
- [x] Supported multi-object document shapes preserved
- [x] Normal, race, full package, vet, and diff checks pass
- [x] DCO sign-off included