### PR TITLE
fix(ci): refresh expired SECURITY-INSIGHTS.yml and enforce its freshness

### DIFF
--- a/.github/workflows/repo-hygiene.yaml
+++ b/.github/workflows/repo-hygiene.yaml
@@ -3,6 +3,11 @@ permissions:
   contents: read
 on:
   workflow_dispatch: {}
+  schedule:
+    # Expiry is a property of time, not of change: SECURITY-INSIGHTS.yml goes
+    # stale while nobody touches it, so the freshness assertions in
+    # internal/ghworkflows must also run while the repository is idle.
+    - cron: '0 0 1 * *'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     # 00-pr-scanner.yaml skips a PR whose every file matches its paths-ignore
@@ -11,9 +16,12 @@ on:
     # at all, which is how an invalid config disabled Dependabot for three
     # months. This workflow uses `paths` - an allow-list - to cover exactly the
     # blind spot the other workflow's deny-list leaves open.
+    # SECURITY-INSIGHTS.yml sits at the repository root and matches the
+    # deny-list's "**.yml" the same way, so it is covered here too.
     paths:
       - ".github/**"
       - "internal/ghworkflows/**"
+      - "SECURITY-INSIGHTS.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,5 +39,5 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Validate workflow and Dependabot configuration
+      - name: Validate workflow, Dependabot and security-insights configuration
         run: go test -v ./internal/ghworkflows/...

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,25 +1,23 @@
 header:
   schema-version: 1.0.0
-  last-updated: '2023-10-12'
-  last-reviewed: '2023-10-12'
-  expiration-date: '2024-10-12T01:00:00.000Z'
+  last-updated: '2026-08-16'
+  last-updated-by: 1PoPTRoN
+  last-reviewed: '2026-08-16'
+  expiration-date: '2027-02-16T00:00:00.000Z'
   project-url: https://github.com/kubescape/kubescape/
-  project-release: 1.0.0
+  project-release: v4.0.12
 project-lifecycle:
   status: active
   bug-fixes-only: false
   core-maintainers:
   - github:amirmalka
-  - github:amitschendel
   - github:bezbran
-  - github:craigbox
-  - github:dwertent
   - github:matthyx
   - github:rotemamsa
   - github:slashben
 contribution-policy:
   accepts-pull-requests: true
-  accepts-automated-pull-requests: false
+  accepts-automated-pull-requests: true
   code-of-conduct: https://github.com/kubescape/kubescape/blob/master/CODE_OF_CONDUCT.md
 dependencies:
   third-party-packages: true
@@ -42,9 +40,14 @@ security-testing:
   integration:
     ad-hoc: false
     ci: true
-    before-release: true
+    before-release: false
   comment: |
-    Dependabot is enabled for this repo.
+    Dependabot is configured in .github/dependabot.yaml and guarded by the
+    tests in internal/ghworkflows. Its pull requests run the full PR suite
+    (00-pr-scanner.yaml) and are accepted and merged, hence
+    accepts-automated-pull-requests: true and ci: true. before-release stays
+    false until a release-time gate requires fresh dependencies or their CI
+    results: 02-release.yaml runs none today.
 security-contacts:
 - type: email
   value: cncf-kubescape-maintainers@lists.cncf.io

--- a/internal/ghworkflows/securityinsights_test.go
+++ b/internal/ghworkflows/securityinsights_test.go
@@ -1,0 +1,178 @@
+package ghworkflows
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// These tests guard SECURITY-INSIGHTS.yml at the repository root, the OpenSSF
+// Security Insights document that supply-chain consumers (OpenSSF Scorecard,
+// CNCF project reviews) read to learn how this repository secures itself.
+//
+// Nothing linked the document to reality, so it rotted for years: the
+// expiration date passed in October 2024, the attested release ("1.0.0") was
+// four major versions behind, two listed core maintainers had already moved
+// to Emeritus in project-governance, and the contribution policy rejected
+// automated pull requests while dependabot[bot] merges sat in the git
+// history. Each of those was a false attestation no consumer could detect.
+//
+// The date assertions are the part review cannot catch: an insights document
+// goes stale while nobody touches it, so expiry is a property of time, not of
+// change. repo-hygiene.yaml therefore runs this package on a monthly schedule
+// in addition to pull requests.
+const securityInsightsName = "SECURITY-INSIGHTS.yml"
+
+// securityInsights is the subset of the Security Insights schema these tests
+// assert on. Unknown keys are tolerated on purpose, like the Dependabot
+// decoder in this package: the spec carries many optional sections, and a
+// strict decoder would turn adopting one into a spurious failure here.
+type securityInsights struct {
+	Header struct {
+		SchemaVersion  string `yaml:"schema-version"`
+		LastUpdated    string `yaml:"last-updated"`
+		ExpirationDate string `yaml:"expiration-date"`
+		ProjectURL     string `yaml:"project-url"`
+		ProjectRelease string `yaml:"project-release"`
+	} `yaml:"header"`
+	ProjectLifecycle struct {
+		Status          string   `yaml:"status"`
+		CoreMaintainers []string `yaml:"core-maintainers"`
+	} `yaml:"project-lifecycle"`
+}
+
+// securityInsightsDateLayouts are the date forms the spec permits: a calendar
+// date, or a full RFC3339 timestamp.
+var securityInsightsDateLayouts = []string{time.RFC3339, "2006-01-02"}
+
+func securityInsightsPath(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(repoRoot(t), securityInsightsName)
+}
+
+func loadSecurityInsights(t *testing.T) securityInsights {
+	t.Helper()
+
+	content, err := os.ReadFile(securityInsightsPath(t))
+	require.NoErrorf(t, err, "cannot read %s", securityInsightsName)
+
+	var insights securityInsights
+	require.NoErrorf(t, yaml.Unmarshal(content, &insights),
+		"%s is not valid YAML; supply-chain consumers read this file, and a parse error invalidates every attestation in it",
+		securityInsightsName)
+
+	return insights
+}
+
+// parseSecurityInsightsDate accepts both spec-permitted date forms and fails
+// listing the layouts it tried. It also reports whether the value carried
+// day granularity, because a date-only value means "sometime during that
+// day", not midnight UTC: comparing it to the instant clock would flag every
+// same-day update as future-dated while UTC is still on the previous day.
+func parseSecurityInsightsDate(t *testing.T, field, value string) (time.Time, bool) {
+	t.Helper()
+
+	for _, layout := range securityInsightsDateLayouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, layout == securityInsightsDateLayouts[1]
+		}
+	}
+
+	t.Fatalf("%s in %s must be a date (YYYY-MM-DD) or an RFC3339 timestamp, got %q",
+		field, securityInsightsName, value)
+	return time.Time{}, false
+}
+
+// isFutureReference reports whether a parsed date reference lies in the
+// future, at the granularity the source value carried.
+//
+// A date-only value may legitimately name tomorrow's UTC date: it is written
+// by a contributor in their local calendar, and every inhabited timezone is
+// ahead of UTC by less than a day. The check exists to catch documents that
+// sit years in the past or typo a far-off year, so one day of skew is
+// tolerated and anything beyond it fails.
+func isFutureReference(parsed time.Time, dateOnly bool) bool {
+	now := time.Now().UTC()
+	if dateOnly {
+		// ISO dates order identically as strings, so this is a calendar-day
+		// comparison against the latest local date any timezone can be on.
+		return parsed.Format("2006-01-02") > now.AddDate(0, 0, 1).Format("2006-01-02")
+	}
+	return parsed.After(now)
+}
+
+// TestSecurityInsightsHeaderIsPopulated keeps the fields consumers key off
+// present and non-empty; the document named release "1.0.0" for years after
+// the project had moved on to v4.
+func TestSecurityInsightsHeaderIsPopulated(t *testing.T) {
+	insights := loadSecurityInsights(t)
+
+	assert.NotEmpty(t, insights.Header.SchemaVersion, "schema-version is required")
+	assert.NotEmpty(t, insights.Header.ProjectURL, "project-url is required")
+	assert.NotEmptyf(t, insights.Header.ProjectRelease,
+		"project-release is required; an insights document that names no release describes no release")
+	assert.Equal(t, "active", insights.ProjectLifecycle.Status)
+}
+
+// TestSecurityInsightsIsNotExpired is the direct regression test for the
+// expired document: the expiration date had passed almost two years earlier
+// and nothing failed, because nothing was checking.
+func TestSecurityInsightsIsNotExpired(t *testing.T) {
+	insights := loadSecurityInsights(t)
+
+	require.NotEmpty(t, insights.Header.ExpirationDate, "expiration-date is required")
+
+	// Strict instant comparison, even for date-only values: for an expiry
+	// check, failing near the boundary is the safe direction.
+	expiration, _ := parseSecurityInsightsDate(t, "expiration-date", insights.Header.ExpirationDate)
+	assert.Truef(t, expiration.After(time.Now().UTC()),
+		"%s expired on %s; an expired document attests nothing and must be reviewed and refreshed",
+		securityInsightsName, expiration.Format(time.RFC3339))
+}
+
+// TestSecurityInsightsDatesAreCoherent keeps the header internally consistent:
+// no future-dated updates, and no document that expires before it was written.
+func TestSecurityInsightsDatesAreCoherent(t *testing.T) {
+	insights := loadSecurityInsights(t)
+
+	require.NotEmpty(t, insights.Header.LastUpdated, "last-updated is required")
+
+	lastUpdated, dateOnly := parseSecurityInsightsDate(t, "last-updated", insights.Header.LastUpdated)
+	assert.Falsef(t, isFutureReference(lastUpdated, dateOnly),
+		"last-updated %s is in the future", insights.Header.LastUpdated)
+
+	if insights.Header.ExpirationDate != "" {
+		expiration, _ := parseSecurityInsightsDate(t, "expiration-date", insights.Header.ExpirationDate)
+		assert.Truef(t, expiration.After(lastUpdated),
+			"expiration-date %s is not after last-updated %s",
+			insights.Header.ExpirationDate, insights.Header.LastUpdated)
+	}
+}
+
+// coreMaintainerRe matches the `github:<handle>` form the document uses for
+// every core-maintainer entry.
+var coreMaintainerRe = regexp.MustCompile(`^github:[A-Za-z0-9][A-Za-z0-9-]*$`)
+
+// TestSecurityInsightsListsCoreMaintainers keeps the maintainer entries
+// well-formed and resolvable: the list had grown two Emeritus maintainers
+// because retirements recorded in project-governance never propagated here.
+func TestSecurityInsightsListsCoreMaintainers(t *testing.T) {
+	insights := loadSecurityInsights(t)
+
+	require.NotEmpty(t, insights.ProjectLifecycle.CoreMaintainers,
+		"core-maintainers is required; a security document with no accountable humans attests nothing")
+
+	for _, maintainer := range insights.ProjectLifecycle.CoreMaintainers {
+		t.Run(maintainer, func(t *testing.T) {
+			assert.Regexp(t, coreMaintainerRe, maintainer,
+				"core-maintainer entries must be `github:<handle>` so consumers can resolve them")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`SECURITY-INSIGHTS.yml` expired in October 2024 and no longer described the repository it attests for: release `1.0.0` against the actual `v4.0.12`, two Emeritus maintainers listed as core, automated pull requests "rejected" while `dependabot[bot]` merges land routinely, and a Dependabot `before-release` claim that no release workflow backs. OpenSSF Scorecard and CNCF project reviews consume this file, so every stale line was a false attestation handed to an auditor.

This refreshes the document against verified state and adds CI enforcement so it cannot silently rot again.

## Additional Information

- `SECURITY-INSIGHTS.yml` — dates refreshed with a 6-month expiry, `project-release: v4.0.12`, only the active core maintainers (per `project-governance/MAINTAINERS.md`), `accepts-automated-pull-requests: true`, and Dependabot `ci: true` / `before-release: false` with a comment stating when that flag may flip (once a release-time dependency gate exists).
- `internal/ghworkflows/securityinsights_test.go` — guards following the existing hygiene-test pattern: not-expired, date coherence (UTC day granularity with a 1-day timezone-skew tolerance for date-only values), populated header, and well-formed `github:<handle>` maintainer entries.
- `.github/workflows/repo-hygiene.yaml` — `SECURITY-INSIGHTS.yml` added to the `paths` allow-list: the file previously ran zero checks, because `00-pr-scanner.yaml` ignores `**.yml` and this workflow only covered `.github/**`. Also adds a monthly schedule, since expiry happens precisely while nobody touches the file — the same failure mode `dependabot_test.go` documents for `dependabot.yaml` ("nothing failed, because nothing was checking").

## How to Test

- `go test -v ./internal/ghworkflows/...`
- Regression evidence for the expiry guard: `TestSecurityInsightsIsNotExpired` fails on the pre-fix file with `SECURITY-INSIGHTS.yml expired on 2024-10-12T01:00:00Z; an expired document attests nothing and must be reviewed and refreshed` and passes after this change.

## Testing

- [x] `go test -race -count=1 ./internal/ghworkflows/...` — 11/11 pass
- [x] `go vet`, `gofmt` clean, `golangci-lint run ./internal/ghworkflows/...` — 0 issues
- [x] Existing Dependabot and workflow-README guards in the same package unaffected

## Related issues

* Resolved #3284

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security metadata, including release, review, and expiration information.
  * Refreshed maintainer details and Dependabot documentation.
  * Updated release readiness settings.

* **Bug Fixes**
  * Security metadata validation now runs monthly and responds to relevant configuration changes.

* **Tests**
  * Added validation for required security fields, date formats, expiration status, date ordering, and maintainer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->