### PR TITLE
fix(printer): support multiple image SBOM generation in CycloneDX and SPDX printers (#3399)

### DIFF
--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -57,10 +58,6 @@ func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *caut
 		logger.L().Ctx(ctx).Error("cyclonedx-json output is only supported for image scans")
 		return fmt.Errorf("cyclonedx-json output is only supported for image scans")
 	}
-	if imageScanData[0].SBOM == nil {
-		logger.L().Ctx(ctx).Error("no SBOM data available for cyclonedx-json output")
-		return fmt.Errorf("no SBOM data available for cyclonedx-json output")
-	}
 
 	encoder, err := cyclonedxjson.NewFormatEncoderWithConfig(cyclonedxjson.DefaultEncoderConfig())
 	if err != nil {
@@ -68,13 +65,39 @@ func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *caut
 		return err
 	}
 
-	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("failed to encode SBOM as cyclonedx-json", helpers.Error(err))
-		return err
+	var encodedDocs []json.RawMessage
+	for _, scan := range imageScanData {
+		if scan.SBOM == nil {
+			logger.L().Ctx(ctx).Warning("skipping image with no SBOM data available for cyclonedx-json output")
+			continue
+		}
+
+		data, err := format.Encode(*scan.SBOM, encoder)
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to encode SBOM as cyclonedx-json", helpers.Error(err))
+			return err
+		}
+
+		encodedDocs = append(encodedDocs, json.RawMessage(data))
 	}
 
-	if _, err := cp.writer.Write(data); err != nil {
+	if len(encodedDocs) == 0 {
+		logger.L().Ctx(ctx).Error("no SBOM data available for cyclonedx-json output")
+		return fmt.Errorf("no SBOM data available for cyclonedx-json output")
+	}
+
+	var outputBytes []byte
+	if len(encodedDocs) == 1 {
+		outputBytes = encodedDocs[0]
+	} else {
+		outputBytes, err = json.MarshalIndent(encodedDocs, "", "  ")
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to marshal multi-image cyclonedx-json output", helpers.Error(err))
+			return err
+		}
+	}
+
+	if _, err := cp.writer.Write(outputBytes); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write cyclonedx-json output", helpers.Error(err))
 		return err
 	}

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
@@ -70,10 +70,80 @@ func TestActionPrint_CycloneDX_NonImageScan_NoOutput(t *testing.T) {
 
 	cp := NewCycloneDXPrinter()
 	cp.writer = tmp
-	cp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	err = cp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	require.Error(t, err)
 	require.NoError(t, tmp.Close())
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
 	assert.Empty(t, raw, "cyclonedx-json must not write anything for a non-image scan")
+}
+
+func TestActionPrint_CycloneDX_MultiImageScan(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		buildSeverityExceptionImageScanData(),
+		buildSeverityExceptionImageScanData(),
+	}
+
+	tmp, err := os.CreateTemp("", "cyclonedx-multi-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	err = cp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var docs []map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &docs), "multi-image CycloneDX output must be valid JSON array")
+	assert.Len(t, docs, 2)
+	assert.Equal(t, "CycloneDX", docs[0]["bomFormat"])
+	assert.Equal(t, "CycloneDX", docs[1]["bomFormat"])
+}
+
+func TestActionPrint_CycloneDX_PartialNilSBOM(t *testing.T) {
+	validScan := buildSeverityExceptionImageScanData()
+	nilScan := cautils.ImageScanData{SBOM: nil}
+
+	imageScanData := []cautils.ImageScanData{nilScan, validScan}
+
+	tmp, err := os.CreateTemp("", "cyclonedx-partial-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	err = cp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, err, "must succeed by processing the valid SBOM while skipping the nil SBOM")
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &doc), "single valid SBOM in partial scan must be valid JSON document")
+	assert.Equal(t, "CycloneDX", doc["bomFormat"])
+}
+
+func TestActionPrint_CycloneDX_AllNilSBOMs_ReturnsError(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{SBOM: nil},
+		{SBOM: nil},
+	}
+
+	tmp, err := os.CreateTemp("", "cyclonedx-allnil-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	err = cp.ActionPrint(context.Background(), nil, imageScanData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SBOM data available")
 }

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -57,10 +58,6 @@ func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		logger.L().Ctx(ctx).Error("spdx-json output is only supported for image scans")
 		return fmt.Errorf("spdx-json output is only supported for image scans")
 	}
-	if imageScanData[0].SBOM == nil {
-		logger.L().Ctx(ctx).Error("no SBOM data available for spdx-json output")
-		return fmt.Errorf("no SBOM data available for spdx-json output")
-	}
 
 	encoder, err := spdxjson.NewFormatEncoderWithConfig(spdxjson.DefaultEncoderConfig())
 	if err != nil {
@@ -68,13 +65,39 @@ func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 		return err
 	}
 
-	data, err := format.Encode(*imageScanData[0].SBOM, encoder)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("failed to encode SBOM as spdx-json", helpers.Error(err))
-		return err
+	var encodedDocs []json.RawMessage
+	for _, scan := range imageScanData {
+		if scan.SBOM == nil {
+			logger.L().Ctx(ctx).Warning("skipping image with no SBOM data available for spdx-json output")
+			continue
+		}
+
+		data, err := format.Encode(*scan.SBOM, encoder)
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to encode SBOM as spdx-json", helpers.Error(err))
+			return err
+		}
+
+		encodedDocs = append(encodedDocs, json.RawMessage(data))
 	}
 
-	if _, err := sp.writer.Write(data); err != nil {
+	if len(encodedDocs) == 0 {
+		logger.L().Ctx(ctx).Error("no SBOM data available for spdx-json output")
+		return fmt.Errorf("no SBOM data available for spdx-json output")
+	}
+
+	var outputBytes []byte
+	if len(encodedDocs) == 1 {
+		outputBytes = encodedDocs[0]
+	} else {
+		outputBytes, err = json.MarshalIndent(encodedDocs, "", "  ")
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to marshal multi-image spdx-json output", helpers.Error(err))
+			return err
+		}
+	}
+
+	if _, err := sp.writer.Write(outputBytes); err != nil {
 		logger.L().Ctx(ctx).Error("failed to write spdx-json output", helpers.Error(err))
 		return err
 	}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
@@ -73,10 +73,86 @@ func TestActionPrint_SPDX_NonImageScan_NoOutput(t *testing.T) {
 
 	sp := NewSPDXPrinter()
 	sp.writer = tmp
-	sp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	err = sp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), nil)
+	require.Error(t, err)
 	require.NoError(t, tmp.Close())
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
 	assert.Empty(t, raw, "spdx-json must not write anything for a non-image scan")
+}
+
+func TestActionPrint_SPDX_MultiImageScan(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		buildSeverityExceptionImageScanData(),
+		buildSeverityExceptionImageScanData(),
+	}
+
+	tmp, err := os.CreateTemp("", "spdx-multi-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	err = sp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var docs []map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &docs), "multi-image SPDX output must be valid JSON array")
+	assert.Len(t, docs, 2)
+	version0, ok := docs[0]["spdxVersion"].(string)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(version0, "SPDX-"))
+	version1, ok := docs[1]["spdxVersion"].(string)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(version1, "SPDX-"))
+}
+
+func TestActionPrint_SPDX_PartialNilSBOM(t *testing.T) {
+	validScan := buildSeverityExceptionImageScanData()
+	nilScan := cautils.ImageScanData{SBOM: nil}
+
+	imageScanData := []cautils.ImageScanData{nilScan, validScan}
+
+	tmp, err := os.CreateTemp("", "spdx-partial-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	err = sp.ActionPrint(context.Background(), nil, imageScanData)
+	require.NoError(t, err, "must succeed by processing the valid SBOM while skipping the nil SBOM")
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &doc), "single valid SBOM in partial scan must be valid JSON document")
+	version, ok := doc["spdxVersion"].(string)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(version, "SPDX-"))
+}
+
+func TestActionPrint_SPDX_AllNilSBOMs_ReturnsError(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{SBOM: nil},
+		{SBOM: nil},
+	}
+
+	tmp, err := os.CreateTemp("", "spdx-allnil-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	err = sp.ActionPrint(context.Background(), nil, imageScanData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SBOM data available")
 }


### PR DESCRIPTION

## Overview
Fixes #3399

When running image vulnerability scans across multiple container images (e.g. `kubescape scan image nginx:1.20 redis:6.0` or multi-container workloads via `--scan-images`), `CycloneDXPrinter.ActionPrint()` and `SPDXPrinter.ActionPrint()` previously hardcoded `imageScanData[0]`. This caused SBOMs for images `1..n` to be silently omitted from the generated report, and caused the entire scan export to fail if the first image in the slice had a `nil` SBOM.

### Changes
- Updated `CycloneDXPrinter.ActionPrint()` and `SPDXPrinter.ActionPrint()` to iterate through all `ImageScanData` items, encoding each valid SBOM while skipping and warning on any image with `nil` SBOM data.
- Ensured errors are only returned if zero valid SBOMs were available across all scanned images.
- Added comprehensive unit tests across both printers:
  - `TestActionPrint_CycloneDX_MultiImageScan` & `TestActionPrint_SPDX_MultiImageScan`: verifies multi-image slices encode all SBOM documents.
  - `TestActionPrint_CycloneDX_PartialNilSBOM` & `TestActionPrint_SPDX_PartialNilSBOM`: verifies slices with partial nil SBOMs process valid entries without failing.
  - `TestActionPrint_CycloneDX_AllNilSBOMs_ReturnsError` & `TestActionPrint_SPDX_AllNilSBOMs_ReturnsError`: verifies proper error propagation when no valid SBOM data exists.

## How to Test
```bash
go test -v ./core/pkg/resultshandling/printer/v2 -run "Test.*CycloneDX|Test.*SPDX"
```

## Related issues/PRs:
* Resolved #3399

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CycloneDX and SPDX exports now include SBOM data from all eligible image scans.
  * Multiple SBOMs are combined into a clearly structured JSON array, while single SBOM exports retain their existing format.
  * Scans without SBOM data are skipped when valid results exist.
  * Exports now report errors when no SBOM data is available or writing fails.

* **Tests**
  * Added coverage for multiple scans, mixed valid and missing SBOM data, and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->