### PR TITLE
fix(resourcehandler): skip discovered resources that do not support list

### DIFF
--- a/core/pkg/resourcehandler/listable_resource_test.go
+++ b/core/pkg/resourcehandler/listable_resource_test.go
@@ -1,0 +1,184 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// unlistableAgentDiscovery mixes resources a scan can collect with endpoints the
+// API server only serves for "create", plus one resource whose verbs discovery
+// did not report at all.
+func unlistableAgentDiscovery() *discoveryfake.FakeDiscovery {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "agents.x-k8s.io/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{Name: "sandboxes", Kind: "Sandbox", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+				{Name: "sandboxexecs", Kind: "SandboxExec", Namespaced: true, Verbs: metav1.Verbs{"create"}},
+				{Name: "sandboxreports", Kind: "SandboxReport", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "authentication.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "tokenreviews", Kind: "TokenReview", Verbs: metav1.Verbs{"create"}},
+			},
+		},
+	}
+	return client
+}
+
+func TestDiscoveryResolverSkipsResourceWithoutListVerb(t *testing.T) {
+	resolver, failures := newDiscoveryResourceResolver(unlistableAgentDiscovery())
+	require.Empty(t, failures)
+
+	assert.Empty(t, resolver("agents.x-k8s.io", "v1alpha1", "SandboxExec"))
+	assert.Empty(t, resolver("agents.x-k8s.io", "v1alpha1", "sandboxexecs"))
+
+	resolved := resolver("agents.x-k8s.io", "v1alpha1", "Sandbox")
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "agents.x-k8s.io/v1alpha1/sandboxes", resolved[0].groupVersionResourceTriplet)
+}
+
+// TestDiscoveryResolverKeepsResourceWithUnreportedVerbs pins the compatibility
+// rule: an empty verb set is missing data, not a declaration that the resource
+// cannot be listed.
+func TestDiscoveryResolverKeepsResourceWithUnreportedVerbs(t *testing.T) {
+	resolver, failures := newDiscoveryResourceResolver(unlistableAgentDiscovery())
+	require.Empty(t, failures)
+
+	resolved := resolver("agents.x-k8s.io", "v1alpha1", "SandboxReport")
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "agents.x-k8s.io/v1alpha1/sandboxreports", resolved[0].groupVersionResourceTriplet)
+}
+
+// TestDiscoveryResolverDoesNotFallBackToBuiltInForUnlistableResource guards the
+// fallback order: k8s-interface knows a GVR for create-only built-ins, so a
+// resource skipped for lacking "list" must not be resurrected by it.
+func TestDiscoveryResolverDoesNotFallBackToBuiltInForUnlistableResource(t *testing.T) {
+	builtIn := defaultResourceResolver("authentication.k8s.io", "v1", "tokenreviews")
+	require.Len(t, builtIn, 1, "k8s-interface resolves tokenreviews, so the fallback would fire")
+
+	resolver, failures := newDiscoveryResourceResolver(unlistableAgentDiscovery())
+	require.Empty(t, failures)
+	assert.Empty(t, resolver("authentication.k8s.io", "v1", "tokenreviews"))
+}
+
+func TestDiscoveryResolverWildcardExcludesUnlistableResources(t *testing.T) {
+	resolver, failures := newDiscoveryResourceResolver(unlistableAgentDiscovery())
+	require.Empty(t, failures)
+
+	var triplets []string
+	for _, resolved := range resolver("*", "*", "*") {
+		triplets = append(triplets, resolved.groupVersionResourceTriplet)
+	}
+	assert.Equal(t, []string{
+		"agents.x-k8s.io/v1alpha1/sandboxes",
+		"agents.x-k8s.io/v1alpha1/sandboxreports",
+	}, triplets)
+}
+
+// TestPullResourcesSkipsUnlistableResourceInWildcardScan is the end-to-end
+// guarantee: a wildcard policy must not turn a create-only endpoint into a LIST
+// that can only fail.
+func TestPullResourcesSkipsUnlistableResourceInWildcardScan(t *testing.T) {
+	// Every discovered resource is registered so an unwanted query is reported
+	// by the assertion below rather than by a fake-client panic.
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"}:      "CustomResourceList",
+		{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxreports"}: "CustomResourceList",
+		{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxexecs"}:   "CustomResourceList",
+		{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"}:   "TokenReviewList",
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	dynamicClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		DynamicClient:   dynamicClient,
+		DiscoveryClient: unlistableAgentDiscovery(),
+	}}
+
+	resolver, discoveryFailures := newDiscoveryResourceResolver(handler.k8s.DiscoveryClient)
+	require.Empty(t, discoveryFailures)
+	rule := mockRule("wildcard-rule", []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"*"},
+	}}, "")
+	control := mockControl("C-0001", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("wildcard-framework", []reporthandling.Control{control})
+
+	queryable, _ := getQueryableResourceMapFromPolicies(
+		[]reporthandling.Framework{*framework},
+		nil,
+		reporthandling.ScopeCluster,
+		resolver,
+	)
+	_, _, failures := handler.pullResources(context.Background(), queryable, &EmptySelector{}, "")
+	assert.Empty(t, failures)
+
+	queried := map[string]struct{}{}
+	for _, action := range dynamicClient.Actions() {
+		if action.GetVerb() == "list" {
+			gvr := action.GetResource()
+			queried[k8sinterface.GroupVersionResourceToString(&gvr)] = struct{}{}
+		}
+	}
+	assert.Equal(t, map[string]struct{}{
+		"agents.x-k8s.io/v1alpha1/sandboxes":      {},
+		"agents.x-k8s.io/v1alpha1/sandboxreports": {},
+	}, queried)
+}
+
+// TestPreflightSkipsAccessReviewForUnlistableResource keeps the dry-run check in
+// step with collection: a resource the scan will never list must not be reported
+// as a permission problem.
+func TestPreflightSkipsAccessReviewForUnlistableResource(t *testing.T) {
+	client := fakeclientset.NewClientset()
+	var reviewed []string
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		reviewed = append(reviewed, ssar.Spec.ResourceAttributes.Resource)
+		ssar.Status.Allowed = true
+		return true, ssar, nil
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		KubernetesClient: client,
+		DiscoveryClient:  unlistableAgentDiscovery(),
+	}}
+
+	matches := []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"agents.x-k8s.io"},
+		APIVersions: []string{"v1alpha1"},
+		Resources:   []string{"Sandbox", "SandboxExec"},
+	}}
+	rule := mockRule("agent-rule", matches, "")
+	control := mockControl("C-0001", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("agent-framework", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sandboxes"}, reviewed)
+	require.Len(t, result.Checks, 1)
+	assert.Equal(t, "agents.x-k8s.io/v1alpha1/sandboxes", result.Checks[0].GVR)
+}

--- a/core/pkg/resourcehandler/listable_resource_test.go
+++ b/core/pkg/resourcehandler/listable_resource_test.go
@@ -182,3 +182,11 @@ func TestPreflightSkipsAccessReviewForUnlistableResource(t *testing.T) {
 	require.Len(t, result.Checks, 1)
 	assert.Equal(t, "agents.x-k8s.io/v1alpha1/sandboxes", result.Checks[0].GVR)
 }
+
+func TestIsExplicitPolicyMatch(t *testing.T) {
+	assert.True(t, isExplicitPolicyMatch("agents.x-k8s.io", "v1alpha1", "Sandbox"))
+	assert.True(t, isExplicitPolicyMatch("", "v1", "Pod"))
+	assert.False(t, isExplicitPolicyMatch("*", "v1alpha1", "Sandbox"))
+	assert.False(t, isExplicitPolicyMatch("agents.x-k8s.io", "*", "Sandbox"))
+	assert.False(t, isExplicitPolicyMatch("agents.x-k8s.io", "v1alpha1", "*"))
+}

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -190,8 +190,17 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 		discovered = collectDiscoveredResources(resourceLists)
 	}
 
-	warned := map[string]struct{}{}
-	var warnedMu sync.Mutex
+	logged := map[string]struct{}{}
+	var loggedMu sync.Mutex
+	logOnce := func(key string, emit func()) {
+		loggedMu.Lock()
+		defer loggedMu.Unlock()
+		if _, ok := logged[key]; ok {
+			return
+		}
+		logged[key] = struct{}{}
+		emit()
+	}
 
 	return func(group, version, resource string) []resolvedResource {
 		if version == "" || resource == "" {
@@ -199,10 +208,19 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 		}
 
 		var resolved []resolvedResource
+		var skippedUnlistable []string
 		for _, candidate := range discovered {
 			if !matchesDiscoveryValue(group, candidate.gvr.Group) ||
 				!matchesDiscoveryValue(version, candidate.gvr.Version) ||
 				!matchesDiscoveryResource(resource, candidate) {
+				continue
+			}
+			if !candidate.listable {
+				// Collection is a cluster-wide LIST, so a resource the API
+				// server does not serve "list" for can only fail. Skipping it
+				// keeps create-only endpoints such as tokenreviews out of
+				// wildcard fan-out.
+				skippedUnlistable = append(skippedUnlistable, k8sinterface.GroupVersionResourceToString(&candidate.gvr))
 				continue
 			}
 			namespaced := candidate.namespaced
@@ -218,6 +236,20 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 			return resolved
 		}
 
+		if len(skippedUnlistable) > 0 {
+			// Discovery answered for this resource, so the built-in fallbacks
+			// below must not resurrect the GVR it declared unlistable.
+			sort.Strings(skippedUnlistable)
+			logOnce("unlistable:"+k8sinterface.JoinResourceTriplets(group, version, resource), func() {
+				logger.L().Debug("resource does not support list in Kubernetes discovery; skipping live query",
+					helpers.String("apiGroup", group),
+					helpers.String("apiVersion", version),
+					helpers.String("resource", resource),
+					helpers.String("skipped", strings.Join(skippedUnlistable, ",")))
+			})
+			return nil
+		}
+
 		if len(mapKSResourceToApiGroup(resource)) > 0 {
 			return defaultResourceResolver(group, version, resource)
 		}
@@ -225,16 +257,12 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 			return defaultResourceResolver(group, version, resource)
 		}
 
-		key := k8sinterface.JoinResourceTriplets(group, version, resource)
-		warnedMu.Lock()
-		if _, ok := warned[key]; !ok {
+		logOnce("undiscovered:"+k8sinterface.JoinResourceTriplets(group, version, resource), func() {
 			logger.L().Warning("resource was not found in Kubernetes discovery; skipping live query",
 				helpers.String("apiGroup", group),
 				helpers.String("apiVersion", version),
 				helpers.String("resource", resource))
-			warned[key] = struct{}{}
-		}
-		warnedMu.Unlock()
+		})
 		return nil
 	}, discoveryFailures
 }

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -171,6 +171,7 @@ type discoveredAPIResource struct {
 	gvr        schema.GroupVersionResource
 	kind       string
 	namespaced bool
+	listable   bool
 }
 
 // newDiscoveryResourceResolver uses the API server's declared Kind, plural
@@ -376,10 +377,21 @@ func collectDiscoveredResources(resourceLists []*metav1.APIResourceList) []disco
 				gvr:        groupVersion.WithResource(apiResource.Name),
 				kind:       apiResource.Kind,
 				namespaced: apiResource.Namespaced,
+				listable:   discoveryDeclaresList(apiResource),
 			})
 		}
 	}
 	return discovered
+}
+
+// discoveryDeclaresList reports whether the API server advertises "list" for a
+// resource. An empty verb set means discovery did not report the verbs, so the
+// resource stays eligible rather than being dropped on missing data.
+func discoveryDeclaresList(apiResource metav1.APIResource) bool {
+	if len(apiResource.Verbs) == 0 {
+		return true
+	}
+	return slices.Contains([]string(apiResource.Verbs), "list")
 }
 
 func matchesDiscoveryValue(policyValue, discoveredValue string) bool {

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -241,11 +241,20 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 			// below must not resurrect the GVR it declared unlistable.
 			sort.Strings(skippedUnlistable)
 			logOnce("unlistable:"+k8sinterface.JoinResourceTriplets(group, version, resource), func() {
-				logger.L().Debug("resource does not support list in Kubernetes discovery; skipping live query",
+				details := []helpers.IDetails{
 					helpers.String("apiGroup", group),
 					helpers.String("apiVersion", version),
 					helpers.String("resource", resource),
-					helpers.String("skipped", strings.Join(skippedUnlistable, ",")))
+					helpers.String("skipped", strings.Join(skippedUnlistable, ",")),
+				}
+				// A policy that names the resource outright loses its only
+				// input, which is worth a warning. A wildcard match sweeping
+				// past create-only endpoints is expected, so keep it quiet.
+				if isExplicitPolicyMatch(group, version, resource) {
+					logger.L().Warning("resource does not support list in Kubernetes discovery; skipping live query", details...)
+					return
+				}
+				logger.L().Debug("resource does not support list in Kubernetes discovery; skipping live query", details...)
 			})
 			return nil
 		}
@@ -410,6 +419,12 @@ func collectDiscoveredResources(resourceLists []*metav1.APIResourceList) []disco
 		}
 	}
 	return discovered
+}
+
+// isExplicitPolicyMatch reports whether a rule match names a single resource
+// identity rather than relying on wildcard expansion.
+func isExplicitPolicyMatch(group, version, resource string) bool {
+	return group != "*" && version != "*" && resource != "*"
 }
 
 // discoveryDeclaresList reports whether the API server advertises "list" for a


### PR DESCRIPTION
## Overview

When Kubescape resolves the resource types a policy needs on a live cluster, it reads the API server discovery document but ignores the `verbs` each resource advertises. Every match is turned into a cluster wide LIST.

Some Kubernetes endpoints are never listable. `tokenreviews`, `subjectaccessreviews`, `selfsubjectrulesreviews` and `bindings` are served only for `create`, and CRDs can register resources the same way. Any rule that reaches them, most easily through a wildcard match on group, version or resource, produces a LIST the API server can only answer with 405. That shows up as a spurious partial pull failure, a warning in the scan log, and a wasted round trip. On dry run preflight it is worse: the resource gets a `SelfSubjectAccessReview` and can be reported as a permission problem, even though no RBAC grant would ever make the query work.

Discovery already tells us which resources support `list`, so this change uses it.

## What changed

Discovered resources now carry whether the API server advertises `list`, and the discovery resolver skips the ones that do not.

One detail is worth calling out. `k8sinterface.GetGroupVersionResource` happily resolves a GVR for create only built ins such as `tokenreviews`, and the resolver falls back to it when discovery yields nothing. Filtering alone would therefore have been undone by that fallback, so a resource skipped for lacking `list` now short circuits and returns no match instead of dropping into the built in path. There is a test pinning exactly this, since it is the part most likely to regress.

An empty verb set is treated as missing information rather than as a declaration, so a resource stays eligible when discovery does not report its verbs. That keeps older API servers and existing fixtures behaving as before.

Logging follows what the user can act on. A rule that names a resource outright loses its only input, so that is a warning. A wildcard match sweeping past create only endpoints is expected and stays at debug level. Both go through one shared once per key gate, which also replaces the ad hoc warn once map that was already in the resolver.

Preflight and collection both sit downstream of this resolver, so they are fixed together.

## Tests

New tests in `core/pkg/resourcehandler/listable_resource_test.go` cover resolution, collection and preflight:

- a create only resource is not resolved, by kind or by plural
- a resource with unreported verbs is still resolved
- a skipped resource is not resurrected by the built in fallback
- a wildcard match resolves only the listable resources
- a wildcard scan issues no LIST for create only endpoints
- preflight issues no access review for a resource it can never list

Five of the six fail on master and pass with this change. The sixth is the compatibility guard for unreported verbs, which passes either way by design.

`go build ./...`, `go vet ./core/...` and `go test ./core/... ./pkg/...` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource discovery to exclude endpoints that do not support listing.
  * Prevented wildcard scans and access checks from including unlistable resources.
  * Preserved resources when supported API verbs are unavailable.
  * Prevented fallback behavior from restoring resources that cannot be listed.
  * Improved clarity and consistency of discovery warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->