### PR TITLE
fix(cel): match CRD plurals the kind guess spells wrong

### DIFF
--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -34,12 +34,12 @@ func (v *VAP) appliesTo(obj map[string]any) bool {
 	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
 		return true // no scoping info: evaluate (a malformed-policy edge)
 	}
-	gvr, ok := objectGVR(obj)
+	gvr, resources, ok := objectGVR(obj)
 	if !ok {
 		return true // kind undeterminable; let evaluation proceed (it will error and skip)
 	}
 	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
-	target := scopedObject{gvr: gvr, name: name, namespaced: isNamespaced(obj)}
+	target := scopedObject{gvr: gvr, resources: resources, name: name, namespaced: isNamespaced(obj)}
 
 	included := false
 	for i := range v.matchConstraints.ResourceRules {
@@ -94,24 +94,69 @@ func objectSelectorMatches(selector *metav1.LabelSelector, obj map[string]any) b
 const resourcePluralAnnotation = "kubescape.io/resource-plural"
 
 // objectGVR resolves an object's GroupVersionResource from its apiVersion and
-// kind. Offline there is no discovery or RESTMapper, so the plural comes from
-// the resource-plural annotation when the object carries one, and otherwise
-// from apimachinery's kind->resource guess (lower-case and pluralize).
-func objectGVR(obj map[string]any) (schema.GroupVersionResource, bool) {
+// kind, along with every resource name that kind may be registered under (see
+// resourceNames). The GVR carries the first of them, the one a live cluster is
+// most likely to serve.
+func objectGVR(obj map[string]any) (schema.GroupVersionResource, []string, bool) {
 	apiVersion, _ := obj["apiVersion"].(string)
 	kind, _ := obj["kind"].(string)
 	if apiVersion == "" || kind == "" {
-		return schema.GroupVersionResource{}, false
+		return schema.GroupVersionResource{}, nil, false
 	}
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
-		return schema.GroupVersionResource{}, false
+		return schema.GroupVersionResource{}, nil, false
 	}
+	names := resourceNames(obj, gv, kind)
+	return gv.WithResource(names[0]), names, true
+}
+
+// resourceNames returns the resource names a kind may be registered under, most
+// likely first. Offline there is no discovery or RESTMapper, and a CRD picks its
+// own spec.names.plural, so the spelling cannot be known: apimachinery's guess
+// misses every sibilant kind (Sandbox -> "sandboxs") and every vowel+"y" kind
+// (Gateway -> "gatewaies"), which an exact compare would drop silently. Keeping
+// both spellings lets a rule match either one, and the annotation stays
+// authoritative when an object declares the plural outright.
+func resourceNames(obj map[string]any, gv schema.GroupVersion, kind string) []string {
 	if plural, ok := annotatedPlural(obj); ok {
-		return gv.WithResource(plural), true
+		return []string{plural}
 	}
-	gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
-	return gvr, true
+	guessed, singular := meta.UnsafeGuessKindToResource(gv.WithKind(kind))
+	if guessed.Resource == singular.Resource {
+		return []string{guessed.Resource} // kind is already plural (Endpoints)
+	}
+	names := []string{pluralize(singular.Resource)}
+	if guessed.Resource != names[0] {
+		names = append(names, guessed.Resource)
+	}
+	return names
+}
+
+// pluralize applies the English rules a CRD author (and controller-gen) follows:
+// a sibilant ending takes "es", a consonant before a final "y" takes "ies", and
+// everything else takes "s".
+func pluralize(singular string) string {
+	switch {
+	case hasAnySuffix(singular, "s", "x", "z", "ch", "sh"):
+		return singular + "es"
+	case strings.HasSuffix(singular, "y") && len(singular) > 1 && !isVowel(singular[len(singular)-2]):
+		return singular[:len(singular)-1] + "ies"
+	}
+	return singular + "s"
+}
+
+func hasAnySuffix(s string, suffixes ...string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(s, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVowel(c byte) bool {
+	return strings.IndexByte("aeiou", c) >= 0
 }
 
 // annotatedPlural reads the resource-plural hint off the object. A missing,
@@ -129,7 +174,10 @@ func annotatedPlural(obj map[string]any) (string, bool) {
 // every resource rule against, so adding a rule field to honor costs one field
 // here rather than another parameter on every call.
 type scopedObject struct {
-	gvr        schema.GroupVersionResource
+	gvr schema.GroupVersionResource
+	// resources are the names the object's kind may be registered under, any of
+	// which a rule may name (see resourceNames).
+	resources  []string
 	name       string
 	namespaced bool
 }
@@ -139,7 +187,7 @@ func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, 
 		matchesScope(rule.Scope, target.namespaced) &&
 		matchesValue(rule.APIGroups, target.gvr.Group) &&
 		matchesValue(rule.APIVersions, target.gvr.Version) &&
-		matchesResource(rule.Resources, target.gvr.Resource) &&
+		matchesResource(rule.Resources, target.resources) &&
 		matchesName(rule.ResourceNames, target.name)
 }
 
@@ -210,27 +258,24 @@ func matchesValue(allowed []string, want string) bool {
 }
 
 // matchesResource is matchesValue for resources, also accepting the "*/*"
-// subresource wildcard. A "resource/subresource" entry never matches a bare
+// subresource wildcard. It matches when the rule names any of the object's
+// candidate resource names. A "resource/subresource" entry never matches a bare
 // resource, which is correct: the scan does not evaluate subresources.
 //
-// A rule resource differing from the object's only in separators still matches:
-// a CRD may register "worker-pools" for kind WorkerPool, which the guess renders
+// A rule resource differing from a candidate only in separators still matches: a
+// CRD may register "worker-pools" for kind WorkerPool, which pluralizing renders
 // "workerpools". Dropping that object would be silent — the policy evaluates
 // against nothing and the control reads as clean. A plural further from the
-// guess than that still needs the resource-plural annotation.
-func matchesResource(allowed []string, want string) bool {
+// candidates than that still needs the resource-plural annotation.
+func matchesResource(allowed, wants []string) bool {
 	for _, a := range allowed {
-		if a == "*" || a == "*/*" || a == want {
+		if a == "*" || a == "*/*" {
 			return true
 		}
-	}
-	if want == "" {
-		return false
-	}
-	normalized := normalizePlural(want)
-	for _, a := range allowed {
-		if normalizePlural(a) == normalized {
-			return true
+		for _, want := range wants {
+			if want != "" && normalizePlural(a) == normalizePlural(want) {
+				return true
+			}
 		}
 	}
 	return false

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -453,3 +453,30 @@ func TestVAPAppliesToResourceNames(t *testing.T) {
 		assert.False(t, vapWithConstraints(named("coredns")).appliesTo(o))
 	})
 }
+
+// TestVAPAppliesToKindPluralCandidates covers the kinds whose registered plural
+// the apimachinery guess gets wrong: a sibilant ending takes "es" and a
+// vowel+"y" ending takes "s", so an exact compare against the single guess drops
+// the object and the control reads clean.
+func TestVAPAppliesToKindPluralCandidates(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     string
+		resource string
+		want     bool
+	}{
+		{"x ending pluralizes with es", "Sandbox", "sandboxes", true},
+		{"sh ending pluralizes with es", "Mesh", "meshes", true},
+		{"ch ending pluralizes with es", "Batch", "batches", true},
+		{"vowel y ending pluralizes with s", "Gateway", "gateways", true},
+		{"consonant y ending still pluralizes with ies", "NetworkPolicy", "networkpolicies", true},
+		{"the apimachinery guess stays accepted", "Sandbox", "sandboxs", true},
+		{"an unrelated plural is out of scope", "Sandbox", "sandboxtemplates", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := vapWithConstraints(rule([]string{"agents.x-k8s.io"}, []string{"v1alpha1"}, []string{tc.resource}))
+			assert.Equal(t, tc.want, v.appliesTo(obj("agents.x-k8s.io/v1alpha1", tc.kind)))
+		})
+	}
+}

--- a/core/pkg/opaprocessor/cel/stub.go
+++ b/core/pkg/opaprocessor/cel/stub.go
@@ -108,7 +108,7 @@ func stubRequest(obj map[string]any) map[string]any {
 // kept only for an object with no determinable kind, which objectGVR reports
 // and appliesTo already treats as "evaluate and let it error".
 func resourcePlural(obj map[string]any) string {
-	gvr, ok := objectGVR(obj)
+	gvr, _, ok := objectGVR(obj)
 	if !ok {
 		return ""
 	}

--- a/core/pkg/opaprocessor/cel/stub_test.go
+++ b/core/pkg/opaprocessor/cel/stub_test.go
@@ -122,6 +122,30 @@ func TestStubRequestResourcePlural(t *testing.T) {
 			want: "actortemplates",
 		},
 		{
+			name: "sibilant kind pluralizes to es",
+			obj: map[string]any{
+				"apiVersion": "agents.x-k8s.io/v1alpha1",
+				"kind":       "Sandbox",
+			},
+			want: "sandboxes",
+		},
+		{
+			name: "vowel before a final y pluralizes to s",
+			obj: map[string]any{
+				"apiVersion": "gateway.networking.k8s.io/v1",
+				"kind":       "Gateway",
+			},
+			want: "gateways",
+		},
+		{
+			name: "an already plural kind is left alone",
+			obj: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Endpoints",
+			},
+			want: "endpoints",
+		},
+		{
 			name: "resource-plural annotation overrides the guess",
 			obj: map[string]any{
 				"apiVersion": "agentsubstrate.google.com/v1",
@@ -156,7 +180,7 @@ func TestStubRequestResourcePlural(t *testing.T) {
 // policy be scoped in and then self-guard itself back out.
 func TestStubRequestResourceMatchesScoping(t *testing.T) {
 	for _, obj := range []map[string]any{namespacedPod(), clusterScopedRole()} {
-		gvr, ok := objectGVR(obj)
+		gvr, _, ok := objectGVR(obj)
 		require.True(t, ok)
 
 		req := stubRequest(obj)


### PR DESCRIPTION
### What

Offline CEL scanning resolves a scanned object's resource name from its kind, because there is no discovery or RESTMapper to ask. That resolution used `meta.UnsafeGuessKindToResource`, which pluralizes by appending `s` unless the kind ends in `s` or `y`. For a lot of real CRDs that produces a plural no cluster serves:

| kind | guessed | registered |
|---|---|---|
| `Sandbox` | `sandboxs` | `sandboxes` |
| `Mesh` | `meshs` | `meshes` |
| `Batch` | `batchs` | `batches` |
| `Gateway` | `gatewaies` | `gateways` |

`appliesTo` compares that single guess against the policy's `matchConstraints`, so a policy scoped to `resources: [sandboxes]` never matched a `Sandbox` object. The object was excluded as out of scope, the control evaluated against nothing, and the report read clean. Same string also feeds `request.resource.resource`, so a policy self-guarding on it saw `sandboxs` where the cluster says `sandboxes`.

The existing escape hatch is the `kubescape.io/resource-plural` annotation, but that only helps when someone already knows the plural was guessed wrong, which is exactly what a silent skip hides.

### How

The object's kind now resolves to a small list of candidate resource names instead of one, and a resource rule matches when it names any of them:

* the English plural (`es` after a sibilant, `ies` after a consonant plus `y`, `s` otherwise), which is what `controller-gen` puts in `spec.names.plural`
* the apimachinery guess, kept so nothing that matched before stops matching

A kind that is already plural is left alone, so `Endpoints` stays `endpoints`. An explicit `kubescape.io/resource-plural` annotation is still authoritative and stands on its own. `request.resource.resource` takes the first candidate, so it agrees with whatever scoped the object in.

Matching only widens here, so no policy that resolved before resolves differently now.

### Testing

`appliesTo` cases for the sibilant, vowel-plus-y and consonant-plus-y endings, plus the old guess still being accepted; `stubRequest` cases for the plural landing in `request.resource.resource` and for `Endpoints` not being double pluralized. Both new cases fail on master. Full `./core/...` suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline resource matching for kinds with irregular plural forms, including sibilant endings and “y” variants.
  - Resource rules now recognize multiple valid resource names and normalized separator formats.
  - Preserved support for wildcard rules and subresources.
  - Resource detection remains compatible with annotations and existing resource-name conventions.

- **Tests**
  - Added coverage for pluralization edge cases and unrelated-resource matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->