### PR TITLE
fix: count manual-control exceptions in the exception audit

### DIFF
--- a/core/pkg/opaprocessor/exceptionaudit.go
+++ b/core/pkg/opaprocessor/exceptionaudit.go
@@ -25,6 +25,7 @@ func buildExceptionAudit(
 	allResources map[string]workloadinterface.IMetadata,
 	policies *cautils.Policies,
 	processor *exceptions.Processor,
+	manualControlMatches []manualControlExceptionMatch,
 ) *cautils.ExceptionAudit {
 	items := make(map[string]*cautils.ExceptionAuditItem, len(loadedExceptions))
 	active := make(map[string]struct{}, len(activeExceptions))
@@ -55,6 +56,19 @@ func buildExceptionAudit(
 				}
 			}
 		}
+	}
+
+	// Manual controls never appear in results (they have no resourcesresults.Result
+	// entries at all), so without this an exception that only suppresses a manual
+	// control is reported as unused even though it is actively applied.
+	for _, match := range manualControlMatches {
+		key := exceptionAuditKey(match.exception)
+		if _, ok := items[key]; !ok {
+			item := exceptionAuditItem(match.exception, policies, processor)
+			items[key] = &item
+		}
+		items[key].MatchCount++
+		items[key].MatchedResources = append(items[key].MatchedResources, cautils.ExceptionAuditMatch{ControlID: match.controlID})
 	}
 
 	audit := &cautils.ExceptionAudit{

--- a/core/pkg/opaprocessor/exceptionaudit_test.go
+++ b/core/pkg/opaprocessor/exceptionaudit_test.go
@@ -1,6 +1,7 @@
 package opaprocessor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/exceptions"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,6 +61,7 @@ func TestBuildExceptionAudit(t *testing.T) {
 			},
 		},
 		exceptions.NewProcessor(),
+		nil,
 	)
 
 	require.NotNil(t, audit)
@@ -90,6 +94,70 @@ func TestBuildExceptionAudit(t *testing.T) {
 	assert.Equal(t, []string{"C-9999"}, items["invalid-control-exception"].InvalidControls)
 }
 
+// Regression for issue-3366: an exception that exists solely to suppress a
+// manual-review control has no resourcesresults.Result entries at all (manual
+// controls produce none), so the audit must be told about the match through
+// manualControlMatches instead - otherwise it reports the exception as unused
+// even though applyExceptionsToManualControls actively applied it.
+func TestBuildExceptionAuditCountsManualControlMatches(t *testing.T) {
+	manualOnlyException := auditException("manual-control-exception", "C-0286", nil)
+
+	audit := buildExceptionAudit(
+		[]armotypes.PostureExceptionPolicy{manualOnlyException},
+		[]armotypes.PostureExceptionPolicy{manualOnlyException},
+		nil, // no resource-backed results at all
+		nil,
+		nil,
+		exceptions.NewProcessor(),
+		[]manualControlExceptionMatch{
+			{exception: manualOnlyException, controlID: "C-0286"},
+		},
+	)
+
+	require.NotNil(t, audit)
+	require.Len(t, audit.Items, 1)
+	item := audit.Items[0]
+
+	assert.Equal(t, exceptionAuditStatusMatched, item.Status, "an exception that suppressed a manual control must not be reported as unused")
+	assert.Equal(t, 1, item.MatchCount)
+	require.Len(t, item.MatchedResources, 1)
+	assert.Equal(t, "C-0286", item.MatchedResources[0].ControlID)
+	assert.Equal(t, 1, audit.Summary.Matched)
+	assert.Equal(t, 0, audit.Summary.Unused)
+}
+
+// End-to-end regression for issue-3366: runs the real updateResults path (via
+// a manual-review-only control summary and AuditExceptions enabled) and checks
+// the resulting ExceptionAudit, rather than calling buildExceptionAudit directly.
+func TestUpdateResults_ExceptionAuditCountsManualControlMatch(t *testing.T) {
+	manualException := auditException("manual-control-exception", "C-0286", nil)
+
+	session := cautils.NewOPASessionObjMock()
+	session.AuditExceptions = true
+	session.Exceptions = []armotypes.PostureExceptionPolicy{manualException}
+	session.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-0286": reportsummary.ControlSummary{
+			ControlID: "C-0286",
+			StatusInfo: apis.StatusInfo{
+				InnerStatus: apis.StatusSkipped,
+				SubStatus:   apis.SubStatusManualReview,
+			},
+		},
+	}
+
+	opap := &OPAProcessor{OPASessionObj: session}
+	opap.updateResults(context.Background())
+
+	require.NotNil(t, opap.ExceptionAudit)
+	require.Len(t, opap.ExceptionAudit.Items, 1)
+	item := opap.ExceptionAudit.Items[0]
+	assert.Equal(t, exceptionAuditStatusMatched, item.Status, "the manual control's exception must not be reported as unused")
+	assert.Equal(t, 1, item.MatchCount)
+
+	ctrl := opap.Report.SummaryDetails.Controls["C-0286"]
+	assert.Equal(t, apis.StatusPassed, ctrl.GetStatus().Status(), "sanity check: the exception did actually suppress the manual control")
+}
+
 func TestBuildExceptionAuditTreatsRegexControlAsValid(t *testing.T) {
 	regexException := auditException("regex-exception", "C-000[12]", nil)
 
@@ -104,6 +172,7 @@ func TestBuildExceptionAuditTreatsRegexControlAsValid(t *testing.T) {
 			},
 		},
 		exceptions.NewProcessor(),
+		nil,
 	)
 
 	require.NotNil(t, audit)
@@ -128,6 +197,7 @@ func TestBuildExceptionAuditDoesNotCollapseDuplicateNamesWithDifferentGUIDs(t *t
 			},
 		},
 		exceptions.NewProcessor(),
+		nil,
 	)
 
 	require.NotNil(t, audit)

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -71,7 +71,7 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	}
 
 	// manual controls have no resource results, so exceptions must be applied directly on the summary.
-	applyExceptionsToManualControls(&opap.Report.SummaryDetails, opap.Exceptions, opap.clusterName, processor)
+	manualControlMatches := applyExceptionsToManualControls(&opap.Report.SummaryDetails, opap.Exceptions, opap.clusterName, processor)
 
 	// set result summary
 	// map control to error
@@ -79,43 +79,62 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	opap.Report.SummaryDetails.InitResourcesSummary(controlToInfoMap)
 
 	if opap.AuditExceptions {
-		opap.ExceptionAudit = buildExceptionAudit(loadedExceptions, opap.Exceptions, opap.ResourcesResult, opap.AllResources, opap.AllPolicies, processor)
+		opap.ExceptionAudit = buildExceptionAudit(loadedExceptions, opap.Exceptions, opap.ResourcesResult, opap.AllResources, opap.AllPolicies, processor, manualControlMatches)
 	}
+}
+
+// manualControlExceptionMatch records that exception matched controlID via the
+// manual-control exception path, so buildExceptionAudit can count it as a match the
+// same way it already counts a resource-backed one - manual controls never appear in
+// opap.ResourcesResult, so without this the audit reports such an exception as unused
+// even while it is actively suppressing the control.
+type manualControlExceptionMatch struct {
+	exception armotypes.PostureExceptionPolicy
+	controlID string
 }
 
 // applyExceptionsToManualControls marks manual controls as passed+w/exceptions when
 // an explicit exception exists for them. Updates both the top-level and per-framework
 // control maps since manual controls produce no resource results for the normal exception loop.
+// Returns the exceptions that matched a manual control, for exception-audit bookkeeping.
 func applyExceptionsToManualControls(
 	summaryDetails *reportsummary.SummaryDetails,
 	exceptionPolicies []armotypes.PostureExceptionPolicy,
 	clusterName string,
 	processor *exceptions.Processor,
-) {
+) []manualControlExceptionMatch {
 	if len(exceptionPolicies) == 0 {
-		return
+		return nil
 	}
 
-	applyExceptionsToControlSummaries(summaryDetails.Controls, exceptionPolicies, clusterName, processor)
+	matches := applyExceptionsToControlSummaries(summaryDetails.Controls, exceptionPolicies, clusterName, processor)
 
 	for i := range summaryDetails.Frameworks {
+		// Top-level and per-framework Controls mirror the same controlIDs, so the
+		// matches collected from the top-level pass above already cover this one;
+		// collecting them again here would only duplicate audit bookkeeping.
 		applyExceptionsToControlSummaries(summaryDetails.Frameworks[i].Controls, exceptionPolicies, clusterName, processor)
 	}
+
+	return matches
 }
 
 // applyExceptionsToControlSummaries updates manual controls in a single ControlSummaries map.
+// Returns the exceptions that matched, for exception-audit bookkeeping.
 func applyExceptionsToControlSummaries(
 	controlSummaries reportsummary.ControlSummaries,
 	exceptionPolicies []armotypes.PostureExceptionPolicy,
 	clusterName string,
 	processor *exceptions.Processor,
-) {
+) []manualControlExceptionMatch {
+	var matches []manualControlExceptionMatch
 	for controlID, ctrl := range controlSummaries {
 		if ctrl.GetSubStatus() != apis.SubStatusManualReview {
 			continue
 		}
 
-		if !hasExplicitControlException(exceptionPolicies, controlID, clusterName, processor) {
+		matchingExceptions := matchingControlExceptions(exceptionPolicies, controlID, clusterName, processor)
+		if len(matchingExceptions) == 0 {
 			continue
 		}
 
@@ -124,7 +143,12 @@ func applyExceptionsToControlSummaries(
 			SubStatus:   apis.SubStatusException,
 		})
 		controlSummaries[controlID] = ctrl
+
+		for _, exception := range matchingExceptions {
+			matches = append(matches, manualControlExceptionMatch{exception: exception, controlID: controlID})
+		}
 	}
+	return matches
 }
 
 // requiresResourceMatch reports whether the designator has constraints
@@ -158,9 +182,12 @@ func filterExpiredExceptions(exceptions []armotypes.PostureExceptionPolicy) []ar
 	return valid
 }
 
-// hasExplicitControlException reports whether an exception policy targets controlID
-// with a cluster-or-global-only designator matching clusterName.
-func hasExplicitControlException(exceptionPolicies []armotypes.PostureExceptionPolicy, controlID, clusterName string, processor *exceptions.Processor) bool {
+// matchingControlExceptions returns the exception policies that explicitly target
+// controlID with a cluster-or-global-only designator matching clusterName. An exception
+// object is returned at most once even if more than one of its PosturePolicies matches.
+func matchingControlExceptions(exceptionPolicies []armotypes.PostureExceptionPolicy, controlID, clusterName string, processor *exceptions.Processor) []armotypes.PostureExceptionPolicy {
+	var matches []armotypes.PostureExceptionPolicy
+policyLoop:
 	for _, policy := range exceptionPolicies {
 		for _, pp := range policy.PosturePolicies {
 			if !processor.RegexCompareControlID(pp.ControlID, controlID) {
@@ -168,19 +195,21 @@ func hasExplicitControlException(exceptionPolicies []armotypes.PostureExceptionP
 			}
 			// no resources = no scope constraint, matches any cluster
 			if len(policy.Resources) == 0 {
-				return true
+				matches = append(matches, policy)
+				continue policyLoop
 			}
 			for _, resource := range policy.Resources {
 				if requiresResourceMatch(resource) {
 					continue
 				}
 				if processor.MatchesCluster(&resource, clusterName) {
-					return true
+					matches = append(matches, policy)
+					continue policyLoop
 				}
 			}
 		}
 	}
-	return false
+	return matches
 }
 
 func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[string]apis.StatusInfo, controlSummary reportsummary.ControlSummaries) map[string]apis.StatusInfo {


### PR DESCRIPTION
## Summary

Fixes #3366.

`buildExceptionAudit` (`core/pkg/opaprocessor/exceptionaudit.go`, added in #3095) counts an exception as a match by walking:

```go
for resourceID, result := range results {
    for _, control := range result.AssociatedControls {
        for _, rule := range control.ResourceAssociatedRules {
            for _, exception := range rule.Exception {
                ...
            }
        }
    }
}
```

i.e. resource-backed findings only. Manual-review controls never appear in `results` at all — they're handled through a separate path, `applyExceptionsToManualControls`/`applyExceptionsToControlSummaries` (`processorhandlerutils.go`), specifically because "manual controls have no resource results, so exceptions must be applied directly on the summary" (see the comment in `updateResults`).

Because the audit never looked at that second path, an exception whose only purpose is to suppress a manual-review control was always reported as `unused`, even though it was active and had actually changed that control's status from `manual-review` to `passed + w/exceptions`.

### Fix

- `hasExplicitControlException` (bool-returning) is now `matchingControlExceptions`, which returns the exception policies that actually matched instead of just a bool.
- `applyExceptionsToControlSummaries` and `applyExceptionsToManualControls` now collect and return those matches as `[]manualControlExceptionMatch{exception, controlID}`.
- `updateResults` threads that slice into `buildExceptionAudit`, which now has a `manualControlMatches` parameter and counts each one exactly like a resource-backed match (incrementing `MatchCount` and appending a `MatchedResources` entry with the `controlID` set).

## How this was verified

Before writing the fix, I called `buildExceptionAudit` directly (the real internal function) with an exception that only targets a manual-review control and an empty `results` map — the exact shape `updateResults` produces when the only exception targets a manual control:

```
audit summary: total=1 matched=0 unused=1
  item "": status=unused matchCount=0 controlIDs=[C-0286]
```

That's the reproduction the linked issue is filed from.

After the fix, I added two regression tests:
1. `TestBuildExceptionAuditCountsManualControlMatches` — calls `buildExceptionAudit` directly with a manual-control match and asserts the item is `matched`, not `unused`.
2. `TestUpdateResults_ExceptionAuditCountsManualControlMatch` — an end-to-end test that runs the real `updateResults` (via a manual-review-only control summary + `AuditExceptions: true`) and checks the resulting `ExceptionAudit`, plus a sanity check that the control was actually suppressed.

This fix changes `buildExceptionAudit`'s signature (a new parameter, `manualControlMatches`), since the old code had no way to represent "this exception matched a manual control" at all — there's no equivalent "runs but returns the wrong value" reproduction against the pre-fix code. Reverting just the two production files while keeping the new tests demonstrates this concretely: it's a compile failure, not a behavioral mismatch, because the capability itself didn't exist before:

```
$ git stash push -- core/pkg/opaprocessor/processorhandlerutils.go core/pkg/opaprocessor/exceptionaudit.go
$ go test ./core/pkg/opaprocessor/... -run "TestBuildExceptionAuditCountsManualControlMatch|TestUpdateResults_ExceptionAuditCountsManualControlMatch" -v
core/pkg/opaprocessor/exceptionaudit_test.go:112:3: too many arguments in call to buildExceptionAudit
core/pkg/opaprocessor/exceptionaudit_test.go:112:5: undefined: manualControlExceptionMatch
FAIL	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor [build failed]
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./core/...
$ go vet ./core/pkg/opaprocessor/...
(both exit 0, no output)

$ go test ./core/pkg/opaprocessor/... -run "TestBuildExceptionAuditCountsManualControlMatch|TestUpdateResults_ExceptionAuditCountsManualControlMatch" -v
=== RUN   TestBuildExceptionAuditCountsManualControlMatches
--- PASS: TestBuildExceptionAuditCountsManualControlMatches (0.00s)
=== RUN   TestUpdateResults_ExceptionAuditCountsManualControlMatch
[success] Done aggregating results
--- PASS: TestUpdateResults_ExceptionAuditCountsManualControlMatch (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor	2.247s

$ go test ./core/pkg/opaprocessor/...
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor	18.114s
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel	(cached)

$ go test ./core/...
(all packages pass, no FAIL anywhere)

$ golangci-lint run core/pkg/opaprocessor/...
0 issues.

$ gofmt -l core/pkg/opaprocessor/processorhandlerutils.go core/pkg/opaprocessor/exceptionaudit.go core/pkg/opaprocessor/exceptionaudit_test.go
(no output — all files formatted)
```

## Test plan

- [x] `go build ./core/...`
- [x] `go vet ./core/pkg/opaprocessor/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] Two new regression tests added and passing (one unit-level, one end-to-end through `updateResults`)
- [x] Full `./core/...` test suite passes, no regressions
- [x] All existing `TestApplyExceptionsToManualControls`/`TestBuildExceptionAudit*` cases still pass unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exception audits so items matched through manual-review controls are correctly recorded as used.
  * Prevented manual-control exceptions from being incorrectly classified as unused.
  * Ensured matching statuses and audit records remain accurate when multiple policies apply.

* **Tests**
  * Added coverage for manual-control matches in direct audits and end-to-end result updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->