### PR TITLE
fix(imagescan): tighten gitlab imageMatches suffix check

### DIFF
--- a/pkg/imagescan/gitlab_adaptor.go
+++ b/pkg/imagescan/gitlab_adaptor.go
@@ -306,14 +306,14 @@ type vulnCacheEntry struct {
 func imageMatches(locationImage string, imageID ContainerImageIdentifier) bool {
 	if imageID.Hash != "" {
 		expectedSuffix := imageID.Repository + "@" + imageID.Hash
-		if strings.HasSuffix(locationImage, expectedSuffix) || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
+		if locationImage == expectedSuffix || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
 			return true
 		}
 	}
 
 	if imageID.Tag != "" {
 		expectedSuffix := imageID.Repository + ":" + imageID.Tag
-		if strings.HasSuffix(locationImage, expectedSuffix) || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
+		if locationImage == expectedSuffix || strings.HasSuffix(locationImage, "/"+expectedSuffix) {
 			return true
 		}
 	}

--- a/pkg/imagescan/gitlab_adaptor_test.go
+++ b/pkg/imagescan/gitlab_adaptor_test.go
@@ -390,3 +390,25 @@ func TestGitlabAdaptor_Destroy(t *testing.T) {
 	adaptor := NewGitlabAdaptor()
 	assert.NoError(t, adaptor.Destroy())
 }
+
+func TestImageMatches(t *testing.T) {
+	t.Run("matches by digest with registry path prefix", func(t *testing.T) {
+		id := ContainerImageIdentifier{Repository: "group/app", Hash: "sha256:abc"}
+		assert.True(t, imageMatches("registry.gitlab.com/group/app@sha256:abc", id))
+	})
+
+	t.Run("matches by tag with no prefix", func(t *testing.T) {
+		id := ContainerImageIdentifier{Repository: "app", Tag: "latest"}
+		assert.True(t, imageMatches("app:latest", id))
+	})
+
+	t.Run("does not match a different repo that happens to share a suffix", func(t *testing.T) {
+		id := ContainerImageIdentifier{Repository: "app", Tag: "latest"}
+		assert.False(t, imageMatches("registry.gitlab.com/group/webapp:latest", id))
+	})
+
+	t.Run("does not match a different repo sharing a suffix, by digest", func(t *testing.T) {
+		id := ContainerImageIdentifier{Repository: "app", Hash: "sha256:abc"}
+		assert.False(t, imageMatches("registry.gitlab.com/group/myapp@sha256:abc", id))
+	})
+}


### PR DESCRIPTION
imageMatches is documented as a "boundary-safe match for the image location", but the plain `strings.HasSuffix(locationImage, expectedSuffix)` check has no boundary at all, it just checks the tail of the string.

So a repo named `app` tagged `latest` will also match a vulnerability location like `.../webapp:latest`, because `"app:latest"` is a suffix of `"webapp:latest"`. Same thing happens on the digest side with `myapp@sha256:...` vs `app@sha256:...`.

The slash-prefixed variant right next to it (`"/"+expectedSuffix`) is the actually boundary-safe check. Dropped the bare suffix check and require either an exact match or the slash-prefixed one.

imageMatches didn't have any tests, added a few covering the legit match cases plus the two false-positive cases above (they fail without the fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image reference matching to require exact matches or valid repository path suffixes.
  * Prevented incorrectly matching repositories that merely share a similar ending.

* **Tests**
  * Added coverage for digest and tag matching with and without registry prefixes.
  * Added validation that unrelated repositories are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->