### PR TITLE
fix(printer): dedupe enriched failed paths against bare delete paths

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -543,6 +543,23 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 		assert.Contains(t, got, "spec.hostPID (current: true)")
 		assert.Len(t, got, 2)
 	})
+
+	t.Run("path shared by delete and failed path is printed once", func(t *testing.T) {
+		// reproduces rules such as C-0012 that assign the same path to both
+		// DeletePath and FailedPath - the enriched failed path must not duplicate
+		// the bare delete path for the same field
+		ctrl := &resourcesresults.ResourceAssociatedControl{
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FailedPath: "spec.hostPID", DeletePath: "spec.hostPID"},
+					},
+				},
+			},
+		}
+		got := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
+		assert.Equal(t, []string{"spec.hostPID"}, got)
+	})
 }
 
 func TestAssistedRemediationPathsWithCurrentValuesFiltered(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -255,18 +255,30 @@ func AssistedRemediationPathsToString(control *resourcesresults.ResourceAssociat
 }
 
 func appendFailedPathsIfNotInPaths(paths []string, failedPaths []string) []string {
-	// Create a set to efficiently check if a failed path already exists in the paths slice
+	// Create a set to efficiently check if a failed path already exists in the paths slice.
+	// Keys are deduplicated on the bare path so a plain delete/fix/review path still matches
+	// its enriched " (current: <value>)" counterpart in failedPaths.
 	pathSet := make(map[string]struct{})
 	for _, path := range paths {
-		pathSet[path] = struct{}{}
+		pathSet[dedupPathKey(path)] = struct{}{}
 	}
 
 	// Append failed paths if they are not already present
 	for _, failedPath := range failedPaths {
-		if _, ok := pathSet[failedPath]; !ok {
+		if _, ok := pathSet[dedupPathKey(failedPath)]; !ok {
 			paths = append(paths, failedPath)
 		}
 	}
 
 	return paths
+}
+
+// dedupPathKey strips the " (current: <value>)" suffix appended by evidence enrichment so a
+// bare path (as emitted by fix/delete/review paths) and its enriched failed-path counterpart
+// are recognized as referring to the same field.
+func dedupPathKey(path string) string {
+	if idx := strings.Index(path, " (current: "); idx >= 0 {
+		return path[:idx]
+	}
+	return path
 }

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -33,6 +33,13 @@ func TestAppendFailedPathsIfNotInPaths(t *testing.T) {
 			failedPaths:   []string{},
 			expectedPaths: []string{"path1", "path2"},
 		},
+		{
+			// a bare delete/fix/review path must still be recognized as covering its
+			// enriched " (current: <value>)" counterpart in failedPaths
+			paths:         []string{"spec.hostNetwork"},
+			failedPaths:   []string{"spec.hostNetwork (current: true)"},
+			expectedPaths: []string{"spec.hostNetwork"},
+		},
 	}
 
 	for _, testcase := range tests {


### PR DESCRIPTION
## Summary
Fixes #2970 (part 1) — paths that appear in both `deletePaths` and `failedPaths` were printed twice.

`AssistedRemediationPathsWithCurrentValues` / `...Filtered` build the printed path list by combining fix/delete/review paths (bare) with an enriched failed-path list (which now carries a `" (current: <value>)"` suffix added by the evidence-enrichment work). `appendFailedPathsIfNotInPaths` de-duplicated by exact string match, so a bare delete path like `spec.hostNetwork` no longer matched its enriched counterpart `spec.hostNetwork (current: true)`, and both were emitted.

This affects every rule that assigns the same path to both `FailedPath` and `DeletePath` — `rule-credentials-in-env-var` (C-0012) is the widest case.

## Fix
`appendFailedPathsIfNotInPaths` now compares paths after stripping the `" (current: <value>)"` enrichment suffix, so a bare path is correctly recognized as already covering its enriched counterpart.

## Test plan
- [x] Added a regression case to `TestAppendFailedPathsIfNotInPaths` covering a bare path vs. its enriched counterpart.
- [x] Added `TestAssistedRemediationPathsWithCurrentValues/path_shared_by_delete_and_failed_path_is_printed_once`, reproducing the C-0012-style scenario from the issue.
- [x] `go test ./core/pkg/resultshandling/printer/v2/...` passes.
- [x] `go build ./...` passes.

Note: this PR only addresses part 1 of #2970 (the duplicate-path issue). Part 2 (container-scoped paths never being enriched because typed container slices aren't walked) is a separate, larger change and is left for a follow-up, per the issue author's note that this area is being kept clear for the LFX mentee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assisted-remediation output to prevent duplicate paths when a field appears in both deletion and failure results.
  * Improved matching for failed paths that include current-value details, ensuring only one path is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->