### PR TITLE
fix(krew): make .krew.yaml renderable and match published asset names

### DIFF
--- a/.github/workflows/repo-hygiene.yaml
+++ b/.github/workflows/repo-hygiene.yaml
@@ -25,6 +25,12 @@ on:
     # "**.sh" respectively, so a PR touching only one of them runs no check at
     # all. Release signing was absent from .goreleaser.yaml for exactly that
     # reason - nothing was looking.
+    #
+    # .krew.yaml and KREW_RELEASE.md are the same story once more, across two
+    # patterns: the krew plugin template matches "**.yaml" and the document that
+    # embeds a copy of it matches "**.md". Neither was checked, and the template
+    # drifted into a form that could not render at all while its own
+    # documentation drifted into a different one.
     paths:
       - ".github/**"
       - "internal/ghworkflows/**"
@@ -32,6 +38,8 @@ on:
       - ".goreleaser.yaml"
       - "install.sh"
       - "install.ps1"
+      - ".krew.yaml"
+      - "KREW_RELEASE.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,3 +1,17 @@
+{{/*
+krew-release-bot renders this file with a function map holding exactly two
+entries, `indent` and `addURIAndSha` (see pkg/source/template.go upstream).
+There is no sprig, so no trimPrefix, and addURIAndSha takes two arguments: a URL
+- itself a template, over a value carrying only .TagName and no functions - and
+the tag. Anything else has to be computed out here and interpolated with printf.
+
+GoReleaser names archives {{"{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"}},
+and .Version is the tag without its leading "v", so a v4.0.12 release publishes
+kubescape_4.0.12_linux_amd64.tar.gz. The URL path needs the tag; the file name
+needs the trimmed form. 02-release.yaml only fires on v[0-9]+.[0-9]+.[0-9]+, so
+the leading "v" is guaranteed to be there to strip.
+*/}}
+{{- $version := slice .TagName 1 -}}
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
@@ -9,37 +23,37 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_linux_amd64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_linux_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_linux_arm64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_linux_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_darwin_amd64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_darwin_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_darwin_arm64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_darwin_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_windows_amd64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_windows_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    {{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_windows_arm64.tar.gz" .TagName) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_windows_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape.exe
   shortDescription: Scan resources and cluster configs against security frameworks.
   description: |

--- a/KREW_RELEASE.md
+++ b/KREW_RELEASE.md
@@ -90,6 +90,20 @@ This is why we use `skip_upload: true` in GoReleaser and let krew-release-bot ha
 The `.krew.yaml` file in the repository root is a Go template that contains placeholders for dynamic values:
 
 ```yaml
+{{/*
+krew-release-bot renders this file with a function map holding exactly two
+entries, `indent` and `addURIAndSha` (see pkg/source/template.go upstream).
+There is no sprig, so no trimPrefix, and addURIAndSha takes two arguments: a URL
+- itself a template, over a value carrying only .TagName and no functions - and
+the tag. Anything else has to be computed out here and interpolated with printf.
+
+GoReleaser names archives {{"{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"}},
+and .Version is the tag without its leading "v", so a v4.0.12 release publishes
+kubescape_4.0.12_linux_amd64.tar.gz. The URL path needs the tag; the file name
+needs the trimmed form. 02-release.yaml only fires on v[0-9]+.[0-9]+.[0-9]+, so
+the leading "v" is guaranteed to be there to strip.
+*/}}
+{{- $version := slice .TagName 1 -}}
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
@@ -101,37 +115,37 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_linux_amd64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_linux_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_linux_arm64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_linux_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_darwin_amd64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_darwin_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_darwin_arm64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_darwin_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_windows_amd64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_windows_amd64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    {{ $version := trimPrefix "v" .TagName }}{{ addURIAndSha "https://github.com/kubescape/kubescape/releases/download/" .TagName (printf "kubescape_%s_windows_arm64.tar.gz" $version) .TagName }}
+    {{ addURIAndSha (printf "https://github.com/kubescape/kubescape/releases/download/%s/kubescape_%s_windows_arm64.tar.gz" .TagName $version) .TagName }}
     bin: kubescape.exe
   shortDescription: Scan resources and cluster configs against security frameworks.
   description: |
@@ -152,7 +166,12 @@ spec:
     Run 'kubescape scan' to scan your Kubernetes cluster or manifests.
 ```
 
-The `{{ .TagName }}` is replaced with the release tag (e.g., `v3.0.0`), `{{ trimPrefix "v" .TagName }}` removes the version prefix, and `{{ addURIAndSha ... }}` calculates the SHA256 checksum for the binary archive.
+`{{ .TagName }}` is replaced with the release tag (e.g. `v4.0.12`). `{{ addURIAndSha <url> <tag> }}` downloads the asset at `<url>` and emits both the `uri:` and `sha256:` lines for it.
+
+Two constraints are easy to get wrong, and the template carries a comment about both:
+
+- **`addURIAndSha` takes exactly two arguments.** Its first argument is a *single* URL string, which the bot renders as a nested template with only `.TagName` available and no functions at all. Passing the base URL and the file name as separate arguments fails at render time with `wrong number of args for addURIAndSha: want 2 got 4`, so the full URL is assembled with `printf` before it is passed in.
+- **The tag and the file name differ.** GoReleaser names archives `{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}`, and `.Version` is the tag without its leading `v` — so tag `v4.0.12` publishes `kubescape_4.0.12_linux_amd64.tar.gz`. The URL *path* needs the tag; the *file name* needs the trimmed form. The bot's function map is only `indent` and `addURIAndSha`, with no sprig, so there is no `trimPrefix` to call — `{{ $version := slice .TagName 1 }}` does the trimming instead.
 
 ### Release Workflow
 
@@ -168,10 +187,23 @@ When the workflow is triggered:
    - It **runs** when triggered by a tag push OR by `workflow_dispatch` with `skip_publish=false`
    - It **skips** when triggered by `workflow_dispatch` with `skip_publish=true` (default)
 3. When it runs, the bot:
-   - Reads the `.krew.yaml` template
+   - Reads the manifest named by the step's `krew_template_file` input
    - Fills in the template with release information
    - Creates a pull request to the `kubernetes-sigs/krew-index` repository
    - The PR is automatically tested and merged by krew's infrastructure
+
+> **Which file the bot actually reads.** The step sets
+> `krew_template_file: dist/krew/kubescape.yaml`, so the released manifest is the
+> one GoReleaser writes from the `krews:` block in `.goreleaser.yaml` — which is
+> why the published entry in `kubernetes-sigs/krew-index` carries a
+> `# This file was generated by GoReleaser. DO NOT EDIT.` header.
+>
+> `.krew.yaml` is the bot's **default** template path (its `krew_template_file`
+> input is documented as "defaults to .krew.yaml"), so it is kept correct and
+> renderable: dropping that one line from the workflow would silently promote it
+> into the release path. It is also what the `krew-release-bot template` command
+> below renders. `internal/ghworkflows/krew_test.go` asserts it stays renderable
+> and keeps naming the assets GoReleaser actually publishes.
 
 ### Workflow Permissions
 
@@ -204,14 +236,20 @@ These permissions are necessary for GoReleaser to create releases and upload art
 Before committing changes to `.krew.yaml`, you can test how the template will be rendered using Docker:
 
 ```bash
-docker run -v $(pwd)/.krew.yaml:/tmp/.krew.yaml ghcr.io/rajatjindal/krew-release-bot:v0.0.47 \
-  krew-release-bot template --tag v3.0.0 --template-file /tmp/.krew.yaml
+docker run --rm -v $(pwd)/.krew.yaml:/tmp/.krew.yaml ghcr.io/rajatjindal/krew-release-bot:v0.0.46 \
+  krew-release-bot template --tag v4.0.12 --template-file /tmp/.krew.yaml
 ```
+
+Use a tag that has already shipped. `addURIAndSha` downloads each asset to checksum it, so an unreleased tag fails with a 404 — which is exactly what makes this a real end-to-end check of the URLs.
+
+Note the image tag is `v0.0.46` even though `02-release.yaml` pins the action at `v0.0.47`: the action is a Docker action, and its `action.yml` runs `ghcr.io/rajatjindal/krew-release-bot:v0.0.46`. There is no `v0.0.47` image to pull.
 
 This will output the generated krew manifest file, allowing you to verify:
 - The version field is correct
 - All download URLs are properly formatted
 - The SHA256 checksum will be calculated correctly
+
+For a released tag the output should be identical to that release's entry in [`kubernetes-sigs/krew-index`](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/kubescape.yaml), which is generated from `.goreleaser.yaml`. If the two differ, the two manifest definitions have drifted.
 
 ### Why skip_upload in GoReleaser?
 
@@ -245,12 +283,15 @@ You can test the release workflow manually without publishing to krew by using `
 
 ### Making Changes to the Template
 
-If you need to update the krew manifest (e.g., change the description, add platforms, or update the binary location):
+If you need to update the krew manifest (e.g., change the description, add platforms, or update the binary location), change **both** definitions — the released manifest comes from `.goreleaser.yaml`, and `.krew.yaml` is the fallback that has to keep matching it:
 
-1. Edit the `.krew.yaml` file
-2. Test your changes with the Docker command shown above
-3. Commit and push the changes
-4. The next release will use the updated template
+1. Edit the `krews:` block in `.goreleaser.yaml`. This is what the next release publishes.
+2. Make the matching edit to `.krew.yaml`.
+3. Test `.krew.yaml` with the Docker command shown above.
+4. Run `go test ./internal/ghworkflows/... -run TestKrew`. It renders `.krew.yaml` under the bot's real function map and checks the asset names still match what GoReleaser publishes, so a change to only one of the two files fails here rather than at the next tag.
+5. Commit and push the changes.
+
+Adding or removing a platform also means updating `krewPlatforms` in `internal/ghworkflows/krew_test.go`.
 
 ### Installing kubescape via krew
 

--- a/internal/ghworkflows/krew_test.go
+++ b/internal/ghworkflows/krew_test.go
@@ -475,6 +475,26 @@ func TestKrewPlatformsMatchGoreleaserBuildMatrix(t *testing.T) {
 		"the %q build in %s covers different platforms than %s lists; update %s and krewPlatforms "+
 			"together, or krew offers an install for a platform with no asset",
 		krewBuildID, goreleaserConfigName, krewTemplateName, krewTemplateName)
+
+	// `bin` is the path krew runs out of the extracted archive, so it has to be
+	// the executable GoReleaser put there. That is builds[].binary, with .exe
+	// appended on Windows. Renaming the binary without editing .krew.yaml leaves
+	// krew invoking a file the archive does not contain.
+	require.NotEmptyf(t, cli.Binary, "the %q build declares no binary", krewBuildID)
+
+	for _, platform := range krewPlatforms {
+		t.Run(platform.os+"/"+platform.arch, func(t *testing.T) {
+			want := cli.Binary
+			if platform.os == "windows" {
+				want += ".exe"
+			}
+
+			assert.Equalf(t, want, platform.binary,
+				"%s lists bin %q for %s/%s, but the %q build produces %q; krew would run a file that "+
+					"is not in the archive", krewTemplateName, platform.binary,
+				platform.os, platform.arch, krewBuildID, want)
+		})
+	}
 }
 
 // TestGoreleaserArchivesUseDefaultNaming pins the assumption the asset-name test

--- a/internal/ghworkflows/krew_test.go
+++ b/internal/ghworkflows/krew_test.go
@@ -76,6 +76,9 @@ const (
 	// krewPluginAPIVersion picks the documentation's copy of the template out of
 	// the other YAML blocks around it.
 	krewPluginAPIVersion = "apiVersion: krew.googlecontainertools.github.com/v1alpha2"
+
+	// krewBuildID is the .goreleaser.yaml build whose archives krew installs.
+	krewBuildID = "cli"
 )
 
 // krewRenderCases are the tags the render assertions run over.
@@ -422,6 +425,56 @@ func krewTemplateBlock(t *testing.T, doc string) string {
 			"one documents the template", krewDocName, krewPluginAPIVersion, len(matched))
 
 	return strings.TrimRight(matched[0], "\n")
+}
+
+// TestKrewPlatformsMatchGoreleaserBuildMatrix ties krewPlatforms, and through it
+// .krew.yaml, to the targets a release actually builds.
+//
+// krewPlatforms is a hand-maintained fixture that currently agrees with the
+// template. Adding a goos to the `cli` build would publish archives .krew.yaml
+// never lists, and removing one would leave it pointing at assets that no longer
+// exist - in both directions every other test in this file still passes, because
+// they all check the template against the same fixture.
+func TestKrewPlatformsMatchGoreleaserBuildMatrix(t *testing.T) {
+	config := loadGoreleaserConfig(t)
+
+	var cli *goreleaserBuild
+	for i := range config.Builds {
+		if config.Builds[i].ID == krewBuildID {
+			cli = &config.Builds[i]
+			break
+		}
+	}
+	require.NotNilf(t, cli, "%s declares no %q build, which is the artifact krew installs",
+		goreleaserConfigName, krewBuildID)
+
+	// `ignore` entries can also pin goarm/goamd64, which this does not decode. An
+	// entry of that shape simply excludes nothing here, so the expected set stays
+	// a superset and the assertion fails loudly rather than passing quietly.
+	ignored := make(map[[2]string]bool, len(cli.Ignore))
+	for _, entry := range cli.Ignore {
+		ignored[[2]string{entry.Goos, entry.Goarch}] = true
+	}
+
+	built := make([][2]string, 0, len(cli.Goos)*len(cli.Goarch))
+	for _, goos := range cli.Goos {
+		for _, goarch := range cli.Goarch {
+			if !ignored[[2]string{goos, goarch}] {
+				built = append(built, [2]string{goos, goarch})
+			}
+		}
+	}
+	require.NotEmptyf(t, built, "the %q build declares no goos/goarch product", krewBuildID)
+
+	listed := make([][2]string, 0, len(krewPlatforms))
+	for _, platform := range krewPlatforms {
+		listed = append(listed, [2]string{platform.os, platform.arch})
+	}
+
+	assert.ElementsMatchf(t, built, listed,
+		"the %q build in %s covers different platforms than %s lists; update %s and krewPlatforms "+
+			"together, or krew offers an install for a platform with no asset",
+		krewBuildID, goreleaserConfigName, krewTemplateName, krewTemplateName)
 }
 
 // TestGoreleaserArchivesUseDefaultNaming pins the assumption the asset-name test

--- a/internal/ghworkflows/krew_test.go
+++ b/internal/ghworkflows/krew_test.go
@@ -72,6 +72,10 @@ const (
 	// addURIAndShaCall identifies the template lines that build an asset URL, in
 	// both the template and its documented copy.
 	addURIAndShaCall = "addURIAndSha"
+
+	// krewPluginAPIVersion picks the documentation's copy of the template out of
+	// the other YAML blocks around it.
+	krewPluginAPIVersion = "apiVersion: krew.googlecontainertools.github.com/v1alpha2"
 )
 
 // krewPlatform is one entry of the plugin manifest's `platforms` list. The
@@ -278,14 +282,46 @@ func TestKrewTemplateRendersValidPluginManifest(t *testing.T) {
 		"%s rendered %d platforms, expected %d",
 		krewTemplateName, len(manifest.Spec.Platforms), len(krewPlatforms))
 
-	for _, platform := range manifest.Spec.Platforms {
-		t.Run(platform.Selector.MatchLabels.OS+"/"+platform.Selector.MatchLabels.Arch, func(t *testing.T) {
-			assert.NotEmpty(t, platform.URI, "platform has no uri, so krew has nothing to download")
-			assert.Equalf(t, krewStubSha, platform.Sha256,
-				"platform has no sha256 at the expected nesting; addURIAndSha pads it by four spaces, "+
-					"so the template call must sit at that indentation")
-			assert.NotEmpty(t, platform.Bin, "platform declares no bin, so krew cannot link the plugin")
+	// Assert the whole mapping, not that the fields are populated. krew picks a
+	// platform by its selector and then runs whatever `bin` that entry names, so
+	// a uri or a bin attached to the wrong selector installs the wrong artifact
+	// while every field is present and every URL resolves.
+	expected := make(map[[2]string]krewPlatform, len(krewPlatforms))
+	for _, platform := range krewPlatforms {
+		expected[[2]string{platform.os, platform.arch}] = platform
+	}
+
+	seen := make(map[[2]string]bool, len(krewPlatforms))
+	for _, rendered := range manifest.Spec.Platforms {
+		selector := [2]string{rendered.Selector.MatchLabels.OS, rendered.Selector.MatchLabels.Arch}
+
+		t.Run(selector[0]+"/"+selector[1], func(t *testing.T) {
+			want, ok := expected[selector]
+			require.Truef(t, ok, "manifest declares %s/%s, which .goreleaser.yaml does not build for the "+
+				"`cli` artifact; krew would offer an install that has no asset", selector[0], selector[1])
+
+			assert.Falsef(t, seen[selector], "%s/%s appears twice; the duplicate shadows whichever entry "+
+				"krew resolves second", selector[0], selector[1])
+			seen[selector] = true
+
+			assert.Equalf(t, want.binary, rendered.Bin,
+				"%s/%s names bin %q; krew runs that path out of the extracted archive, and the Windows "+
+					"archives carry kubescape.exe", selector[0], selector[1], rendered.Bin)
+
+			assert.Equalf(t, expectedKrewURI(krewSampleTag, krewSampleVersion, want), rendered.URI,
+				"%s/%s points at the wrong asset; a uri under the wrong selector installs another "+
+					"platform's binary", selector[0], selector[1])
+
+			assert.Equalf(t, krewStubSha, rendered.Sha256,
+				"%s/%s has no sha256 at the expected nesting; addURIAndSha pads it by four spaces, "+
+					"so the template call must sit at that indentation", selector[0], selector[1])
 		})
+	}
+
+	for _, platform := range krewPlatforms {
+		assert.Truef(t, seen[[2]string{platform.os, platform.arch}],
+			"%s renders no entry for %s/%s, so krew cannot install on it",
+			krewTemplateName, platform.os, platform.arch)
 	}
 }
 
@@ -301,17 +337,64 @@ func TestKrewDocMatchesTemplate(t *testing.T) {
 	docContent, err := os.ReadFile(docPath)
 	require.NoErrorf(t, err, "cannot read %s", krewDocName)
 
-	fromTemplate := addURIAndShaLines(string(templateContent))
+	template := strings.TrimRight(string(templateContent), "\n")
+	embedded := krewTemplateBlock(t, string(docContent))
+
+	// The URL-building lines are what drifted, and comparing them on their own
+	// gives a failure a reader can act on without diffing 70 lines.
+	fromTemplate := addURIAndShaLines(template)
 	require.NotEmptyf(t, fromTemplate, "%s builds no asset URLs at all", krewTemplateName)
 
-	fromDoc := addURIAndShaLines(string(docContent))
-	require.NotEmptyf(t, fromDoc,
-		"%s no longer shows any %s call; it documents the template, so it has to show the real one",
-		krewDocName, addURIAndShaCall)
+	assert.ElementsMatchf(t, fromTemplate, addURIAndShaLines(embedded),
+		"%s documents different %s calls than %s ships; a contributor following the documentation "+
+			"would reintroduce the form that cannot render", krewDocName, addURIAndShaCall, krewTemplateName)
 
-	assert.ElementsMatchf(t, fromTemplate, fromDoc,
-		"%s documents a different template than %s ships; a contributor following the documentation "+
-			"would reintroduce the form that cannot render", krewDocName, krewTemplateName)
+	// Then the block as a whole. Selectors, bin names, the header comment and the
+	// description can all drift while the URL lines still agree.
+	assert.Equalf(t, template, embedded,
+		"the template embedded in %s is not %s. It is a copy, so it goes stale silently - paste the "+
+			"current file into that fenced block", krewDocName, krewTemplateName)
+}
+
+// krewTemplateBlock returns the fenced YAML block in the documentation that
+// holds the copy of .krew.yaml. It is selected by content rather than position,
+// because the document fences other YAML too (the release job's permissions and
+// the GoReleaser krews: block).
+func krewTemplateBlock(t *testing.T, doc string) string {
+	t.Helper()
+
+	const fence = "```"
+
+	var (
+		blocks  []string
+		current []string
+		inBlock bool
+	)
+	for _, line := range strings.Split(doc, "\n") {
+		switch {
+		case !inBlock && strings.HasPrefix(strings.TrimSpace(line), fence+"yaml"):
+			inBlock, current = true, nil
+		case inBlock && strings.TrimSpace(line) == fence:
+			blocks = append(blocks, strings.Join(current, "\n"))
+			inBlock = false
+		case inBlock:
+			current = append(current, line)
+		}
+	}
+	require.Falsef(t, inBlock, "%s has an unterminated ```yaml block", krewDocName)
+
+	var matched []string
+	for _, block := range blocks {
+		if strings.Contains(block, krewPluginAPIVersion) {
+			matched = append(matched, block)
+		}
+	}
+
+	require.Lenf(t, matched, 1,
+		"expected exactly one fenced YAML block in %s carrying %q, found %d; this test cannot tell which "+
+			"one documents the template", krewDocName, krewPluginAPIVersion, len(matched))
+
+	return strings.TrimRight(matched[0], "\n")
 }
 
 // TestGoreleaserArchivesUseDefaultNaming pins the assumption the asset-name test

--- a/internal/ghworkflows/krew_test.go
+++ b/internal/ghworkflows/krew_test.go
@@ -1,0 +1,335 @@
+// Package ghworkflows holds repository-hygiene tests. These ones guard
+// .krew.yaml, the plugin manifest template krew-release-bot renders when it
+// opens a version-bump pull request against kubernetes-sigs/krew-index.
+//
+// The template could not render at all. It called addURIAndSha with four
+// arguments against a function that takes two, and KREW_RELEASE.md documented a
+// `trimPrefix "v"` binding for a template environment whose function map holds
+// only `indent` and `addURIAndSha` - no sprig, so no trimPrefix. Each form
+// fails a different way (execution error, parse error) and the file and its own
+// documentation disagreed about which to use.
+//
+// None of that surfaced, for two compounding reasons. 02-release.yaml passes
+// `krew_template_file: dist/krew/kubescape.yaml` - the manifest GoReleaser
+// writes from its own `krews:` block - so releases never touch .krew.yaml and
+// krew-index stayed correct while the template rotted. And the action documents
+// that input as defaulting to .krew.yaml, so dropping that one workflow line
+// would have silently promoted a file that cannot render into the release path.
+//
+// The asset names are the other half. GoReleaser's default archive name is
+// {{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}, and .Version is the tag
+// without its leading "v", so a release publishes kubescape_4.0.12_linux_amd64
+// while the tag is v4.0.12. A template that interpolates .TagName into the file
+// name asks for an asset that does not exist.
+//
+// These tests reproduce krew-release-bot's template environment offline - the
+// same two functions, the same nested-template URL rendering - so a wrong
+// argument count, an undefined function, or a drifted asset name fails on the
+// pull request that introduces it rather than at the next tag.
+//
+// Deliberately test-only: this is a repository-hygiene guard, so it adds no
+// production surface.
+package ghworkflows
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	krewTemplateName = ".krew.yaml"
+
+	// krewDocName documents the template. It embeds a copy of it, which is
+	// exactly the arrangement that drifted, so the copy is asserted against the
+	// file rather than trusted to be updated alongside it.
+	krewDocName = "KREW_RELEASE.md"
+
+	// krewSampleTag renders the template for a tag that has actually shipped, so
+	// the expected asset names below can be checked against a published release
+	// and against kubernetes-sigs/krew-index/plugins/kubescape.yaml.
+	krewSampleTag = "v4.0.12"
+
+	// krewSampleVersion is krewSampleTag as GoReleaser's .Version renders it.
+	krewSampleVersion = "4.0.12"
+
+	// krewReleaseDownloadPrefix is where every published asset is served from.
+	krewReleaseDownloadPrefix = "https://github.com/kubescape/kubescape/releases/download"
+
+	// krewStubSha stands in for the checksum the real addURIAndSha computes by
+	// downloading the asset. These tests assert on names and structure, which
+	// need no network.
+	krewStubSha = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	// addURIAndShaCall identifies the template lines that build an asset URL, in
+	// both the template and its documented copy.
+	addURIAndShaCall = "addURIAndSha"
+)
+
+// krewPlatform is one entry of the plugin manifest's `platforms` list. The
+// binary name differs on Windows, which is the only reason the manifest carries
+// six entries rather than one per os/arch pair generated from a matrix.
+type krewPlatform struct {
+	os     string
+	arch   string
+	binary string
+}
+
+// krewPlatforms is the set of platforms .goreleaser.yaml builds the `cli`
+// artifact for: goos linux/darwin/windows crossed with goarch amd64/arm64.
+var krewPlatforms = []krewPlatform{
+	{os: "linux", arch: "amd64", binary: "kubescape"},
+	{os: "linux", arch: "arm64", binary: "kubescape"},
+	{os: "darwin", arch: "amd64", binary: "kubescape"},
+	{os: "darwin", arch: "arm64", binary: "kubescape"},
+	{os: "windows", arch: "amd64", binary: "kubescape.exe"},
+	{os: "windows", arch: "arm64", binary: "kubescape.exe"},
+}
+
+// krewReleaseRequest mirrors the fields of krew-release-bot's ReleaseRequest,
+// the value it executes the template against. Only TagName is used today;
+// the rest are present so referencing one is not a spurious failure here.
+type krewReleaseRequest struct {
+	TagName    string
+	PluginName string
+	PluginRepo string
+}
+
+// krewPluginSpec is the subset of the rendered manifest these tests assert on.
+// It is the shape krew itself consumes, so parsing into it proves the template
+// produced a plugin manifest and not merely well-formed YAML.
+type krewPluginSpec struct {
+	Spec struct {
+		Version   string `yaml:"version"`
+		Platforms []struct {
+			URI      string `yaml:"uri"`
+			Sha256   string `yaml:"sha256"`
+			Bin      string `yaml:"bin"`
+			Selector struct {
+				MatchLabels struct {
+					OS   string `yaml:"os"`
+					Arch string `yaml:"arch"`
+				} `yaml:"matchLabels"`
+			} `yaml:"selector"`
+		} `yaml:"platforms"`
+	} `yaml:"spec"`
+}
+
+// krewRender collects what a template execution produced: the URLs
+// addURIAndSha was asked to resolve, and any error raised while resolving them.
+// Errors are recorded rather than panicked, unlike upstream, because a panic
+// out of a template function crosses the test binary rather than failing a test.
+type krewRender struct {
+	uris []string
+	errs []error
+}
+
+// krewFuncs reproduces krew-release-bot's template function map exactly - see
+// pkg/source/template.go in rajatjindal/krew-release-bot. Both the signatures
+// and the omissions are load-bearing: addURIAndSha takes two arguments, and
+// nothing else is defined, so a four-argument call or a `trimPrefix` reference
+// fails here the same way it fails in the bot.
+func krewFuncs(render *krewRender) template.FuncMap {
+	return template.FuncMap{
+		// indent matches upstream, including its fixShaIndentation step: the
+		// sha256 line addURIAndSha emits carries a hardcoded 4-space pad that is
+		// stripped before re-padding.
+		"indent": func(spaces int, v string) string {
+			v = strings.ReplaceAll(v, "    sha256:", "sha256:")
+			pad := strings.Repeat(" ", spaces)
+			return strings.TrimSpace(pad + strings.ReplaceAll(v, "\n", "\n"+pad))
+		},
+		"addURIAndSha": func(url, tag string) string {
+			// The url argument is itself a template, rendered against a value
+			// carrying only TagName and with no functions at all. Anything the
+			// outer template needs to compute - the "v"-less version among them -
+			// has to be interpolated before it gets here.
+			inner, err := template.New("url").Parse(url)
+			if err != nil {
+				render.errs = append(render.errs, fmt.Errorf("parsing url template %q: %w", url, err))
+				return ""
+			}
+
+			buf := new(bytes.Buffer)
+			if err := inner.Execute(buf, struct{ TagName string }{TagName: tag}); err != nil {
+				render.errs = append(render.errs, fmt.Errorf("executing url template %q: %w", url, err))
+				return ""
+			}
+
+			render.uris = append(render.uris, buf.String())
+
+			// Upstream's exact return shape. The 4-space pad before sha256 is what
+			// aligns it under the `uri:` line the template call is indented to.
+			return fmt.Sprintf("uri: %s\n    sha256: %s", buf.String(), krewStubSha)
+		},
+	}
+}
+
+func krewTemplatePath(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(repoRoot(t), krewTemplateName)
+}
+
+// renderKrewTemplate parses and executes .krew.yaml the way krew-release-bot
+// does, and fails the test with the template engine's own message if it cannot.
+// Upstream names the template after the file's base name and loads it with
+// ParseFiles, so this does too; Execute resolves the wrong name otherwise.
+func renderKrewTemplate(t *testing.T, tag string) (string, *krewRender) {
+	t.Helper()
+
+	path := krewTemplatePath(t)
+	render := &krewRender{}
+
+	parsed, err := template.New(filepath.Base(path)).Funcs(krewFuncs(render)).ParseFiles(path)
+	require.NoErrorf(t, err, "%s does not parse under krew-release-bot's function map; "+
+		"the bot would fail the same way and open no krew-index pull request", krewTemplateName)
+
+	buf := new(bytes.Buffer)
+	require.NoErrorf(t, parsed.Execute(buf, krewReleaseRequest{TagName: tag}),
+		"%s does not render for tag %s; the bot would fail the same way and open no krew-index "+
+			"pull request", krewTemplateName, tag)
+
+	for _, renderErr := range render.errs {
+		assert.NoErrorf(t, renderErr, "%s built a URL that addURIAndSha cannot resolve", krewTemplateName)
+	}
+
+	return buf.String(), render
+}
+
+// expectedKrewURI is the asset URL a release actually publishes: the tag in the
+// path, and GoReleaser's .Version - the tag without its "v" - in the file name.
+func expectedKrewURI(tag, version string, platform krewPlatform) string {
+	return fmt.Sprintf("%s/%s/kubescape_%s_%s_%s.tar.gz",
+		krewReleaseDownloadPrefix, tag, version, platform.os, platform.arch)
+}
+
+// addURIAndShaLines returns every asset-URL-building line in content, trimmed,
+// so the template and its documented copy can be compared without depending on
+// indentation or ordering. A line has to open with an action to count, which is
+// what separates a template line in the documented copy from prose that merely
+// mentions addURIAndSha while explaining it.
+func addURIAndShaLines(content string) []string {
+	var lines []string
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "{{") && strings.Contains(trimmed, addURIAndShaCall) {
+			lines = append(lines, trimmed)
+		}
+	}
+
+	return lines
+}
+
+// TestKrewTemplateRendersUnderReleaseBotFuncs is the direct regression test.
+// The shipped template called addURIAndSha with four arguments against a
+// two-argument function, so it could never render; the documented alternative
+// referenced trimPrefix, which is not defined in this environment either.
+func TestKrewTemplateRendersUnderReleaseBotFuncs(t *testing.T) {
+	_, render := renderKrewTemplate(t, krewSampleTag)
+
+	assert.Lenf(t, render.uris, len(krewPlatforms),
+		"%s resolved %d asset URLs, expected one per platform (%d); a platform that builds no URL "+
+			"installs nothing through krew", krewTemplateName, len(render.uris), len(krewPlatforms))
+}
+
+// TestKrewTemplateURIsMatchGoreleaserAssetNames closes the gap the issue
+// reported: a template can render perfectly and still name assets that were
+// never published. The expected names here match the release v4.0.12 published
+// and the entry it produced in kubernetes-sigs/krew-index.
+func TestKrewTemplateURIsMatchGoreleaserAssetNames(t *testing.T) {
+	_, render := renderKrewTemplate(t, krewSampleTag)
+
+	expected := make([]string, 0, len(krewPlatforms))
+	for _, platform := range krewPlatforms {
+		expected = append(expected, expectedKrewURI(krewSampleTag, krewSampleVersion, platform))
+	}
+
+	assert.ElementsMatchf(t, expected, render.uris,
+		"%s builds asset URLs that do not match what GoReleaser publishes; addURIAndSha downloads "+
+			"each one to checksum it, so a wrong name fails the release with a 404 instead of "+
+			"opening a krew-index pull request", krewTemplateName)
+}
+
+// TestKrewTemplateRendersValidPluginManifest checks the output is a manifest
+// krew can consume, not just valid YAML. It is the guard on indentation: the
+// sha256 line addURIAndSha emits is padded by exactly four spaces, so an entry
+// indented differently silently reparents sha256 or breaks the document.
+func TestKrewTemplateRendersValidPluginManifest(t *testing.T) {
+	rendered, _ := renderKrewTemplate(t, krewSampleTag)
+
+	var manifest krewPluginSpec
+	require.NoErrorf(t, yaml.Unmarshal([]byte(rendered), &manifest),
+		"%s renders invalid YAML:\n%s", krewTemplateName, rendered)
+
+	assert.Equalf(t, krewSampleTag, manifest.Spec.Version,
+		"spec.version must be the tag; krew-index rejects a manifest whose version does not match "+
+			"the release it points at")
+
+	require.Lenf(t, manifest.Spec.Platforms, len(krewPlatforms),
+		"%s rendered %d platforms, expected %d",
+		krewTemplateName, len(manifest.Spec.Platforms), len(krewPlatforms))
+
+	for _, platform := range manifest.Spec.Platforms {
+		t.Run(platform.Selector.MatchLabels.OS+"/"+platform.Selector.MatchLabels.Arch, func(t *testing.T) {
+			assert.NotEmpty(t, platform.URI, "platform has no uri, so krew has nothing to download")
+			assert.Equalf(t, krewStubSha, platform.Sha256,
+				"platform has no sha256 at the expected nesting; addURIAndSha pads it by four spaces, "+
+					"so the template call must sit at that indentation")
+			assert.NotEmpty(t, platform.Bin, "platform declares no bin, so krew cannot link the plugin")
+		})
+	}
+}
+
+// TestKrewDocMatchesTemplate is the drift guard proper. KREW_RELEASE.md embeds a
+// copy of the template and instructs contributors to edit .krew.yaml, so the two
+// have to agree - the reported bug was precisely the file having drifted from
+// its own documentation, with each carrying a different unrenderable form.
+func TestKrewDocMatchesTemplate(t *testing.T) {
+	templateContent, err := os.ReadFile(krewTemplatePath(t))
+	require.NoErrorf(t, err, "cannot read %s", krewTemplateName)
+
+	docPath := filepath.Join(repoRoot(t), krewDocName)
+	docContent, err := os.ReadFile(docPath)
+	require.NoErrorf(t, err, "cannot read %s", krewDocName)
+
+	fromTemplate := addURIAndShaLines(string(templateContent))
+	require.NotEmptyf(t, fromTemplate, "%s builds no asset URLs at all", krewTemplateName)
+
+	fromDoc := addURIAndShaLines(string(docContent))
+	require.NotEmptyf(t, fromDoc,
+		"%s no longer shows any %s call; it documents the template, so it has to show the real one",
+		krewDocName, addURIAndShaCall)
+
+	assert.ElementsMatchf(t, fromTemplate, fromDoc,
+		"%s documents a different template than %s ships; a contributor following the documentation "+
+			"would reintroduce the form that cannot render", krewDocName, krewTemplateName)
+}
+
+// TestGoreleaserArchivesUseDefaultNaming pins the assumption the asset-name test
+// rests on. With no name_template, GoReleaser uses
+// {{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}, and .Version is the tag minus
+// its "v" - which is the whole reason .krew.yaml has to trim the tag. Setting a
+// name_template here would rename every published asset and leave .krew.yaml
+// pointing at the old names, so it must fail until both are updated together.
+func TestGoreleaserArchivesUseDefaultNaming(t *testing.T) {
+	config := loadGoreleaserConfig(t)
+
+	require.NotEmptyf(t, config.Archives, "%s declares no archives; there would be no .tar.gz for krew "+
+		"to install", goreleaserConfigName)
+
+	for _, archive := range config.Archives {
+		assert.Emptyf(t, archive.NameTemplate,
+			"archive %q sets name_template %q, so published asset names no longer follow "+
+				"{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}; update the printf in %s to match, "+
+				"then update this test", archive.ID, archive.NameTemplate, krewTemplateName)
+	}
+}

--- a/internal/ghworkflows/krew_test.go
+++ b/internal/ghworkflows/krew_test.go
@@ -78,6 +78,23 @@ const (
 	krewPluginAPIVersion = "apiVersion: krew.googlecontainertools.github.com/v1alpha2"
 )
 
+// krewRenderCases are the tags the render assertions run over.
+//
+// krewSampleTag is the anchor: it shipped, so the URLs expected for it can be
+// checked by hand against that release's assets and against its entry in
+// kubernetes-sigs/krew-index. On its own it is a weak test of the version
+// handling, because every derivation of "4.0.12" from "v4.0.12" agrees at that
+// one input - a version hardcoded into the template would pass. The second tag
+// is synthetic and differs in digit count, so it fails for a hardcoded version
+// and for a trim that only works on a single-digit major.
+var krewRenderCases = []struct {
+	tag     string
+	version string
+}{
+	{tag: krewSampleTag, version: krewSampleVersion},
+	{tag: "v10.2.0", version: "10.2.0"},
+}
+
 // krewPlatform is one entry of the plugin manifest's `platforms` list. The
 // binary name differs on Windows, which is the only reason the manifest carries
 // six entries rather than one per os/arch pair generated from a matrix.
@@ -250,17 +267,21 @@ func TestKrewTemplateRendersUnderReleaseBotFuncs(t *testing.T) {
 // never published. The expected names here match the release v4.0.12 published
 // and the entry it produced in kubernetes-sigs/krew-index.
 func TestKrewTemplateURIsMatchGoreleaserAssetNames(t *testing.T) {
-	_, render := renderKrewTemplate(t, krewSampleTag)
+	for _, renderCase := range krewRenderCases {
+		t.Run(renderCase.tag, func(t *testing.T) {
+			_, render := renderKrewTemplate(t, renderCase.tag)
 
-	expected := make([]string, 0, len(krewPlatforms))
-	for _, platform := range krewPlatforms {
-		expected = append(expected, expectedKrewURI(krewSampleTag, krewSampleVersion, platform))
+			expected := make([]string, 0, len(krewPlatforms))
+			for _, platform := range krewPlatforms {
+				expected = append(expected, expectedKrewURI(renderCase.tag, renderCase.version, platform))
+			}
+
+			assert.ElementsMatchf(t, expected, render.uris,
+				"%s builds asset URLs that do not match what GoReleaser publishes for %s; addURIAndSha "+
+					"downloads each one to checksum it, so a wrong name fails the release with a 404 "+
+					"instead of opening a krew-index pull request", krewTemplateName, renderCase.tag)
+		})
 	}
-
-	assert.ElementsMatchf(t, expected, render.uris,
-		"%s builds asset URLs that do not match what GoReleaser publishes; addURIAndSha downloads "+
-			"each one to checksum it, so a wrong name fails the release with a 404 instead of "+
-			"opening a krew-index pull request", krewTemplateName)
 }
 
 // TestKrewTemplateRendersValidPluginManifest checks the output is a manifest
@@ -268,60 +289,66 @@ func TestKrewTemplateURIsMatchGoreleaserAssetNames(t *testing.T) {
 // sha256 line addURIAndSha emits is padded by exactly four spaces, so an entry
 // indented differently silently reparents sha256 or breaks the document.
 func TestKrewTemplateRendersValidPluginManifest(t *testing.T) {
-	rendered, _ := renderKrewTemplate(t, krewSampleTag)
+	for _, renderCase := range krewRenderCases {
+		t.Run(renderCase.tag, func(t *testing.T) {
+			rendered, _ := renderKrewTemplate(t, renderCase.tag)
 
-	var manifest krewPluginSpec
-	require.NoErrorf(t, yaml.Unmarshal([]byte(rendered), &manifest),
-		"%s renders invalid YAML:\n%s", krewTemplateName, rendered)
+			var manifest krewPluginSpec
+			require.NoErrorf(t, yaml.Unmarshal([]byte(rendered), &manifest),
+				"%s renders invalid YAML:\n%s", krewTemplateName, rendered)
 
-	assert.Equalf(t, krewSampleTag, manifest.Spec.Version,
-		"spec.version must be the tag; krew-index rejects a manifest whose version does not match "+
-			"the release it points at")
+			assert.Equalf(t, renderCase.tag, manifest.Spec.Version,
+				"spec.version must be the tag; krew-index rejects a manifest whose version does not "+
+					"match the release it points at")
 
-	require.Lenf(t, manifest.Spec.Platforms, len(krewPlatforms),
-		"%s rendered %d platforms, expected %d",
-		krewTemplateName, len(manifest.Spec.Platforms), len(krewPlatforms))
+			require.Lenf(t, manifest.Spec.Platforms, len(krewPlatforms),
+				"%s rendered %d platforms, expected %d",
+				krewTemplateName, len(manifest.Spec.Platforms), len(krewPlatforms))
 
-	// Assert the whole mapping, not that the fields are populated. krew picks a
-	// platform by its selector and then runs whatever `bin` that entry names, so
-	// a uri or a bin attached to the wrong selector installs the wrong artifact
-	// while every field is present and every URL resolves.
-	expected := make(map[[2]string]krewPlatform, len(krewPlatforms))
-	for _, platform := range krewPlatforms {
-		expected[[2]string{platform.os, platform.arch}] = platform
-	}
+			// Assert the whole mapping, not that the fields are populated. krew picks
+			// a platform by its selector and then runs whatever `bin` that entry
+			// names, so a uri or a bin attached to the wrong selector installs the
+			// wrong artifact while every field is present and every URL resolves.
+			expected := make(map[[2]string]krewPlatform, len(krewPlatforms))
+			for _, platform := range krewPlatforms {
+				expected[[2]string{platform.os, platform.arch}] = platform
+			}
 
-	seen := make(map[[2]string]bool, len(krewPlatforms))
-	for _, rendered := range manifest.Spec.Platforms {
-		selector := [2]string{rendered.Selector.MatchLabels.OS, rendered.Selector.MatchLabels.Arch}
+			seen := make(map[[2]string]bool, len(krewPlatforms))
+			for _, entry := range manifest.Spec.Platforms {
+				selector := [2]string{entry.Selector.MatchLabels.OS, entry.Selector.MatchLabels.Arch}
 
-		t.Run(selector[0]+"/"+selector[1], func(t *testing.T) {
-			want, ok := expected[selector]
-			require.Truef(t, ok, "manifest declares %s/%s, which .goreleaser.yaml does not build for the "+
-				"`cli` artifact; krew would offer an install that has no asset", selector[0], selector[1])
+				t.Run(selector[0]+"/"+selector[1], func(t *testing.T) {
+					want, ok := expected[selector]
+					require.Truef(t, ok, "manifest declares %s/%s, which .goreleaser.yaml does not build "+
+						"for the `cli` artifact; krew would offer an install that has no asset",
+						selector[0], selector[1])
 
-			assert.Falsef(t, seen[selector], "%s/%s appears twice; the duplicate shadows whichever entry "+
-				"krew resolves second", selector[0], selector[1])
-			seen[selector] = true
+					assert.Falsef(t, seen[selector], "%s/%s appears twice; the duplicate shadows "+
+						"whichever entry krew resolves second", selector[0], selector[1])
+					seen[selector] = true
 
-			assert.Equalf(t, want.binary, rendered.Bin,
-				"%s/%s names bin %q; krew runs that path out of the extracted archive, and the Windows "+
-					"archives carry kubescape.exe", selector[0], selector[1], rendered.Bin)
+					assert.Equalf(t, want.binary, entry.Bin,
+						"%s/%s names bin %q; krew runs that path out of the extracted archive, and the "+
+							"Windows archives carry kubescape.exe", selector[0], selector[1], entry.Bin)
 
-			assert.Equalf(t, expectedKrewURI(krewSampleTag, krewSampleVersion, want), rendered.URI,
-				"%s/%s points at the wrong asset; a uri under the wrong selector installs another "+
-					"platform's binary", selector[0], selector[1])
+					assert.Equalf(t, expectedKrewURI(renderCase.tag, renderCase.version, want), entry.URI,
+						"%s/%s points at the wrong asset; a uri under the wrong selector installs "+
+							"another platform's binary", selector[0], selector[1])
 
-			assert.Equalf(t, krewStubSha, rendered.Sha256,
-				"%s/%s has no sha256 at the expected nesting; addURIAndSha pads it by four spaces, "+
-					"so the template call must sit at that indentation", selector[0], selector[1])
+					assert.Equalf(t, krewStubSha, entry.Sha256,
+						"%s/%s has no sha256 at the expected nesting; addURIAndSha pads it by four "+
+							"spaces, so the template call must sit at that indentation",
+						selector[0], selector[1])
+				})
+			}
+
+			for _, platform := range krewPlatforms {
+				assert.Truef(t, seen[[2]string{platform.os, platform.arch}],
+					"%s renders no entry for %s/%s, so krew cannot install on it",
+					krewTemplateName, platform.os, platform.arch)
+			}
 		})
-	}
-
-	for _, platform := range krewPlatforms {
-		assert.Truef(t, seen[[2]string{platform.os, platform.arch}],
-			"%s renders no entry for %s/%s, so krew cannot install on it",
-			krewTemplateName, platform.os, platform.arch)
 	}
 }
 

--- a/internal/ghworkflows/releasesigning_test.go
+++ b/internal/ghworkflows/releasesigning_test.go
@@ -80,6 +80,12 @@ var guardedFiles = append([]string{
 	goreleaserConfigName,
 	filepath.Join(".github", "workflows", releaseWorkflowName),
 	filepath.Join("internal", "ghworkflows", "releasesigning_test.go"),
+	// krew_test.go guards these two, and both sit in the same blind spot as the
+	// files above: .krew.yaml matches "**.yaml" and KREW_RELEASE.md matches
+	// "**.md" in 00-pr-scanner.yaml's deny-list.
+	krewTemplateName,
+	krewDocName,
+	filepath.Join("internal", "ghworkflows", "krew_test.go"),
 }, installScripts...)
 
 // goreleaserSign is the subset of a `signs` / `docker_signs` entry these tests
@@ -100,8 +106,17 @@ type goreleaserSign struct {
 	Stdin       string   `yaml:"stdin"`
 }
 
+// goreleaserArchive is the subset of an `archives` entry these tests assert on.
+// NameTemplate decides every published asset name, which .krew.yaml has to
+// reproduce by hand - see TestGoreleaserArchivesUseDefaultNaming in krew_test.go.
+type goreleaserArchive struct {
+	ID           string `yaml:"id"`
+	NameTemplate string `yaml:"name_template"`
+}
+
 type goreleaserConfig struct {
-	Signs    []goreleaserSign `yaml:"signs"`
+	Signs    []goreleaserSign    `yaml:"signs"`
+	Archives []goreleaserArchive `yaml:"archives"`
 	Checksum struct {
 		NameTemplate string `yaml:"name_template"`
 	} `yaml:"checksum"`

--- a/internal/ghworkflows/releasesigning_test.go
+++ b/internal/ghworkflows/releasesigning_test.go
@@ -116,10 +116,12 @@ type goreleaserArchive struct {
 
 // goreleaserBuild is the subset of a `builds` entry these tests assert on. The
 // goos/goarch product, less anything under `ignore`, is the set of platforms a
-// release publishes archives for, which .krew.yaml has to list by hand - see
+// release publishes archives for, and Binary is the executable inside each of
+// them. .krew.yaml has to restate both by hand - see
 // TestKrewPlatformsMatchGoreleaserBuildMatrix in krew_test.go.
 type goreleaserBuild struct {
 	ID     string   `yaml:"id"`
+	Binary string   `yaml:"binary"`
 	Goos   []string `yaml:"goos"`
 	Goarch []string `yaml:"goarch"`
 	Ignore []struct {

--- a/internal/ghworkflows/releasesigning_test.go
+++ b/internal/ghworkflows/releasesigning_test.go
@@ -114,9 +114,24 @@ type goreleaserArchive struct {
 	NameTemplate string `yaml:"name_template"`
 }
 
+// goreleaserBuild is the subset of a `builds` entry these tests assert on. The
+// goos/goarch product, less anything under `ignore`, is the set of platforms a
+// release publishes archives for, which .krew.yaml has to list by hand - see
+// TestKrewPlatformsMatchGoreleaserBuildMatrix in krew_test.go.
+type goreleaserBuild struct {
+	ID     string   `yaml:"id"`
+	Goos   []string `yaml:"goos"`
+	Goarch []string `yaml:"goarch"`
+	Ignore []struct {
+		Goos   string `yaml:"goos"`
+		Goarch string `yaml:"goarch"`
+	} `yaml:"ignore"`
+}
+
 type goreleaserConfig struct {
 	Signs    []goreleaserSign    `yaml:"signs"`
 	Archives []goreleaserArchive `yaml:"archives"`
+	Builds   []goreleaserBuild   `yaml:"builds"`
 	Checksum struct {
 		NameTemplate string `yaml:"name_template"`
 	} `yaml:"checksum"`


### PR DESCRIPTION
## Overview

`.krew.yaml` cannot be rendered by krew-release-bot, and hasn't been able to since it was reintroduced in `01bb19bf` (shipped in v4.0.0). Two faults in the file, one in the document that describes it:

- **Wrong arity.** All six platform entries pass four arguments to `addURIAndSha`, which takes two. Every render dies with `wrong number of args for addURIAndSha: want 2 got 4`.
- **Wrong asset names.** Filenames are built from `.TagName`, asking for `kubescape_v4.0.12_linux_amd64.tar.gz`. Releases publish `kubescape_4.0.12_linux_amd64.tar.gz` — GoReleaser names archives from `.Version`, which is the tag without its leading `v`.
- **`KREW_RELEASE.md` documents a form that fails too.** It shows `{{ trimPrefix "v" .TagName }}`, but the bot's function map holds only `indent` and `addURIAndSha`, with no sprig. That one fails at parse time rather than exec time, so the file and its spec were broken in two different ways.

This PR builds the URL with `printf` in the outer template and trims the tag with `slice`, which is the only workable shape: `addURIAndSha` renders its URL argument as a nested template carrying `.TagName` and no functions, so there is nowhere inside it to strip the `v`.

It also corrects `KREW_RELEASE.md`, and adds a test that renders `.krew.yaml` under a function map mirroring the bot's so this can't drift again.

## Additional Information

**No release is currently broken, and I'd rather say that up front than have it look worse than it is.** `02-release.yaml` passes `krew_template_file: dist/krew/kubescape.yaml`, the manifest GoReleaser writes from its `krews:` block, so `.krew.yaml` is never read during a release. The published entry in krew-index carries a `# This file was generated by GoReleaser. DO NOT EDIT.` header and correct URLs.

What makes it worth fixing rather than ignoring: `krew_template_file` is [documented](https://github.com/rajatjindal/krew-release-bot/blob/master/action.yml) as *"defaults to .krew.yaml"*. Dropping that one input during a future cleanup would silently move a file that cannot render onto the release path, and the failure would land on a tag push instead of a PR.

**How the drift happened.** `01bb19bf` reintroduced `.krew.yaml` together with `KREW_RELEASE.md` in the four-argument `trimPrefix` form. `cfe022ff` then replaced `$version` with `.TagName` across the six lines, which removed the `trimPrefix` parse error, left the arity error, and introduced the `v`-in-the-filename problem. The document wasn't touched, so it still shows the `01bb19bf` form.

**Why nothing caught it.** `00-pr-scanner.yaml` skips a PR whose every changed file matches its `paths-ignore` list. `.krew.yaml` matches `**.yaml`, `KREW_RELEASE.md` matches `**.md`, and neither was in `repo-hygiene.yaml`'s allow-list — so a PR touching only those two ran no checks at all. That's the same hole that let `dependabot.yaml` sit broken for three months and `.goreleaser.yaml` ship without a `signs` block, both already written up in `internal/ghworkflows`. Adding the two files to the allow-list and to `guardedFiles` is part of this PR; without it the new test exists but never runs on the PR that would break it.

**One question for maintainers.** `.goreleaser.yaml` is what actually publishes, so `.krew.yaml` is a second definition of the same manifest kept in sync by hand — the test now guards that sync, but deleting the file would remove the class of drift outright. I've kept it, since it's the action's default path and the `krew-release-bot template` command in `KREW_RELEASE.md` renders it. Happy to go the other way if you'd prefer.

## How to Test

The offline guard, which is what CI will run:

```bash
go test ./internal/ghworkflows/... -run 'TestKrew|TestGoreleaserArchives' -v
```

All five fail on `master` and pass here. The first failure on `master` is the diagnosis itself:

```
.krew.yaml does not render for tag v4.0.12; the bot would fail the same way and open no krew-index pull request
  template: .krew.yaml:12:7: executing ".krew.yaml" at <addURIAndSha>:
  wrong number of args for addURIAndSha: want 2 got 4
```

End-to-end against the real bot. Note the image tag is `v0.0.46`, not the `v0.0.47` the docs used to name — the action pins `v0.0.47` but its `action.yml` runs the `v0.0.46` image, and there is no `v0.0.47` image to pull. Use a tag that has shipped, because `addURIAndSha` downloads each asset to checksum it:

```bash
docker run --rm -v $(pwd)/.krew.yaml:/tmp/.krew.yaml \
  ghcr.io/rajatjindal/krew-release-bot:v0.0.46 \
  krew-release-bot template --tag v4.0.12 --template-file /tmp/.krew.yaml
```

On `master` that fails to render. Here it produces a manifest **identical to [v4.0.12's entry in krew-index](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/kubescape.yaml)** — same version, same six URIs, same six checksums.

Also run to confirm nothing else moved:

```bash
go test ./...
(cd httphandler && go test ./...)
```

## Examples/Screenshots

Rendering `.krew.yaml` for `v4.0.12` through `krew-release-bot:v0.0.46`.

Before:

```
level=fatal msg="template: .krew.yaml:12:7: executing \".krew.yaml\" at <addURIAndSha>: wrong number of args for addURIAndSha: want 2 got 4"
```

After (first two platforms shown; checksums are the real ones, downloaded from the v4.0.12 release):

```yaml
  - selector:
      matchLabels:
        os: linux
        arch: amd64
    uri: https://github.com/kubescape/kubescape/releases/download/v4.0.12/kubescape_4.0.12_linux_amd64.tar.gz
    sha256: 707aec6c708b7e90c1aeba71d9f7ce8050a03a84c6c146227d8c050e8155a7bc
    bin: kubescape
  - selector:
      matchLabels:
        os: linux
        arch: arm64
    uri: https://github.com/kubescape/kubescape/releases/download/v4.0.12/kubescape_4.0.12_linux_arm64.tar.gz
    sha256: b7b1b42d5ded8d805ee4ba7e2cf9146989a6ec9d27e94266644d9948e102ed10
    bin: kubescape
```

Those match the published krew-index entry exactly, which is the check I'd want a reviewer to make.

## Related issues/PRs

* Resolved #3384

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Krew plugin release templates to generate correct versioned download URLs and archive names.
  * Added validation to keep plugin manifests, documentation, and release assets consistent.

* **Documentation**
  * Updated Krew publishing, testing, and maintenance guidance.
  * Clarified template behavior and release asset naming.

* **Bug Fixes**
  * Repository checks now run when Krew templates or release documentation change.
  * Fixed mismatched asset references and validation gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->