### PR TITLE
fix: repair master build breaks (stale v3 import + jsonprinter test arg)

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -39,7 +39,7 @@ func TestSetWriter_Json_CaseInsensitiveExtension(t *testing.T) {
 			tmpDir := t.TempDir()
 			target := tmpDir + string(os.PathSeparator) + tt.outputFile
 
-			jp := NewJsonPrinter("")
+			jp := NewJsonPrinter()
 			require.NoError(t, jp.SetWriter(context.TODO(), target))
 			require.NotNil(t, jp.writer)
 			defer jp.writer.Close()

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"strings"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"testing"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

`master`'s `Create cross-platform build` CI check is currently red on every open PR — a stale `github.com/kubescape/kubescape/v3` import left over from the `/v4` module-path bump (#3350) pulls in an incompatible dependency tree, and a leftover argument in a `NewJsonPrinter` test call breaks `go vet`. This fixes both with one-line corrections and no behavior change.

## Root causes

1. **`core/pkg/resultshandling/severity_filter.go` and its test still imported the old external `github.com/kubescape/kubescape/v3` module** instead of the local `v4` one, left over from before the module-path bump in #3350. Because that file is part of the main module's own build graph, it pulled the *entire* old `v3` dependency tree into the build — including an incompatible `docker/distribution`/`distribution/reference` combination — which is what produced the `undefined: reference.SplitHostname` build failure seen in CI, plus a type mismatch between the two different `OPASessionObj` types (`v3` vs `v4`) at the `ApplySeverityFilters` call site in `core/pkg/resultshandling/results.go`.
2. **`core/pkg/resultshandling/printer/v2/jsonprinter_test.go:42`** still called `NewJsonPrinter("")` with a leftover argument from before #3337 dropped the constructor's parameter — breaking `go vet ./...`.

I verified this is a pre-existing `master` break, not introduced by any specific open PR — the identical failure signature appears on #3353, #3356, #3357, #3358, and #3359 regardless of what each one touches.

## Verification

```sh
go build ./...   # was failing on master, now clean
go vet ./...     # was failing on master, now clean
go test ./...    # clean except a pre-existing, environment-specific
                  # failure in Test_NewClusterConfig unrelated to this change
                  # (local sandbox env vars leak into an unset-env-var test)
gofmt -l <changed files>                              # clean
golangci-lint run ./... --new-from-rev=origin/master   # 0 issues
```

## Checklist

- [x] Verified this is a pre-existing `master` break, not introduced by any specific open PR
- [x] `go build`, `go vet` pass repo-wide
- [x] `go test ./...` passes except one unrelated, pre-existing environment-specific test
- [x] `gofmt` / `golangci-lint` clean on changed files
- [x] No behavior change — import path and call-site corrections only
- [x] DCO sign-off

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the current JSON output configuration.
  * Updated severity filtering to use the latest supported utility version.

* **Tests**
  * Updated coverage to reflect the current JSON printer setup and utility version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->