### PR TITLE
feat(vap): allow a policy binding to declare multiple validation actions

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -35,6 +35,8 @@ var vapHelperCmdExamples = fmt.Sprintf(`
   %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --namespace=my-namespace | kubectl apply -f -
   # Create a policy binding by ValidatingAdmissionPolicy name
   %[1]s vap create-policy-binding --name my-policy-binding --policy kubescape-c-0016-allow-privilege-escalation --namespace=my-namespace | kubectl apply -f -
+  # Roll a control out in report-only mode before switching it to Deny
+  %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --action Audit --action Warn | kubectl apply -f -
 `, cautils.ExecName())
 
 func GetVapHelperCmd() *cobra.Command {
@@ -88,7 +90,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	var controlID string
 	var namespaceArr []string
 	var labelArr []string
-	var action string
+	var actionArr []string
 	var parameterReference string
 	var outputFile string
 
@@ -150,8 +152,9 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 					}
 				}
 			}
-			if action != "Deny" && action != "Audit" && action != "Warn" {
-				return fmt.Errorf("invalid action: %s", action)
+			actions, err := parseValidationActions(actionArr)
+			if err != nil {
+				return err
 			}
 			if parameterReference != "" {
 				if err := isValidK8sObjectName(parameterReference); err != nil {
@@ -159,7 +162,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				}
 			}
 
-			content, err := createPolicyBinding(policyBindingName, resolvedPolicyName, action, parameterReference, namespaceArr, labelArr)
+			content, err := createPolicyBinding(policyBindingName, resolvedPolicyName, actions, parameterReference, namespaceArr, labelArr)
 			if err != nil {
 				return err
 			}
@@ -173,7 +176,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringVarP(&controlID, "control", "c", "", "Kubescape control ID to bind resources to")
 	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector")
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
-	createPolicyBindingCmd.Flags().StringVarP(&action, "action", "a", "Deny", "Action to take when policy fails")
+	createPolicyBindingCmd.Flags().StringSliceVarP(&actionArr, "action", "a", []string{string(admissionv1.Deny)}, "Action to take when policy fails, repeatable (Deny, Warn, Audit). Deny and Warn cannot be combined")
 	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Parameter reference object name")
 	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
@@ -303,8 +306,59 @@ func isValidNamespace(name string) error {
 	return nil
 }
 
+// supportedValidationActions are the enforcement actions the admission API
+// accepts on a binding, matched case-sensitively as the API spells them.
+var supportedValidationActions = []admissionv1.ValidationAction{
+	admissionv1.Deny,
+	admissionv1.Warn,
+	admissionv1.Audit,
+}
+
+// parseValidationActions turns the --action values into the binding's
+// validationActions set. The field is a set on the API, so a binding can carry
+// more than one action — the usual rollout is Audit plus Warn first and Deny
+// once the findings are clean, which a single-valued flag could not express.
+//
+// The two combinations the apiserver rejects are refused here rather than at
+// apply time: a repeated action (the field is a listType=set) and Deny with
+// Warn, which the API forbids because it would report the same failure twice.
+// Order is preserved so the emitted YAML reads back the way it was asked for.
+func parseValidationActions(values []string) ([]admissionv1.ValidationAction, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("at least one --action is required")
+	}
+	actions := make([]admissionv1.ValidationAction, 0, len(values))
+	seen := make(map[admissionv1.ValidationAction]struct{}, len(values))
+	for _, value := range values {
+		action := admissionv1.ValidationAction(strings.TrimSpace(value))
+		if !isSupportedValidationAction(action) {
+			return nil, fmt.Errorf("invalid action: %s", value)
+		}
+		if _, dup := seen[action]; dup {
+			return nil, fmt.Errorf("duplicate action: %s", action)
+		}
+		seen[action] = struct{}{}
+		actions = append(actions, action)
+	}
+	if _, deny := seen[admissionv1.Deny]; deny {
+		if _, warn := seen[admissionv1.Warn]; warn {
+			return nil, fmt.Errorf("actions Deny and Warn cannot be combined")
+		}
+	}
+	return actions, nil
+}
+
+func isSupportedValidationAction(action admissionv1.ValidationAction) bool {
+	for _, supported := range supportedValidationActions {
+		if action == supported {
+			return true
+		}
+	}
+	return false
+}
+
 // Create a policy binding
-func createPolicyBinding(bindingName string, policyName string, action string, paramRefName string, namespaceArr []string, labelMatch []string) (string, error) {
+func createPolicyBinding(bindingName string, policyName string, actions []admissionv1.ValidationAction, paramRefName string, namespaceArr []string, labelMatch []string) (string, error) {
 	// Create a policy binding struct
 	policyBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
 	policyBinding.APIVersion = "admissionregistration.k8s.io/v1"
@@ -341,7 +395,7 @@ func createPolicyBinding(bindingName string, policyName string, action string, p
 		}
 	}
 
-	policyBinding.Spec.ValidationActions = []admissionv1.ValidationAction{admissionv1.ValidationAction(action)}
+	policyBinding.Spec.ValidationActions = actions
 	paramAction := admissionv1.DenyAction
 	if paramRefName != "" {
 		policyBinding.Spec.ParamRef = &admissionv1.ParamRef{

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -314,7 +314,7 @@ func TestDeployLibraryFromRelease(t *testing.T) {
 
 func TestCreatePolicyBinding(t *testing.T) {
 	t.Run("minimal binding with name and policy", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -331,7 +331,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with namespaces", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Audit", "", []string{"ns1", "ns2"}, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit}, "", []string{"ns1", "ns2"}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -345,7 +345,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with labels", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Warn", "", nil, []string{"app=nginx", "env=prod"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Warn}, "", nil, []string{"app=nginx", "env=prod"})
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -357,7 +357,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("labels with whitespace are trimmed", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, []string{"app = nginx"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{"app = nginx"})
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -368,7 +368,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("with parameter reference", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", nil, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", nil, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -381,7 +381,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("all fields combined", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "my-params", []string{"ns1"}, []string{"app=nginx"})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "my-params", []string{"ns1"}, []string{"app=nginx"})
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -395,7 +395,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("empty namespace slice does not add selector", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", []string{}, nil)
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", []string{}, nil)
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -405,7 +405,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("empty label slice does not add selector", func(t *testing.T) {
-		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, []string{})
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{})
 		require.NoError(t, err)
 
 		var binding admissionv1.ValidatingAdmissionPolicyBinding
@@ -601,7 +601,7 @@ func TestGetCreatePolicyBindingCmd(t *testing.T) {
 
 	actionFlag := cmd.Flags().Lookup("action")
 	require.NotNil(t, actionFlag)
-	assert.Equal(t, "Deny", actionFlag.DefValue)
+	assert.Equal(t, "[Deny]", actionFlag.DefValue)
 
 	paramRefFlag := cmd.Flags().Lookup("parameter-reference")
 	require.NotNil(t, paramRefFlag)
@@ -715,7 +715,7 @@ func TestLabelSelectorRegexEdgeCases(t *testing.T) {
 
 func TestCreatePolicyBindingCmdAllActions(t *testing.T) {
 	validActions := []string{"Deny", "Audit", "Warn"}
-	invalidActions := []string{"Allow", "deny", "audit", "warn", "", "Log", "Reject"}
+	invalidActions := []string{"Allow", "deny", "audit", "warn", "Log", "Reject"}
 
 	for _, action := range validActions {
 		t.Run("valid action "+action, func(t *testing.T) {
@@ -735,6 +735,133 @@ func TestCreatePolicyBindingCmdAllActions(t *testing.T) {
 			assert.Contains(t, err.Error(), "invalid action")
 		})
 	}
+
+	// An empty value clears the slice rather than adding a blank action, so it
+	// reports the missing action instead of an invalid one.
+	t.Run("empty action clears the default", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", ""})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one --action is required")
+	})
+}
+
+func TestParseValidationActions(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		want    []admissionv1.ValidationAction
+		wantErr string
+	}{
+		{
+			name:   "single action",
+			values: []string{"Deny"},
+			want:   []admissionv1.ValidationAction{admissionv1.Deny},
+		},
+		{
+			name:   "audit and warn roll out together",
+			values: []string{"Audit", "Warn"},
+			want:   []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn},
+		},
+		{
+			name:   "deny and audit are a valid pair",
+			values: []string{"Deny", "Audit"},
+			want:   []admissionv1.ValidationAction{admissionv1.Deny, admissionv1.Audit},
+		},
+		{
+			name:   "order is preserved",
+			values: []string{"Warn", "Audit"},
+			want:   []admissionv1.ValidationAction{admissionv1.Warn, admissionv1.Audit},
+		},
+		{
+			name:   "surrounding whitespace is trimmed",
+			values: []string{" Audit ", "Warn"},
+			want:   []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn},
+		},
+		{
+			name:    "no action at all",
+			values:  nil,
+			wantErr: "at least one --action is required",
+		},
+		{
+			name:    "unknown action",
+			values:  []string{"Allow"},
+			wantErr: "invalid action: Allow",
+		},
+		{
+			name:    "lowercase is not the API spelling",
+			values:  []string{"deny"},
+			wantErr: "invalid action: deny",
+		},
+		{
+			name:    "repeated action",
+			values:  []string{"Audit", "Audit"},
+			wantErr: "duplicate action: Audit",
+		},
+		{
+			name:    "deny with warn is refused by the API",
+			values:  []string{"Deny", "Warn"},
+			wantErr: "actions Deny and Warn cannot be combined",
+		},
+		{
+			name:    "deny with warn in either order",
+			values:  []string{"Warn", "Deny"},
+			wantErr: "actions Deny and Warn cannot be combined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseValidationActions(tt.values)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreatePolicyBindingMultipleActions(t *testing.T) {
+	out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn}, "", nil, nil)
+	require.NoError(t, err)
+
+	var binding admissionv1.ValidatingAdmissionPolicyBinding
+	require.NoError(t, yaml.Unmarshal([]byte(out), &binding))
+	assert.Equal(t, []admissionv1.ValidationAction{admissionv1.Audit, admissionv1.Warn}, binding.Spec.ValidationActions)
+}
+
+func TestCreatePolicyBindingCmdMultipleActions(t *testing.T) {
+	t.Run("repeated flag", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", "Audit", "--action", "Warn"})
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("comma separated", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", "Audit,Warn"})
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("deny with warn is rejected", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", "Deny,Warn"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined")
+	})
+
+	t.Run("duplicate is rejected", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--action", "Warn,Warn"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate action")
+	})
 }
 
 func TestCreatePolicyBindingCmdRequiredFlags(t *testing.T) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -519,19 +519,19 @@ kubescape vap create-policy-binding \
 ### Example
 
 ```bash
-# Create a policy that denies non-compliant resources in production
+# Report on non-compliant resources in production first
 kubescape vap create-policy-binding \
-  --name deny-privileged-containers \
-  --policy c-0057 \
-  --namespace production \
-  --action Deny | kubectl apply -f -
-
-# Report on non-compliant resources first, then switch the binding to Deny
-kubescape vap create-policy-binding \
-  --name audit-privileged-containers \
+  --name privileged-containers \
   --policy c-0057 \
   --namespace production \
   --action Audit --action Warn | kubectl apply -f -
+
+# Once the findings look right, switch the same binding to Deny
+kubescape vap create-policy-binding \
+  --name privileged-containers \
+  --policy c-0057 \
+  --namespace production \
+  --action Deny | kubectl apply -f -
 ```
 
 ## MCP Server (AI Integration)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -513,7 +513,7 @@ kubescape vap create-policy-binding \
 | `-p, --policy` | Policy/control to bind | Yes |
 | `--namespace` | Namespace selector (can be repeated) | No |
 | `--label` | Label selector in `key=value` format | No |
-| `-a, --action` | Action on failure: `Deny`, `Audit`, `Warn` | No (default: `Deny`) |
+| `-a, --action` | Action on failure: `Deny`, `Audit`, `Warn` (can be repeated; `Deny` and `Warn` cannot be combined) | No (default: `Deny`) |
 | `-r, --parameter-reference` | Parameter reference object name | No |
 
 ### Example
@@ -525,6 +525,13 @@ kubescape vap create-policy-binding \
   --policy c-0057 \
   --namespace production \
   --action Deny | kubectl apply -f -
+
+# Report on non-compliant resources first, then switch the binding to Deny
+kubescape vap create-policy-binding \
+  --name audit-privileged-containers \
+  --policy c-0057 \
+  --namespace production \
+  --action Audit --action Warn | kubectl apply -f -
 ```
 
 ## MCP Server (AI Integration)


### PR DESCRIPTION
## Overview

`kubescape vap create-policy-binding` could only put a single action into the generated binding's `validationActions`, because `--action` was a plain string flag. The Kubernetes API models that field as a set, and the combination people actually reach for first is `Audit` plus `Warn`: report what would break, look at the findings, then flip the binding to `Deny`. That binding was impossible to generate, so the usual workflow was to generate the YAML and then hand edit it, which is the thing the generator exists to avoid.

`--action` is now repeatable and accepts a comma separated list, and the values land on the binding in the order they were given.

```bash
kubescape vap create-policy-binding --name rollout-c-0016 --control C-0016 --action Audit --action Warn
```

```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: rollout-c-0016
spec:
  matchResources: {}
  policyName: kubescape-c-0016-allow-privilege-escalation
  validationActions:
  - Audit
  - Warn
```

The two combinations the apiserver rejects are now caught locally instead of at apply time:

- a repeated action, since `validationActions` is a `listType=set`
- `Deny` together with `Warn`, which the API forbids because it would report the same failure both in the response body and in the HTTP warning headers

Action spelling stays case sensitive and matches the API exactly, same as before.

## Compatibility

`--action Deny`, `--action Audit` and `--action Warn` behave exactly as they did, and omitting the flag still produces `Deny`. The only visible difference for an existing invocation is the flag help, which now reads `strings` with a default of `[Deny]`.

Passing an empty value (`--action ""`) clears the slice rather than adding a blank action, so it now reports `at least one --action is required` instead of `invalid action:`.

## Tests

- table tests over `parseValidationActions` covering single and multi action inputs, order preservation, whitespace trimming, the unknown and lowercase spellings, duplicates, and `Deny`/`Warn` in both orders
- command level tests for the repeated flag form, the comma separated form, and both rejection paths
- existing binding tests updated for the new signature

`go test ./cmd/...` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VAP supports multiple repeatable or comma-separated validation actions, including combinations such as `Audit` and `Warn`.
  * Actions are validated for supported values, duplicates, missing entries, and incompatible combinations.
  * Policy bindings can emit multiple validation actions.

* **Documentation**
  * Added rollout guidance for using `Audit`/`Warn` before switching to `Deny`.
  * Documented that `Deny` and `Warn` cannot be combined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->