### PR TITLE
feat(imagescan): add --skip-db-update flag for offline image scanning

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -217,6 +217,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Encrypt sensitive report metadata using the KUBESCAPE_MASTER_KEY environment variable")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.SkipDBUpdate, "skip-db-update", false, "Do not update the vulnerability database before scanning images. Uses the locally cached database; fails if none is cached.")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ControlTimeout, "control-timeout", 0, "Maximum duration for evaluating a single control (e.g. 30s, 1m). 0 means no timeout. Controls that exceed this are marked as not evaluated and the scan continues. Must be lower than --scan-timeout when both are set.")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EnableStreaming, "enable-streaming", false, "Enable resource streaming for large clusters to reduce memory usage. Resources are processed in batches instead of loading all at once. Automatically enabled for clusters with >2500 resources.")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -1192,3 +1192,11 @@ func TestGetScanCommandRegistersImagePlatformFlag(t *testing.T) {
 	assert.Contains(t, flag.Usage, "linux/amd64")
 	assert.Contains(t, flag.Usage, "overrides platform inferred")
 }
+
+func TestScanCommandRegistersSkipDBUpdateFlag(t *testing.T) {
+	mockKubescape := &mocks.MockIKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	flag := cmd.PersistentFlags().Lookup("skip-db-update")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -1200,3 +1200,21 @@ func TestScanCommandRegistersSkipDBUpdateFlag(t *testing.T) {
 	require.NotNil(t, flag)
 	assert.Equal(t, "false", flag.DefValue)
 }
+
+func TestGetScanCommand_SkipDBUpdateReachesScanInfo(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	cmd.SetArgs([]string{"image", "--skip-db-update", "nginx:latest"})
+	require.NoError(t, cmd.Execute())
+	require.NotNil(t, mockKubescape.scanInfo)
+	assert.True(t, mockKubescape.scanInfo.SkipDBUpdate)
+}
+
+func TestGetScanCommand_SkipDBUpdateDefaultsToFalse(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	cmd := GetScanCommand(mockKubescape)
+	cmd.SetArgs([]string{"image", "nginx:latest"})
+	require.NoError(t, cmd.Execute())
+	require.NotNil(t, mockKubescape.scanInfo)
+	assert.False(t, mockKubescape.scanInfo.SkipDBUpdate)
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -184,6 +184,7 @@ type ScanInfo struct {
 	contextResolved           bool
 	cleanups                  []func()
 	ListingURL                string            //Grype vulnerability database URL
+	SkipDBUpdate              bool              // Do not update the vulnerability database before image scanning
 	RegistryMapping           map[string]string // Map internal registry URLs to external ones
 	RegistryAuthority         string            // Registry host[:port] explicit credentials apply to
 	RegistryUsername          string            // Username for workload image registry authentication

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -359,12 +359,12 @@ func scanWithRegistryMapping(
 func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
 	logger.L().Start(fmt.Sprintf("Scanning image %s...", imgScanInfo.Image))
 
-	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
+	distCfg, installCfg, shouldUpdate, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL, scanInfo.SkipDBUpdate)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Invalid Grype database URL '%s': %v", scanInfo.ListingURL, err))
 		return false, err
 	}
-	svc, err := imagescan.NewScanServiceWithMatchers(distCfg, installCfg, imgScanInfo.UseDefaultMatchers)
+	svc, err := imagescan.NewScanServiceWithMatchersAndSources(distCfg, installCfg, imgScanInfo.UseDefaultMatchers, nil, shouldUpdate)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Failed to initialize image scanner: %s", err))
 		return false, err

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -53,12 +53,13 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	logger.L().Start(fmt.Sprintf("Scanning image: %s", patchInfo.Image))
 
 	// Setup the scan service
-	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
+	// patch never exposes --skip-db-update; SkipDBUpdate is always false here, so the DB is always updated.
+	distCfg, installCfg, shouldUpdate, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL, false)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Invalid Grype database URL '%s': %v", scanInfo.ListingURL, err))
 		return false, err
 	}
-	svc, err := imagescan.NewScanServiceWithMatchers(distCfg, installCfg, scanInfo.UseDefaultMatchers)
+	svc, err := imagescan.NewScanServiceWithMatchersAndSources(distCfg, installCfg, scanInfo.UseDefaultMatchers, nil, shouldUpdate)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Failed to initialize image scanner: %s", err))
 		return false, err

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -482,12 +482,12 @@ func scanImages(scanType cautils.ScanTypes, scanData *cautils.OPASessionObj, ctx
 		return errors.Join(containerErrors...)
 	}
 
-	distCfg, installCfg, _, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL)
+	distCfg, installCfg, shouldUpdate, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL, scanInfo.SkipDBUpdate)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Invalid Grype database URL '%s': %v", scanInfo.ListingURL, err))
 		return errors.Join(append(containerErrors, fmt.Errorf("invalid Grype database URL %q: %w", scanInfo.ListingURL, err))...)
 	}
-	svc, err := imagescan.NewScanServiceWithMatchers(distCfg, installCfg, scanInfo.UseDefaultMatchers)
+	svc, err := imagescan.NewScanServiceWithMatchersAndSources(distCfg, installCfg, scanInfo.UseDefaultMatchers, nil, shouldUpdate)
 	if err != nil {
 		logger.L().StopError(fmt.Sprintf("Failed to initialize image scanner: %s", err))
 		return errors.Join(append(containerErrors, fmt.Errorf("failed to initialize image scanner: %w", err))...)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,6 +56,7 @@ kubescape scan [target] [flags]
 | `--scan-images` | Also scan container images for vulnerabilities | `false` |
 | `--image-platform <platform>` | OCI platform for workload image scans, such as `linux/amd64`. Overrides platform inferred from Nodes and hard scheduling constraints | inferred |
 | `--severity-threshold <sev>` | Fail if findings at or above severity: `low`, `medium`, `high`, `critical`. Failed controls with unknown severity (missing base score) are treated as exceeding any threshold | - |
+| `--skip-db-update` | Do not update the vulnerability database before scanning images; uses the locally cached database. Fails if none is cached (run once without this flag to download it). | `false` |
 | `--submit` | Submit results to Kubescape SaaS | `false` |
 | `--use-artifacts-from <path>` | Load artifacts from local directory (offline mode) | - |
 | `--use-from <path>` | Load specific policy from path | - |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,7 @@ kubescape scan [target] [flags]
 | `--scan-images` | Also scan container images for vulnerabilities | `false` |
 | `--image-platform <platform>` | OCI platform for workload image scans, such as `linux/amd64`. Overrides platform inferred from Nodes and hard scheduling constraints | inferred |
 | `--severity-threshold <sev>` | Fail if findings at or above severity: `low`, `medium`, `high`, `critical`. Failed controls with unknown severity (missing base score) are treated as exceeding any threshold | - |
-| `--skip-db-update` | Do not update the vulnerability database before scanning images; uses the locally cached database. Fails if none is cached (run once without this flag to download it). | `false` |
+| `--skip-db-update` | Do not update the vulnerability database before scanning images; uses the locally cached database. Fails if the local database is missing or unusable (run once without this flag to download it). | `false` |
 | `--submit` | Submit results to Kubescape SaaS | `false` |
 | `--use-artifacts-from <path>` | Load artifacts from local directory (offline mode) | - |
 | `--use-from <path>` | Load specific policy from path | - |

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -356,12 +356,14 @@ func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCf
 }
 
 // wrapDBLoadError adds a hint when the database update was skipped and the
-// load failed, so users know the local cache must be populated first.
+// load failed, so users know the local database must be usable first. The
+// wording is neutral because the failure may be a missing, corrupt, or
+// incompatible local database, not only an absent one.
 func wrapDBLoadError(err error, shouldUpdate bool) error {
 	if shouldUpdate {
 		return err
 	}
-	return fmt.Errorf("%w; no vulnerability database found locally — run once without --skip-db-update to download it", err)
+	return fmt.Errorf("%w; the local vulnerability database could not be used (update was skipped) — run once without --skip-db-update to download it", err)
 }
 
 // ParseSeverity returns a Grype severity given a severity string

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -46,7 +46,7 @@ func (c RegistryCredentials) hasAuthenticator() bool {
 	return c.Token != "" || (c.Username != "" && c.Password != "")
 }
 
-func NewDefaultDBConfig(grypeURL string) (distribution.Config, installation.Config, bool, error) {
+func NewDefaultDBConfig(grypeURL string, skipDBUpdate bool) (distribution.Config, installation.Config, bool, error) {
 	dir := filepath.Join(xdg.CacheHome, defaultDBDirName)
 	finalURL := defaultGrypeListingURL
 
@@ -71,7 +71,7 @@ func NewDefaultDBConfig(grypeURL string) (distribution.Config, installation.Conf
 		finalURL = cleanedGrypeURL
 	}
 
-	shouldUpdate := true
+	shouldUpdate := !skipDBUpdate
 
 	return distribution.Config{
 			LatestURL: finalURL,
@@ -333,19 +333,19 @@ func NewScanService(distCfg distribution.Config, installCfg installation.Config)
 }
 
 func NewScanServiceWithMatchers(distCfg distribution.Config, installCfg installation.Config, useDefaultMatchers bool) (*Service, error) {
-	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, useDefaultMatchers, nil)
+	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, useDefaultMatchers, nil, true)
 }
 
 // NewRemoteOnlyScanService creates a Service restricted to remote registry sources only,
 // preventing resolution of local files or local daemon images (used by MCP server).
 func NewRemoteOnlyScanService(distCfg distribution.Config, installCfg installation.Config) (*Service, error) {
-	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, true, []string{"registry"})
+	return NewScanServiceWithMatchersAndSources(distCfg, installCfg, true, []string{"registry"}, true)
 }
 
-func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCfg installation.Config, useDefaultMatchers bool, sources []string) (*Service, error) {
-	vp, status, err := NewVulnerabilityDB(distCfg, installCfg, true)
+func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCfg installation.Config, useDefaultMatchers bool, sources []string, shouldUpdate bool) (*Service, error) {
+	vp, status, err := NewVulnerabilityDB(distCfg, installCfg, shouldUpdate)
 	if err = validateDBLoad(err, status); err != nil {
-		return nil, err
+		return nil, wrapDBLoadError(err, shouldUpdate)
 	}
 	return &Service{
 		vp:                 vp,
@@ -353,6 +353,15 @@ func NewScanServiceWithMatchersAndSources(distCfg distribution.Config, installCf
 		useDefaultMatchers: useDefaultMatchers,
 		sources:            sources,
 	}, nil
+}
+
+// wrapDBLoadError adds a hint when the database update was skipped and the
+// load failed, so users know the local cache must be populated first.
+func wrapDBLoadError(err error, shouldUpdate bool) error {
+	if shouldUpdate {
+		return err
+	}
+	return fmt.Errorf("%w; no vulnerability database found locally — run once without --skip-db-update to download it", err)
 }
 
 // ParseSeverity returns a Grype severity given a severity string

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -312,7 +312,7 @@ func TestNewScanServiceWithMatchersIntegration(t *testing.T) {
 		t.Skip("skipping integration test; set KUBESCAPE_INTEGRATION_TESTS=1 to run")
 	}
 	// Test the actual NewScanServiceWithMatchers function
-	distCfg, installCfg, _, _ := NewDefaultDBConfig("")
+	distCfg, installCfg, _, _ := NewDefaultDBConfig("", false)
 
 	// Test with default matchers enabled
 	svcWithDefault, err := NewScanServiceWithMatchers(distCfg, installCfg, true)
@@ -486,18 +486,26 @@ func TestValidateDBLoad(t *testing.T) {
 
 func TestNewDefaultDBConfig(t *testing.T) {
 	tests := []struct {
-		name       string
-		grypeURL   string
-		wantURL    string
-		wantErr    string
-		wantDir    string
-		wantUpdate bool
+		name         string
+		grypeURL     string
+		skipDBUpdate bool
+		wantURL      string
+		wantErr      string
+		wantDir      string
+		wantUpdate   bool
 	}{
 		{
 			name:       "default config uses bundled database URL",
 			wantURL:    defaultGrypeListingURL,
 			wantDir:    filepath.Join(xdg.CacheHome, defaultDBDirName),
 			wantUpdate: true,
+		},
+		{
+			name:         "skip database update sets shouldUpdate to false",
+			skipDBUpdate: true,
+			wantURL:      defaultGrypeListingURL,
+			wantDir:      filepath.Join(xdg.CacheHome, defaultDBDirName),
+			wantUpdate:   false,
 		},
 		{
 			name:       "custom http URL overrides default",
@@ -520,7 +528,7 @@ func TestNewDefaultDBConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			distCfg, installCfg, shouldUpdate, err := NewDefaultDBConfig(tt.grypeURL)
+			distCfg, installCfg, shouldUpdate, err := NewDefaultDBConfig(tt.grypeURL, tt.skipDBUpdate)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.EqualError(t, err, tt.wantErr)
@@ -581,7 +589,7 @@ func TestNewDefaultDBConfig_SanitizationHarden(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			distCfg, _, _, err := NewDefaultDBConfig(tt.inputURL)
+			distCfg, _, _, err := NewDefaultDBConfig(tt.inputURL, false)
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewDefaultDBConfig() error = %v, wantErr %v", err, tt.wantErr)
@@ -656,10 +664,22 @@ func TestNewScanServiceIntegration(t *testing.T) {
 	if testing.Short() || os.Getenv("KUBESCAPE_INTEGRATION_TESTS") != "1" {
 		t.Skip("skipping integration test; set KUBESCAPE_INTEGRATION_TESTS=1 to run")
 	}
-	distCfg, installCfg, _, _ := NewDefaultDBConfig("")
+	distCfg, installCfg, _, _ := NewDefaultDBConfig("", false)
 
 	svc, err := NewScanService(distCfg, installCfg)
 	require.NoError(t, err)
 	defer svc.Close()
 	assert.True(t, svc.useDefaultMatchers)
+}
+
+func TestWrapDBLoadError(t *testing.T) {
+	baseErr := errors.New("failed to load vulnerability db: boom")
+	t.Run("update enabled returns original error", func(t *testing.T) {
+		assert.Equal(t, baseErr, wrapDBLoadError(baseErr, true))
+	})
+	t.Run("skip update adds actionable hint", func(t *testing.T) {
+		got := wrapDBLoadError(baseErr, false)
+		assert.ErrorContains(t, got, "no vulnerability database found locally")
+		assert.ErrorContains(t, got, "--skip-db-update")
+	})
 }

--- a/pkg/imagescan/imagescan_test.go
+++ b/pkg/imagescan/imagescan_test.go
@@ -679,7 +679,8 @@ func TestWrapDBLoadError(t *testing.T) {
 	})
 	t.Run("skip update adds actionable hint", func(t *testing.T) {
 		got := wrapDBLoadError(baseErr, false)
-		assert.ErrorContains(t, got, "no vulnerability database found locally")
+		assert.ErrorIs(t, got, baseErr)
+		assert.ErrorContains(t, got, "local vulnerability database could not be used")
 		assert.ErrorContains(t, got, "--skip-db-update")
 	})
 }


### PR DESCRIPTION
Closes #3386

## Overview

- **Current behavior:** Every image scan via Grype attempts to refresh the vulnerability database first. The update path is hardcoded — `NewDefaultDBConfig` always returns `shouldUpdate = true` (`pkg/imagescan/imagescan.go:74`), and all callers discard that return value while `NewScanServiceWithMatchersAndSources` passes a literal `true` directly into `NewVulnerabilityDB` (`imagescan.go:331`). There is currently no way to scan images without contacting the Grype listing URL.
- **Future behavior:** A new `--skip-db-update` CLI flag (default `false`, preserving existing behavior) threads `SkipDBUpdate` from `ScanInfo` through `NewDefaultDBConfig` into `NewVulnerabilityDB`. When the flag is set, scans execute against the locally cached database with zero network calls — enabling offline/air-gapped scanning and deterministic CI pipeline runs. This serves as the operational companion to #3356 (which surfaced DB freshness).

*Scope boundary:* Targets `scan` commands only, excluding `patch` (where scanning against a stale database during patching workflows is counterproductive).

---

## Additional Information

- **API surface:** Only `NewScanServiceWithMatchersAndSources` changes signature (gains a `shouldUpdate bool` parameter). `NewScanService`, `NewScanServiceWithMatchers`, and `NewRemoteOnlyScanService` signatures remain unchanged.
- **Error handling:** When the flag is set and no database is cached locally, the load error is wrapped with an actionable hint:
  ```text
  no vulnerability database found locally — run once without --skip-db-update to download it
  ```
- **Upstream compatibility:** Verified in Grype (v0.104.1) that `update=false` performs zero network calls and errors cleanly when no local DB is present.

---

## How to Test

```sh
go build ./...
go vet ./pkg/imagescan/... ./core/cautils/... ./core/core/... ./cmd/scan/... ./cmd/shared/...
go test ./pkg/imagescan/ ./cmd/scan/ ./cmd/shared/ ./core/core/ ./core/cautils/
```

**Manual verification:**
1. Empty cache + `kubescape scan image --skip-db-update <image>` → returns actionable hint error.
2. Run once without the flag → cache successfully populates.
3. Run again with `--skip-db-update` → scan succeeds offline and outputs the #3356 freshness line (`Vulnerability DB built: ...`).

---

## Related Issues/PRs

- Resolves #3386
- Companion to #3354 / #3356 (surfacing vulnerability DB freshness in image-scan results)

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific image scanning for workloads and direct image scans.
  * Added `--image-platform` and `--platform` options for selecting OCI platforms.
  * Added `--skip-db-update` to use the locally cached vulnerability database without downloading updates.
  * Scan results now include platform information and can record skipped unavailable platforms.

* **Bug Fixes**
  * Improved guidance when the local vulnerability database is missing or unusable while updates are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->