### PR TITLE
fix(rules): handle empty resourceNames in modify-privileged-pods-v1

### DIFF
--- a/rules/modify-privileged-pods-v1/raw.rego
+++ b/rules/modify-privileged-pods-v1/raw.rego
@@ -21,7 +21,8 @@ deny contains msga if {
 	rule := role.rules[p]
 
 	# a rule restricted to named pods cannot be pointed at an arbitrary privileged pod
-	not rule.resourceNames
+	# (an omitted or explicitly empty resourceNames list is unrestricted)
+	count(object.get(rule, "resourceNames", [])) == 0
 
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)

--- a/rules/modify-privileged-pods-v1/test/resourcenames-empty/expected.json
+++ b/rules/modify-privileged-pods-v1/test/resourcenames-empty/expected.json
@@ -1,0 +1,74 @@
+[
+    {
+        "alertMessage": "Subject: User-jane can modify pods in privileged namespaces",
+        "failedPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "reviewPaths": [
+            "relatedObjects[1].rules[0].resources[0]",
+            "relatedObjects[1].rules[0].verbs[0]",
+            "relatedObjects[1].rules[0].apiGroups[0]",
+            "relatedObjects[0].roleRef.name",
+            "relatedObjects[0].subjects[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "externalObjects": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "User",
+                "name": "jane",
+                "relatedObjects": [
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "RoleBinding",
+                        "metadata": {
+                            "name": "kube-system-pod-patcher-rb",
+                            "namespace": "kube-system"
+                        },
+                        "roleRef": {
+                            "apiGroup": "rbac.authorization.k8s.io",
+                            "kind": "Role",
+                            "name": "kube-system-pod-patcher"
+                        },
+                        "subjects": [
+                            {
+                                "apiGroup": "rbac.authorization.k8s.io",
+                                "kind": "User",
+                                "name": "jane"
+                            }
+                        ]
+                    },
+                    {
+                        "apiVersion": "rbac.authorization.k8s.io/v1",
+                        "kind": "Role",
+                        "metadata": {
+                            "name": "kube-system-pod-patcher",
+                            "namespace": "kube-system"
+                        },
+                        "rules": [
+                            {
+                                "apiGroups": [
+                                    ""
+                                ],
+                                "resources": [
+                                    "pods"
+                                ],
+                                "resourceNames": [],
+                                "verbs": [
+                                    "update"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+]

--- a/rules/modify-privileged-pods-v1/test/resourcenames-empty/input/role.yaml
+++ b/rules/modify-privileged-pods-v1/test/resourcenames-empty/input/role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-system-pod-patcher
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  resourceNames: []
+  verbs: ["update"]

--- a/rules/modify-privileged-pods-v1/test/resourcenames-empty/input/rolebinding.yaml
+++ b/rules/modify-privileged-pods-v1/test/resourcenames-empty/input/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-system-pod-patcher-rb
+  namespace: kube-system
+subjects:
+- kind: User
+  name: jane
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: kube-system-pod-patcher
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes : : #3312 
## Overview

- **Current Behavior:** `modify-privileged-pods-v1` incorrectly ignores RBAC rules when `resourceNames` is explicitly set to an empty list.
- **Future Behavior:** Treats omitted or empty `resourceNames` as unrestricted, while continuing to exclude rules scoped to specific resource names.

## Additional Information

- **Fix:** Replaces the presence-based `not rule.resourceNames` check with `count(object.get(rule, "resourceNames", [])) == 0`.
- **Regression Coverage:** Adds a `resourcenames-empty` fixture verifying that an explicitly empty `resourceNames` list still produces an alert.



### Related issues/PRs

Follow-up to [feat(rules): add modify-privileged-pods-v1 #3146](https://github.com/kubescape/kubescape/pull/3146?utm_source=chatgpt.com)
Related to fix(rules): guard privilege-escalation RBAC rules with resourceNames #3201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected privileged pod modification checks so omitted and explicitly empty resource name lists are treated consistently as unrestricted.

- **Tests**
  - Added coverage for permissions granted through an empty `resourceNames` list.
  - Added expected results confirming the associated user, role binding, role, review paths, alert metadata, and pod update permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->