### PR TITLE
fix(resourcehandler): dedupe served-version aliases in streaming collector

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -387,6 +387,15 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		}
 	}
 
+	// A resource served at several API versions is scoped identically under
+	// every version (same metadata.namespace), so its aliases always land in
+	// the same batch and can be deduplicated per batch. See
+	// dedupeServedVersionAliases.
+	dedupeServedVersionAliases(resident.K8SResources, resident.AllResources)
+	for _, batch := range namespaceBatches {
+		dedupeServedVersionAliases(batch.K8SResources, batch.AllResources)
+	}
+
 	// Preserve the eager collector's failure contract. Whole-GVR failures feed
 	// InfoMap, while selector failures for a GVR that returned some resources
 	// remain non-fatal and are surfaced as partial coverage.

--- a/core/pkg/resourcehandler/k8sresources_streaming_dedupe_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_dedupe_test.go
@@ -1,0 +1,82 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestCollectAndStreamBatches_DeduplicatesResourceServedAtSeveralVersions pins
+// the bug: unlike pullResources (see
+// TestPullResourcesDeduplicatesResourceServedAtSeveralVersions), the streaming
+// collector never calls dedupeServedVersionAliases, so a single object served
+// under two API versions is collected and reported twice on large/streaming
+// scans.
+func TestCollectAndStreamBatches_DeduplicatesResourceServedAtSeveralVersions(t *testing.T) {
+	const uid = "11111111-1111-1111-1111-111111111111"
+	alpha := schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"}
+	beta := schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+
+	// One Sandbox, returned by both served versions as a real CRD does.
+	served := map[schema.GroupVersionResource]*unstructured.Unstructured{
+		alpha: servedResource("agents.x-k8s.io/v1alpha1", "Sandbox", "agents", "alpha-sandbox", uid),
+		beta:  servedResource("agents.x-k8s.io/v1beta1", "Sandbox", "agents", "alpha-sandbox", uid),
+	}
+	listKinds := map[schema.GroupVersionResource]string{alpha: "CustomResourceList", beta: "CustomResourceList"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	dynamicClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{}
+		if object, ok := served[action.GetResource()]; ok {
+			list.Items = []unstructured.Unstructured{*object}
+		}
+		return true, list, nil
+	})
+
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		KubernetesClient: fakeclientset.NewClientset(),
+		DynamicClient:    dynamicClient,
+		DiscoveryClient:  agentRuntimeDiscovery(),
+	}}
+	resolver, discoveryFailures := newDiscoveryResourceResolver(handler.k8s.DiscoveryClient)
+	require.Empty(t, discoveryFailures)
+
+	namespaced := true
+	queryable := QueryableResources{
+		k8sinterface.GroupVersionResourceToString(&alpha): {GroupVersionResourceTriplet: k8sinterface.GroupVersionResourceToString(&alpha), Namespaced: &namespaced},
+		k8sinterface.GroupVersionResourceToString(&beta):  {GroupVersionResourceTriplet: k8sinterface.GroupVersionResourceToString(&beta), Namespaced: &namespaced},
+	}
+
+	ctx := context.Background()
+	scanInfo, session := streamingTestSession(ctx)
+	batches := make(chan *cautils.ResourceBatch, 4)
+
+	err := handler.collectAndStreamBatches(
+		ctx,
+		queryable,
+		&EmptySelector{},
+		session,
+		scanInfo,
+		cautils.ExternalResources{},
+		batches,
+		resolver,
+	)
+	require.NoError(t, err)
+	close(batches)
+
+	total := 0
+	for batch := range batches {
+		total += len(batch.AllResources)
+	}
+
+	assert.Equal(t, 1, total, "one Sandbox served at two API versions must be streamed once, not once per served version")
+}


### PR DESCRIPTION
## Overview
Fixes #3302.

The streaming resource collector (`collectAndStreamBatches` in `core/pkg/resourcehandler/k8sresources.go`) pulls each declared GVR independently and appends every returned object straight into the resident or namespace batch:

```go
for _, metaObj := range metaObjs {
    scope := streamingResourceScope(metaObj, qr.Namespaced)
    if scope == cautils.ClusterScope {
        resident.K8SResources[qr.GroupVersionResourceTriplet] = append(resident.K8SResources[qr.GroupVersionResourceTriplet], metaObj.GetID())
        resident.AllResources[metaObj.GetID()] = metaObj
    } else {
        ...
        batch.K8SResources[qr.GroupVersionResourceTriplet] = append(batch.K8SResources[qr.GroupVersionResourceTriplet], metaObj.GetID())
        batch.AllResources[metaObj.GetID()] = metaObj
    }
}
```

A resource served under several API versions (e.g. a Gateway API object served at both `v1beta1` and `v1`) is the same object returned once per version, converted. Since the resource ID embeds the apiVersion, both copies get distinct IDs and both survive into the batches, so the object is evaluated and reported twice whenever a matching control declares more than one of those versions.

The eager (non-streaming) collector already handles this: `pullResources` ends with a call to `dedupeServedVersionAliases`, which joins on `metadata.uid` and keeps the version the API server itself would prefer. The streaming collector never called it.

The fix adds the same call, once per batch, right after the partition loop:

```go
dedupeServedVersionAliases(resident.K8SResources, resident.AllResources)
for _, batch := range namespaceBatches {
    dedupeServedVersionAliases(batch.K8SResources, batch.AllResources)
}
```

This is safe to apply per batch because a streaming batch's scope is derived from the object's own `metadata.namespace`, which is identical across served-version aliases of the same object — so aliases of one object always land in the same batch.

## Test
Added `TestCollectAndStreamBatches_DeduplicatesResourceServedAtSeveralVersions`, mirroring the existing eager-path test (`TestPullResourcesDeduplicatesResourceServedAtSeveralVersions`): one object served at two API versions, both matched by a rule, streamed through `collectAndStreamBatches`. Asserts exactly one resource is collected across all batches.

Verified by reverting the fix locally: the test fails with `expected: 1, actual: 2`, confirming it pins the bug. Restoring the fix makes it pass again, and the full `resourcehandler` package suite passes.

## Checklist
- [x] I've read the contribution guidelines
- [x] I've created a test to cover my changes
- [x] I've referenced the issue this PR fixes
- [x] I've checked my PR against the coding standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate Kubernetes resources from being streamed when they are available through multiple API versions.
  - Applied consistent deduplication across resident and namespace-scoped resource batches.

- **Tests**
  - Added regression coverage confirming that versioned duplicates are collected and streamed only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->