### PR TITLE
feat(vap): scope a generated policy binding to specific resources

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -38,6 +38,8 @@ var vapHelperCmdExamples = fmt.Sprintf(`
   %[1]s vap create-policy-binding --name my-policy-binding --policy kubescape-c-0016-allow-privilege-escalation --namespace=my-namespace | kubectl apply -f -
   # Roll a control out in report-only mode before switching it to Deny
   %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --action Audit --action Warn | kubectl apply -f -
+  # Narrow a policy binding to specific resources, including custom ones
+  %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --resource-rule apps/v1/deployments --resource-rule /v1/pods | kubectl apply -f -
 `, cautils.ExecName())
 
 func GetVapHelperCmd() *cobra.Command {
@@ -92,6 +94,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	var namespaceArr []string
 	var labelArr []string
 	var actionArr []string
+	var resourceRuleArr []string
 	var parameterReference string
 	var outputFile string
 
@@ -163,7 +166,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				}
 			}
 
-			content, err := createPolicyBinding(policyBindingName, resolvedPolicyName, actions, parameterReference, namespaceArr, labelArr)
+			content, err := createPolicyBinding(policyBindingName, resolvedPolicyName, actions, parameterReference, namespaceArr, labelArr, resourceRuleArr)
 			if err != nil {
 				return err
 			}
@@ -178,6 +181,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector")
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringSliceVarP(&actionArr, "action", "a", []string{string(admissionv1.Deny)}, "Action to take when policy fails, repeatable (Deny, Warn, Audit). Deny and Warn cannot be combined")
+	createPolicyBindingCmd.Flags().StringSliceVar(&resourceRuleArr, "resource-rule", []string{}, "Restrict the binding to a group/version/resource, repeatable (e.g. apps/v1/deployments, /v1/pods). Omit to bind everything the policy matches")
 	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Parameter reference object name")
 	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
@@ -386,8 +390,70 @@ func isSupportedValidationAction(action admissionv1.ValidationAction) bool {
 	return false
 }
 
+// resourceRuleParts is the group/version/resource form of --resource-rule. The
+// resource keeps any subresource, so "apps/v1/deployments/scale" still splits
+// into three.
+const resourceRuleParts = 3
+
+// parseResourceRule turns a "group/version/resource" value into a rule for the
+// binding's matchResources. The core group is the empty first segment
+// ("/v1/pods") and "*" is accepted in any segment.
+//
+// Operations stay at "*" because a binding intersects with the policy's
+// matchConstraints, which already declares the operations the policy cares
+// about; narrowing them here could only drop matches the policy intends.
+func parseResourceRule(rule string) (admissionv1.NamedRuleWithOperations, error) {
+	parts := strings.SplitN(strings.TrimSpace(rule), "/", resourceRuleParts)
+	if len(parts) != resourceRuleParts {
+		return admissionv1.NamedRuleWithOperations{}, fmt.Errorf("invalid resource rule %q: expected group/version/resource, e.g. apps/v1/deployments or /v1/pods for the core group", rule)
+	}
+	group, version, resource := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])
+	if version == "" || resource == "" {
+		return admissionv1.NamedRuleWithOperations{}, fmt.Errorf("invalid resource rule %q: version and resource are required", rule)
+	}
+	// The group is the one segment allowed to be empty: that is how the core
+	// group is spelled, both here and on the resulting rule.
+	if group != "" {
+		if err := validateRuleSegment("api group", group, validation.IsDNS1123Subdomain); err != nil {
+			return admissionv1.NamedRuleWithOperations{}, err
+		}
+	}
+	if err := validateRuleSegment("api version", version, validation.IsDNS1123Label); err != nil {
+		return admissionv1.NamedRuleWithOperations{}, err
+	}
+	// A resource may carry a subresource ("deployments/scale"); each side is a
+	// plain name on its own.
+	for _, segment := range strings.Split(resource, "/") {
+		if err := validateRuleSegment("resource", segment, validation.IsDNS1123Label); err != nil {
+			return admissionv1.NamedRuleWithOperations{}, err
+		}
+	}
+	return admissionv1.NamedRuleWithOperations{
+		RuleWithOperations: admissionv1.RuleWithOperations{
+			Operations: []admissionv1.OperationType{admissionv1.OperationAll},
+			Rule: admissionv1.Rule{
+				APIGroups:   []string{group},
+				APIVersions: []string{version},
+				Resources:   []string{resource},
+			},
+		},
+	}, nil
+}
+
+// validateRuleSegment checks one segment of a resource rule, accepting the "*"
+// wildcard the admission API allows in any of them.
+func validateRuleSegment(kind string, value string, validate func(string) []string) error {
+	if value == "*" {
+		return nil
+	}
+	if errs := validate(value); len(errs) > 0 {
+		return fmt.Errorf("invalid %s %q: %s", kind, value, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
 // Create a policy binding
-func createPolicyBinding(bindingName string, policyName string, actions []admissionv1.ValidationAction, paramRefName string, namespaceArr []string, labelMatch []string) (string, error) {
+func createPolicyBinding(bindingName string, policyName string, actions []admissionv1.ValidationAction, paramRefName string, namespaceArr []string, labelMatch []string, resourceRuleArr []string) (string, error) {
 	// Create a policy binding struct
 	policyBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
 	policyBinding.APIVersion = "admissionregistration.k8s.io/v1"
@@ -422,6 +488,16 @@ func createPolicyBinding(bindingName string, policyName string, actions []admiss
 				}
 			}
 		}
+	}
+
+	// Left empty, matchResources binds everything the policy matches, so a rule
+	// is only emitted when the caller asked to narrow it.
+	for _, rule := range resourceRuleArr {
+		parsed, err := parseResourceRule(rule)
+		if err != nil {
+			return "", err
+		}
+		policyBinding.Spec.MatchResources.ResourceRules = append(policyBinding.Spec.MatchResources.ResourceRules, parsed)
 	}
 
 	policyBinding.Spec.ValidationActions = actions

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -436,7 +438,7 @@ func TestDeployLibraryAcceptsRealReleaseTags(t *testing.T) {
 
 func TestCreatePolicyBinding(t *testing.T) {
 	t.Run("minimal binding with name and policy", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -453,7 +455,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with namespaces", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit}, "", []string{"ns1", "ns2"}, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit}, "", []string{"ns1", "ns2"}, nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -467,7 +469,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with labels", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Warn}, "", nil, []string{"app=nginx", "env=prod"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Warn}, "", nil, []string{"app=nginx", "env=prod"}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -479,7 +481,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("labels with whitespace are trimmed", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{"app = nginx"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{"app = nginx"}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -490,7 +492,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with parameter reference", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", nil, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", nil, nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -503,7 +505,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("all fields combined", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", []string{"ns1"}, []string{"app=nginx"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", []string{"ns1"}, []string{"app=nginx"}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -517,7 +519,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("empty namespace slice does not add selector", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", []string{}, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", []string{}, nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -527,13 +529,118 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("empty label slice does not add selector", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
 		err = yaml.Unmarshal([]byte(out), &binding)
 		require.NoError(t, err)
 		assert.Nil(t, binding.Spec.MatchResources.ObjectSelector)
+	})
+
+	// No rules means the binding covers everything the policy matches, which is
+	// what the apiserver does with an empty resourceRules.
+	t.Run("empty resource rule slice does not add rules", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil, []string{})
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err = yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		assert.Empty(t, binding.Spec.MatchResources.ResourceRules)
+	})
+
+	t.Run("with resource rules", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil, []string{"apps/v1/deployments", "/v1/pods"})
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err = yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		require.Len(t, binding.Spec.MatchResources.ResourceRules, 2)
+
+		apps := binding.Spec.MatchResources.ResourceRules[0]
+		assert.Equal(t, []string{"apps"}, apps.APIGroups)
+		assert.Equal(t, []string{"v1"}, apps.APIVersions)
+		assert.Equal(t, []string{"deployments"}, apps.Resources)
+		assert.Equal(t, []admissionv1.OperationType{admissionv1.OperationAll}, apps.Operations)
+
+		core := binding.Spec.MatchResources.ResourceRules[1]
+		assert.Equal(t, []string{""}, core.APIGroups)
+		assert.Equal(t, []string{"pods"}, core.Resources)
+	})
+
+	t.Run("with custom resource rule", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil, []string{"agentsubstrate.google.com/v1/actortemplates"})
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		err = yaml.Unmarshal([]byte(out), &binding)
+		require.NoError(t, err)
+		require.Len(t, binding.Spec.MatchResources.ResourceRules, 1)
+		assert.Equal(t, []string{"agentsubstrate.google.com"}, binding.Spec.MatchResources.ResourceRules[0].APIGroups)
+		assert.Equal(t, []string{"actortemplates"}, binding.Spec.MatchResources.ResourceRules[0].Resources)
+	})
+
+	t.Run("invalid resource rule is rejected", func(t *testing.T) {
+		_, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil, []string{"deployments"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected group/version/resource")
+	})
+}
+
+func TestParseResourceRule(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			group    string
+			version  string
+			resource string
+		}{
+			{name: "grouped resource", input: "apps/v1/deployments", group: "apps", version: "v1", resource: "deployments"},
+			{name: "core group", input: "/v1/pods", group: "", version: "v1", resource: "pods"},
+			{name: "custom resource", input: "agentsubstrate.google.com/v1beta1/workerpools", group: "agentsubstrate.google.com", version: "v1beta1", resource: "workerpools"},
+			{name: "subresource", input: "apps/v1/deployments/scale", group: "apps", version: "v1", resource: "deployments/scale"},
+			{name: "wildcards", input: "*/*/*", group: "*", version: "*", resource: "*"},
+			{name: "wildcard resource", input: "apps/v1/*", group: "apps", version: "v1", resource: "*"},
+			{name: "surrounding whitespace", input: " apps / v1 / deployments ", group: "apps", version: "v1", resource: "deployments"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rule, err := parseResourceRule(tt.input)
+				require.NoError(t, err)
+				assert.Equal(t, []string{tt.group}, rule.APIGroups)
+				assert.Equal(t, []string{tt.version}, rule.APIVersions)
+				assert.Equal(t, []string{tt.resource}, rule.Resources)
+				assert.Equal(t, []admissionv1.OperationType{admissionv1.OperationAll}, rule.Operations)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			input  string
+			errMsg string
+		}{
+			{name: "empty", input: "", errMsg: "expected group/version/resource"},
+			{name: "resource only", input: "deployments", errMsg: "expected group/version/resource"},
+			{name: "group and version only", input: "apps/v1", errMsg: "expected group/version/resource"},
+			{name: "missing version", input: "apps//deployments", errMsg: "version and resource are required"},
+			{name: "missing resource", input: "apps/v1/", errMsg: "version and resource are required"},
+			{name: "bad group", input: "App$/v1/deployments", errMsg: "invalid api group"},
+			{name: "bad version", input: "apps/V1/deployments", errMsg: "invalid api version"},
+			{name: "bad resource", input: "apps/v1/Deployments", errMsg: "invalid resource"},
+			{name: "bad subresource", input: "apps/v1/deployments/Scale", errMsg: "invalid resource"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := parseResourceRule(tt.input)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			})
+		}
 	})
 }
 
@@ -565,6 +672,30 @@ func TestCreatePolicyBindingCmdValidation(t *testing.T) {
 		err := cmd.Execute()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported control ID")
+	})
+
+	t.Run("resource rule is written to the binding", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--resource-rule", "apps/v1/deployments", "--output", outputFile})
+		require.NoError(t, cmd.Execute())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal(content, &binding))
+		require.Len(t, binding.Spec.MatchResources.ResourceRules, 1)
+		assert.Equal(t, []string{"apps"}, binding.Spec.MatchResources.ResourceRules[0].APIGroups)
+		assert.Equal(t, []string{"deployments"}, binding.Spec.MatchResources.ResourceRules[0].Resources)
+	})
+
+	t.Run("invalid resource rule fails the command", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--resource-rule", "deployments"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected group/version/resource")
 	})
 
 	t.Run("policy and control are mutually exclusive", func(t *testing.T) {
@@ -720,6 +851,9 @@ func TestGetCreatePolicyBindingCmd(t *testing.T) {
 
 	labelFlag := cmd.Flags().Lookup("label")
 	require.NotNil(t, labelFlag)
+
+	resourceRuleFlag := cmd.Flags().Lookup("resource-rule")
+	require.NotNil(t, resourceRuleFlag)
 
 	actionFlag := cmd.Flags().Lookup("action")
 	require.NotNil(t, actionFlag)
@@ -948,7 +1082,7 @@ func TestParseValidationActions(t *testing.T) {
 }
 
 func TestCreatePolicyBindingMultipleActions(t *testing.T) {
-	out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn}, "", nil, nil)
+	out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn}, "", nil, nil, nil)
 	require.NoError(t, err)
 
 	var binding admissionv1.ValidatingAdmissionPolicyBinding


### PR DESCRIPTION
## Overview

`kubescape vap create-policy-binding` builds a `ValidatingAdmissionPolicyBinding`, and today it can narrow that binding by namespace and by object labels, but never by resource. `spec.matchResources.resourceRules` is left empty on every binding the command emits.

An empty `resourceRules` is not a no-op. The apiserver reads it as "bind everything the policy matches" (see `matchesResourceRules` in `k8s.io/apiserver/pkg/admission/plugin/policy/matching`), so a generated binding always applies to the policy's full matchConstraints. There is no way to take a policy that matches several resources and bind it to just one of them, and no way to bind a policy to a custom resource at all.

This adds a repeatable `--resource-rule` flag that fills those rules in.

```
kubescape vap create-policy-binding --name my-binding --control C-0016 \
  --resource-rule apps/v1/deployments \
  --resource-rule /v1/pods
```

## Details

The value is `group/version/resource`. The core group is the empty first segment, so pods are `/v1/pods`, which is how the core group is spelled on the resulting rule too. A resource may carry a subresource (`apps/v1/deployments/scale`), and `*` is accepted in any segment.

Operations stay at `*`. A binding is intersected with the policy's `matchConstraints`, which already declares the operations the policy cares about, so narrowing them on the binding could only drop matches the policy intends to catch.

Parsing and validation live in `parseResourceRule`, so adding another segment later is a change in one place. Groups are validated as DNS 1123 subdomains, versions and resource names as DNS 1123 labels, with the wildcard allowed through. Bad input fails the command with a message naming the offending segment rather than emitting YAML the apiserver will reject on apply.

Leaving the flag off keeps the current behaviour exactly: no rules are written and the binding covers everything the policy matches.

## Testing

`go test ./cmd/vap/...` passes. New cases cover the valid forms (grouped, core group, custom group, subresource, wildcards, whitespace), the rejected ones (too few segments, empty version or resource, bad characters in each segment), the generated binding for single and multiple rules, and the flag wiring end to end through the command including the failure path.

Also verified the generated YAML by hand for a mix of core, grouped and custom resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--resource-rule` support when creating policy bindings.
  * Supports core, custom, wildcard, and subresource formats.
  * Resource rules apply across all operations.
* **Bug Fixes**
  * Invalid resource rules now produce clear validation errors.
  * Omitting resource rules preserves unrestricted resource matching.
* **Documentation**
  * Updated command examples to demonstrate resource-rule usage.
  * Added guidance for specifying resource rules in supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->