### PR TITLE
fix(results): preserve exception audit in programmatic JSON

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -114,6 +114,7 @@ func (rh *ResultsHandler) ToJson() ([]byte, error) {
 		Results        []resultWithEnrichment       `json:"results,omitempty"`
 		ResourceLabels map[string]map[string]string `json:"resourceLabels,omitempty"`
 		ScanCoverage   *cautils.ScanCoverage        `json:"scanCoverage,omitempty"`
+		ExceptionAudit *cautils.ExceptionAudit      `json:"exceptionAudit,omitempty"`
 	}{
 		PostureReport: finalizedReport,
 		SummaryDetails: summaryWithEnrichment{
@@ -123,6 +124,7 @@ func (rh *ResultsHandler) ToJson() ([]byte, error) {
 		Results:        results,
 		ResourceLabels: enrichedReport.ResourceLabels,
 		ScanCoverage:   enrichedReport.ScanCoverage,
+		ExceptionAudit: rh.ScanData.ExceptionAudit,
 	}
 
 	return json.Marshal(&output)

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -608,6 +608,35 @@ func TestToJson(t *testing.T) {
 	// verify it is valid JSON
 	var out map[string]any
 	assert.NoError(t, json.Unmarshal(data, &out))
+	assert.NotContains(t, out, "exceptionAudit")
+}
+
+func TestToJsonIncludesExceptionAuditWhenSet(t *testing.T) {
+	rh := makeResultsHandler(75.0, 50.0)
+	rh.ScanData.ExceptionAudit = &cautils.ExceptionAudit{
+		Generated: true,
+		Summary: cautils.ExceptionAuditSummary{
+			Total:   1,
+			Active:  1,
+			Matched: 1,
+		},
+		Items: []cautils.ExceptionAuditItem{{
+			Name:       "matched-exception",
+			Status:     "matched",
+			MatchCount: 1,
+			ControlIDs: []string{"C-0001"},
+		}},
+	}
+
+	data, err := rh.ToJson()
+	require.NoError(t, err)
+
+	var out struct {
+		ExceptionAudit *cautils.ExceptionAudit `json:"exceptionAudit"`
+	}
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.NotNil(t, out.ExceptionAudit)
+	assert.Equal(t, rh.ScanData.ExceptionAudit, out.ExceptionAudit)
 }
 
 // requireJSONSubset verifies that every value in the legacy JSON remains at


### PR DESCRIPTION
Fixes #3276.

## Overview

Preserve generated exception-audit evidence in the programmatic JSON representation used by `ResultsHandler.ToJson()` and canonical HTTP result persistence.

The v2 JSON file printer already emits `OPASessionObj.ExceptionAudit`. The programmatic serializer rebuilt an additive DTO without that field, so it returned valid but incomplete JSON.

## What changed

- Add optional `exceptionAudit` to the existing `ToJson()` output DTO.
- Populate it directly from the scan session.
- Keep nil audits omitted with `omitempty`.
- Add exact round-trip coverage for a generated matched-exception audit.
- Pin the established nil behavior so scans without auditing gain no new field.

## Production propagation

`persistCanonicalResult` already writes `result.ToJson()` directly to the canonical result artifact. No HTTP-specific serialization change is needed: preserving the field at this single boundary fixes both programmatic callers and canonical persistence. The existing raw-message result reader retains additive JSON fields.

## Compatibility and scope

- `ResultsHandler.ToJson()` keeps its existing signature.
- The change is additive only when an audit was generated.
- Nil audits remain absent from JSON.
- Legacy posture-report fields, enriched controls, resource labels, scan coverage, raw resources, and timestamp precision are unchanged.
- Scan evaluation, exception matching, scoring, submission payloads, and file-printer behavior are unchanged.

## Regression proof

With the new test applied alone to base `355e4432bdf7feec15df902c265a4dbec8f3bb87`:

```text
--- FAIL: TestToJsonIncludesExceptionAuditWhenSet
    Error: Expected value not to be nil.
FAIL
```

With this change, the audit round-trips exactly and the nil case remains omitted.

## Validation

```bash
go test -p=1 ./core/pkg/resultshandling \
  -run '^(TestToJson|TestToJsonIncludesExceptionAuditWhenSet|TestResultsHandlerToJSONPreservesLegacyFieldsAndAddsEnrichment)$' \
  -count=1

go test -p=1 ./core/pkg/resultshandling -count=1 -timeout=10m
go vet -p=1 ./core/pkg/resultshandling
go test -race -p=1 ./core/pkg/resultshandling \
  -run '^TestToJsonIncludesExceptionAuditWhenSet$' \
  -count=1 -timeout=10m
git diff --check
```

All commands pass on Go 1.26.0.

## Related work / duplicate check

- #3094 / #3095 introduced opt-in exception audits and JSON-printer coverage.
- #2861 / #2862 established the compatibility-preserving `ToJson()` enrichment DTO and canonical raw-message retention.
- Exact issue/PR searches found no existing report or implementation for this dropped field.

## Checklist

- [x] Deterministic base-fail regression
- [x] Optional/additive JSON change only
- [x] Programmatic and canonical persistence paths covered at their shared boundary
- [x] Focused, full-package, vet, and race checks pass
- [x] DCO sign-off included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON results now include exception audit details when available.
  * Exception audit information is omitted when no data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->