### PR TITLE
fix(html): embed report logo instead of fetching it from GitHub

### DIFF
--- a/core/pkg/resultshandling/printer/v2/html/report.gohtml
+++ b/core/pkg/resultshandling/printer/v2/html/report.gohtml
@@ -69,7 +69,7 @@
   }
   </style>
   <body>
-    <img class="logo" src="https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/resultshandling/printer/v2/pdf/logo.png">
+    <img class="logo" src="{{.LogoDataURI}}">
     <h1>Kubescape Scan Report</h1>
     {{ if .OPASessionObj }}
     {{ with .OPASessionObj.Report.SummaryDetails }}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"fmt"
 	"html/template"
 	"os"
@@ -28,6 +29,13 @@ const (
 //go:embed html/report.gohtml
 var reportTemplate string
 
+// kubescapeLogoPNG is embedded (rather than fetched from a live GitHub URL at
+// render time) so generated reports render their logo offline and are not
+// tied to the content of a moving branch reference (#3328).
+//
+//go:embed pdf/logo.png
+var kubescapeLogoPNG []byte
+
 var _ printer.IPrinter = &HtmlPrinter{}
 
 type HTMLReportingCtx struct {
@@ -36,6 +44,9 @@ type HTMLReportingCtx struct {
 	// ImageScanSummary is set instead of the two fields above when this report
 	// is for an image scan rather than a posture scan (#2782).
 	ImageScanSummary *imageprinter.ImageScanSummary
+	// LogoDataURI embeds the Kubescape logo as a data URI so the report
+	// renders offline instead of fetching it from GitHub (#3328).
+	LogoDataURI template.URL
 }
 
 type HtmlPrinter struct {
@@ -137,7 +148,8 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		imageScanSummary = buildImageScanSummary(imageScanData)
 	}
 
-	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView, imageScanSummary}
+	logoDataURI := template.URL("data:image/png;base64," + base64.StdEncoding.EncodeToString(kubescapeLogoPNG)) // #nosec G203 -- built entirely from an embedded, compile-time-fixed asset, not user input
+	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView, imageScanSummary, logoDataURI}
 	err := tpl.Execute(hp.writer, reportingCtx)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to render template", helpers.Error(err))

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -145,3 +145,26 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	assert.Contains(t, htmlContent, `<td class="controlRiskCell numericCell">1</td>`)
 	assert.NotContains(t, htmlContent, `<td class="controlRiskCell numericCell">0</td>`)
 }
+
+func TestHtmlPrinter_ActionPrint_LogoEmbeddedNotFetched(t *testing.T) {
+	ctx := context.Background()
+	out := filepath.Join(t.TempDir(), "report.html")
+
+	hp := NewHtmlPrinter()
+	hp.SetWriter(ctx, out)
+
+	session := cautils.NewOPASessionObjMock()
+
+	hp.ActionPrint(ctx, session, nil)
+	hp.CloseWriter()
+
+	content, err := os.ReadFile(out)
+	assert.NoError(t, err)
+	htmlContent := string(content)
+
+	// Report must never depend on a live, branch-tracking GitHub URL to render its logo.
+	assert.NotContains(t, htmlContent, "raw.githubusercontent.com",
+		"HTML report must not fetch its logo from a live GitHub URL")
+	assert.Contains(t, htmlContent, `<img class="logo" src="data:image/png;base64,`,
+		"HTML report must embed its logo as a data URI")
+}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -1,9 +1,13 @@
 package printer
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"html"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/kubescape/kubescape/v3/core/cautils"
@@ -165,6 +169,15 @@ func TestHtmlPrinter_ActionPrint_LogoEmbeddedNotFetched(t *testing.T) {
 	// Report must never depend on a live, branch-tracking GitHub URL to render its logo.
 	assert.NotContains(t, htmlContent, "raw.githubusercontent.com",
 		"HTML report must not fetch its logo from a live GitHub URL")
-	assert.Contains(t, htmlContent, `<img class="logo" src="data:image/png;base64,`,
-		"HTML report must embed its logo as a data URI")
+
+	// html/template HTML-entity-escapes some base64 characters (e.g. '+') in
+	// attribute values, so the raw payload never appears verbatim in the rendered
+	// HTML; unescape it back before decoding and comparing against the logo bytes.
+	match := regexp.MustCompile(`<img class="logo" src="data:image/png;base64,([^"]+)">`).FindStringSubmatch(htmlContent)
+	if assert.Len(t, match, 2, "HTML report must embed its logo as a data URI") {
+		payload, err := base64.StdEncoding.DecodeString(html.UnescapeString(match[1]))
+		assert.NoError(t, err, "embedded logo payload must be valid base64")
+		assert.True(t, bytes.HasPrefix(payload, []byte("\x89PNG\r\n\x1a\n")), "embedded logo payload must be a valid PNG")
+		assert.Equal(t, kubescapeLogoPNG, payload, "embedded logo payload must match the embedded kubescape logo")
+	}
 }


### PR DESCRIPTION
## Overview

The HTML report template (`core/pkg/resultshandling/printer/v2/html/report.gohtml`) rendered its logo via `<img src="https://raw.githubusercontent.com/kubescape/kubescape/master/.../logo.png">` — a live, branch-tracking GitHub URL. Every time a generated report is opened in a browser, it makes an outbound request to GitHub, which leaks viewing metadata and breaks (shows a broken image) in offline/air-gapped compliance review environments. It's also unpinned: the asset behind `master` can change or move at any time, silently altering or 404ing old reports.

This mirrors the same pattern the PDF printer already solved via `//go:embed logo.png` (`core/pkg/resultshandling/printer/v2/pdf/report_template.go`). The HTML printer now does the same: the logo is embedded at build time and rendered as a `data:` URI, with no runtime network dependency.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

```
go test -race ./core/pkg/resultshandling/printer/...
```

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

* Report: https://github.com/kubescape/kubescape/issues/3328

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Fixes #3328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML reports now embed the Kubescape logo directly, allowing it to display without external image access.
  * Improved report reliability in offline or restricted-network environments.

* **Tests**
  * Added coverage verifying that generated reports embed the logo and avoid external repository references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->