### PR TITLE
fix(printer): format N/A and percentage compliance score correctly in…

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -39,7 +39,7 @@ func TestSetWriter_Json_CaseInsensitiveExtension(t *testing.T) {
 			tmpDir := t.TempDir()
 			target := tmpDir + string(os.PathSeparator) + tt.outputFile
 
-			jp := NewJsonPrinter("")
+			jp := NewJsonPrinter()
 			require.NoError(t, jp.SetWriter(context.TODO(), target))
 			require.NotNil(t, jp.writer)
 			defer jp.writer.Close()

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -64,7 +64,11 @@ func (mp *MarkdownPrinter) ActionPrint(ctx context.Context, opaSessionObj *cauti
 
 	ew := &mdErrWriter{w: w}
 	ew.printf("# Kubescape Security Report\n\n")
-	ew.printf("**Compliance Score:** %d\n\n", cautils.ComplianceScoreToInt(summaryDetails.ComplianceScore))
+	if score := cautils.ComplianceScoreToInt(summaryDetails.ComplianceScore); score < 0 {
+		ew.printf("**Compliance Score:** N/A\n\n")
+	} else {
+		ew.printf("**Compliance Score:** %d%%\n\n", score)
+	}
 	if ew.err != nil {
 		return ew.err
 	}

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -195,7 +195,7 @@ func TestMarkdownPrinter_ActionPrint_Header(t *testing.T) {
 	out := mdRunActionPrint(t, mdSessionFixture())
 
 	assert.True(t, strings.HasPrefix(out, "# Kubescape Security Report"), "must start with h1 heading")
-	assert.Contains(t, out, "**Compliance Score:** 42", "compliance score must appear")
+	assert.Contains(t, out, "**Compliance Score:** 42%", "compliance score must appear with percentage")
 }
 
 func TestMarkdownPrinter_ActionPrint_SummaryTablePresent(t *testing.T) {
@@ -285,8 +285,54 @@ func TestMarkdownPrinter_ActionPrint_EmptyControls(t *testing.T) {
 	out := mdRunActionPrint(t, session)
 
 	assert.Contains(t, out, "# Kubescape Security Report")
-	assert.Contains(t, out, "**Compliance Score:** 0")
+	assert.Contains(t, out, "**Compliance Score:** 0%")
 	assert.Contains(t, out, "## Summary")
+}
+
+func TestMarkdownPrinter_ActionPrint_NegativeScoreRendersNA(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: -1,
+			Controls:        reportsummary.ControlSummaries{},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "# Kubescape Security Report")
+	assert.Contains(t, out, "**Compliance Score:** N/A")
+	assert.NotContains(t, out, "**Compliance Score:** -1")
+}
+
+func TestMarkdownPrinter_ActionPrint_PerfectScoreRenders100Percent(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: 100,
+			Controls:        reportsummary.ControlSummaries{},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "# Kubescape Security Report")
+	assert.Contains(t, out, "**Compliance Score:** 100%")
+}
+
+func TestMarkdownPrinter_ActionPrint_FractionalScoreRendersPercentage(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			ComplianceScore: 99.5,
+			Controls:        reportsummary.ControlSummaries{},
+		},
+	}
+
+	out := mdRunActionPrint(t, session)
+
+	assert.Contains(t, out, "# Kubescape Security Report")
+	assert.Contains(t, out, "**Compliance Score:** 99%")
 }
 
 func TestMdSortedControls(t *testing.T) {

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"strings"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"testing"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"


### PR DESCRIPTION
## Overview
Fixes #3360

In `core/pkg/resultshandling/printer/v2/markdownprinter.go`, the Markdown report header previously printed compliance scores as a raw integer `%d`. When a scan produced no compliance score (e.g. all controls were skipped or uncalculated), `cautils.ComplianceScoreToInt()` returned `-1`, causing the report to output `**Compliance Score:** -1`. Valid scores also omitted the standard percentage `%` suffix.

### Changes
- Updated `MarkdownPrinter.ActionPrint()` to check if the compliance score is `< 0`, rendering `**Compliance Score:** N/A\n\n` for uncalculated/negative scores and `**Compliance Score:** %d%%\n\n` for valid scores.
- Added comprehensive unit tests in `markdownprinter_test.go`:
  - `TestMarkdownPrinter_ActionPrint_NegativeScoreRendersNA`: verifies `-1` renders as `N/A`.
  - `TestMarkdownPrinter_ActionPrint_PerfectScoreRenders100Percent`: verifies `100%` rendering.
  - `TestMarkdownPrinter_ActionPrint_FractionalScoreRendersPercentage`: verifies fractional scores (e.g. `99.5` ➔ `99%`).
  - Updated existing header test assertions to expect `%`.

## Additional Information
- Consistent with compliance score formatting in `controltable.go`, `summarytable.go`, and `csvprinter.go`.

## How to Test
Run the markdown printer test suite:
```bash
go test -v ./core/pkg/resultshandling/printer/v2 -run TestMarkdownPrinter
```

## Related issues/PRs:
* Resolved #3360

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown reports now display compliance scores as percentages with a `%` suffix.
  * Unavailable or negative compliance scores are shown as `N/A` instead of misleading numeric values.
  * Improved score presentation for empty controls, perfect scores (`100%`), and fractional scores.
  * Compliance reporting is now clearer and more consistent across common score scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->