### PR TITLE
fix: diff --severity-threshold fails closed on unresolvable severity

### DIFF
--- a/core/pkg/resultshandling/diff/diff.go
+++ b/core/pkg/resultshandling/diff/diff.go
@@ -361,7 +361,16 @@ func severityRank(value string) int {
 	}
 }
 
-// FilterBySeverity returns changes at or above the requested threshold.
+// FilterBySeverity returns changes at or above the requested threshold. A
+// change whose severity cannot be resolved to a known bucket (severityRank
+// returns 0 for anything other than low/medium/high/critical, e.g. a control
+// with a zero or missing baseScore) is treated as at or above any threshold
+// rather than silently excluded - the same fail-closed policy
+// enforceSeverityThresholds already applies to the plain scan gate for the
+// identical case (see countFailedResourcesWithUnbucketedSeverity in
+// cmd/scan/framework.go). Dropping a finding whose real severity is simply
+// unknown would be the exact "false-green output" ChangeSet's own doc
+// comment says Incomparable findings exist to prevent.
 func FilterBySeverity(changes []ControlChange, threshold string) []ControlChange {
 	if threshold == "" {
 		return changes
@@ -369,7 +378,7 @@ func FilterBySeverity(changes []ControlChange, threshold string) []ControlChange
 	minimum := severityRank(threshold)
 	filtered := make([]ControlChange, 0, len(changes))
 	for _, change := range changes {
-		if severityRank(change.Severity) >= minimum {
+		if rank := severityRank(change.Severity); rank == 0 || rank >= minimum {
 			filtered = append(filtered, change)
 		}
 	}

--- a/core/pkg/resultshandling/diff/diff_test.go
+++ b/core/pkg/resultshandling/diff/diff_test.go
@@ -325,6 +325,47 @@ func TestFilterBySeverity_BelowThresholdReturnsEmpty(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+// Regression for issue-3405: a change whose severity could not be resolved
+// (empty, or "Unknown" - what apis.ControlSeverityToString returns for a
+// control with a zero/missing baseScore, see buildSeverityMap) must not be
+// silently dropped by a severity threshold. Dropping it would be the exact
+// "false-green output" ChangeSet's own doc comment says Incomparable findings
+// exist to prevent, and contradicts the fail-closed policy
+// countFailedResourcesWithUnbucketedSeverity already applies to the plain
+// scan gate for the identical case.
+func TestFilterBySeverity_UnresolvableSeverityFailsClosed(t *testing.T) {
+	changes := []ControlChange{
+		{ControlID: "C-KNOWN-LOW", Severity: "Low"},
+		{ControlID: "C-UNKNOWN", Severity: "Unknown"},
+		{ControlID: "C-EMPTY", Severity: ""},
+	}
+
+	result := FilterBySeverity(changes, "critical")
+
+	var gotIDs []string
+	for _, c := range result {
+		gotIDs = append(gotIDs, c.ControlID)
+	}
+	assert.ElementsMatch(t, []string{"C-UNKNOWN", "C-EMPTY"}, gotIDs,
+		"unresolvable-severity findings must fail closed (kept) even under the highest threshold, while a known Low finding is correctly filtered out")
+}
+
+// End-to-end regression for issue-3405: an Incomparable finding with
+// unresolvable severity must still count toward Regressions' output - and
+// therefore toward the real kubescape diff --fail-on-new exit code, which
+// core/core/diff.go computes from exactly this filtered set - instead of
+// disappearing once --severity-threshold is set.
+func TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold(t *testing.T) {
+	cs := &ChangeSet{
+		Incomparable: []ControlChange{
+			{ResourceID: "res-1", ControlID: "C-9999", Severity: "Unknown", BaseStatus: "failed", HeadStatus: "failed", Reason: "scan coverage changed"},
+		},
+	}
+
+	assert.Len(t, Regressions(cs, "").Incomparable, 1)
+	assert.Len(t, Regressions(cs, "medium").Incomparable, 1, "an Incomparable finding with unresolvable severity must still gate the build under a threshold")
+}
+
 func TestFilterBySeverity_CIGate(t *testing.T) {
 	sum := summaryDetails{Controls: map[string]controlSummary{
 		"C-HIGH":     {ScoreFactor: 7.0},


### PR DESCRIPTION
## Summary

Fixes #3405.

`ChangeSet`'s own doc comment (`core/pkg/resultshandling/diff/diff.go`) states:

> Incomparable failures never appear as resolved, avoiding false-green output when scan scope or coverage changed.

`kubescape diff --fail-on-new` computes its exit-code gate directly from the filtered count:

```go
// core/core/diff.go
return len(diff.FilterBySeverity(cs.New, diffInfo.SeverityThreshold)) +
       len(diff.FilterBySeverity(cs.Incomparable, diffInfo.SeverityThreshold)), nil
```

But `FilterBySeverity` ranked severity purely by string match, with `severityRank` defaulting to `0` for anything that isn't `critical`/`high`/`medium`/`low`:

```go
func severityRank(value string) int {
	switch strings.ToLower(value) {
	case "critical": return 4
	...
	default: return 0
	}
}
```

`buildSeverityMap` (`report.go`) falls back to `apis.ControlSeverityToString(summary.ScoreFactor)` when a control has no explicit `Severity` string — and `apis.ControlSeverityToString(0)` (a control with a zero/missing `baseScore`) returns the literal string `"Unknown"`. `severityRank("unknown")` is `0`, and since any real threshold (low=1 through critical=4) is `> 0`, `FilterBySeverity` silently **dropped** that finding as soon as any `--severity-threshold` was set — exactly the false-green scenario `ChangeSet`'s own doc comment says `Incomparable` findings exist to prevent.

This is a narrower, residual gap left after #2411 (already fixed) — #2411 was about `Severity` being *always* empty due to reading the wrong JSON field; this is about the case where severity is *genuinely* unresolvable even after that fix, the same scenario `cmd/scan/framework.go`'s sibling `scan` gate already defends against explicitly via `countFailedResourcesWithUnbucketedSeverity`:

> Failed controls with a zero or missing baseScore never reach the counters above, so a threshold could pass on findings whose severity cannot be determined. Fail closed: treat them as at or above any threshold the user set.

`kubescape diff` had no equivalent.

### Fix

`FilterBySeverity` now treats `severityRank(change.Severity) == 0` (unresolvable) as "at or above any threshold" instead of excluding it — the same fail-closed policy the scan gate already applies.

## How this was verified

Called the real internal functions directly (`Regressions`/`FilterBySeverity`, the same ones `ks.Diff` uses — not a mock):

```go
cs := &ChangeSet{
    Incomparable: []ControlChange{
        {ResourceID: "res-1", ControlID: "C-9999", Severity: "Unknown", BaseStatus: "failed", HeadStatus: "failed", Reason: "scan coverage changed"},
    },
}
noThreshold := Regressions(cs, "")
withThreshold := Regressions(cs, "medium")
```

Before the fix:
```
Incomparable findings with no threshold: 1
Incomparable findings with --severity-threshold medium: 0
```

Added two regression tests:
1. `TestFilterBySeverity_UnresolvableSeverityFailsClosed` — a mix of a known `Low` finding (correctly filtered out under `critical`) and `Unknown`/empty-severity findings (must survive under `critical`, the highest threshold).
2. `TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold` — end-to-end through `Regressions`, matching exactly what `ks.Diff` calls for the real `--fail-on-new` gate.

Confirmed both are real regression tests by running them against the pre-fix code (`git stash` on just `diff.go`):

```
$ git stash push -- core/pkg/resultshandling/diff/diff.go
$ go test ./core/pkg/resultshandling/diff/... -run "TestFilterBySeverity_UnresolvableSeverityFailsClosed|TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold" -v
--- FAIL: TestFilterBySeverity_UnresolvableSeverityFailsClosed (0.00s)
    Messages: unresolvable-severity findings must fail closed (kept) even under the highest threshold
--- FAIL: TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold (0.00s)
    Error: "[]" should have 1 item(s), but has 0
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./...
(exit 0, no output)

$ go test ./core/pkg/resultshandling/diff/... -run "TestFilterBySeverity_UnresolvableSeverityFailsClosed|TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold" -v
=== RUN   TestFilterBySeverity_UnresolvableSeverityFailsClosed
--- PASS: TestFilterBySeverity_UnresolvableSeverityFailsClosed (0.00s)
=== RUN   TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold
--- PASS: TestRegressions_IncomparableUnknownSeverityNotDroppedByThreshold (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/pkg/resultshandling/diff	0.779s

$ go test ./core/pkg/resultshandling/diff/... ./core/core/... ./cmd/diff/...
ok  	github.com/kubescape/kubescape/v4/core/pkg/resultshandling/diff	0.360s
ok  	github.com/kubescape/kubescape/v4/core/core	36.352s
ok  	github.com/kubescape/kubescape/v4/cmd/diff	1.451s

$ go test ./...
(all packages pass, no FAIL anywhere)

$ golangci-lint run core/pkg/resultshandling/diff/...
0 issues.

$ gofmt -l core/pkg/resultshandling/diff/diff.go core/pkg/resultshandling/diff/diff_test.go
(no output — both files formatted)
```

Existing tests for `FilterBySeverity` (`TestFilterBySeverity`, `TestFilterBySeverity_BelowThresholdReturnsEmpty`, `TestFilterBySeverity_CIGate`, `TestFilterBySeverity_DoesNotMutateInput`) only exercise known severities (Critical/High/Medium/Low) and all still pass unchanged — this fix only changes behavior for the previously-mishandled unresolvable case.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./core/pkg/resultshandling/diff/...`
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — no unformatted files
- [x] Two new regression tests added, confirmed to fail against the pre-fix code and pass with the fix
- [x] Full `./...` test suite passes, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Findings with unknown or unresolved severity are now retained when severity thresholds are applied.
  * Prevented unresolved findings from being excluded and incorrectly producing a passing result.
  * Build and regression checks now correctly account for these findings under severity filters.

* **Tests**
  * Added regression coverage for unknown, empty, and incomparable severity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->