### PR TITLE
fix(scan): report parse failures suppressed by "{{" content sniff

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -667,11 +667,15 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 
 		w, e := ReadFile(f, getFileFormat(filePaths[i]))
 		if e != nil {
-			// Raw Helm templates are a best-effort fallback when chart rendering
-			// fails. Go-template actions are not valid YAML, so keep scanning any
-			// static templates without treating templated siblings as corrupt
-			// standalone manifests.
-			if !bytes.Contains(f, []byte("{{")) {
+			// Only chart-owned templates/ files reach this loader unrendered —
+			// excludeHelmTemplateFiles drops the templates of every chart whose
+			// render succeeded — and their Go-template actions are not valid
+			// YAML, so record the drop without treating it as manifest
+			// corruption. Any other parse failure is always reported: "{{" in a
+			// comment, label value or string is not evidence of a template.
+			if isUnrenderedHelmTemplate(filePaths[i]) {
+				skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: "unrendered Helm template: " + e.Error()})
+			} else {
 				errs = append(errs, fmt.Errorf("failed to parse %q: %w", filePaths[i], e))
 				skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: "parse error: " + e.Error()})
 			}
@@ -695,6 +699,28 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 		}
 	}
 	return workloads, skips, errs
+}
+
+// isUnrenderedHelmTemplate reports whether path lives below the templates/
+// directory of a Helm chart, detected with the same chart-directory check
+// chart discovery uses. excludeHelmTemplateFiles removes the templates of
+// every chart whose render succeeded, so a chart-owned file parsed here
+// belongs to a chart whose render failed; its Go-template actions are
+// expected to be unparseable as plain YAML.
+func isUnrenderedHelmTemplate(path string) bool {
+	dir := filepath.Dir(path)
+	for {
+		if filepath.Base(dir) == "templates" {
+			if isChart, err := IsHelmDirectory(filepath.Dir(dir)); err == nil && isChart {
+				return true
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
 }
 
 func loadFile(filePath string) ([]byte, error) {

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -325,4 +326,107 @@ func TestLoadResourcesFromFiles_IgnoresChartMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, workloads, filepath.Join(dir, "valid.yaml"))
 	assert.Empty(t, skips, "Chart.yaml, Chart.lock and values.yaml must not be reported as skipped manifests")
+}
+
+// A manifest that merely contains Go-template syntax must not have its parse
+// failure silenced: "{{" in the content is not evidence that a file is a Helm
+// template, only its location below a chart's templates/ directory is.
+const corruptManifestWithTemplateSyntax = `apiVersion: v1
+kind: Pod
+metadata:
+  name: corrupt
+  annotations:
+    owner: "{{ .Values.owner }}"
+spec: [unterminated
+`
+
+func TestLoadResourcesFromFilesReportsCorruptManifestContainingTemplateSyntax(t *testing.T) {
+	dir := t.TempDir()
+	corrupt := writeManifestFixture(t, dir, "corrupt.yaml", corruptManifestWithTemplateSyntax)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), corrupt, dir, nil)
+
+	require.Error(t, err)
+	assert.Empty(t, workloads)
+	require.Len(t, skips, 1)
+	assert.Equal(t, corrupt, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "parse error")
+	assert.Contains(t, err.Error(), strconv.Quote(corrupt))
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestLoadResourcesFromFilesKeepsValidResourcesWhenCorruptManifestContainsTemplateSyntax(t *testing.T) {
+	dir := t.TempDir()
+	valid := writeManifestFixture(t, dir, "valid.yaml", validPodManifest)
+	corrupt := writeManifestFixture(t, dir, "corrupt.yaml", corruptManifestWithTemplateSyntax)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), dir, dir, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, workloads, valid)
+	assert.Len(t, workloads[valid], 1)
+	assert.NotContains(t, workloads, corrupt)
+	require.Len(t, skips, 1)
+	assert.Equal(t, corrupt, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "parse error")
+}
+
+// A "templates" directory whose parent holds no Chart.yaml is not a Helm
+// chart, so a parse failure below it is plain manifest corruption.
+func TestLoadResourcesFromFilesTreatsTemplateSyntaxOutsideChartsAsCorruption(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "templates"), 0o700))
+	corrupt := writeManifestFixture(t, dir, filepath.Join("templates", "corrupt.yaml"), corruptManifestWithTemplateSyntax)
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), corrupt, dir, nil)
+
+	require.Error(t, err)
+	assert.Empty(t, workloads)
+	require.Len(t, skips, 1)
+	assert.Equal(t, corrupt, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "parse error")
+}
+
+// The plain-file fallback for a chart whose render failed must keep its drops
+// visible: templated templates are recorded as unrendered Helm templates,
+// while static siblings are still scanned.
+func TestLoadResourcesFromFilesRecordsUnrenderedChartTemplatesAsSkips(t *testing.T) {
+	testDir := helmChartLayoutPath()
+
+	workloads, skips, err := LoadResourcesFromFiles(context.Background(), testDir, testDir, nil)
+
+	require.NoError(t, err)
+	staticTemplate := filepath.Join(testDir, "mychart", "templates", "serviceaccount.yaml")
+	require.Contains(t, workloads, staticTemplate, "static templates must still be scanned when their chart did not render")
+
+	require.Len(t, skips, 2)
+	for _, skip := range skips {
+		assert.True(t, strings.HasPrefix(skip.Reason, "unrendered Helm template"), "unexpected skip reason %q", skip.Reason)
+		assert.Contains(t, skip.Path, filepath.Join("templates"), "templated files outside templates/ must not be classified as unrendered")
+	}
+}
+
+func TestIsUnrenderedHelmTemplate(t *testing.T) {
+	dir := t.TempDir()
+	chart := filepath.Join(dir, "mychart")
+	require.NoError(t, os.MkdirAll(filepath.Join(chart, "templates", "sub"), 0o700))
+	writeManifestFixture(t, chart, "Chart.yaml", "apiVersion: v2\nname: mychart\nversion: 0.1.0\n")
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"chart template", filepath.Join(chart, "templates", "deployment.yaml"), true},
+		{"nested chart template", filepath.Join(chart, "templates", "sub", "role.yaml"), true},
+		{"templates directory without Chart.yaml", filepath.Join(dir, "templates", "deployment.yaml"), false},
+		{"sibling sharing the templates prefix", filepath.Join(chart, "templates-docs", "deployment.yaml"), false},
+		{"chart file outside templates", filepath.Join(chart, "values.yaml"), false},
+		{"chart root itself", chart, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isUnrenderedHelmTemplate(tc.path))
+		})
+	}
 }


### PR DESCRIPTION
## Overview

**Current behavior:** `loadFiles()` suppresses the parse failure of any manifest whose content contains `{{` (`core/cautils/fileutils.go`). The guard was added to keep the Helm-render fallback quiet — a chart whose render failed leaves its raw templates in the plain-file loader, and Go-template actions are not valid YAML — but it classifies by a substring of the file's content. So a corrupt *plain* manifest with `{{` in a comment, annotation, or label value is silently dropped: no error, no skip entry, never scanned, and invisible to the skip summary added in #3031. Since file scans often run against untrusted repo content in CI, a manifest can be hidden from the scan just by including `{{` alongside a syntax error.

**Future behavior:** the fallback is distinguished by the file's role, not its content. A parse failure in a file living under a chart's `templates/` directory (detected with `IsHelmDirectory`, the same chart check discovery uses) is recorded as a visible `unrendered Helm template` skip; every other parse failure is always reported as an error plus a skip entry. Behavior that is unchanged: partial workloads from multi-document files still contribute, the best-effort directory policy (warn instead of fail while valid resources load) still holds, and successfully rendered charts never reach this path.

Fixes #3267

## How to Test

```sh
mkdir /tmp/repro && cd /tmp/repro

cat > bad-templated.yaml <<'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: hidden-pod
  annotations:
    owner: "{{ .Values.owner }}"
spec: [unterminated
EOF

cat > good-pod.yaml <<'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: good-pod
spec:
  containers:
    - name: app
      image: nginx:latest
      securityContext:
        privileged: true
EOF

kubescape scan framework nsa .
```

On `master` the scan exits 0 and `bad-templated.yaml` is mentioned zero times in the entire output — the privileged-pod manifest is silently excluded. With this change the same scan surfaces:

```text
[warning] Skipping invalid manifest files. error: ... failed to parse ".../bad-templated.yaml": document 1: yaml: line 6: did not find expected ',' or ']'
[warning] 1 manifests skipped during scan
[warning]   .../bad-templated.yaml: parse error: document 1: yaml: line 6: did not find expected ',' or ']'
```

Also worth checking:

- `kubescape scan framework nsa bad-templated.yaml` (explicit single file) now fails with the real parse error instead of the misleading `no scannable Kubernetes resources found for input ...`
- `kubescape scan framework nsa <healthy-chart-dir>` renders normally with no spurious "unrendered" skips
- unit tests: `go test -race ./core/cautils/...` — the four new regression tests fail on the previous guard and pass with this change

## Examples/Screenshots

Terminal output is pasted under "How to Test" (before/after of the same directory scan).

## Additional Information

- The content-based guard originated in #2546; the general dropped-file surfacing discussion is #3027 (closed by #3031). This guard was a stronger suppression because it bypassed that skip tracking entirely.
- Local verification before opening: `go test -race` on all six affected packages, full `go test ./...` (53 packages), `golangci-lint run --new-from-rev` against the base commit (0 issues), and `smoke_testing/init.py` against a fresh build (exit 0, all output formats).
- Branch is rebased on current `master`; no overlapping files with recent upstream commits.

## Related issues/PRs

* Resolved #3267

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved manifest parsing so invalid files are reported as errors instead of being incorrectly treated as Helm templates.
  - Helm template files are now recognized only when located within a valid chart’s `templates/` directory.
  - Static chart files continue to be scanned even when templated files are skipped.
  - Added clearer handling for corrupt manifests containing Helm-like syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->