### PR TITLE
feat(scan): add --include-kinds and --exclude-kinds resource kind filters

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -195,6 +195,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output file format. Supported formats: "%s"`, strings.Join(shared.ScanFormats, `", "`)))
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeKinds, "include-kinds", "", "scan only the specified Kubernetes resource kinds (case-insensitive, Kind name only — not group/version qualified). e.g: --include-kinds Deployment,DaemonSet")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.ExcludeKinds, "exclude-kinds", "", "exclude the specified Kubernetes resource kinds from the scan (case-insensitive, Kind name only — not group/version qualified). e.g: --exclude-kinds Job,CronJob")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -145,5 +145,29 @@ func ValidateCommonScanFlags(cmd *cobra.Command, scanInfo *cautils.ScanInfo, sup
 	if err := ValidateScanFormat(scanInfo.Format, supportedFormats); err != nil {
 		return err
 	}
+	if err := ValidateKindFilters(scanInfo); err != nil {
+		return err
+	}
 	return nil
+}
+
+// ValidateKindFilters returns an error when --include-kinds or --exclude-kinds
+// contain only whitespace tokens, which would silently discard every resource.
+func ValidateKindFilters(scanInfo *cautils.ScanInfo) error {
+	if err := validateKindList("--include-kinds", scanInfo.IncludeKinds); err != nil {
+		return err
+	}
+	return validateKindList("--exclude-kinds", scanInfo.ExcludeKinds)
+}
+
+func validateKindList(flag, value string) error {
+	if value == "" {
+		return nil
+	}
+	for _, k := range strings.Split(value, ",") {
+		if strings.TrimSpace(k) != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s value %q contains no valid kind names", flag, value)
 }

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -224,3 +224,77 @@ func TestValidateCommonScanFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateKindFilters(t *testing.T) {
+	tests := []struct {
+		name         string
+		includeKinds string
+		excludeKinds string
+		expectedErr  string
+	}{
+		{
+			name:         "both empty is valid",
+			includeKinds: "",
+			excludeKinds: "",
+			expectedErr:  "",
+		},
+		{
+			name:         "valid include-kinds",
+			includeKinds: "Deployment,DaemonSet",
+			excludeKinds: "",
+			expectedErr:  "",
+		},
+		{
+			name:         "valid exclude-kinds",
+			includeKinds: "",
+			excludeKinds: "Job,CronJob",
+			expectedErr:  "",
+		},
+		{
+			name:         "both set is valid",
+			includeKinds: "Deployment",
+			excludeKinds: "DaemonSet",
+			expectedErr:  "",
+		},
+		{
+			name:         "include-kinds whitespace-only tokens are rejected",
+			includeKinds: " , , ",
+			excludeKinds: "",
+			expectedErr:  "contains no valid kind names",
+		},
+		{
+			name:         "exclude-kinds whitespace-only tokens are rejected",
+			includeKinds: "",
+			excludeKinds: "  ,  ",
+			expectedErr:  "contains no valid kind names",
+		},
+		{
+			name:         "single valid kind in include",
+			includeKinds: "Pod",
+			excludeKinds: "",
+			expectedErr:  "",
+		},
+		{
+			name:         "padded valid kind passes",
+			includeKinds: "  Deployment  ",
+			excludeKinds: "",
+			expectedErr:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				IncludeKinds: tt.includeKinds,
+				ExcludeKinds: tt.excludeKinds,
+			}
+			err := ValidateKindFilters(scanInfo)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -132,6 +132,8 @@ type ScanInfo struct {
 	CustomClusterName         string                       // Set the custom name of the cluster
 	ExcludedNamespaces        string                       // used for host scanner namespace
 	IncludeNamespaces         string                       //
+	IncludeKinds              string                       // comma-separated Kubernetes kinds to include (case-insensitive, Kind name only); e.g. "Deployment,DaemonSet"
+	ExcludeKinds              string                       // comma-separated Kubernetes kinds to exclude (case-insensitive, Kind name only); e.g. "Job,CronJob"
 	LabelSelector             string                       // filter collected resources by Kubernetes label selector (e.g. "app=nginx,env!=dev")
 	Namespace                 string                       // target namespace for workload scans
 	InputPatterns             []string                     // Yaml files input patterns

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -103,6 +103,10 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 	// save input resource in resource maps
 	addSingleResourceToResourceMaps(k8sResources, allResources, sessionObj.SingleResourceScan, offlineResolver)
 
+	if err := applyKindFilter(k8sResources, allResources, scanInfo, sessionObj.SingleResourceScan); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	return k8sResources, allResources, externalResources, excludedRulesMap, nil
 }
 

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -140,6 +140,15 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 		addSingleResourceToResourceMaps(k8sResourcesMap, allResources, sessionObj.SingleResourceScan, resolver)
 	}
 
+	// Apply kind filter before external resource collection (host, RBAC, cloud)
+	// so that external control-plane data added below is never discarded.
+	// Pass the single-resource-scan target so the filter can fail fast instead
+	// of silently dropping the explicitly requested workload.
+	if err := applyKindFilter(k8sResourcesMap, allResources, scanInfo, sessionObj.SingleResourceScan); err != nil {
+		cautils.StopSpinner()
+		return nil, nil, nil, nil, err
+	}
+
 	metrics.UpdateKubernetesResourcesCount(ctx, int64(len(allResources)))
 	numberOfWorkerNodes, err := k8sHandler.pullWorkerNodesNumber(ctx)
 
@@ -429,6 +438,15 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 
 	if !scanInfo.IsDeletedScanObject && sessionObj.SingleResourceScan != nil {
 		addSingleResourceToResourceMaps(resident.K8SResources, allResources, sessionObj.SingleResourceScan, resolver)
+	}
+
+	if err := applyKindFilter(resident.K8SResources, resident.AllResources, scanInfo, sessionObj.SingleResourceScan); err != nil {
+		return err
+	}
+	for _, batch := range namespaceBatches {
+		if err := applyKindFilter(batch.K8SResources, batch.AllResources, scanInfo, nil); err != nil {
+			return err
+		}
 	}
 
 	// Match the eager collector's metric timing: report the complete Kubernetes

--- a/core/pkg/resourcehandler/kindfilter.go
+++ b/core/pkg/resourcehandler/kindfilter.go
@@ -1,0 +1,117 @@
+package resourcehandler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+)
+
+// parseKindSet splits a comma-separated kind list into a normalised (lowercase)
+// set. An empty input returns a nil map so callers can use a cheap len() guard.
+func parseKindSet(kinds string) map[string]struct{} {
+	if kinds == "" {
+		return nil
+	}
+	set := make(map[string]struct{})
+	for _, k := range strings.Split(kinds, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			set[strings.ToLower(k)] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// kindAllowed reports whether kind (already lowercased) passes the include/exclude
+// filters. When include is non-nil only listed kinds pass; when exclude is
+// non-nil listed kinds are rejected. Both filters may be active simultaneously:
+// include is checked first, then exclude.
+func kindAllowed(kind string, include, exclude map[string]struct{}) bool {
+	if include != nil {
+		if _, ok := include[kind]; !ok {
+			return false
+		}
+	}
+	if exclude != nil {
+		if _, ok := exclude[kind]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// applyKindFilter removes resources that do not satisfy the kind filters
+// expressed by scanInfo.IncludeKinds and scanInfo.ExcludeKinds. It modifies
+// both allResources (the full object store) and k8sResources (the GVR→ID
+// index) so that downstream OPA evaluation never sees a filtered-out resource.
+//
+// singleScan is the explicit workload targeted by a single-resource scan
+// (sessionObj.SingleResourceScan). When non-nil and its kind would be excluded
+// by the active filters the function returns an error instead of silently
+// dropping the requested target — a silent drop produces a false-negative that
+// reads as "nothing to report" rather than "nothing was scanned".
+//
+// When neither flag is set the function is a no-op.
+func applyKindFilter(
+	k8sResources cautils.K8SResources,
+	allResources map[string]workloadinterface.IMetadata,
+	scanInfo *cautils.ScanInfo,
+	singleScan workloadinterface.IMetadata,
+) error {
+	include := parseKindSet(scanInfo.IncludeKinds)
+	exclude := parseKindSet(scanInfo.ExcludeKinds)
+	if include == nil && exclude == nil {
+		return nil
+	}
+
+	if singleScan != nil {
+		kind := strings.ToLower(singleScan.GetKind())
+		if !kindAllowed(kind, include, exclude) {
+			return fmt.Errorf(
+				"kind filter excludes the explicitly requested scan target %q (kind: %s); "+
+					"adjust --include-kinds / --exclude-kinds or remove the conflicting filter",
+				singleScan.GetName(), singleScan.GetKind(),
+			)
+		}
+	}
+
+	removed := make(map[string]struct{})
+	for id, res := range allResources {
+		if !kindAllowed(strings.ToLower(res.GetKind()), include, exclude) {
+			removed[id] = struct{}{}
+			delete(allResources, id)
+		}
+	}
+
+	if len(removed) == 0 {
+		return nil
+	}
+
+	logger.L().Debug("kind filter removed resources",
+		helpers.Int("count", len(removed)),
+		helpers.String("include", scanInfo.IncludeKinds),
+		helpers.String("exclude", scanInfo.ExcludeKinds),
+	)
+
+	for gvr, ids := range k8sResources {
+		kept := ids[:0]
+		for _, id := range ids {
+			if _, drop := removed[id]; !drop {
+				kept = append(kept, id)
+			}
+		}
+		if len(kept) == 0 {
+			delete(k8sResources, gvr)
+		} else {
+			k8sResources[gvr] = kept
+		}
+	}
+	return nil
+}

--- a/core/pkg/resourcehandler/kindfilter_test.go
+++ b/core/pkg/resourcehandler/kindfilter_test.go
@@ -1,0 +1,322 @@
+package resourcehandler
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeResource(kind string) workloadinterface.IMetadata {
+	obj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      "test-" + kind,
+			"namespace": "default",
+		},
+	}
+	return workloadinterface.NewWorkloadObj(obj)
+}
+
+func TestParseKindSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]struct{}
+	}{
+		{
+			name:  "empty returns nil",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single kind",
+			input: "Deployment",
+			want:  map[string]struct{}{"deployment": {}},
+		},
+		{
+			name:  "multiple kinds normalised to lowercase",
+			input: "Deployment,DaemonSet,StatefulSet",
+			want:  map[string]struct{}{"deployment": {}, "daemonset": {}, "statefulset": {}},
+		},
+		{
+			name:  "whitespace trimmed",
+			input: "  Pod ,  Job  ",
+			want:  map[string]struct{}{"pod": {}, "job": {}},
+		},
+		{
+			name:  "only commas returns nil",
+			input: ",,,",
+			want:  nil,
+		},
+		{
+			name:  "mixed blank and valid",
+			input: ",Deployment,",
+			want:  map[string]struct{}{"deployment": {}},
+		},
+		{
+			name:  "already lowercase",
+			input: "deployment",
+			want:  map[string]struct{}{"deployment": {}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKindSet(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKindAllowed(t *testing.T) {
+	include := map[string]struct{}{"deployment": {}, "daemonset": {}}
+	exclude := map[string]struct{}{"job": {}, "cronjob": {}}
+
+	tests := []struct {
+		name    string
+		kind    string
+		include map[string]struct{}
+		exclude map[string]struct{}
+		want    bool
+	}{
+		{"no filters allows all", "deployment", nil, nil, true},
+		{"include list passes listed kind", "deployment", include, nil, true},
+		{"include list blocks unlisted kind", "pod", include, nil, false},
+		{"exclude list blocks excluded kind", "job", nil, exclude, false},
+		{"exclude list passes non-excluded kind", "deployment", nil, exclude, true},
+		{"both filters: kind in include not in exclude", "deployment", include, exclude, true},
+		{"both filters: kind in include and in exclude (exclude wins)", "deployment",
+			map[string]struct{}{"deployment": {}},
+			map[string]struct{}{"deployment": {}},
+			false,
+		},
+		{"both filters: kind not in include", "pod", include, exclude, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kindAllowed(tt.kind, tt.include, tt.exclude)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyKindFilter_NoOp(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-pod":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"v1/pods":             {"id-pod"},
+	}
+
+	require.NoError(t, applyKindFilter(k8s, allResources, &cautils.ScanInfo{}, nil))
+
+	assert.Len(t, allResources, 2)
+	assert.Len(t, k8s["apps/v1/deployments"], 1)
+	assert.Len(t, k8s["v1/pods"], 1)
+}
+
+func TestApplyKindFilter_IncludeOnly(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-pod":    makeResource("Pod"),
+		"id-daemon": makeResource("DaemonSet"),
+		"id-job":    makeResource("Job"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"v1/pods":             {"id-pod"},
+		"apps/v1/daemonsets":  {"id-daemon"},
+		"batch/v1/jobs":       {"id-job"},
+	}
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "Deployment,DaemonSet"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	require.Len(t, allResources, 2)
+	assert.Contains(t, allResources, "id-deploy")
+	assert.Contains(t, allResources, "id-daemon")
+	assert.NotContains(t, allResources, "id-pod")
+	assert.NotContains(t, allResources, "id-job")
+
+	assert.Len(t, k8s["apps/v1/deployments"], 1)
+	assert.Len(t, k8s["apps/v1/daemonsets"], 1)
+	assert.NotContains(t, k8s, "v1/pods")
+	assert.NotContains(t, k8s, "batch/v1/jobs")
+}
+
+func TestApplyKindFilter_ExcludeOnly(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-job":    makeResource("Job"),
+		"id-cron":   makeResource("CronJob"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"batch/v1/jobs":       {"id-job"},
+		"batch/v1/cronjobs":   {"id-cron"},
+	}
+
+	scanInfo := &cautils.ScanInfo{ExcludeKinds: "Job,CronJob"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	require.Len(t, allResources, 1)
+	assert.Contains(t, allResources, "id-deploy")
+	assert.NotContains(t, k8s, "batch/v1/jobs")
+	assert.NotContains(t, k8s, "batch/v1/cronjobs")
+	assert.Len(t, k8s["apps/v1/deployments"], 1)
+}
+
+func TestApplyKindFilter_BothIncludeAndExclude(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-daemon": makeResource("DaemonSet"),
+		"id-pod":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"apps/v1/daemonsets":  {"id-daemon"},
+		"v1/pods":             {"id-pod"},
+	}
+
+	scanInfo := &cautils.ScanInfo{
+		IncludeKinds: "Deployment,DaemonSet",
+		ExcludeKinds: "DaemonSet",
+	}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	require.Len(t, allResources, 1)
+	assert.Contains(t, allResources, "id-deploy")
+	assert.NotContains(t, allResources, "id-daemon")
+	assert.NotContains(t, allResources, "id-pod")
+}
+
+func TestApplyKindFilter_CaseInsensitive(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-pod":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"v1/pods":             {"id-pod"},
+	}
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "DEPLOYMENT"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	assert.Len(t, allResources, 1)
+	assert.Contains(t, allResources, "id-deploy")
+}
+
+func TestApplyKindFilter_EmptyAllResources(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{}
+	k8s := cautils.K8SResources{}
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "Deployment"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+	assert.Empty(t, allResources)
+}
+
+func TestApplyKindFilter_MultipleResourcesPerGVR(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy-a": makeResource("Deployment"),
+		"id-deploy-b": makeResource("Deployment"),
+		"id-pod-a":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy-a", "id-deploy-b"},
+		"v1/pods":             {"id-pod-a"},
+	}
+
+	scanInfo := &cautils.ScanInfo{ExcludeKinds: "Pod"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	assert.Len(t, allResources, 2)
+	assert.Len(t, k8s["apps/v1/deployments"], 2)
+	assert.NotContains(t, k8s, "v1/pods")
+}
+
+func TestApplyKindFilter_WhitespacePaddedKinds(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-pod":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"v1/pods":             {"id-pod"},
+	}
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "  Deployment  ,  "}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+
+	assert.Len(t, allResources, 1)
+	assert.Contains(t, allResources, "id-deploy")
+}
+
+func TestApplyKindFilter_SingleScanConflict_IncludeKinds(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-pod": makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"v1/pods": {"id-pod"},
+	}
+	singleScan := makeResource("Pod")
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "Deployment"}
+	err := applyKindFilter(k8s, allResources, scanInfo, singleScan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kind filter excludes the explicitly requested scan target")
+	assert.Contains(t, err.Error(), "Pod")
+}
+
+func TestApplyKindFilter_SingleScanConflict_ExcludeKinds(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+	}
+	singleScan := makeResource("Deployment")
+
+	scanInfo := &cautils.ScanInfo{ExcludeKinds: "Deployment"}
+	err := applyKindFilter(k8s, allResources, scanInfo, singleScan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kind filter excludes the explicitly requested scan target")
+	assert.Contains(t, err.Error(), "Deployment")
+}
+
+func TestApplyKindFilter_SingleScanAllowed(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-deploy": makeResource("Deployment"),
+		"id-pod":    makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"apps/v1/deployments": {"id-deploy"},
+		"v1/pods":             {"id-pod"},
+	}
+	singleScan := makeResource("Deployment")
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "Deployment"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, singleScan))
+
+	assert.Len(t, allResources, 1)
+	assert.Contains(t, allResources, "id-deploy")
+}
+
+func TestApplyKindFilter_SingleScanNilNoConflict(t *testing.T) {
+	allResources := map[string]workloadinterface.IMetadata{
+		"id-pod": makeResource("Pod"),
+	}
+	k8s := cautils.K8SResources{
+		"v1/pods": {"id-pod"},
+	}
+
+	scanInfo := &cautils.ScanInfo{IncludeKinds: "Deployment"}
+	require.NoError(t, applyKindFilter(k8s, allResources, scanInfo, nil))
+	assert.Empty(t, allResources)
+}


### PR DESCRIPTION
## Summary

- No flag existed to filter scanned resources by Kubernetes kind; the only scope controls were namespace and label selector
- Added `--include-kinds` and `--exclude-kinds` persistent flags to `kubescape scan`, symmetric with `--include-namespaces`/`--exclude-namespaces`
- `applyKindFilter` prunes both `allResources` and the GVR→ID index after collection, so OPA evaluation sees a consistent view with no filtered-out resources leaking through
- Filter runs in all three collection paths: eager k8s, streaming k8s (per batch), and file-based scan
- `ValidateKindFilters` rejects whitespace-only lists; kind matching is case-insensitive
- Tested: `TestParseKindSet`, `TestKindAllowed`, `TestApplyKindFilter_*` (10 cases), `TestValidateKindFilters` (8 cases)

**Which issue(s) this PR fixes:**
N/A - new feature

**Special notes for your reviewer:**
The filter is post-collection by design: the control framework determines what GVRs to fetch, not the user, so pre-filtering query-time would require deep framework changes. Post-filter keeps the diff minimal and works identically for all collection paths.

**Does this PR introduce a user-facing change?**
Yes two new flags: `--include-kinds` and `--exclude-kinds` on all `scan` subcommands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent `--include-kinds` and `--exclude-kinds` scan options.
  * Scans can target or omit specific Kubernetes resource kinds using case-insensitive, comma-separated filters.
  * Added baseline comparison options for detecting newly introduced findings by severity and granularity.
  * Configurable scan behavior is available when new findings exceed the selected baseline threshold.
  * Filtered resources are excluded from scan results and downstream processing.

* **Bug Fixes**
  * Added validation for blank kind filters and excluded explicitly requested resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->