### PR TITLE
feat: surface vulnerability DB freshness in image-scan results

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/pkg"
@@ -33,6 +34,10 @@ type ImageScanData struct {
 	Packages              []pkg.Package
 	SBOM                  *sbom.SBOM
 	VulnerabilityProvider vulnerability.Provider
+	// VulnDBBuilt is the build timestamp of the vulnerability DB used for this
+	// scan. It lets users (especially air-gapped ones) see how fresh the data
+	// was. Nil when the DB status is unknown.
+	VulnDBBuilt *time.Time `json:"vulnDBBuilt,omitempty"`
 }
 
 // SkippedManifest records a manifest file that was discovered but could not

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
@@ -3,9 +3,13 @@ package prettyprinter
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 )
 
 func TestNewImagePrinter(t *testing.T) {
@@ -92,4 +96,54 @@ func TestPrintNextSteps_ImageScan(t *testing.T) {
 			assert.Equal(t, tt.want, string(got))
 		})
 	}
+}
+
+func TestPrintImageScanningSummary_DBLinePresentWhenBuilt(t *testing.T) {
+	builtAt := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	summary := imageprinter.ImageScanSummary{
+		CVEs:                  []imageprinter.CVE{},
+		PackageScores:         map[string]*imageprinter.PackageScore{},
+		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
+		Images:                []string{"img:1"},
+		VulnDBBuilt:           &builtAt,
+	}
+
+	f, err := os.CreateTemp("", "db-line")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	printImageScanningSummary(f, summary, false)
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, string(got), "Vulnerability DB built: "+builtAt.UTC().Format("2006-01-02"))
+}
+
+func TestPrintImageScanningSummary_NoDBLineWhenNil(t *testing.T) {
+	summary := imageprinter.ImageScanSummary{
+		CVEs:                  []imageprinter.CVE{},
+		PackageScores:         map[string]*imageprinter.PackageScore{},
+		MapsSeverityToSummary: map[string]*imageprinter.SeveritySummary{},
+		Images:                []string{"img:1"},
+	}
+
+	f, err := os.CreateTemp("", "db-line")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	printImageScanningSummary(f, summary, false)
+
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.False(t, strings.Contains(string(got), "Vulnerability DB built:"))
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/imagescan_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 )
 
 func TestNewImagePrinter(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/datastructures.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/datastructures.go
@@ -1,10 +1,15 @@
 package imageprinter
 
+import "time"
+
 type ImageScanSummary struct {
 	MapsSeverityToSummary map[string]*SeveritySummary
 	CVEs                  []CVE
 	PackageScores         map[string]*PackageScore // map of package name to package score
 	Images                []string
+	// VulnDBBuilt is the vulnerability DB build timestamp, surfaced so users can
+	// judge data freshness. Nil when unknown.
+	VulnDBBuilt *time.Time
 }
 
 type SeveritySummary struct {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jwalton/gchalk"
 	"github.com/kubescape/kubescape/v4/core/cautils"
@@ -206,6 +207,17 @@ func printTopComponents(writer *os.File, summary imageprinter.ImageScanSummary) 
 }
 
 func printImageScanningSummary(writer *os.File, summary imageprinter.ImageScanSummary, verboseMode bool) {
+	if summary.VulnDBBuilt != nil {
+		age := time.Since(*summary.VulnDBBuilt)
+		days := int(age.Hours() / 24)
+		info := summary.VulnDBBuilt.UTC().Format("2006-01-02")
+		if days < 1 {
+			cautils.InfoDisplay(writer, fmt.Sprintf("Vulnerability DB built: %s\n", info))
+		} else {
+			cautils.InfoDisplay(writer, fmt.Sprintf("Vulnerability DB built: %s (%d days ago)\n", info, days))
+		}
+	}
+
 	mapSeverityTSummary := getSeverityToSummaryMap(summary, verboseMode)
 
 	// sort keys by severity

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -447,6 +447,10 @@ func buildImageScanSummary(imageScanData []cautils.ImageScanData) *imageprinter.
 			imageScanSummary.Images = append(imageScanSummary.Images, image)
 		}
 
+		if imageScanSummary.VulnDBBuilt == nil {
+			imageScanSummary.VulnDBBuilt = imageScanData[i].VulnDBBuilt
+		}
+
 		cves := extractCVEs(imageScanData[i].Matches, image)
 		imageScanSummary.CVEs = append(imageScanSummary.CVEs, cves...)
 

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -1279,3 +1279,29 @@ func TestFilterBySeverity_EmptyMinSeverityNoOp(t *testing.T) {
 	FilterBySeverity(report, "")
 	assert.Len(t, report.SummaryDetails.Controls, 1)
 }
+
+func TestBuildImageScanSummary_CarriesVulnDBBuilt(t *testing.T) {
+	builtAt := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+
+	imageData := []cautils.ImageScanData{
+		{Image: "img:1", VulnDBBuilt: &builtAt},
+		{Image: "img:2"}, // no built time; first non-nil wins
+	}
+
+	summary := buildImageScanSummary(imageData)
+
+	require.NotNil(t, summary)
+	assert.Equal(t, builtAt, *summary.VulnDBBuilt)
+	assert.Equal(t, []string{"img:1", "img:2"}, summary.Images)
+}
+
+func TestBuildImageScanSummary_NilWhenNoBuilt(t *testing.T) {
+	imageData := []cautils.ImageScanData{
+		{Image: "img:1"},
+	}
+
+	summary := buildImageScanSummary(imageData)
+
+	require.NotNil(t, summary)
+	assert.Nil(t, summary.VulnDBBuilt)
+}

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -167,6 +167,9 @@ type Service struct {
 	// Used by MCP server to restrict scans to remote registry providers.
 	sources []string
 	vp      vulnerability.Provider
+	// dbStatus carries the loaded vulnerability DB status so scan results can
+	// surface DB freshness (ProviderStatus.Built). Nil when the DB failed to load.
+	dbStatus *vulnerability.ProviderStatus
 }
 
 func getIgnoredMatches(vulnerabilityExceptions []string, vp vulnerability.Provider, packages []pkg.Package, pkgContext pkg.Context, useDefaultMatchers bool) (*match.Matches, []match.IgnoredMatch, error) {
@@ -253,7 +256,18 @@ func (s *Service) Scan(_ context.Context, userInput string, creds RegistryCreden
 		SBOM:                  sbom,
 		VulnerabilityProvider: s.vp,
 	}
+
+	applyDBFreshness(&pb, s.dbStatus)
+
 	return &pb, nil
+}
+
+// applyDBFreshness sets VulnDBBuilt on the scan result from the loaded DB
+// status. It is a no-op when the status is nil or the build time is unknown.
+func applyDBFreshness(pb *cautils.ImageScanData, status *vulnerability.ProviderStatus) {
+	if status != nil && !status.Built.IsZero() {
+		pb.VulnDBBuilt = &status.Built
+	}
 }
 
 // ExceedsSeverityThreshold returns true if vulnerabilities in the scan results exceed the severity threshold, false otherwise.
@@ -320,6 +334,7 @@ func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCf
 	}
 	return &Service{
 		vp:                 vp,
+		dbStatus:           status,
 		useDefaultMatchers: useDefaultMatchers,
 		sources:            sources,
 	}, nil

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/adrg/xdg"
 
@@ -13,6 +14,7 @@ import (
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,6 +127,47 @@ func matchIDs(matches match.Matches) []string {
 		ids = append(ids, m.Vulnerability.ID)
 	}
 	return ids
+}
+
+func TestApplyDBFreshness(t *testing.T) {
+	builtAt := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+
+	tests := []struct {
+		name     string
+		status   *vulnerability.ProviderStatus
+		wantSet  bool
+	}{
+		{
+			name:    "nil status leaves field unset",
+			status:  nil,
+			wantSet: false,
+		},
+		{
+			name:    "zero Built leaves field unset",
+			status:  &vulnerability.ProviderStatus{},
+			wantSet: false,
+		},
+		{
+			name: "Built is surfaced",
+			status: &vulnerability.ProviderStatus{
+				Built: builtAt,
+			},
+			wantSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := &cautils.ImageScanData{}
+			applyDBFreshness(pb, tt.status)
+			if tt.wantSet {
+				require.NotNil(t, pb.VulnDBBuilt)
+				assert.Equal(t, builtAt, *pb.VulnDBBuilt)
+			} else {
+				assert.Nil(t, pb.VulnDBBuilt)
+			}
+		})
+	}
 }
 
 func TestParseSeverity(t *testing.T) {

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -14,7 +14,7 @@ import (
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -133,9 +133,9 @@ func TestApplyDBFreshness(t *testing.T) {
 	builtAt := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
 
 	tests := []struct {
-		name     string
-		status   *vulnerability.ProviderStatus
-		wantSet  bool
+		name    string
+		status  *vulnerability.ProviderStatus
+		wantSet bool
 	}{
 		{
 			name:    "nil status leaves field unset",


### PR DESCRIPTION
Closes #3354

## Overview

Surfaces the vulnerability database build timestamp in image-scan results so users can see how fresh the data is. Today `NewVulnerabilityDB` returns a `*vulnerability.ProviderStatus` (`pkg/imagescan/imagescan.go:291`) but every caller discards it (`core/core/scan.go:445`), using it only on the error path. A stale Grype DB silently misses CVEs with no visibility — worst for air-gapped users, who cannot update the DB at all and have no way to know their data is old.

---

## Changes

### `pkg/imagescan/imagescan.go`
- Adds `dbStatus *vulnerability.ProviderStatus` to `Service` (nil when the DB failed to load).
- Captures the already-loaded status in `NewScanServiceWithMatchersAndSources` instead of discarding it.
- Adds `applyDBFreshness` — sets `VulnDBBuilt` on the scan result from `ProviderStatus.Built`, guarded for nil status and zero/unknown build time.

### `core/cautils/datastructures.go`
- Adds `VulnDBBuilt *time.Time` (`json:"vulnDBBuilt,omitempty"`) to `ImageScanData` — purely additive; existing output is byte-identical when unset.

### Printer chain
- `ImageScanSummary` gains `VulnDBBuilt *time.Time`.
- `buildImageScanSummary` copies it from `ImageScanData` (first non-nil wins).
- `printImageScanningSummary` renders one line at the top (before the zero-CVE early return, so it shows in both paths):

  `Vulnerability DB built: 2026-08-01 (15 days ago)`

---

## Tests

5 new test functions, all passing:

- `TestApplyDBFreshness` — nil status / zero `Built` leave the field unset (no panic); populated `Built` is surfaced
- `TestBuildImageScanSummary_CarriesVulnDBBuilt` / `_NilWhenNoBuilt` — the summary carries the field through the converter
- `TestPrintImageScanningSummary_DBLinePresentWhenBuilt` / `_NoDBLineWhenNil` — the line renders when present and is omitted when nil (including the zero-CVE path)

---

## How to Test

```sh
go build ./pkg/imagescan/... ./core/cautils/... ./core/pkg/resultshandling/...
go test ./pkg/imagescan/ ./core/cautils/ ./core/pkg/resultshandling/...
```

---

## Scope note

`--skip-db-update` (`shouldUpdate := true` at `imagescan.go:74`) is a **separate follow-up** — this PR only surfaces the timestamp, it does not change DB-update behavior.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] New and existing tests pass locally (imagescan, cautils, resultshandling)
- [x] `go build` and `go vet` pass
- [x] Follows the maintainer's agreed shape (`vulnDBBuilt` timestamp, not a boolean)
- [x] No breakage — additive `omitempty` field, display-only printer change
- [x] DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image scan summaries now display the vulnerability database build date.
  - Summaries indicate how many days have elapsed when the database is more than one day old.
  - Scan results retain vulnerability database freshness information when available.

- **Bug Fixes**
  - Freshness details are omitted when no build timestamp is provided.

- **Tests**
  - Added coverage for freshness propagation, display, missing values, and image ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->