### PR TITLE
fix: accept key==value label selectors in vap create-policy-binding

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -155,8 +155,8 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				}
 				requirements, _ := parsed.Requirements()
 				for _, r := range requirements {
-					if r.Operator() != selection.Equals {
-						return fmt.Errorf("only '=' equality label selectors are supported: %s", label)
+					if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
+						return fmt.Errorf("only equality label selectors ('=' or '==') are supported: %s", label)
 					}
 				}
 			}

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -946,8 +946,12 @@ func TestGetVapHelperCmd(t *testing.T) {
 }
 
 func TestLabelSelectorRegexEdgeCases(t *testing.T) {
-	validLabels := []string{"app=nginx", "env1=prod2", "App=Value", "appName=NginxValue", "app-name=nginx", "app.name=nginx", "app_name=nginx", "app.kubernetes.io/name=nginx", "key=", "app = nginx"}
-	invalidLabels := []string{"key value", "=value", "key=val=extra", "app@=nginx", "app=nginx@", "app!=nginx", "app", "app==nginx"}
+	// Regression for issue-3403: "==" is DoubleEquals, a distinct operator from
+	// "=" (Equals) in k8s.io/apimachinery/pkg/selection, but both spellings mean
+	// the same thing - a plain equality selector - and kubectl treats them
+	// identically. "app==nginx" belongs in validLabels, not invalidLabels.
+	validLabels := []string{"app=nginx", "env1=prod2", "App=Value", "appName=NginxValue", "app-name=nginx", "app.name=nginx", "app_name=nginx", "app.kubernetes.io/name=nginx", "key=", "app = nginx", "app==nginx"}
+	invalidLabels := []string{"key value", "=value", "key=val=extra", "app@=nginx", "app=nginx@", "app!=nginx", "app"}
 
 	for _, label := range validLabels {
 		t.Run("valid label "+label, func(t *testing.T) {
@@ -964,7 +968,7 @@ func TestLabelSelectorRegexEdgeCases(t *testing.T) {
 			cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--label", label})
 			err := cmd.Execute()
 			require.Error(t, err)
-			assert.True(t, strings.Contains(err.Error(), "invalid label selector") || strings.Contains(err.Error(), "only '=' equality"), "unexpected error: %v", err)
+			assert.True(t, strings.Contains(err.Error(), "invalid label selector") || strings.Contains(err.Error(), "only equality label selectors"), "unexpected error: %v", err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3403.

`kubescape vap create-policy-binding --label` validates each label selector by parsing it with `k8s.io/apimachinery/pkg/labels.Parse` and checking every requirement's operator:

```go
if r.Operator() != selection.Equals {
    return fmt.Errorf("only '=' equality label selectors are supported: %s", label)
}
```

`k8s.io/apimachinery/pkg/selection` defines equality as two distinct operator constants — `Equals` ("=") and `DoubleEquals` ("==") — and `labels.Parse` reports a different `Operator()` depending on which spelling was used, even though both mean exactly the same thing (this is also how `kubectl -l` treats them). The existing check only accepted `Equals`, so `--label app==nginx` was rejected with a misleading error, even though it's a perfectly valid equality selector.

### Fix

Accept both operators in the validation gate:

```go
if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
    return fmt.Errorf("only equality label selectors ('=' or '==') are supported: %s", label)
}
```

`!=` and set-based operators (`in`, `notin`, `exists`, `!`) remain rejected — `createPolicyBinding` builds a plain `matchLabels` map, which genuinely can't express negation or set membership, so that part of the check is correct and untouched. `createPolicyBinding` itself needed no change: it already extracts values via `r.Values().List()` the same way regardless of which equality operator matched.

Also moved `"app==nginx"` from `invalidLabels` to `validLabels` in `TestLabelSelectorRegexEdgeCases`, where it had been grouped with genuinely unsupported operators like `!=` — the test itself needed to reflect the corrected behavior.

## How this was verified

Confirmed the root cause directly against the real `k8s.io/apimachinery/pkg/labels` package (not a mock): `foo=bar` parses to `Operator() == selection.Equals`, `foo==bar` parses to `Operator() == selection.DoubleEquals` — a different value, so the old check rejected it.

Then reproduced against the real, built `kubescape` binary, before the fix:

```
$ kubescape vap create-policy-binding --name test-binding --control C-0016 --namespace my-namespace --label "app==nginx"
Error: only '=' equality label selectors are supported: app==nginx

$ kubescape vap create-policy-binding --name test-binding --control C-0016 --namespace my-namespace --label "app=nginx"
apiVersion: admissionregistration.k8s.io/v1
...
    objectSelector:
      matchLabels:
        app: nginx
...
```

I confirmed the updated test is a real regression test by running it against the pre-fix code (`git stash` on just `cmd/vap/vap.go`):

```
$ git stash push -- cmd/vap/vap.go
$ go test ./cmd/vap/... -run "TestLabelSelectorRegexEdgeCases/valid_label_app==nginx" -v
    vap_test.go:961:
        Error: Received unexpected error:
               only '=' equality label selectors are supported: app==nginx
--- FAIL: TestLabelSelectorRegexEdgeCases (0.01s)
    --- FAIL: TestLabelSelectorRegexEdgeCases/valid_label_app==nginx (0.01s)
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./...
$ go vet ./cmd/vap/...
(both exit 0, no output)

$ go test ./cmd/vap/... -run TestLabelSelectorRegexEdgeCases -v
=== RUN   TestLabelSelectorRegexEdgeCases
...
=== RUN   TestLabelSelectorRegexEdgeCases/valid_label_app==nginx
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: my-binding
spec:
  matchResources:
    objectSelector:
      matchLabels:
        app: nginx
  policyName: c-0016
  validationActions:
  - Deny
...
=== RUN   TestLabelSelectorRegexEdgeCases/invalid_label_app!=nginx
Error: only equality label selectors ('=' or '==') are supported: app!=nginx
...
--- PASS: TestLabelSelectorRegexEdgeCases (0.01s)
    --- PASS: TestLabelSelectorRegexEdgeCases/valid_label_app==nginx (0.00s)
    --- PASS: TestLabelSelectorRegexEdgeCases/invalid_label_app!=nginx (0.00s)
    (all 18 subtests pass)
PASS
ok  	github.com/kubescape/kubescape/v4/cmd/vap	1.797s

$ go test ./cmd/vap/...
ok  	github.com/kubescape/kubescape/v4/cmd/vap	1.213s

$ go test ./...
(all packages pass, no FAIL anywhere)

$ golangci-lint run cmd/vap/...
0 issues.

$ gofmt -l cmd/vap/vap.go cmd/vap/vap_test.go
(no output — both files formatted)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/vap/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] Existing test moved to the correct list and confirmed to fail against the pre-fix code and pass with the fix
- [x] Full `./...` test suite passes, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Label selectors now accept both `=` and `==` equality syntax.
  * Improved validation messages clearly indicate the supported equality formats.
  * Updated validation behavior for invalid label selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->