### PR TITLE
fix(hostsensor): stop caching empty host sensor collections

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -121,6 +121,13 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 		return nil, err
 	}
 
+	if len(envelopes) == 0 {
+		// An empty entry carries no node data, only the absence of it. Serving it
+		// keeps a node-agent outage reported as "didn't report any <resource>"
+		// until the TTL runs out, long after the agent is back.
+		return nil, os.ErrNotExist
+	}
+
 	logger.L().Debug("Loaded host sensor envelopes from cache", helpers.String("resource", resourceName), helpers.Int("count", len(envelopes)))
 	return envelopes, nil
 }
@@ -134,6 +141,13 @@ func saveToCacheWithRename(clusterName, resourceName string, envelopes []hostsen
 		// An unresolved API server host is a shared cache key across every
 		// caller in that state; loadFromCache always refuses to read it back,
 		// so writing it is dead I/O and unnecessary disk data at rest.
+		return nil
+	}
+
+	if len(envelopes) == 0 {
+		// Nothing collected means the node-agent had nothing to report yet, not
+		// that the cluster has no node data. Persisting it would pin that outage
+		// for the whole TTL, and loadFromCache refuses to serve it back anyway.
 		return nil
 	}
 

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -1,7 +1,11 @@
 package hostsensorutils
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -29,6 +33,26 @@ func withTempCacheDir(t *testing.T) {
 	original := DefaultCacheDir
 	t.Cleanup(func() { DefaultCacheDir = original })
 	DefaultCacheDir = t.TempDir()
+}
+
+// writeCacheEntry writes a cache file directly, bypassing the saveToCache
+// guards, to stand in for an entry left behind by an earlier version.
+func writeCacheEntry(t *testing.T, clusterName, resourceName string, envelopes []hostsensor.HostSensorDataEnvelope) {
+	t.Helper()
+
+	path, err := getCacheFilePath(clusterName, resourceName)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+
+	data, err := json.Marshal(envelopes)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0600))
 }
 
 // TestLoadFromCache_DisabledByDefault guards against host sensor data being
@@ -142,6 +166,36 @@ func TestSaveToCache_ConcurrentWritersUseDistinctTemporaryFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Contains(t, []string{"node-a", "node-b"}, got[0].GetName())
+}
+
+// TestSaveToCache_SkipsEmptyEnvelopes guards against a node-agent outage being
+// pinned for the whole TTL: an empty collection records the absence of node
+// data, which every later scan in the window would then serve as fact.
+func TestSaveToCache_SkipsEmptyEnvelopes(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	require.NoError(t, saveToCache("ctx", "KubeletInfo", nil))
+	require.NoError(t, saveToCache("ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{}))
+
+	path, err := getCacheFilePath("ctx", "KubeletInfo")
+	require.NoError(t, err)
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "an empty collection must not be persisted")
+}
+
+// An empty entry already on disk must read as a miss so the scan collects
+// again, rather than as a cluster with no node data.
+func TestLoadFromCache_EmptyEntryIsTreatedAsMiss(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	writeCacheEntry(t, "ctx", "KubeletInfo", []hostsensor.HostSensorDataEnvelope{})
+
+	_, err := loadFromCache("ctx", "KubeletInfo")
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 // TestLoadFromCache_UnresolvedClusterIdentityIsRejected guards against the

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -138,6 +138,30 @@ func TestCRDResourceGetters(t *testing.T) {
 	}
 }
 
+// Covers the scan sequence a node-agent restart produces: one scan collects
+// nothing, the next one collects normally. With the cache enabled, the second
+// scan must query the cluster instead of being served the empty first result.
+func TestGetCRDResources_RecoversAfterEmptyCollection(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	hsh := &HostSensorHandler{dynamicClient: newCRDDynamicClient(t)}
+	got, rawCount, err := hsh.getKubeletInfo(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.Zero(t, rawCount)
+
+	item := newCRDItem("KubeletInfo", "node-1", map[string]any{"KubeletInfo": map[string]any{"version": "v1.30.0"}})
+	hsh.dynamicClient = newCRDDynamicClient(t, item)
+
+	got, rawCount, err = hsh.getKubeletInfo(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, 1, rawCount)
+	assert.Equal(t, "node-1", got[0].GetName())
+}
+
 func TestCollectResources_SkipsControlPlaneInfoWhenCloudProviderPresent(t *testing.T) {
 	items := []*unstructured.Unstructured{
 		newCRDItem("CloudProviderInfo", "node-1", map[string]any{"providerMetaDataAPIAccess": true}),


### PR DESCRIPTION
## Overview

Host sensor CRD data can be cached across scans by setting `HOSTSENSOR_CACHE_TTL`. Right now the cache also stores the result of a collection that found nothing at all, and that turns a temporary node-agent problem into a lasting one.

The sequence is easy to hit on a cluster where the node-agent is restarting or still starting up. A scan runs, the CRDs are not there yet, so `getCRDResources` returns an empty list and writes it to the cache. The node-agent comes back a minute later, but every scan for the rest of the TTL window is served that empty entry instead of querying the cluster. Since #3172 the zero item count is surfaced as `node-agent didn't report any <resource> for N nodes`, so the user keeps seeing kubelet, kube-proxy, control plane and kernel hardening controls skipped with an explanation that is no longer true, and there is nothing in the output pointing at the cache as the reason.

An empty collection is not a cacheable fact about a cluster. It only says the agent had nothing to report at that moment, which is exactly the state we want the next scan to re-check.

## What changed

Both sides of the cache now agree that an entry has to carry actual node data:

* `saveToCache` skips the write when there are no envelopes, so a bad moment never reaches disk.
* `loadFromCache` treats an empty entry as a miss and returns `os.ErrNotExist`, so entries already sitting in `~/.kubescape/cache/hostsensor` from an earlier version stop suppressing collection and the scan falls through to the cluster. Returning the not-exist error keeps it a quiet miss rather than a cache failure warning, matching how the disabled and unresolved identity cases already behave.

Nothing changes when the cache is off, which is still the default.

## Tests

* `TestSaveToCache_SkipsEmptyEnvelopes` checks that an empty collection leaves no file behind.
* `TestLoadFromCache_EmptyEntryIsTreatedAsMiss` writes an empty entry directly to the cache path, standing in for a file left by an earlier version, and checks it reads as a miss.
* `TestGetCRDResources_RecoversAfterEmptyCollection` walks the actual scan sequence with the cache enabled: an empty collection followed by a populated one, asserting the second scan sees the node.

All three fail before the change and pass after it. `go test ./core/pkg/hostsensorutils/... ./core/pkg/resourcehandler/... ./core/pkg/score/...` passes, and golangci-lint reports no issues on the package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty host sensor results are no longer saved or served from the cache.
  - Previously cached empty results are treated as cache misses, allowing newly available data to be retrieved.
  - Host sensor collection now recovers correctly after an initial empty result.

- **Tests**
  - Added coverage for empty cache entries, skipped persistence, and recovery when data becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->