### PR TITLE
fix(config): mask the cached access key in `config view` output

### DIFF
--- a/core/cautils/config_output.go
+++ b/core/cautils/config_output.go
@@ -73,6 +73,30 @@ func configOutputFields(cfg *ConfigObj) []configOutputField {
 		{name: "clusterName", value: cfg.ClusterName},
 		{name: "cloudReportURL", value: cfg.CloudReportURL},
 		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
-		{name: "accessKey", value: cfg.AccessKey},
+		{name: "accessKey", value: maskAccessKey(cfg.AccessKey)},
 	}
+}
+
+// accessKeyMask replaces the secret part of the access key when it is rendered.
+const accessKeyMask = "****"
+
+// maskAccessKey hides the cached access key. The key is a Kubescape Cloud
+// credential - it is persisted with 0600 permissions and elsewhere only ever
+// logged by length - while this output is written straight to stdout,
+// including in the CI logs and shared terminals the command is documented
+// for. Only the last four characters are kept, so an operator can still tell
+// which key is cached, and the mask has a fixed width so the length of the key
+// is not disclosed either.
+// The key itself remains readable in the config file for anyone who needs it.
+func maskAccessKey(accessKey string) string {
+	if accessKey == "" {
+		return ""
+	}
+	// Keeping the tail of a short key would give away most of it, so such a
+	// key is masked in full.
+	key := []rune(accessKey)
+	if len(key) <= 8 {
+		return accessKeyMask
+	}
+	return accessKeyMask + string(key[len(key)-4:])
 }

--- a/core/cautils/config_output_test.go
+++ b/core/cautils/config_output_test.go
@@ -33,9 +33,12 @@ func TestFormatConfigOutputYAML(t *testing.T) {
 	output, err := FormatConfigOutput(cfg, "yaml", true)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(output), "accountID: account-123")
-	assert.Contains(t, string(output), "accessKey: super-secret")
-	assert.Contains(t, string(output), "clusterName: prod-cluster")
+	var payload map[string]string
+	require.NoError(t, yaml.Unmarshal(output, &payload))
+
+	assert.Equal(t, "account-123", payload["accountID"])
+	assert.Equal(t, "****cret", payload["accessKey"])
+	assert.Equal(t, "prod-cluster", payload["clusterName"])
 }
 
 func TestFormatConfigOutputText(t *testing.T) {
@@ -162,4 +165,43 @@ func TestFormatConfigOutputYAMLParsesAsMap(t *testing.T) {
 	assert.Equal(t, "https://api.example.com", payload["cloudAPIURL"])
 	assert.Equal(t, "https://report.example.com", payload["cloudReportURL"])
 	assert.NotContains(t, payload, "accessKey")
+}
+
+func TestFormatConfigOutputMasksAccessKey(t *testing.T) {
+	const accessKey = "test-access-key-1234"
+	cfg := &ConfigObj{AccountID: "account-123", AccessKey: accessKey}
+
+	for _, format := range []string{"text", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			output, err := FormatConfigOutput(cfg, format, false)
+			require.NoError(t, err)
+
+			assert.NotContains(t, string(output), accessKey)
+			assert.Contains(t, string(output), "****1234")
+			assert.Contains(t, string(output), "account-123")
+		})
+	}
+}
+
+func TestFormatConfigOutputMasksShortAccessKeyInFull(t *testing.T) {
+	for _, accessKey := range []string{"k", "12345678"} {
+		t.Run(accessKey, func(t *testing.T) {
+			output, err := FormatConfigOutput(&ConfigObj{AccessKey: accessKey}, "text", false)
+			require.NoError(t, err)
+
+			assert.Equal(t, "accessKey: ****\n", string(output))
+		})
+	}
+}
+
+func TestFormatConfigOutputKeepsEmptyAccessKeyEmpty(t *testing.T) {
+	output, err := FormatConfigOutput(&ConfigObj{AccountID: "account-123"}, "json", true)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(output, &payload))
+
+	accessKey, ok := payload["accessKey"]
+	require.True(t, ok, "--include-empty must still render the accessKey field")
+	assert.Equal(t, "", accessKey)
 }

--- a/docs/config-output.md
+++ b/docs/config-output.md
@@ -117,6 +117,12 @@ The rendered fields use stable lower camel case names:
 - `cloudAPIURL`
 - `accessKey`
 
+`accessKey` is a credential, so it is rendered masked in every format: only its
+last four characters are shown, prefixed with `****` (a key of eight characters
+or fewer is masked in full). The command is meant for CI logs and shared
+terminals, so it never prints the key itself; read the cached configuration file
+directly if you need the full value.
+
 By default, fields with empty values are not rendered. This keeps terminal
 output short and avoids noisy structured payloads in scripts that only need
 configured values.


### PR DESCRIPTION
## Overview

`kubescape config view` printed the cached Kubescape Cloud **access key in full** to stdout, in every output format.

Current behavior:

```console
$ kubescape config view
accountID: account-123
clusterName: prod-cluster
cloudReportURL: https://report.example.com
cloudAPIURL: https://api.example.com
accessKey: test-access-key-1234
```

The access key is treated as a secret everywhere else: the config file is written `0600` inside a `0700` directory, `configMarshal` carries an explicit `//nolint:gosec // G117: AccessKey is intentionally persisted to the local config file`, and the one log line that touches it logs `len()` rather than the value. Meanwhile `docs/config-output.md` recommends `config view` precisely for "CI logs and shared terminals", where the printed key is retained and readable by anyone with access to the job.

Future behavior:

```console
$ kubescape config view
accountID: account-123
clusterName: prod-cluster
cloudReportURL: https://report.example.com
cloudAPIURL: https://api.example.com
accessKey: ****1234
```

## Additional Information

The masking lives in `FormatConfigOutput`, which is display-only and has a single caller (`Kubescape.ViewCachedConfig`), so nothing that actually authenticates is affected and the stored configuration is untouched.

- the last four characters are kept so an operator can still tell which key is cached
- the mask has a fixed width, so the length of the key is not disclosed either
- a key of eight characters or fewer is masked in full, since its tail would give away most of it
- an empty key still renders as empty, so `--include-empty` and the omit-empty default behave exactly as before

`docs/config-output.md` now documents the masking in the output contract, and points at the config file for anyone who needs the full value.

## How to Test

```console
$ mkdir -p "$HOME/.kubescape"
$ cat > "$HOME/.kubescape/config.json" <<'JSON'
{"accountID":"account-123","accessKey":"test-access-key-1234"}
JSON
$ kubescape config view
$ kubescape config view -o json
$ kubescape config view -o yaml --include-empty
```

Before this change all three print the key verbatim; after it they print `****1234`, and `~/.kubescape/config.json` still holds the real value.

Unit tests:

```console
$ go test ./core/cautils/ -run TestFormatConfigOutput
```

`TestFormatConfigOutputMasksAccessKey` (text/json/yaml), `TestFormatConfigOutputMasksShortAccessKeyInFull` and `TestFormatConfigOutputKeepsEmptyAccessKeyEmpty` are new and fail on `master`. `TestFormatConfigOutputYAML` previously asserted the full secret was rendered, so it was updated to assert the masked value instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Configuration output now masks access keys in text, JSON, and YAML formats.
  * Longer keys display only the final four characters; shorter non-empty keys are fully masked.
  * Empty access keys remain empty when empty fields are included.

* **Documentation**
  * Updated configuration output guidance to describe access-key masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->