### PR TITLE
Keep CRD exceptions that a narrower cloud exception does not actually cover

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter_dedup_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_dedup_test.go
@@ -122,3 +122,95 @@ func TestDeduplicateExceptions(t *testing.T) {
 		})
 	}
 }
+
+func TestDeduplicateExceptionsScopeContainment(t *testing.T) {
+	designator := identifiers.PortalDesignator{
+		DesignatorType: identifiers.DesignatorAttributes,
+		Attributes: map[string]string{
+			identifiers.AttributeNamespace: "team-a",
+			identifiers.AttributeKind:      "Deployment",
+			identifiers.AttributeApiGroup:  "apps",
+			identifiers.AttributeName:      "api",
+		},
+	}
+	buildPolicy := func(name string, policy armotypes.PosturePolicy) armotypes.PostureExceptionPolicy {
+		return armotypes.PostureExceptionPolicy{
+			PortalBase:      armotypes.PortalBase{Name: name},
+			PosturePolicies: []armotypes.PosturePolicy{policy},
+			Resources:       []identifiers.PortalDesignator{designator},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		cloud     armotypes.PosturePolicy
+		crd       armotypes.PosturePolicy
+		wantNames []string
+	}{
+		{
+			name:      "cloud exception for another framework does not suppress the CRD",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "NSA"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "MITRE"},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name:      "framework scoped cloud exception does not suppress a framework wide CRD",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "NSA"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001"},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name:      "framework wide cloud exception suppresses a framework scoped CRD",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "NSA"},
+			wantNames: []string{"cloud-1"},
+		},
+		{
+			name:      "framework names are compared case insensitively",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "nsa"},
+			crd:       armotypes.PosturePolicy{ControlID: "c-0001", FrameworkName: "NSA"},
+			wantNames: []string{"cloud-1"},
+		},
+		{
+			name:      "cloud framework pattern covers the framework it matches",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "MIT.*"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "MITRE"},
+			wantNames: []string{"cloud-1"},
+		},
+		{
+			name:      "cloud framework pattern does not cover an unrelated framework",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "MIT.*"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001", FrameworkName: "NSA"},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name:      "rule scoped cloud exception does not suppress the control wide CRD",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", RuleName: "rule-a"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001"},
+			wantNames: []string{"cloud-1", "crd-1"},
+		},
+		{
+			name:      "rule scoped cloud exception suppresses the same rule from the CRD",
+			cloud:     armotypes.PosturePolicy{ControlID: "C-0001", RuleName: "rule-a"},
+			crd:       armotypes.PosturePolicy{ControlID: "C-0001", RuleName: "rule-a"},
+			wantNames: []string{"cloud-1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deduplicateExceptions(
+				[]armotypes.PostureExceptionPolicy{buildPolicy("cloud-1", tc.cloud)},
+				[]armotypes.PostureExceptionPolicy{buildPolicy("crd-1", tc.crd)},
+			)
+			if len(got) != len(tc.wantNames) {
+				t.Fatalf("expected %d exceptions, got %d", len(tc.wantNames), len(got))
+			}
+			for i, wantName := range tc.wantNames {
+				if got[i].Name != wantName {
+					t.Fatalf("expected exception %d to be %q, got %q", i, wantName, got[i].Name)
+				}
+			}
+		})
+	}
+}

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -2,6 +2,9 @@ package getter
 
 import (
 	"context"
+	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
@@ -69,23 +72,14 @@ func deduplicateExceptions(
 		return []armotypes.PostureExceptionPolicy{}
 	}
 
-	covered := make(map[string]struct{}, len(cloudExceptions))
-	for _, cloud := range cloudExceptions {
-		for _, policy := range cloud.PosturePolicies {
-			if policy.ControlID == "" {
-				continue
-			}
-			for _, resource := range cloud.Resources {
-				covered[exceptionDedupKey(policy.ControlID, resource)] = struct{}{}
-			}
-		}
-	}
-
 	merged := make([]armotypes.PostureExceptionPolicy, 0, len(cloudExceptions)+len(crdExceptions))
 	merged = append(merged, cloudExceptions...)
 	if len(crdExceptions) == 0 {
 		return merged
 	}
+
+	covered := coveredPostureScopes(cloudExceptions)
+	matcher := newScopeMatcher()
 
 	for _, crd := range crdExceptions {
 		// Exceptions without resolvable control+workload keys can't be deduped; keep them.
@@ -97,11 +91,7 @@ func deduplicateExceptions(
 		for _, policy := range crd.PosturePolicies {
 			filteredResources := make([]identifiers.PortalDesignator, 0, len(crd.Resources))
 			for _, resource := range crd.Resources {
-				if policy.ControlID == "" {
-					filteredResources = append(filteredResources, resource)
-					continue
-				}
-				if _, found := covered[exceptionDedupKey(policy.ControlID, resource)]; !found {
+				if !matcher.coveredBy(covered[designatorDedupKey(resource)], policy) {
 					filteredResources = append(filteredResources, resource)
 				}
 			}
@@ -118,14 +108,84 @@ func deduplicateExceptions(
 	return merged
 }
 
-func exceptionDedupKey(controlID string, designator identifiers.PortalDesignator) string {
+// coveredPostureScopes indexes the primary posture-policy scopes by workload
+// designator. A policy without a control ID carries nothing to measure a CRD policy
+// against, so it never suppresses one.
+func coveredPostureScopes(exceptions []armotypes.PostureExceptionPolicy) map[string][]armotypes.PosturePolicy {
+	covered := make(map[string][]armotypes.PosturePolicy, len(exceptions))
+	for _, exception := range exceptions {
+		for _, policy := range exception.PosturePolicies {
+			if policy.ControlID == "" {
+				continue
+			}
+			for _, resource := range exception.Resources {
+				key := designatorDedupKey(resource)
+				if !slices.Contains(covered[key], policy) {
+					covered[key] = append(covered[key], policy)
+				}
+			}
+		}
+	}
+	return covered
+}
+
+// scopeMatcher compares posture-policy scopes the way the exception processor does
+// at evaluation time: a case-insensitive literal or anchored case-insensitive
+// pattern. Compiled patterns are reused across the whole merge.
+type scopeMatcher struct {
+	patterns map[string]*regexp.Regexp
+}
+
+func newScopeMatcher() *scopeMatcher {
+	return &scopeMatcher{patterns: make(map[string]*regexp.Regexp)}
+}
+
+// coveredBy reports whether any primary scope already applies everywhere policy does.
+// A primary exception that does not reach the CRD policy's framework or rule cannot
+// take precedence over it.
+func (m *scopeMatcher) coveredBy(primaries []armotypes.PosturePolicy, policy armotypes.PosturePolicy) bool {
+	for _, primary := range primaries {
+		if m.covers(primary.FrameworkName, policy.FrameworkName) &&
+			m.covers(primary.ControlID, policy.ControlID) &&
+			m.covers(primary.RuleName, policy.RuleName) {
+			return true
+		}
+	}
+	return false
+}
+
+// covers reports whether a primary scope field applies wherever the CRD one does. An
+// empty primary field is unscoped and covers any value; a named one cannot cover an
+// empty CRD field, which is broader.
+func (m *scopeMatcher) covers(primary, crd string) bool {
+	if primary == "" {
+		return true
+	}
+	if crd == "" {
+		return false
+	}
+	if strings.EqualFold(primary, crd) {
+		return true
+	}
+	pattern, compiled := m.patterns[primary]
+	if !compiled {
+		// A pattern that does not compile is cached as nil and read as a
+		// non-match, which is how the exception processor treats it.
+		pattern, _ = regexp.Compile("(?i)^" + primary + "$")
+		m.patterns[primary] = pattern
+	}
+	return pattern != nil && pattern.MatchString(crd)
+}
+
+func designatorDedupKey(designator identifiers.PortalDesignator) string {
 	apiGroup := ""
 	if designator.Attributes != nil {
 		apiGroup = designator.Attributes[identifiers.AttributeApiGroup]
 	}
-	return controlID + exceptionKeySeparator +
-		designator.GetNamespace() + exceptionKeySeparator +
-		designator.GetName() + exceptionKeySeparator +
-		designator.GetKind() + exceptionKeySeparator +
-		apiGroup
+	return strings.Join([]string{
+		designator.GetNamespace(),
+		designator.GetName(),
+		designator.GetKind(),
+		apiGroup,
+	}, exceptionKeySeparator)
 }


### PR DESCRIPTION
While looking at how in-cluster SecurityException CRDs merge with cloud and file exceptions, I noticed the dedup step keys overlap on the control ID and the workload designator only. A posture policy is scoped by three things: framework name, control ID and rule name. Two of those were being ignored, so a cloud exception that does not even apply to the same framework would still suppress the CRD one.

The case that got me was a cloud exception for C-0001 scoped to NSA sitting next to a SecurityException for C-0001 scoped to MITRE on the same Deployment. The CRD exception is thrown away, and the MITRE scan then alerts on a workload the cluster operator had explicitly excepted. Same story when the cloud exception is scoped to a single ruleName and the CRD one covers the whole control. There was also a smaller mismatch: control IDs were compared byte for byte here, but opa-utils compares them case insensitively when it evaluates them, so C-0001 and c-0001 were treated as two different controls at merge time and one control at scan time.

The fix replaces the string key comparison with a containment check across all three scope fields, using the same matching rules the exception processor applies, so a case insensitive literal or an anchored case insensitive pattern. An empty field on the cloud side means unscoped and covers anything; a named field cannot cover an empty CRD field because that one is broader. Compiled patterns are cached in a small matcher that lives for the duration of one merge, so there is no package level state and no repeated compilation as the number of exceptions grows.

The change only ever keeps exceptions that used to be dropped. Nothing that survived the merge before is removed now.

Added eight table cases for the scope containment rules. Five of them fail on master and pass with the fix. The existing dedup tests are unchanged and still pass, along with go build, go vet and go test ./core/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception deduplication so overlapping framework, control, and rule scopes are handled more accurately.
  * Cloud exceptions now suppress matching CRD exceptions only when their applicable scopes overlap.
  * Matching is case-insensitive and supports anchored framework patterns.
  * Invalid patterns are safely treated as non-matches, preventing unintended exception suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->