### PR TITLE
fix: compare --output file extensions case-insensitively

### DIFF
--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -66,7 +66,10 @@ const (
 // --output Report.JSON (or any differently-cased extension) failed the check
 // in every one of them and silently doubled up: Report.JSON.json.
 func HasOutputExt(outputFile, ext string) bool {
-	return strings.EqualFold(filepath.Ext(outputFile), ext)
+	if len(outputFile) < len(ext) {
+		return false
+	}
+	return strings.EqualFold(outputFile[len(outputFile)-len(ext):], ext)
 }
 
 // FormatOutputExt maps a format to the extension its printer enforces in

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -58,6 +59,15 @@ const (
 	SPDXOutputExt         = ".spdx.json"
 	PolicyReportOutputExt = ".yaml"
 )
+
+// HasOutputExt reports whether outputFile already ends with ext, compared
+// case-insensitively. Every v2 printer's SetWriter previously re-implemented
+// this check with a case-sensitive filepath.Ext(...) != ext comparison, so
+// --output Report.JSON (or any differently-cased extension) failed the check
+// in every one of them and silently doubled up: Report.JSON.json.
+func HasOutputExt(outputFile, ext string) bool {
+	return strings.EqualFold(filepath.Ext(outputFile), ext)
+}
 
 // FormatOutputExt maps a format to the extension its printer enforces in
 // SetWriter. Callers resolving an --output path must read it from here rather

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -225,6 +225,10 @@ func TestHasOutputExt(t *testing.T) {
 		{"different extension does not match", "report.yaml", ".json", false},
 		{"no extension does not match", "report", ".json", false},
 		{"empty outputFile does not match", "", ".json", false},
+		{"compound lowercase match", "report.cdx.json", ".cdx.json", true},
+		{"compound uppercase match", "Report.CDX.JSON", ".cdx.json", true},
+		{"compound partial match", "report.cdx.json", ".json", true},
+		{"compound different extension", "report.spdx.json", ".cdx.json", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -211,3 +211,24 @@ func TestFormatOutputExtCoversAllFormats(t *testing.T) {
 		assert.NotEmpty(t, ext, "format %q maps to an empty extension", format)
 	}
 }
+
+func TestHasOutputExt(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+		ext        string
+		want       bool
+	}{
+		{"exact lowercase match", "report.json", ".json", true},
+		{"uppercase extension matches lowercase ext", "Report.JSON", ".json", true},
+		{"mixed case extension matches", "Report.Json", ".json", true},
+		{"different extension does not match", "report.yaml", ".json", false},
+		{"no extension does not match", "report", ".json", false},
+		{"empty outputFile does not match", "", ".json", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasOutputExt(tt.outputFile, tt.ext))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -37,8 +36,7 @@ func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = csvOutputFile
 		}
-		ext := filepath.Ext(strings.TrimSpace(outputFile))
-		if ext != printer.CsvOutputExt {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.CsvOutputExt) {
 			outputFile = outputFile + printer.CsvOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -34,7 +34,7 @@ func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) er
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = cyclonedxOutputFile
 		}
-		if !strings.HasSuffix(strings.TrimSpace(outputFile), printer.CycloneDXOutputExt) {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.CycloneDXOutputExt) {
 			outputFile = outputFile + printer.CycloneDXOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
@@ -32,6 +32,16 @@ func TestSetWriter_CycloneDX_AppendsExtension(t *testing.T) {
 	assert.Contains(t, cp.writer.Name(), ".cdx.json")
 }
 
+func TestSetWriter_CycloneDX_CaseInsensitiveExtension(t *testing.T) {
+	cp := NewCycloneDXPrinter()
+	tmpDir := t.TempDir()
+	cp.SetWriter(context.TODO(), tmpDir+"/Report.CDX.JSON")
+	defer cp.CloseWriter()
+
+	assert.NotContains(t, cp.writer.Name(), ".cdx.json.cdx.json")
+	assert.Contains(t, cp.writer.Name(), "Report.CDX.JSON")
+}
+
 func TestActionPrint_CycloneDX_ImageScan(t *testing.T) {
 	imageScanData := []cautils.ImageScanData{buildSeverityExceptionImageScanData()}
 

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -137,7 +137,7 @@ func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) e
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = gitLabSASTOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JsonOutputExt {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JsonOutputExt) {
 			outputFile = outputFile + printer.JsonOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -54,7 +53,7 @@ func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		outputFile = htmlOutputFile + printer.HtmlOutputExt
 		logger.L().Info("no --output specified for html format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(outputFile) != printer.HtmlOutputExt {
+	} else if !printer.HasOutputExt(outputFile, printer.HtmlOutputExt) {
 		outputFile = outputFile + printer.HtmlOutputExt
 	}
 	if explicitOutput {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/anchore/clio"
@@ -40,7 +39,7 @@ func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = jsonOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JsonOutputExt {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JsonOutputExt) {
 			outputFile = outputFile + printer.JsonOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -22,6 +22,34 @@ func TestNewJsonPrinter(t *testing.T) {
 	assert.Empty(t, pp)
 }
 
+// TestSetWriter_Json_CaseInsensitiveExtension guards against the extension
+// check regressing to a case-sensitive comparison: an outputFile whose
+// extension already matches --output's target extension in a different case
+// (e.g. "Report.JSON") must not have the extension appended a second time.
+func TestSetWriter_Json_CaseInsensitiveExtension(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputFile string
+	}{
+		{"lowercase extension", "report.json"},
+		{"uppercase extension", "Report.JSON"},
+		{"mixed case extension", "Report.Json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			target := tmpDir + string(os.PathSeparator) + tt.outputFile
+
+			jp := NewJsonPrinter("")
+			require.NoError(t, jp.SetWriter(context.TODO(), target))
+			require.NotNil(t, jp.writer)
+			defer jp.writer.Close()
+
+			assert.Equal(t, target, jp.writer.Name(), "extension should not be appended a second time")
+		})
+	}
+}
+
 func TestScore_Json(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -105,7 +104,7 @@ func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) error 
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = junitOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.JunitOutputExt {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JunitOutputExt) {
 			outputFile = outputFile + printer.JunitOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -39,7 +38,7 @@ func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) err
 		outputFile = markdownOutputFile + printer.MarkdownOutputExt
 		logger.L().Info("no --output specified for markdown format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(outputFile) != printer.MarkdownOutputExt {
+	} else if !printer.HasOutputExt(outputFile, printer.MarkdownOutputExt) {
 		outputFile = outputFile + printer.MarkdownOutputExt
 	}
 	if explicitOutput {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -44,7 +43,7 @@ func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		outputFile = pdfOutputFile + printer.PdfOutputExt
 		logger.L().Info("no --output specified for pdf format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if filepath.Ext(outputFile) != printer.PdfOutputExt {
+	} else if !printer.HasOutputExt(outputFile, printer.PdfOutputExt) {
 		outputFile = outputFile + printer.PdfOutputExt
 	}
 	if explicitOutput {

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -97,8 +96,7 @@ func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string)
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = policyReportOutputFile
 		}
-		ext := filepath.Ext(strings.TrimSpace(outputFile))
-		if ext != printer.YamlOutputExt && ext != ".yml" {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.YamlOutputExt) && !printer.HasOutputExt(strings.TrimSpace(outputFile), ".yml") {
 			outputFile = outputFile + printer.YamlOutputExt
 		}
 		var err error

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -178,7 +177,7 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) error
 			outputFile = prettyOutputFile
 		}
 		// os.DevNull is used to silence the UI printer, appending an extension would turn it into a regular file
-		if outputFile != os.DevNull && filepath.Ext(outputFile) != printer.PrettyOutputExt {
+		if outputFile != os.DevNull && !printer.HasOutputExt(outputFile, printer.PrettyOutputExt) {
 			outputFile = outputFile + printer.PrettyOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -44,7 +43,7 @@ func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) e
 		if outputFile == "" {
 			outputFile = prometheusOutputFile
 		}
-		if filepath.Ext(outputFile) != printer.PrometheusOutputExt {
+		if !printer.HasOutputExt(outputFile, printer.PrometheusOutputExt) {
 			outputFile = outputFile + printer.PrometheusOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -85,7 +85,7 @@ func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) error 
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = sarifOutputFile
 		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != printer.SARIFOutputExt {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.SARIFOutputExt) {
 			outputFile = outputFile + printer.SARIFOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -34,7 +34,7 @@ func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = spdxOutputFile
 		}
-		if !strings.HasSuffix(strings.TrimSpace(outputFile), printer.SPDXOutputExt) {
+		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.SPDXOutputExt) {
 			outputFile = outputFile + printer.SPDXOutputExt
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
@@ -33,6 +33,16 @@ func TestSetWriter_SPDX_AppendsExtension(t *testing.T) {
 	assert.Contains(t, sp.writer.Name(), ".spdx.json")
 }
 
+func TestSetWriter_SPDX_CaseInsensitiveExtension(t *testing.T) {
+	sp := NewSPDXPrinter()
+	tmpDir := t.TempDir()
+	sp.SetWriter(context.TODO(), tmpDir+"/Report.SPDX.JSON")
+	defer sp.CloseWriter()
+
+	assert.NotContains(t, sp.writer.Name(), ".spdx.json.spdx.json")
+	assert.Contains(t, sp.writer.Name(), "Report.SPDX.JSON")
+}
+
 func TestActionPrint_SPDX_ImageScan(t *testing.T) {
 	imageScanData := []cautils.ImageScanData{buildSeverityExceptionImageScanData()}
 

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/anchore/clio"
@@ -38,8 +37,8 @@ func (yp *YamlPrinter) SetWriter(ctx context.Context, outputFile string) error {
 		if strings.TrimSpace(outputFile) == "" {
 			outputFile = yamlOutputFile
 		}
-		ext := filepath.Ext(strings.TrimSpace(outputFile))
-		if ext != printer.YamlOutputExt && ext != ".yml" {
+		trimmed := strings.TrimSpace(outputFile)
+		if !printer.HasOutputExt(trimmed, printer.YamlOutputExt) && !printer.HasOutputExt(trimmed, ".yml") {
 			outputFile = outputFile + printer.YamlOutputExt
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #3327.

Every v2 printer's `SetWriter` checks whether `outputFile` already ends in the printer's expected extension before appending it, e.g.:

```go
if filepath.Ext(outputFile) != printer.JsonOutputExt {
    outputFile = outputFile + printer.JsonOutputExt
}
```

`filepath.Ext` returns the extension verbatim, so this comparison is case-sensitive. Running `kubescape scan --format json --output Report.JSON` (or any differently-cased extension) fails the check in every one of the 10 affected printers and silently doubles the extension, writing to `Report.JSON.json` instead of the file the user asked for.

This PR adds a shared `HasOutputExt(outputFile, ext string) bool` helper in `core/pkg/resultshandling/printer/printresults.go` that compares extensions with `strings.EqualFold`, and switches all affected printers (`json`, `sarif`, `gitlabsast`, `junit`, `html`, `markdown`, `pdf`, `prettyprinter`, `prometheus`, `yaml`, `csv`) to use it instead of the case-sensitive comparison.

## How this was verified

Before the fix, on `master`, I confirmed the bug with a standalone reproduction calling `JsonPrinter.SetWriter(ctx, "Report.JSON")` and observed the writer opened `Report.JSON.json` on disk instead of `Report.JSON`.

After the fix, I added a permanent regression test (`TestSetWriter_Json_CaseInsensitiveExtension` in `core/pkg/resultshandling/printer/v2/jsonprinter_test.go`) covering lowercase, uppercase, and mixed-case extensions, plus a unit test for the new helper itself (`TestHasOutputExt` in `core/pkg/resultshandling/printer/printresults_test.go`).

### Real test output (this run, on this branch)

```
$ go build ./core/pkg/resultshandling/...
$ go vet ./core/pkg/resultshandling/...
(both exit 0, no output)

$ go test ./core/pkg/resultshandling/printer/... -run 'TestHasOutputExt|TestSetWriter_Json_CaseInsensitiveExtension' -v
=== RUN   TestHasOutputExt
=== RUN   TestHasOutputExt/exact_lowercase_match
=== RUN   TestHasOutputExt/uppercase_extension_matches_lowercase_ext
=== RUN   TestHasOutputExt/mixed_case_extension_matches
=== RUN   TestHasOutputExt/different_extension_does_not_match
=== RUN   TestHasOutputExt/no_extension_does_not_match
=== RUN   TestHasOutputExt/empty_outputFile_does_not_match
--- PASS: TestHasOutputExt (0.00s)
    --- PASS: TestHasOutputExt/exact_lowercase_match (0.00s)
    --- PASS: TestHasOutputExt/uppercase_extension_matches_lowercase_ext (0.00s)
    --- PASS: TestHasOutputExt/mixed_case_extension_matches (0.00s)
    --- PASS: TestHasOutputExt/different_extension_does_not_match (0.00s)
    --- PASS: TestHasOutputExt/no_extension_does_not_match (0.00s)
    --- PASS: TestHasOutputExt/empty_outputFile_does_not_match (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer	1.446s
=== RUN   TestSetWriter_Json_CaseInsensitiveExtension
=== RUN   TestSetWriter_Json_CaseInsensitiveExtension/lowercase_extension
=== RUN   TestSetWriter_Json_CaseInsensitiveExtension/uppercase_extension
=== RUN   TestSetWriter_Json_CaseInsensitiveExtension/mixed_case_extension
--- PASS: TestSetWriter_Json_CaseInsensitiveExtension (0.00s)
    --- PASS: TestSetWriter_Json_CaseInsensitiveExtension/lowercase_extension (0.00s)
    --- PASS: TestSetWriter_Json_CaseInsensitiveExtension/uppercase_extension (0.00s)
    --- PASS: TestSetWriter_Json_CaseInsensitiveExtension/mixed_case_extension (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2	4.405s

$ go test ./core/pkg/resultshandling/...
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling	1.058s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/diff	12.068s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/gotree	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer	1.058s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v1	10.317s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2	1.828s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/pdf	11.587s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter	6.634s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter	4.076s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter	7.858s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils	2.831s
?   	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter	[no test files]
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2	11.832s

$ golangci-lint run core/pkg/resultshandling/printer/...
0 issues.

$ gofmt -l core/pkg/resultshandling/printer/printresults.go core/pkg/resultshandling/printer/v2/*.go
(no output — all files formatted)
```

## Test plan

- [x] `go build ./core/pkg/resultshandling/...`
- [x] `go vet ./core/pkg/resultshandling/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] New regression tests added and passing
- [x] Full existing test suite for the package passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Output filenames now recognize extensions regardless of capitalization, preventing duplicate extensions such as `.JSON` or `.Json`.
  * Consistent extension handling is applied across CSV, JSON, YAML, HTML, Markdown, PDF, SARIF, JUnit, Prometheus, CycloneDX, SPDX, and other report formats.

* **Tests**
  * Added coverage for exact, mixed-case, missing, empty, compound, and mismatched extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->