### PR TITLE
fix(printer): normalize resource object before evidence path extraction

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -92,6 +92,29 @@ func anyToString(v any) (string, bool) {
 	}
 }
 
+// normalizeForPathExtraction converts obj into a tree built entirely from
+// encoding/json's generic decoding types (map[string]any, []any, float64,
+// string, bool, nil). Earlier processing stages (for example
+// opaprocessor.removePodData, which reads containers via
+// workload.GetContainers() and writes the resulting []corev1.Container back
+// into the object map) can leave typed structs in place of the plain
+// map/slice shape the manifest originally had. extractValueAtPath only knows
+// how to walk map[string]any and []any, so those typed sections would
+// otherwise be invisible to it - which is most posture findings, since they
+// target container-scoped fields. Round-tripping through JSON once per
+// resource makes the whole tree walkable regardless of how it got there.
+func normalizeForPathExtraction(obj map[string]any) map[string]any {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return obj
+	}
+	var normalized map[string]any
+	if err := json.Unmarshal(b, &normalized); err != nil {
+		return obj
+	}
+	return normalized
+}
+
 func extractValueAtPath(obj map[string]any, path string) (string, bool) {
 	if len(obj) == 0 || path == "" {
 		return "", false
@@ -153,7 +176,7 @@ func isSensitivePath(kind, path string) bool {
 // path string so the output is never degraded or a security risk.
 func enrichedPathsForField(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
 	var paths []string
-	obj := resource.GetObject()
+	obj := normalizeForPathExtraction(resource.GetObject())
 	kind := resource.GetKind()
 	for j := range control.ResourceAssociatedRules {
 		for k := range control.ResourceAssociatedRules[j].Paths {
@@ -212,7 +235,7 @@ func fixPathsToStringFiltered(control *resourcesresults.ResourceAssociatedContro
 // Secret.data / Secret.stringData values surfaced.
 func enrichedPathsForFieldUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
 	var paths []string
-	obj := resource.GetObject()
+	obj := normalizeForPathExtraction(resource.GetObject())
 	for j := range control.ResourceAssociatedRules {
 		for k := range control.ResourceAssociatedRules[j].Paths {
 			p := getPath(control.ResourceAssociatedRules[j].Paths[k])
@@ -258,7 +281,7 @@ func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults
 
 func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
 	var paths []string
-	obj := resource.GetObject()
+	obj := normalizeForPathExtraction(resource.GetObject())
 	kind := resource.GetKind()
 	for j := range control.ResourceAssociatedRules {
 		for k := range control.ResourceAssociatedRules[j].Paths {

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSplitPath(t *testing.T) {
@@ -493,6 +494,33 @@ func TestFailedPathsWithCurrentValues(t *testing.T) {
 		got := failedPathsWithCurrentValues(ctrl, objResource)
 		require.Len(t, got, 1)
 		assert.Equal(t, `spec.containers[0].securityContext (current: {"capabilities":{"add":["SYS_ADMIN"]},"privileged":true})`, got[0])
+	})
+
+	t.Run("container path is enriched when containers were replaced with typed structs", func(t *testing.T) {
+		// opaprocessor.removePodData sanitizes containers by calling workload.GetContainers()
+		// (which returns []corev1.Container) and writing that typed slice back into the object
+		// map via workloadinterface.SetInMap. By the time the printer runs, spec.containers is
+		// a []corev1.Container rather than []any, so the majority of posture findings - which
+		// target container-scoped fields - must still be walkable.
+		privileged := true
+		objResource := &mockResource{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []corev1.Container{
+						{
+							Name: "app",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &privileged,
+							},
+						},
+					},
+				},
+			},
+		}
+		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
+		got := failedPathsWithCurrentValues(ctrl, objResource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[0])
 	})
 }
 


### PR DESCRIPTION
## Summary
Fixes #2970 (part 2) — evidence enrichment (`" (current: <value>)"`) never fired for container-scoped paths, which are the majority of posture findings.

## Root cause
`extractValueAtPath` (`pathvalue.go`) walks the resource object with a type switch over `map[string]any` and `[]any`, falling through to `"", false` for anything else.

By the time the printer runs, `opaprocessor.removePodData` has already called `workload.GetContainers()` (which returns `[]corev1.Container`) and written that typed slice back into the object map via `workloadinterface.SetInMap` (same for `initContainers` / `ephemeralContainers`). So `spec.containers` is a `[]corev1.Container`, not a `[]any`, and the walk stops as soon as it reaches that field — silently falling back to the bare path with no enrichment.

This is the same hazard described in #2691 / #2701, which handled it by round-tripping the resource through `encoding/json` so the walk only ever sees plain maps/slices.

## Fix
Added `normalizeForPathExtraction`, which JSON round-trips the resource object once per lookup site (`enrichedPathsForField`, `enrichedPathsForFieldUnredacted`, `enrichedPathsForFieldRedacted`) before walking it, so `extractValueAtPath` sees a consistent plain map/slice tree regardless of which processing stage produced it.

## Test plan
- [x] Added `TestFailedPathsWithCurrentValues/container_path_is_enriched_when_containers_were_replaced_with_typed_structs`, which builds a resource object with `spec.containers` as `[]corev1.Container` (mirroring `removePodData`'s output) and confirms the path is now enriched with the current value — this test fails without the fix and passes with it.
- [x] `go test ./core/pkg/resultshandling/printer/v2/...` passes.
- [x] `go build ./...` passes.

This PR is independent of #3358 (part 1 of the same issue, duplicate paths) — both are scoped separately per the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-value reporting for nested, typed resource data.
  * Failed-path messages now correctly include current values in more cases, such as container security settings.
  * Preserved existing fallback behavior when current values cannot be extracted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->