### PR TITLE
test(cautils): skip helm chart symlink test when symlinks are unavailable

### DIFF
--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -147,7 +147,9 @@ func TestListHelmChartDirsReportsMetadataIOErrorsAndKeepsValidCharts(t *testing.
 	brokenChart := filepath.Join(dir, "z-broken")
 	require.NoError(t, os.Mkdir(brokenChart, 0o700))
 	chartFile := filepath.Join(brokenChart, "Chart.yaml")
-	require.NoError(t, os.Symlink("Chart.yaml", chartFile))
+	if err := os.Symlink("Chart.yaml", chartFile); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
 
 	charts, errs := listHelmChartDirs(dir)
 


### PR DESCRIPTION
## Summary
Addresses cause 4 of #2951 — the last of the four Windows test failures described there (causes 1–3 were already fixed by #2952 and #2977).

`TestListHelmChartDirsReportsMetadataIOErrorsAndKeepsValidCharts` builds a broken Helm chart fixture with:

```go
require.NoError(t, os.Symlink("Chart.yaml", chartFile))
```

On Windows, `os.Symlink` requires Developer Mode or an elevated process; without it, this call fails with `ERROR_PRIVILEGE_NOT_HELD` and the test errors out on fixture setup, before it ever exercises the behavior it's meant to check (that a broken chart is reported via `errs` while a valid sibling chart still loads via `charts`).

## Fix
Skip gracefully when the symlink can't be created, matching the convention already used elsewhere in the same package for exactly this situation:

```go
if err := os.Symlink("Chart.yaml", chartFile); err != nil {
    t.Skipf("symlinks are unavailable: %v", err)
}
```

(see `core/cautils/fileutils_test.go:390,519,547`, `core/pkg/resourcehandler/filesloader_test.go:1105`, `core/cautils/getter/getpoliciesutils_test.go:280`)

## Test plan
- [x] `go test ./core/cautils/...` passes (symlinks are available in this environment, so the test still runs its full assertions, not just the skip path).
- [x] `go build ./...` passes.
- [x] No production code changed — test-only fix, cannot regress runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test behavior on platforms where symbolic links are unavailable.
  * Tests now skip with a diagnostic message instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->