### PR TITLE
fix(cautils): use sync.Once to safely stop PortForwarder without dropping stop signals (#3272)

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	v1 "k8s.io/api/core/v1"
@@ -23,6 +24,7 @@ type portForward struct {
 	*portforward.PortForwarder
 	localPort string
 	stopChan  chan struct{}
+	stopOnce  sync.Once
 	readyChan chan struct{}
 	errChan   chan error
 	out       *bytes.Buffer
@@ -111,11 +113,11 @@ func (p *portForward) GetPortForwardLocalhost() string {
 	return "localhost:" + p.localPort
 }
 
+// StopPortForwarder safely terminates the port forwarder by closing the stop channel idempotently.
 func (p *portForward) StopPortForwarder() {
-	select {
-	case p.stopChan <- struct{}{}:
-	default:
-	}
+	p.stopOnce.Do(func() {
+		close(p.stopChan)
+	})
 }
 
 func (p *portForward) StartPortForwarder() error {

--- a/core/cautils/portforwarder_test.go
+++ b/core/cautils/portforwarder_test.go
@@ -303,9 +303,11 @@ func Test_GetPortForwardLocalhost(t *testing.T) {
 		})
 	}
 }
+// TestStopPortForwarder_Idempotent verifies that repeated or concurrent calls to StopPortForwarder
+// safely close the stop channel and never panic or block.
 func TestStopPortForwarder_Idempotent(t *testing.T) {
 	p := &portForward{
-		stopChan: make(chan struct{}, 1),
+		stopChan: make(chan struct{}),
 	}
 
 	done := make(chan struct{})
@@ -321,4 +323,18 @@ func TestStopPortForwarder_Idempotent(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("StopPortForwarder blocked on repeated stop")
 	}
+
+	// Verify the channel was closed so all readers receive the stop broadcast
+	select {
+	case _, ok := <-p.stopChan:
+		assert.False(t, ok, "stopChan must be closed")
+	default:
+		t.Fatal("stopChan was not closed by StopPortForwarder")
+	}
+
+	// Assert repeated calls do not panic
+	assert.NotPanics(t, func() {
+		p.StopPortForwarder()
+		p.StopPortForwarder()
+	})
 }


### PR DESCRIPTION

## Overview
Ensures `StopPortForwarder()` closes `stopChan` using `sync.Once` instead of a non-blocking channel send that could drop stop signals during I/O waits or background loops.

### Problem
`StopPortForwarder()` attempted to signal `stopChan` using a non-blocking select:
```go
select {
case p.stopChan <- struct{}{}:
default:
}
```
If called while `ForwardPorts()` was in a blocking network I/O wait, initialization phase, or not actively receiving on `stopChan`, the `default:` branch executed, silently discarding the stop signal and leaking the background goroutine and socket listener.

### Changes
- Added `stopOnce sync.Once` to the `portForward` struct in `core/cautils/portforwarder.go`.
- Updated `StopPortForwarder()` to close `p.stopChan` inside `p.stopOnce.Do`, satisfying client-go's broadcast closure contract.
- Added Go docstring to `StopPortForwarder`.
- Updated `TestStopPortForwarder_Idempotent` in `portforwarder_test.go` to verify channel closure and idempotent, non-panicking termination.

## How to Test
Run the portforwarder unit tests and static analysis:
```bash
go test -v -run TestStopPortForwarder ./core/cautils/...
go vet ./core/cautils/...
go build -v .
```

## Related issues/PRs:
* Resolved #3272

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port-forwarder shutdown reliability.
  * Repeated or concurrent stop requests now complete safely without blocking or causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->