### PR TITLE
fix(exceptions): error on zero-match namespaceSelector in ClusterSecurityException

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -256,6 +256,13 @@ func buildResourceDesignators(
 			if err != nil {
 				return nil, err
 			}
+			if len(names) == 0 {
+				// A selector matching no namespace must not fall through to the
+				// scopeless-exception fallback below: an empty designator list
+				// means "matches every cluster" downstream, which would turn a
+				// deliberately narrow exception into a cluster-wide one.
+				return nil, fmt.Errorf("namespaceSelector matched no namespaces")
+			}
 			namespaceNames = names
 		}
 	}

--- a/core/cautils/getter/crdexceptionsgetter_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_test.go
@@ -548,6 +548,7 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 		selector  map[string]any
 		resources []map[string]any
 		want      []map[string]string
+		wantErr   bool
 	}{
 		{
 			name: "namespaceSelector matches one namespace",
@@ -602,7 +603,7 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 			selector: map[string]any{
 				"matchLabels": map[string]any{"env": "dev"},
 			},
-			want: []map[string]string{},
+			wantErr: true,
 		},
 		{
 			name: "namespaceSelector matches no namespaces with resources",
@@ -617,7 +618,7 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 					"apiGroup": "apps",
 				},
 			},
-			want: []map[string]string{},
+			wantErr: true,
 		},
 		{
 			name:     "empty namespaceSelector matches all namespaces",
@@ -674,6 +675,10 @@ func TestBuildResourceDesignators_NamespaceSelector(t *testing.T) {
 			}}
 
 			got, err := buildResourceDesignators(context.TODO(), obj, tc.kind, k8sClient)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tc.want, got)
 		})

--- a/core/cautils/getter/crdexceptionsgetter_zeromatch_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_zeromatch_test.go
@@ -1,0 +1,69 @@
+package getter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestCRDExceptionsGetter_ZeroMatchNamespaceSelectorMustNotWiden pins the bug:
+// a ClusterSecurityException whose namespaceSelector matches no namespace in
+// the cluster must not degrade into a scopeless (Resources == nil) exception
+// policy, because Kubescape's own exception matching treats an empty
+// Resources list as "matches every cluster" (see
+// opaprocessor.hasExplicitControlException), turning a narrowly-scoped
+// exception into a silent, cluster-wide one. The CRD is dropped (with a
+// logged warning, like any other malformed CRD) instead of being widened.
+func TestCRDExceptionsGetter_ZeroMatchNamespaceSelectorMustNotWiden(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	// No namespace in the cluster carries the label the selector asks for.
+	k8sClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod", Labels: map[string]string{"env": "prod"}}},
+	).Build()
+
+	listKinds := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds,
+		&unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "kubescape.io/v1beta1",
+				"kind":       "ClusterSecurityException",
+				"metadata":   map[string]any{"name": "cse-typo", "uid": "uid-1"},
+				"spec": map[string]any{
+					"match": map[string]any{
+						"namespaceSelector": map[string]any{
+							"matchLabels": map[string]any{"env": "staging-typo"},
+						},
+					},
+					"posture": []any{
+						map[string]any{"controlID": "C-0003", "action": "alert_only"},
+					},
+				},
+			},
+		},
+	)
+
+	g := &CRDExceptionsGetter{client: dynamicClient, k8sClient: k8sClient}
+	exceptions, err := g.GetExceptions(context.TODO(), "cluster-a")
+	require.NoError(t, err)
+
+	// A selector that matched nothing must not produce an exception that
+	// downstream treats as matching everything.
+	for _, exception := range exceptions {
+		require.NotEmpty(t, exception.Resources,
+			"a namespaceSelector that matched zero namespaces must not yield a scopeless (cluster-wide) exception policy")
+	}
+	require.Empty(t, exceptions, "a zero-match namespaceSelector should drop the CRD, not silently widen it")
+}


### PR DESCRIPTION
## Overview
Fixes #3309.

`buildResourceDesignators` in `core/cautils/getter/crdexceptionsgetter.go` resolves a `ClusterSecurityException`'s `namespaceSelector` into a list of namespace names, then builds resource designators from that list:

```go
names, err := resolveNamespaceSelector(ctx, labelSelector, k8sClient)
if err != nil {
    return nil, err
}
namespaceNames = names
```

When the selector matches zero namespaces, `resolveNamespaceSelector` returns an empty slice with no error. Every designator-building branch below is gated on `len(namespaceNames) > 0`, so nothing gets appended, and the fallback that guarantees "at least one scope designator" is gated on `!namespaceSelectorFound`, so it's skipped too. The function ends up returning an empty `Resources` list.

`hasExplicitControlException` in the OPA processor treats an empty `Resources` list as "no scope constraint, matches any cluster", which is correct for a genuinely global exception, but wrong here: this exception had a `namespaceSelector`, it just didn't match anything. So a `ClusterSecurityException` that was meant to narrowly target a labeled set of namespaces (a typo in the label, or the namespace not created yet) silently becomes a cluster-wide exception, with no error and no warning anywhere in the scan output.

## Fix
`buildResourceDesignators` now returns an explicit error when the selector matches zero namespaces:

```go
names, err := resolveNamespaceSelector(ctx, labelSelector, k8sClient)
if err != nil {
    return nil, err
}
if len(names) == 0 {
    return nil, fmt.Errorf("namespaceSelector matched no namespaces")
}
namespaceNames = names
```

This routes through the exact same handling `GetExceptions` already applies to any other malformed CRD: the CRD is skipped and a warning is logged naming it, instead of the exception being silently accepted with an empty scope.

## Test
Added `TestCRDExceptionsGetter_ZeroMatchNamespaceSelectorMustNotWiden`, which applies a `ClusterSecurityException` whose `namespaceSelector` matches no namespace in the cluster and asserts `GetExceptions` drops it entirely rather than returning a scopeless policy.

Two existing cases in `TestBuildResourceDesignators_NamespaceSelector` ("namespaceSelector matches no namespaces" and the variant with resources) previously asserted `want: []map[string]string{}` with no error, encoding the old behavior. Updated them to expect an error instead, since that's the whole point of this change.

Verified by reverting the production change locally: the new regression test fails with the exact scopeless-Resources symptom described above. Restoring the fix makes it pass again, and the rest of the package's tests still pass.

## Checklist
- [x] I've read the contribution guidelines
- [x] I've created a test to cover my changes
- [x] I've referenced the issue this PR fixes
- [x] I've checked my PR against the coding standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented namespace-scoped security exceptions with no matching namespaces from being treated as cluster-wide exceptions.
  * Such unmatched exceptions are now safely discarded without producing incorrect cluster-wide results.

* **Tests**
  * Added coverage for namespace selectors that match no namespaces, including cases with resource constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->