### PR TITLE
fix: PolicyReportPrinter.CloseWriter now returns the close error

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -316,8 +316,10 @@ func mapPolicyReportSeverity(severity string) string {
 	}
 }
 
-func (pp *PolicyReportPrinter) CloseWriter() {
+// CloseWriter closes the PolicyReport output writer, returning any error from flushing or closing.
+func (pp *PolicyReportPrinter) CloseWriter() error {
 	if pp.writer != nil && pp.writer != os.Stdout {
-		pp.writer.Close()
+		return pp.writer.Close()
 	}
+	return nil
 }

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter_test.go
@@ -1,0 +1,49 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPolicyReportPrinter(t *testing.T) {
+	pp := NewPolicyReportPrinter()
+	assert.NotNil(t, pp)
+	assert.Nil(t, pp.writer)
+}
+
+func TestCloseWriter_PolicyReport(t *testing.T) {
+	pp := NewPolicyReportPrinter()
+	require.NoError(t, pp.SetWriter(context.TODO(), ""))
+	assert.NotNil(t, pp.writer)
+	assert.NoError(t, pp.CloseWriter())
+}
+
+// Regression for issue-3407: PolicyReportPrinter previously implemented the
+// void CloseWriter() signature every other v2 printer moved away from in
+// #3214, so a real close failure had no way to reach the caller. CloseWriter
+// must now return the error, matching every sibling printer.
+func TestCloseWriter_PolicyReport_ReturnsCloseError(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "policyreport-*.yaml")
+	require.NoError(t, err)
+	require.NoError(t, f.Close()) // pre-close so the printer's own Close() call fails
+
+	pp := &PolicyReportPrinter{writer: f}
+	err = pp.CloseWriter()
+
+	require.Error(t, err, "a genuine close failure must be surfaced, not silently discarded")
+	assert.ErrorIs(t, err, os.ErrClosed)
+}
+
+func TestCloseWriter_PolicyReport_NilWriter(t *testing.T) {
+	pp := NewPolicyReportPrinter()
+	assert.NoError(t, pp.CloseWriter())
+}
+
+func TestCloseWriter_PolicyReport_Stdout(t *testing.T) {
+	pp := &PolicyReportPrinter{writer: os.Stdout}
+	assert.NoError(t, pp.CloseWriter(), "must never close stdout")
+}


### PR DESCRIPTION
## Summary

Fixes #3407.

#3214 migrated every v2 report printer from a void `CloseWriter()` to `CloseWriter() error`, specifically so `closePrinter` (`core/pkg/resultshandling/results.go`) could catch a real flush/close failure (full disk, broken pipe, NFS hiccup) and propagate it instead of the command reporting success (exit 0) over a truncated report file:

```go
// core/pkg/resultshandling/results.go
// Printers migrated to return an error from CloseWriter are preferred; the
// legacy void contract is still supported for backwards compatibility.
func closePrinter(p printer.IPrinter) error {
	type errorCloser interface{ CloseWriter() error }
	if c, ok := p.(errorCloser); ok {
		return c.CloseWriter()
	}
	type voidCloser interface{ CloseWriter() }
	if c, ok := p.(voidCloser); ok {
		c.CloseWriter()
	}
	return nil
}
```

`PolicyReportPrinter` was added after #3214 merged and shipped with exactly the void signature that migration eliminated everywhere else:

```go
func (pp *PolicyReportPrinter) CloseWriter() {
	if pp.writer != nil && pp.writer != os.Stdout {
		pp.writer.Close()
	}
}
```

Because `closePrinter` prefers the error-returning interface and only falls back to the void one, `PolicyReportPrinter`'s close error is structurally unreachable to any caller — the exact failure mode #3214 fixed, specifically for `kubescape scan --format policyreport`.

### Fix

`CloseWriter()` now returns `pp.writer.Close()`, matching every other v2 printer (yaml, json, sarif, html, junit, markdown, pdf, prometheus, spdx, gitlabsast, csv, pretty, cyclonedx, silent).

## How this was verified

There was no existing test file for this printer at all (`policyreportprinter_test.go` didn't exist). Compared the real close behavior of `PolicyReportPrinter` and `YamlPrinter` side by side, forcing a genuine close failure (closing an already-closed `*os.File`, which reports `os.ErrClosed`):

```go
f, _ := os.CreateTemp(t.TempDir(), "policyreport-*.yaml")
f.Close() // pre-close so the printer's own Close() call fails

pp := &PolicyReportPrinter{writer: f}
pp.CloseWriter() // void signature: any error is unreachable to the caller

yp := &YamlPrinter{writer: f}
yamlErr := yp.CloseWriter()
```

### Real output (before the fix, from the linked issue's reproduction)

```
YamlPrinter.CloseWriter() on an already-closed file: err=close /var/folders/.../policyreport-....yaml: file already closed
PolicyReportPrinter.CloseWriter() has no return value at all - the equivalent error is unreachable to any caller
```

This is a signature-level fix (the old code had no way to express "return this error" at all), so there's no equivalent "runs but returns the wrong value" reproduction against the pre-fix code — reverting just the production file while keeping the new tests demonstrates this concretely: it's a compile failure, not a behavioral mismatch, because the return value itself didn't exist before:

```
$ git stash push -- core/pkg/resultshandling/printer/v2/policyreportprinter.go
$ go test ./core/pkg/resultshandling/printer/v2/... -run TestCloseWriter_PolicyReport_ReturnsCloseError -v
core/pkg/resultshandling/printer/v2/policyreportprinter_test.go:22:20: pp.CloseWriter() (no value) used as value
core/pkg/resultshandling/printer/v2/policyreportprinter_test.go:35:8: pp.CloseWriter() (no value) used as value
...
FAIL	github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2 [build failed]
$ git stash pop
```

### Real test output (this run, on this branch, with the fix applied)

```
$ go build ./...
$ go vet ./core/pkg/resultshandling/printer/v2/...
(both exit 0, no output)

$ go test ./core/pkg/resultshandling/printer/v2/... -run "TestNewPolicyReportPrinter|TestCloseWriter_PolicyReport" -v
=== RUN   TestNewPolicyReportPrinter
--- PASS: TestNewPolicyReportPrinter (0.00s)
=== RUN   TestCloseWriter_PolicyReport
--- PASS: TestCloseWriter_PolicyReport (0.00s)
=== RUN   TestCloseWriter_PolicyReport_ReturnsCloseError
--- PASS: TestCloseWriter_PolicyReport_ReturnsCloseError (0.00s)
=== RUN   TestCloseWriter_PolicyReport_NilWriter
--- PASS: TestCloseWriter_PolicyReport_NilWriter (0.00s)
=== RUN   TestCloseWriter_PolicyReport_Stdout
--- PASS: TestCloseWriter_PolicyReport_Stdout (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2	7.886s

$ go test ./core/pkg/resultshandling/...
ok  	github.com/kubescape/kubescape/v4/core/pkg/resultshandling/... (all sub-packages)

$ go test ./...
(all packages pass, no FAIL anywhere)

$ golangci-lint run core/pkg/resultshandling/printer/v2/...
core/pkg/resultshandling/printer/v2/controltable.go:87:36: G602: slice index out of range (gosec)
1 issues:
* gosec: 1
```

That one `gosec` finding is in `controltable.go`, a file this PR does not touch — confirmed pre-existing on `master` and unrelated to this change (`git diff --name-only` shows only `policyreportprinter.go` and the new test file).

```
$ gofmt -l core/pkg/resultshandling/printer/v2/policyreportprinter.go core/pkg/resultshandling/printer/v2/policyreportprinter_test.go
(no output — both files formatted)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./core/pkg/resultshandling/printer/v2/...`
- [x] `golangci-lint run` — 0 issues in the changed files (one pre-existing, unrelated finding elsewhere)
- [x] `gofmt -l` — no unformatted files
- [x] New test file added (none existed before) with a real regression test, confirmed to fail (compile error) against the pre-fix code and pass with the fix
- [x] Full `./...` test suite passes, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved output handling by reporting errors that occur when configured report files are closed.
  - Preserved successful behavior for standard output and unavailable output writers.

- **Tests**
  - Added coverage for printer creation and output-closing behavior.
  - Verified successful closures, nil outputs, standard output handling, and close-error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->