### PR TITLE
feat: emit exception-match events for file/cloud exceptions too

### DIFF
--- a/core/pkg/opaprocessor/exceptionevents.go
+++ b/core/pkg/opaprocessor/exceptionevents.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kubescape/kubescape/v4/core/pkg/securityexception"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func (opap *OPAProcessor) emitExceptionMatchEvents(resource workloadinterface.IMetadata, result resourcesresults.Result) {
@@ -34,16 +36,22 @@ func (opap *OPAProcessor) emitExceptionMatchEvents(resource workloadinterface.IM
 		}
 		for _, rule := range control.ResourceAssociatedRules {
 			for _, exception := range rule.Exception {
-				ref, ok := securityexception.CRDReferenceFromPolicy(exception)
-				if !ok {
-					continue
+				var obj runtime.Object
+				var key string
+				if ref, ok := securityexception.CRDReferenceFromPolicy(exception); ok {
+					key = fmt.Sprintf("crd/%s/%s/%s/%s/%s", ref.Kind, ref.Namespace, ref.Name, control.ControlID, resourceID)
+					obj = securityexception.UnstructuredForCRD(ref)
+				} else {
+					// A file/cloud-sourced exception has no CRD instance of its
+					// own to attach the event to, so fall back to the scanned
+					// resource the exception was matched against.
+					key = fmt.Sprintf("resource/%s/%s", control.ControlID, resourceID)
+					obj = &unstructured.Unstructured{Object: resource.GetObject()}
 				}
-				key := fmt.Sprintf("%s/%s/%s/%s/%s", ref.Kind, ref.Namespace, ref.Name, control.ControlID, resourceID)
 				if _, exists := emitted[key]; exists {
 					continue
 				}
 				emitted[key] = struct{}{}
-				obj := securityexception.UnstructuredForCRD(ref)
 				opap.exceptionEventRecorder.Eventf(
 					obj,
 					corev1.EventTypeNormal,

--- a/core/pkg/opaprocessor/exceptionevents_test.go
+++ b/core/pkg/opaprocessor/exceptionevents_test.go
@@ -1,6 +1,7 @@
 package opaprocessor
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,8 +10,37 @@ import (
 	"github.com/kubescape/kubescape/v4/core/pkg/securityexception"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
+
+// capturingRecorder records every Eventf call's object argument, so a test can
+// assert on which object an event was attached to - something record.FakeRecorder's
+// plain "type reason message" string channel can't express.
+type capturingRecorder struct {
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	object    runtime.Object
+	eventtype string
+	reason    string
+	message   string
+}
+
+func (r *capturingRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	r.events = append(r.events, capturedEvent{object, eventtype, reason, message})
+}
+
+func (r *capturingRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *capturingRecorder) AnnotatedEventf(object runtime.Object, _ map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.Eventf(object, eventtype, reason, messageFmt, args...)
+}
 
 func TestEmitExceptionMatchEvents(t *testing.T) {
 	resourceJSON := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx-frontend","namespace":"production"}}`)
@@ -42,9 +72,13 @@ func TestEmitExceptionMatchEvents(t *testing.T) {
 			expectedMessage: "Matched control C-0034 on Deployment/nginx-frontend in namespace production",
 		},
 		{
-			name:        "no event on non-crd exception",
-			exceptions:  []armotypes.PostureExceptionPolicy{{}},
-			expectEvent: false,
+			// Regression for issue-3369: a file/cloud-sourced exception (no CRD
+			// attributes) used to be silently skipped. It must now still emit an
+			// event, attached to the scanned resource itself.
+			name:            "event emitted on non-crd exception, attached to the resource",
+			exceptions:      []armotypes.PostureExceptionPolicy{{}},
+			expectEvent:     true,
+			expectedMessage: "Matched control C-0034 on Deployment/nginx-frontend in namespace production",
 		},
 		{
 			name:        "no event on no match",
@@ -84,4 +118,92 @@ func TestEmitExceptionMatchEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression for issue-3369: a non-CRD exception's event must be attached to
+// the scanned resource itself, since it has no CRD instance of its own.
+func TestEmitExceptionMatchEvents_NonCRDExceptionAttachesToScannedResource(t *testing.T) {
+	resourceJSON := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx-frontend","namespace":"production"}}`)
+	resource, err := workloadinterface.NewWorkload(resourceJSON)
+	require.NoError(t, err)
+
+	recorder := &capturingRecorder{}
+	opap := &OPAProcessor{exceptionEventRecorder: recorder}
+
+	result := resourcesresults.Result{
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0034",
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Exception: []armotypes.PostureExceptionPolicy{{}}}, // no CRD attributes
+				},
+			},
+		},
+	}
+
+	opap.emitExceptionMatchEvents(resource, result)
+
+	require.Len(t, recorder.events, 1)
+	obj, ok := recorder.events[0].object.(*unstructured.Unstructured)
+	require.True(t, ok, "event object must be an *unstructured.Unstructured")
+	assert.Equal(t, "Deployment", obj.GetKind())
+	assert.Equal(t, "nginx-frontend", obj.GetName())
+	assert.Equal(t, "production", obj.GetNamespace())
+}
+
+// A CRD-backed and a file/cloud-backed exception matching the same control on
+// the same resource use different dedup keys (crd/... vs resource/...), so
+// both must emit their own event rather than one being silently deduped
+// against the other.
+func TestEmitExceptionMatchEvents_CRDAndNonCRDExceptionsBothEmit(t *testing.T) {
+	resourceJSON := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"nginx-frontend","namespace":"production"}}`)
+	resource, err := workloadinterface.NewWorkload(resourceJSON)
+	require.NoError(t, err)
+
+	crdException := armotypes.PostureExceptionPolicy{
+		PortalBase: armotypes.PortalBase{
+			Attributes: securityexception.CRDReferenceAttributes(securityexception.CRDReference{
+				Kind:      "SecurityException",
+				Name:      "nginx-exceptions",
+				Namespace: "production",
+			}),
+		},
+	}
+	fileException := armotypes.PostureExceptionPolicy{}
+
+	recorder := &capturingRecorder{}
+	opap := &OPAProcessor{exceptionEventRecorder: recorder}
+
+	result := resourcesresults.Result{
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0034",
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Exception: []armotypes.PostureExceptionPolicy{crdException, fileException}},
+				},
+			},
+		},
+	}
+
+	opap.emitExceptionMatchEvents(resource, result)
+
+	require.Len(t, recorder.events, 2, "the CRD-backed and file-backed exceptions must each emit their own event")
+
+	var sawCRDObject, sawResourceObject bool
+	for _, e := range recorder.events {
+		obj, ok := e.object.(*unstructured.Unstructured)
+		require.True(t, ok)
+		switch obj.GetKind() {
+		case "SecurityException":
+			sawCRDObject = true
+			assert.Equal(t, "nginx-exceptions", obj.GetName())
+		case "Deployment":
+			sawResourceObject = true
+			assert.Equal(t, "nginx-frontend", obj.GetName())
+		default:
+			t.Fatalf("unexpected event object kind %q", obj.GetKind())
+		}
+	}
+	assert.True(t, sawCRDObject, "expected one event attached to the SecurityException CRD")
+	assert.True(t, sawResourceObject, "expected one event attached to the scanned resource")
 }


### PR DESCRIPTION
## Summary

Closes #3369.

`emitExceptionMatchEvents` (`core/pkg/opaprocessor/exceptionevents.go`, added in #2291) emitted a Kubernetes `ExceptionMatched` Event only when a matched exception's origin resolved to a `SecurityException`/`ClusterSecurityException` CRD:

```go
ref, ok := securityexception.CRDReferenceFromPolicy(exception)
if !ok {
    continue
}
```

That scoping was deliberate (PR #2291's own summary: "Emit Kubernetes Events when posture exceptions from SecurityException or ClusterSecurityException match a scanned resource"), but it means a file-based (`--exceptions exceptions.json`) or cloud-based exception matches and suppresses findings exactly the same way, yet leaves no Event trail at all — someone watching `ExceptionMatched` events as a lightweight in-cluster audit trail gets full coverage for CRD-based exceptions and a silent gap for everything else.

### Change

A file/cloud exception has no CRD instance of its own to serve as the event's `involvedObject`, so it now falls back to the **scanned resource** the exception matched against (wrapped as `&unstructured.Unstructured{Object: resource.GetObject()}`, the same resource already used to build the event message).

The two paths use distinct dedup keys (`crd/<kind>/<ns>/<name>/<controlID>/<resourceID>` vs `resource/<controlID>/<resourceID>`), so if a control on one resource happens to be matched by both a CRD-backed exception and a file/cloud-backed one, each still emits its own event instead of one silently deduping against the other.

## How this was verified

Updated the existing table-driven test (`TestEmitExceptionMatchEvents`) — the case previously named "no event on non-crd exception" (`expectEvent: false`) now expects an event, since that's exactly the gap being closed.

Added two new tests using a small `capturingRecorder` test double (since `record.FakeRecorder`'s plain string channel can't express which object an event was attached to):

- `TestEmitExceptionMatchEvents_NonCRDExceptionAttachesToScannedResource` — asserts the event's object is the scanned Deployment (kind/name/namespace), not a CRD reference.
- `TestEmitExceptionMatchEvents_CRDAndNonCRDExceptionsBothEmit` — a control matched by both a CRD-backed and a file-backed exception on the same resource emits **two** distinct events, one attached to the `SecurityException` object and one to the `Deployment` itself.

I confirmed these are real regression tests by running them against the pre-fix code (`git stash` on just `exceptionevents.go`):

```
$ git stash push -- core/pkg/opaprocessor/exceptionevents.go
$ go test ./core/pkg/opaprocessor/... -run "TestEmitExceptionMatchEvents" -v
--- FAIL: TestEmitExceptionMatchEvents (0.20s)
    --- FAIL: TestEmitExceptionMatchEvents/event_emitted_on_non-crd_exception,_attached_to_the_resource (0.10s)
        exceptionevents_test.go:116: expected an event but none was recorded
--- FAIL: TestEmitExceptionMatchEvents_NonCRDExceptionAttachesToScannedResource
    exceptionevents_test.go:146: "[]" should have 1 item(s), but has 0
--- FAIL: TestEmitExceptionMatchEvents_CRDAndNonCRDExceptionsBothEmit
    exceptionevents_test.go:190: "[...]" should have 2 item(s), but has 1
        Messages: the CRD-backed and file-backed exceptions must each emit their own event
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./core/...
$ go vet ./core/pkg/opaprocessor/...
(both exit 0, no output)

$ go test ./core/pkg/opaprocessor/... -run "TestEmitExceptionMatchEvents" -v
=== RUN   TestEmitExceptionMatchEvents
=== RUN   TestEmitExceptionMatchEvents/event_emitted_on_match
=== RUN   TestEmitExceptionMatchEvents/event_emitted_on_non-crd_exception,_attached_to_the_resource
=== RUN   TestEmitExceptionMatchEvents/no_event_on_no_match
--- PASS: TestEmitExceptionMatchEvents (0.10s)
=== RUN   TestEmitExceptionMatchEvents_NonCRDExceptionAttachesToScannedResource
--- PASS: TestEmitExceptionMatchEvents_NonCRDExceptionAttachesToScannedResource (0.00s)
=== RUN   TestEmitExceptionMatchEvents_CRDAndNonCRDExceptionsBothEmit
--- PASS: TestEmitExceptionMatchEvents_CRDAndNonCRDExceptionsBothEmit (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor	2.032s

$ go test ./core/pkg/opaprocessor/...
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor	15.767s
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel	(cached)

$ go test ./core/...
(all packages pass, no FAIL anywhere)

$ golangci-lint run core/pkg/opaprocessor/...
0 issues.

$ gofmt -l core/pkg/opaprocessor/exceptionevents.go core/pkg/opaprocessor/exceptionevents_test.go
(no output — both files formatted)
```

## Test plan

- [x] `go build ./core/...`
- [x] `go vet ./core/pkg/opaprocessor/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] Existing test updated to reflect the new intended behavior; two new regression tests added, confirmed to fail against the pre-fix code and pass with the fix
- [x] Full `./core/...` test suite passes, no regressions
