### PR TITLE
fix(scan): reject NaN posture thresholds

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 
@@ -235,10 +236,7 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if scanInfo.Submit.GetBool() && scanInfo.Local {
 		return ErrKeepLocalOrSubmit
 	}
-	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
-		return ErrBadThreshold
-	}
-	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
+	if postureThresholdsOutOfRange(scanInfo) {
 		return ErrBadThreshold
 	}
 	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
@@ -277,11 +275,15 @@ func validateControlTimeout(scanInfo *cautils.ScanInfo) error {
 // Unlike validateFrameworkScanInfo, this function does not mutate scanInfo
 // or enforce unrelated constraints.
 func validateThresholdsOnly(scanInfo *cautils.ScanInfo) error {
-	if 100 < scanInfo.ComplianceThreshold || 0 > scanInfo.ComplianceThreshold {
-		return ErrBadThreshold
-	}
-	if 100 < scanInfo.FailCoverageThreshold || 0 > scanInfo.FailCoverageThreshold {
+	if postureThresholdsOutOfRange(scanInfo) {
 		return ErrBadThreshold
 	}
 	return validateControlTimeout(scanInfo)
+}
+
+func postureThresholdsOutOfRange(scanInfo *cautils.ScanInfo) bool {
+	return math.IsNaN(float64(scanInfo.ComplianceThreshold)) ||
+		math.IsNaN(float64(scanInfo.FailCoverageThreshold)) ||
+		scanInfo.ComplianceThreshold < 0 || scanInfo.ComplianceThreshold > 100 ||
+		scanInfo.FailCoverageThreshold < 0 || scanInfo.FailCoverageThreshold > 100
 }

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"math"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/cmd/shared"
@@ -117,6 +118,16 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 			ErrBadThreshold,
 		},
 		{
+			"NaN compliance threshold should be invalid",
+			&cautils.ScanInfo{ComplianceThreshold: float32(math.NaN()), AccountID: validAccountID},
+			ErrBadThreshold,
+		},
+		{
+			"NaN coverage threshold should be invalid",
+			&cautils.ScanInfo{FailCoverageThreshold: float32(math.NaN()), AccountID: validAccountID},
+			ErrBadThreshold,
+		},
+		{
 			"Invalid account ID should be rejected",
 			&cautils.ScanInfo{AccountID: "not-a-uuid"},
 			nil,
@@ -174,6 +185,7 @@ func Test_validateCoverageThreshold(t *testing.T) {
 		{"100 is a valid threshold", &cautils.ScanInfo{FailCoverageThreshold: 100}, nil},
 		{"101 is out of range", &cautils.ScanInfo{FailCoverageThreshold: 101}, ErrBadThreshold},
 		{"negative value is out of range", &cautils.ScanInfo{FailCoverageThreshold: -1}, ErrBadThreshold},
+		{"NaN is out of range", &cautils.ScanInfo{FailCoverageThreshold: float32(math.NaN())}, ErrBadThreshold},
 	}
 
 	for _, tc := range testCases {
@@ -196,6 +208,7 @@ func Test_validateThresholdsOnly_Compliance(t *testing.T) {
 		{"Compliance threshold below 0 is out of range", &cautils.ScanInfo{ComplianceThreshold: -1}, ErrBadThreshold},
 		{"Compliance threshold at 0 is valid", &cautils.ScanInfo{ComplianceThreshold: 0}, nil},
 		{"Compliance threshold at 100 is valid", &cautils.ScanInfo{ComplianceThreshold: 100}, nil},
+		{"NaN compliance threshold is out of range", &cautils.ScanInfo{ComplianceThreshold: float32(math.NaN())}, ErrBadThreshold},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #3278.

## Overview

Posture scan commands validated `--compliance-threshold` and `--fail-coverage-below` only with finite-style lower/upper-bound comparisons. pflag accepts `NaN` for `Float32` flags, and every ordered comparison with NaN is false.

The value therefore passed posture validation and also bypassed the later compliance or coverage comparison, allowing a requested CI failure gate to fail open.

This change rejects NaN with the existing `scan.ErrBadThreshold` result before scanning starts.

## Affected behavior

Before:

```bash
kubescape scan framework nsa pod.yaml --compliance-threshold NaN
# scan proceeds; complianceScore < NaN is false

kubescape scan framework nsa pod.yaml --fail-coverage-below NaN
# scan proceeds; coverageScore < NaN is false
```

The affected validators serve the bare posture, framework, control, and workload paths. Compliance gating remains intentionally inapplicable to workload scans, while workload coverage validation is corrected.

Image and patch commands already reject NaN through `shared.ValidateThresholds`.

## What changed

- Add a package-local `postureThresholdsOutOfRange` predicate for the two active posture percentage fields.
- Reject NaN in addition to the existing `[0, 100]` bounds.
- Use the same predicate from `validateFrameworkScanInfo` and `validateThresholdsOnly`.
- Add regressions for both fields through both posture validation paths.

## Why the shared validator is not called directly

`cmd/shared.ValidateThresholds` also validates the removed legacy `ScanInfo.FailThreshold` field and returns `shared.ErrBadThreshold`. The posture package has an established, distinct `scan.ErrBadThreshold` sentinel, and existing tests/callers compare it by identity.

Calling the shared validator directly would either broaden posture validation to a legacy field or change its error identity. The local helper keeps the change bounded: validation order, accepted finite values, legacy-field behavior, and the existing sentinel are unchanged.

## Compatibility and scope

- No exported API, CLI flag, or report-schema changes.
- All previously valid finite values remain valid.
- Existing finite out-of-range inputs return the same error object.
- The only newly rejected inputs are NaN values, which cannot represent a percentage.
- Image and patch behavior is unchanged.

## Regression proof

With the four new cases applied alone to base `355e4432bdf7feec15df902c265a4dbec8f3bb87`, each fails because the validator returns `nil` rather than `scan.ErrBadThreshold`.

With this change, all four return the established error sentinel.

## Validation

```bash
go test -p=1 ./cmd/scan \
  -run '^(Test_validateFrameworkScanInfo|Test_validateCoverageThreshold|Test_validateThresholdsOnly_Compliance)$' \
  -count=1

go test -p=1 ./cmd/scan -count=1

go test -race -p=1 ./cmd/scan \
  -run '^(Test_validateFrameworkScanInfo|Test_validateCoverageThreshold|Test_validateThresholdsOnly_Compliance)$' \
  -count=1

go vet -p=1 ./cmd/scan
git diff --check
```

All commands pass with Go 1.26.0.

## Related work / duplicate check

- #2039 / #2040 and #2260 / #2261 cover ordinary finite range validation.
- #2271 / #2274 cover threshold validation, including NaN, for image and patch commands.
- #3045 proposes broader validation deduplication.
- Exact searches found no existing posture NaN issue or implementation.

## Checklist

- [x] Deterministic base-fail regression
- [x] Both active posture percentage fields covered
- [x] Both posture validation paths covered
- [x] Existing error identity and legacy behavior preserved
- [x] Focused, full-package, race, vet, and diff checks pass
- [x] DCO sign-off included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for compliance and coverage thresholds containing invalid numeric values.
  * Thresholds that are not numbers or fall outside the accepted 0–100 range are now rejected consistently.
  * Preserved validation for control timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->