### PR TITLE
fix(reportcrypto): derive the report master key with Argon2id

### DIFF
--- a/cmd/decrypt/decrypt.go
+++ b/cmd/decrypt/decrypt.go
@@ -9,10 +9,9 @@ import (
 )
 
 var decryptCmdExamples = `
-  # The key is used as raw bytes and must be exactly 32 characters long.
-  # Note: openssl rand -base64 32 (44 chars) and openssl rand -hex 32 (64 chars)
-  # are NOT valid because they exceed 32 bytes when passed as raw text.
-  export KUBESCAPE_MASTER_KEY="01234567890123456789012345678901"
+  # Supply the same passphrase that encrypted the report. Hex-encoded key
+  # material goes in KUBESCAPE_MASTER_KEY_HEX instead.
+  export KUBESCAPE_MASTER_KEY="$(cat master-key.txt)"
 
   # Decrypt an encrypted report
   kubescape decrypt encrypted-report.json
@@ -26,7 +25,8 @@ func GetDecryptCommand() *cobra.Command {
 		Use:          "decrypt <report.json>",
 		Short:        "Decrypt a report produced by kubescape scan --encrypt",
 		SilenceUsage: true,
-		Long: `Decrypt all encrypted report fields using KUBESCAPE_MASTER_KEY.
+		Long: `Decrypt all encrypted report fields using KUBESCAPE_MASTER_KEY
+(or KUBESCAPE_MASTER_KEY_HEX).
 
 The command restores metadata, resources, result raw resources, resource
 labels, and resource ID references. The decrypted report is written to

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -39,10 +39,12 @@ var scanCmdExamples = fmt.Sprintf(`
   # Generate an anonymized report
   %[1]s scan --hide --format json -o report.json
 
-  # The key is used as raw bytes and must be exactly 32 characters long.
-  # Note: openssl rand -base64 32 (44 chars) and openssl rand -hex 32 (64 chars)
-  # are NOT valid — they exceed 32 bytes once passed through as raw text.
-  export KUBESCAPE_MASTER_KEY="01234567890123456789012345678901"
+  # The key is a passphrase of at least 16 characters. It is stretched into an
+  # AES-256 key with Argon2id under a per-report salt, so length is what buys
+  # you security here — prefer a long passphrase or generated key material.
+  export KUBESCAPE_MASTER_KEY="$(openssl rand -base64 32)"
+  # Hex-encoded key material works too, via a separate variable:
+  # export KUBESCAPE_MASTER_KEY_HEX="$(openssl rand -hex 32)"
   %[1]s scan --encrypt --format json -o encrypted-report.json
 
   # Decrypt an encrypted report

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -65,7 +65,7 @@ func ApplyEncrypted(
 	encryptionMetadata := &reporthandlingv2.EncryptionMetadata{
 		Version:      "v1",
 		DEKAlgorithm: "AES256_GCM",
-		KEKAlgorithm: "AES256_GCM",
+		KEKAlgorithm: reportcrypto.KEKAlgorithm,
 		EncryptedDEK: wrappedDEK,
 	}
 

--- a/core/pkg/anonymizer/anonymizer_test.go
+++ b/core/pkg/anonymizer/anonymizer_test.go
@@ -69,7 +69,7 @@ func TestApplyEncrypted(t *testing.T) {
 
 	assert.Equal(t, "v1", metadata.Version)
 	assert.Equal(t, "AES256_GCM", metadata.DEKAlgorithm)
-	assert.Equal(t, "AES256_GCM", metadata.KEKAlgorithm)
+	assert.Equal(t, "ARGON2ID_AES256_GCM", metadata.KEKAlgorithm)
 	assert.NotEmpty(t, metadata.EncryptedDEK)
 
 	unwrappedDEK, err := reportcrypto.UnwrapDEK(

--- a/core/pkg/reportcrypto/crypto.go
+++ b/core/pkg/reportcrypto/crypto.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 )
 
@@ -132,46 +131,4 @@ func DecryptString(ciphertext string, dek []byte) (string, error) {
 	}
 
 	return string(plaintext), nil
-}
-
-// ValidateMasterKey validates that a master key is suitable
-// for wrapping and unwrapping DEKs.
-func ValidateMasterKey(masterKey []byte) error {
-	if len(masterKey) != dekSize {
-		return fmt.Errorf(
-			"invalid master key length: got %d, want %d",
-			len(masterKey),
-			dekSize,
-		)
-	}
-
-	return nil
-}
-
-// GetMasterKeyFromEnv loads and validates the master key
-// from the KUBESCAPE_MASTER_KEY environment variable.
-func GetMasterKeyFromEnv(operation string) ([]byte, error) {
-
-	masterKey := os.Getenv(
-		"KUBESCAPE_MASTER_KEY",
-	)
-
-	if masterKey == "" {
-		return nil, fmt.Errorf(
-			"%s requires KUBESCAPE_MASTER_KEY to be configured",
-			operation,
-		)
-	}
-
-	keyBytes := []byte(masterKey)
-
-	if err := ValidateMasterKey(
-		keyBytes,
-	); err != nil {
-		return nil, fmt.Errorf(
-			"invalid KUBESCAPE_MASTER_KEY configuration",
-		)
-	}
-
-	return keyBytes, nil
 }

--- a/core/pkg/reportcrypto/dek.go
+++ b/core/pkg/reportcrypto/dek.go
@@ -2,11 +2,18 @@ package reportcrypto
 
 import (
 	"encoding/base64"
+	"fmt"
+	"strings"
 )
 
-// WrapDEK encrypts a DEK using the provided master key
-// and returns a base64-encoded encrypted representation
-// suitable for storing in report metadata.
+// WrapDEK encrypts a DEK using a key-encryption key derived from the supplied
+// master secret and returns an envelope suitable for storing in report
+// metadata.
+//
+// The master secret is stretched with Argon2id under a salt unique to this
+// envelope; the work factors and salt are stored alongside the ciphertext so
+// the envelope is self-describing and the factors can be raised in a later
+// release without stranding existing reports.
 func WrapDEK(dek []byte, masterKey []byte) (string, error) {
 
 	if err := ValidateDEK(dek); err != nil {
@@ -17,28 +24,50 @@ func WrapDEK(dek []byte, masterKey []byte) (string, error) {
 		return "", err
 	}
 
+	params, err := newKEKParams()
+	if err != nil {
+		return "", err
+	}
+
+	kek, err := deriveKEK(masterKey, params)
+	if err != nil {
+		return "", err
+	}
+	defer zeroBytes(kek)
+
 	encryptedDEK, err := EncryptString(
 		base64.StdEncoding.EncodeToString(dek),
-		masterKey,
+		kek,
 	)
 	if err != nil {
 		return "", err
 	}
 
-	return encryptedDEK, nil
+	return formatKEKCiphertext(params, encryptedDEK)
 }
 
-// UnwrapDEK decrypts a wrapped DEK using the provided
-// master key and returns the original DEK bytes.
+// UnwrapDEK decrypts a wrapped DEK using the supplied master secret and returns
+// the original DEK bytes.
+//
+// Both envelope formats are accepted. Envelopes written before key derivation
+// was introduced carry no salt and used the master secret as the AES key
+// directly, so they still require exactly dekSize bytes; reports produced by
+// those releases stay readable.
 func UnwrapDEK(wrappedDEK string, masterKey []byte) ([]byte, error) {
 
 	if err := ValidateMasterKey(masterKey); err != nil {
 		return nil, err
 	}
 
+	kek, envelope, err := resolveKEK(wrappedDEK, masterKey)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroBytes(kek)
+
 	dekString, err := DecryptString(
-		wrappedDEK,
-		masterKey,
+		envelope,
+		kek,
 	)
 	if err != nil {
 		return nil, err
@@ -56,4 +85,40 @@ func UnwrapDEK(wrappedDEK string, masterKey []byte) ([]byte, error) {
 	}
 
 	return dek, nil
+}
+
+// resolveKEK returns the AES key that decrypts wrappedDEK together with the
+// inner ENC[AES256_GCM,...] envelope DecryptString consumes.
+//
+// Current envelopes carry their own salt and work factors, so the key is
+// derived. Legacy envelopes carry neither and used the master secret as the AES
+// key directly, so it is passed through after the length check that the old
+// ValidateMasterKey used to perform.
+//
+// The returned key is always a copy, so callers can zero it unconditionally
+// without clobbering the caller's master secret.
+func resolveKEK(wrappedDEK string, masterKey []byte) ([]byte, string, error) {
+	if !strings.HasPrefix(wrappedDEK, kekPrefix) {
+		if err := ValidateDEK(masterKey); err != nil {
+			return nil, "", fmt.Errorf(
+				"this report predates master key derivation and needs the original %d-byte master key: %w",
+				dekSize,
+				err,
+			)
+		}
+
+		return append([]byte(nil), masterKey...), wrappedDEK, nil
+	}
+
+	params, inner, err := parseKEKCiphertext(wrappedDEK)
+	if err != nil {
+		return nil, "", err
+	}
+
+	kek, err := deriveKEK(masterKey, params)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return kek, inner, nil
 }

--- a/core/pkg/reportcrypto/dek_test.go
+++ b/core/pkg/reportcrypto/dek_test.go
@@ -77,7 +77,7 @@ func TestWrapDEKInvalidMasterKey(t *testing.T) {
 
 	wrappedDEK, err := WrapDEK(
 		dek,
-		[]byte("invalid-master-key"),
+		[]byte("too-short"),
 	)
 
 	assert.Error(t, err)
@@ -113,7 +113,7 @@ func TestUnwrapDEKInvalidMasterKey(t *testing.T) {
 
 	unwrappedDEK, err := UnwrapDEK(
 		wrappedDEK,
-		[]byte("invalid-master-key"),
+		[]byte("too-short"),
 	)
 
 	assert.Error(t, err)

--- a/core/pkg/reportcrypto/masterkey.go
+++ b/core/pkg/reportcrypto/masterkey.go
@@ -1,0 +1,356 @@
+package reportcrypto
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	masterKeyEnvVar    = "KUBESCAPE_MASTER_KEY"
+	masterKeyHexEnvVar = "KUBESCAPE_MASTER_KEY_HEX"
+
+	// minMasterKeySize is the shortest master secret accepted. The previous
+	// implementation required exactly 32 bytes and fed them to AES-256
+	// unchanged, so users supplied 32 typed characters of printable ASCII —
+	// well under 256 bits of entropy — as a raw key. The secret is now stretched
+	// with Argon2id instead, which is what makes a human-chosen passphrase
+	// viable. Widening the floor to 16 cannot break an existing configuration:
+	// every previously valid key was exactly 32 bytes and is still accepted.
+	minMasterKeySize = 16
+
+	// kekPrefix opens the envelope produced by WrapDEK. It is deliberately
+	// distinct from prefix so that a wrapped DEK is never mistaken for a
+	// DEK-encrypted field, and so that report.go's leftover-ciphertext scan
+	// (which matches on prefix) keeps meaning exactly what it meant before.
+	kekPrefix   = "ENC[ARGON2ID_AES256_GCM,"
+	kekVersion  = "v1"
+	kekSaltSize = 16
+
+	// KEKAlgorithm is recorded in EncryptionMetadata.kekAlgorithm so a report
+	// states how its data key is protected rather than implying bare AES.
+	KEKAlgorithm = "ARGON2ID_AES256_GCM"
+)
+
+// Argon2id work factors for newly written envelopes, following the second
+// recommended option of RFC 9106 (64 MiB, 3 passes, 4 lanes). That is the
+// memory-constrained profile, chosen because this code also runs inside CI
+// containers and in-cluster components with tight limits. The factors are
+// written into every envelope, so they can be raised later without making
+// already-encrypted reports undecryptable.
+const (
+	argon2Time      uint32 = 3
+	argon2MemoryKiB uint32 = 64 * 1024
+	argon2Threads   uint8  = 4
+)
+
+// Upper bounds applied to work factors read back out of an envelope. A report
+// is untrusted input: without these a crafted header could request terabytes of
+// memory and turn `kubescape decrypt` into a denial of service against whoever
+// opens the file. The lower bounds also keep argon2.IDKey out of its panic
+// range (memory < 8*threads, time < 1).
+const (
+	maxArgon2Time      uint32 = 16
+	maxArgon2MemoryKiB uint32 = 1024 * 1024 // 1 GiB
+	maxArgon2Threads   uint8  = 16
+)
+
+var (
+	ErrMasterKeyNotConfigured = errors.New("master key is not configured")
+	ErrMasterKeyAmbiguous     = errors.New("both " + masterKeyEnvVar + " and " + masterKeyHexEnvVar + " are set")
+	ErrInvalidKEKEnvelope     = errors.New("invalid wrapped DEK envelope")
+)
+
+// ValidateMasterKey validates that a master secret is long enough to be
+// stretched into a key-encryption key.
+//
+// This checks the secret supplied by the operator, not the AES key derived from
+// it: deriveKEK always emits exactly dekSize bytes regardless of input length.
+func ValidateMasterKey(masterKey []byte) error {
+	if len(masterKey) < minMasterKeySize {
+		return fmt.Errorf(
+			"invalid master key length: got %d, want at least %d",
+			len(masterKey),
+			minMasterKeySize,
+		)
+	}
+
+	return nil
+}
+
+// GetMasterKeyFromEnv loads and validates the master secret from the
+// environment.
+//
+// KUBESCAPE_MASTER_KEY holds a passphrase of any length at or above
+// minMasterKeySize. KUBESCAPE_MASTER_KEY_HEX holds the same secret
+// hex-encoded, which is what `openssl rand -hex 32` produces and is the way to
+// supply full-entropy key material without pushing raw bytes through the
+// environment. Both are stretched identically; the hex form is an encoding
+// choice, not a way to skip the KDF.
+func GetMasterKeyFromEnv(operation string) ([]byte, error) {
+
+	masterKey := os.Getenv(masterKeyEnvVar)
+	masterKeyHex := os.Getenv(masterKeyHexEnvVar)
+
+	if masterKey != "" && masterKeyHex != "" {
+		return nil, fmt.Errorf(
+			"%s cannot proceed: %w, set exactly one",
+			operation,
+			ErrMasterKeyAmbiguous,
+		)
+	}
+
+	var keyBytes []byte
+
+	switch {
+	case masterKeyHex != "":
+		decoded, err := hex.DecodeString(strings.TrimSpace(masterKeyHex))
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid %s configuration: value is not valid hex",
+				masterKeyHexEnvVar,
+			)
+		}
+		keyBytes = decoded
+
+	case masterKey != "":
+		keyBytes = []byte(masterKey)
+
+	default:
+		return nil, fmt.Errorf(
+			"%s requires %s or %s to be configured",
+			operation,
+			masterKeyEnvVar,
+			masterKeyHexEnvVar,
+		)
+	}
+
+	if err := ValidateMasterKey(keyBytes); err != nil {
+		zeroBytes(keyBytes)
+
+		envVar := masterKeyEnvVar
+		if masterKeyHex != "" {
+			envVar = masterKeyHexEnvVar
+		}
+
+		return nil, fmt.Errorf("invalid %s configuration: %w", envVar, err)
+	}
+
+	return keyBytes, nil
+}
+
+// kekParams describes the Argon2id work factors and salt of one envelope.
+type kekParams struct {
+	time      uint32
+	memoryKiB uint32
+	threads   uint8
+	salt      []byte
+}
+
+// newKEKParams builds the parameters for a freshly wrapped DEK, with a salt
+// unique to this report so that two reports protected by the same passphrase
+// never share a key-encryption key.
+func newKEKParams() (kekParams, error) {
+	salt := make([]byte, kekSaltSize)
+
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return kekParams{}, err
+	}
+
+	return kekParams{
+		time:      argon2Time,
+		memoryKiB: argon2MemoryKiB,
+		threads:   argon2Threads,
+		salt:      salt,
+	}, nil
+}
+
+// validate rejects work factors outside the supported range before they reach
+// argon2.IDKey, which panics on some of them and would happily allocate on the
+// rest.
+func (p kekParams) validate() error {
+	if p.time < 1 || p.time > maxArgon2Time {
+		return fmt.Errorf(
+			"%w: unsupported argon2 time cost %d",
+			ErrInvalidKEKEnvelope,
+			p.time,
+		)
+	}
+
+	if p.threads < 1 || p.threads > maxArgon2Threads {
+		return fmt.Errorf(
+			"%w: unsupported argon2 parallelism %d",
+			ErrInvalidKEKEnvelope,
+			p.threads,
+		)
+	}
+
+	if p.memoryKiB > maxArgon2MemoryKiB || p.memoryKiB < 8*uint32(p.threads) {
+		return fmt.Errorf(
+			"%w: unsupported argon2 memory cost %d KiB",
+			ErrInvalidKEKEnvelope,
+			p.memoryKiB,
+		)
+	}
+
+	if len(p.salt) < kekSaltSize {
+		return fmt.Errorf(
+			"%w: argon2 salt is %d bytes, want at least %d",
+			ErrInvalidKEKEnvelope,
+			len(p.salt),
+			kekSaltSize,
+		)
+	}
+
+	return nil
+}
+
+// deriveKEK stretches a master secret into an AES-256 key-encryption key.
+//
+// The caller owns the returned key and should zero it once the wrap or unwrap
+// completes.
+func deriveKEK(masterKey []byte, params kekParams) ([]byte, error) {
+	if err := ValidateMasterKey(masterKey); err != nil {
+		return nil, err
+	}
+
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	return argon2.IDKey(
+		masterKey,
+		params.salt,
+		params.time,
+		params.memoryKiB,
+		params.threads,
+		dekSize,
+	), nil
+}
+
+// formatKEKCiphertext wraps an inner ENC[AES256_GCM,...] envelope in the header
+// that records how its key was derived.
+//
+// The inner envelope is reused verbatim rather than resealed so that the DEK is
+// encrypted by exactly the same primitive as every other field in the report,
+// with one implementation to audit.
+func formatKEKCiphertext(params kekParams, inner string) (string, error) {
+	payload, err := ciphertextPayload(inner)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(
+		"%s%s,%d,%d,%d,%s,%s%s",
+		kekPrefix,
+		kekVersion,
+		params.time,
+		params.memoryKiB,
+		params.threads,
+		base64.StdEncoding.EncodeToString(params.salt),
+		payload,
+		suffix,
+	), nil
+}
+
+// parseKEKCiphertext splits an envelope into its work factors and the inner
+// ENC[AES256_GCM,...] envelope that DecryptString understands.
+func parseKEKCiphertext(ciphertext string) (kekParams, string, error) {
+	if !strings.HasPrefix(ciphertext, kekPrefix) ||
+		!strings.HasSuffix(ciphertext, suffix) {
+		return kekParams{}, "", ErrInvalidKEKEnvelope
+	}
+
+	payload := strings.TrimSuffix(
+		strings.TrimPrefix(ciphertext, kekPrefix),
+		suffix,
+	)
+
+	// version, time, memory, threads, salt, nonce, ciphertext
+	parts := strings.Split(payload, ",")
+	if len(parts) != 7 {
+		return kekParams{}, "", fmt.Errorf(
+			"%w: got %d fields, want 7",
+			ErrInvalidKEKEnvelope,
+			len(parts),
+		)
+	}
+
+	if parts[0] != kekVersion {
+		return kekParams{}, "", fmt.Errorf(
+			"%w: unsupported envelope version %q",
+			ErrInvalidKEKEnvelope,
+			parts[0],
+		)
+	}
+
+	timeCost, err := parseUint32Field(parts[1], "argon2 time cost")
+	if err != nil {
+		return kekParams{}, "", err
+	}
+
+	memoryCost, err := parseUint32Field(parts[2], "argon2 memory cost")
+	if err != nil {
+		return kekParams{}, "", err
+	}
+
+	threads, err := parseUint32Field(parts[3], "argon2 parallelism")
+	if err != nil {
+		return kekParams{}, "", err
+	}
+	if threads > uint32(maxArgon2Threads) {
+		return kekParams{}, "", fmt.Errorf(
+			"%w: unsupported argon2 parallelism %d",
+			ErrInvalidKEKEnvelope,
+			threads,
+		)
+	}
+
+	salt, err := base64.StdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return kekParams{}, "", fmt.Errorf(
+			"%w: salt is not valid base64",
+			ErrInvalidKEKEnvelope,
+		)
+	}
+
+	params := kekParams{
+		time:      timeCost,
+		memoryKiB: memoryCost,
+		threads:   uint8(threads),
+		salt:      salt,
+	}
+
+	return params, formatCiphertext(parts[5], parts[6]), nil
+}
+
+func parseUint32Field(value string, name string) (uint32, error) {
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s is not a number", ErrInvalidKEKEnvelope, name)
+	}
+
+	return uint32(parsed), nil
+}
+
+// ciphertextPayload returns the "<nonce>,<ciphertext>" body of an envelope
+// produced by EncryptString.
+func ciphertextPayload(ciphertext string) (string, error) {
+	if !strings.HasPrefix(ciphertext, prefix) ||
+		!strings.HasSuffix(ciphertext, suffix) {
+		return "", errors.New("invalid ciphertext format")
+	}
+
+	return strings.TrimSuffix(
+		strings.TrimPrefix(ciphertext, prefix),
+		suffix,
+	), nil
+}

--- a/core/pkg/reportcrypto/masterkey_test.go
+++ b/core/pkg/reportcrypto/masterkey_test.go
@@ -1,0 +1,314 @@
+package reportcrypto
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyWrapDEK reproduces the pre-derivation wrapping scheme: the master key
+// was used as the AES key with no stretching and no salt. It exists so the
+// backward-compatibility tests exercise a real legacy envelope rather than one
+// this package can still produce.
+func legacyWrapDEK(t *testing.T, dek []byte, masterKey []byte) string {
+	t.Helper()
+
+	wrapped, err := EncryptString(
+		base64.StdEncoding.EncodeToString(dek),
+		masterKey,
+	)
+	require.NoError(t, err)
+
+	return wrapped
+}
+
+// TestWrapDEKDerivesKeyFromMasterSecret is the regression test for the bug:
+// the master secret must never be used as the AES key directly.
+//
+// Deliberately written against the exported API only, so it compiles against
+// the pre-fix implementation too and genuinely fails there: that version passed
+// the 32 bytes of KUBESCAPE_MASTER_KEY straight to aes.NewCipher, which made
+// DecryptString(wrapped, masterKey) succeed.
+func TestWrapDEKDerivesKeyFromMasterSecret(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey := []byte("01234567890123456789012345678901")
+
+	wrapped, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	_, err = DecryptString(wrapped, masterKey)
+	assert.Error(
+		t,
+		err,
+		"master secret must not double as the AES key that protects the DEK",
+	)
+
+	unwrapped, err := UnwrapDEK(wrapped, masterKey)
+	require.NoError(t, err)
+	assert.Equal(t, dek, unwrapped)
+}
+
+// TestWrapDEKEnvelopeAnnouncesDerivation checks the envelope header separately,
+// using package internals, so a future change cannot keep the test above green
+// by switching to some other undeclared scheme.
+func TestWrapDEKEnvelopeAnnouncesDerivation(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrapped, err := WrapDEK(dek, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+
+	require.True(
+		t,
+		strings.HasPrefix(wrapped, kekPrefix),
+		"wrapped DEK must carry the Argon2id envelope, got %q",
+		wrapped,
+	)
+
+	_, inner, err := parseKEKCiphertext(wrapped)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(inner, prefix))
+}
+
+// TestWrapDEKUsesUniqueSaltPerEnvelope guards the property that makes the KDF
+// worth having: two reports protected by the same passphrase must not share a
+// key-encryption key, so a precomputed attack against one buys nothing against
+// the other.
+func TestWrapDEKUsesUniqueSaltPerEnvelope(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey := []byte("a-sufficiently-long-passphrase")
+
+	first, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	second, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	firstParams, _, err := parseKEKCiphertext(first)
+	require.NoError(t, err)
+
+	secondParams, _, err := parseKEKCiphertext(second)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, firstParams.salt, secondParams.salt)
+	assert.Len(t, firstParams.salt, kekSaltSize)
+}
+
+// TestWrapDEKAcceptsPassphrasesOfAnyLength covers the usability half of the
+// bug: requiring exactly 32 bytes is what pushed users toward typed ASCII.
+// `openssl rand -base64 32` and `-hex 32` were both rejected before the fix.
+func TestWrapDEKAcceptsPassphrasesOfAnyLength(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		masterKey string
+	}{
+		{"minimum length", "0123456789abcdef"},
+		{"legacy exact 32 bytes", "01234567890123456789012345678901"},
+		{"openssl rand -base64 32", "3q2+7wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},
+		{"openssl rand -hex 32", strings.Repeat("ab", 32)},
+		{"long passphrase", strings.Repeat("correct horse battery staple ", 8)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped, err := WrapDEK(dek, []byte(tt.masterKey))
+			require.NoError(t, err)
+
+			unwrapped, err := UnwrapDEK(wrapped, []byte(tt.masterKey))
+			require.NoError(t, err)
+			assert.Equal(t, dek, unwrapped)
+		})
+	}
+}
+
+func TestWrapDEKRejectsShortMasterSecret(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	_, err = WrapDEK(dek, []byte(strings.Repeat("x", minMasterKeySize-1)))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid master key length")
+}
+
+// TestUnwrapDEKReadsLegacyEnvelope keeps reports written before this change
+// readable. A regression here silently strands every already-encrypted report.
+func TestUnwrapDEKReadsLegacyEnvelope(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey := []byte("01234567890123456789012345678901")
+	legacy := legacyWrapDEK(t, dek, masterKey)
+
+	require.True(t, strings.HasPrefix(legacy, prefix))
+	require.False(t, strings.HasPrefix(legacy, kekPrefix))
+
+	unwrapped, err := UnwrapDEK(legacy, masterKey)
+	require.NoError(t, err)
+	assert.Equal(t, dek, unwrapped)
+}
+
+func TestUnwrapDEKLegacyEnvelopeStillRequiresExactKeyLength(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	legacy := legacyWrapDEK(t, dek, []byte("01234567890123456789012345678901"))
+
+	// Long enough for the derivation path, wrong size for a legacy raw key.
+	_, err = UnwrapDEK(legacy, []byte("0123456789abcdefghij"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "predates master key derivation")
+}
+
+// TestUnwrapDEKRejectsHostileWorkFactors covers the denial-of-service surface
+// the envelope introduces: work factors are read from an attacker-controlled
+// report, so an unbounded memory cost would let a crafted file exhaust the
+// memory of whoever runs `kubescape decrypt`.
+func TestUnwrapDEKRejectsHostileWorkFactors(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey := []byte("a-sufficiently-long-passphrase")
+
+	wrapped, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	_, inner, err := parseKEKCiphertext(wrapped)
+	require.NoError(t, err)
+
+	payload, err := ciphertextPayload(inner)
+	require.NoError(t, err)
+
+	salt := base64.StdEncoding.EncodeToString(make([]byte, kekSaltSize))
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"memory cost beyond the cap", "v1,3,4294967295,4"},
+		{"time cost beyond the cap", "v1,999,65536,4"},
+		{"parallelism beyond the cap", "v1,3,65536,255"},
+		{"memory below argon2 minimum", "v1,3,1,4"},
+		{"zero time cost", "v1,0,65536,4"},
+		{"unsupported version", "v2,3,65536,4"},
+		{"non-numeric memory cost", "v1,3,lots,4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostile := kekPrefix + tt.header + "," + salt + "," + payload + suffix
+
+			unwrapped, err := UnwrapDEK(hostile, masterKey)
+
+			require.Error(t, err)
+			assert.Nil(t, unwrapped)
+		})
+	}
+}
+
+func TestUnwrapDEKRejectsMalformedEnvelope(t *testing.T) {
+	masterKey := []byte("a-sufficiently-long-passphrase")
+
+	tests := []struct {
+		name    string
+		wrapped string
+	}{
+		{"too few fields", kekPrefix + "v1,3,65536,4]"},
+		{"bad salt encoding", kekPrefix + "v1,3,65536,4,not-base64!!,bm9uY2U=,Y3Q=]"},
+		{"missing terminator", kekPrefix + "v1,3,65536,4,c2FsdA==,bm9uY2U=,Y3Q="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := UnwrapDEK(tt.wrapped, masterKey)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestGetMasterKeyFromEnv(t *testing.T) {
+	t.Run("passphrase", func(t *testing.T) {
+		t.Setenv(masterKeyEnvVar, "a-sufficiently-long-passphrase")
+
+		key, err := GetMasterKeyFromEnv("encryption")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("a-sufficiently-long-passphrase"), key)
+	})
+
+	t.Run("hex key material is decoded", func(t *testing.T) {
+		raw := strings.Repeat("ab", 32)
+		t.Setenv(masterKeyHexEnvVar, raw)
+
+		key, err := GetMasterKeyFromEnv("encryption")
+		require.NoError(t, err)
+
+		want, err := hex.DecodeString(raw)
+		require.NoError(t, err)
+		assert.Equal(t, want, key)
+	})
+
+	t.Run("both variables set is ambiguous", func(t *testing.T) {
+		t.Setenv(masterKeyEnvVar, "a-sufficiently-long-passphrase")
+		t.Setenv(masterKeyHexEnvVar, strings.Repeat("ab", 32))
+
+		_, err := GetMasterKeyFromEnv("encryption")
+		require.ErrorIs(t, err, ErrMasterKeyAmbiguous)
+	})
+
+	t.Run("invalid hex is rejected", func(t *testing.T) {
+		t.Setenv(masterKeyHexEnvVar, "nothexatall")
+
+		_, err := GetMasterKeyFromEnv("encryption")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), masterKeyHexEnvVar)
+	})
+
+	t.Run("short secret is rejected", func(t *testing.T) {
+		t.Setenv(masterKeyEnvVar, "short")
+
+		_, err := GetMasterKeyFromEnv("encryption")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid master key length")
+	})
+
+	t.Run("unset reports both variables", func(t *testing.T) {
+		t.Setenv(masterKeyEnvVar, "")
+		t.Setenv(masterKeyHexEnvVar, "")
+
+		_, err := GetMasterKeyFromEnv("decryption")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), masterKeyEnvVar)
+		assert.Contains(t, err.Error(), "decryption")
+	})
+}
+
+// TestEnvelopeReportsCurrentWorkFactors pins the parameters written into new
+// reports. Raising them is a deliberate act: old reports stay readable because
+// each envelope carries its own, but the constants should not drift silently.
+func TestEnvelopeReportsCurrentWorkFactors(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrapped, err := WrapDEK(dek, []byte("a-sufficiently-long-passphrase"))
+	require.NoError(t, err)
+
+	params, _, err := parseKEKCiphertext(wrapped)
+	require.NoError(t, err)
+
+	assert.Equal(t, argon2Time, params.time)
+	assert.Equal(t, argon2MemoryKiB, params.memoryKiB)
+	assert.Equal(t, argon2Threads, params.threads)
+	require.NoError(t, params.validate())
+}

--- a/core/pkg/reportcrypto/report_test.go
+++ b/core/pkg/reportcrypto/report_test.go
@@ -307,7 +307,7 @@ func TestDecryptReportAllowsWrappedDEKToRemain(t *testing.T) {
 	report := decodeTestObject(t, decrypted)
 	metadata := requireTestObject(t, report, "metadata")
 	encryptionMetadata := requireTestObject(t, metadata, "encryptionMetadata")
-	assert.Contains(t, encryptionMetadata["encryptedDEK"], "ENC[AES256_GCM,")
+	assert.Contains(t, encryptionMetadata["encryptedDEK"], kekPrefix)
 }
 
 func TestDecryptEmbeddedCiphertextsHandlesSlashesInsideEnvelopes(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
+	golang.org/x/crypto v0.53.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
@@ -587,7 +588,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/image v0.44.0 // indirect
 	golang.org/x/net v0.56.0 // indirect


### PR DESCRIPTION
## Overview

`KUBESCAPE_MASTER_KEY` was being used as the AES-256 key directly. `GetMasterKeyFromEnv` turned the variable into bytes unchanged, `ValidateMasterKey` demanded exactly 32 of them, and `WrapDEK` passed those bytes to `aes.NewCipher` with nothing in between — no PBKDF2, no scrypt, no Argon2, and no salt.

The "exactly 32 bytes" rule is what made it worse in practice. Our own help text told users that `openssl rand -base64 32` and `-hex 32` were invalid, because both are longer than 32 characters, so the documented way to satisfy the check was to invent a 32-character string by hand. The result: reports encrypted under a low-entropy secret, where a guess costs one AES-GCM operation and one cracked passphrase opens every report that secret ever encrypted.

This derives the KEK from the master secret with Argon2id under a per-report salt.

## Additional Information

**Where the salt lives.** `EncryptionMetadata` is defined in opa-utils and has a hand-written gojay unmarshaller, so adding a `salt` field would mean a second repository *and* a new field in a public output schema. `encryptedDEK` is already an opaque string, so the salt and work factors go inside it instead:

```
ENC[ARGON2ID_AES256_GCM,v1,3,65536,4,BASE64_SALT,BASE64_NONCE,BASE64_CIPHERTEXT]
```

Self-describing and versioned, so the work factors can be raised in a future release without stranding reports encrypted by this one. The inner `ENC[AES256_GCM,...]` envelope is reused verbatim rather than resealed, so the DEK is protected by exactly the same primitive as every other encrypted field and there is one implementation to audit rather than two.

**Work factors.** RFC 9106's second recommended option — 64 MiB, 3 passes, 4 lanes. That is the memory-constrained profile, picked because this also runs in CI containers and memory-capped pods rather than only on a laptop.

**Parameters from a report are untrusted.** Once work factors are read back out of an envelope they are attacker-controlled, and `argon2.IDKey` will allocate whatever it is handed and panics outright on some combinations. A crafted report asking for a terabyte of memory would turn `kubescape decrypt` into a denial of service against whoever opened it. Parsed values are clamped (memory ≤ 1 GiB, time ≤ 16, threads ≤ 16, and argon2's own `memory ≥ 8×threads` floor) before they reach the KDF. `TestUnwrapDEKRejectsHostileWorkFactors` covers seven variants of this.

**Backward compatibility.** Envelopes written before this change carry no salt and used the master key as the AES key. They are detected by prefix and still decrypt under the old rules, so already-encrypted reports stay readable. Verified against a report produced by a binary built from current `master`, not just a synthetic fixture. Forward compatibility is one-way, as you would expect: an older binary cannot read the new envelope.

### Two things reviewers should look at deliberately

**1. `kekAlgorithm` changes value in JSON output** — `AES256_GCM` → `ARGON2ID_AES256_GCM`. This is a schema-visible change. It is not a field rename and nothing is removed, but anyone matching on that value will see something new. It was previously claiming more protection than the code delivered, so leaving it seemed worse than changing it. Flagging it rather than slipping it in.

**2. No way to skip derivation.** #3381 raised whether to offer a raw-32-byte mode for callers whose KMS already produced proper key material. I went with the conservative reading: `KUBESCAPE_MASTER_KEY_HEX` is added purely as an *encoding* for the secret — so `openssl rand -hex 32` finally works — and it is still stretched. There is no code path that reaches AES without passing through Argon2id. Happy to add the escape hatch if you would rather have it; it is a small change from here.

The accepted secret length becomes a floor of 16 rather than an exact 32. That cannot invalidate anyone's existing setup, because every previously valid key was exactly 32 bytes and 32 ≥ 16.

### Tests that changed, and why

Four existing assertions were about the behaviour this PR deliberately changes. I updated them rather than tuning constants to dodge them:

- `dek_test.go` (×2) used `"invalid-master-key"` — 18 bytes — as an example of an invalid key. 18 is now valid, so those use a genuinely short secret instead.
- `anonymizer_test.go` pinned `kekAlgorithm == "AES256_GCM"`, which would now be asserting a false claim.
- `report_test.go` matched the old envelope prefix on the surviving wrapped DEK.

## How to Test

```bash
go test ./core/pkg/reportcrypto/... ./core/pkg/anonymizer/... ./cmd/...
```

The regression test that matters is `TestWrapDEKDerivesKeyFromMasterSecret`. It is written against the exported API only, so it compiles against the pre-fix code too and genuinely fails there — on `master`, `DecryptString(wrapped, masterKey)` succeeds, which is the bug stated as an assertion.

End to end, with a key length that was rejected outright before:

```bash
go build -o kubescape .
export KUBESCAPE_MASTER_KEY="$(openssl rand -base64 32)"     # 44 chars
./kubescape scan --encrypt --keep-local --format json -o enc.json ./examples/online-boutique/frontend.yaml
./kubescape decrypt enc.json > dec.json
```

To confirm old reports still open, build a binary from `master`, encrypt with a 32-character key, then decrypt that file with this branch.

## Examples/Screenshots

Envelope on disk after `--encrypt`:

```console
$ jq -r '.metadata.encryptionMetadata | .kekAlgorithm, .encryptedDEK' enc.json
ARGON2ID_AES256_GCM
ENC[ARGON2ID_AES256_GCM,v1,3,65536,4,w0zC5vB02IEiZGZiYQuXYw==,ZEwPxwWHCU6POTYR,...]
```

Wrong passphrase:

```console
$ KUBESCAPE_MASTER_KEY="a-completely-different-passphrase" ./kubescape decrypt enc.json
Error: failed to decrypt report data key: cipher: message authentication failed
```

A pre-change report, opened with a key of the wrong size:

```console
Error: failed to decrypt report data key: this report predates master key derivation
and needs the original 32-byte master key: invalid DEK length: got 20, want 32
```

Verification run locally, matching the PR workflow: `go test -race ./...` (53 packages, no races), `CGO_ENABLED=1 go test -race ./core/cautils/...`, the `httphandler` module suite, `goreleaser build --clean --snapshot --single-target`, `python3 smoke_testing/init.py`, and `golangci-lint --new-from-rev` against the merge base — 0 new issues. I know the E2E system tests do not run on fork PRs, so the change is covered by unit tests throughout.

## Related issues/PRs

* Resolves #3381

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passphrase-based encryption using Argon2id-derived keys.
  * Added support for plaintext and hex-encoded master-key configuration.
  * Added versioned encryption envelopes with recorded derivation parameters.
  * Preserved compatibility with legacy encrypted data.

* **Bug Fixes**
  * Encryption metadata now accurately identifies the key-encryption algorithm.
  * Added validation and clearer handling for invalid or malformed key configurations and encrypted data.

* **Documentation**
  * Updated encryption and decryption examples for passphrases, file-based secrets, and encoded key material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->