### PR TITLE
fix: enforce submit flag mutual exclusivity for all scan commands

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -124,10 +124,6 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 func validateControlScanInfo(scanInfo *cautils.ScanInfo) error {
 	severity := scanInfo.FailThresholdSeverity
 
-	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
-		return ErrOmitRawResourcesOrSubmit
-	}
-
 	if err := validateControlTimeout(scanInfo); err != nil {
 		return err
 	}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -43,8 +43,6 @@ var (
 	ErrSecurityViewNotSupported = errors.New("security view is not supported for framework scan")
 	ErrBadThreshold             = errors.New("bad argument: out of range threshold")
 	ErrControlTimeoutTooHigh    = errors.New("--control-timeout must be lower than --scan-timeout")
-	ErrKeepLocalOrSubmit        = errors.New("you can use `keep-local` or `submit`, but not both")
-	ErrOmitRawResourcesOrSubmit = errors.New("you can use `omit-raw-resources` or `submit`, but not both")
 )
 
 func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
@@ -261,15 +259,8 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 	if scanInfo.View == string(cautils.SecurityViewType) {
 		scanInfo.View = string(cautils.ResourceViewType)
 	}
-
-	if scanInfo.Submit.GetBool() && scanInfo.Local {
-		return ErrKeepLocalOrSubmit
-	}
 	if postureThresholdsOutOfRange(scanInfo) {
 		return ErrBadThreshold
-	}
-	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
-		return ErrOmitRawResourcesOrSubmit
 	}
 	if err := validateControlTimeout(scanInfo); err != nil {
 		return err

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -83,34 +83,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if scanInfo.FailThresholdSeverity != "" {
-				if err := shared.ValidateSeverity(
-					scanInfo.FailThresholdSeverity,
-				); err != nil {
-					return err
-				}
-			}
-
-			if scanInfo.MinSeverity != "" {
-				if err := shared.ValidateSeverity(scanInfo.MinSeverity); err != nil {
-					return err
-				}
-			}
-
-			if f := cmd.Flags().Lookup("format"); f != nil &&
-				f.Changed &&
-				scanInfo.Format == "" {
-
-				return fmt.Errorf(
-					"format cannot be empty, supported formats: %s",
-					strings.Join(shared.ScanFormats, ", "),
-				)
-			}
-
-			if err := shared.ValidateScanFormat(
-				scanInfo.Format,
-				shared.ScanFormats,
-			); err != nil {
+			if err := shared.ValidateCommonScanFlags(cmd, &scanInfo, shared.ScanFormats); err != nil {
 				return err
 			}
 			if scanInfo.ScanImages {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -1076,3 +1076,14 @@ func TestEnforceImageSeverityThresholdsUsesEmbeddedMetadataWithoutProvider(t *te
 
 	assert.EqualError(t, err, "image scan result exceeds severity threshold: high")
 }
+
+func TestGetScanCommand_RunE_SubmitExclusivity(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+
+	require.NoError(t, cmd.PersistentFlags().Set("submit", "true"))
+	require.NoError(t, cmd.PersistentFlags().Set("keep-local", "true"))
+
+	err := cmd.RunE(cmd, []string{""})
+	assert.EqualError(t, err, "you can use `keep-local` or `submit`, but not both")
+}

--- a/cmd/scan/validators_test.go
+++ b/cmd/scan/validators_test.go
@@ -30,11 +30,7 @@ func Test_validateControlScanInfo(t *testing.T) {
 			&cautils.ScanInfo{FailThresholdSeverity: "Unknown"},
 			shared.ErrUnknownSeverity,
 		},
-		{
-			"Submit with omit-raw-resources should be invalid",
-			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), OmitRawResources: true},
-			ErrOmitRawResourcesOrSubmit,
-		},
+
 		{
 			"Compliance threshold below 0 should be invalid",
 			&cautils.ScanInfo{ComplianceThreshold: -1},
@@ -97,16 +93,7 @@ func Test_validateFrameworkScanInfo(t *testing.T) {
 			&cautils.ScanInfo{AccountID: validAccountID},
 			nil,
 		},
-		{
-			"Submit with keep-local should be invalid",
-			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), Local: true, AccountID: validAccountID},
-			ErrKeepLocalOrSubmit,
-		},
-		{
-			"Submit with omit-raw-resources should be invalid",
-			&cautils.ScanInfo{Submit: cautils.NewBoolPtr(new(true)), OmitRawResources: true, AccountID: validAccountID},
-			ErrOmitRawResourcesOrSubmit,
-		},
+
 		{
 			"Compliance threshold below 0 should be invalid",
 			&cautils.ScanInfo{ComplianceThreshold: -1, AccountID: validAccountID},

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -25,6 +25,11 @@ var ErrUnknownSeverity = fmt.Errorf("unknown severity. Supported severities are:
 // ErrBadThreshold is returned when a numeric threshold is outside the valid range [0, 100].
 var ErrBadThreshold = fmt.Errorf("bad argument: out of range threshold")
 
+var (
+	ErrKeepLocalOrSubmit        = fmt.Errorf("you can use `keep-local` or `submit`, but not both")
+	ErrOmitRawResourcesOrSubmit = fmt.Errorf("you can use `omit-raw-resources` or `submit`, but not both")
+)
+
 // ValidateThresholds validates that FailThreshold, ComplianceThreshold and
 // FailCoverageThreshold are all within [0, 100]. This mirrors the check in
 // validateFrameworkScanInfo and validateControlScanInfo.
@@ -75,6 +80,13 @@ func ValidateScanFormat(format string, supported []string) error {
 
 // ValidateCommonScanFlags validates flags that are common to all scan subcommands
 func ValidateCommonScanFlags(cmd *cobra.Command, scanInfo *cautils.ScanInfo, supportedFormats []string) error {
+	if scanInfo.Submit.GetBool() && scanInfo.Local {
+		return ErrKeepLocalOrSubmit
+	}
+	if scanInfo.Submit.GetBool() && scanInfo.OmitRawResources {
+		return ErrOmitRawResourcesOrSubmit
+	}
+
 	if scanInfo.FailThresholdSeverity != "" {
 		if err := ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
 			return err

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -80,6 +80,9 @@ func TestValidateCommonScanFlags(t *testing.T) {
 		minSeverity   string
 		format        string
 		formatChanged bool
+		submit        bool
+		local         bool
+		omitRaw       bool
 		expectedErr   string
 	}{
 		{
@@ -119,6 +122,22 @@ func TestValidateCommonScanFlags(t *testing.T) {
 			formatChanged: true,
 			expectedErr:   "invalid format",
 		},
+		{
+			name:          "Submit with keep-local",
+			submit:        true,
+			local:         true,
+			format:        "json",
+			formatChanged: true,
+			expectedErr:   "you can use `keep-local` or `submit`, but not both",
+		},
+		{
+			name:          "Submit with omit-raw-resources",
+			submit:        true,
+			omitRaw:       true,
+			format:        "json",
+			formatChanged: true,
+			expectedErr:   "you can use `omit-raw-resources` or `submit`, but not both",
+		},
 	}
 
 	for _, tt := range tests {
@@ -127,6 +146,9 @@ func TestValidateCommonScanFlags(t *testing.T) {
 				FailThresholdSeverity: tt.severity,
 				MinSeverity:           tt.minSeverity,
 				Format:                tt.format,
+				Local:                 tt.local,
+				OmitRawResources:      tt.omitRaw,
+				Submit:                cautils.NewBoolPtr(&tt.submit),
 			}
 
 			cmd := &cobra.Command{}


### PR DESCRIPTION
Fixes a bug where `--submit` could be used with `--keep-local` or `--omit-raw-resources` in `scan workload` and `scan image` commands without returning an error.

The validations for these mutually exclusive flags were originally scoped to `validateFrameworkScanInfo` and `validateControlScanInfo`. They have been moved to `shared.ValidateCommonScanFlags` so they are correctly enforced across all `scan` subcommands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan validation now consistently rejects incompatible combinations of `submit` with `keep-local` or `omit-raw-resources`.
  * Validation behavior is aligned across scan types, providing clearer handling of invalid command options.
  * Added coverage to verify these option combinations are detected correctly.
  * Scan commands now apply common option validation consistently, including existing severity and output-format checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->