### PR TITLE
fix: Add chunked pagination to SecurityException CRD retrieval

### DIFF
--- a/core/cautils/getter/crdexceptionsgetter.go
+++ b/core/cautils/getter/crdexceptionsgetter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v3/core/pkg/securityexception"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -85,48 +86,94 @@ func (g *CRDExceptionsGetter) GetExceptions(ctx context.Context, _ string) ([]ar
 
 	var out []armotypes.PostureExceptionPolicy
 
-	seList, err := g.client.Resource(securityExceptionGVR).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	for i := range seList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &seList.Items[i], "SecurityException", g.k8sClient)
-		if convErr != nil {
-			if isContextErr(convErr) {
-				return nil, convErr
+	processFunc := func(list *unstructured.UnstructuredList, kind string) error {
+		for i := range list.Items {
+			policies, convErr := convertCRDObjectToPosturePolicies(ctx, &list.Items[i], kind, g.k8sClient)
+			if convErr != nil {
+				if isContextErr(convErr) {
+					return convErr
+				}
+				logger.L().Warning(fmt.Sprintf("skipping %s that failed to convert to posture exceptions", kind),
+					helpers.String("name", list.Items[i].GetName()),
+					helpers.String("namespace", list.Items[i].GetNamespace()),
+					helpers.Error(convErr))
+				continue
 			}
-			// Partial application: skip this one CRD but keep the rest, and make the
-			// drop observable instead of silently swallowing it.
-			logger.L().Warning("skipping SecurityException that failed to convert to posture exceptions",
-				helpers.String("name", seList.Items[i].GetName()),
-				helpers.String("namespace", seList.Items[i].GetNamespace()),
-				helpers.Error(convErr))
-			continue
+			out = append(out, policies...)
 		}
-		out = append(out, policies...)
+		return nil
 	}
 
-	cseList, err := g.client.Resource(clusterSecurityExceptionGVR).List(ctx, metav1.ListOptions{})
+	err := listCRDsWithPagination(ctx, securityExceptionGVR, g.client, func(list *unstructured.UnstructuredList) error {
+		return processFunc(list, "SecurityException")
+	})
 	if err != nil {
 		return nil, err
 	}
-	for i := range cseList.Items {
-		policies, convErr := convertCRDObjectToPosturePolicies(ctx, &cseList.Items[i], "ClusterSecurityException", g.k8sClient)
-		if convErr != nil {
-			if isContextErr(convErr) {
-				return nil, convErr
-			}
-			// Partial application: skip this one CRD but keep the rest, and make the
-			// drop observable instead of silently swallowing it.
-			logger.L().Warning("skipping ClusterSecurityException that failed to convert to posture exceptions",
-				helpers.String("name", cseList.Items[i].GetName()),
-				helpers.Error(convErr))
-			continue
-		}
-		out = append(out, policies...)
+
+	err = listCRDsWithPagination(ctx, clusterSecurityExceptionGVR, g.client, func(list *unstructured.UnstructuredList) error {
+		return processFunc(list, "ClusterSecurityException")
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return out, nil
+}
+
+func listCRDsWithPagination(ctx context.Context, gvr schema.GroupVersionResource, dynamicClient dynamic.Interface, processFunc func(*unstructured.UnstructuredList) error) error {
+	limit := int64(100)
+	continueToken := ""
+
+	for {
+		listOptions := metav1.ListOptions{Limit: limit, Continue: continueToken}
+		var list *unstructured.UnstructuredList
+		var err error
+
+		retries := 5
+		backoff := 1 * time.Second
+		for i := 0; i < retries; i++ {
+			list, err = dynamicClient.Resource(gvr).List(ctx, listOptions)
+			if err != nil {
+				if k8serrors.IsTooManyRequests(err) {
+					logger.L().Warning("Rate limited (429) when listing CRDs, retrying",
+						helpers.String("gvr", gvr.String()),
+						helpers.Int("retry", i+1))
+
+					if i == retries-1 {
+						break
+					}
+
+					timer := time.NewTimer(backoff)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return ctx.Err()
+					case <-timer.C:
+						backoff *= 2
+						continue
+					}
+				}
+				break
+			}
+			break
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list %s CRDs: %w", gvr.Resource, err)
+		}
+
+		if err := processFunc(list); err != nil {
+			return err
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return nil
 }
 
 func convertCRDObjectToPosturePolicies(

--- a/core/cautils/getter/crdexceptionsgetter_pagination_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_pagination_test.go
@@ -1,0 +1,143 @@
+package getter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type mockPaginatedDynamicClient struct {
+	dynamic.Interface
+	t        *testing.T
+	listFunc func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+}
+
+func (m *mockPaginatedDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &mockPaginatedNamespaceableResource{client: m}
+}
+
+type mockPaginatedNamespaceableResource struct {
+	dynamic.NamespaceableResourceInterface
+	client *mockPaginatedDynamicClient
+}
+
+func (m *mockPaginatedNamespaceableResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return m.client.listFunc(opts)
+}
+
+func TestListCRDsWithPagination_MultiPage(t *testing.T) {
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Resource: "test"}
+
+	pageCount := 0
+	mockClient := &mockPaginatedDynamicClient{
+		t: t,
+		listFunc: func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			pageCount++
+			list := &unstructured.UnstructuredList{}
+			if opts.Continue == "" {
+				list.Items = []unstructured.Unstructured{{}, {}}
+				list.SetContinue("token1")
+			} else if opts.Continue == "token1" {
+				list.Items = []unstructured.Unstructured{{}}
+				list.SetContinue("")
+			} else {
+				return nil, fmt.Errorf("unexpected token")
+			}
+			return list, nil
+		},
+	}
+
+	var totalItems []unstructured.Unstructured
+	err := listCRDsWithPagination(ctx, gvr, mockClient, func(list *unstructured.UnstructuredList) error {
+		totalItems = append(totalItems, list.Items...)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, pageCount)
+	assert.Len(t, totalItems, 3)
+}
+
+func TestListCRDsWithPagination_Retry429(t *testing.T) {
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Resource: "test"}
+
+	attempts := 0
+	mockClient := &mockPaginatedDynamicClient{
+		t: t,
+		listFunc: func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			attempts++
+			if attempts < 3 {
+				// return 429
+				return nil, k8serrors.NewTooManyRequests("too many requests", 1)
+			}
+			list := &unstructured.UnstructuredList{}
+			list.Items = []unstructured.Unstructured{{}}
+			return list, nil
+		},
+	}
+
+	var totalItems []unstructured.Unstructured
+	err := listCRDsWithPagination(ctx, gvr, mockClient, func(list *unstructured.UnstructuredList) error {
+		totalItems = append(totalItems, list.Items...)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts)
+	assert.Len(t, totalItems, 1)
+}
+
+func TestListCRDsWithPagination_RetriesExhausted(t *testing.T) {
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Resource: "test"}
+
+	attempts := 0
+	mockClient := &mockPaginatedDynamicClient{
+		t: t,
+		listFunc: func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			attempts++
+			return nil, k8serrors.NewTooManyRequests("too many requests", 1)
+		},
+	}
+
+	err := listCRDsWithPagination(ctx, gvr, mockClient, func(list *unstructured.UnstructuredList) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many requests")
+	assert.Equal(t, 5, attempts) // 5 is the max retries defined in the function
+}
+
+func TestListCRDsWithPagination_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	gvr := schema.GroupVersionResource{Resource: "test"}
+
+	mockClient := &mockPaginatedDynamicClient{
+		t: t,
+		listFunc: func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			cancel() // cancel during the backoff
+			return nil, k8serrors.NewTooManyRequests("too many requests", 1)
+		},
+	}
+
+	err := listCRDsWithPagination(ctx, gvr, mockClient, func(list *unstructured.UnstructuredList) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/core/cautils/getter/crdexceptionsgetter_pagination_test.go
+++ b/core/cautils/getter/crdexceptionsgetter_pagination_test.go
@@ -46,13 +46,14 @@ func TestListCRDsWithPagination_MultiPage(t *testing.T) {
 		listFunc: func(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 			pageCount++
 			list := &unstructured.UnstructuredList{}
-			if opts.Continue == "" {
+			switch opts.Continue {
+			case "":
 				list.Items = []unstructured.Unstructured{{}, {}}
 				list.SetContinue("token1")
-			} else if opts.Continue == "token1" {
+			case "token1":
 				list.Items = []unstructured.Unstructured{{}}
 				list.SetContinue("")
-			} else {
+			default:
 				return nil, fmt.Errorf("unexpected token")
 			}
 			return list, nil


### PR DESCRIPTION
## Description
This PR fixes a silent failure scenario in `core/cautils/getter/crdexceptionsgetter.go` where SecurityException CRDs were retrieved using an unbounded `List()` call. 

In environments with a large number of exceptions or heavily loaded API servers, this unpaginated call could lead to:
- Out of Memory (OOM) errors in the collector.
- Kubernetes API rate limit errors (429) that drop exceptions entirely.
- Timeout errors leading to incomplete vulnerability scans.

### Changes
* Introduced `listCRDsWithPagination` helper in `crdexceptionsgetter.go`, mirroring the resilient pagination logic already utilized in `hostsensorcrdshandler.go`.
* Replaced `g.client.Resource(securityExceptionGVR).List(ctx, metav1.ListOptions{})` with the paginated helper for both `SecurityException` and `ClusterSecurityException` resources.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of security-related resources from Kubernetes environments.
  * Large result sets are now processed reliably across multiple pages.
  * Added automatic handling for temporary rate-limit responses with retry support.
  * Operations now stop promptly when cancelled, with clearer error context.
  * Improved consistency when processing security exceptions across paginated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->