### PR TITLE
test(httphandler): skip directory permission test on Windows

### DIFF
--- a/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
@@ -86,6 +87,9 @@ func TestWriteScanErrorToFile(t *testing.T) {
 // exercise the MkdirAll call - t.TempDir() itself always exists, so this
 // nests one level under it.
 func TestWriteScanErrorToFile_CreatesDirectoryWithRestrictivePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping directory permission test on Windows")
+	}
 	nested := filepath.Join(t.TempDir(), "failed")
 	oldFailedOutputDir := FailedOutputDir
 	FailedOutputDir = nested


### PR DESCRIPTION
## Overview
This PR fixes a cross-platform test failure on Windows for `TestWriteScanErrorToFile_CreatesDirectoryWithRestrictivePermissions` in the `httphandler/handlerequests/v1` package. 

Currently, Windows NTFS filesystems do not natively support strict Unix-style permission bits (like `0750`). As a result, `os.MkdirAll` creates the directory, but the subsequent permission check fails on Windows machines, throwing a `more permissive than 0750` error. This PR skips this specific permission check when `runtime.GOOS == "windows"` to allow local testing and cross-platform CI to pass successfully, while preserving the strict security check for Unix/Linux environments.

## Additional Information

> This fix specifically targets the `requestshandlerutils_extra_test.go` suite to unblock contributors testing locally on Windows and to satisfy the cross-platform GitHub Actions build CI.

## How to Test

> 1. Pull this branch to a Windows machine.
> 2. Run `go test ./...` in the `httphandler/handlerequests/v1` package.
> 3. Verify that `TestWriteScanErrorToFile_CreatesDirectoryWithRestrictivePermissions` is safely skipped and the overall test suite passes instead of failing on the permission assertion.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the directory-permission regression test to skip on Windows, where permission behavior differs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->