### PR TITLE
fix(preflight): skip Kubescape-served resources in dry-run access review

### DIFF
--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -123,6 +123,15 @@ func mapKSResourceToApiGroup(resource string) []string {
 	return []string{}
 }
 
+// isExternalResource reports whether a resolved group/version/resource triplet
+// names a resource Kubescape serves itself - host sensor data, cloud provider
+// descriptions, image vulnerabilities. Their API groups belong to Kubescape, so
+// no cluster ever serves them and they are never collected with a LIST.
+func isExternalResource(triplet string) bool {
+	_, _, resource := k8sinterface.StringToResourceGroup(triplet)
+	return len(mapKSResourceToApiGroup(resource)) > 0
+}
+
 func insertControls(resource string, resourceToControl map[string][]string, control reporthandling.Control) {
 	ksResources := mapKSResourceToApiGroup(resource)
 	for _, ksResource := range ksResources {

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -78,6 +78,12 @@ func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj 
 	result := &PreflightResult{DiscoveryFailures: discoveryFailures}
 	seen := make(map[string]struct{}, len(queryableResources))
 	for _, qr := range queryableResources {
+		// An access review for a resource Kubescape serves itself is always
+		// denied, which would fail the dry-run over a resource the scan never
+		// asks the API server for.
+		if isExternalResource(qr.GroupVersionResourceTriplet) {
+			continue
+		}
 		if _, ok := seen[qr.GroupVersionResourceTriplet]; ok {
 			continue
 		}

--- a/core/pkg/resourcehandler/preflight_test.go
+++ b/core/pkg/resourcehandler/preflight_test.go
@@ -119,3 +119,57 @@ func TestFileResourceHandler_PreflightNotSupported(t *testing.T) {
 	_, err := handler.Preflight(context.Background(), &cautils.OPASessionObj{}, &cautils.ScanInfo{})
 	assert.ErrorIs(t, err, ErrPreflightNotSupported)
 }
+
+// TestPreflight_SkipsExternalResources covers credentials scoped to the API
+// groups a cluster actually serves: Kubescape's own resources must not turn
+// into denials that fail the dry-run.
+func TestPreflight_SkipsExternalResources(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+
+	var reviewed []string
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		reviewed = append(reviewed, ssar.Spec.ResourceAttributes.Resource)
+		// Stand in for credentials scoped to real API groups: anything outside
+		// the core group is refused.
+		ssar.Status.Allowed = ssar.Spec.ResourceAttributes.Group == ""
+		return true, ssar, nil
+	})
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{""},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"Pod"},
+	}}, "")
+	hostRule := mockRule("host-rule", []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"hostdata.kubescape.cloud"},
+		APIVersions: []string{"v1beta0"},
+		Resources:   []string{KubeletConfiguration, CNIInfo},
+	}, {
+		APIGroups:   []string{"armo.vuln.images"},
+		APIVersions: []string{"v1"},
+		Resources:   []string{ImageVulnerabilities},
+	}, {
+		APIGroups:   []string{"eks.amazonaws.com"},
+		APIVersions: []string{"v1"},
+		Resources:   []string{ClusterDescribe},
+	}}, "")
+	control := mockControl("C-0001", []reporthandling.PolicyRule{podRule, hostRule})
+	framework := mockFramework("test-framework", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Denied())
+	assert.Equal(t, []string{"pods"}, reviewed)
+	for _, check := range result.Checks {
+		assert.NotContains(t, check.GVR, "hostdata.kubescape.cloud")
+	}
+}


### PR DESCRIPTION
### Overview

The dry run preflight asks the API server, via SelfSubjectAccessReview, whether the current credentials can list every resource type the selected policies need. The list it walks comes from the same queryable resource map the collector uses, and that map also carries the resources Kubescape produces itself: host sensor data under `hostdata.kubescape.cloud`, cloud provider descriptions under `eks.amazonaws.com` and friends, and image vulnerabilities under `armo.vuln.images`.

Those API groups do not exist on any cluster. Nothing can grant list on them, so RBAC answers "not allowed" every time, and the preflight counts each one as a denial. Since the default frameworks pull in a lot of host sensor controls, a service account scoped to the API groups a cluster actually serves fails the dry run with a dozen or so denied resource types it has no way to fix.

The collector already tolerates this: it treats a 404 from those groups as a non failure and gets the real data from the host scanner and the cloud APIs instead. The preflight was the one place still reading the answer as an RBAC problem.

This change skips those resources before the access review runs. They are recognised the same way the discovery resolver already recognises them, through `mapKSResourceToApiGroup`, so there is one definition of "Kubescape serves this" rather than a second list to keep in sync. Real resource types, including CRDs resolved from discovery, are checked exactly as before.

### Testing

Added `TestPreflight_SkipsExternalResources`, which runs the preflight with credentials that only allow the core group and asserts that no access review is issued for the Kubescape served resources and that the run reports no denials. It fails on master and passes with the fix.

`go build ./...`, `go vet`, and `go test ./core/... ./cmd/...` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight access checks by excluding internal Kubescape-served resources from unnecessary RBAC reviews.
  * Continued validating access for external API resources while avoiding false permission denials.
* **Tests**
  * Added coverage confirming that only resources served by the cluster are reviewed during preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->