### PR TITLE
fix(scan): fail closed on unknown-severity findings in --severity-threshold

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -100,7 +100,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
 				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
 			}
-			if err := enforceSeverityThresholds(results.GetResults().SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
+			if err := enforceSeverityThresholds(&results.GetResults().SummaryDetails, scanInfo); err != nil {
 				return err
 			}
 			if scanInfo.ScanImages {

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -121,7 +121,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
 			}
 
-			if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
+			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
 				return err
 			}
 			if scanInfo.ScanImages {
@@ -209,19 +209,48 @@ func enforcePolicyDegradation(coverage cautils.ScanCoverage, scanInfo *cautils.S
 	return fmt.Errorf("scan policy inputs were degraded (fail-on-degraded-config is true)")
 }
 
+// countFailedResourcesWithUnbucketedSeverity returns the number of failed
+// resources on controls whose severity SeverityCounters.Increase silently
+// drops: Unknown, Negligible, and any other severity it has no bucket for.
+// The severity is derived from the control's score factor the same way
+// SummaryDetails.AppendResourceResult derives it when feeding the counters.
+func countFailedResourcesWithUnbucketedSeverity(summaryDetails *reportsummary.SummaryDetails) int {
+	count := 0
+	for _, controlSummary := range summaryDetails.Controls {
+		switch reporthandlingapis.ControlSeverityToString(controlSummary.GetScoreFactor()) {
+		case reporthandlingapis.SeverityCriticalString,
+			reporthandlingapis.SeverityHighString,
+			reporthandlingapis.SeverityMediumString,
+			reporthandlingapis.SeverityLowString:
+		default:
+			count += controlSummary.StatusCounters.Failed()
+		}
+	}
+	return count
+}
+
 // enforceSeverityThresholds ensures that the scan results are below the defined severity threshold
 //
 // The function returns an error if at least one failed control has a severity at or above the set severity threshold
-func enforceSeverityThresholds(severityCounters reportsummary.ISeverityCounters, scanInfo *cautils.ScanInfo) error {
+func enforceSeverityThresholds(summaryDetails *reportsummary.SummaryDetails, scanInfo *cautils.ScanInfo) error {
 	// If a severity threshold is not set, we don’t need to enforce it
 	if scanInfo.FailThresholdSeverity == "" {
 		return nil
 	}
 
-	if val, err := countersExceedSeverityThreshold(severityCounters, scanInfo); val && err == nil {
+	if val, err := countersExceedSeverityThreshold(summaryDetails.GetResourcesSeverityCounters(), scanInfo); val && err == nil {
 		return fmt.Errorf("compliance result exceeds severity threshold: %s", scanInfo.FailThresholdSeverity)
 	} else if err != nil {
 		return err
+	}
+
+	// Failed controls with a zero or missing baseScore never reach the
+	// counters above, so a threshold could pass on findings whose severity
+	// cannot be determined. Fail closed: treat them as at or above any
+	// threshold the user set.
+	if unbucketed := countFailedResourcesWithUnbucketedSeverity(summaryDetails); unbucketed > 0 {
+		logger.L().Warning("failed resources with unknown severity counted toward the severity threshold", helpers.Int("failedResources", unbucketed))
+		return fmt.Errorf("compliance result exceeds severity threshold: %s (%d failed resource(s) with unknown severity)", scanInfo.FailThresholdSeverity, unbucketed)
 	}
 	return nil
 }

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -187,7 +187,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().Float32Var(&scanInfo.FailCoverageThreshold, "fail-coverage-below", 0, "Fail (exit code 1) when the scan coverage score drops below this percentage (0 to disable). The score is the ratio of evaluated controls discounted by 3 points per silent failed GVR pull (a resource type that failed to collect entirely but whose dependent controls still evaluated via other resource types), 2 points per partial GVR pull, and 5 points per degraded policy input, so a scan with every control evaluated can still fail on partial resource collection or fallback policy inputs")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.FailOnDegradedConfig, "fail-on-degraded-config", false, "Fail the scan (exit code 1) if control configurations or exceptions could not be loaded from their configured source and bundled defaults were used instead")
 
-	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.FailThresholdSeverity, "severity-threshold", "", "Severity threshold is the severity of failed controls at which the command fails and returns exit code 1. Failed controls whose severity is unknown (missing base score) are treated as exceeding any threshold")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.OnlyFixable, "only-fixable", false, "When used with --severity-threshold on image scans, only count CVEs that have an available fix toward the pass/fail decision")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ControlsVersion, "controls-version", "", "Pin the regolibrary release tag used to download controls (see https://github.com/kubescape/regolibrary/releases). If not used will download the latest release. Has no effect when --account is set (cloud backend is used instead)")
 
@@ -334,7 +334,7 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifie
 		return err
 	}
 
-	if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), &scanInfo); err != nil {
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, &scanInfo); err != nil {
 		return err
 	}
 	if scanInfo.ScanImages {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -141,21 +141,56 @@ func TestExceedsSeverity(t *testing.T) {
 
 func Test_enforceSeverityThresholds(t *testing.T) {
 	testCases := []struct {
-		Description      string
-		SeverityCounters *reportsummary.SeverityCounters
-		ScanInfo         *cautils.ScanInfo
-		Want             bool
+		Description    string
+		SummaryDetails *reportsummary.SummaryDetails
+		ScanInfo       *cautils.ScanInfo
+		Want           bool
 	}{
 		{
 			"Exceeding Critical severity counter should call the terminating function",
-			&reportsummary.SeverityCounters{CriticalSeverityCounter: 1},
+			&reportsummary.SummaryDetails{ResourcesSeverityCounters: reportsummary.SeverityCounters{CriticalSeverityCounter: 1}},
 			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
 			true,
 		},
 		{
 			"Non-exceeding severity counter should call not the terminating function",
-			&reportsummary.SeverityCounters{},
+			&reportsummary.SummaryDetails{ResourcesSeverityCounters: reportsummary.SeverityCounters{}},
 			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
+			false,
+		},
+		{
+			// Regression: SeverityCounters.Increase silently drops Unknown
+			// severity, so a failing control with a zero score factor never
+			// reaches the counters and used to pass every threshold.
+			"Failed resources on a control with unknown severity trip the lowest threshold",
+			&reportsummary.SummaryDetails{Controls: map[string]reportsummary.ControlSummary{
+				"C-0001": {ScoreFactor: 0, StatusCounters: reportsummary.StatusCounters{FailedResources: 2}},
+			}},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityLowString},
+			true,
+		},
+		{
+			"Failed resources on a control with unknown severity trip the highest threshold",
+			&reportsummary.SummaryDetails{Controls: map[string]reportsummary.ControlSummary{
+				"C-0001": {ScoreFactor: 0, StatusCounters: reportsummary.StatusCounters{FailedResources: 1}},
+			}},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityCriticalString},
+			true,
+		},
+		{
+			"Passed resources on a control with unknown severity do not trip the threshold",
+			&reportsummary.SummaryDetails{Controls: map[string]reportsummary.ControlSummary{
+				"C-0001": {ScoreFactor: 0, StatusCounters: reportsummary.StatusCounters{PassedResources: 3}},
+			}},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityLowString},
+			false,
+		},
+		{
+			"Failed resources on bucketed severities are not counted as unknown",
+			&reportsummary.SummaryDetails{Controls: map[string]reportsummary.ControlSummary{
+				"C-0002": {ScoreFactor: 5, StatusCounters: reportsummary.StatusCounters{FailedResources: 4}},
+			}},
+			&cautils.ScanInfo{FailThresholdSeverity: apis.SeverityHighString},
 			false,
 		},
 	}
@@ -164,17 +199,32 @@ func Test_enforceSeverityThresholds(t *testing.T) {
 		t.Run(
 			tc.Description,
 			func(t *testing.T) {
-				severityCounters := tc.SeverityCounters
+				summaryDetails := tc.SummaryDetails
 				scanInfo := tc.ScanInfo
 				want := tc.Want
 
-				err := enforceSeverityThresholds(severityCounters, scanInfo)
+				err := enforceSeverityThresholds(summaryDetails, scanInfo)
 
 				if (err != nil) != want {
-					t.Errorf("got error: %v, want error: %v", err != nil, want)
+					t.Errorf("got error: %v, want error: %v", err, want)
 				}
 			},
 		)
+	}
+}
+
+func Test_countFailedResourcesWithUnbucketedSeverity(t *testing.T) {
+	summaryDetails := &reportsummary.SummaryDetails{Controls: map[string]reportsummary.ControlSummary{
+		"C-0001": {ScoreFactor: 9.5, StatusCounters: reportsummary.StatusCounters{FailedResources: 3}}, // Critical
+		"C-0002": {ScoreFactor: 0, StatusCounters: reportsummary.StatusCounters{FailedResources: 2}},   // Unknown
+		"C-0003": {ScoreFactor: 2, StatusCounters: reportsummary.StatusCounters{FailedResources: 1}},   // Low
+		"C-0004": {ScoreFactor: 0, StatusCounters: reportsummary.StatusCounters{PassedResources: 7}},   // Unknown, passed only
+	}}
+
+	got := countFailedResourcesWithUnbucketedSeverity(summaryDetails)
+	want := 2
+	if got != want {
+		t.Errorf("got: %d, want: %d", got, want)
 	}
 }
 

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -101,7 +101,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
-			if err := enforceSeverityThresholds(results.GetData().Report.SummaryDetails.GetResourcesSeverityCounters(), scanInfo); err != nil {
+			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
 				return err
 			}
 			if scanInfo.ScanImages {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,7 +54,7 @@ kubescape scan [target] [flags]
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
 | `--scan-images` | Also scan container images for vulnerabilities | `false` |
-| `--severity-threshold <sev>` | Fail if findings at or above severity: `low`, `medium`, `high`, `critical` | - |
+| `--severity-threshold <sev>` | Fail if findings at or above severity: `low`, `medium`, `high`, `critical`. Failed controls with unknown severity (missing base score) are treated as exceeding any threshold | - |
 | `--submit` | Submit results to Kubescape SaaS | `false` |
 | `--use-artifacts-from <path>` | Load artifacts from local directory (offline mode) | - |
 | `--use-from <path>` | Load specific policy from path | - |


### PR DESCRIPTION
## Overview

`--severity-threshold` could never fail the build on a finding whose severity is **unknown** — i.e. a control with a zero or missing `baseScore`. Three pieces line up to cause it:

- `ControlSeverityToString` maps any `baseScore < 1` to `"Unknown"`
- `SeverityCounters.Increase` (opa-utils) only buckets Critical/High/Medium/Low and ends with `default: return`, so `"Unknown"` (and `"Negligible"`) are dropped silently
- `countersExceedSeverityThreshold` reads only those four counters

So a failing control with a zero score factor landed in no bucket the gate inspects, and `--severity-threshold` — even `low` — exited 0. All four scan paths were affected (`scan framework`, `scan control`, `scan workload`, default `scan`) since they all call `enforceSeverityThresholds`. For a CI gate this is a false negative: a user believes their cluster is clean when it isn't.

**After:** `enforceSeverityThresholds` now takes the full `SummaryDetails` and, after the existing counter check, counts failed resources on controls whose severity does not map to one of the four bucketed severities — derived via `ControlSeverityToString(control.GetScoreFactor())`, the exact same derivation `SummaryDetails.AppendResourceResult` uses when feeding the counters — and fails closed, with a warning log so users know why the gate tripped. The counting mirrors `AppendResourceResult` pair-for-pair (per failed resource × failed control), so exceptions/ignored/skipped statuses behave identically.

Notes on scope:

- `--severity-threshold` remains opt-in (default empty = gate disabled), so no user is affected unless they explicitly set the flag
- no output schema change — the helper is read-only over `SummaryDetails.Controls`; printers/prometheus/junit output unchanged
- opa-utils is untouched; adding Unknown/Negligible buckets to `SeverityCounters` upstream would be the longer-term complement (it would also fix the pretty-printer's four-bucket severity summary, which under-reports the same controls) — happy to file that separately in opa-utils
- flag help and `docs/cli-reference.md` document the new behavior

## How to Test

Minimal repro — a single-control framework whose control has no severity (`kubescape download framework nsa`, copy the `C-0016` entry — it carries its rules — into a new framework JSON with `baseScore: 0`), plus any pod without `allowPrivilegeEscalation: false`:

```
kubescape scan framework unknownsev --use-from ./myfw.json ./bad.yaml --severity-threshold low
```

Before/after, run against the same inputs (built from this branch vs. `master`):

```
$ master:  exit code 0   # control fails, severity column shows "Unknown", High/Medium/Low counters all 0
$ this PR: Error: compliance result exceeds severity threshold: low (1 failed resource(s) with unknown severity)
           exit code 1
[warning] failed resources with unknown severity counted toward the severity threshold. failedResources: 1
```

Unit tests: `Test_enforceSeverityThresholds` gained fail-closed cases (unknown severity trips both the lowest and highest thresholds; passed-only unknown controls don't trip; bucketed severities aren't miscounted as unknown), plus `Test_countFailedResourcesWithUnbucketedSeverity` for the counting helper.

## Examples/Screenshots

Before (master) — failure visible, gate silent, exit 0:

```
│ Severity │ Control name               │ Failed resources │ All Resources │ Compliance score │
│  Unknown │ Allow privilege escalation │         1        │       1       │        N/A       │
```

After (this PR) — `Error: compliance result exceeds severity threshold: low (1 failed resource(s) with unknown severity)`, exit 1.

## Related issues/PRs

* Resolves #3280

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes (`go test ./...`, `go test -race ./cmd/scan/...`, httphandler module tests, `golangci-lint` clean on changed packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity thresholds now correctly fail scans when failed resources have unknown or unbucketed severity.
  * Passed resources with unknown severity no longer incorrectly affect threshold enforcement.
  * Severity handling is now consistent across control, framework, and workload scans.

* **Documentation**
  * Clarified that unknown severity exceeds any configured threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->