### PR TITLE
perf(opaprocessor): cache LARGE_CLUSTER_SIZE threshold per OPAProcessor

### DIFF
--- a/core/cautils/resourcebatch.go
+++ b/core/cautils/resourcebatch.go
@@ -14,7 +14,7 @@ import (
 // whole evaluation while namespace batches come and go.
 const ClusterScope = "clusterScope"
 
-const defaultLargeClusterSize = 2500
+const DefaultLargeClusterSize = 2500
 
 // IsLargeCluster reports whether a cluster of clusterSize resources is large
 // enough to be evaluated one namespace at a time rather than as a single
@@ -25,7 +25,7 @@ const defaultLargeClusterSize = 2500
 // The threshold is overridable through the LARGE_CLUSTER_SIZE environment
 // variable.
 func IsLargeCluster(clusterSize int) bool {
-	largeClusterSize, _ := ParseIntEnvVar("LARGE_CLUSTER_SIZE", defaultLargeClusterSize)
+	largeClusterSize, _ := ParseIntEnvVar("LARGE_CLUSTER_SIZE", DefaultLargeClusterSize)
 	return clusterSize > largeClusterSize
 }
 

--- a/core/cautils/resourcebatch.go
+++ b/core/cautils/resourcebatch.go
@@ -108,9 +108,11 @@ func PartitionResources(clusterSize int, k8sResources K8SResources, externalReso
 		}
 	}
 
-	byNamespace := IsLargeCluster(clusterSize)
+	var byNamespace bool
 	if len(threshold) > 0 && threshold[0] > 0 {
 		byNamespace = clusterSize > threshold[0]
+	} else {
+		byNamespace = IsLargeCluster(clusterSize)
 	}
 	namespaced := make(map[string]*ResourceBatch)
 

--- a/core/cautils/resourcebatch.go
+++ b/core/cautils/resourcebatch.go
@@ -94,7 +94,7 @@ func (batch *ResourceBatch) Len() int {
 //
 // Resource IDs present in the indexes but missing from allResources are
 // skipped rather than materialised as nil entries.
-func PartitionResources(clusterSize int, k8sResources K8SResources, externalResources ExternalResources, allResources map[string]workloadinterface.IMetadata) (resident *ResourceBatch, batches []*ResourceBatch) {
+func PartitionResources(clusterSize int, k8sResources K8SResources, externalResources ExternalResources, allResources map[string]workloadinterface.IMetadata, threshold ...int) (resident *ResourceBatch, batches []*ResourceBatch) {
 	resident = NewResourceBatch(ClusterScope)
 
 	for groupResource, ids := range externalResources {
@@ -109,6 +109,9 @@ func PartitionResources(clusterSize int, k8sResources K8SResources, externalReso
 	}
 
 	byNamespace := IsLargeCluster(clusterSize)
+	if len(threshold) > 0 && threshold[0] > 0 {
+		byNamespace = clusterSize > threshold[0]
+	}
 	namespaced := make(map[string]*ResourceBatch)
 
 	for groupResource, ids := range k8sResources {

--- a/core/cautils/resourcebatch_test.go
+++ b/core/cautils/resourcebatch_test.go
@@ -186,6 +186,31 @@ func TestPartitionResources_SkipsUnknownIDs(t *testing.T) {
 	assert.Equal(t, []string{pod.GetID()}, resident.K8SResources["/v1/pods"])
 }
 
+// TestPartitionResources_ExplicitThresholdOverridesEnv asserts that the
+// threshold passed to PartitionResources takes precedence over the
+// LARGE_CLUSTER_SIZE environment variable.
+func TestPartitionResources_ExplicitThresholdOverridesEnv(t *testing.T) {
+	t.Setenv("LARGE_CLUSTER_SIZE", "2500") // env would keep this small
+
+	podB := mustWorkload(t, `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-b","namespace":"ns-b"}}`)
+	podA := mustWorkload(t, `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod-a","namespace":"ns-a"}}`)
+
+	k8sResources := K8SResources{
+		"/v1/pods": {podB.GetID(), podA.GetID()},
+	}
+	allResources := map[string]workloadinterface.IMetadata{
+		podA.GetID(): podA,
+		podB.GetID(): podB,
+	}
+
+	resident, batches := PartitionResources(len(allResources), k8sResources, nil, allResources, 1)
+
+	require.Len(t, batches, 2)
+	assert.Equal(t, "ns-a", batches[0].Scope)
+	assert.Equal(t, "ns-b", batches[1].Scope)
+	assert.Empty(t, resident.K8SResources)
+}
+
 func mustWorkload(t *testing.T, raw string) workloadinterface.IMetadata {
 	t.Helper()
 	workload, err := workloadinterface.NewWorkload([]byte(raw))

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -137,9 +137,9 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		initialResourceCount = len(sessionObj.AllResources)
 	}
 
-	largeClusterSizeThreshold, _ := cautils.ParseIntEnvVar("LARGE_CLUSTER_SIZE", 2500)
+	largeClusterSizeThreshold, _ := cautils.ParseIntEnvVar("LARGE_CLUSTER_SIZE", cautils.DefaultLargeClusterSize)
 	if largeClusterSizeThreshold <= 0 {
-		largeClusterSizeThreshold = 2500
+		largeClusterSizeThreshold = cautils.DefaultLargeClusterSize
 	}
 
 	return &OPAProcessor{

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -41,8 +41,6 @@ import (
 
 const ScoreConfigPath = "/resources/config"
 
-
-
 // ControlAttributeRequiresWholeClusterInput marks a control whose rules join
 // objects that live in different namespaces. Such a control must be evaluated
 // once against the whole cluster — after per-namespace evaluation has merged
@@ -116,6 +114,11 @@ type OPAProcessor struct {
 	// getNamespaceName) is made once per scan instead of drifting mid-scan as
 	// rules write aggregator-produced resources back into AllResources.
 	initialResourceCount int
+	// largeClusterSizeThreshold is the cluster size above which a scan is
+	// evaluated one namespace at a time. It is read from the LARGE_CLUSTER_SIZE
+	// environment variable once at construction so that the decision does not
+	// race on a package-level global.
+	largeClusterSizeThreshold int
 }
 
 // NewOPAProcessor snapshots len(sessionObj.AllResources) at construction for
@@ -134,18 +137,24 @@ func NewOPAProcessor(sessionObj *cautils.OPASessionObj, regoDependenciesData *re
 		initialResourceCount = len(sessionObj.AllResources)
 	}
 
+	largeClusterSizeThreshold, _ := cautils.ParseIntEnvVar("LARGE_CLUSTER_SIZE", 2500)
+	if largeClusterSizeThreshold <= 0 {
+		largeClusterSizeThreshold = 2500
+	}
+
 	return &OPAProcessor{
-		OPASessionObj:          sessionObj,
-		regoDependenciesData:   regoDependenciesData,
-		clusterName:            clusterName,
-		exceptionEventRecorder: exceptionEventRecorder,
-		excludeNamespaces:      split(excludeNamespaces),
-		includeNamespaces:      split(includeNamespaces),
-		printEnabled:           enableRegoPrint,
-		compiledModules:        make(map[string]compiledRule),
-		TimedOutControls:       make(map[string]string),
-		initialResourceCount:   initialResourceCount,
-		celNamespaceIndex:      indexNamespaces(sessionObj),
+		OPASessionObj:             sessionObj,
+		regoDependenciesData:      regoDependenciesData,
+		clusterName:               clusterName,
+		exceptionEventRecorder:    exceptionEventRecorder,
+		excludeNamespaces:         split(excludeNamespaces),
+		includeNamespaces:         split(includeNamespaces),
+		printEnabled:              enableRegoPrint,
+		compiledModules:           make(map[string]compiledRule),
+		TimedOutControls:          make(map[string]string),
+		initialResourceCount:      initialResourceCount,
+		celNamespaceIndex:         indexNamespaces(sessionObj),
+		largeClusterSizeThreshold: largeClusterSizeThreshold,
 	}
 }
 
@@ -642,7 +651,7 @@ func (scope evaluationScope) matchedObjects(rule *reporthandling.PolicyRule) []w
 // so aggregator write-back during evaluation cannot re-bucket namespaces
 // mid-scan.
 func (opap *OPAProcessor) evaluationScopes() []evaluationScope {
-	resident, batches := cautils.PartitionResources(opap.initialResourceCount, opap.K8SResources, opap.ExternalResources, opap.AllResources)
+	resident, batches := cautils.PartitionResources(opap.initialResourceCount, opap.K8SResources, opap.ExternalResources, opap.AllResources, opap.largeClusterSizeThreshold)
 
 	residentGroups := newResidentIndex(resident)
 


### PR DESCRIPTION
## Summary
 close #3341 
The original issue (#3341) described a package-level `largeClusterSize` global in `core/pkg/opaprocessor/processorhandlerutils.go` that no longer exists on current `master`. The large-cluster threshold logic has since moved to `core/cautils/resourcebatch.go`, where `cautils.IsLargeCluster` reads `LARGE_CLUSTER_SIZE` from the environment on every call. There is no shared mutable state and therefore no data race.

This PR is an optimization (not a race fix): it parses `LARGE_CLUSTER_SIZE` once at `OPAProcessor` construction and passes that cached threshold through to `cautils.PartitionResources`, avoiding repeated env parsing in the real OPA evaluation path.

## Changes

- `core/cautils/resourcebatch.go`
  - Export `DefaultLargeClusterSize` so callers can reuse the default.
  - `PartitionResources` accepts an optional `threshold ...int` override; when provided it uses that value directly, otherwise it falls back to `cautils.IsLargeCluster` for backward compatibility.
  - `IsLargeCluster` now uses the exported `DefaultLargeClusterSize`.

- `core/pkg/opaprocessor/processorhandler.go`
  - Add `largeClusterSizeThreshold` field to `OPAProcessor`.
  - Parse `LARGE_CLUSTER_SIZE` once in `NewOPAProcessor` using `cautils.DefaultLargeClusterSize` as the default.
  - Pass the cached threshold into `cautils.PartitionResources` in `evaluationScopes`.

- `core/cautils/resourcebatch_test.go`
  - Add `TestPartitionResources_ExplicitThresholdOverridesEnv` to verify the explicit threshold takes precedence over `LARGE_CLUSTER_SIZE`.

## Note

The earlier description mentioned `getNamespaceName`, `getKubernetesObjects`, `getAllSupportedObjects`, `TestIsLargeCluster`, `TestGetNamespaceName`, and `TestProcessRule_ClusterScopedPathsAcrossNamespaces`. Those functions/tests were from a much older version of `opaprocessor` and do not exist on current `master`; they are not part of this change.

## Test plan

- `go test -count=1 ./core/cautils`
- `go test -count=1 ./core/pkg/opaprocessor`
- `go test -race -count=1 -run 'TestPartitionResources|TestIsLargeCluster' ./core/cautils`