### PR TITLE
fix: prevent multiple and empty setNotBusy calls in requestshandler

### DIFF
--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -74,7 +74,6 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	select {
 	case handler.scanRequestChan <- scanParams:
 	default:
-		handler.state.setNotBusy(scanID)
 		w.Header().Set("Retry-After", "1")
 		handler.writeErrorWithStatus(w,
 			fmt.Errorf("scan queue is full; retry the request later"),

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -449,5 +449,4 @@ func (handler *HTTPHandler) writeErrorWithStatus(w http.ResponseWriter, err erro
 	response.Response = err.Error()
 	response.Type = utilsapisv1.ErrorScanResponseType
 	w.Write(responseToBytes(&response))
-	handler.state.setNotBusy(scanID)
 }


### PR DESCRIPTION
This PR fixes issue #3109 where `setNotBusy()` was being called multiple times on the metrics queue-full path.

**Root cause:**
When the scan queue is full, the `Metrics` handler explicitly called `handler.state.setNotBusy(scanID)`, while also letting `writeErrorWithStatus` mistakenly call `setNotBusy("")`. Furthermore, the `Metrics` handler already uses `defer handler.state.setNotBusy(scanID)` at the top, leading to a total of 3 calls.

**Fix:**
- Removed `handler.state.setNotBusy(scanID)` from `writeErrorWithStatus`. It was improperly setting the state for an empty scanID on the queue-full path, and it was redundant for all other valid callers, since callers of `writeErrorWithStatus` handle `setNotBusy` themselves via defer.
- Removed the explicit `handler.state.setNotBusy(scanID)` in the queue-full path in `prometheus.go` so that the `defer` handles it gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized scan option validation so incompatible combinations of submission, local retention, and raw-resource omission are handled consistently.
  - Improved scan request cleanup to prevent scan status from remaining incorrectly marked as busy after queueing or error responses.
- **Validation**
  - Preserved existing posture-threshold and control-timeout checks while consolidating common scan-option checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->