### PR TITLE
fix(printer): aggregate multiple image scan runs in SARIF report printer (#3395)

### DIFF
--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -150,7 +150,7 @@ func TestSARIFPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
 	sp := NewSARIFPrinter()
 	sp.writer = tmp
 
-	require.NoError(t, sp.printImageScan(imageScanData))
+	require.NoError(t, sp.printImageScan([]cautils.ImageScanData{imageScanData}))
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestSARIFPrinter_ImageScan_StdoutPipeCompletes(t *testing.T) {
 	if os.Getenv(imageSARIFStdoutHelperEnv) == "1" {
 		sp := NewSARIFPrinter()
 		sp.SetWriter(context.Background(), "")
-		if err := sp.printImageScan(buildSeverityExceptionImageScanData()); err != nil {
+		if err := sp.printImageScan([]cautils.ImageScanData{buildSeverityExceptionImageScanData()}); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -207,36 +207,46 @@ func resolveFailedPathLocations(opaSessionObj *cautils.OPASessionObj, locationRe
 	return locations
 }
 
-func (sp *SARIFPrinter) printImageScan(scanResults cautils.ImageScanData) error {
-	model, err := models.NewDocument(clio.Identification{}, scanResults.Packages, scanResults.Context,
-		scanResults.Matches, scanResults.IgnoredMatches, scanResults.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+func (sp *SARIFPrinter) printImageScan(scanResults []cautils.ImageScanData) error {
+	combinedReport, err := sarif.New(sarif.Version210)
 	if err != nil {
-		return fmt.Errorf("failed to create document: %w", err)
-	}
-
-	// Render into an in-memory buffer rather than sp.writer directly: when no
-	// --output file is given, sp.writer is os.Stdout, and reopening it by
-	// name below to patch the driver name would deadlock if stdout is a pipe
-	// (this process still holds the write end open, so a second reader on
-	// the same pipe never sees EOF). Rendering and patching in memory, then
-	// writing to sp.writer exactly once, avoids that entirely.
-	var rendered bytes.Buffer
-	pres := grypesarif.NewPresenter(models.PresenterConfig{Document: model, SBOM: scanResults.SBOM})
-	if err := pres.Present(&rendered); err != nil {
 		return err
 	}
 
-	var sarifReport sarif.Report
-	if err := json.Unmarshal(rendered.Bytes(), &sarifReport); err != nil {
-		return err
+	for _, scan := range scanResults {
+		model, err := models.NewDocument(clio.Identification{}, scan.Packages, scan.Context,
+			scan.Matches, scan.IgnoredMatches, scan.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+		if err != nil {
+			return fmt.Errorf("failed to create document: %w", err)
+		}
+
+		// Render into an in-memory buffer rather than sp.writer directly: when no
+		// --output file is given, sp.writer is os.Stdout, and reopening it by
+		// name below to patch the driver name would deadlock if stdout is a pipe
+		// (this process still holds the write end open, so a second reader on
+		// the same pipe never sees EOF). Rendering and patching in memory, then
+		// writing to sp.writer exactly once, avoids that entirely.
+		var rendered bytes.Buffer
+		pres := grypesarif.NewPresenter(models.PresenterConfig{Document: model, SBOM: scan.SBOM})
+		if err := pres.Present(&rendered); err != nil {
+			return err
+		}
+
+		var sarifReport sarif.Report
+		if err := json.Unmarshal(rendered.Bytes(), &sarifReport); err != nil {
+			return err
+		}
+
+		// Patch driver name to Kubescape and aggregate runs
+		for _, run := range sarifReport.Runs {
+			if run.Tool.Driver != nil {
+				run.Tool.Driver.Name = "Kubescape"
+			}
+			combinedReport.AddRun(run)
+		}
 	}
 
-	// Patch driver name to Kubescape
-	for i := range sarifReport.Runs {
-		sarifReport.Runs[i].Tool.Driver.Name = "Kubescape"
-	}
-
-	updatedSarifReport, err := json.MarshalIndent(sarifReport, "", "  ")
+	updatedSarifReport, err := json.MarshalIndent(combinedReport, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -259,7 +269,7 @@ func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 		}
 
 		// image scan
-		if err := sp.printImageScan(imageScanData[0]); err != nil {
+		if err := sp.printImageScan(imageScanData); err != nil {
 			logger.L().Ctx(ctx).Error("failed to write results in sarif format", helpers.Error(err))
 			return fmt.Errorf("failed to write results in sarif format: %w", err)
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -1135,3 +1135,30 @@ func TestPrintImageScan_WriterIsNonSeekablePipe(t *testing.T) {
 	require.Len(t, report.Runs, 1)
 	assert.Equal(t, "Kubescape", report.Runs[0].Tool.Driver.Name, "driver name must still be patched when writing to a pipe")
 }
+
+func TestPrintImageScan_MultipleImagesAggregatesRuns(t *testing.T) {
+	tmp, err := os.CreateTemp("", "sarif-multiimage-*.sarif")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSARIFPrinter()
+	sp.writer = tmp
+
+	scan1 := buildSeverityExceptionImageScanData()
+	scan2 := buildSeverityExceptionImageScanData()
+
+	err = sp.ActionPrint(context.Background(), nil, []cautils.ImageScanData{scan1, scan2})
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(raw, &report))
+	require.Len(t, report.Runs, 2, "SARIF report must contain a run for each scanned image")
+	for i, run := range report.Runs {
+		require.NotNil(t, run.Tool.Driver)
+		assert.Equal(t, "Kubescape", run.Tool.Driver.Name, "driver name must be Kubescape for run %d", i)
+	}
+}


### PR DESCRIPTION

## Overview
Fixes #3395

When running image vulnerability scans across multiple container images (e.g. `kubescape scan image image1 image2` or workload image scanning), `SARIFPrinter.ActionPrint()` previously hardcoded `imageScanData[0]`, silently omitting all vulnerability findings for images `1..n` from the generated SARIF report.

### Changes
- Updated `SARIFPrinter.printImageScan()` to accept `[]cautils.ImageScanData` and aggregate each image's SARIF `Runs` into a single combined `sarif.Report`.
- Ensured tool driver name patching (`Kubescape`) applies across all aggregated runs.
- Added comprehensive unit test in `sarifprinter_test.go`:
  - `TestPrintImageScan_MultipleImagesAggregatesRuns`: verifies that multi-image scans produce a valid SARIF document containing individual `sarif.Run` entries with patched driver names for every scanned image.
- Updated `imagescan_severity_test.go` to use the updated slice signature.

## Additional Information
- Strictly adheres to the SARIF v2.1.0 specification for multi-run reports.

## How to Test
```bash
go test -v ./core/pkg/resultshandling/printer/v2 -run "TestSARIFPrinter|TestPrintImageScan"
```

## Related issues/PRs:
* Resolved #3395

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SARIF image-scan reporting to support multiple images in a single scan.
  * Each scanned image now appears as a separate run in the combined SARIF report.
  * Updated report metadata to consistently identify the scanning tool as Kubescape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->