### PR TITLE
fix(resultshandling): filter per-resource findings by severity, not the unused Report.Results field

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -135,15 +135,13 @@ func (rh *ResultsHandler) GetResults() *reporthandlingv2.PostureReport {
 	return printerv2.FinalizeResults(rh.ScanData)
 }
 
-// reportSnapshot holds the parts of ScanData.Report that ApplySeverityFilters
-// mutates in place, so HandleResults can restore them after printers and
-// submission have run.
+// reportSnapshot holds the parts of ScanData that ApplySeverityFilters mutates
+// in place, so HandleResults can restore them after printers and submission
+// have run.
 type reportSnapshot struct {
 	controls map[string]reportsummary.ControlSummary
-	// Per-result copies of AssociatedControls. The filter uses a [:0] append
-	// which overwrites the backing array, so we must copy the elements before
-	// the filter runs — saving the slice header alone is not enough.
-	associatedControls [][]resourcesresults.ResourceAssociatedControl
+	// Per-resource copies of AssociatedControls, keyed like ScanData.ResourcesResult.
+	associatedControls map[string][]resourcesresults.ResourceAssociatedControl
 }
 
 func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
@@ -157,12 +155,11 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 		controls[k] = v
 	}
 
-	results := sessionObj.Report.Results
-	ac := make([][]resourcesresults.ResourceAssociatedControl, len(results))
-	for i, r := range results {
+	ac := make(map[string][]resourcesresults.ResourceAssociatedControl, len(sessionObj.ResourcesResult))
+	for id, r := range sessionObj.ResourcesResult {
 		copy_ := make([]resourcesresults.ResourceAssociatedControl, len(r.AssociatedControls))
 		copy(copy_, r.AssociatedControls)
-		ac[i] = copy_
+		ac[id] = copy_
 	}
 
 	return reportSnapshot{controls: controls, associatedControls: ac}
@@ -173,9 +170,10 @@ func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
 		return
 	}
 	sessionObj.Report.SummaryDetails.Controls = snap.controls
-	for i := range sessionObj.Report.Results {
-		if i < len(snap.associatedControls) {
-			sessionObj.Report.Results[i].AssociatedControls = snap.associatedControls[i]
+	for id, ac := range snap.associatedControls {
+		if result, ok := sessionObj.ResourcesResult[id]; ok {
+			result.AssociatedControls = ac
+			sessionObj.ResourcesResult[id] = result
 		}
 	}
 }
@@ -188,7 +186,7 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 	}
 
 	// Snapshot both Report.SummaryDetails.Controls and every
-	// Results[i].AssociatedControls before applying severity filters.
+	// ResourcesResult[id].AssociatedControls before applying severity filters.
 	// ApplySeverityFilters mutates both in place; printers and submission see
 	// the narrowed set, but the caller (cmd/scan) evaluates exit thresholds
 	// and coverage counts after HandleResults returns and must see the full

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -912,12 +912,12 @@ func TestHandleResults_RestoresReportAfterSeverityFilter(t *testing.T) {
 					"C-medium": {ControlID: "C-medium", ScoreFactor: 4},
 				},
 			},
-			Results: []resourcesresults.Result{
-				{
-					AssociatedControls: []resourcesresults.ResourceAssociatedControl{
-						{ControlID: "C-low"},
-						{ControlID: "C-high"},
-					},
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"resource-1": {
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{ControlID: "C-low"},
+					{ControlID: "C-high"},
 				},
 			},
 		},
@@ -936,7 +936,7 @@ func TestHandleResults_RestoresReportAfterSeverityFilter(t *testing.T) {
 	// Both Controls and AssociatedControls must be fully restored so that
 	// any caller reading rh.ScanData after HandleResults sees a consistent report.
 	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 3, "Controls must be unfiltered after HandleResults")
-	assert.Len(t, rh.ScanData.Report.Results[0].AssociatedControls, 2, "AssociatedControls must be unfiltered after HandleResults")
+	assert.Len(t, rh.ScanData.ResourcesResult["resource-1"].AssociatedControls, 2, "AssociatedControls must be unfiltered after HandleResults")
 }
 
 func makeFilteredSession() *cautils.OPASessionObj {
@@ -948,12 +948,12 @@ func makeFilteredSession() *cautils.OPASessionObj {
 					"C-high": {ControlID: "C-high", ScoreFactor: 7},
 				},
 			},
-			Results: []resourcesresults.Result{
-				{
-					AssociatedControls: []resourcesresults.ResourceAssociatedControl{
-						{ControlID: "C-low"},
-						{ControlID: "C-high"},
-					},
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"resource-1": {
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{ControlID: "C-low"},
+					{ControlID: "C-high"},
 				},
 			},
 		},
@@ -977,7 +977,7 @@ func TestHandleResults_RestoresReportOnPrinterError(t *testing.T) {
 
 	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 2,
 		"Controls must be restored after printer error")
-	assert.Len(t, rh.ScanData.Report.Results[0].AssociatedControls, 2,
+	assert.Len(t, rh.ScanData.ResourcesResult["resource-1"].AssociatedControls, 2,
 		"AssociatedControls must be restored after printer error")
 }
 
@@ -1012,6 +1012,6 @@ func TestHandleResults_RestoresReportOnSubmitError(t *testing.T) {
 
 	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 2,
 		"Controls must be restored after submit error")
-	assert.Len(t, rh.ScanData.Report.Results[0].AssociatedControls, 2,
+	assert.Len(t, rh.ScanData.ResourcesResult["resource-1"].AssociatedControls, 2,
 		"AssociatedControls must be restored after submit error")
 }

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
 // ApplySeverityFilters removes controls from the OPASessionObj that fall outside the
@@ -35,14 +36,15 @@ func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSev
 		}
 	}
 
-	for i := range sessionObj.Report.Results {
-		ac := sessionObj.Report.Results[i].AssociatedControls[:0]
-		for _, ctrl := range sessionObj.Report.Results[i].AssociatedControls {
+	for id, result := range sessionObj.ResourcesResult {
+		ac := make([]resourcesresults.ResourceAssociatedControl, 0, len(result.AssociatedControls))
+		for _, ctrl := range result.AssociatedControls {
 			if _, ok := retained[ctrl.GetID()]; ok {
 				ac = append(ac, ctrl)
 			}
 		}
-		sessionObj.Report.Results[i].AssociatedControls = ac
+		result.AssociatedControls = ac
+		sessionObj.ResourcesResult[id] = result
 	}
 }
 

--- a/core/pkg/resultshandling/severity_filter_regression_test.go
+++ b/core/pkg/resultshandling/severity_filter_regression_test.go
@@ -1,0 +1,50 @@
+package resultshandling
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplySeverityFilters_FiltersRealPerResourceFindings pins the bug: the scan
+// pipeline never populates Report.Results, so filtering it is a no-op. Findings
+// live in ResourcesResult, which every printer reads (directly or through
+// FinalizeResults), and must be filtered alongside SummaryDetails.Controls.
+func TestApplySeverityFilters_FiltersRealPerResourceFindings(t *testing.T) {
+	s := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"res-1": {
+				ResourceID: "res-1",
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{ControlID: "C-low"},
+					{ControlID: "C-critical"},
+				},
+			},
+		},
+	}
+	s.Report.SummaryDetails.Controls = map[string]reportsummary.ControlSummary{
+		"C-low":      makeControl("C-low", scoreLow),
+		"C-critical": makeControl("C-critical", scoreCritical),
+	}
+
+	// Production shape: the pipeline builds Report.Results only inside FinalizeResults.
+	require.Nil(t, s.Report.Results)
+
+	ApplySeverityFilters(s, "critical", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 1)
+
+	got := s.ResourcesResult["res-1"].AssociatedControls
+	ids := make([]string, 0, len(got))
+	for _, c := range got {
+		ids = append(ids, c.GetID())
+	}
+	assert.Equal(t, []string{"C-critical"}, ids,
+		"per-resource findings must be filtered too, otherwise results reference controls absent from the summary")
+}

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -131,16 +131,16 @@ func TestApplySeverityFilters_ResultsFilteredAlongWithControls(t *testing.T) {
 		"C-high": makeControl("C-high", scoreHigh),
 	}
 	s := makeSessionWithControls(controls)
-	s.Report.Results = []resourcesresults.Result{
-		makeResult("resource-1", "C-low", "C-high"),
-		makeResult("resource-2", "C-low"),
+	s.ResourcesResult = map[string]resourcesresults.Result{
+		"resource-1": makeResult("resource-1", "C-low", "C-high"),
+		"resource-2": makeResult("resource-2", "C-low"),
 	}
 	ApplySeverityFilters(s, "high", "")
 
-	require.Len(t, s.Report.Results, 2)
-	assert.Len(t, s.Report.Results[0].AssociatedControls, 1)
-	assert.Equal(t, "C-high", s.Report.Results[0].AssociatedControls[0].GetID())
-	assert.Len(t, s.Report.Results[1].AssociatedControls, 0)
+	require.Len(t, s.ResourcesResult, 2)
+	assert.Len(t, s.ResourcesResult["resource-1"].AssociatedControls, 1)
+	assert.Equal(t, "C-high", s.ResourcesResult["resource-1"].AssociatedControls[0].GetID())
+	assert.Len(t, s.ResourcesResult["resource-2"].AssociatedControls, 0)
 }
 
 func TestApplySeverityFilters_CaseInsensitive(t *testing.T) {


### PR DESCRIPTION
## Overview

I found that `--min-severity` and `--max-severity` only narrow the summary counts, not the actual findings a scan reports. `ApplySeverityFilters` trims `Report.SummaryDetails.Controls` correctly, but it also tries to filter `Report.Results`:

```go
for i := range sessionObj.Report.Results {
    ac := sessionObj.Report.Results[i].AssociatedControls[:0]
    ...
    sessionObj.Report.Results[i].AssociatedControls = ac
}
```

`Report.Results` is never populated by the scan pipeline. Findings live in `ResourcesResult`, and `Report.Results` is only built later, per printer, inside `FinalizeResults`. So this loop iterates a nil slice and does nothing at runtime.

The result: I can pass `--min-severity critical` and the summary drops everything below critical, but every printer (JSON, YAML, CSV, HTML, pretty table, PolicyReport, submission) still shows the unfiltered findings, referencing control IDs that no longer exist in the trimmed summary.

## Fix

I changed `ApplySeverityFilters` to filter `sessionObj.ResourcesResult` instead, since that is what every printer actually reads. I also updated the snapshot/restore helpers in `HandleResults` to match, so callers reading `rh.ScanData` after the call still see the full, unfiltered report (needed for exit-threshold checks and downstream submission consumers).

I also updated a few existing tests that had hand-populated `Report.Results` directly, since that state never occurs in a real scan.

## Test

I added a regression test that reproduces the real data shape (findings in `ResourcesResult`, `Report.Results` left nil) and asserts the per-resource findings get filtered along with the summary. I confirmed it fails against the old code and passes with the fix, then ran the full `core/pkg/resultshandling` test suite locally.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved severity filtering to consistently remove controls below the selected severity across summaries and individual resource results.
  * Preserved complete control data during processing so downstream reporting and submission workflows retain accurate results.
  * Ensured resource results remain available even when summary results are not initialized.

* **Tests**
  * Added regression coverage for filtering controls across summary and per-resource results.
  * Updated restoration and error-handling scenarios to verify associated controls remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->