### PR TITLE
fix(printer): annotate init/ephemeral container names on evidence paths

### DIFF
--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
-var specContainerRegex = regexp.MustCompile(`spec\.containers\[(\d+)]`)
+var specContainerRegex = regexp.MustCompile(`spec\.(containers|initContainers|ephemeralContainers)\[(\d+)]`)
 
 const (
 	resourceColumnSeverity = iota
@@ -101,25 +101,51 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 
 func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata, paths *[]string) {
 	wl := workloadinterface.NewWorkloadObj(resource.GetObject())
-	containers, err := wl.GetContainers()
-	if err != nil {
-		return
-	}
+	namesByKind := containerNamesByKind(wl)
 
 	for i := range *paths {
 		match := specContainerRegex.FindStringSubmatch((*paths)[i])
-		if len(match) != 2 {
+		if len(match) != 3 {
 			continue
 		}
-		index, err := strconv.Atoi(match[1])
+		index, err := strconv.Atoi(match[2])
 		if err != nil {
 			continue
 		}
-		if index >= len(containers) {
+		names := namesByKind[match[1]]
+		if index >= len(names) {
 			continue
 		}
-		(*paths)[i] += " (" + containers[index].Name + ")"
+		(*paths)[i] += " (" + names[index] + ")"
 	}
+}
+
+func containerNamesByKind(wl *workloadinterface.Workload) map[string][]string {
+	namesByKind := make(map[string][]string, 3)
+
+	if cs, err := wl.GetContainers(); err == nil {
+		names := make([]string, len(cs))
+		for i := range cs {
+			names[i] = cs[i].Name
+		}
+		namesByKind["containers"] = names
+	}
+	if cs, err := wl.GetInitContainers(); err == nil {
+		names := make([]string, len(cs))
+		for i := range cs {
+			names[i] = cs[i].Name
+		}
+		namesByKind["initContainers"] = names
+	}
+	if cs, err := wl.GetEphemeralContainers(); err == nil {
+		names := make([]string, len(cs))
+		for i := range cs {
+			names[i] = cs[i].Name
+		}
+		namesByKind["ephemeralContainers"] = names
+	}
+
+	return namesByKind
 }
 
 func generateResourceHeader(short bool) table.Row {

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -597,6 +597,46 @@ func TestAddContainerNameToAssistedRemediation_OutOfBounds(t *testing.T) {
 			},
 		},
 		{
+			name: "init and ephemeral container indices append names",
+			resource: workloadinterface.NewWorkloadObj(map[string]any{
+				"kind": "Pod",
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "nginx",
+							"image": "nginx:latest",
+						},
+					},
+					"initContainers": []any{
+						map[string]any{
+							"name":  "init-db",
+							"image": "busybox:latest",
+						},
+					},
+					"ephemeralContainers": []any{
+						map[string]any{
+							"name":  "debugger",
+							"image": "busybox:latest",
+						},
+					},
+				},
+			}),
+			paths: []string{
+				"spec.initContainers[0].securityContext.privileged",
+				"spec.ephemeralContainers[0].securityContext.privileged",
+				"spec.template.spec.initContainers[0].securityContext.privileged",
+				"spec.initContainers[5].securityContext.privileged",
+				"spec.ephemeralContainers[3].securityContext.privileged",
+			},
+			expectedPaths: []string{
+				"spec.initContainers[0].securityContext.privileged (init-db)",
+				"spec.ephemeralContainers[0].securityContext.privileged (debugger)",
+				"spec.template.spec.initContainers[0].securityContext.privileged (init-db)",
+				"spec.initContainers[5].securityContext.privileged",
+				"spec.ephemeralContainers[3].securityContext.privileged",
+			},
+		},
+		{
 			name: "path without container index is unchanged",
 			resource: workloadinterface.NewWorkloadObj(map[string]any{
 				"kind": "Pod",


### PR DESCRIPTION


## Overview

Pretty-printer assisted remediation already appended the container name for `spec.containers[N]` (e.g. `spec.containers[0].securityContext.privileged (nginx)`). Paths for `initContainers` and `ephemeralContainers` were left as bare indices, including under `spec.template.spec.`. CSV fixtures already carried `spec.initContainers[0]…`; the pretty table did not name them.

`addContainerNameToAssistedRemediation` now matches `spec.containers[N]`, `spec.initContainers[N]`, and `spec.ephemeralContainers[N]` (including nested template paths) and resolves names from `GetContainers()` / `GetInitContainers()` / `GetEphemeralContainers()`. Out-of-range indexes stay unannotated.

## How to Test

```bash
go test ./core/pkg/resultshandling/printer/v2/ -run TestAddContainerNameToAssistedRemediation
```

Or scan a Pod/Deployment with a privileged initContainer and confirm pretty `-v` / resource-table output shows the init container name on the path, not only `spec.initContainers[0]`.

## Related issues/PRs

Follow-up to the evidence-of-finding printer work (#2882). Does not close #1563 / #1737; it only fills the container-name gap called out there for init/ephemeral paths.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remediation path annotations for regular, init, and ephemeral containers.
  * Correctly associates container names with templated pod paths.
  * Prevents invalid container indices from producing incorrect annotations.

* **Tests**
  * Added coverage for valid and out-of-bounds container references across supported container types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->