### PR TITLE
fix(vap): reject a resource rule the bound policy can never match

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -139,6 +139,9 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 			if err := isValidK8sObjectName(resolvedPolicyName); err != nil {
 				return fmt.Errorf("invalid policy name %s: %w", resolvedPolicyName, err)
 			}
+			if err := checkResourceRulesInPolicyScope(resourceRuleArr, normalizedControlID, resolvedPolicyName); err != nil {
+				return err
+			}
 			for _, namespace := range namespaceArr {
 				if err := isValidNamespace(namespace); err != nil {
 					return fmt.Errorf("invalid namespace %s: %w", namespace, err)
@@ -181,7 +184,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector")
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringSliceVarP(&actionArr, "action", "a", []string{string(admissionv1.Deny)}, "Action to take when policy fails, repeatable (Deny, Warn, Audit). Deny and Warn cannot be combined")
-	createPolicyBindingCmd.Flags().StringSliceVar(&resourceRuleArr, "resource-rule", []string{}, "Restrict the binding to a group/version/resource, repeatable (e.g. apps/v1/deployments, /v1/pods). Omit to bind everything the policy matches")
+	createPolicyBindingCmd.Flags().StringSliceVar(&resourceRuleArr, "resource-rule", []string{}, "Restrict the binding to a group/version/resource the policy already matches, repeatable (e.g. apps/v1/deployments, /v1/pods). Omit to bind everything the policy matches")
 	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Parameter reference object name")
 	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
@@ -450,6 +453,132 @@ func validateRuleSegment(kind string, value string, validate func(string) []stri
 		return fmt.Errorf("invalid %s %q: %s", kind, value, strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// checkResourceRulesInPolicyScope refuses a --resource-rule the bound policy can
+// never match. The apiserver intersects a binding's matchResources with the
+// policy's matchConstraints, so a rule outside them applies cleanly and enforces
+// nothing.
+//
+// The lookup mirrors the paramKind check: --control reads the constraints off
+// the control's policy, --policy off the named one. A policy we know nothing
+// about — a name outside the embedded bundle, or one declaring no resource
+// rules — is left unchecked rather than blocked.
+func checkResourceRulesInPolicyScope(rules []string, controlID, policyName string) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	constraints, err := policyMatchConstraints(controlID, policyName)
+	if err != nil {
+		return err
+	}
+	if constraints == nil || len(constraints.ResourceRules) == 0 {
+		return nil
+	}
+	for _, rule := range rules {
+		parsed, err := parseResourceRule(rule)
+		if err != nil {
+			return err
+		}
+		if !resourceRuleInScope(parsed, constraints.ResourceRules) {
+			return fmt.Errorf("resource rule %q is outside the matchConstraints of policy %s, so the binding would match nothing; the policy matches %s",
+				strings.TrimSpace(rule), policyName, describeResourceRules(constraints.ResourceRules))
+		}
+	}
+	return nil
+}
+
+// policyMatchConstraints resolves the bound policy's matchConstraints, nil when
+// there are none to check a rule against.
+func policyMatchConstraints(controlID, policyName string) (*admissionv1.MatchResources, error) {
+	if controlID != "" {
+		return cel.MatchConstraintsForControl(controlID)
+	}
+	constraints, found, err := cel.MatchConstraintsForPolicy(policyName)
+	if err != nil || !found {
+		return nil, err
+	}
+	return constraints, nil
+}
+
+// resourceRuleInScope reports whether a binding rule overlaps any of the
+// policy's resource rules. Only an empty overlap is refused, since narrowing the
+// policy is what --resource-rule is for. excludeResourceRules are not consulted:
+// they carve out part of a surface rather than define it.
+//
+// Operations and scope are not compared either. A parsed --resource-rule always
+// carries "*" for both, so comparing them could never refuse anything.
+func resourceRuleInScope(rule admissionv1.NamedRuleWithOperations, constraints []admissionv1.NamedRuleWithOperations) bool {
+	for i := range constraints {
+		constraint := &constraints[i]
+		if valuesOverlap(rule.APIGroups, constraint.APIGroups) &&
+			valuesOverlap(rule.APIVersions, constraint.APIVersions) &&
+			resourcesOverlap(rule.Resources, constraint.Resources) {
+			return true
+		}
+	}
+	return false
+}
+
+func valuesOverlap(a, b []string) bool {
+	for _, want := range a {
+		for _, have := range b {
+			if valueMatches(want, have) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resourcesOverlap is valuesOverlap for resources, honoring the subresource form
+// the admission API uses: "pods" and "pods/exec" are separate surfaces, "*"
+// covers every resource but no subresource, and "*/*" covers both.
+func resourcesOverlap(a, b []string) bool {
+	for _, want := range a {
+		wantResource, wantSubresource := splitSubresource(want)
+		for _, have := range b {
+			haveResource, haveSubresource := splitSubresource(have)
+			if valueMatches(wantResource, haveResource) && valueMatches(wantSubresource, haveSubresource) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func splitSubresource(resource string) (string, string) {
+	if name, subresource, found := strings.Cut(resource, "/"); found {
+		return name, subresource
+	}
+	return resource, ""
+}
+
+func valueMatches(a, b string) bool {
+	return a == "*" || b == "*" || a == b
+}
+
+// describeResourceRules renders a policy's resource rules in the
+// group/version/resource form --resource-rule takes, so the refusal names what
+// the flag would have to say instead.
+func describeResourceRules(rules []admissionv1.NamedRuleWithOperations) string {
+	seen := make(map[string]struct{})
+	described := make([]string, 0, len(rules))
+	for i := range rules {
+		for _, group := range rules[i].APIGroups {
+			for _, version := range rules[i].APIVersions {
+				for _, resource := range rules[i].Resources {
+					entry := strings.Join([]string{group, version, resource}, "/")
+					if _, duplicate := seen[entry]; duplicate {
+						continue
+					}
+					seen[entry] = struct{}{}
+					described = append(described, entry)
+				}
+			}
+		}
+	}
+	return strings.Join(described, ", ")
 }
 
 // Create a policy binding

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
 	"github.com/spf13/cobra"
@@ -480,9 +481,15 @@ func checkResourceRulesInPolicyScope(rules []string, controlID, policyName strin
 		if err != nil {
 			return err
 		}
-		if !resourceRuleInScope(parsed, constraints.ResourceRules) {
+		switch classifyResourceRule(parsed, constraints.ResourceRules) {
+		case ruleOutsidePolicy:
 			return fmt.Errorf("resource rule %q is outside the matchConstraints of policy %s, so the binding would match nothing; the policy matches %s",
 				strings.TrimSpace(rule), policyName, describeResourceRules(constraints.ResourceRules))
+		case ruleConvertsToPolicy:
+			logger.L().Warning("resource rule names another API group or version than the policy constrains; the binding matches only if the cluster serves them as equivalent forms of one resource",
+				helpers.String("rule", strings.TrimSpace(rule)),
+				helpers.String("policy", policyName),
+				helpers.String("policyMatches", describeResourceRules(constraints.ResourceRules)))
 		}
 	}
 	return nil
@@ -501,23 +508,53 @@ func policyMatchConstraints(controlID, policyName string) (*admissionv1.MatchRes
 	return constraints, nil
 }
 
-// resourceRuleInScope reports whether a binding rule overlaps any of the
-// policy's resource rules. Only an empty overlap is refused, since narrowing the
-// policy is what --resource-rule is for. excludeResourceRules are not consulted:
-// they carve out part of a surface rather than define it.
+// resourceRuleScope is what this command can conclude offline about one
+// --resource-rule, given the policy it is being bound to.
+type resourceRuleScope int
+
+const (
+	// ruleOutsidePolicy: the policy constrains no resource the rule names, which
+	// no API conversion can bridge. The binding would match nothing.
+	ruleOutsidePolicy resourceRuleScope = iota
+	// ruleConvertsToPolicy: the policy constrains the resource, but at another
+	// API group or version. Whether those are equivalent forms of one resource
+	// is a cluster fact, so this is reported rather than refused.
+	ruleConvertsToPolicy
+	// ruleMatchesPolicy: the rule names a resource the policy constrains, at the
+	// same group and version.
+	ruleMatchesPolicy
+)
+
+// classifyResourceRule compares a binding rule against the policy's resource
+// rules. Only a resource mismatch is conclusive offline.
 //
-// Operations and scope are not compared either. A parsed --resource-rule always
-// carries "*" for both, so comparing them could never refuse anything.
-func resourceRuleInScope(rule admissionv1.NamedRuleWithOperations, constraints []admissionv1.NamedRuleWithOperations) bool {
+// A group or version mismatch is not, because matchResources defaults to
+// matchPolicy Equivalent and this command never sets it: the emitted binding
+// matches a request for the resource even when it arrives via another group or
+// version, so a rule naming apps/v1beta1/deployments still intersects a policy
+// constraining apps/v1/deployments. Which forms are equivalent is something only
+// the cluster knows, so the two cannot be told apart from a typo here. The
+// policy's own matchPolicy does not change this — the binding side alone is
+// enough to bridge the gap. A resource name, by contrast, is stable across
+// equivalent forms, and conversion never turns a subresource into a resource.
+//
+// excludeResourceRules are not consulted: they carve out part of a surface
+// rather than define it. Operations and scope are not compared either, since a
+// parsed --resource-rule always carries "*" for both.
+func classifyResourceRule(rule admissionv1.NamedRuleWithOperations, constraints []admissionv1.NamedRuleWithOperations) resourceRuleScope {
+	scope := ruleOutsidePolicy
 	for i := range constraints {
 		constraint := &constraints[i]
-		if valuesOverlap(rule.APIGroups, constraint.APIGroups) &&
-			valuesOverlap(rule.APIVersions, constraint.APIVersions) &&
-			resourcesOverlap(rule.Resources, constraint.Resources) {
-			return true
+		if !resourcesOverlap(rule.Resources, constraint.Resources) {
+			continue
 		}
+		if valuesOverlap(rule.APIGroups, constraint.APIGroups) &&
+			valuesOverlap(rule.APIVersions, constraint.APIVersions) {
+			return ruleMatchesPolicy
+		}
+		scope = ruleConvertsToPolicy
 	}
-	return false
+	return scope
 }
 
 func valuesOverlap(a, b []string) bool {

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1252,6 +1252,13 @@ func TestCheckResourceRulesInPolicyScope(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// Equivalent matching is the default and this command never sets matchPolicy,
+	// so a rule the apiserver may convert into the policy is reported, not refused.
+	t.Run("another version of a constrained resource is allowed", func(t *testing.T) {
+		require.NoError(t, checkResourceRulesInPolicyScope([]string{"apps/v1beta1/deployments"}, "C-0016", c0016Policy))
+		require.NoError(t, checkResourceRulesInPolicyScope([]string{"extensions/v1beta1/deployments"}, "C-0016", c0016Policy))
+	})
+
 	t.Run("policy outside the bundle is left unchecked", func(t *testing.T) {
 		require.NoError(t, checkResourceRulesInPolicyScope([]string{"ate.dev/v1alpha1/workerpools"}, "", "my-own-sandbox-policy"))
 	})
@@ -1271,7 +1278,11 @@ func TestCheckResourceRulesInPolicyScope(t *testing.T) {
 	})
 }
 
-func TestResourceRuleInScope(t *testing.T) {
+// TestClassifyResourceRule covers what the offline check can and cannot
+// conclude. Only a resource mismatch is conclusive: matchResources defaults to
+// matchPolicy Equivalent, so a group or version the policy does not name may
+// still be an equivalent form of the same resource on the cluster.
+func TestClassifyResourceRule(t *testing.T) {
 	constraint := func(group, version, resource string) admissionv1.NamedRuleWithOperations {
 		rule, err := parseResourceRule(strings.Join([]string{group, version, resource}, "/"))
 		require.NoError(t, err)
@@ -1282,43 +1293,55 @@ func TestResourceRuleInScope(t *testing.T) {
 		name        string
 		rule        string
 		constraints []admissionv1.NamedRuleWithOperations
-		want        bool
+		want        resourceRuleScope
 	}{
 		{
 			name:        "exact match",
 			rule:        "agents.x-k8s.io/v1beta1/sandboxes",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("agents.x-k8s.io", "v1beta1", "sandboxes")},
-			want:        true,
+			want:        ruleMatchesPolicy,
 		},
 		{
-			name:        "different version of the same resource",
+			name:        "another version of the same resource may be converted",
 			rule:        "agents.x-k8s.io/v1alpha1/sandboxes",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("agents.x-k8s.io", "v1beta1", "sandboxes")},
-			want:        false,
+			want:        ruleConvertsToPolicy,
+		},
+		{
+			name:        "another group serving the same resource may be converted",
+			rule:        "extensions/v1beta1/deployments",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("apps", "v1", "deployments")},
+			want:        ruleConvertsToPolicy,
+		},
+		{
+			name:        "a resource the policy never constrains",
+			rule:        "agents.x-k8s.io/v1beta1/sandboxes",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("apps", "v1", "deployments")},
+			want:        ruleOutsidePolicy,
 		},
 		{
 			name:        "policy wildcard covers the rule",
 			rule:        "agents.x-k8s.io/v1beta1/sandboxes",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")},
-			want:        true,
+			want:        ruleMatchesPolicy,
 		},
 		{
 			name:        "rule wildcard reaches one of the policy's groups",
 			rule:        "*/v1/pods",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods")},
-			want:        true,
+			want:        ruleMatchesPolicy,
 		},
 		{
 			name:        "resource wildcard does not cover a subresource",
 			rule:        "/v1/*",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods/exec")},
-			want:        false,
+			want:        ruleOutsidePolicy,
 		},
 		{
 			name:        "full wildcard covers a subresource",
 			rule:        "/v1/*/*",
 			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods/exec")},
-			want:        true,
+			want:        ruleMatchesPolicy,
 		},
 		{
 			name: "matches the second of several policy rules",
@@ -1327,7 +1350,16 @@ func TestResourceRuleInScope(t *testing.T) {
 				constraint("", "v1", "pods"),
 				constraint("batch", "v1", "cronjobs"),
 			},
-			want: true,
+			want: ruleMatchesPolicy,
+		},
+		{
+			name: "an exact match outranks a convertible one",
+			rule: "apps/v1/deployments",
+			constraints: []admissionv1.NamedRuleWithOperations{
+				constraint("extensions", "v1beta1", "deployments"),
+				constraint("apps", "v1", "deployments"),
+			},
+			want: ruleMatchesPolicy,
 		},
 	}
 
@@ -1335,7 +1367,7 @@ func TestResourceRuleInScope(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rule, err := parseResourceRule(tt.rule)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, resourceRuleInScope(rule, tt.constraints))
+			assert.Equal(t, tt.want, classifyResourceRule(rule, tt.constraints))
 		})
 	}
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1222,3 +1222,145 @@ func TestDownloadFileToStringTimeout(t *testing.T) {
 		assert.Equal(t, "fast", result)
 	})
 }
+
+// TestCheckResourceRulesInPolicyScope covers the refusal of a --resource-rule
+// the bound policy can never match. The apiserver intersects the binding with
+// the policy's matchConstraints, so such a rule yields a binding that applies
+// cleanly and enforces nothing.
+func TestCheckResourceRulesInPolicyScope(t *testing.T) {
+	const c0016Policy = "kubescape-c-0016-allow-privilege-escalation"
+
+	t.Run("rule outside the policy is refused", func(t *testing.T) {
+		err := checkResourceRulesInPolicyScope([]string{"agents.x-k8s.io/v1beta1/sandboxes"}, "C-0016", c0016Policy)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "would match nothing")
+		assert.Contains(t, err.Error(), "apps/v1/deployments", "the refusal names what the policy does match")
+	})
+
+	t.Run("rule inside the policy is accepted", func(t *testing.T) {
+		require.NoError(t, checkResourceRulesInPolicyScope([]string{"apps/v1/deployments", "/v1/pods"}, "C-0016", c0016Policy))
+	})
+
+	t.Run("one out-of-scope rule refuses the whole binding", func(t *testing.T) {
+		err := checkResourceRulesInPolicyScope([]string{"/v1/pods", "ate.dev/v1alpha1/actortemplates"}, "C-0016", c0016Policy)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ate.dev/v1alpha1/actortemplates")
+	})
+
+	t.Run("policy resolved by name only", func(t *testing.T) {
+		err := checkResourceRulesInPolicyScope([]string{"ate.dev/v1alpha1/workerpools"}, "", c0016Policy)
+		require.Error(t, err)
+	})
+
+	t.Run("policy outside the bundle is left unchecked", func(t *testing.T) {
+		require.NoError(t, checkResourceRulesInPolicyScope([]string{"ate.dev/v1alpha1/workerpools"}, "", "my-own-sandbox-policy"))
+	})
+
+	t.Run("no rules is nothing to check", func(t *testing.T) {
+		require.NoError(t, checkResourceRulesInPolicyScope(nil, "C-0016", c0016Policy))
+	})
+
+	// A subresource policy is a separate surface: binding it to the bare
+	// resource would enforce nothing.
+	t.Run("bare resource does not reach a subresource policy", func(t *testing.T) {
+		err := checkResourceRulesInPolicyScope([]string{"/v1/pods"}, "", "cluster-policy-deny-exec")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "/v1/pods/exec")
+
+		require.NoError(t, checkResourceRulesInPolicyScope([]string{"/v1/pods/exec"}, "", "cluster-policy-deny-exec"))
+	})
+}
+
+func TestResourceRuleInScope(t *testing.T) {
+	constraint := func(group, version, resource string) admissionv1.NamedRuleWithOperations {
+		rule, err := parseResourceRule(strings.Join([]string{group, version, resource}, "/"))
+		require.NoError(t, err)
+		return rule
+	}
+
+	tests := []struct {
+		name        string
+		rule        string
+		constraints []admissionv1.NamedRuleWithOperations
+		want        bool
+	}{
+		{
+			name:        "exact match",
+			rule:        "agents.x-k8s.io/v1beta1/sandboxes",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("agents.x-k8s.io", "v1beta1", "sandboxes")},
+			want:        true,
+		},
+		{
+			name:        "different version of the same resource",
+			rule:        "agents.x-k8s.io/v1alpha1/sandboxes",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("agents.x-k8s.io", "v1beta1", "sandboxes")},
+			want:        false,
+		},
+		{
+			name:        "policy wildcard covers the rule",
+			rule:        "agents.x-k8s.io/v1beta1/sandboxes",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")},
+			want:        true,
+		},
+		{
+			name:        "rule wildcard reaches one of the policy's groups",
+			rule:        "*/v1/pods",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods")},
+			want:        true,
+		},
+		{
+			name:        "resource wildcard does not cover a subresource",
+			rule:        "/v1/*",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods/exec")},
+			want:        false,
+		},
+		{
+			name:        "full wildcard covers a subresource",
+			rule:        "/v1/*/*",
+			constraints: []admissionv1.NamedRuleWithOperations{constraint("", "v1", "pods/exec")},
+			want:        true,
+		},
+		{
+			name: "matches the second of several policy rules",
+			rule: "batch/v1/cronjobs",
+			constraints: []admissionv1.NamedRuleWithOperations{
+				constraint("", "v1", "pods"),
+				constraint("batch", "v1", "cronjobs"),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, err := parseResourceRule(tt.rule)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, resourceRuleInScope(rule, tt.constraints))
+		})
+	}
+}
+
+func TestCreatePolicyBindingCmdResourceRuleScope(t *testing.T) {
+	t.Run("out-of-scope rule fails the command", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0016", "--resource-rule", "agents.x-k8s.io/v1beta1/sandboxes"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "would match nothing")
+	})
+
+	t.Run("in-scope rule is written to the binding", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0016", "--resource-rule", "batch/v1/cronjobs", "--output", outputFile})
+		require.NoError(t, cmd.Execute())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal(content, &binding))
+		require.Len(t, binding.Spec.MatchResources.ResourceRules, 1)
+		assert.Equal(t, []string{"cronjobs"}, binding.Spec.MatchResources.ResourceRules[0].Resources)
+	})
+}

--- a/core/pkg/opaprocessor/cel/catalog.go
+++ b/core/pkg/opaprocessor/cel/catalog.go
@@ -71,3 +71,36 @@ func copyParamKind(paramKind *admissionregistrationv1.ParamKind) *admissionregis
 	c := *paramKind
 	return &c
 }
+
+// MatchConstraintsForControl returns the spec.matchConstraints of the control's
+// policy, nil when the policy declares none. The apiserver intersects a
+// binding's matchResources with these constraints, so they decide whether a
+// narrowed binding can match anything at all. It errors when the control has no
+// policy in the bundle.
+func MatchConstraintsForControl(controlID string) (*admissionregistrationv1.MatchResources, error) {
+	vap, err := lookupVAP(controlID)
+	if err != nil {
+		return nil, err
+	}
+	return vap.matchConstraints.DeepCopy(), nil
+}
+
+// MatchConstraintsForPolicy is the name-keyed variant of
+// MatchConstraintsForControl, covering every policy in the bundle including the
+// cluster-scoped helpers that carry no controlId. found reports whether the name
+// is in the bundle at all, so a caller handed a policy name from outside the
+// library (e.g. cmd/vap --policy) skips the constraint check rather than fails.
+func MatchConstraintsForPolicy(policyName string) (matchConstraints *admissionregistrationv1.MatchResources, found bool, err error) {
+	catalog, err := getVAPCatalog()
+	if err != nil {
+		return nil, false, err
+	}
+	if _, dup := catalog.dupNames[policyName]; dup {
+		return nil, false, fmt.Errorf("policy %q is defined more than once in the VAP bundle; refusing it rather than pick one", policyName)
+	}
+	vap, ok := catalog.byName[policyName]
+	if !ok {
+		return nil, false, nil
+	}
+	return vap.matchConstraints.DeepCopy(), true, nil
+}

--- a/core/pkg/opaprocessor/cel/catalog_test.go
+++ b/core/pkg/opaprocessor/cel/catalog_test.go
@@ -97,3 +97,42 @@ spec:
 	require.NotNil(t, named)
 	assert.Equal(t, "C-1001", named.ControlID)
 }
+
+// TestMatchConstraintsForControl checks the constraints come off the embedded
+// policy, since cmd/vap refuses a --resource-rule that falls outside them.
+func TestMatchConstraintsForControl(t *testing.T) {
+	constraints, err := MatchConstraintsForControl("C-0016")
+	require.NoError(t, err)
+	require.NotNil(t, constraints)
+
+	var resources []string
+	for _, rule := range constraints.ResourceRules {
+		resources = append(resources, rule.Resources...)
+	}
+	assert.Contains(t, resources, "pods")
+	assert.NotContains(t, resources, "sandboxes")
+
+	_, err = MatchConstraintsForControl("C-9999")
+	require.Error(t, err)
+}
+
+// TestMatchConstraintsForPolicyCopiesBundle proves callers get their own copy,
+// so mutating the answer cannot poison the catalog every later lookup reads.
+func TestMatchConstraintsForPolicyCopiesBundle(t *testing.T) {
+	constraints, found, err := MatchConstraintsForPolicy("kubescape-c-0016-allow-privilege-escalation")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, constraints.ResourceRules)
+
+	constraints.ResourceRules[0].Resources = []string{"sandboxes"}
+
+	fresh, _, err := MatchConstraintsForPolicy("kubescape-c-0016-allow-privilege-escalation")
+	require.NoError(t, err)
+	assert.NotEqual(t, []string{"sandboxes"}, fresh.ResourceRules[0].Resources)
+
+	// A name outside the bundle reports found=false rather than erroring, so a
+	// user-supplied policy name is left unchecked instead of blocked.
+	_, found, err = MatchConstraintsForPolicy("some-custom-policy")
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
## Overview

`kubescape vap create-policy-binding --resource-rule` lets you narrow a generated binding to a specific group/version/resource. The apiserver intersects a binding's `matchResources` with the policy's own `matchConstraints`, so a rule naming something the policy never matches produces a binding that applies cleanly and then enforces nothing.

Today nothing catches that. This is what you get on master:

```
$ kubescape vap create-policy-binding --name sandbox-binding \
    --control C-0016 --resource-rule agents.x-k8s.io/v1beta1/sandboxes
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
...
  matchResources:
    resourceRules:
    - apiGroups:
      - agents.x-k8s.io
      resources:
      - sandboxes
  policyName: kubescape-c-0016-allow-privilege-escalation
  validationActions:
  - Deny
```

C-0016's policy only constrains pods, deployments, replicasets, daemonsets, statefulsets, jobs and cronjobs. The intersection is empty, `kubectl apply` accepts the manifest, and the control looks enforced while nothing is ever validated. It is an easy mistake to make once you start binding policies to custom resources, and there is no feedback loop that surfaces it.

## What changed

The command now checks each `--resource-rule` against the bound policy's `matchConstraints` and refuses one that cannot overlap:

```
$ kubescape vap create-policy-binding --name sandbox-binding \
    --control C-0016 --resource-rule agents.x-k8s.io/v1beta1/sandboxes
Error: resource rule "agents.x-k8s.io/v1beta1/sandboxes" is outside the matchConstraints of
policy kubescape-c-0016-allow-privilege-escalation, so the binding would match nothing;
the policy matches /v1/pods, apps/v1/deployments, apps/v1/replicasets, apps/v1/daemonsets,
apps/v1/statefulsets, batch/v1/jobs, batch/v1/cronjobs
```

The constraints come from the embedded VAP bundle, the same source `--control` already resolves policy names and paramKinds from, so the check needs no cluster access and stays in sync with what `vap deploy-library` ships. Two lookups were added next to the existing `ParamKindFor*` pair, following the same shape.

The check mirrors the paramKind refusal that is already in this command: `--control` reads the constraints off the control's policy, `--policy` off the named one. It deliberately stays quiet where it has no basis to judge:

* a policy name outside the embedded bundle (someone binding their own VAP) is left unchecked
* a policy declaring no resource rules is left unchecked
* only an empty overlap is refused, since narrowing a policy is the whole point of the flag
* `excludeResourceRules` are not consulted, since they carve out part of a surface rather than define it
* operations and scope are not compared, because a parsed `--resource-rule` always carries `*` for both and could never be refused on them

Only the resource name is conclusive offline. `matchResources` defaults to `matchPolicy: Equivalent` and this command never sets it, so the emitted binding matches a request for the resource even when it arrives via another API group or version. A rule naming `apps/v1beta1/deployments` therefore still intersects a policy constraining `apps/v1/deployments`. Which forms are equivalent is a cluster fact, so a group or version the policy does not name is warned about on stderr rather than refused, which keeps `| kubectl apply -f -` intact. A resource name, by contrast, is stable across equivalent forms, and conversion never turns a subresource into a resource.

Subresources are compared the way the admission API treats them: `pods` and `pods/exec` are separate surfaces, `*` covers every resource but no subresource, and `*/*` covers both. Binding a `pods/exec` policy to bare `/v1/pods` is refused for the same reason as the CRD case above.

## Commits

* `feat(cel)` exposes a policy's matchConstraints from the embedded bundle
* `test(cel)` covers those lookups, including that callers get their own copy
* `fix(vap)` refuses a resource rule outside the bound policy
* `test(vap)` covers the refusal, the overlap rules and the command path
* `fix(vap)` narrows the refusal to a resource the policy never constrains, after review
* `test(vap)` covers rules the apiserver may convert into the policy

## Testing

New tests cover the out-of-scope refusal, in-scope rules still being written, wildcard and subresource overlap, convertible group and version forms being accepted, a policy name outside the bundle being left alone, and the end to end command path. Verified the command-level test fails on master before the fix and passes after.

```
go test ./cmd/vap/... ./core/pkg/opaprocessor/...
ok  	github.com/kubescape/kubescape/v4/cmd/vap
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor
ok  	github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel
```

`go build ./...`, `go vet` and `golangci-lint run` are clean on the changed packages, and the wider `./cmd/... ./core/...` suite passes.

## Notes

This came out of reading through #2557, where extending `create-policy-binding` to custom apiGroup and resource pairs for the agent runtime CRDs is called out. `--resource-rule` already accepts them; the gap was that a rule pointing at a CRD the policy does not cover fails silently rather than loudly, which is exactly the case that gets hit while wiring up bindings for a new CRD group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added resource-rule validation when creating policy bindings.
  - Supports matching exact resources, wildcards, versions, and subresources.
  - Recognizes equivalent API group and version variants that may be converted by the API server.
  - Improved validation messages by listing resources covered by the policy.
  - Updated `--resource-rule` help text to clarify policy coverage requirements.

- **Bug Fixes**
  - Continues rejecting resource rules outside the policy’s scope.
  - Exact policy matches now take precedence over potentially equivalent variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->