### PR TITLE
fix(prettyprinter): stop treating resource-derived text as a format string

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -290,7 +290,7 @@ func (pp *PrettyPrinter) printGroupedResource(indent string, title string, rsc [
 
 	sort.Strings(resources)
 	for i := range resources {
-		cautils.SimpleDisplay(pp.writer, resources[i]+"\n")
+		cautils.SimpleDisplay(pp.writer, "%s\n", resources[i])
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan.go
@@ -73,8 +73,8 @@ func (cp *ClusterPrinter) printTopWorkloads(topWorkloadsByScore []reporthandling
 		ns := wl.GetNamespace()
 		name := wl.GetName()
 		kind := wl.GetKind()
-		cautils.SimpleDisplay(cp.writer, fmt.Sprintf("%d. namespace: %s, name: %s, kind: %s\n", i+1, ns, name, kind))
-		cautils.SimpleDisplay(cp.writer, fmt.Sprintf("   '%s'\n", getCallToActionString(cp.getWorkloadScanCommand(ns, kind, name))))
+		cautils.SimpleDisplay(cp.writer, "%d. namespace: %s, name: %s, kind: %s\n", i+1, ns, name, kind)
+		cautils.SimpleDisplay(cp.writer, "   '%s'\n", getCallToActionString(cp.getWorkloadScanCommand(ns, kind, name)))
 	}
 
 	cautils.SimpleDisplay(cp.writer, "\n")

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,4 +136,40 @@ func TestGetWorkloadScanCommand(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestClusterScan_printTopWorkloads_ResourceNameWithPercentVerbs guards
+// against a regression where resource-derived text was passed as the format
+// argument to cautils.SimpleDisplay instead of as a %s value: a resource name
+// containing %-verbs (reachable from an untrusted scanned manifest) was
+// silently corrupted by fmt's format-string interpretation instead of being
+// printed literally.
+func TestClusterScan_printTopWorkloads_ResourceNameWithPercentVerbs(t *testing.T) {
+	f, err := os.CreateTemp("", "print-top-workloads")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	cp := &ClusterPrinter{writer: f}
+
+	name := "my-deployment-%s-%d-leaked"
+	resource := reporthandling.NewResource(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+	})
+
+	cp.printTopWorkloads([]reporthandling.IResource{resource})
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Contains(t, string(got), name, "resource name must be printed literally, not interpreted as a format string")
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/reposcan.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/reposcan.go
@@ -74,8 +74,8 @@ func (rp *RepoPrinter) printTopWorkloads(topWorkloadsByScore []reporthandling.IR
 		name := wl.GetName()
 		kind := wl.GetKind()
 		cmdPrefix := getWorkloadPrefixForCmd(ns, kind, name)
-		cautils.SimpleDisplay(rp.writer, fmt.Sprintf("%d. %s\n", i+1, cmdPrefix))
-		cautils.SimpleDisplay(rp.writer, fmt.Sprintf("   %s\n", getCallToActionString(rp.getWorkloadScanCommand(ns, kind, name, *wl.GetSource()))))
+		cautils.SimpleDisplay(rp.writer, "%d. %s\n", i+1, cmdPrefix)
+		cautils.SimpleDisplay(rp.writer, "   %s\n", getCallToActionString(rp.getWorkloadScanCommand(ns, kind, name, *wl.GetSource())))
 	}
 
 	cautils.SimpleDisplay(rp.writer, "\n")

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/reposcan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/reposcan_test.go
@@ -1,10 +1,13 @@
 package prettyprinter
 
 import (
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRepoScan_getNextSteps(t *testing.T) {
@@ -111,4 +114,41 @@ func TestRepoScan_getWorkloadScanCommand(t *testing.T) {
 		})
 	}
 
+}
+
+// TestRepoScan_printTopWorkloads_ResourceNameWithPercentVerbs guards against a
+// regression where resource-derived text was passed as the format argument to
+// cautils.SimpleDisplay instead of as a %s value: a resource name containing
+// %-verbs (reachable from an untrusted scanned manifest) was silently
+// corrupted by fmt's format-string interpretation instead of being printed
+// literally.
+func TestRepoScan_printTopWorkloads_ResourceNameWithPercentVerbs(t *testing.T) {
+	f, err := os.CreateTemp("", "print-top-workloads")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	rp := &RepoPrinter{writer: f}
+
+	name := "my-deployment-%s-%d-leaked"
+	resource := reporthandling.NewResource(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+	})
+	resource.SetSource(&reporthandling.Source{Path: "path", RelativePath: "relativePath"})
+
+	rp.printTopWorkloads([]reporthandling.IResource{resource})
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Contains(t, string(got), name, "resource name must be printed literally, not interpreted as a format string")
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -199,7 +199,7 @@ func printTopComponents(writer *os.File, summary imageprinter.ImageScanSummary) 
 
 		output = output[:len(output)-1]
 
-		cautils.StarDisplay(writer, output+"\n")
+		cautils.StarDisplay(writer, "%s\n", output)
 	}
 
 	cautils.SimpleDisplay(writer, "\n")

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
@@ -708,3 +708,37 @@ func TestGetFilteredCVEs(t *testing.T) {
 		})
 	}
 }
+
+// TestPrintTopComponents_PackageNameWithPercentVerbs guards against a
+// regression where a pre-built package summary line was passed as the format
+// argument to cautils.StarDisplay instead of as a %s value: a package name
+// containing %-verbs (reachable from scanned image metadata) was silently
+// corrupted by fmt's format-string interpretation instead of being printed
+// literally.
+func TestPrintTopComponents_PackageNameWithPercentVerbs(t *testing.T) {
+	f, err := os.CreateTemp("", "print-top-components")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	name := "left-pad-%s-%d-leaked"
+	summary := imageprinter.ImageScanSummary{
+		PackageScores: map[string]*imageprinter.PackageScore{
+			name: {
+				Name:    name,
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	printTopComponents(f, summary)
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Contains(t, string(got), name, "package name must be printed literally, not interpreted as a format string")
+}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -2,11 +2,13 @@ package printer
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,4 +182,38 @@ func TestSetWriter_Pretty(t *testing.T) {
 	}
 
 	assert.NoFileExists(t, sourceTreeArtifact)
+}
+
+// TestPrintGroupedResource_ResourceNameWithPercentVerbs guards against a
+// regression where a resource-derived line was passed as the format argument
+// to cautils.SimpleDisplay instead of as a %s value: a workload name
+// containing %-verbs (reachable from an untrusted scanned manifest) was
+// silently corrupted by fmt's format-string interpretation instead of being
+// printed literally.
+func TestPrintGroupedResource_ResourceNameWithPercentVerbs(t *testing.T) {
+	f, err := os.CreateTemp("", "print-grouped-resource")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	name := "my-deployment-%s-%d-leaked"
+	resource := workloadinterface.NewBaseObject(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name": name,
+		},
+	})
+
+	pp := &PrettyPrinter{writer: f}
+	pp.printGroupedResource("", "", []WorkloadSummary{{resource: resource}})
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Contains(t, string(got), name, "resource name must be printed literally, not interpreted as a format string")
 }


### PR DESCRIPTION
## Overview

`cautils.SimpleDisplay`/`StarDisplay` (`core/cautils/display.go`) both forward their second argument to `fmt.Fprintf` as the format string. Four call sites in the pretty-printer built resource-derived text and passed the built string directly as that format argument, with zero variadic args:

- `core/pkg/resultshandling/printer/v2/prettyprinter.go` — `printGroupedResource`
- `core/pkg/resultshandling/printer/v2/prettyprinter/utils.go` — `printTopComponents`
- `core/pkg/resultshandling/printer/v2/prettyprinter/reposcan.go` — `RepoPrinter.printTopWorkloads`
- `core/pkg/resultshandling/printer/v2/prettyprinter/clusterscan.go` — `ClusterPrinter.printTopWorkloads`

File and repo scans parse YAML directly with no Kubernetes admission validation, so a crafted manifest can set `metadata.name` (or another field that ends up in one of these lines) to contain `%`-verbs, e.g. `my-deployment-%s-%d-leaked`. `fmt.Fprintf` then tries to consume those as format verbs instead of printing the text literally, corrupting the terminal report (`%!s(MISSING)`, `%!d(MISSING)`, ...) and making it harder to tell which resource a failed control is actually attributed to.

Each call site now passes the built text as a `%s` argument instead of as the format string itself.

## How to Test

`go test ./core/pkg/resultshandling/printer/v2/...` — added a regression test per call site that renders a resource/package name containing `%s`/`%d` and asserts it comes through unchanged.

## Related issues/PRs:

Resolved #3326