### PR TITLE
fix: add missing CronJob, ReplicaSet, and Job support to MCP get_configuration_drift tool

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -336,7 +336,7 @@ func createRuntimeToolsAndResources(ksServer *KubescapeMcpserver) {
 		),
 		mcp.WithString("workload_kind",
 			mcp.Required(),
-			mcp.Description("Kind of the workload (e.g., Pod, Deployment, DaemonSet, StatefulSet)."),
+			mcp.Description("Kind of the workload (e.g., Pod, Deployment, DaemonSet, StatefulSet, ReplicaSet, Job, CronJob)."),
 		),
 	)
 
@@ -1077,6 +1077,12 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			workloadObj, err = k8sClient.KubernetesClient.AppsV1().DaemonSets(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
 		case "statefulset":
 			workloadObj, err = k8sClient.KubernetesClient.AppsV1().StatefulSets(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
+		case "replicaset":
+			workloadObj, err = k8sClient.KubernetesClient.AppsV1().ReplicaSets(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
+		case "job":
+			workloadObj, err = k8sClient.KubernetesClient.BatchV1().Jobs(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
+		case "cronjob":
+			workloadObj, err = k8sClient.KubernetesClient.BatchV1().CronJobs(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unsupported workload kind: %s", workloadKindStr)), nil
 		}

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -265,3 +265,35 @@ func TestGetConfigurationDrift_MarshalErrorIsToolError(t *testing.T) {
 	assert.Contains(t, text, "failed to marshal workload manifest")
 	assert.Contains(t, text, "marshal boom")
 }
+
+func TestGetConfigurationDrift_SupportsAllWorkloadKinds(t *testing.T) {
+	profile := &storagev1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-profile", Namespace: "default"},
+	}
+	ksClient := storagefake.NewClientset(profile)
+
+	// The fake k8s client returns "not found" for all workloads, but that's fine:
+	// we only need to verify the tool doesn't reject the kind as "unsupported".
+	ksServer := &KubescapeMcpserver{
+		ksClient: ksClient.SpdxV1beta1(),
+		k8sClient: &k8sinterface.KubernetesApi{
+			KubernetesClient: fake.NewClientset(),
+		},
+	}
+
+	for _, kind := range []string{"pod", "deployment", "daemonset", "statefulset", "replicaset", "job", "cronjob"} {
+		t.Run(kind, func(t *testing.T) {
+			result, err := ksServer.CallTool(context.Background(), "get_configuration_drift", map[string]any{
+				"profile_name":  "test-profile",
+				"workload_name": "test-workload",
+				"workload_kind": kind,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			text := toolResultText(t, result)
+			// The error should be "not found" (workload doesn't exist in the fake client),
+			// NOT "unsupported workload kind" which would mean the kind was rejected.
+			assert.NotContains(t, text, "unsupported workload kind")
+		})
+	}
+}


### PR DESCRIPTION
## Description

The MCP server's `get_configuration_drift` tool only supports `Pod`, `Deployment`, `DaemonSet`, and `StatefulSet` workload kinds. However, the underlying `DetectProfileDrift` function in `prioritizationhandler.go` already supports `CronJob`, `ReplicaSet`, and `Job` as well.

This means requesting configuration drift for a CronJob, ReplicaSet, or Job via the MCP server returns `"unsupported workload kind"` even though the backend can handle them.

## Changes

- Added `replicaset`, `job`, and `cronjob` case branches to the `get_configuration_drift` switch in `mcpserver.go`
- Updated the `workload_kind` tool parameter description to list all supported kinds
- Added `TestGetConfigurationDrift_SupportsAllWorkloadKinds` unit test covering all 7 workload kinds

## Testing

- `go test -v -run TestGetConfigurationDrift_SupportsAllWorkloadKinds ./cmd/mcpserver/` — all 7 subtests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration drift checks now support ReplicaSet, Job, and CronJob workloads in addition to existing workload types.

* **Bug Fixes**
  * Improved handling and validation of supported workload kinds, including clearer errors when requested workloads are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->