### PR TITLE
fix(diff): detect evidence-level regressions

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/kubescape/v3/core/cautils"
 	"github.com/kubescape/kubescape/v3/core/meta"
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
+	resultsdiff "github.com/kubescape/kubescape/v3/core/pkg/resultshandling/diff"
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +23,11 @@ var diffCmdExamples = fmt.Sprintf(`
   3) %[1]s scan --format json --output head.json .
   4) %[1]s diff base.json head.json
 
-  # Fail CI when new high-severity or above failures are introduced
-  %[1]s diff base.json head.json --fail-on-new --severity-threshold high
+	# Fail CI when new high-severity or above failures are introduced
+	%[1]s diff base.json head.json --fail-on-new --severity-threshold high
+
+	# Compare resource-and-control aggregates while keeping safety checks
+	%[1]s diff base.json head.json --granularity control
 
   # Output diff as JSON
   %[1]s diff base.json head.json --format json --output diff.json
@@ -35,7 +39,7 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 	diffCmd := &cobra.Command{
 		Use:     "diff <base-report.json> <head-report.json>",
 		Short:   "Compare two Kubescape scan JSON reports and show what changed",
-		Long:    `Compare a base scan report against a head scan report to surface new failures, resolved issues, and controls that are still failing.`,
+		Long:    `Compare a base scan report against a head scan report to surface new failures, resolved issues, unchanged evidence, and results that cannot be compared safely. By default, failed rules and paths are compared so regressions inside an already-failing control are detected.`,
 		Example: diffCmdExamples,
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,6 +57,9 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			if err := resultsdiff.ValidateGranularity(diffInfo.Granularity); err != nil {
+				return err
+			}
 
 			newFailures, err := ks.Diff(&diffInfo)
 			if err != nil {
@@ -60,7 +67,7 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 			}
 
 			if diffInfo.FailOnNew && newFailures > 0 {
-				return fmt.Errorf("found %d new failure(s) at or above severity threshold %q",
+				return fmt.Errorf("found %d new or incomparable failure(s) at or above severity threshold %q",
 					newFailures, severityLabel(diffInfo.SeverityThreshold))
 			}
 
@@ -68,10 +75,11 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 		},
 	}
 
-	diffCmd.Flags().BoolVar(&diffInfo.FailOnNew, "fail-on-new", false, "Exit with code 1 when new failures are found (combine with --severity-threshold to limit the gate)")
-	diffCmd.Flags().StringVar(&diffInfo.SeverityThreshold, "severity-threshold", "", "Only count failures at or above this severity when using --fail-on-new (low, medium, high, critical)")
+	diffCmd.Flags().BoolVar(&diffInfo.FailOnNew, "fail-on-new", false, "Exit with code 1 when new or incomparable failures are found (combine with --severity-threshold to limit the gate)")
+	diffCmd.Flags().StringVar(&diffInfo.SeverityThreshold, "severity-threshold", "", "Only count new and incomparable failures at or above this severity when using --fail-on-new (low, medium, high, critical)")
 	diffCmd.Flags().StringVarP(&diffInfo.Format, "format", "f", "pretty-printer", `Output format: "pretty-printer", "json", or "yaml"`)
 	diffCmd.Flags().StringVarP(&diffInfo.Output, "output", "o", "", "Output file; defaults to stdout")
+	diffCmd.Flags().StringVar(&diffInfo.Granularity, "granularity", string(resultsdiff.GranularityEvidence), `Comparison unit: "evidence" or "control"`)
 
 	return diffCmd
 }

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "github.com/kubescape/kubescape/v3/core/meta/datastructures/v1"
@@ -13,9 +14,12 @@ import (
 type stubKubescape struct {
 	mocks.MockIKubescape
 	newFailures int
+	received    *metav1.DiffInfo
 }
 
-func (s *stubKubescape) Diff(_ *metav1.DiffInfo) (int, error) {
+func (s *stubKubescape) Diff(info *metav1.DiffInfo) (int, error) {
+	copy := *info
+	s.received = &copy
 	return s.newFailures, nil
 }
 
@@ -48,6 +52,84 @@ func TestGetDiffCmd_FormatValidation(t *testing.T) {
 	}
 }
 
+func TestGetDiffCmd_Granularity(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantGranularity string
+		wantError       string
+	}{
+		{
+			name:            "evidence is the default",
+			args:            []string{"base.json", "head.json"},
+			wantGranularity: "evidence",
+		},
+		{
+			name:            "evidence can be explicit",
+			args:            []string{"base.json", "head.json", "--granularity", "evidence"},
+			wantGranularity: "evidence",
+		},
+		{
+			name:            "control compatibility mode",
+			args:            []string{"base.json", "head.json", "--granularity", "control"},
+			wantGranularity: "control",
+		},
+		{
+			name:            "case-insensitive value is accepted and forwarded",
+			args:            []string{"base.json", "head.json", "--granularity", "CONTROL"},
+			wantGranularity: "CONTROL",
+		},
+		{
+			name:      "unknown value is rejected",
+			args:      []string{"base.json", "head.json", "--granularity", "path"},
+			wantError: "invalid diff granularity",
+		},
+		{
+			name:      "near miss is rejected",
+			args:      []string{"base.json", "head.json", "--granularity", "controls"},
+			wantError: "invalid diff granularity",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stub := &stubKubescape{}
+			command := GetDiffCmd(stub)
+			command.SilenceUsage = true
+			command.SilenceErrors = true
+			command.SetArgs(test.args)
+
+			err := command.Execute()
+			if test.wantError != "" {
+				assert.ErrorContains(t, err, test.wantError)
+				assert.Nil(t, stub.received, "validation must happen before invoking core")
+				return
+			}
+			assert.NoError(t, err)
+			if assert.NotNil(t, stub.received) {
+				assert.Equal(t, test.wantGranularity, stub.received.Granularity)
+				assert.Equal(t, "base.json", stub.received.BaseFile)
+				assert.Equal(t, "head.json", stub.received.HeadFile)
+			}
+		})
+	}
+}
+
+func TestGetDiffCmd_HelpExplainsEvidenceComparison(t *testing.T) {
+	command := GetDiffCmd(&stubKubescape{})
+	var output strings.Builder
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{"--help"})
+
+	assert.NoError(t, command.Execute())
+	help := output.String()
+	assert.Contains(t, help, "--granularity")
+	assert.Contains(t, help, `"evidence" or "control"`)
+	assert.Contains(t, help, "failed rules and paths are compared")
+	assert.Contains(t, help, "--granularity control")
+}
+
 func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -59,13 +141,13 @@ func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {
 			name:        "fail-on-new with new failures and empty severity reports all",
 			args:        []string{"base.json", "head.json", "--fail-on-new"},
 			newFailures: 2,
-			wantErr:     `found 2 new failure(s) at or above severity threshold "all"`,
+			wantErr:     `found 2 new or incomparable failure(s) at or above severity threshold "all"`,
 		},
 		{
 			name:        "fail-on-new with new failures uses the given severity threshold",
 			args:        []string{"base.json", "head.json", "--fail-on-new", "--severity-threshold", "high"},
 			newFailures: 1,
-			wantErr:     `found 1 new failure(s) at or above severity threshold "high"`,
+			wantErr:     `found 1 new or incomparable failure(s) at or above severity threshold "high"`,
 		},
 		{
 			name:        "fail-on-new with no new failures succeeds",

--- a/core/core/diff.go
+++ b/core/core/diff.go
@@ -11,9 +11,11 @@ import (
 	"github.com/kubescape/kubescape/v3/core/pkg/resultshandling/printer"
 )
 
-// Diff writes the diff between the two scan reports and returns the number of new failures at or above the severity threshold; the caller decides whether to exit 1.
+// Diff writes the diff between the two scan reports and returns the number of new or incomparable failures at or above the severity threshold; the caller decides whether to exit 1.
 func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (newFailures int, err error) {
-	cs, err := diff.Compute(diffInfo.BaseFile, diffInfo.HeadFile)
+	cs, err := diff.ComputeWithOptions(diffInfo.BaseFile, diffInfo.HeadFile, diff.Options{
+		Granularity: diff.Granularity(diffInfo.Granularity),
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -44,7 +46,7 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (newFailures int, err error
 		}
 	}
 
-	return len(diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)), nil
+	return len(diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)) + len(diff.FilterBySeverity(cs.Incomparable, diffInfo.SeverityThreshold)), nil
 }
 
 func closeDiffOutput(closer io.Closer, err error) error {

--- a/core/core/diff_test.go
+++ b/core/core/diff_test.go
@@ -31,7 +31,7 @@ func writeReport(t *testing.T, json string) string {
 	return f.Name()
 }
 
-// TestDiff_ReturnsNewFailureCount verifies that Diff returns the number of new failures at or above the severity threshold.
+// TestDiff_ReturnsNewFailureCount verifies that Diff returns the number of new or incomparable failures at or above the severity threshold.
 func TestDiff_ReturnsNewFailureCount(t *testing.T) {
 	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
 	head := writeReport(t, `{
@@ -86,6 +86,33 @@ func TestDiff_ReturnsNewFailureCount(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
+	})
+
+	t.Run("scope mismatch counts incomparable failures", func(t *testing.T) {
+		baseScoped := writeReport(t, `{
+			"results":[{"resourceID":"res1","controls":[
+				{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}}
+			]}],
+			"summaryDetails":{"controls":{"C-HIGH":{"scoreFactor":7.0}}},
+			"metadata":{"scanMetadata":{"excludedNamespaces":["kube-system"]}}
+		}`)
+		headScoped := writeReport(t, `{
+			"results":[{"resourceID":"res1","controls":[
+				{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}}
+			]}],
+			"summaryDetails":{"controls":{"C-HIGH":{"scoreFactor":7.0}}},
+			"metadata":{"scanMetadata":{"excludedNamespaces":["kube-system","monitoring"]}}
+		}`)
+
+		count, err := ks.Diff(&metav1.DiffInfo{
+			BaseFile:          baseScoped,
+			HeadFile:          headScoped,
+			Format:            "json",
+			SeverityThreshold: "high",
+			Output:            filepath.Join(outDir, "scope.json"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
 	})
 }
 

--- a/core/meta/datastructures/v1/diff.go
+++ b/core/meta/datastructures/v1/diff.go
@@ -7,4 +7,5 @@ type DiffInfo struct {
 	Output            string // output file path; empty means stdout
 	FailOnNew         bool   // exit code 1 when new failures are found
 	SeverityThreshold string // only count failures at or above this severity when enforcing --fail-on-new
+	Granularity       string // comparison unit: "evidence" (default) or "control"
 }

--- a/core/pkg/resultshandling/diff/comparison_test.go
+++ b/core/pkg/resultshandling/diff/comparison_test.go
@@ -1,0 +1,820 @@
+package diff
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testResource = "apps/v1/default/Deployment/api"
+	testControl  = "C-1000"
+	testRule     = "require-security-context"
+)
+
+func evidenceReport(resourceID string, control controlEntry) scanReport {
+	return scanReport{
+		Results: []resultEntry{makeResult(resourceID, control)},
+		SummaryDetails: summaryDetails{Controls: map[string]controlSummary{
+			control.ControlID: {Severity: "High", ScoreFactor: 7},
+		}},
+	}
+}
+
+func reportWithPath(path string) scanReport {
+	return evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Require a security context",
+		failedRule(testRule, evidencePath{ResourceID: testResource, FailedPath: path}),
+	))
+}
+
+func computeReports(t *testing.T, base, head scanReport) *ChangeSet {
+	t.Helper()
+	result, err := Compute(writeTempReport(t, base), writeTempReport(t, head))
+	require.NoError(t, err)
+	return result
+}
+
+func computeReportsWithOptions(t *testing.T, base, head scanReport, options Options) *ChangeSet {
+	t.Helper()
+	result, err := ComputeWithOptions(writeTempReport(t, base), writeTempReport(t, head), options)
+	require.NoError(t, err)
+	return result
+}
+
+func TestComputeEvidence_DetectsPathAddedInsideFailingControl(t *testing.T) {
+	base := reportWithPath("$.spec.template.spec.containers[0].securityContext.runAsNonRoot")
+	head := reportWithPath("$.spec.template.spec.containers[0].securityContext.runAsNonRoot")
+	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		head.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{
+			ResourceID: testResource,
+			FailedPath: "$.spec.template.spec.containers[0].securityContext.privileged",
+		},
+	)
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, testControl, changes.New[0].ControlID)
+	assert.Equal(t, testRule, changes.New[0].RuleName)
+	assert.Equal(t, evidenceTypeFailedPath, changes.New[0].EvidenceType)
+	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", changes.New[0].Path)
+	assert.Equal(t, "failed", changes.New[0].BaseStatus, "the aggregate control was already failed")
+	assert.Equal(t, "failed", changes.New[0].HeadStatus)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Equal(t, "spec.template.spec.containers[0].securityContext.runAsNonRoot", changes.Unchanged[0].Path)
+	assert.Empty(t, changes.Resolved)
+	assert.Empty(t, changes.Incomparable)
+}
+
+func TestComputeEvidence_DetectsNewFailedRuleInsideFailingControl(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules = append(
+		head.Results[0].AssociatedControls[0].Rules,
+		failedRule("disallow-host-ipc", evidencePath{FailedPath: "$.spec.hostIPC"}),
+	)
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, "disallow-host-ipc", changes.New[0].RuleName)
+	assert.Equal(t, "spec.hostIPC", changes.New[0].Path)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Empty(t, changes.Resolved)
+}
+
+func TestComputeEvidence_DetectsNewPosturePathEvidenceInsideFailingControl(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingPath evidencePath
+		newPath      evidencePath
+		evidenceType string
+		wantPath     string
+	}{
+		{
+			name:         "fix path",
+			existingPath: evidencePath{FixPath: fixPath{Path: "$.spec.template.spec.containers[0].securityContext.runAsNonRoot", Value: []byte("true")}},
+			newPath:      evidencePath{FixPath: fixPath{Path: "$.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation", Value: []byte("false")}},
+			evidenceType: evidenceTypeFixPath,
+			wantPath:     "spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
+		},
+		{
+			name:         "delete path",
+			existingPath: evidencePath{DeletePath: "$.spec.hostPID"},
+			newPath:      evidencePath{DeletePath: "$.spec.hostIPC"},
+			evidenceType: evidenceTypeDeletePath,
+			wantPath:     "spec.hostIPC",
+		},
+		{
+			name:         "fix command",
+			existingPath: evidencePath{FixCommand: "kubectl patch deploy api --type merge"},
+			newPath:      evidencePath{FixCommand: "kubectl label ns default owner=platform"},
+			evidenceType: evidenceTypeFixCommand,
+			wantPath:     "kubectl label ns default owner=platform",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := evidenceReport(testResource, failedControlWithRules(testControl, "Control", failedRule(testRule, test.existingPath)))
+			head := evidenceReport(testResource, failedControlWithRules(testControl, "Control", failedRule(testRule, test.existingPath, test.newPath)))
+
+			changes := computeReports(t, base, head)
+
+			require.Len(t, changes.New, 1)
+			assert.Equal(t, test.evidenceType, changes.New[0].EvidenceType)
+			assert.Equal(t, test.wantPath, changes.New[0].Path)
+			assert.Empty(t, changes.Resolved)
+			require.Len(t, changes.Unchanged, 1)
+		})
+	}
+}
+
+func TestComputeEvidence_DetectsPathResolvedInsideFailingControl(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		base.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{FailedPath: "$.spec.hostIPC"},
+	)
+	head := reportWithPath("$.spec.hostPID")
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.Resolved, 1)
+	assert.Equal(t, "spec.hostIPC", changes.Resolved[0].Path)
+	assert.Equal(t, "failed", changes.Resolved[0].BaseStatus)
+	assert.Equal(t, "failed", changes.Resolved[0].HeadStatus, "one evidence item resolved while the control remained failed")
+	require.Len(t, changes.Unchanged, 1)
+	assert.Empty(t, changes.New)
+}
+
+func TestComputeEvidence_EquivalentRootNotationIsUnchanged(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath(".spec.hostPID")
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Equal(t, "spec.hostPID", changes.Unchanged[0].Path)
+}
+
+func TestComputeEvidence_ReorderedRulesAndPathsAreUnchanged(t *testing.T) {
+	baseControl := failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("rule-a",
+			evidencePath{FailedPath: "$.spec.a"},
+			evidencePath{FailedPath: "$.spec.b"},
+		),
+		failedRule("rule-b",
+			evidencePath{ReviewPath: "$.spec.c"},
+		),
+	)
+	headControl := failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("rule-b",
+			evidencePath{ReviewPath: ".spec.c"},
+		),
+		failedRule("rule-a",
+			evidencePath{FailedPath: "spec.b"},
+			evidencePath{FailedPath: "$.spec.a"},
+		),
+	)
+
+	changes := computeReports(t, evidenceReport(testResource, baseControl), evidenceReport(testResource, headControl))
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 3)
+	assert.Equal(t, []string{"spec.a", "spec.b", "spec.c"}, []string{
+		changes.Unchanged[0].Path,
+		changes.Unchanged[1].Path,
+		changes.Unchanged[2].Path,
+	})
+}
+
+func TestComputeEvidence_DuplicatePathsDoNotInflateCounts(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		head.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{ResourceID: testResource, FailedPath: ".spec.hostPID"},
+		evidencePath{ResourceID: testResource, FailedPath: " spec.hostPID "},
+	)
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	assert.Len(t, changes.Unchanged, 1)
+}
+
+func TestComputeEvidence_PathlessFailedRulesCompareByRuleName(t *testing.T) {
+	base := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("existing-rule"),
+	))
+	head := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("existing-rule"),
+		failedRule("new-rule"),
+	))
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, "new-rule", changes.New[0].RuleName)
+	assert.Equal(t, evidenceTypeRule, changes.New[0].EvidenceType)
+	assert.Empty(t, changes.New[0].Path)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Equal(t, "existing-rule", changes.Unchanged[0].RuleName)
+}
+
+func TestComputeEvidence_ReviewAndFailedPathsAreDifferentEvidence(t *testing.T) {
+	base := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule(testRule, evidencePath{ReviewPath: "$.spec.hostPID"}),
+	))
+	head := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}),
+	))
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, evidenceTypeFailedPath, changes.New[0].EvidenceType)
+	require.Len(t, changes.Resolved, 1)
+	assert.Equal(t, evidenceTypeReviewPath, changes.Resolved[0].EvidenceType)
+	assert.Empty(t, changes.Unchanged)
+}
+
+func TestComputeEvidence_EvidenceResourceIDParticipatesInIdentity(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	base.Results[0].AssociatedControls[0].Rules[0].Paths[0].ResourceID = "child-a"
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules[0].Paths[0].ResourceID = "child-b"
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, "child-b", changes.New[0].EvidenceResourceID)
+	require.Len(t, changes.Resolved, 1)
+	assert.Equal(t, "child-a", changes.Resolved[0].EvidenceResourceID)
+}
+
+func TestComputeEvidence_DetailedAndLegacyFailuresAreIncomparable(t *testing.T) {
+	legacy := evidenceReport(testResource, makeControl(testControl, "Control", "failed"))
+	detailed := reportWithPath("$.spec.hostPID")
+
+	for _, test := range []struct {
+		name string
+		base scanReport
+		head scanReport
+	}{
+		{name: "legacy base", base: legacy, head: detailed},
+		{name: "legacy head", base: detailed, head: legacy},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changes := computeReports(t, test.base, test.head)
+
+			assert.Empty(t, changes.New)
+			assert.Empty(t, changes.Resolved)
+			assert.Empty(t, changes.Unchanged)
+			require.Len(t, changes.Incomparable, 2)
+			for _, change := range changes.Incomparable {
+				assert.Contains(t, change.Reason, "different failed evidence detail")
+			}
+		})
+	}
+}
+
+func TestComputeEvidence_RuleAndPathLevelFailuresAreIncomparable(t *testing.T) {
+	base := evidenceReport(testResource, failedControlWithRules(testControl, "Control", failedRule(testRule)))
+	head := reportWithPath("$.spec.hostPID")
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	assert.Empty(t, changes.Unchanged)
+	require.Len(t, changes.Incomparable, 2)
+	for _, change := range changes.Incomparable {
+		assert.Contains(t, change.Reason, "different failed evidence detail")
+	}
+}
+
+func TestComputeEvidence_TwoLegacyFailuresRemainCompatible(t *testing.T) {
+	base := evidenceReport(testResource, makeControl(testControl, "Control", "failed"))
+	head := evidenceReport(testResource, makeControl(testControl, "Control", "failed"))
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Equal(t, evidenceTypeControl, changes.Unchanged[0].EvidenceType)
+}
+
+func TestComputeControlGranularity_PreservesAggregateBehavior(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		head.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{FailedPath: "$.spec.hostIPC"},
+	)
+
+	changes := computeReportsWithOptions(t, base, head, Options{Granularity: GranularityControl})
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	assert.Equal(t, evidenceTypeControl, changes.Unchanged[0].EvidenceType)
+	assert.Empty(t, changes.Unchanged[0].RuleName)
+	assert.Empty(t, changes.Unchanged[0].Path)
+}
+
+func TestComputeEvidence_StatusTransitions(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseStatus       string
+		baseSubStatus    string
+		headStatus       string
+		headSubStatus    string
+		wantNew          int
+		wantResolved     int
+		wantIncomparable int
+	}{
+		{name: "passed to failed is new", baseStatus: "passed", headStatus: "failed", wantNew: 1},
+		{name: "failed to passed is resolved", baseStatus: "failed", headStatus: "passed", wantResolved: 1},
+		{name: "skipped to failed is incomparable", baseStatus: "skipped", headStatus: "failed", wantIncomparable: 1},
+		{name: "error to failed is incomparable", baseStatus: "error", headStatus: "failed", wantIncomparable: 1},
+		{name: "unknown to failed is incomparable", baseStatus: "unknown", headStatus: "failed", wantIncomparable: 1},
+		{name: "failed to skipped is incomparable", baseStatus: "failed", headStatus: "skipped", wantIncomparable: 1},
+		{name: "failed to error is incomparable", baseStatus: "failed", headStatus: "error", wantIncomparable: 1},
+		{name: "failed to passed not evaluated is incomparable", baseStatus: "failed", headStatus: "passed", headSubStatus: "notEvaluated", wantIncomparable: 1},
+		{name: "not evaluated passed to failed is incomparable", baseStatus: "passed", baseSubStatus: "notEvaluated", headStatus: "failed", wantIncomparable: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseControl := makeControl(testControl, "Control", test.baseStatus)
+			baseControl.Status.SubStatus = test.baseSubStatus
+			headControl := makeControl(testControl, "Control", test.headStatus)
+			headControl.Status.SubStatus = test.headSubStatus
+			if test.baseStatus == "failed" {
+				baseControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}))
+			}
+			if test.headStatus == "failed" {
+				headControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}))
+			}
+			changes := computeReports(t, evidenceReport(testResource, baseControl), evidenceReport(testResource, headControl))
+
+			assert.Len(t, changes.New, test.wantNew)
+			assert.Len(t, changes.Resolved, test.wantResolved)
+			assert.Len(t, changes.Incomparable, test.wantIncomparable)
+			if test.wantIncomparable > 0 {
+				assert.NotEmpty(t, changes.Incomparable[0].Reason)
+			}
+		})
+	}
+}
+
+func TestComputeEvidence_AbsentFailureResolutionSafety(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+
+	tests := []struct {
+		name             string
+		mutateHead       func(*scanReport)
+		wantResolved     int
+		wantIncomparable int
+		wantReason       string
+	}{
+		{
+			name:         "legacy empty head resolves removed resource",
+			mutateHead:   func(*scanReport) {},
+			wantResolved: 1,
+		},
+		{
+			name: "declared scope missing control is incomparable",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls["C-OTHER"] = controlSummary{Severity: "Low"}
+			},
+			wantIncomparable: 1,
+			wantReason:       "declared control scope",
+		},
+		{
+			name: "not evaluated control is incomparable",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+				head.ScanCoverage.NotEvaluatedControls = []notEvaluatedControl{{ControlID: testControl, Reason: "timeout"}}
+			},
+			wantIncomparable: 1,
+			wantReason:       "not evaluated",
+		},
+		{
+			name: "degraded coverage is incomparable",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+				head.ScanCoverage.Degraded = true
+			},
+			wantIncomparable: 1,
+			wantReason:       "degraded scan coverage",
+		},
+		{
+			name: "failed GVR pull is incomparable even without degraded bit",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+				head.ScanCoverage.FailedGVRPulls = []json.RawMessage{json.RawMessage(`{"gvr":"apps/v1/deployments"}`)}
+			},
+			wantIncomparable: 1,
+			wantReason:       "degraded scan coverage",
+		},
+		{
+			name: "partial GVR pull is incomparable",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+				head.ScanCoverage.PartialGVRPulls = []json.RawMessage{json.RawMessage(`{"gvr":"apps/v1/deployments"}`)}
+			},
+			wantIncomparable: 1,
+			wantReason:       "degraded scan coverage",
+		},
+		{
+			name: "policy degradation is incomparable",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+				head.ScanCoverage.PolicyDegradations = []json.RawMessage{json.RawMessage(`{"component":"exceptions"}`)}
+			},
+			wantIncomparable: 1,
+			wantReason:       "degraded scan coverage",
+		},
+		{
+			name: "complete declared scope resolves removed resource",
+			mutateHead: func(head *scanReport) {
+				head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "High"}
+			},
+			wantResolved: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			head := makeReport()
+			test.mutateHead(&head)
+
+			changes := computeReports(t, base, head)
+
+			assert.Len(t, changes.Resolved, test.wantResolved)
+			assert.Len(t, changes.Incomparable, test.wantIncomparable)
+			if test.wantReason != "" {
+				require.NotEmpty(t, changes.Incomparable)
+				assert.Contains(t, changes.Incomparable[0].Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestComputeEvidence_BothFailedNewEvidenceHonorsBaseCoverageSafety(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	base.ScanCoverage.Degraded = true
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		head.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{FailedPath: "$.spec.hostIPC"},
+	)
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	require.Len(t, changes.Incomparable, 1)
+	assert.Contains(t, changes.Incomparable[0].Reason, "degraded scan coverage")
+}
+
+func TestComputeEvidence_BothFailedResolvedEvidenceHonorsHeadCoverageSafety(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		base.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{FailedPath: "$.spec.hostIPC"},
+	)
+	head := reportWithPath("$.spec.hostPID")
+	head.ScanCoverage.NotEvaluatedControls = []notEvaluatedControl{{ControlID: testControl, Reason: "timeout"}}
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	require.Len(t, changes.Incomparable, 1)
+	assert.Contains(t, changes.Incomparable[0].Reason, "not evaluated")
+}
+
+func TestComputeEvidence_BothFailedResolvedEvidenceHonorsRuleSubStatus(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
+		base.Results[0].AssociatedControls[0].Rules[0].Paths,
+		evidencePath{FailedPath: "$.spec.hostIPC"},
+	)
+	head := reportWithPath("$.spec.hostPID")
+	head.Results[0].AssociatedControls[0].Rules[0].SubStatus = "notEvaluated"
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.New)
+	assert.Empty(t, changes.Resolved)
+	require.Len(t, changes.Unchanged, 1)
+	require.Len(t, changes.Incomparable, 1)
+	assert.Contains(t, changes.Incomparable[0].Reason, "was not evaluated")
+}
+
+func TestComputeEvidence_NewFailureScopeSafety(t *testing.T) {
+	head := reportWithPath("$.spec.hostPID")
+
+	tests := []struct {
+		name             string
+		base             scanReport
+		wantNew          int
+		wantIncomparable int
+	}{
+		{
+			name:    "legacy empty base accepts new resource",
+			base:    makeReport(),
+			wantNew: 1,
+		},
+		{
+			name: "declared scope missing control is incomparable",
+			base: scanReport{SummaryDetails: summaryDetails{Controls: map[string]controlSummary{
+				"C-OTHER": {Severity: "Low"},
+			}}},
+			wantIncomparable: 1,
+		},
+		{
+			name: "declared scope includes control accepts new resource",
+			base: scanReport{SummaryDetails: summaryDetails{Controls: map[string]controlSummary{
+				testControl: {Severity: "High"},
+			}}},
+			wantNew: 1,
+		},
+		{
+			name: "base not evaluated control is incomparable",
+			base: scanReport{
+				SummaryDetails: summaryDetails{Controls: map[string]controlSummary{
+					testControl: {Severity: "High"},
+				}},
+				ScanCoverage: scanCoverage{
+					NotEvaluatedControls: []notEvaluatedControl{{ControlID: testControl, Reason: "timeout"}},
+				},
+			},
+			wantIncomparable: 1,
+		},
+		{
+			name: "degraded base coverage is incomparable",
+			base: scanReport{
+				SummaryDetails: summaryDetails{Controls: map[string]controlSummary{
+					testControl: {Severity: "High"},
+				}},
+				ScanCoverage: scanCoverage{Degraded: true},
+			},
+			wantIncomparable: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changes := computeReports(t, test.base, head)
+
+			assert.Len(t, changes.New, test.wantNew)
+			assert.Len(t, changes.Incomparable, test.wantIncomparable)
+		})
+	}
+}
+
+func TestComputeEvidence_IncompatibleScanScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutateBase func(*scanReport)
+		mutateHead func(*scanReport)
+		wantReason string
+	}{
+		{
+			name:       "target type",
+			mutateBase: func(report *scanReport) { report.Metadata.ScanMetadata.TargetType = "cluster" },
+			mutateHead: func(report *scanReport) { report.Metadata.ScanMetadata.TargetType = "repo" },
+			wantReason: "scan target types differ",
+		},
+		{
+			name: "scanning target enum",
+			mutateBase: func(report *scanReport) {
+				value := uint16(1)
+				report.Metadata.ScanMetadata.ScanningTarget = &value
+			},
+			mutateHead: func(report *scanReport) {
+				value := uint16(2)
+				report.Metadata.ScanMetadata.ScanningTarget = &value
+			},
+			wantReason: "scanning targets differ",
+		},
+		{
+			name:       "included namespaces",
+			mutateBase: func(report *scanReport) { report.Metadata.ScanMetadata.IncludeNamespaces = []string{"default"} },
+			mutateHead: func(report *scanReport) { report.Metadata.ScanMetadata.IncludeNamespaces = []string{"production"} },
+			wantReason: "included namespaces differ",
+		},
+		{
+			name:       "excluded namespaces",
+			mutateBase: func(report *scanReport) { report.Metadata.ScanMetadata.ExcludedNamespaces = []string{"kube-system"} },
+			mutateHead: func(report *scanReport) { report.Metadata.ScanMetadata.ExcludedNamespaces = []string{"monitoring"} },
+			wantReason: "excluded namespaces differ",
+		},
+		{
+			name:       "target names",
+			mutateBase: func(report *scanReport) { report.Metadata.ScanMetadata.TargetNames = []string{"api"} },
+			mutateHead: func(report *scanReport) { report.Metadata.ScanMetadata.TargetNames = []string{"worker"} },
+			wantReason: "target names differ",
+		},
+		{
+			name: "cluster context",
+			mutateBase: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Cluster = &clusterContext{ContextName: "development"}
+			},
+			mutateHead: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Cluster = &clusterContext{ContextName: "production"}
+			},
+			wantReason: "cluster contexts differ",
+		},
+		{
+			name: "repository owner",
+			mutateBase: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Repo = &repoContext{Provider: "github", Owner: "team-a", Repo: "service"}
+			},
+			mutateHead: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Repo = &repoContext{Provider: "github", Owner: "team-b", Repo: "service"}
+			},
+			wantReason: "repository identities differ",
+		},
+		{
+			name: "repository remote URL",
+			mutateBase: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Repo = &repoContext{RemoteURL: "https://github.com/team/service-a.git"}
+			},
+			mutateHead: func(report *scanReport) {
+				report.Metadata.TargetMetadata.Repo = &repoContext{RemoteURL: "https://github.com/team/service-b.git"}
+			},
+			wantReason: "repository identities differ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := reportWithPath("$.spec.hostPID")
+			head := reportWithPath("$.spec.hostIPC")
+			test.mutateBase(&base)
+			test.mutateHead(&head)
+
+			changes := computeReports(t, base, head)
+
+			assert.Empty(t, changes.New)
+			assert.Empty(t, changes.Resolved)
+			assert.Empty(t, changes.Unchanged)
+			require.Len(t, changes.Warnings, 1)
+			assert.Contains(t, changes.Warnings[0], test.wantReason)
+			require.Len(t, changes.Incomparable, 2)
+			for _, change := range changes.Incomparable {
+				assert.Contains(t, change.Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestComputeEvidence_CompatibleScopeMetadata(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath("$.spec.hostPID")
+	base.Metadata.ScanMetadata.TargetType = "repo"
+	head.Metadata.ScanMetadata.TargetType = "repo"
+	base.Metadata.ScanMetadata.IncludeNamespaces = []string{"production", "default", "default"}
+	head.Metadata.ScanMetadata.IncludeNamespaces = []string{"default", "production"}
+	base.Metadata.ScanMetadata.ExcludedNamespaces = []string{"kube-system", ""}
+	head.Metadata.ScanMetadata.ExcludedNamespaces = []string{"kube-system"}
+	base.Metadata.ScanMetadata.TargetNames = []string{"worker", "api"}
+	head.Metadata.ScanMetadata.TargetNames = []string{"api", "worker"}
+	base.Metadata.TargetMetadata.Repo = &repoContext{Provider: "GitHub", Owner: "Team", Repo: "Service", Branch: "main"}
+	head.Metadata.TargetMetadata.Repo = &repoContext{Provider: "github", Owner: "team", Repo: "service", Branch: "feature"}
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.Warnings)
+	assert.Empty(t, changes.Incomparable)
+	assert.Len(t, changes.Unchanged, 1)
+}
+
+func TestComputeEvidence_MissingMetadataDoesNotBreakLegacyComparison(t *testing.T) {
+	base := reportWithPath("$.spec.hostPID")
+	head := reportWithPath("$.spec.hostPID")
+	head.Metadata.ScanMetadata.TargetType = "cluster"
+	head.Metadata.TargetMetadata.Cluster = &clusterContext{ContextName: "production"}
+
+	changes := computeReports(t, base, head)
+
+	assert.Empty(t, changes.Warnings)
+	assert.Empty(t, changes.Incomparable)
+	assert.Len(t, changes.Unchanged, 1)
+}
+
+func TestComputeEvidence_SeverityComesFromOwningSide(t *testing.T) {
+	base := reportWithPath("$.spec.old")
+	head := reportWithPath("$.spec.new")
+	base.SummaryDetails.Controls[testControl] = controlSummary{Severity: "Medium"}
+	head.SummaryDetails.Controls[testControl] = controlSummary{Severity: "Critical"}
+
+	changes := computeReports(t, base, head)
+
+	require.Len(t, changes.New, 1)
+	assert.Equal(t, "Critical", changes.New[0].Severity)
+	require.Len(t, changes.Resolved, 1)
+	assert.Equal(t, "Medium", changes.Resolved[0].Severity)
+}
+
+func TestComputeEvidence_DeterministicEvidenceOrder(t *testing.T) {
+	base := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("z-rule", evidencePath{FailedPath: "$.z"}),
+		failedRule("a-rule", evidencePath{FailedPath: "$.a"}),
+	))
+	head := evidenceReport(testResource, failedControlWithRules(
+		testControl,
+		"Control",
+		failedRule("m-rule", evidencePath{FailedPath: "$.m"}),
+		failedRule("b-rule", evidencePath{ReviewPath: "$.b"}),
+	))
+
+	first := computeReports(t, base, head)
+	require.Len(t, first.New, 2)
+	require.Len(t, first.Resolved, 2)
+	assert.Equal(t, []string{"b-rule", "m-rule"}, []string{first.New[0].RuleName, first.New[1].RuleName})
+	assert.Equal(t, []string{"a-rule", "z-rule"}, []string{first.Resolved[0].RuleName, first.Resolved[1].RuleName})
+
+	for run := 0; run < 10; run++ {
+		next := computeReports(t, base, head)
+		assert.Equal(t, first, next)
+	}
+}
+
+func TestGranularityValidation(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    Granularity
+		wantErr bool
+	}{
+		{value: "", want: GranularityEvidence},
+		{value: "evidence", want: GranularityEvidence},
+		{value: "EVIDENCE", want: GranularityEvidence},
+		{value: " evidence ", want: GranularityEvidence},
+		{value: "control", want: GranularityControl},
+		{value: "CONTROL", want: GranularityControl},
+		{value: "path", wantErr: true},
+		{value: "resource", wantErr: true},
+		{value: "rule", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			actual, err := normalizeGranularity(Granularity(test.value))
+			if test.wantErr {
+				assert.ErrorContains(t, err, "invalid diff granularity")
+				assert.Error(t, ValidateGranularity(test.value))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, actual)
+			assert.NoError(t, ValidateGranularity(test.value))
+		})
+	}
+}
+
+func TestFilterBySeverity_DoesNotMutateInput(t *testing.T) {
+	input := []ControlChange{
+		{ControlID: "critical", Severity: "Critical"},
+		{ControlID: "low", Severity: "Low"},
+		{ControlID: "high", Severity: "High"},
+	}
+	original := append([]ControlChange(nil), input...)
+
+	filtered := FilterBySeverity(input, "high")
+
+	assert.Equal(t, original, input)
+	assert.Equal(t, []ControlChange{original[0], original[2]}, filtered)
+}

--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -1,67 +1,57 @@
 package diff
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 )
 
-// statusAbsent marks a resource+control pair that is missing from one side of the diff
-// (it is not one of the apis.ScanningStatus values).
 const statusAbsent = "absent"
 
-// minimal structs for reading the v2 JSON scan output produced by jsonprinter.go
-type scanReport struct {
-	Results        []resultEntry  `json:"results"`
-	SummaryDetails summaryDetails `json:"summaryDetails"`
+// Granularity selects the unit used to compare failures.
+type Granularity string
+
+const (
+	// GranularityEvidence compares failed rules and their failed/review paths.
+	// It is the default because a control can gain a regression while remaining
+	// failed at the aggregate level.
+	GranularityEvidence Granularity = "evidence"
+	// GranularityControl preserves the pre-evidence resource+control behavior.
+	GranularityControl Granularity = "control"
+)
+
+// Options controls the comparison without changing report parsing.
+type Options struct {
+	Granularity Granularity
 }
 
-type resultEntry struct {
-	ResourceID         string         `json:"resourceID"`
-	AssociatedControls []controlEntry `json:"controls"`
-}
-
-type controlEntry struct {
-	ControlID string     `json:"controlID"`
-	Name      string     `json:"name"`
-	Status    statusInfo `json:"status"`
-}
-
-type statusInfo struct {
-	InnerStatus string `json:"status"`
-}
-
-type summaryDetails struct {
-	Controls map[string]controlSummary `json:"controls"`
-}
-
-type controlSummary struct {
-	ScoreFactor float32 `json:"scoreFactor"`
-	Severity    string  `json:"severity"`
-}
-
-// ControlChange represents a single resource+control pair whose status changed (or stayed failed).
+// ControlChange represents one comparable failure unit. The first six fields
+// are retained for compatibility with consumers of the original diff format.
 type ControlChange struct {
-	ResourceID  string `json:"resourceID"`
-	ControlID   string `json:"controlID"`
-	ControlName string `json:"controlName"`
-	Severity    string `json:"severity"`
-	BaseStatus  string `json:"baseStatus"`
-	HeadStatus  string `json:"headStatus"`
+	ResourceID         string `json:"resourceID"`
+	ControlID          string `json:"controlID"`
+	ControlName        string `json:"controlName"`
+	Severity           string `json:"severity"`
+	BaseStatus         string `json:"baseStatus"`
+	HeadStatus         string `json:"headStatus"`
+	RuleName           string `json:"ruleName,omitempty"`
+	EvidenceType       string `json:"evidenceType,omitempty"`
+	Path               string `json:"path,omitempty"`
+	EvidenceResourceID string `json:"evidenceResourceID,omitempty"`
+	Reason             string `json:"reason,omitempty"`
 }
 
-// ChangeSet groups the diff results into three buckets.
+// ChangeSet groups comparable regressions and explicitly separates results
+// that cannot be classified safely. Incomparable failures never appear as
+// resolved, avoiding false-green output when scan scope or coverage changed.
 type ChangeSet struct {
-	New       []ControlChange `json:"new"`
-	Resolved  []ControlChange `json:"resolved"`
-	Unchanged []ControlChange `json:"unchanged"`
+	New          []ControlChange `json:"new"`
+	Resolved     []ControlChange `json:"resolved"`
+	Unchanged    []ControlChange `json:"unchanged"`
+	Incomparable []ControlChange `json:"incomparable,omitempty"`
+	Warnings     []string        `json:"warnings,omitempty"`
 }
 
 type key struct {
@@ -69,8 +59,19 @@ type key struct {
 	controlID  string
 }
 
-// Compute loads two scan JSON reports and returns the diff.
+// Compute loads two scan JSON reports and compares failed evidence. It keeps
+// the existing signature while making the safe evidence behavior the default.
 func Compute(basePath, headPath string) (*ChangeSet, error) {
+	return ComputeWithOptions(basePath, headPath, Options{Granularity: GranularityEvidence})
+}
+
+// ComputeWithOptions loads and compares two scan reports.
+func ComputeWithOptions(basePath, headPath string, options Options) (*ChangeSet, error) {
+	granularity, err := normalizeGranularity(options.Granularity)
+	if err != nil {
+		return nil, err
+	}
+
 	base, err := loadReport(basePath)
 	if err != nil {
 		return nil, fmt.Errorf("loading base report: %w", err)
@@ -80,201 +81,273 @@ func Compute(basePath, headPath string) (*ChangeSet, error) {
 		return nil, fmt.Errorf("loading head report: %w", err)
 	}
 
+	return compareReports(base, head, granularity), nil
+}
+
+// ValidateGranularity validates a CLI/API value without reading reports.
+func ValidateGranularity(value string) error {
+	_, err := normalizeGranularity(Granularity(value))
+	return err
+}
+
+func normalizeGranularity(value Granularity) (Granularity, error) {
+	if value == "" {
+		return GranularityEvidence, nil
+	}
+	value = Granularity(strings.ToLower(strings.TrimSpace(string(value))))
+	switch value {
+	case GranularityEvidence, GranularityControl:
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid diff granularity %q, supported granularities: evidence, control", value)
+	}
+}
+
+func compareReports(base, head *scanReport, granularity Granularity) *ChangeSet {
+	cs := &ChangeSet{}
 	baseMap := buildMap(base)
 	headMap := buildMap(head)
-	baseSev := buildSeverityMap(base)
-	headSev := buildSeverityMap(head)
+	baseSeverity := buildSeverityMap(base)
+	headSeverity := buildSeverityMap(head)
 
-	cs := &ChangeSet{}
+	if reasons := incompatibleScopeReasons(base, head); len(reasons) > 0 {
+		cs.Warnings = append(cs.Warnings, reasons...)
+		markAllFailuresIncomparable(cs, base, head, granularity, reasons[0])
+		sortChangeSet(cs)
+		return cs
+	}
 
-	// walk head: find new and unchanged failures
-	for k, hc := range headMap {
-		if hc.Status.InnerStatus != string(apis.StatusFailed) {
-			continue
+	keys := unionKeys(baseMap, headMap)
+	for _, controlKey := range keys {
+		baseControl, inBase := baseMap[controlKey]
+		headControl, inHead := headMap[controlKey]
+		baseStatus := statusOf(baseControl, inBase)
+		headStatus := statusOf(headControl, inHead)
+
+		switch {
+		case baseStatus == string(apis.StatusFailed) && headStatus == string(apis.StatusFailed):
+			compareFailedPair(cs, base, head, controlKey, baseControl, headControl, baseSeverity, headSeverity, granularity)
+		case headStatus == string(apis.StatusFailed):
+			classifyHeadFailure(cs, base, controlKey, baseControl, headControl, inBase, baseStatus, headSeverity, granularity)
+		case baseStatus == string(apis.StatusFailed):
+			classifyBaseFailure(cs, head, controlKey, baseControl, headControl, inHead, headStatus, baseSeverity, granularity)
 		}
-		change := ControlChange{
-			ResourceID:  k.resourceID,
-			ControlID:   k.controlID,
-			ControlName: hc.Name,
-			Severity:    headSev[k.controlID],
-			BaseStatus:  statusAbsent,
-			HeadStatus:  hc.Status.InnerStatus,
-		}
-		if bc, ok := baseMap[k]; ok {
-			change.BaseStatus = bc.Status.InnerStatus
-		}
-		if change.BaseStatus == string(apis.StatusFailed) {
-			cs.Unchanged = append(cs.Unchanged, change)
+	}
+
+	sortChangeSet(cs)
+	return cs
+}
+
+func compareFailedPair(cs *ChangeSet, base, head *scanReport, controlKey key, baseControl, headControl controlEntry, baseSeverity, headSeverity map[string]string, granularity Granularity) {
+	baseFindings := findingsForControl(controlKey, baseControl, baseSeverity[controlKey.controlID], granularity)
+	headFindings := findingsForControl(controlKey, headControl, headSeverity[controlKey.controlID], granularity)
+
+	if granularity == GranularityEvidence && evidenceDetailMismatch(baseFindings, headFindings) {
+		reason := "reports use different failed evidence detail; aggregate, rule-level, and path-level failures cannot be compared safely"
+		appendFindings(&cs.Incomparable, baseFindings, string(apis.StatusFailed), string(apis.StatusFailed), reason)
+		appendFindings(&cs.Incomparable, headFindings, string(apis.StatusFailed), string(apis.StatusFailed), reason)
+		return
+	}
+
+	baseByFingerprint := indexFindings(baseFindings)
+	headByFingerprint := indexFindings(headFindings)
+	for fingerprint, finding := range headByFingerprint {
+		if _, exists := baseByFingerprint[fingerprint]; exists {
+			cs.Unchanged = append(cs.Unchanged, finding.change(string(apis.StatusFailed), string(apis.StatusFailed), ""))
 		} else {
-			cs.New = append(cs.New, change)
+			if reason := existingFailureNewRisk(base, baseControl, controlKey.controlID, finding.fingerprint.ruleName); reason != "" {
+				cs.Incomparable = append(cs.Incomparable, finding.change(string(apis.StatusFailed), string(apis.StatusFailed), reason))
+				continue
+			}
+			cs.New = append(cs.New, finding.change(string(apis.StatusFailed), string(apis.StatusFailed), ""))
 		}
+	}
+	for fingerprint, finding := range baseByFingerprint {
+		if _, exists := headByFingerprint[fingerprint]; !exists {
+			if reason := existingFailureResolutionRisk(head, headControl, controlKey.controlID, finding.fingerprint.ruleName); reason != "" {
+				cs.Incomparable = append(cs.Incomparable, finding.change(string(apis.StatusFailed), string(apis.StatusFailed), reason))
+				continue
+			}
+			cs.Resolved = append(cs.Resolved, finding.change(string(apis.StatusFailed), string(apis.StatusFailed), ""))
+		}
+	}
+}
+
+func classifyHeadFailure(cs *ChangeSet, base *scanReport, controlKey key, baseControl, headControl controlEntry, inBase bool, baseStatus string, severity map[string]string, granularity Granularity) {
+	findings := findingsForControl(controlKey, headControl, severity[controlKey.controlID], granularity)
+	if inBase && !isConclusiveNonFailure(baseControl) {
+		reason := fmt.Sprintf("base control status %q is not a conclusive non-failure", displayStatus(baseStatus))
+		appendFindings(&cs.Incomparable, findings, baseStatus, string(apis.StatusFailed), reason)
+		return
+	}
+	if !inBase && controlDefinitelyOutOfScope(base, controlKey.controlID) {
+		reason := "control is not present in the base report's declared control scope"
+		appendFindings(&cs.Incomparable, findings, statusAbsent, string(apis.StatusFailed), reason)
+		return
+	}
+	if !inBase {
+		if reason := absentNewFailureRisk(base, controlKey.controlID); reason != "" {
+			appendFindings(&cs.Incomparable, findings, statusAbsent, string(apis.StatusFailed), reason)
+			return
+		}
+	}
+	appendFindings(&cs.New, findings, baseStatus, string(apis.StatusFailed), "")
+}
+
+func classifyBaseFailure(cs *ChangeSet, head *scanReport, controlKey key, baseControl, headControl controlEntry, inHead bool, headStatus string, severity map[string]string, granularity Granularity) {
+	findings := findingsForControl(controlKey, baseControl, severity[controlKey.controlID], granularity)
+	if inHead {
+		if !isConclusiveNonFailure(headControl) {
+			reason := fmt.Sprintf("head control status %q is not a conclusive resolution", displayStatus(headStatus))
+			appendFindings(&cs.Incomparable, findings, string(apis.StatusFailed), headStatus, reason)
+			return
+		}
+		appendFindings(&cs.Resolved, findings, string(apis.StatusFailed), headStatus, "")
+		return
 	}
 
-	// walk base: find resolved (was failed, now not failed or absent)
-	for k, bc := range baseMap {
-		if bc.Status.InnerStatus != string(apis.StatusFailed) {
-			continue
-		}
-		hc, inHead := headMap[k]
-		if !inHead || hc.Status.InnerStatus != string(apis.StatusFailed) {
-			headStatus := statusAbsent
-			if inHead {
-				headStatus = hc.Status.InnerStatus
-			}
-			cs.Resolved = append(cs.Resolved, ControlChange{
-				ResourceID:  k.resourceID,
-				ControlID:   k.controlID,
-				ControlName: bc.Name,
-				Severity:    baseSev[k.controlID],
-				BaseStatus:  string(apis.StatusFailed),
-				HeadStatus:  headStatus,
-			})
+	if reason := absentResolutionRisk(head, controlKey.controlID); reason != "" {
+		appendFindings(&cs.Incomparable, findings, string(apis.StatusFailed), statusAbsent, reason)
+		return
+	}
+	appendFindings(&cs.Resolved, findings, string(apis.StatusFailed), statusAbsent, "")
+}
+
+func isConclusiveNonFailure(control controlEntry) bool {
+	return control.Status.InnerStatus == string(apis.StatusPassed) && control.Status.SubStatus != string(apis.SubStatusNotEvaluated)
+}
+
+func existingFailureNewRisk(report *scanReport, control controlEntry, controlID, ruleName string) string {
+	if reason := absentNewFailureRisk(report, controlID); reason != "" {
+		return reason
+	}
+	return notEvaluatedRuleReason(control, ruleName, "base", "new")
+}
+
+func existingFailureResolutionRisk(report *scanReport, control controlEntry, controlID, ruleName string) string {
+	if reason := absentResolutionRisk(report, controlID); reason != "" {
+		return reason
+	}
+	return notEvaluatedRuleReason(control, ruleName, "head", "resolved")
+}
+
+func notEvaluatedRuleReason(control controlEntry, ruleName, side, action string) string {
+	if control.Status.SubStatus == string(apis.SubStatusNotEvaluated) {
+		return fmt.Sprintf("%s control was not evaluated, so missing evidence cannot be classified as %s", side, action)
+	}
+	for _, rule := range control.Rules {
+		if rule.Name == ruleName && rule.SubStatus == string(apis.SubStatusNotEvaluated) {
+			return fmt.Sprintf("%s rule %q was not evaluated, so missing evidence cannot be classified as %s", side, ruleName, action)
 		}
 	}
-	// Go randomizes map iteration order per run, so kubescape diff returned the
-	// same findings in a different order on every invocation over the same two reports.
+	return ""
+}
+
+func displayStatus(status string) string {
+	if status == "" {
+		return "unknown"
+	}
+	return status
+}
+
+func statusOf(control controlEntry, exists bool) string {
+	if !exists {
+		return statusAbsent
+	}
+	return control.Status.InnerStatus
+}
+
+func unionKeys(base, head map[key]controlEntry) []key {
+	set := make(map[key]struct{}, len(base)+len(head))
+	for k := range base {
+		set[k] = struct{}{}
+	}
+	for k := range head {
+		set[k] = struct{}{}
+	}
+	keys := make([]key, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].resourceID != keys[j].resourceID {
+			return keys[i].resourceID < keys[j].resourceID
+		}
+		return keys[i].controlID < keys[j].controlID
+	})
+	return keys
+}
+
+func markAllFailuresIncomparable(cs *ChangeSet, base, head *scanReport, granularity Granularity, reason string) {
+	seen := make(map[findingFingerprint]struct{})
+	for _, side := range []struct {
+		report     *scanReport
+		baseStatus string
+		headStatus string
+	}{
+		{base, string(apis.StatusFailed), statusAbsent},
+		{head, statusAbsent, string(apis.StatusFailed)},
+	} {
+		severity := buildSeverityMap(side.report)
+		for controlKey, control := range buildMap(side.report) {
+			if control.Status.InnerStatus != string(apis.StatusFailed) {
+				continue
+			}
+			for _, finding := range findingsForControl(controlKey, control, severity[controlKey.controlID], granularity) {
+				if _, exists := seen[finding.fingerprint]; exists {
+					continue
+				}
+				seen[finding.fingerprint] = struct{}{}
+				cs.Incomparable = append(cs.Incomparable, finding.change(side.baseStatus, side.headStatus, reason))
+			}
+		}
+	}
+}
+
+func appendFindings(destination *[]ControlChange, findings []finding, baseStatus, headStatus, reason string) {
+	for _, item := range findings {
+		*destination = append(*destination, item.change(baseStatus, headStatus, reason))
+	}
+}
+
+func sortChangeSet(cs *ChangeSet) {
 	sortChanges(cs.New)
 	sortChanges(cs.Resolved)
 	sortChanges(cs.Unchanged)
-
-	return cs, nil
+	sortChanges(cs.Incomparable)
+	sort.Strings(cs.Warnings)
 }
 
 func sortChanges(changes []ControlChange) {
 	sort.Slice(changes, func(i, j int) bool {
-		if iRank, jRank := severityRank(changes[i].Severity), severityRank(changes[j].Severity); iRank != jRank {
-			return iRank > jRank
+		left, right := changes[i], changes[j]
+		if leftRank, rightRank := severityRank(left.Severity), severityRank(right.Severity); leftRank != rightRank {
+			return leftRank > rightRank
 		}
-		if changes[i].ResourceID != changes[j].ResourceID {
-			return changes[i].ResourceID < changes[j].ResourceID
+		if left.ResourceID != right.ResourceID {
+			return left.ResourceID < right.ResourceID
 		}
-		return changes[i].ControlID < changes[j].ControlID
+		if left.ControlID != right.ControlID {
+			return left.ControlID < right.ControlID
+		}
+		if left.RuleName != right.RuleName {
+			return left.RuleName < right.RuleName
+		}
+		if left.EvidenceType != right.EvidenceType {
+			return left.EvidenceType < right.EvidenceType
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.EvidenceResourceID != right.EvidenceResourceID {
+			return left.EvidenceResourceID < right.EvidenceResourceID
+		}
+		return left.Reason < right.Reason
 	})
 }
 
-func loadReport(path string) (*scanReport, error) {
-	f, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	data, err := io.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-
-	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || trimmed[0] != '{' {
-		return nil, fmt.Errorf("invalid report: expected a JSON object")
-	}
-
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-	if fields == nil {
-		return nil, fmt.Errorf("invalid report: expected a JSON object")
-	}
-
-	resultsJSON, ok := fields["results"]
-	if !ok {
-		return nil, fmt.Errorf("invalid report: missing required results field; provide JSON output from kubescape scan")
-	}
-	if isJSONNull(resultsJSON) {
-		return nil, fmt.Errorf("invalid report: results must be an array, not null")
-	}
-
-	summaryJSON, ok := fields["summaryDetails"]
-	if !ok {
-		return nil, fmt.Errorf("invalid report: missing required summaryDetails field; provide JSON output from kubescape scan")
-	}
-	if isJSONNull(summaryJSON) {
-		return nil, fmt.Errorf("invalid report: summaryDetails must be an object, not null")
-	}
-
-	var r scanReport
-	if err := json.Unmarshal(resultsJSON, &r.Results); err != nil {
-		return nil, fmt.Errorf("invalid report results: %w", err)
-	}
-	if err := validateReport(&r, summaryJSON); err != nil {
-		return nil, err
-	}
-	return &r, nil
-}
-
-func isJSONNull(raw json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
-}
-
-func validateReport(r *scanReport, summaryJSON json.RawMessage) error {
-	var summaryFields map[string]json.RawMessage
-	if err := json.Unmarshal(summaryJSON, &summaryFields); err != nil {
-		return fmt.Errorf("invalid report summaryDetails: %w", err)
-	}
-	if summaryFields == nil {
-		return fmt.Errorf("invalid report: summaryDetails must be an object")
-	}
-	controlsJSON, ok := summaryFields["controls"]
-	if !ok {
-		return fmt.Errorf("invalid report: summaryDetails is missing required controls field")
-	}
-	if isJSONNull(controlsJSON) {
-		return fmt.Errorf("invalid report: summaryDetails.controls must be an object, not null")
-	}
-	var controls map[string]controlSummary
-	if err := json.Unmarshal(controlsJSON, &controls); err != nil {
-		return fmt.Errorf("invalid report summaryDetails.controls: %w", err)
-	}
-	r.SummaryDetails.Controls = controls
-
-	seen := make(map[key]struct{})
-	for resultIndex, result := range r.Results {
-		if strings.TrimSpace(result.ResourceID) == "" {
-			return fmt.Errorf("invalid report: results[%d].resourceID is empty", resultIndex)
-		}
-		for controlIndex, control := range result.AssociatedControls {
-			if strings.TrimSpace(control.ControlID) == "" {
-				return fmt.Errorf("invalid report: results[%d].controls[%d].controlID is empty", resultIndex, controlIndex)
-			}
-			if strings.TrimSpace(control.Status.InnerStatus) == "" {
-				return fmt.Errorf("invalid report: results[%d].controls[%d].status.status is empty", resultIndex, controlIndex)
-			}
-			controlKey := key{resourceID: result.ResourceID, controlID: control.ControlID}
-			if _, exists := seen[controlKey]; exists {
-				return fmt.Errorf("invalid report: duplicate resource and control pair %q / %q", result.ResourceID, control.ControlID)
-			}
-			seen[controlKey] = struct{}{}
-		}
-	}
-	return nil
-}
-
-func buildMap(r *scanReport) map[key]controlEntry {
-	m := make(map[key]controlEntry)
-	for _, res := range r.Results {
-		for _, ctrl := range res.AssociatedControls {
-			m[key{res.ResourceID, ctrl.ControlID}] = ctrl
-		}
-	}
-	return m
-}
-
-func buildSeverityMap(r *scanReport) map[string]string {
-	m := make(map[string]string, len(r.SummaryDetails.Controls))
-	for id, cs := range r.SummaryDetails.Controls {
-		sev := cs.Severity
-		if sev == "" {
-			sev = apis.ControlSeverityToString(cs.ScoreFactor)
-		}
-		m[id] = sev
-	}
-	return m
-}
-
-// severityRank maps severity strings to comparable ints (higher = more severe).
-func severityRank(s string) int {
-	switch strings.ToLower(s) {
+func severityRank(value string) int {
+	switch strings.ToLower(value) {
 	case "critical":
 		return 4
 	case "high":
@@ -288,18 +361,17 @@ func severityRank(s string) int {
 	}
 }
 
-// FilterBySeverity returns only the changes at or above the given severity threshold string.
-// An empty threshold returns all changes unchanged.
+// FilterBySeverity returns changes at or above the requested threshold.
 func FilterBySeverity(changes []ControlChange, threshold string) []ControlChange {
 	if threshold == "" {
 		return changes
 	}
-	min := severityRank(threshold)
-	out := changes[:0:0]
-	for _, c := range changes {
-		if severityRank(c.Severity) >= min {
-			out = append(out, c)
+	minimum := severityRank(threshold)
+	filtered := make([]ControlChange, 0, len(changes))
+	for _, change := range changes {
+		if severityRank(change.Severity) >= minimum {
+			filtered = append(filtered, change)
 		}
 	}
-	return out
+	return filtered
 }

--- a/core/pkg/resultshandling/diff/evidence.go
+++ b/core/pkg/resultshandling/diff/evidence.go
@@ -1,0 +1,191 @@
+package diff
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+)
+
+const (
+	evidenceTypeControl    = "control"
+	evidenceTypeRule       = "rule"
+	evidenceTypeFailedPath = "failedPath"
+	evidenceTypeReviewPath = "reviewPath"
+	evidenceTypeDeletePath = "deletePath"
+	evidenceTypeFixPath    = "fixPath"
+	evidenceTypeFixCommand = "fixCommand"
+)
+
+type findingFingerprint struct {
+	resourceID         string
+	controlID          string
+	ruleName           string
+	evidenceType       string
+	path               string
+	evidenceResourceID string
+}
+
+type finding struct {
+	fingerprint findingFingerprint
+	controlName string
+	severity    string
+}
+
+func (item finding) change(baseStatus, headStatus, reason string) ControlChange {
+	return ControlChange{
+		ResourceID:         item.fingerprint.resourceID,
+		ControlID:          item.fingerprint.controlID,
+		ControlName:        item.controlName,
+		Severity:           item.severity,
+		BaseStatus:         baseStatus,
+		HeadStatus:         headStatus,
+		RuleName:           item.fingerprint.ruleName,
+		EvidenceType:       item.fingerprint.evidenceType,
+		Path:               item.fingerprint.path,
+		EvidenceResourceID: item.fingerprint.evidenceResourceID,
+		Reason:             reason,
+	}
+}
+
+func findingsForControl(controlKey key, control controlEntry, severity string, granularity Granularity) []finding {
+	if granularity == GranularityControl {
+		return []finding{aggregateFinding(controlKey, control, severity)}
+	}
+
+	findings := make([]finding, 0)
+	for _, rule := range control.Rules {
+		if rule.Status != string(apis.StatusFailed) {
+			continue
+		}
+		failedRuleFindings := findingsForRule(controlKey, control, rule, severity)
+		findings = append(findings, failedRuleFindings...)
+	}
+	if len(findings) == 0 {
+		return []finding{aggregateFinding(controlKey, control, severity)}
+	}
+	return deduplicateFindings(findings)
+}
+
+func aggregateFinding(controlKey key, control controlEntry, severity string) finding {
+	return finding{
+		fingerprint: findingFingerprint{
+			resourceID:   controlKey.resourceID,
+			controlID:    controlKey.controlID,
+			evidenceType: evidenceTypeControl,
+		},
+		controlName: control.Name,
+		severity:    severity,
+	}
+}
+
+func findingsForRule(controlKey key, control controlEntry, rule ruleEntry, severity string) []finding {
+	findings := make([]finding, 0, len(rule.Paths)*5)
+	for _, path := range rule.Paths {
+		failedPath := normalizeEvidencePath(path.FailedPath)
+		if failedPath != "" {
+			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeFailedPath, failedPath, path.ResourceID, severity))
+		}
+		reviewPath := normalizeEvidencePath(path.ReviewPath)
+		if reviewPath != "" {
+			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeReviewPath, reviewPath, path.ResourceID, severity))
+		}
+		deletePath := normalizeEvidencePath(path.DeletePath)
+		if deletePath != "" {
+			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeDeletePath, deletePath, path.ResourceID, severity))
+		}
+		fixPath := normalizeEvidencePath(path.FixPath.Path)
+		if fixPath != "" {
+			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeFixPath, fixPath, path.ResourceID, severity))
+		}
+		fixCommand := normalizeEvidenceCommand(path.FixCommand)
+		if fixCommand != "" {
+			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeFixCommand, fixCommand, path.ResourceID, severity))
+		}
+	}
+	if len(findings) == 0 {
+		findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeRule, "", "", severity))
+	}
+	return findings
+}
+
+func makeEvidenceFinding(controlKey key, control controlEntry, ruleName, evidenceType, path, evidenceResourceID, severity string) finding {
+	return finding{
+		fingerprint: findingFingerprint{
+			resourceID:         strings.TrimSpace(controlKey.resourceID),
+			controlID:          strings.TrimSpace(controlKey.controlID),
+			ruleName:           strings.TrimSpace(ruleName),
+			evidenceType:       evidenceType,
+			path:               path,
+			evidenceResourceID: strings.TrimSpace(evidenceResourceID),
+		},
+		controlName: control.Name,
+		severity:    severity,
+	}
+}
+
+// normalizeEvidencePath only removes equivalent JSONPath root notation and
+// surrounding whitespace. It deliberately avoids case conversion, index
+// rewriting, or wildcard expansion because those can merge distinct evidence.
+func normalizeEvidencePath(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "$" {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "$")
+	value = strings.TrimPrefix(value, ".")
+	return strings.TrimSpace(value)
+}
+
+func normalizeEvidenceCommand(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func deduplicateFindings(findings []finding) []finding {
+	byFingerprint := indexFindings(findings)
+	result := make([]finding, 0, len(byFingerprint))
+	for _, item := range byFingerprint {
+		result = append(result, item)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := result[i].fingerprint, result[j].fingerprint
+		if left.ruleName != right.ruleName {
+			return left.ruleName < right.ruleName
+		}
+		if left.evidenceType != right.evidenceType {
+			return left.evidenceType < right.evidenceType
+		}
+		if left.path != right.path {
+			return left.path < right.path
+		}
+		return left.evidenceResourceID < right.evidenceResourceID
+	})
+	return result
+}
+
+func indexFindings(findings []finding) map[findingFingerprint]finding {
+	indexed := make(map[findingFingerprint]finding, len(findings))
+	for _, item := range findings {
+		indexed[item.fingerprint] = item
+	}
+	return indexed
+}
+
+func evidenceDetailMismatch(base, head []finding) bool {
+	return detailLevels(base) != detailLevels(head)
+}
+
+func detailLevels(findings []finding) uint8 {
+	var levels uint8
+	for _, item := range findings {
+		switch item.fingerprint.evidenceType {
+		case evidenceTypeControl:
+			levels |= 1
+		case evidenceTypeRule:
+			levels |= 2
+		default:
+			levels |= 4
+		}
+	}
+	return levels
+}

--- a/core/pkg/resultshandling/diff/evidence_test.go
+++ b/core/pkg/resultshandling/diff/evidence_test.go
@@ -1,0 +1,309 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func failedRule(name string, paths ...evidencePath) ruleEntry {
+	return ruleEntry{Name: name, Status: "failed", Paths: paths}
+}
+
+func passedRule(name string, paths ...evidencePath) ruleEntry {
+	return ruleEntry{Name: name, Status: "passed", Paths: paths}
+}
+
+func failedControlWithRules(id, name string, rules ...ruleEntry) controlEntry {
+	control := makeControl(id, name, "failed")
+	control.Rules = rules
+	return control
+}
+
+func TestNormalizeEvidencePath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "whitespace", input: "   ", want: ""},
+		{name: "root only", input: "$", want: ""},
+		{name: "root with whitespace", input: "  $  ", want: ""},
+		{name: "dollar dot notation", input: "$.spec.hostNetwork", want: "spec.hostNetwork"},
+		{name: "dollar notation", input: "$spec.hostNetwork", want: "spec.hostNetwork"},
+		{name: "leading dot notation", input: ".spec.hostNetwork", want: "spec.hostNetwork"},
+		{name: "plain path", input: "spec.hostNetwork", want: "spec.hostNetwork"},
+		{name: "surrounding whitespace", input: "  $.spec.containers[0].securityContext  ", want: "spec.containers[0].securityContext"},
+		{name: "keeps inner spaces", input: `$.metadata.labels["team name"]`, want: `metadata.labels["team name"]`},
+		{name: "keeps case", input: "$.Spec.HostPID", want: "Spec.HostPID"},
+		{name: "keeps indices", input: "$.spec.containers[12].image", want: "spec.containers[12].image"},
+		{name: "keeps wildcard", input: "$.spec.containers[*].image", want: "spec.containers[*].image"},
+		{name: "keeps slash syntax", input: "/spec/template/spec/hostPID", want: "/spec/template/spec/hostPID"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, normalizeEvidencePath(test.input))
+		})
+	}
+}
+
+func TestFindingsForControl_ControlGranularity(t *testing.T) {
+	controlKey := key{resourceID: "/v1/default/Pod/demo", controlID: "C-001"}
+	control := failedControlWithRules(
+		"C-001",
+		"Control",
+		failedRule("host-network", evidencePath{FailedPath: "$.spec.hostNetwork"}),
+		failedRule("host-pid", evidencePath{FailedPath: "$.spec.hostPID"}),
+	)
+
+	findings := findingsForControl(controlKey, control, "High", GranularityControl)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, findingFingerprint{
+		resourceID:   "/v1/default/Pod/demo",
+		controlID:    "C-001",
+		evidenceType: evidenceTypeControl,
+	}, findings[0].fingerprint)
+	assert.Equal(t, "Control", findings[0].controlName)
+	assert.Equal(t, "High", findings[0].severity)
+}
+
+func TestFindingsForControl_ExtractsFailedAndReviewPaths(t *testing.T) {
+	controlKey := key{resourceID: "/v1/default/Pod/demo", controlID: "C-002"}
+	control := failedControlWithRules(
+		"C-002",
+		"Workload configuration",
+		failedRule("container-security", evidencePath{
+			ResourceID: "/v1/default/Pod/demo",
+			FailedPath: "$.spec.containers[0].securityContext.privileged",
+			ReviewPath: "$.spec.containers[0].securityContext.capabilities",
+		}),
+	)
+
+	findings := findingsForControl(controlKey, control, "Critical", GranularityEvidence)
+
+	require.Len(t, findings, 2)
+	assert.Equal(t, evidenceTypeFailedPath, findings[0].fingerprint.evidenceType)
+	assert.Equal(t, "spec.containers[0].securityContext.privileged", findings[0].fingerprint.path)
+	assert.Equal(t, "container-security", findings[0].fingerprint.ruleName)
+	assert.Equal(t, "/v1/default/Pod/demo", findings[0].fingerprint.evidenceResourceID)
+	assert.Equal(t, evidenceTypeReviewPath, findings[1].fingerprint.evidenceType)
+	assert.Equal(t, "spec.containers[0].securityContext.capabilities", findings[1].fingerprint.path)
+}
+
+func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
+	controlKey := key{resourceID: "/v1/default/Pod/demo", controlID: "C-010"}
+	control := failedControlWithRules(
+		"C-010",
+		"Workload configuration",
+		failedRule("container-security", evidencePath{
+			ResourceID: "/v1/default/Pod/demo",
+			FailedPath: "$.spec.containers[0].securityContext.privileged",
+			ReviewPath: "$.spec.containers[0].securityContext.capabilities",
+			DeletePath: "$.spec.hostNetwork",
+			FixPath:    fixPath{Path: "$.spec.securityContext.runAsNonRoot", Value: []byte("true")},
+			FixCommand: "kubectl patch deployment demo",
+		}),
+	)
+
+	findings := findingsForControl(controlKey, control, "Critical", GranularityEvidence)
+
+	require.Len(t, findings, 5)
+	assert.ElementsMatch(t, []findingFingerprint{
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFailedPath, path: "spec.containers[0].securityContext.privileged", evidenceResourceID: "/v1/default/Pod/demo"},
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeReviewPath, path: "spec.containers[0].securityContext.capabilities", evidenceResourceID: "/v1/default/Pod/demo"},
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeDeletePath, path: "spec.hostNetwork", evidenceResourceID: "/v1/default/Pod/demo"},
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFixPath, path: "spec.securityContext.runAsNonRoot", evidenceResourceID: "/v1/default/Pod/demo"},
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFixCommand, path: "kubectl patch deployment demo", evidenceResourceID: "/v1/default/Pod/demo"},
+	}, []findingFingerprint{
+		findings[0].fingerprint,
+		findings[1].fingerprint,
+		findings[2].fingerprint,
+		findings[3].fingerprint,
+		findings[4].fingerprint,
+	})
+}
+
+func TestFindingsForControl_PathlessFailedRuleUsesRuleFingerprint(t *testing.T) {
+	controlKey := key{resourceID: "apps/v1/default/Deployment/api", controlID: "C-003"}
+	control := failedControlWithRules(
+		"C-003",
+		"Pathless rule control",
+		failedRule("image-vulnerability"),
+	)
+
+	findings := findingsForControl(controlKey, control, "Medium", GranularityEvidence)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, findingFingerprint{
+		resourceID:   "apps/v1/default/Deployment/api",
+		controlID:    "C-003",
+		ruleName:     "image-vulnerability",
+		evidenceType: evidenceTypeRule,
+	}, findings[0].fingerprint)
+}
+
+func TestFindingsForControl_EmptyPathsUseRuleFingerprint(t *testing.T) {
+	controlKey := key{resourceID: "resource", controlID: "C-004"}
+	control := failedControlWithRules(
+		"C-004",
+		"Control",
+		failedRule("empty-paths",
+			evidencePath{},
+			evidencePath{FailedPath: "   ", ReviewPath: "$"},
+		),
+	)
+
+	findings := findingsForControl(controlKey, control, "Low", GranularityEvidence)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, evidenceTypeRule, findings[0].fingerprint.evidenceType)
+	assert.Equal(t, "empty-paths", findings[0].fingerprint.ruleName)
+}
+
+func TestFindingsForControl_IgnoresNonFailedRules(t *testing.T) {
+	statuses := []string{"passed", "skipped", "excluded", "irrelevant", "error"}
+	rules := make([]ruleEntry, 0, len(statuses))
+	for _, status := range statuses {
+		rules = append(rules, ruleEntry{
+			Name:   "rule-" + status,
+			Status: status,
+			Paths:  []evidencePath{{FailedPath: "$.spec." + status}},
+		})
+	}
+	controlKey := key{resourceID: "resource", controlID: "C-005"}
+	control := failedControlWithRules("C-005", "Control", rules...)
+
+	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, evidenceTypeControl, findings[0].fingerprint.evidenceType)
+}
+
+func TestFindingsForControl_MixedRuleStatuses(t *testing.T) {
+	controlKey := key{resourceID: "resource", controlID: "C-006"}
+	control := failedControlWithRules(
+		"C-006",
+		"Control",
+		passedRule("passing", evidencePath{FailedPath: "$.ignored"}),
+		failedRule("failing", evidencePath{FailedPath: "$.included"}),
+		ruleEntry{Name: "skipped", Status: "skipped", Paths: []evidencePath{{FailedPath: "$.alsoIgnored"}}},
+	)
+
+	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "failing", findings[0].fingerprint.ruleName)
+	assert.Equal(t, "included", findings[0].fingerprint.path)
+}
+
+func TestFindingsForControl_DeduplicatesIdenticalEvidence(t *testing.T) {
+	controlKey := key{resourceID: "resource", controlID: "C-007"}
+	control := failedControlWithRules(
+		"C-007",
+		"Control",
+		failedRule("duplicate",
+			evidencePath{ResourceID: "resource", FailedPath: "$.spec.hostPID"},
+			evidencePath{ResourceID: "resource", FailedPath: ".spec.hostPID"},
+			evidencePath{ResourceID: "resource", FailedPath: " spec.hostPID "},
+		),
+	)
+
+	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "spec.hostPID", findings[0].fingerprint.path)
+}
+
+func TestFindingsForControl_DoesNotMergeDistinctEvidence(t *testing.T) {
+	controlKey := key{resourceID: "resource", controlID: "C-008"}
+	control := failedControlWithRules(
+		"C-008",
+		"Control",
+		failedRule("rule-a", evidencePath{ResourceID: "child-a", FailedPath: "$.spec.hostPID"}),
+		failedRule("rule-b", evidencePath{ResourceID: "child-a", FailedPath: "$.spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-b", FailedPath: "$.spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-a", ReviewPath: "$.spec.hostPID"}),
+	)
+
+	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
+
+	require.Len(t, findings, 4)
+	assert.ElementsMatch(t, []findingFingerprint{
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-b"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-b", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+	}, []findingFingerprint{
+		findings[0].fingerprint,
+		findings[1].fingerprint,
+		findings[2].fingerprint,
+		findings[3].fingerprint,
+	})
+}
+
+func TestFindingChangeCopiesEvidenceFields(t *testing.T) {
+	item := finding{
+		fingerprint: findingFingerprint{
+			resourceID:         "resource",
+			controlID:          "C-009",
+			ruleName:           "rule",
+			evidenceType:       evidenceTypeFailedPath,
+			path:               "spec.hostIPC",
+			evidenceResourceID: "related-resource",
+		},
+		controlName: "Control name",
+		severity:    "Critical",
+	}
+
+	change := item.change("failed", "failed", "comparison reason")
+
+	assert.Equal(t, "resource", change.ResourceID)
+	assert.Equal(t, "C-009", change.ControlID)
+	assert.Equal(t, "Control name", change.ControlName)
+	assert.Equal(t, "Critical", change.Severity)
+	assert.Equal(t, "failed", change.BaseStatus)
+	assert.Equal(t, "failed", change.HeadStatus)
+	assert.Equal(t, "rule", change.RuleName)
+	assert.Equal(t, evidenceTypeFailedPath, change.EvidenceType)
+	assert.Equal(t, "spec.hostIPC", change.Path)
+	assert.Equal(t, "related-resource", change.EvidenceResourceID)
+	assert.Equal(t, "comparison reason", change.Reason)
+}
+
+func TestEvidenceDetailMismatch(t *testing.T) {
+	aggregate := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeControl}}}
+	detailed := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeRule}}}
+	paths := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeFailedPath}}}
+
+	assert.False(t, evidenceDetailMismatch(aggregate, aggregate))
+	assert.False(t, evidenceDetailMismatch(detailed, detailed))
+	assert.True(t, evidenceDetailMismatch(detailed, paths))
+	assert.True(t, evidenceDetailMismatch(aggregate, detailed))
+	assert.True(t, evidenceDetailMismatch(paths, aggregate))
+}
+
+func TestDeduplicateFindingsUsesFullFingerprint(t *testing.T) {
+	base := finding{
+		fingerprint: findingFingerprint{
+			resourceID:         "resource",
+			controlID:          "control",
+			ruleName:           "rule",
+			evidenceType:       evidenceTypeFailedPath,
+			path:               "path",
+			evidenceResourceID: "evidence-resource",
+		},
+	}
+	duplicate := base
+	differentControl := base
+	differentControl.fingerprint.controlID = "other-control"
+	differentPath := base
+	differentPath.fingerprint.path = "other-path"
+
+	result := deduplicateFindings([]finding{base, duplicate, differentControl, differentPath})
+
+	assert.Len(t, result, 3)
+}

--- a/core/pkg/resultshandling/diff/printer.go
+++ b/core/pkg/resultshandling/diff/printer.go
@@ -11,6 +11,11 @@ import (
 
 // PrintPretty writes a human-readable diff summary to w.
 func PrintPretty(w io.Writer, cs *ChangeSet) error {
+	for _, warning := range cs.Warnings {
+		if _, err := fmt.Fprintf(w, "WARNING: %s\n", warning); err != nil {
+			return err
+		}
+	}
 	if err := printSection(w, "New failures", cs.New, "+"); err != nil {
 		return err
 	}
@@ -22,9 +27,14 @@ func PrintPretty(w io.Writer, cs *ChangeSet) error {
 			return err
 		}
 	}
+	if len(cs.Incomparable) > 0 {
+		if err := printSection(w, "Incomparable", cs.Incomparable, "?"); err != nil {
+			return err
+		}
+	}
 
-	_, err := fmt.Fprintf(w, "\nSummary: %d new, %d resolved, %d unchanged\n",
-		len(cs.New), len(cs.Resolved), len(cs.Unchanged))
+	_, err := fmt.Fprintf(w, "\nSummary: %d new, %d resolved, %d unchanged, %d incomparable\n",
+		len(cs.New), len(cs.Resolved), len(cs.Unchanged), len(cs.Incomparable))
 	return err
 }
 
@@ -39,6 +49,34 @@ func printSection(w io.Writer, title string, changes []ControlChange, prefix str
 		if _, err := fmt.Fprintf(w, "%s [%s] %s (%s)\n    Resource: %s\n",
 			prefix, c.Severity, c.ControlName, c.ControlID, c.ResourceID); err != nil {
 			return err
+		}
+		if c.RuleName != "" {
+			if _, err := fmt.Fprintf(w, "    Rule: %s\n", c.RuleName); err != nil {
+				return err
+			}
+		}
+		if c.EvidenceType != "" && c.EvidenceType != evidenceTypeControl {
+			if _, err := fmt.Fprintf(w, "    Evidence: %s", c.EvidenceType); err != nil {
+				return err
+			}
+			if c.Path != "" {
+				if _, err := fmt.Fprintf(w, " %s", c.Path); err != nil {
+					return err
+				}
+			}
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if c.EvidenceResourceID != "" && c.EvidenceResourceID != c.ResourceID {
+			if _, err := fmt.Fprintf(w, "    Evidence resource: %s\n", c.EvidenceResourceID); err != nil {
+				return err
+			}
+		}
+		if c.Reason != "" {
+			if _, err := fmt.Fprintf(w, "    Reason: %s\n", c.Reason); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/core/pkg/resultshandling/diff/printer_test.go
+++ b/core/pkg/resultshandling/diff/printer_test.go
@@ -1,0 +1,192 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func printableChange() ControlChange {
+	return ControlChange{
+		ResourceID:         "apps/v1/default/Deployment/api",
+		ControlID:          "C-1000",
+		ControlName:        "Require a security context",
+		Severity:           "High",
+		BaseStatus:         "failed",
+		HeadStatus:         "failed",
+		RuleName:           "require-security-context",
+		EvidenceType:       evidenceTypeFailedPath,
+		Path:               "spec.template.spec.containers[0].securityContext.privileged",
+		EvidenceResourceID: "apps/v1/default/Pod/api-abc",
+	}
+}
+
+func TestPrintPretty_PrintsEvidenceAndAllBuckets(t *testing.T) {
+	newChange := printableChange()
+	resolvedChange := printableChange()
+	resolvedChange.Path = "spec.template.spec.hostPID"
+	unchangedChange := printableChange()
+	unchangedChange.Path = "spec.template.spec.hostIPC"
+	incomparableChange := printableChange()
+	incomparableChange.Path = "spec.template.spec.hostNetwork"
+	incomparableChange.Reason = "head scan coverage was degraded"
+	changes := &ChangeSet{
+		New:          []ControlChange{newChange},
+		Resolved:     []ControlChange{resolvedChange},
+		Unchanged:    []ControlChange{unchangedChange},
+		Incomparable: []ControlChange{incomparableChange},
+		Warnings:     []string{"included namespaces differ"},
+	}
+
+	var output bytes.Buffer
+	PrintPretty(&output, changes)
+	actual := output.String()
+
+	assert.Contains(t, actual, "WARNING: included namespaces differ")
+	assert.Contains(t, actual, "New failures (1)")
+	assert.Contains(t, actual, "Resolved (1)")
+	assert.Contains(t, actual, "Still failing (unchanged) (1)")
+	assert.Contains(t, actual, "Incomparable (1)")
+	assert.Contains(t, actual, "+ [High] Require a security context (C-1000)")
+	assert.Contains(t, actual, "Resource: apps/v1/default/Deployment/api")
+	assert.Contains(t, actual, "Rule: require-security-context")
+	assert.Contains(t, actual, "Evidence: failedPath spec.template.spec.containers[0].securityContext.privileged")
+	assert.Contains(t, actual, "Evidence resource: apps/v1/default/Pod/api-abc")
+	assert.Contains(t, actual, "Reason: head scan coverage was degraded")
+	assert.Contains(t, actual, "Summary: 1 new, 1 resolved, 1 unchanged, 1 incomparable")
+}
+
+func TestPrintPretty_OmitsEmptySectionsAndEvidenceDetails(t *testing.T) {
+	changes := &ChangeSet{
+		New: []ControlChange{{
+			ResourceID:   "resource",
+			ControlID:    "C-0001",
+			ControlName:  "Legacy control",
+			Severity:     "Low",
+			BaseStatus:   "passed",
+			HeadStatus:   "failed",
+			EvidenceType: evidenceTypeControl,
+		}},
+	}
+
+	var output bytes.Buffer
+	PrintPretty(&output, changes)
+	actual := output.String()
+
+	assert.Contains(t, actual, "New failures (1)")
+	assert.NotContains(t, actual, "Resolved (")
+	assert.NotContains(t, actual, "Still failing")
+	assert.NotContains(t, actual, "Incomparable (")
+	assert.NotContains(t, actual, "Rule:")
+	assert.NotContains(t, actual, "Evidence:")
+	assert.NotContains(t, actual, "Evidence resource:")
+	assert.NotContains(t, actual, "Reason:")
+	assert.Contains(t, actual, "Summary: 1 new, 0 resolved, 0 unchanged, 0 incomparable")
+}
+
+func TestPrintPretty_SameEvidenceResourceIsNotRepeated(t *testing.T) {
+	change := printableChange()
+	change.EvidenceResourceID = change.ResourceID
+
+	var output bytes.Buffer
+	PrintPretty(&output, &ChangeSet{New: []ControlChange{change}})
+
+	assert.NotContains(t, output.String(), "Evidence resource:")
+}
+
+func TestPrintPretty_PathlessRuleEvidence(t *testing.T) {
+	change := printableChange()
+	change.EvidenceType = evidenceTypeRule
+	change.Path = ""
+	change.EvidenceResourceID = ""
+
+	var output bytes.Buffer
+	PrintPretty(&output, &ChangeSet{New: []ControlChange{change}})
+
+	assert.Contains(t, output.String(), "Rule: require-security-context")
+	assert.Contains(t, output.String(), "Evidence: rule\n")
+}
+
+func TestPrintJSON_PreservesEvidenceSchema(t *testing.T) {
+	change := printableChange()
+	changes := &ChangeSet{
+		New:          []ControlChange{change},
+		Resolved:     []ControlChange{},
+		Unchanged:    []ControlChange{},
+		Incomparable: []ControlChange{{Reason: "unsafe comparison"}},
+		Warnings:     []string{"scope differs"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, PrintJSON(&output, changes))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &decoded))
+	require.Contains(t, decoded, "new")
+	require.Contains(t, decoded, "resolved")
+	require.Contains(t, decoded, "unchanged")
+	require.Contains(t, decoded, "incomparable")
+	require.Contains(t, decoded, "warnings")
+	newItems, ok := decoded["new"].([]any)
+	require.True(t, ok)
+	require.Len(t, newItems, 1)
+	item, ok := newItems[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "require-security-context", item["ruleName"])
+	assert.Equal(t, "failedPath", item["evidenceType"])
+	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", item["path"])
+	assert.Equal(t, "apps/v1/default/Pod/api-abc", item["evidenceResourceID"])
+}
+
+func TestPrintJSON_OmitsOptionalCompatibilityFields(t *testing.T) {
+	changes := &ChangeSet{
+		New:       []ControlChange{{ResourceID: "resource", ControlID: "control"}},
+		Resolved:  []ControlChange{},
+		Unchanged: []ControlChange{},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, PrintJSON(&output, changes))
+	actual := output.String()
+
+	assert.NotContains(t, actual, `"incomparable"`)
+	assert.NotContains(t, actual, `"warnings"`)
+	assert.NotContains(t, actual, `"ruleName"`)
+	assert.NotContains(t, actual, `"evidenceType"`)
+	assert.NotContains(t, actual, `"path"`)
+	assert.NotContains(t, actual, `"evidenceResourceID"`)
+	assert.NotContains(t, actual, `"reason"`)
+}
+
+func TestPrintYAML_PreservesNewBucketsAndEvidence(t *testing.T) {
+	change := printableChange()
+	changes := &ChangeSet{
+		New:          []ControlChange{change},
+		Resolved:     []ControlChange{},
+		Unchanged:    []ControlChange{},
+		Incomparable: []ControlChange{{Reason: "not evaluated"}},
+		Warnings:     []string{"coverage degraded"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, PrintYAML(&output, changes))
+	actual := output.String()
+
+	assert.Contains(t, actual, "ruleName: require-security-context")
+	assert.Contains(t, actual, "evidenceType: failedPath")
+	assert.Contains(t, actual, "path: spec.template.spec.containers[0].securityContext.privileged")
+	assert.Contains(t, actual, "incomparable:")
+	assert.Contains(t, actual, "reason: not evaluated")
+	assert.Contains(t, actual, "warnings:")
+	assert.Contains(t, actual, "- coverage degraded")
+
+	var decoded map[string]any
+	require.NoError(t, yaml.Unmarshal(output.Bytes(), &decoded))
+	assert.Contains(t, decoded, "new")
+	assert.Contains(t, decoded, "incomparable")
+	assert.Contains(t, decoded, "warnings")
+}

--- a/core/pkg/resultshandling/diff/report.go
+++ b/core/pkg/resultshandling/diff/report.go
@@ -1,0 +1,360 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+)
+
+// These intentionally small report types parse only fields that affect diff
+// identity, severity, scope, and evaluation completeness. Unknown fields from
+// newer Kubescape versions remain forward compatible.
+type scanReport struct {
+	Results        []resultEntry  `json:"results"`
+	SummaryDetails summaryDetails `json:"summaryDetails"`
+	Metadata       reportMetadata `json:"metadata,omitempty"`
+	ScanCoverage   scanCoverage   `json:"scanCoverage,omitempty"`
+}
+
+type resultEntry struct {
+	ResourceID         string         `json:"resourceID"`
+	AssociatedControls []controlEntry `json:"controls"`
+}
+
+type controlEntry struct {
+	ControlID string      `json:"controlID"`
+	Name      string      `json:"name"`
+	Status    statusInfo  `json:"status"`
+	Rules     []ruleEntry `json:"rules,omitempty"`
+}
+
+type statusInfo struct {
+	InnerStatus string `json:"status"`
+	SubStatus   string `json:"subStatus,omitempty"`
+}
+
+type ruleEntry struct {
+	Name                string         `json:"name"`
+	Status              string         `json:"status"`
+	SubStatus           string         `json:"subStatus,omitempty"`
+	Paths               []evidencePath `json:"paths,omitempty"`
+	RelatedResourcesIDs []string       `json:"relatedResourcesIDs,omitempty"`
+}
+
+type evidencePath struct {
+	ResourceID string  `json:"resourceID,omitempty"`
+	FailedPath string  `json:"failedPath,omitempty"`
+	ReviewPath string  `json:"reviewPath,omitempty"`
+	DeletePath string  `json:"deletePath,omitempty"`
+	FixPath    fixPath `json:"fixPath,omitempty"`
+	FixCommand string  `json:"fixCommand,omitempty"`
+}
+
+type fixPath struct {
+	Path  string          `json:"path,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+type summaryDetails struct {
+	Controls map[string]controlSummary `json:"controls"`
+}
+
+type controlSummary struct {
+	ScoreFactor float32 `json:"scoreFactor"`
+	Severity    string  `json:"severity"`
+}
+
+type reportMetadata struct {
+	TargetMetadata contextMetadata `json:"targetMetadata,omitempty"`
+	ScanMetadata   scanMetadata    `json:"scanMetadata,omitempty"`
+}
+
+type contextMetadata struct {
+	Cluster *clusterContext `json:"clusterContextMetadata,omitempty"`
+	Repo    *repoContext    `json:"gitRepoContextMetadata,omitempty"`
+}
+
+type clusterContext struct {
+	ContextName string `json:"contextName,omitempty"`
+}
+
+type repoContext struct {
+	Provider  string `json:"provider,omitempty"`
+	Repo      string `json:"repo,omitempty"`
+	Owner     string `json:"owner,omitempty"`
+	RemoteURL string `json:"remoteURL,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+}
+
+type scanMetadata struct {
+	TargetType         string   `json:"targetType,omitempty"`
+	ScanningTarget     *uint16  `json:"scanningTarget,omitempty"`
+	IncludeNamespaces  []string `json:"includeNamespaces,omitempty"`
+	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty"`
+	TargetNames        []string `json:"targetNames,omitempty"`
+}
+
+type scanCoverage struct {
+	FailedGVRPulls       []json.RawMessage     `json:"failedGVRPulls,omitempty"`
+	PartialGVRPulls      []json.RawMessage     `json:"partialGVRPulls,omitempty"`
+	PolicyDegradations   []json.RawMessage     `json:"policyDegradations,omitempty"`
+	NotEvaluatedControls []notEvaluatedControl `json:"notEvaluatedControls,omitempty"`
+	Degraded             bool                  `json:"degraded,omitempty"`
+}
+
+type notEvaluatedControl struct {
+	ControlID string `json:"controlID"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+func loadReport(path string) (*scanReport, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("invalid report: expected a JSON object")
+	}
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if topLevel == nil {
+		return nil, fmt.Errorf("invalid report: expected a JSON object")
+	}
+
+	resultsJSON, exists := topLevel["results"]
+	if !exists {
+		return nil, fmt.Errorf("invalid report: missing required results field; provide JSON output from kubescape scan")
+	}
+	if isJSONNull(resultsJSON) {
+		return nil, fmt.Errorf("invalid report: results must be an array, not null")
+	}
+	summaryJSON, exists := topLevel["summaryDetails"]
+	if !exists {
+		return nil, fmt.Errorf("invalid report: missing required summaryDetails field; provide JSON output from kubescape scan")
+	}
+	if isJSONNull(summaryJSON) {
+		return nil, fmt.Errorf("invalid report: summaryDetails must be an object, not null")
+	}
+
+	var report scanReport
+	if err := json.Unmarshal(resultsJSON, &report.Results); err != nil {
+		return nil, fmt.Errorf("invalid report results: %w", err)
+	}
+	if err := validateSummary(&report, summaryJSON); err != nil {
+		return nil, err
+	}
+	if metadataJSON, exists := topLevel["metadata"]; exists && !isJSONNull(metadataJSON) {
+		if err := json.Unmarshal(metadataJSON, &report.Metadata); err != nil {
+			return nil, fmt.Errorf("invalid report metadata: %w", err)
+		}
+	}
+	if coverageJSON, exists := topLevel["scanCoverage"]; exists && !isJSONNull(coverageJSON) {
+		if err := json.Unmarshal(coverageJSON, &report.ScanCoverage); err != nil {
+			return nil, fmt.Errorf("invalid report scanCoverage: %w", err)
+		}
+	}
+	if err := validateReport(&report); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+func validateSummary(report *scanReport, summaryJSON json.RawMessage) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(summaryJSON, &fields); err != nil {
+		return fmt.Errorf("invalid report summaryDetails: %w", err)
+	}
+	if fields == nil {
+		return fmt.Errorf("invalid report: summaryDetails must be an object")
+	}
+	controlsJSON, exists := fields["controls"]
+	if !exists {
+		return fmt.Errorf("invalid report: summaryDetails is missing required controls field")
+	}
+	if isJSONNull(controlsJSON) {
+		return fmt.Errorf("invalid report: summaryDetails.controls must be an object, not null")
+	}
+	var controls map[string]controlSummary
+	if err := json.Unmarshal(controlsJSON, &controls); err != nil {
+		return fmt.Errorf("invalid report summaryDetails.controls: %w", err)
+	}
+	report.SummaryDetails.Controls = controls
+	return nil
+}
+
+func validateReport(report *scanReport) error {
+	seen := make(map[key]struct{})
+	for resultIndex, result := range report.Results {
+		if strings.TrimSpace(result.ResourceID) == "" {
+			return fmt.Errorf("invalid report: results[%d].resourceID is empty", resultIndex)
+		}
+		for controlIndex, control := range result.AssociatedControls {
+			if strings.TrimSpace(control.ControlID) == "" {
+				return fmt.Errorf("invalid report: results[%d].controls[%d].controlID is empty", resultIndex, controlIndex)
+			}
+			if strings.TrimSpace(control.Status.InnerStatus) == "" {
+				return fmt.Errorf("invalid report: results[%d].controls[%d].status.status is empty", resultIndex, controlIndex)
+			}
+			controlKey := key{resourceID: result.ResourceID, controlID: control.ControlID}
+			if _, exists := seen[controlKey]; exists {
+				return fmt.Errorf("invalid report: duplicate resource and control pair %q / %q", result.ResourceID, control.ControlID)
+			}
+			seen[controlKey] = struct{}{}
+			for ruleIndex, rule := range control.Rules {
+				if strings.TrimSpace(rule.Name) == "" {
+					return fmt.Errorf("invalid report: results[%d].controls[%d].rules[%d].name is empty", resultIndex, controlIndex, ruleIndex)
+				}
+				if strings.TrimSpace(rule.Status) == "" {
+					return fmt.Errorf("invalid report: results[%d].controls[%d].rules[%d].status is empty", resultIndex, controlIndex, ruleIndex)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func buildMap(report *scanReport) map[key]controlEntry {
+	controls := make(map[key]controlEntry)
+	for _, result := range report.Results {
+		for _, control := range result.AssociatedControls {
+			controls[key{resourceID: result.ResourceID, controlID: control.ControlID}] = control
+		}
+	}
+	return controls
+}
+
+func buildSeverityMap(report *scanReport) map[string]string {
+	severities := make(map[string]string, len(report.SummaryDetails.Controls))
+	for controlID, summary := range report.SummaryDetails.Controls {
+		severity := summary.Severity
+		if severity == "" {
+			severity = apis.ControlSeverityToString(summary.ScoreFactor)
+		}
+		severities[controlID] = severity
+	}
+	return severities
+}
+
+func incompatibleScopeReasons(base, head *scanReport) []string {
+	reasons := make([]string, 0)
+	baseScan, headScan := base.Metadata.ScanMetadata, head.Metadata.ScanMetadata
+	if differentNonEmpty(baseScan.TargetType, headScan.TargetType) {
+		reasons = append(reasons, fmt.Sprintf("scan target types differ: base=%q head=%q", baseScan.TargetType, headScan.TargetType))
+	}
+	if baseScan.ScanningTarget != nil && headScan.ScanningTarget != nil && *baseScan.ScanningTarget != *headScan.ScanningTarget {
+		reasons = append(reasons, fmt.Sprintf("scanning targets differ: base=%d head=%d", *baseScan.ScanningTarget, *headScan.ScanningTarget))
+	}
+	compareStringSet(&reasons, "included namespaces", baseScan.IncludeNamespaces, headScan.IncludeNamespaces)
+	compareStringSet(&reasons, "excluded namespaces", baseScan.ExcludedNamespaces, headScan.ExcludedNamespaces)
+	compareStringSet(&reasons, "target names", baseScan.TargetNames, headScan.TargetNames)
+
+	baseContext, headContext := base.Metadata.TargetMetadata, head.Metadata.TargetMetadata
+	if baseContext.Cluster != nil && headContext.Cluster != nil && differentNonEmpty(baseContext.Cluster.ContextName, headContext.Cluster.ContextName) {
+		reasons = append(reasons, fmt.Sprintf("cluster contexts differ: base=%q head=%q", baseContext.Cluster.ContextName, headContext.Cluster.ContextName))
+	}
+	if baseContext.Repo != nil && headContext.Repo != nil {
+		baseIdentity, headIdentity := repositoryIdentity(baseContext.Repo), repositoryIdentity(headContext.Repo)
+		if differentNonEmpty(baseIdentity, headIdentity) {
+			reasons = append(reasons, fmt.Sprintf("repository identities differ: base=%q head=%q", baseIdentity, headIdentity))
+		}
+	}
+	return reasons
+}
+
+func differentNonEmpty(left, right string) bool {
+	return strings.TrimSpace(left) != "" && strings.TrimSpace(right) != "" && strings.TrimSpace(left) != strings.TrimSpace(right)
+}
+
+func compareStringSet(reasons *[]string, label string, left, right []string) {
+	if len(left) == 0 && len(right) == 0 {
+		return
+	}
+	leftCanonical, rightCanonical := canonicalSet(left), canonicalSet(right)
+	if strings.Join(leftCanonical, "\x00") != strings.Join(rightCanonical, "\x00") {
+		*reasons = append(*reasons, fmt.Sprintf("%s differ: base=%v head=%v", label, leftCanonical, rightCanonical))
+	}
+}
+
+func canonicalSet(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func repositoryIdentity(repo *repoContext) string {
+	if repo == nil {
+		return ""
+	}
+	if repo.Owner != "" || repo.Repo != "" {
+		return strings.Trim(strings.ToLower(strings.TrimSpace(repo.Provider)+"/"+strings.TrimSpace(repo.Owner)+"/"+strings.TrimSpace(repo.Repo)), "/")
+	}
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(repo.RemoteURL)), ".git")
+}
+
+func controlDefinitelyOutOfScope(report *scanReport, controlID string) bool {
+	return len(report.SummaryDetails.Controls) > 0 && !summaryContainsControl(report, controlID)
+}
+
+func absentNewFailureRisk(report *scanReport, controlID string) string {
+	for _, control := range report.ScanCoverage.NotEvaluatedControls {
+		if control.ControlID == controlID {
+			return "control was not evaluated in the base report, so the head failure cannot be classified as new"
+		}
+	}
+	coverage := report.ScanCoverage
+	if coverage.Degraded || len(coverage.FailedGVRPulls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0 {
+		return "base report has degraded scan coverage, so the head failure cannot be classified as new"
+	}
+	return ""
+}
+
+func summaryContainsControl(report *scanReport, controlID string) bool {
+	_, exists := report.SummaryDetails.Controls[controlID]
+	return exists
+}
+
+func absentResolutionRisk(report *scanReport, controlID string) string {
+	if controlDefinitelyOutOfScope(report, controlID) {
+		return "control is not present in the head report's declared control scope"
+	}
+	for _, control := range report.ScanCoverage.NotEvaluatedControls {
+		if control.ControlID == controlID {
+			return "control was not evaluated in the head report"
+		}
+	}
+	coverage := report.ScanCoverage
+	if coverage.Degraded || len(coverage.FailedGVRPulls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0 {
+		return "head report has degraded scan coverage, so an absent failure is not a conclusive resolution"
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

This PR makes `kubescape diff` compare failed evidence rather than only resource/control aggregate status.

Previously, if a resource/control pair was already failing in both the base and head reports, newly introduced failed paths, review paths, fix paths, fix commands, or failed rules could be hidden under the unchanged aggregate control result. That can produce a false-green PR gate: the control was already failed, but the head report still introduced a new concrete regression.

The diff now defaults to evidence-level comparison and keeps the previous aggregate behavior available through `--granularity control`.

## What changed

- Adds evidence fingerprints for failed rules and rule paths.
- Detects new, resolved, unchanged, and incomparable evidence inside already-failing controls.
- Marks unsafe comparisons as `incomparable` when scan scope or evidence detail differs.
- Adds `--granularity evidence|control` to the diff command.
- Preserves JSON/YAML compatibility while adding optional evidence fields.
- Extends pretty output with rule/evidence details and incomparable reasons.
- Adds focused regression coverage for path-level, rule-level, aggregate fallback, severity filtering, scope mismatch, and output behavior.

## Why this matters

CI users rely on `kubescape diff --fail-on-new` to block only newly introduced posture regressions. Aggregate comparison can miss regressions when a control was already failed before the change. Evidence-level comparison closes that gap and makes the default safer for PR workflows.

This also lays the groundwork for future CI-native diff artifacts such as SARIF, JUnit, GitLab SAST, and Markdown regression reports. See #3376.

## Testing

```bash
go test ./core/pkg/resultshandling/diff ./cmd/diff ./core/core
git diff --check upstream/master...HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Diff comparisons now default to evidence-level detail, with control-level comparison available through `--granularity control`.
  - Results identify added, resolved, unchanged, and incomparable findings with expanded evidence details.
  - Diff output includes warnings, reasons, evidence paths, rule names, and resource identifiers where available.
- **Bug Fixes**
  - Comparisons now safely flag results as incomparable when scan scope or evidence coverage differs.
  - `--fail-on-new` also detects qualifying incomparable failures.
- **Validation**
  - Invalid granularity values are rejected before comparison begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->