### PR TITLE
fix(printer): prevent out-of-bounds slice index panic in getSortedControlsIDs (#3363)

### DIFF
--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -81,6 +81,9 @@ func getSortedControlsIDs(controls reportsummary.ControlSummaries) [][]string {
 	for k := range controls {
 		c := controls[k]
 		i := apis.ControlSeverityToInt(c.GetScoreFactor())
+		if i < 0 || i >= len(controlIDs) {
+			i = 0
+		}
 		controlIDs[i] = append(controlIDs[i], c.GetID())
 	}
 	for i := range controlIDs {

--- a/core/pkg/resultshandling/printer/v2/controltable_test.go
+++ b/core/pkg/resultshandling/printer/v2/controltable_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_generateRowPdf(t *testing.T) {
@@ -90,6 +91,55 @@ func Test_generateTableRow_UTF8(t *testing.T) {
 	row := generateTableRow(ctrl, nil)
 
 	assert.True(t, utf8.ValidString(row.name), "truncated control name must be valid UTF-8")
+}
+
+func TestGetSortedControlsIDs_OutOfBoundsScoreFactorDoesNotPanic(t *testing.T) {
+	controls := reportsummary.ControlSummaries{
+		"C-0001": reportsummary.ControlSummary{ControlID: "C-0001", Name: "LowControl", ScoreFactor: 1.0},
+		"C-0002": reportsummary.ControlSummary{ControlID: "C-0002", Name: "CriticalControl", ScoreFactor: 9.0},
+		"C-0003": reportsummary.ControlSummary{ControlID: "C-0003", Name: "NegativeScoreFactor", ScoreFactor: -50.0},
+		"C-0004": reportsummary.ControlSummary{ControlID: "C-0004", Name: "ExcessiveScoreFactor", ScoreFactor: 999.0},
+		"C-0005": reportsummary.ControlSummary{ControlID: "C-0005", Name: "ZeroScoreFactor", ScoreFactor: 0.0},
+	}
+
+	var sortedIDs [][]string
+	assert.NotPanics(t, func() {
+		sortedIDs = getSortedControlsIDs(controls)
+	}, "getSortedControlsIDs must not panic on out-of-bounds score factors")
+
+	require.Len(t, sortedIDs, 5)
+	// Bucket 0 should contain unknown/out-of-bounds controls
+	assert.Contains(t, sortedIDs[0], "C-0003")
+	assert.Contains(t, sortedIDs[0], "C-0005")
+	assert.Contains(t, sortedIDs[apis.SeverityCritical], "C-0002")
+}
+
+func TestGetSortedControlsIDs_Empty(t *testing.T) {
+	sortedIDs := getSortedControlsIDs(reportsummary.ControlSummaries{})
+	require.Len(t, sortedIDs, 5)
+	for i := range sortedIDs {
+		assert.Empty(t, sortedIDs[i])
+	}
+}
+
+func TestGetColor_AllSeverities(t *testing.T) {
+	severities := []int{
+		apis.SeverityCritical,
+		apis.SeverityHigh,
+		apis.SeverityMedium,
+		apis.SeverityLow,
+		apis.SeverityUnknown,
+		-1,
+		99,
+	}
+
+	for _, s := range severities {
+		t.Run(fmt.Sprintf("severity_%d", s), func(t *testing.T) {
+			fn := getColor(s)
+			assert.NotNil(t, fn)
+			assert.NotEmpty(t, fn("TEST"))
+		})
+	}
 }
 
 func mockSummaryDetails() (*reportsummary.SummaryDetails, error) {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -39,7 +39,7 @@ func TestSetWriter_Json_CaseInsensitiveExtension(t *testing.T) {
 			tmpDir := t.TempDir()
 			target := tmpDir + string(os.PathSeparator) + tt.outputFile
 
-			jp := NewJsonPrinter("")
+			jp := NewJsonPrinter()
 			require.NoError(t, jp.SetWriter(context.TODO(), target))
 			require.NotNil(t, jp.writer)
 			defer jp.writer.Close()

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"strings"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -3,7 +3,7 @@ package resultshandling
 import (
 	"testing"
 
-	"github.com/kubescape/kubescape/v3/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"


### PR DESCRIPTION

## Overview
Fixes #3363

In `core/pkg/resultshandling/printer/v2/controltable.go`, `getSortedControlsIDs` categorizes controls into buckets by severity index using `controlIDs[i]`, where `controlIDs` is initialized with length 5 (`make([][]string, 5)`). If a control from a custom framework or extension returns an unexpected score factor (or negative value) from `apis.ControlSeverityToInt()`, `controlIDs[i]` previously triggered a runtime index-out-of-range panic.

### Changes
- Added bounds checking for severity index `i` in `controltable.go`:
  ```go
  if i < 0 || i >= len(controlIDs) {
      i = 0
  }
  ```
- Added comprehensive unit tests in `controltable_test.go`:
  - `TestGetSortedControlsIDs_OutOfBoundsScoreFactorDoesNotPanic`: verifies handling of negative, excessive, zero, and standard score factors.
  - `TestGetSortedControlsIDs_Empty`: verifies empty control summaries.
  - `TestGetColor_AllSeverities`: tests color resolution across all standard, negative, and out-of-range severity levels.

## Additional Information
- Preserves sorting behavior for all valid severity levels (Critical, High, Medium, Low, Unknown) while gracefully defaulting unexpected or out-of-range values to bucket 0 instead of crashing.

## How to Test
Run the controltable test suite:
```bash
go test -v ./core/pkg/resultshandling/printer/v2 -run "Test_generate|TestGetSortedControlsIDs|TestGetColor"
```

## Related issues/PRs:
* Resolved #3363

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported severity values to prevent errors when sorting control results.
  * Ensured unknown severity factors are handled consistently and assigned to a default category.
  * Preserved reliable color output across valid and invalid severity values.

* **Tests**
  * Added coverage for empty results, out-of-range severity values, and severity-based color generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->