### PR TITLE
fix(scan): preserve exact manifest file selection

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -735,6 +736,11 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 		paths = append(paths, pattern)
 		return paths, errs
 	}
+	// A concrete path is an exact scan target. Do not reinterpret a missing
+	// file as a recursive basename pattern and silently scan a nested namesake.
+	if !isDir(pattern) && !hasGlobMeta(pattern) {
+		return paths, errs
+	}
 
 	root, shouldMatch := filepath.Split(pattern)
 
@@ -753,6 +759,15 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 	}
 
 	return paths, errs
+}
+
+// hasGlobMeta mirrors the set of magic characters recognized by filepath.Match.
+func hasGlobMeta(path string) bool {
+	magicChars := `*?[`
+	if runtime.GOOS != "windows" {
+		magicChars = `*?[\`
+	}
+	return strings.ContainsAny(path, magicChars)
 }
 
 func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err error) {

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -34,6 +34,28 @@ func TestListFiles(t *testing.T) {
 	assert.Equal(t, 13, len(files))
 }
 
+func TestLoadResourcesFromFilesDoesNotSubstituteNestedBasenameForMissingExactPath(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "manifest.yaml"), []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: nested
+`), 0o600))
+
+	requestedPath := filepath.Join(root, "manifest.yaml")
+	workloads, skipped, err := LoadResourcesFromFiles(context.Background(), requestedPath, root, nil)
+
+	require.ErrorIs(t, err, ErrNoManifestFiles)
+	assert.Empty(t, workloads)
+	assert.Empty(t, skipped)
+
+	workloads, _, err = LoadResourcesFromFiles(context.Background(), filepath.Join(root, "*.yaml"), root, nil)
+	require.NoError(t, err)
+	assert.Contains(t, workloads, filepath.Join(nestedDir, "manifest.yaml"), "explicit glob behavior must remain recursive")
+}
+
 func TestLoadResourcesFromFiles(t *testing.T) {
 	workloads, _, err := LoadResourcesFromFiles(context.Background(), onlineBoutiquePath(), "", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #3265.

## Overview

Preserve the identity of an explicitly requested local manifest path.

When a concrete file path did not exist, `listFilesOrDirectories` skipped its existing-file fast path, split the input into parent directory plus basename, and recursively matched that basename against descendants. A request for `/repo/manifest.yaml` could therefore succeed by loading `/repo/nested/manifest.yaml`.

This change treats non-existent paths without glob metacharacters as exact inputs. The existing caller then returns `ErrNoManifestFiles` instead of scanning a different file.

## Change

- Detect the metacharacters recognized by `filepath.Match`, including the platform-specific backslash rule.
- If the input is neither an existing directory nor an explicit glob, return no discovery matches.
- Preserve the existing direct path for real files.
- Preserve recursive discovery for real directories.
- Preserve recursive matching for explicit globs such as `/repo/*.yaml`.

The guard is in the shared file/directory discovery helper so all callers retain the same concrete-path boundary.

## Regression coverage

`TestLoadResourcesFromFilesDoesNotSubstituteNestedBasenameForMissingExactPath` creates:

```text
repo/
└── nested/
    └── manifest.yaml
```

It then requests the missing `repo/manifest.yaml` and verifies:

- `ErrNoManifestFiles` is returned;
- no workloads or skipped manifests are returned;
- the nested Pod is not selected.

The same test then passes the explicit `repo/*.yaml` glob and verifies that recursive glob discovery still finds the nested manifest.

Against the base implementation, the first assertion fails because the missing exact path returns success and loads the namesake.

## Compatibility and scope

- Existing files and directories retain their current behavior.
- Explicit glob behavior is unchanged.
- A missing bare path no longer doubles as an implicit recursive basename pattern; callers that intentionally want pattern matching must use explicit metacharacters.
- Parsing, policy evaluation, cluster scans, report schemas, and output formats are unchanged.
- This is a local single-scan input-selection fix.

## Validation

On `master` at `355e4432bdf7feec15df902c265a4dbec8f3bb87`:

```bash
go test ./core/cautils \
  -run '^TestLoadResourcesFromFilesDoesNotSubstituteNestedBasenameForMissingExactPath$' \
  -count=1

go test -race ./core/cautils \
  -run '^TestLoadResourcesFromFilesDoesNotSubstituteNestedBasenameForMissingExactPath$' \
  -count=1

go test ./core/cautils -count=1 -timeout=5m
go vet ./core/cautils
git diff --check
```

All commands pass. The regression was also run against the unmodified base and deterministically failed with `expected ErrNoManifestFiles ... got nil`.

## Related work / duplicate check

Searches for missing/nonexistent manifest paths, recursive basename matching, exact file selection, and `listFiles` found no matching issue or PR.

- #2546 surfaces parser errors after a file has been selected.
- #3263 / #3264 rejects unread trailing content inside an existing JSON file.

Neither addresses path substitution when the requested artifact is absent.

## Checklist

- [x] Deterministic base-fail regression
- [x] Existing file/directory behavior preserved
- [x] Explicit recursive glob behavior preserved
- [x] Normal, focused race, full package, vet, and diff checks pass
- [x] DCO sign-off included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected manifest file detection so explicitly specified paths are handled as exact targets.
  * Missing manifest paths now return the appropriate error instead of unexpectedly selecting a nested file with the same name.
  * Recursive glob patterns continue to discover matching manifests as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->