### PR TITLE
feat(opaprocessor): add inline exception suppression via resource annotations

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -193,6 +193,10 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "host-scan", "", "Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use --host-scan=false to disable host data collection. See https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator for the operator-based alternative")
 	hostF.NoOptDefVal = "true"
 
+	// Off by default for cluster/image/workload scans, on by default for manifest/repo scans.
+	honorInlineF := scanCmd.PersistentFlags().VarPF(&scanInfo.HonorInlineExceptions, "honor-inline-exceptions", "", "Honor kubescape.io/skip-* annotations as inline exception policies. By default this is enabled for manifest scans and disabled for cluster/image/workload scans")
+	honorInlineF.NoOptDefVal = "true"
+
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output file format. Supported formats: "%s"`, strings.Join(shared.ScanFormats, `", "`)))
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -193,8 +193,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "host-scan", "", "Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use --host-scan=false to disable host data collection. See https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator for the operator-based alternative")
 	hostF.NoOptDefVal = "true"
 
-	// Off by default for cluster/image/workload scans, on by default for manifest/repo scans.
-	honorInlineF := scanCmd.PersistentFlags().VarPF(&scanInfo.HonorInlineExceptions, "honor-inline-exceptions", "", "Honor kubescape.io/skip-* annotations as inline exception policies. By default this is enabled for manifest scans and disabled for cluster/image/workload scans")
+	// Off by default for live-cluster scans, on by default for local manifest scans.
+	honorInlineF := scanCmd.PersistentFlags().VarPF(&scanInfo.HonorInlineExceptions, "honor-inline-exceptions", "", "Honor kubescape.io/skip-* annotations as inline exception policies. By default this is enabled when scanning local manifest files and disabled for live-cluster scans")
 	honorInlineF.NoOptDefVal = "true"
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output file format. Supported formats: "%s"`, strings.Join(shared.ScanFormats, `", "`)))

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -86,6 +86,7 @@ type OPASessionObj struct {
 	Exceptions            []armotypes.PostureExceptionPolicy // list of exceptions to apply on scan results
 	ExceptionAudit        *ExceptionAudit                    // optional exception usage audit
 	AuditExceptions       bool                               // include exception usage audit in supported outputs
+	HonorInlineExceptions bool                               // honor kubescape.io/skip-* annotations as inline exception policies
 	OmitRawResources      bool                               // omit raw resources from output
 	SingleResourceScan    workloadinterface.IWorkload        // single resource scan
 	TopWorkloadsByScore   []reporthandling.IResource
@@ -96,6 +97,11 @@ type OPASessionObj struct {
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {
+	// Inline annotation exceptions are off by default for cluster/workload/image scans
+	// and on by default for manifest/repo scans, unless the CLI explicitly sets the flag.
+	if scanInfo.HonorInlineExceptions.Get() == nil {
+		scanInfo.HonorInlineExceptions.SetBool(scanInfo.ScanType == ScanTypeRepo)
+	}
 	clusterSize := max(estimateClusterSize(k8sResources), 100)
 
 	return &OPASessionObj{
@@ -112,6 +118,7 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		Metadata:              scanInfoToScanMetadata(ctx, scanInfo, policyIdentifiers),
 		OmitRawResources:      scanInfo.OmitRawResources,
 		AuditExceptions:       scanInfo.AuditExceptions,
+		HonorInlineExceptions: scanInfo.HonorInlineExceptions.GetBool(),
 		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		LabelsToCopy:          scanInfo.LabelsToCopy,
 	}

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -97,10 +97,10 @@ type OPASessionObj struct {
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {
-	// Inline annotation exceptions are off by default for cluster/workload/image scans
-	// and on by default for manifest/repo scans, unless the CLI explicitly sets the flag.
+	// Inline annotation exceptions are off by default for live-cluster scans and on by
+	// default when scanning local manifests, unless the CLI explicitly sets the flag.
 	if scanInfo.HonorInlineExceptions.Get() == nil {
-		scanInfo.HonorInlineExceptions.SetBool(scanInfo.ScanType == ScanTypeRepo)
+		scanInfo.HonorInlineExceptions.SetBool(len(scanInfo.InputPatterns) > 0)
 	}
 	clusterSize := max(estimateClusterSize(k8sResources), 100)
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -114,16 +114,17 @@ type PolicyIdentifier struct {
 }
 
 type ScanInfo struct {
-	UseExceptions             string   // Load file with exceptions configuration
-	AuditExceptions           bool     // Include exception usage audit in supported scan outputs
-	ControlsInputs            string   // Load file with inputs for controls
-	AttackTracks              string   // Load file with attack tracks
-	UseFrom                   []string // Load framework from local file (instead of download). Use when running offline
-	UseDefault                bool     // Load framework from cached file (instead of download). Use when running offline
-	UseArtifactsFrom          string   // Load artifacts from local path. Use when running offline
-	ControlsVersion           string   // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
-	VerboseMode               bool     // Display all the input resources and not only failed resources
-	Hide                      bool     // Hide sensitive identifiers (names, namespaces, images) in results
+	UseExceptions             string      // Load file with exceptions configuration
+	AuditExceptions           bool        // Include exception usage audit in supported scan outputs
+	HonorInlineExceptions     BoolPtrFlag // Honor kubescape.io/skip-* annotations as inline exception policies
+	ControlsInputs            string      // Load file with inputs for controls
+	AttackTracks              string      // Load file with attack tracks
+	UseFrom                   []string    // Load framework from local file (instead of download). Use when running offline
+	UseDefault                bool        // Load framework from cached file (instead of download). Use when running offline
+	UseArtifactsFrom          string      // Load artifacts from local path. Use when running offline
+	ControlsVersion           string      // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
+	VerboseMode               bool        // Display all the input resources and not only failed resources
+	Hide                      bool        // Hide sensitive identifiers (names, namespaces, images) in results
 	EncryptionEnabled         bool
 	View                      string                       //
 	Format                    string                       // Format results (table, json, junit ...)

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
@@ -247,9 +248,15 @@ func inlineExceptionFromResource(obj workloadinterface.IMetadata, clusterName st
 
 	var expirationDate *time.Time
 	if expiry != "" {
-		if t, err := time.Parse(time.RFC3339, expiry); err == nil {
-			expirationDate = &t
+		t, err := time.Parse(time.RFC3339, expiry)
+		if err != nil {
+			logger.L().Warning("ignoring kubescape.io/skip-expiry annotation: malformed timestamp; inline exception will not be created",
+				helpers.String("resourceID", obj.GetID()),
+				helpers.String("expiry", expiry),
+				helpers.Error(err))
+			return nil
 		}
+		expirationDate = &t
 	}
 
 	policies := make([]armotypes.PosturePolicy, 0, len(controls))

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -42,6 +42,9 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	}
 
 	processor := exceptions.NewProcessor()
+
+	// synthesise inline exceptions from resource annotations before filtering
+	opap.Exceptions = append(opap.Exceptions, opap.gatherInlineExceptions()...)
 	loadedExceptions := append([]armotypes.PostureExceptionPolicy(nil), opap.Exceptions...)
 
 	// filter expired exceptions before applying them
@@ -180,6 +183,123 @@ func filterExpiredExceptions(exceptions []armotypes.PostureExceptionPolicy) []ar
 		}
 	}
 	return valid
+}
+
+const (
+	skipControlsAnnotation = "kubescape.io/skip-controls"
+	skipReasonAnnotation   = "kubescape.io/skip-reason"
+	skipExpiryAnnotation   = "kubescape.io/skip-expiry"
+)
+
+// getAnnotation returns the value of a Kubernetes annotation from a workload
+// metadata object. It prefers the typed accessor when available, and falls back
+// to a manual map inspection for non-workload implementations of IMetadata.
+func getAnnotation(obj workloadinterface.IMetadata, key string) (string, bool) {
+	if w, ok := obj.(interface {
+		GetAnnotation(string) (string, bool)
+	}); ok {
+		return w.GetAnnotation(key)
+	}
+
+	if val, ok := workloadinterface.InspectMap(obj.GetObject(), "metadata", "annotations"); ok {
+		if m, ok := val.(map[string]interface{}); ok {
+			if v, ok := m[key]; ok {
+				if s, ok := v.(string); ok {
+					return s, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// parseControlList splits a comma-separated control ID list and trims whitespace.
+func parseControlList(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// inlineExceptionFromResource synthesises a PostureExceptionPolicy from the
+// kubescape.io/skip-* annotations on a single resource.
+func inlineExceptionFromResource(obj workloadinterface.IMetadata, clusterName string) []armotypes.PostureExceptionPolicy {
+	raw, ok := getAnnotation(obj, skipControlsAnnotation)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	controls := parseControlList(raw)
+	if len(controls) == 0 {
+		return nil
+	}
+
+	reason, _ := getAnnotation(obj, skipReasonAnnotation)
+	expiry, _ := getAnnotation(obj, skipExpiryAnnotation)
+
+	var expirationDate *time.Time
+	if expiry != "" {
+		if t, err := time.Parse(time.RFC3339, expiry); err == nil {
+			expirationDate = &t
+		}
+	}
+
+	policies := make([]armotypes.PosturePolicy, 0, len(controls))
+	for _, c := range controls {
+		policies = append(policies, armotypes.PosturePolicy{ControlID: c})
+	}
+
+	attrs := map[string]string{}
+	if name := obj.GetName(); name != "" {
+		attrs["name"] = name
+	}
+	if kind := obj.GetKind(); kind != "" {
+		attrs["kind"] = kind
+	}
+	if ns := obj.GetNamespace(); ns != "" {
+		attrs["namespace"] = ns
+	}
+	if id := obj.GetID(); id != "" {
+		attrs["resourceID"] = id
+	}
+
+	var reasonPtr *string
+	if reason != "" {
+		reasonPtr = &reason
+	}
+
+	return []armotypes.PostureExceptionPolicy{{
+		PortalBase: armotypes.PortalBase{
+			Name: "inline-" + obj.GetID(),
+		},
+		PolicyType:      "postureExceptionPolicy",
+		PosturePolicies: policies,
+		Resources: []identifiers.PortalDesignator{{
+			DesignatorType: identifiers.DesignatorAttributes,
+			Attributes:     attrs,
+		}},
+		Reason:         reasonPtr,
+		ExpirationDate: expirationDate,
+		Actions:        []armotypes.PostureExceptionPolicyActions{armotypes.Disable},
+	}}
+}
+
+// gatherInlineExceptions scans all collected resources and returns exception
+// policies synthesised from their kubescape.io/skip-* annotations.
+func (opap *OPAProcessor) gatherInlineExceptions() []armotypes.PostureExceptionPolicy {
+	var exceptions []armotypes.PostureExceptionPolicy
+	for _, resource := range opap.AllResources {
+		if resource == nil {
+			continue
+		}
+		exceptions = append(exceptions, inlineExceptionFromResource(resource, opap.clusterName)...)
+	}
+	return exceptions
 }
 
 // matchingControlExceptions returns the exception policies that explicitly target

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -44,7 +44,10 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 	processor := exceptions.NewProcessor()
 
 	// synthesise inline exceptions from resource annotations before filtering
-	opap.Exceptions = append(opap.Exceptions, opap.gatherInlineExceptions()...)
+	// (only when the caller has opted in; disabled by default for cluster scans)
+	if opap.HonorInlineExceptions {
+		opap.Exceptions = append(opap.Exceptions, opap.gatherInlineExceptions()...)
+	}
 	loadedExceptions := append([]armotypes.PostureExceptionPolicy(nil), opap.Exceptions...)
 
 	// filter expired exceptions before applying them

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1031,3 +1031,112 @@ func TestFilterExpiredExceptions(t *testing.T) {
 		})
 	}
 }
+
+func makeTestWorkload(t *testing.T, raw string) workloadinterface.IMetadata {
+	t.Helper()
+	workload, err := workloadinterface.NewWorkload([]byte(raw))
+	require.NoError(t, err)
+	require.NotNil(t, workload)
+	return workload
+}
+
+func TestParseControlList(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"empty string", "", []string{}},
+		{"single id", "C-0016", []string{"C-0016"}},
+		{"comma separated with spaces", "C-0016, C-0017 , C-0018", []string{"C-0016", "C-0017", "C-0018"}},
+		{"extra commas", ",C-0016,,C-0017,", []string{"C-0016", "C-0017"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseControlList(tt.value))
+		})
+	}
+}
+
+func TestInlineExceptionFromResource(t *testing.T) {
+	workload := makeTestWorkload(t, `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "nginx",
+			"namespace": "default",
+			"annotations": {
+				"kubescape.io/skip-controls": "C-0016, C-0017",
+				"kubescape.io/skip-reason":   "accepted by security team",
+				"kubescape.io/skip-expiry":   "2026-12-31T23:59:59Z"
+			}
+		},
+		"spec": {"containers": [{"name": "nginx", "image": "nginx"}]}
+	}`)
+
+	got := inlineExceptionFromResource(workload, "test-cluster")
+	require.Len(t, got, 1)
+
+	ex := got[0]
+	assert.Equal(t, "postureExceptionPolicy", ex.PolicyType)
+	assert.Equal(t, "inline-"+workload.GetID(), ex.Name)
+	require.Len(t, ex.PosturePolicies, 2)
+	assert.Equal(t, "C-0016", ex.PosturePolicies[0].ControlID)
+	assert.Equal(t, "C-0017", ex.PosturePolicies[1].ControlID)
+
+	require.NotNil(t, ex.Reason)
+	assert.Equal(t, "accepted by security team", *ex.Reason)
+
+	require.NotNil(t, ex.ExpirationDate)
+	expected, _ := time.Parse(time.RFC3339, "2026-12-31T23:59:59Z")
+	assert.Equal(t, expected.UTC(), ex.ExpirationDate.UTC())
+
+	require.Len(t, ex.Resources, 1)
+	attrs := ex.Resources[0].Attributes
+	assert.Equal(t, "nginx", attrs["name"])
+	assert.Equal(t, "Pod", attrs["kind"])
+	assert.Equal(t, "default", attrs["namespace"])
+	assert.Equal(t, workload.GetID(), attrs["resourceID"])
+}
+
+func TestInlineExceptionFromResource_NoSkipAnnotation(t *testing.T) {
+	workload := makeTestWorkload(t, `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "nginx", "namespace": "default"},
+		"spec": {"containers": [{"name": "nginx", "image": "nginx"}]}
+	}`)
+
+	assert.Empty(t, inlineExceptionFromResource(workload, "test-cluster"))
+}
+
+func TestGatherInlineExceptions(t *testing.T) {
+	withSkip := makeTestWorkload(t, `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "nginx",
+			"namespace": "default",
+			"annotations": {"kubescape.io/skip-controls": "C-0001"}
+		}
+	}`)
+	withoutSkip := makeTestWorkload(t, `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "redis", "namespace": "default"}
+	}`)
+
+	opap := &OPAProcessor{
+		OPASessionObj: &cautils.OPASessionObj{
+			AllResources: map[string]workloadinterface.IMetadata{
+				withSkip.GetID():    withSkip,
+				withoutSkip.GetID(): withoutSkip,
+			},
+		},
+		clusterName: "test-cluster",
+	}
+
+	got := opap.gatherInlineExceptions()
+	require.Len(t, got, 1)
+	assert.Equal(t, "C-0001", got[0].PosturePolicies[0].ControlID)
+}

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1110,6 +1110,23 @@ func TestInlineExceptionFromResource_NoSkipAnnotation(t *testing.T) {
 	assert.Empty(t, inlineExceptionFromResource(workload, "test-cluster"))
 }
 
+func TestInlineExceptionFromResource_MalformedExpiry(t *testing.T) {
+	workload := makeTestWorkload(t, `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "nginx",
+			"namespace": "default",
+			"annotations": {
+				"kubescape.io/skip-controls": "C-0001",
+				"kubescape.io/skip-expiry":   "2026-12-31"
+			}
+		}
+	}`)
+
+	assert.Empty(t, inlineExceptionFromResource(workload, "test-cluster"))
+}
+
 func TestGatherInlineExceptions(t *testing.T) {
 	withSkip := makeTestWorkload(t, `{
 		"apiVersion": "v1",


### PR DESCRIPTION

## Summary
close #3390 
Adds support for inline exception suppression through Kubernetes workload annotations. GitOps teams can now declare that a specific resource is an accepted exception directly in the manifest, so the justification lives in the same PR as the resource.

## Usage

```yaml
metadata:
  annotations:
    kubescape.io/skip-controls: "C-0016,C-0017"
    kubescape.io/skip-reason: "Accepted risk: this workload is intentionally privileged (ticket FOO-123)"
    kubescape.io/skip-expiry: "2026-12-31T23:59:59Z"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resources can define control exceptions directly through annotations.
  - Exceptions support selected controls, optional reasons, expiration dates, and resource-specific scope.
  - Added an option to honor inline exceptions during live-cluster and local manifest scans.
  - Inline exception handling is enabled by default when input patterns are provided and can be configured otherwise.
  - Expired exceptions are automatically excluded before results are applied.
- **Bug Fixes**
  - Improved parsing and collection of inline exceptions across processed resources.
  - Resources without exception annotations continue to be processed normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->