### PR TITLE
fix(vap): validate the --from-release tag before building the release URL

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -231,11 +232,39 @@ var libraryReleaseFiles = []string{
 	"kubescape-validating-admission-policies.yaml",
 }
 
+// releaseTagPattern is the shape a cel-admission-library release tag may take.
+// It is deliberately an allowlist: the tag is interpolated into the release
+// URL, so any character that carries meaning in a URL path has to stay out.
+// Requiring an alphanumeric first character also rules out "." and ".." on its
+// own. Real tags ("v0.11") and the usual semver decorations ("v1.2.3-rc1",
+// "v1.2.3+build.5") all satisfy it.
+var releaseTagPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+
+// validateReleaseTag rejects a tag that would change the shape of the release
+// URL rather than just name a release within it. Without this the tag can walk
+// out of the kubescape release path entirely ("../../../../owner/repo/..."):
+// Go's HTTP client forwards the "../" segments verbatim and GitHub resolves
+// them server-side, so the library is served from an unrelated repository while
+// the log line still names the requested kubescape release. A "?" or "#" is the
+// same class of bug without an attacker - it truncates the URL, so every file
+// in libraryReleaseFiles resolves to the same object and the concatenated
+// output is silently wrong.
+func validateReleaseTag(tag string) error {
+	if !releaseTagPattern.MatchString(tag) {
+		return fmt.Errorf("invalid release tag %q: expected a release tag such as v0.11", tag)
+	}
+	return nil
+}
+
 // downloadLibrary fetches the library files from one pinned release tag and
 // concatenates them into a single multi-document YAML stream. The tag is
 // always explicit — downloading whatever "latest" points at would reintroduce
 // the skew deployLibrary's embedded default exists to prevent.
 func downloadLibrary(tag string, timeout time.Duration) (string, error) {
+	if err := validateReleaseTag(tag); err != nil {
+		return "", err
+	}
+
 	logger.L().Info(fmt.Sprintf("Downloading the Kubescape CEL admission policy library release %s", tag))
 
 	parts := make([]string, 0, len(libraryReleaseFiles))

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -312,6 +312,128 @@ func TestDeployLibraryFromRelease(t *testing.T) {
 	})
 }
 
+// A release tag is pasted straight into the release URL, so anything that can
+// change the URL's shape has to be rejected before the request is built. Go's
+// HTTP client forwards "../" segments verbatim and GitHub resolves them
+// server-side, so a tag carrying them silently serves the admission policy
+// library out of an unrelated repository - which deploy-library's own examples
+// then pipe into "kubectl apply -f -".
+func TestDeployLibraryRejectsTagsThatEscapeTheReleaseURL(t *testing.T) {
+	malicious := []struct {
+		name string
+		tag  string
+	}{
+		{name: "parent directory traversal", tag: "../../../../attacker/evil-repo/releases/download/v1"},
+		{name: "traversal after a real tag", tag: "v0.11/../../../../attacker/evil-repo/releases/download/v1"},
+		{name: "plain path separator", tag: "attacker/evil-repo"},
+		{name: "backslash separator", tag: `..\..\attacker`},
+		{name: "query string truncates the path", tag: "v0.11?ref="},
+		{name: "fragment truncates the path", tag: "v0.11#"},
+		{name: "absolute url", tag: "https://attacker.example.com/x"},
+	}
+	// An empty tag is not in this table on purpose: it is how deployLibrary
+	// selects the embedded bundle, so it never reaches the download path.
+
+	const wantPrefix = "/kubescape/cel-admission-library/releases/download/"
+
+	for _, tc := range malicious {
+		t.Run(tc.name, func(t *testing.T) {
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "attacker-controlled-content")
+			}))
+			defer server.Close()
+
+			origTransport := http.DefaultTransport
+			http.DefaultTransport = &redirectTransport{
+				baseURL:           strings.TrimPrefix(server.URL, "http://"),
+				originalTransport: server.Client().Transport,
+			}
+			defer func() { http.DefaultTransport = origTransport }()
+
+			_, err := deployLibrary(tc.tag, 0)
+
+			// The request must never be built at all: rejecting the tag up front
+			// is what keeps the download pinned to the kubescape release.
+			for _, path := range paths {
+				assert.True(t, strings.HasPrefix(path, wantPrefix),
+					"request escaped the pinned release URL: %q", path)
+			}
+			assert.Empty(t, paths, "an invalid release tag must not reach the network")
+			require.Error(t, err, "an invalid release tag must be rejected")
+			assert.Contains(t, err.Error(), "invalid release tag")
+		})
+	}
+}
+
+func TestValidateReleaseTag(t *testing.T) {
+	valid := []string{"v0.11", "v0.0.1", "1.2.3", "v1.2.3-rc1", "v1.2.3+build.5", "release_2024", "v10"}
+	for _, tag := range valid {
+		t.Run("valid/"+tag, func(t *testing.T) {
+			assert.NoError(t, validateReleaseTag(tag))
+		})
+	}
+
+	invalid := []struct {
+		name string
+		tag  string
+	}{
+		{name: "empty", tag: ""},
+		{name: "dot", tag: "."},
+		{name: "dot dot", tag: ".."},
+		{name: "leading dot", tag: ".v0.11"},
+		{name: "leading hyphen", tag: "-v0.11"},
+		{name: "forward slash", tag: "v0.11/x"},
+		{name: "backslash", tag: `v0.11\x`},
+		{name: "question mark", tag: "v0.11?x"},
+		{name: "hash", tag: "v0.11#x"},
+		{name: "percent encoded slash", tag: "v0.11%2F.."},
+		{name: "space", tag: "v0.11 x"},
+		{name: "at sign", tag: "v0.11@host"},
+		{name: "colon", tag: "https:"},
+		{name: "newline", tag: "v0.11\nx"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			err := validateReleaseTag(tc.tag)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid release tag")
+		})
+	}
+}
+
+func TestDeployLibraryAcceptsRealReleaseTags(t *testing.T) {
+	// Tags the cel-admission-library actually publishes, plus the shapes
+	// semver releases commonly take, must keep working.
+	for _, tag := range []string{"v0.11", "v0.0.1", "1.2.3", "v1.2.3-rc1", "v1.2.3+build.5", "release_2024"} {
+		t.Run(tag, func(t *testing.T) {
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "content")
+			}))
+			defer server.Close()
+
+			origTransport := http.DefaultTransport
+			http.DefaultTransport = &redirectTransport{
+				baseURL:           strings.TrimPrefix(server.URL, "http://"),
+				originalTransport: server.Client().Transport,
+			}
+			defer func() { http.DefaultTransport = origTransport }()
+
+			_, err := deployLibrary(tag, 0)
+			require.NoError(t, err)
+			require.Len(t, paths, len(libraryReleaseFiles))
+			for _, path := range paths {
+				assert.Equal(t, "/kubescape/cel-admission-library/releases/download/"+tag+"/", path[:strings.LastIndex(path, "/")+1])
+			}
+		})
+	}
+}
+
 func TestCreatePolicyBinding(t *testing.T) {
 	t.Run("minimal binding with name and policy", func(t *testing.T) {
 		out, err := createPolicyBinding("my-binding", "c-0016", "Deny", "", nil, nil)


### PR DESCRIPTION
`downloadLibrary` interpolated the `--from-release` tag straight into the `cel-admission-library` release URL. Go's HTTP client forwards `"../"` path segments verbatim and GitHub resolves them server-side, so a tag carrying them walks out of the pinned release path and serves the admission policy library from an arbitrary repository, while the log line still names the requested Kubescape release. `deploy-library`'s own examples pipe that output into `kubectl apply -f -`.

The same gap misbehaves without an attacker: a `"?"` or `"#"` in the tag truncates the URL, so all three files in `libraryReleaseFiles` resolve to the same object and the concatenated library is silently wrong, yet the command reports success.

Validate the tag against an allowlist before the URL is built. Real tags such as `"v0.11"` and the usual semver decorations such as `"v1.2.3-rc1"` and `"v1.2.3+build.5"` are unaffected; an empty tag still selects the embedded bundle.

## Overview

Added release-tag validation before constructing the download URL and added regression tests covering URL traversal, URL delimiters, invalid tag formats, and valid release tags.

The regression tests verify that malicious tags are rejected before any request is made and that valid release tags continue to download the expected files.

## Validation

The vulnerable behavior was reproduced against the previous implementation using a release tag containing path traversal. The request escaped the intended release path and GitHub served content from another repository.

The fixed implementation rejects the same tag before making the request.

The existing `v0.11` release behavior was also verified to remain unchanged.

<!-- Thanks for sending a pull request! -->

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have commented on my code, particularly in hard-to-understand areas
* [x] I have performed a self-review of my code
* [x] If it is a core feature, I have added thorough tests.
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for release tags used with `deploy-library --from-release`.
  * Invalid, malformed, or potentially unsafe tags are rejected before downloads begin.
  * Valid release tags continue to download the intended pinned release assets.

* **Tests**
  * Added coverage for valid tags and unsafe inputs, including traversal, URL, encoding, whitespace, and control-character cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->