### PR TITLE
fix: embed HTML report logo instead of loading it from GitHub

### DIFF
--- a/core/pkg/resultshandling/printer/v2/html/report.gohtml
+++ b/core/pkg/resultshandling/printer/v2/html/report.gohtml
@@ -69,7 +69,7 @@
   }
   </style>
   <body>
-    <img class="logo" src="https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/resultshandling/printer/v2/pdf/logo.png">
+    <img class="logo" src="{{ .LogoDataURI }}">
     <h1>Kubescape Scan Report</h1>
     {{ if .OPASessionObj }}
     {{ with .OPASessionObj.Report.SummaryDetails }}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"fmt"
 	"html/template"
 	"os"
@@ -28,6 +29,25 @@ const (
 //go:embed html/report.gohtml
 var reportTemplate string
 
+// The HTML report previously loaded this logo from raw.githubusercontent.com
+// at view time, so the report only rendered correctly with network access
+// and leaked the viewer's IP/UA to GitHub every time an offline scan report
+// was opened. Embed the same logo the PDF printer already ships
+// (pdf/logo.png) and inline it as a data URI instead.
+//
+//go:embed pdf/logo.png
+var htmlLogoPNG []byte
+
+// logoDataURI returns the embedded Kubescape logo as a data: URI. It is
+// returned as template.URL, not a plain string, so html/template's URL
+// sanitizer (which rejects the data: scheme by default) doesn't replace it
+// with "#ZgotmplZ" when used as an <img src>.
+func logoDataURI() template.URL {
+	// #nosec G203 -- the input is our own go:embed'd logo.png, not
+	// attacker-controlled data, so bypassing the URL sanitizer here is safe.
+	return template.URL("data:image/png;base64," + base64.StdEncoding.EncodeToString(htmlLogoPNG))
+}
+
 var _ printer.IPrinter = &HtmlPrinter{}
 
 type HTMLReportingCtx struct {
@@ -36,6 +56,9 @@ type HTMLReportingCtx struct {
 	// ImageScanSummary is set instead of the two fields above when this report
 	// is for an image scan rather than a posture scan (#2782).
 	ImageScanSummary *imageprinter.ImageScanSummary
+	// LogoDataURI is the embedded Kubescape logo, inlined so the report
+	// renders correctly without network access.
+	LogoDataURI template.URL
 }
 
 type HtmlPrinter struct {
@@ -137,7 +160,7 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		imageScanSummary = buildImageScanSummary(imageScanData)
 	}
 
-	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView, imageScanSummary}
+	reportingCtx := HTMLReportingCtx{opaSessionObj, resourceTableView, imageScanSummary, logoDataURI()}
 	err := tpl.Execute(hp.writer, reportingCtx)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to render template", helpers.Error(err))

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -111,6 +111,32 @@ func TestBuildResourceTableView_SkipsMissingResource(t *testing.T) {
 	assert.Empty(t, view, "missing resource should be skipped, not included with nil")
 }
 
+// Regression for issue-3328: the HTML report's logo previously loaded from
+// raw.githubusercontent.com at view time, so it silently broke for anyone
+// viewing an offline scan report without network access, and leaked the
+// viewer's IP/UA to GitHub on every view. The logo must be embedded and
+// inlined as a data URI instead.
+func TestHtmlPrinter_ActionPrint_LogoIsEmbeddedNotFetchedFromNetwork(t *testing.T) {
+	ctx := context.Background()
+	out := filepath.Join(t.TempDir(), "report.html")
+
+	hp := NewHtmlPrinter()
+	assert.NoError(t, hp.SetWriter(ctx, out))
+
+	session := cautils.NewOPASessionObjMock()
+	assert.NoError(t, hp.ActionPrint(ctx, session, nil))
+	assert.NoError(t, hp.CloseWriter())
+
+	content, err := os.ReadFile(out)
+	assert.NoError(t, err)
+	htmlContent := string(content)
+
+	assert.NotContains(t, htmlContent, "raw.githubusercontent.com",
+		"HTML report must not depend on fetching the logo from GitHub at view time")
+	assert.Contains(t, htmlContent, `<img class="logo" src="data:image/png;base64,`,
+		"HTML report must inline the logo as an embedded data URI")
+}
+
 func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	ctx := context.Background()
 	out := filepath.Join(t.TempDir(), "report.html")


### PR DESCRIPTION
## Summary

Fixes #3328.

The HTML printer's template (`core/pkg/resultshandling/printer/v2/html/report.gohtml`) rendered the Kubescape logo as:

```html
<img class="logo" src="https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/resultshandling/printer/v2/pdf/logo.png">
```

Since `kubescape scan --format html` is meant to produce a static, offline report, this has two problems:
- The logo silently fails to render for anyone viewing the report without network access (e.g. an airgapped environment, or just opening the file later on a machine without internet).
- Every time someone opens the report, their IP/User-Agent is sent to GitHub to fetch the image, which is an unexpected network call for what should be a static artifact.

The PDF printer (`core/pkg/resultshandling/printer/v2/pdf/report_template.go`) already solves this correctly for PDF reports by embedding the same logo via `go:embed` and drawing it from bytes. This PR applies the same approach to the HTML printer:

- `core/pkg/resultshandling/printer/v2/htmlprinter.go`: adds `//go:embed pdf/logo.png` (reusing the PDF printer's existing logo file — no new asset added) and a `logoDataURI()` helper that base64-encodes it into a `data:image/png;base64,...` URI, returned as `template.URL` so `html/template`'s URL sanitizer doesn't strip the `data:` scheme.
- `HTMLReportingCtx` gets a new `LogoDataURI` field, populated in `ActionPrint`.
- `report.gohtml`'s `<img>` tag now renders `{{ .LogoDataURI }}` instead of the GitHub URL.

## How this was verified

Added a regression test, `TestHtmlPrinter_ActionPrint_LogoIsEmbeddedNotFetchedFromNetwork` in `core/pkg/resultshandling/printer/v2/htmlprinter_test.go`, which runs a real `ActionPrint` and asserts the rendered HTML contains no `raw.githubusercontent.com` reference and does contain an embedded `data:image/png;base64,` logo tag.

I also ran a standalone (not committed) reproduction that rendered a real report and printed the actual output file size and the embedded tag, to confirm this isn't just passing the assertion by accident:

```
=== RUN   TestScratchRepro_LogoEmbedded
    scratch_repro_test.go:29: file size: 79119 bytes
    scratch_repro_test.go:38: found embedded logo tag at offset 1310: <img class="logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABRsAAASsCAY...
--- PASS: TestScratchRepro_LogoEmbedded (0.00s)
```

(That file was a throwaway reproduction, deleted after confirming — it's not part of this PR.)

### Real test output (this run, on this branch)

```
$ go build ./core/pkg/resultshandling/...
$ go vet ./core/pkg/resultshandling/...
(both exit 0, no output)

$ go test ./core/pkg/resultshandling/printer/v2/... -run TestHtml -v
=== RUN   TestHtmlPrinter_ActionPrint_LogoIsEmbeddedNotFetchedFromNetwork
[success] Scan results saved. filename: /var/folders/.../report.html
--- PASS: TestHtmlPrinter_ActionPrint_LogoIsEmbeddedNotFetchedFromNetwork (0.00s)
=== RUN   TestHtmlPrinter_ActionPrint_RiskScoreRounding
[success] Scan results saved. filename: /var/folders/.../report.html
--- PASS: TestHtmlPrinter_ActionPrint_RiskScoreRounding (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2	1.512s

$ go test ./core/pkg/resultshandling/...
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling	1.399s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/diff	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/gotree	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/locationresolver	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer	2.627s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v1	4.795s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2	3.691s
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/pdf	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/configurationprinter	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter	(cached)
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils	(cached)
?   	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter	[no test files]
ok  	github.com/kubescape/kubescape/v3/core/pkg/resultshandling/reporter/v2	(cached)

$ golangci-lint run core/pkg/resultshandling/printer/...
0 issues.

$ gofmt -l core/pkg/resultshandling/printer/v2/htmlprinter.go core/pkg/resultshandling/printer/v2/htmlprinter_test.go
(no output — all files formatted)
```

Note: `golangci-lint`'s `gosec` linter initially flagged `G203` on the `template.URL(...)` conversion (it disables `html/template`'s auto-escaping, which is generally risky when the input can be attacker-controlled). Here the input is our own embedded `logo.png`, not user/attacker input, so I added a `#nosec G203` comment with that justification rather than suppressing the check globally.

## Test plan

- [x] `go build ./core/pkg/resultshandling/...`
- [x] `go vet ./core/pkg/resultshandling/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] New regression test added and passing
- [x] Full existing test suite for the package passes
- [x] Manually confirmed the rendered report's `<img>` tag contains the embedded data URI and no GitHub reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML reports now include the logo directly, allowing them to render correctly without an internet connection.
  * Removed reliance on external logo-hosting URLs when viewing or sharing reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->