### PR TITLE
fix: a scope-less cloud exception now subsumes CRD exceptions for the same control

### DIFF
--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -78,7 +78,7 @@ func deduplicateExceptions(
 		return merged
 	}
 
-	covered := coveredPostureScopes(cloudExceptions)
+	covered, global := coveredPostureScopes(cloudExceptions)
 	matcher := newScopeMatcher()
 
 	for _, crd := range crdExceptions {
@@ -89,6 +89,14 @@ func deduplicateExceptions(
 		}
 
 		for _, policy := range crd.PosturePolicies {
+			if matcher.coveredBy(global, policy) {
+				// A cloud exception with no Resources at all applies with no scope
+				// constraint - the same convention hasExplicitControlException uses
+				// for manual controls - so it already covers this policy everywhere
+				// and fully subsumes the CRD policy, not just designators it happens
+				// to share a resource key with.
+				continue
+			}
 			filteredResources := make([]identifiers.PortalDesignator, 0, len(crd.Resources))
 			for _, resource := range crd.Resources {
 				if !matcher.coveredBy(covered[designatorDedupKey(resource)], policy) {
@@ -109,13 +117,24 @@ func deduplicateExceptions(
 }
 
 // coveredPostureScopes indexes the primary posture-policy scopes by workload
-// designator. A policy without a control ID carries nothing to measure a CRD policy
-// against, so it never suppresses one.
-func coveredPostureScopes(exceptions []armotypes.PostureExceptionPolicy) map[string][]armotypes.PosturePolicy {
-	covered := make(map[string][]armotypes.PosturePolicy, len(exceptions))
+// designator, and separately collects policies from a primary exception that has
+// no Resources at all into global. Such an exception applies with no scope
+// constraint - the same convention hasExplicitControlException already uses for
+// manual controls - so it covers every designator for a matching control/framework/
+// rule scope, not just one indexed by a specific resource key. A policy without a
+// control ID carries nothing to measure a CRD policy against, so it never
+// suppresses one.
+func coveredPostureScopes(exceptions []armotypes.PostureExceptionPolicy) (covered map[string][]armotypes.PosturePolicy, global []armotypes.PosturePolicy) {
+	covered = make(map[string][]armotypes.PosturePolicy, len(exceptions))
 	for _, exception := range exceptions {
 		for _, policy := range exception.PosturePolicies {
 			if policy.ControlID == "" {
+				continue
+			}
+			if len(exception.Resources) == 0 {
+				if !slices.Contains(global, policy) {
+					global = append(global, policy)
+				}
 				continue
 			}
 			for _, resource := range exception.Resources {
@@ -126,7 +145,7 @@ func coveredPostureScopes(exceptions []armotypes.PostureExceptionPolicy) map[str
 			}
 		}
 	}
-	return covered
+	return covered, global
 }
 
 // scopeMatcher compares posture-policy scopes the way the exception processor does

--- a/core/cautils/getter/mergedexceptionsgetter_test.go
+++ b/core/cautils/getter/mergedexceptionsgetter_test.go
@@ -285,6 +285,34 @@ func TestMergedExceptionsGetter_Deduplication(t *testing.T) {
 			crd:   []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
 			want:  []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
 		},
+		{
+			// Regression for issue-3367: a cloud exception with no Resources at
+			// all applies with no scope constraint (the same "no resources = no
+			// scope constraint" convention used for manual controls), so it must
+			// subsume a CRD exception for the same control on any workload, not
+			// just one that happens to share a resource key.
+			name: "scope-less cloud exception subsumes a narrower CRD exception for the same control",
+			cloud: []armotypes.PostureExceptionPolicy{{
+				PolicyType:      "cloud",
+				PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}},
+			}},
+			crd:  []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0034", nginx("production"))},
+			want: []armotypes.PostureExceptionPolicy{{PolicyType: "cloud", PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}}}},
+		},
+		{
+			// The scope-less cloud exception only covers the control it names;
+			// a CRD exception for a different control must survive untouched.
+			name: "scope-less cloud exception does not subsume a CRD exception for a different control",
+			cloud: []armotypes.PostureExceptionPolicy{{
+				PolicyType:      "cloud",
+				PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}},
+			}},
+			crd: []armotypes.PostureExceptionPolicy{posturePolicy("crd", "C-0035", nginx("production"))},
+			want: []armotypes.PostureExceptionPolicy{
+				{PolicyType: "cloud", PosturePolicies: []armotypes.PosturePolicy{{ControlID: "C-0034"}}},
+				posturePolicy("crd", "C-0035", nginx("production")),
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Fixes #3367.

`deduplicateExceptions` (`core/cautils/getter/mergedexceptionsgetter.go`) implements the "cloud/file exceptions take precedence, a CRD exception is only kept for control+workload combinations not already covered by a cloud exception" rule from the SecurityException design review (previously tracked in #2364, #2804/#2805, and most recently refined for framework/rule-scoped precedence in #3351).

`coveredPostureScopes` builds its coverage index by iterating each cloud exception's `Resources`:

```go
for _, resource := range exception.Resources {
    key := designatorDedupKey(resource)
    ...
}
```

A cloud exception with an **empty** `Resources` list applies with no scope constraint — the same "no resources = no scope constraint, matches any cluster" convention `hasExplicitControlException` already documents and uses for manual controls (`core/pkg/opaprocessor/processorhandlerutils.go`). But since this loop has nothing to iterate, such an exception contributed **nothing** to the coverage index, so `deduplicateExceptions` never recognized it as covering anything — a narrower CRD exception for the same control survived fully duplicated instead of being subsumed.

### Fix

- `coveredPostureScopes` now returns a second value, `global []armotypes.PosturePolicy`: the posture policies from any cloud exception whose `Resources` list is empty.
- `deduplicateExceptions` checks each CRD policy against `global` (via the existing `scopeMatcher`, so framework/rule-name scoping still applies correctly) before falling through to the existing per-designator check. A CRD policy already covered by a scope-less cloud exception is dropped without needing to match any specific resource key.

The existing "CRD exception without resolvable workload keys is kept" behavior (a CRD exception itself has no `Resources`) is intentionally left untouched — that's a different, untested edge case from the one reported and reproduced here, and changing it wasn't part of this fix's scope.

## How this was verified

Before writing the fix, I reproduced the bug directly against the real internal function (not a mock): a scope-less cloud exception for `C-0034` plus a narrow CRD exception for `C-0034` on a specific `nginx` deployment produced **2** merged exceptions (should be 1 — the CRD one fully subsumed).

After the fix, I added two table-driven cases to `TestMergedExceptionsGetter_Deduplication` in `mergedexceptionsgetter_test.go`:
1. a scope-less cloud exception subsumes a narrower CRD exception for the *same* control (down to 1 merged exception)
2. a scope-less cloud exception does *not* subsume a CRD exception for a *different* control (both kept)

I confirmed case 1 is a real regression test, not just an assertion that happens to pass, by running it against the pre-fix code (`git stash` on just `mergedexceptionsgetter.go`):

```
$ git stash push -- core/cautils/getter/mergedexceptionsgetter.go
$ go test ./core/cautils/getter/... -run "MergedExceptionsGetter_Deduplication/scope-less" -v
--- FAIL: TestMergedExceptionsGetter_Deduplication (0.00s)
    --- FAIL: TestMergedExceptionsGetter_Deduplication/scope-less_cloud_exception_subsumes_a_narrower_CRD_exception_for_the_same_control (0.00s)
        mergedexceptionsgetter_test.go:326:
            Error: Not equal:
            expected: len=1
            actual  : len=2   (the CRD exception for C-0034/nginx survived, duplicated)
    --- PASS: TestMergedExceptionsGetter_Deduplication/scope-less_cloud_exception_does_not_subsume_a_CRD_exception_for_a_different_control (0.00s)
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./core/...
$ go vet ./core/cautils/getter/...
(both exit 0, no output)

$ go test ./core/cautils/getter/... -v -run "MergedExceptionsGetter_Deduplication"
=== RUN   TestMergedExceptionsGetter_Deduplication
=== RUN   TestMergedExceptionsGetter_Deduplication/full_overlap_drops_the_CRD_exception
=== RUN   TestMergedExceptionsGetter_Deduplication/no_overlap_keeps_both_exceptions
=== RUN   TestMergedExceptionsGetter_Deduplication/different_control_on_same_workload_is_not_an_overlap
=== RUN   TestMergedExceptionsGetter_Deduplication/partial_overlap_keeps_only_the_non-overlapping_designators
=== RUN   TestMergedExceptionsGetter_Deduplication/multiple_policies_in_CRD_exception_with_partial_overlap_keeps_the_non-overlapping_policy
=== RUN   TestMergedExceptionsGetter_Deduplication/CRD_exception_without_resolvable_workload_keys_is_kept
=== RUN   TestMergedExceptionsGetter_Deduplication/cross_deduplication_with_multiple_policies_and_resources
=== RUN   TestMergedExceptionsGetter_Deduplication/only_cloud_exceptions
=== RUN   TestMergedExceptionsGetter_Deduplication/only_CRD_exceptions
=== RUN   TestMergedExceptionsGetter_Deduplication/scope-less_cloud_exception_subsumes_a_narrower_CRD_exception_for_the_same_control
=== RUN   TestMergedExceptionsGetter_Deduplication/scope-less_cloud_exception_does_not_subsume_a_CRD_exception_for_a_different_control
--- PASS: TestMergedExceptionsGetter_Deduplication (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/cautils/getter	1.042s

$ go test ./core/...
(all packages pass, no FAIL anywhere)

$ golangci-lint run core/cautils/getter/...
0 issues.

$ gofmt -l core/cautils/getter/mergedexceptionsgetter.go core/cautils/getter/mergedexceptionsgetter_test.go
(no output — both files formatted)
```

## Test plan

- [x] `go build ./core/...`
- [x] `go vet ./core/cautils/getter/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] Two new regression cases added; confirmed the primary one fails against the pre-fix code and passes with the fix
- [x] Full `./core/...` test suite passes, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud exceptions without a specified resource now correctly suppress matching, narrower policy exceptions for the same control.
  - Exceptions for different controls remain unaffected.
  - Resource-specific exception handling continues to work as expected.

- **Tests**
  - Added regression coverage for scope-less cloud exception behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->