### PR TITLE
fix(scan): collect a resource once when several API versions serve it

### DIFF
--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"testing"
 
@@ -19,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -464,6 +467,147 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 		assert.Equal(t, "metadata.namespace=agents", seenSelectors[gvr])
 		assert.Contains(t, resources, k8sinterface.GroupVersionResourceToString(&gvr))
 	}
+}
+
+// servedResource is one object as a single served version returns it: same
+// metadata.uid, apiVersion of the version that was listed.
+func servedResource(apiVersion, kind, namespace, name, uid string) *unstructured.Unstructured {
+	resource := unstructuredResource(apiVersion, kind, namespace, name)
+	resource.SetUID(types.UID(uid))
+	return resource
+}
+
+func servedWorkload(apiVersion, kind, namespace, name, uid string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(servedResource(apiVersion, kind, namespace, name, uid).Object)
+}
+
+func TestPullResourcesDeduplicatesResourceServedAtSeveralVersions(t *testing.T) {
+	const uid = "11111111-1111-1111-1111-111111111111"
+	alpha := schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"}
+	beta := schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+
+	// One Sandbox, returned by both served versions as a real CRD does.
+	served := map[schema.GroupVersionResource]*unstructured.Unstructured{
+		alpha: servedResource("agents.x-k8s.io/v1alpha1", "Sandbox", "agents", "alpha-sandbox", uid),
+		beta:  servedResource("agents.x-k8s.io/v1beta1", "Sandbox", "agents", "alpha-sandbox", uid),
+	}
+	listKinds := map[schema.GroupVersionResource]string{alpha: "CustomResourceList", beta: "CustomResourceList"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	dynamicClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{}
+		if object, ok := served[action.GetResource()]; ok {
+			list.Items = []unstructured.Unstructured{*object}
+		}
+		return true, list, nil
+	})
+
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		DynamicClient:   dynamicClient,
+		DiscoveryClient: agentRuntimeDiscovery(),
+	}}
+	resolver, discoveryFailures := newDiscoveryResourceResolver(handler.k8s.DiscoveryClient)
+	require.Empty(t, discoveryFailures)
+
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{"agents.x-k8s.io"},
+		APIVersions: []string{"v1alpha1", "v1beta1"},
+		Resources:   []string{"Sandbox"},
+	}
+	framework := *mockFramework("agent-runtime", []reporthandling.Control{
+		mockControl("agent-runtime", []reporthandling.PolicyRule{
+			mockRule("agent-runtime", []reporthandling.RuleMatchObjects{match}, ""),
+		}),
+	})
+	queryable, _ := getQueryableResourceMapFromPolicies(
+		[]reporthandling.Framework{framework}, nil, reporthandling.ScopeCluster, resolver)
+	resources, allResources, failures := handler.pullResources(context.Background(), queryable, NewIncludeSelector("agents"), "")
+
+	assert.Empty(t, failures)
+	require.Len(t, allResources, 1, "one Sandbox served at two versions must be collected once")
+
+	surviving := slices.Collect(maps.Keys(allResources))[0]
+	assert.Equal(t, "agents.x-k8s.io/v1beta1/agents/Sandbox/alpha-sandbox", surviving,
+		"the newest served version must survive")
+
+	// A rule declaring either version still resolves to the same object.
+	for _, gvr := range []schema.GroupVersionResource{alpha, beta} {
+		assert.Equal(t, []string{surviving}, resources[k8sinterface.GroupVersionResourceToString(&gvr)])
+	}
+}
+
+func TestDedupeServedVersionAliases(t *testing.T) {
+	const uid = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("prefers GA over pre-release versions", func(t *testing.T) {
+		allResources := map[string]workloadinterface.IMetadata{}
+		for _, apiVersion := range []string{"ate.dev/v1alpha1", "ate.dev/v1beta1", "ate.dev/v1"} {
+			workload := servedWorkload(apiVersion, "WorkerPool", "agents", "shared", uid)
+			allResources[workload.GetID()] = workload
+		}
+		require.Len(t, allResources, 3)
+
+		dedupeServedVersionAliases(cautils.K8SResources{}, allResources)
+
+		require.Len(t, allResources, 1)
+		assert.Equal(t, "ate.dev/v1", slices.Collect(maps.Values(allResources))[0].GetApiVersion())
+	})
+
+	t.Run("keeps objects with different uids", func(t *testing.T) {
+		first := servedWorkload("ate.dev/v1alpha1", "WorkerPool", "agents", "first", uid)
+		second := servedWorkload("ate.dev/v1alpha1", "WorkerPool", "agents", "second", "22222222-2222-2222-2222-222222222222")
+		allResources := map[string]workloadinterface.IMetadata{
+			first.GetID(): first, second.GetID(): second,
+		}
+
+		dedupeServedVersionAliases(cautils.K8SResources{}, allResources)
+
+		assert.Len(t, allResources, 2)
+	})
+
+	t.Run("leaves objects without a uid alone", func(t *testing.T) {
+		first := workloadinterface.NewWorkloadObj(unstructuredResource("ate.dev/v1alpha1", "WorkerPool", "agents", "first").Object)
+		second := workloadinterface.NewWorkloadObj(unstructuredResource("ate.dev/v1beta1", "WorkerPool", "agents", "first").Object)
+		allResources := map[string]workloadinterface.IMetadata{
+			first.GetID(): first, second.GetID(): second,
+		}
+
+		dedupeServedVersionAliases(cautils.K8SResources{}, allResources)
+
+		assert.Len(t, allResources, 2)
+	})
+
+	t.Run("rewrites every reference to the dropped alias", func(t *testing.T) {
+		alpha := servedWorkload("ate.dev/v1alpha1", "WorkerPool", "agents", "shared", uid)
+		beta := servedWorkload("ate.dev/v1beta1", "WorkerPool", "agents", "shared", uid)
+		allResources := map[string]workloadinterface.IMetadata{
+			alpha.GetID(): alpha, beta.GetID(): beta,
+		}
+		k8sResources := cautils.K8SResources{
+			"ate.dev/v1alpha1/workerpools": {alpha.GetID()},
+			"ate.dev/v1beta1/workerpools":  {beta.GetID()},
+		}
+
+		dedupeServedVersionAliases(k8sResources, allResources)
+
+		assert.Equal(t, []string{beta.GetID()}, k8sResources["ate.dev/v1alpha1/workerpools"])
+		assert.Equal(t, []string{beta.GetID()}, k8sResources["ate.dev/v1beta1/workerpools"])
+		assert.NotContains(t, allResources, alpha.GetID())
+	})
+
+	t.Run("collapses an alias listed twice under one resource", func(t *testing.T) {
+		alpha := servedWorkload("ate.dev/v1alpha1", "WorkerPool", "agents", "shared", uid)
+		beta := servedWorkload("ate.dev/v1beta1", "WorkerPool", "agents", "shared", uid)
+		allResources := map[string]workloadinterface.IMetadata{
+			alpha.GetID(): alpha, beta.GetID(): beta,
+		}
+		k8sResources := cautils.K8SResources{
+			"ate.dev/v1beta1/workerpools": {alpha.GetID(), beta.GetID()},
+		}
+
+		dedupeServedVersionAliases(k8sResources, allResources)
+
+		assert.Equal(t, []string{beta.GetID()}, k8sResources["ate.dev/v1beta1/workerpools"])
+	})
 }
 
 func TestFileResourceHandlerUsesManifestAPIVersionsForBuiltIns(t *testing.T) {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -840,7 +840,96 @@ func (k8sHandler *K8sResourceHandler) pullResources(ctx context.Context, queryab
 	}
 
 	wg.Wait()
+	dedupeServedVersionAliases(k8sResources, allResources)
 	return k8sResources, allResources, failedQueries
+}
+
+// dedupeServedVersionAliases collapses objects the API server returned under
+// more than one served version of the same resource. A CRD served at both
+// v1alpha1 and v1beta1 answers each LIST with the same objects converted to the
+// requested version, so a control matching both versions collects, counts and
+// reports one custom resource twice.
+//
+// metadata.uid is the join key: Kubernetes keeps it stable across versions and
+// unique across the cluster, so equal uids are the same object and no two
+// distinct objects can be merged by mistake. Objects without one (offline and
+// synthetic resources) are left alone.
+//
+// Every GVR keeps pointing at the surviving object, so a rule declaring either
+// version still matches it.
+func dedupeServedVersionAliases(k8sResources cautils.K8SResources, allResources map[string]workloadinterface.IMetadata) {
+	byUID := make(map[string][]string, len(allResources))
+	for _, id := range slices.Sorted(maps.Keys(allResources)) {
+		if uid := resourceUID(allResources[id]); uid != "" {
+			byUID[uid] = append(byUID[uid], id)
+		}
+	}
+
+	alias := map[string]string{} // dropped resource ID -> surviving one
+	for _, ids := range byUID {
+		if len(ids) < 2 {
+			continue
+		}
+		survivor := ids[0]
+		for _, id := range ids[1:] {
+			if preferServedVersion(allResources[id], allResources[survivor]) {
+				survivor = id
+			}
+		}
+		for _, id := range ids {
+			if id != survivor {
+				alias[id] = survivor
+			}
+		}
+	}
+	if len(alias) == 0 {
+		return
+	}
+
+	for dropped := range alias {
+		delete(allResources, dropped)
+	}
+	for gvr, resourceIDs := range k8sResources {
+		seen := make(map[string]struct{}, len(resourceIDs))
+		deduped := make([]string, 0, len(resourceIDs))
+		for _, id := range resourceIDs {
+			if survivor, dropped := alias[id]; dropped {
+				id = survivor
+			}
+			if _, duplicate := seen[id]; duplicate {
+				continue
+			}
+			seen[id] = struct{}{}
+			deduped = append(deduped, id)
+		}
+		k8sResources[gvr] = deduped
+	}
+}
+
+// resourceUID reads metadata.uid off a collected object.
+func resourceUID(resource workloadinterface.IMetadata) string {
+	if resource == nil {
+		return ""
+	}
+	uid, _, err := unstructured.NestedString(resource.GetObject(), "metadata", "uid")
+	if err != nil {
+		return ""
+	}
+	return uid
+}
+
+// preferServedVersion reports whether candidate is the better copy to keep of
+// two aliases of one object. It follows the API server's own version ranking
+// (GA over beta over alpha, newest first), so a scan reports the version a
+// client would get by default. The ID comparison keeps the choice stable when
+// the ranking cannot separate them, since the pulls complete in any order.
+func preferServedVersion(candidate, current workloadinterface.IMetadata) bool {
+	_, candidateVersion := k8sinterface.SplitApiVersion(candidate.GetApiVersion())
+	_, currentVersion := k8sinterface.SplitApiVersion(current.GetApiVersion())
+	if ranking := version.CompareKubeAwareVersionStrings(candidateVersion, currentVersion); ranking != 0 {
+		return ranking > 0
+	}
+	return candidate.GetID() < current.GetID()
 }
 
 func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResources cautils.K8SResources, infoMap map[string]apis.StatusInfo) []cautils.PartialGVRPull {


### PR DESCRIPTION
## Overview

A CRD can serve the same object at more than one version, and the API server converts on read, so listing `agents.x-k8s.io/v1alpha1/sandboxes` and `agents.x-k8s.io/v1beta1/sandboxes` returns the same Sandbox twice, once in each version's shape. Kubescape resolves every version a rule declares into its own live query and keys the result on the object's apiVersion, so those two copies land as two different resource IDs. The scan then counts one custom resource as two, and a control that fails on it fails twice.

This matters most for the CRDs tracked in #2557. A control targeting `Sandbox`, `SandboxTemplate`, `ActorTemplate` or `WorkerPool` has to declare several apiVersions to be useful, because those APIs are still moving between alpha and beta, and the contract tests in this package already model rules written that way.

Collected resources are now joined on `metadata.uid` after the pulls finish. Kubernetes keeps a uid stable across served versions and unique across the cluster, so equal uids are the same object and no two distinct objects can be merged by accident. Objects that carry no uid, which is every offline and synthetic resource, are left untouched.

The copy that survives is the one the API server itself would rank highest, using the same GA over beta over alpha ordering discovery uses for preferred versions, so a scan reports the version a client gets by default. Where the ranking cannot separate two copies the resource ID breaks the tie, which keeps the result stable no matter what order the parallel pulls happen to finish in.

Every resource key still points at the surviving object, so a rule declaring the older version keeps matching it and nothing drops out of a control's inputs.

## Before and after

One Sandbox in the cluster, served at `v1alpha1` and `v1beta1`, with a rule declaring both:

```
before: agents.x-k8s.io/v1alpha1/agents/Sandbox/alpha-sandbox
        agents.x-k8s.io/v1beta1/agents/Sandbox/alpha-sandbox

after:  agents.x-k8s.io/v1beta1/agents/Sandbox/alpha-sandbox
```

## Scope

Only the live cluster collection path changes. File scans read whatever the manifest declares and carry no uid, so they behave exactly as before. A resource served at a single version is untouched, which is every built in resource on a current cluster.

## Tests

Added to the agent runtime CRD contract tests:

- an end to end pull where one Sandbox is served at two versions, asserting it is collected once, that the newer version is the one kept, and that both resource keys still resolve to it
- GA winning over beta and alpha for the same object
- distinct uids left as separate resources
- objects with no uid left alone
- a dropped alias rewritten everywhere it was referenced, including twice under one resource key

`go test ./core/...` passes, and the resourcehandler package passes under `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Kubernetes resources from appearing when exposed through multiple API versions.
  * Retains the newest served API version while preserving distinct resources and UID-less objects.
  * Updated resource references and indexes to point to the correct surviving version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->