### PR TITLE
fix(download): handle nested output directory creation and error wrapping (#3305)

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -81,7 +81,7 @@ func DownloadSupportCommands() []string {
 func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) (*metav1.DownloadResult, error) {
 	setPathAndFilename(downloadInfo)
 	if err := os.MkdirAll(downloadInfo.Path, downloadDirPerm); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create download directory %q: %w", downloadInfo.Path, err)
 	}
 	files, err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc)
 	if err != nil {
@@ -110,6 +110,8 @@ func setPathAndFilename(downloadInfo *metav1.DownloadInfo) {
 	if downloadInfo.FileName != "" {
 		if downloadInfo.Path == "" {
 			downloadInfo.Path = "."
+		} else {
+			downloadInfo.Path = filepath.Clean(downloadInfo.Path)
 		}
 		return
 	}
@@ -139,6 +141,8 @@ func setPathAndFilename(downloadInfo *metav1.DownloadInfo) {
 	if strings.Contains(file, ".json") {
 		downloadInfo.Path = filepath.Clean(dir)
 		downloadInfo.FileName = file
+	} else {
+		downloadInfo.Path = filepath.Clean(downloadInfo.Path)
 	}
 }
 

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -209,6 +209,31 @@ func TestSetPathAndFilename(t *testing.T) {
 			expectedPath:     "sub",
 			expectedFilename: "nsa.json",
 		},
+		{
+			// Deep nested .json path pre-split
+			downloadInfo: &metav1.DownloadInfo{
+				Path:     filepath.Join("a", "b", "c"),
+				FileName: "framework.json",
+			},
+			expectedPath:     filepath.Join("a", "b", "c"),
+			expectedFilename: "framework.json",
+		},
+		{
+			// Deep nested .json file in full path
+			downloadInfo: &metav1.DownloadInfo{
+				Path: filepath.Join("custom", "output", "dir", "nsa.json"),
+			},
+			expectedPath:     filepath.Join("custom", "output", "dir"),
+			expectedFilename: "nsa.json",
+		},
+		{
+			// Deep nested directory with trailing directory format
+			downloadInfo: &metav1.DownloadInfo{
+				Path: filepath.Join("custom", "output", "nested_dir"),
+			},
+			expectedPath:     filepath.Join("custom", "output", "nested_dir"),
+			expectedFilename: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -262,6 +287,53 @@ func TestDownload_CreatesOutputDirectoryWithRestrictivePermissions(t *testing.T)
 	require.NoError(t, err)
 	mode := info.Mode().Perm()
 	assert.Zerof(t, mode&0o077, "directory %s has mode %o, more permissive than 0700", path, mode)
+}
+
+func TestDownload_CreatesNestedCustomOutputDirectory(t *testing.T) {
+	withTenantConfig(t, &fakeTenantConfig{})
+	want := &reporthandling.Framework{PortalBase: armotypes.PortalBase{Name: "nsa"}}
+	withPolicyGetter(t, &fakePolicyGetter{framework: want}, nil)
+
+	origDownloadFunc := downloadFunc
+	t.Cleanup(func() { downloadFunc = origDownloadFunc })
+
+	tempDir := t.TempDir()
+	nestedTargetDir := filepath.Join(tempDir, "custom", "nested", "reports")
+	targetFilePath := filepath.Join(nestedTargetDir, "nsa.json")
+
+	ks := NewKubescape(context.Background())
+	res, err := ks.Download(&metav1.DownloadInfo{
+		Target:     TargetFramework,
+		Identifier: "nsa",
+		Path:       targetFilePath,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.Files, 1)
+
+	assert.FileExists(t, targetFilePath)
+	info, err := os.Stat(nestedTargetDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	mode := info.Mode().Perm()
+	assert.Zerof(t, mode&0o077, "directory %s has mode %o, more permissive than 0700", nestedTargetDir, mode)
+}
+
+func TestDownload_DirectoryCreationErrorWrapped(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "blocking-file")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0600))
+
+	// Attempting to create a directory under a file should fail
+	invalidDirPath := filepath.Join(filePath, "sub-dir")
+
+	ks := NewKubescape(context.Background())
+	_, err := ks.Download(&metav1.DownloadInfo{
+		Target: TargetFramework,
+		Path:   invalidDirPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create download directory")
 }
 
 // TestDownload_BareJSONOutputPathIsRespected is a regression test for


### PR DESCRIPTION

## Overview
When running `kubescape download` with custom `--output` paths pointing to non-existent or deeply nested intermediate directories, Kubescape previously returned unhandled OS errors.

This PR:
- Adds descriptive error wrapping around `os.MkdirAll(downloadInfo.Path, downloadDirPerm)` in `Kubescape.Download()` to provide clear context when directory creation fails.
- Normalizes destination paths with `filepath.Clean` in `setPathAndFilename` to handle deeply nested and formatted paths cleanly.
- Adds comprehensive unit tests in `download_test.go` to verify nested directory creation with restrictive permissions (`0700`) and error wrapping.

## Additional Information
- Preserves the existing `0700` restrictive directory permissions policy enforced by Kubescape.
- Directory and file split logic in `setPathAndFilename` remains fully backward-compatible with pre-split shapes and default paths.

## How to Test
Run the download unit test suite:
```bash
go test -v ./core/core -run "TestDownload|TestSetPathAndFilename"
```

## Related issues/PRs:
* Resolved #3305

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of custom output paths, including nested directories.
  - Download directory creation errors now provide clearer context.
  - Explicit output directories are normalized consistently for reliable file placement.

- **Tests**
  - Added coverage for nested output directories, pre-split filenames, and deeply nested paths.
  - Added verification that created directories use restrictive permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->