### PR TITLE
feat(scan): implement missing controls listing in ScanAll functionality

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -278,9 +278,20 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 		return nil, err
 	}
 
-	// TODO - list supported frameworks/controls
 	if scanInfo.ScanAll {
+		// Add all frameworks
 		policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, listFrameworksNames(getters.PolicyGetter), apisv1.KindFramework)
+
+		// Add all controls
+		if controls, err := getters.PolicyGetter.ListControls(); err == nil {
+			controlIDs := make([]string, 0, len(controls))
+			for _, control := range controls {
+				controlIDs = append(controlIDs, parseControlEntry(control).ID)
+			}
+			policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, controlIDs, apisv1.KindControl)
+		} else {
+			logger.L().Ctx(ctxInit).Warning("failed to list controls for ScanAll", helpers.Error(err))
+		}
 	}
 
 	logger.L().StopSuccess("Initialized scanner")


### PR DESCRIPTION
Remove TODO comment and implement controls listing when ScanAll is enabled.

This completes the ScanAll functionality to include both frameworks and controls as intended.

Fixes the TODO in core/core/scan.go to list both supported frameworks and controls when ScanAll=true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scans can now automatically include all available framework identifiers and control IDs when scanning all policies.

* **Bug Fixes**
  * Scanning continues successfully when control-list discovery encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->