### PR TITLE
fix(scan): apply the resource kind filters before collection, not after

### DIFF
--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -37,6 +37,9 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	}
 
 	if len(opaSessionObj.K8SResources) == 0 && len(opaSessionObj.ExternalResources) == 0 || len(opaSessionObj.AllResources) == 0 {
+		if hint := kindFilterHint(scanInfo); hint != "" {
+			return fmt.Errorf("no resources found to scan: the kind filter (%s) left nothing to evaluate", hint)
+		}
 		return fmt.Errorf("no resources found to scan")
 	}
 

--- a/core/pkg/resourcehandler/handlerpullresources_extra_test.go
+++ b/core/pkg/resourcehandler/handlerpullresources_extra_test.go
@@ -51,6 +51,7 @@ func TestCollectResources(t *testing.T) {
 	tests := []struct {
 		name       string
 		handler    collectResourcesMock
+		scanInfo   *cautils.ScanInfo
 		wantErr    string
 		assertions func(t *testing.T, session *cautils.OPASessionObj)
 	}{
@@ -91,6 +92,15 @@ func TestCollectResources(t *testing.T) {
 			wantErr: "no resources found to scan",
 		},
 		{
+			name: "names the kind filter that emptied the scan",
+			handler: collectResourcesMock{
+				k8sResources: cautils.K8SResources{},
+				allResources: map[string]workloadinterface.IMetadata{},
+			},
+			scanInfo: &cautils.ScanInfo{IncludeKinds: "Sandbox", ExcludeKinds: "Job"},
+			wantErr:  "kind filter (--include-kinds Sandbox --exclude-kinds Job) left nothing to evaluate",
+		},
+		{
 			name: "ignores unknown cloud provider",
 			handler: collectResourcesMock{
 				k8sResources:  cautils.K8SResources{"v1/configmaps": []string{"cm-1"}},
@@ -110,7 +120,12 @@ func TestCollectResources(t *testing.T) {
 				Report:   &reportv2.PostureReport{},
 			}
 
-			err := CollectResources(context.Background(), tt.handler, session, &cautils.ScanInfo{})
+			scanInfo := tt.scanInfo
+			if scanInfo == nil {
+				scanInfo = &cautils.ScanInfo{}
+			}
+
+			err := CollectResources(context.Background(), tt.handler, session, scanInfo)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -90,6 +90,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	// map resources based on framework required resources: map["/group/version/kind"][]<k8s workloads ids>
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
+	filterQueryableResourcesByKind(queryableResources, scanInfo)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 
@@ -272,6 +273,7 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 	resourceToControl := make(map[string][]string)
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
+	filterQueryableResourcesByKind(queryableResources, scanInfo)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 	sessionObj.ResourceToControlsMap = resourceToControl

--- a/core/pkg/resourcehandler/kindfilter.go
+++ b/core/pkg/resourcehandler/kindfilter.go
@@ -92,6 +92,24 @@ func filterQueryableResourcesByKind(queryableResources QueryableResources, scanI
 	)
 }
 
+// kindFilterHint describes the active kind filters, empty when neither narrows
+// anything. A scan that collected nothing reads as an empty cluster otherwise,
+// when the flags are the likelier reason.
+func kindFilterHint(scanInfo *cautils.ScanInfo) string {
+	filters := newKindFilters(scanInfo)
+	if !filters.active() {
+		return ""
+	}
+	flags := make([]string, 0, 2)
+	if filters.include != nil {
+		flags = append(flags, "--include-kinds "+strings.TrimSpace(scanInfo.IncludeKinds))
+	}
+	if filters.exclude != nil {
+		flags = append(flags, "--exclude-kinds "+strings.TrimSpace(scanInfo.ExcludeKinds))
+	}
+	return strings.Join(flags, " ")
+}
+
 // kindAllowed reports whether kind (already lowercased) passes the include/exclude
 // filters. When include is non-nil only listed kinds pass; when exclude is
 // non-nil listed kinds are rejected. Both filters may be active simultaneously:

--- a/core/pkg/resourcehandler/kindfilter.go
+++ b/core/pkg/resourcehandler/kindfilter.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -27,6 +28,68 @@ func parseKindSet(kinds string) map[string]struct{} {
 		return nil
 	}
 	return set
+}
+
+// kindFilters is the parsed --include-kinds/--exclude-kinds pair. Parsing the
+// flags once keeps query planning and the post-collection pass reading them the
+// same way.
+type kindFilters struct {
+	include map[string]struct{}
+	exclude map[string]struct{}
+}
+
+func newKindFilters(scanInfo *cautils.ScanInfo) kindFilters {
+	return kindFilters{
+		include: parseKindSet(scanInfo.IncludeKinds),
+		exclude: parseKindSet(scanInfo.ExcludeKinds),
+	}
+}
+
+func (f kindFilters) active() bool {
+	return f.include != nil || f.exclude != nil
+}
+
+func (f kindFilters) allows(kind string) bool {
+	return kindAllowed(strings.ToLower(kind), f.include, f.exclude)
+}
+
+// filterQueryableResourcesByKind drops the queries whose Kind the filters
+// reject. Pruning only after collection still listed every excluded kind
+// cluster-wide, and a listing that failed reached InfoMap, where
+// BuildScanCoverage docks the coverage score over a kind the scan was told to
+// leave out.
+//
+// A query whose Kind the resolver could not name is kept; applyKindFilter still
+// prunes its objects after collection.
+func filterQueryableResourcesByKind(queryableResources QueryableResources, scanInfo *cautils.ScanInfo) {
+	filters := newKindFilters(scanInfo)
+	if !filters.active() {
+		return
+	}
+
+	skipped := make(map[string]struct{})
+	for key := range queryableResources {
+		kind := queryableResources[key].Kind
+		if kind == "" || filters.allows(kind) {
+			continue
+		}
+		skipped[queryableResources[key].GroupVersionResourceTriplet] = struct{}{}
+		delete(queryableResources, key)
+	}
+	if len(skipped) == 0 {
+		return
+	}
+
+	triplets := make([]string, 0, len(skipped))
+	for triplet := range skipped {
+		triplets = append(triplets, triplet)
+	}
+	sort.Strings(triplets)
+	logger.L().Debug("kind filter skipped resource queries",
+		helpers.String("skipped", strings.Join(triplets, ",")),
+		helpers.String("include", scanInfo.IncludeKinds),
+		helpers.String("exclude", scanInfo.ExcludeKinds),
+	)
 }
 
 // kindAllowed reports whether kind (already lowercased) passes the include/exclude
@@ -65,15 +128,13 @@ func applyKindFilter(
 	scanInfo *cautils.ScanInfo,
 	singleScan workloadinterface.IMetadata,
 ) error {
-	include := parseKindSet(scanInfo.IncludeKinds)
-	exclude := parseKindSet(scanInfo.ExcludeKinds)
-	if include == nil && exclude == nil {
+	filters := newKindFilters(scanInfo)
+	if !filters.active() {
 		return nil
 	}
 
 	if singleScan != nil {
-		kind := strings.ToLower(singleScan.GetKind())
-		if !kindAllowed(kind, include, exclude) {
+		if !filters.allows(singleScan.GetKind()) {
 			return fmt.Errorf(
 				"kind filter excludes the explicitly requested scan target %q (kind: %s); "+
 					"adjust --include-kinds / --exclude-kinds or remove the conflicting filter",
@@ -84,7 +145,7 @@ func applyKindFilter(
 
 	removed := make(map[string]struct{})
 	for id, res := range allResources {
-		if !kindAllowed(strings.ToLower(res.GetKind()), include, exclude) {
+		if !filters.allows(res.GetKind()) {
 			removed[id] = struct{}{}
 			delete(allResources, id)
 		}

--- a/core/pkg/resourcehandler/kindfilter_query_test.go
+++ b/core/pkg/resourcehandler/kindfilter_query_test.go
@@ -243,3 +243,27 @@ func TestPreflightSkipsAccessReviewForKindFilteredResource(t *testing.T) {
 	assert.Empty(t, result.Denied())
 	assert.NotEmpty(t, result.Checks)
 }
+
+func TestKindFilterHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		scanInfo *cautils.ScanInfo
+		want     string
+	}{
+		{name: "no filters", scanInfo: &cautils.ScanInfo{}},
+		{name: "blank filter is not a filter", scanInfo: &cautils.ScanInfo{IncludeKinds: " , "}},
+		{name: "include only", scanInfo: &cautils.ScanInfo{IncludeKinds: "Sandbox"}, want: "--include-kinds Sandbox"},
+		{name: "exclude only", scanInfo: &cautils.ScanInfo{ExcludeKinds: "Job,CronJob"}, want: "--exclude-kinds Job,CronJob"},
+		{
+			name:     "both filters",
+			scanInfo: &cautils.ScanInfo{IncludeKinds: " Sandbox ", ExcludeKinds: "Job"},
+			want:     "--include-kinds Sandbox --exclude-kinds Job",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, kindFilterHint(test.scanInfo))
+		})
+	}
+}

--- a/core/pkg/resourcehandler/kindfilter_query_test.go
+++ b/core/pkg/resourcehandler/kindfilter_query_test.go
@@ -1,0 +1,245 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func queryableResource(triplet, kind string) QueryableResource {
+	return QueryableResource{GroupVersionResourceTriplet: triplet, Kind: kind}
+}
+
+func kindFilteredQueries(t *testing.T, scanInfo *cautils.ScanInfo, resources ...QueryableResource) []string {
+	t.Helper()
+	queryable := make(QueryableResources, len(resources))
+	for _, resource := range resources {
+		queryable.Add(resource)
+	}
+	filterQueryableResourcesByKind(queryable, scanInfo)
+
+	kept := make([]string, 0, len(queryable))
+	for key := range queryable {
+		kept = append(kept, key)
+	}
+	sort.Strings(kept)
+	return kept
+}
+
+func TestFilterQueryableResourcesByKind(t *testing.T) {
+	pods := queryableResource("/v1/pods", "Pod")
+	deployments := queryableResource("apps/v1/deployments", "Deployment")
+	jobs := queryableResource("batch/v1/jobs", "Job")
+	// A resource the resolver could not name a Kind for: no discovery answer.
+	sandboxes := queryableResource("agents.x-k8s.io/v1alpha1/sandboxes", "")
+
+	tests := []struct {
+		name     string
+		scanInfo *cautils.ScanInfo
+		want     []string
+	}{
+		{
+			name:     "no filters keeps everything",
+			scanInfo: &cautils.ScanInfo{},
+			want:     []string{"/v1/pods", "agents.x-k8s.io/v1alpha1/sandboxes", "apps/v1/deployments", "batch/v1/jobs"},
+		},
+		{
+			name:     "include keeps only the listed kinds",
+			scanInfo: &cautils.ScanInfo{IncludeKinds: "Deployment"},
+			want:     []string{"agents.x-k8s.io/v1alpha1/sandboxes", "apps/v1/deployments"},
+		},
+		{
+			name:     "exclude drops the listed kinds",
+			scanInfo: &cautils.ScanInfo{ExcludeKinds: "Job,Pod"},
+			want:     []string{"agents.x-k8s.io/v1alpha1/sandboxes", "apps/v1/deployments"},
+		},
+		{
+			name:     "include and exclude both apply",
+			scanInfo: &cautils.ScanInfo{IncludeKinds: "Deployment,Job", ExcludeKinds: "Job"},
+			want:     []string{"agents.x-k8s.io/v1alpha1/sandboxes", "apps/v1/deployments"},
+		},
+		{
+			name:     "kind matching is case insensitive",
+			scanInfo: &cautils.ScanInfo{ExcludeKinds: " DEPLOYMENT "},
+			want:     []string{"/v1/pods", "agents.x-k8s.io/v1alpha1/sandboxes", "batch/v1/jobs"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, kindFilteredQueries(t, test.scanInfo, pods, deployments, jobs, sandboxes))
+		})
+	}
+}
+
+// TestFilterQueryableResourcesByKindKeepsFieldSelectorVariants covers the map
+// key being the triplet plus its field selectors: every variant of a rejected
+// kind has to go, not just the bare one.
+func TestFilterQueryableResourcesByKindKeepsFieldSelectorVariants(t *testing.T) {
+	scoped := queryableResource("batch/v1/jobs", "Job")
+	scoped.AddFieldSelector("metadata.namespace=default")
+
+	kept := kindFilteredQueries(t, &cautils.ScanInfo{ExcludeKinds: "Job"},
+		queryableResource("batch/v1/jobs", "Job"), scoped, queryableResource("/v1/pods", "Pod"))
+
+	assert.Equal(t, []string{"/v1/pods"}, kept)
+}
+
+func agentRuntimeListKinds() map[schema.GroupVersionResource]string {
+	listKinds := map[schema.GroupVersionResource]string{}
+	for _, gvr := range []schema.GroupVersionResource{
+		{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"},
+		{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"},
+		{Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxtemplates"},
+		{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxtemplates"},
+		{Group: "ate.dev", Version: "v1alpha1", Resource: "actortemplates"},
+		{Group: "ate.dev", Version: "v1alpha1", Resource: "workerpools"},
+	} {
+		listKinds[gvr] = "CustomResourceList"
+	}
+	return listKinds
+}
+
+func listedTriplets(actions []k8stesting.Action) []string {
+	var listed []string
+	for _, action := range actions {
+		if action.GetVerb() != "list" {
+			continue
+		}
+		gvr := action.GetResource()
+		listed = append(listed, k8sinterface.GroupVersionResourceToString(&gvr))
+	}
+	sort.Strings(listed)
+	return listed
+}
+
+func agentRuntimeQueryableResources(t *testing.T, scanInfo *cautils.ScanInfo) QueryableResources {
+	t.Helper()
+	resolver, discoveryFailures := newDiscoveryResourceResolver(agentRuntimeDiscovery())
+	require.Empty(t, discoveryFailures)
+	queryable, _ := getQueryableResourceMapFromPolicies(
+		[]reporthandling.Framework{agentRuntimeFramework()},
+		nil,
+		reporthandling.ScopeCluster,
+		resolver,
+	)
+	filterQueryableResourcesByKind(queryable, scanInfo)
+	return queryable
+}
+
+// TestPullResourcesSkipsKindFilteredQueries is the point of filtering at query
+// planning: an excluded kind must never reach the API server, since collection
+// is what a scan of a large cluster spends its time on.
+func TestPullResourcesSkipsKindFilteredQueries(t *testing.T) {
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), agentRuntimeListKinds())
+	dynamicClient.PrependReactor("list", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{DynamicClient: dynamicClient}}
+
+	queryable := agentRuntimeQueryableResources(t, &cautils.ScanInfo{ExcludeKinds: "Sandbox,WorkerPool"})
+	_, _, failures := handler.pullResources(context.Background(), queryable, &EmptySelector{}, "")
+	require.Empty(t, failures)
+
+	assert.Equal(t, []string{
+		"ate.dev/v1alpha1/actortemplates",
+		"extensions.agents.x-k8s.io/v1alpha1/sandboxtemplates",
+		"extensions.agents.x-k8s.io/v1beta1/sandboxtemplates",
+	}, listedTriplets(dynamicClient.Actions()))
+}
+
+func TestPullResourcesKeepsOnlyIncludedKindQueries(t *testing.T) {
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), agentRuntimeListKinds())
+	dynamicClient.PrependReactor("list", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{DynamicClient: dynamicClient}}
+
+	queryable := agentRuntimeQueryableResources(t, &cautils.ScanInfo{IncludeKinds: "sandbox"})
+	_, _, failures := handler.pullResources(context.Background(), queryable, &EmptySelector{}, "")
+	require.Empty(t, failures)
+
+	assert.Equal(t, []string{
+		"agents.x-k8s.io/v1alpha1/sandboxes",
+		"agents.x-k8s.io/v1beta1/sandboxes",
+	}, listedTriplets(dynamicClient.Actions()))
+}
+
+// TestKindFilteredQueryFailureStaysOutOfScanCoverage is the reported-result half
+// of the same bug: a listing that ran anyway could still fail, and a failed pull
+// reaches InfoMap, where BuildScanCoverage turns it into a failed GVR pull and
+// docks the coverage score over a kind the scan was told to leave out.
+func TestKindFilteredQueryFailureStaysOutOfScanCoverage(t *testing.T) {
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), agentRuntimeListKinds())
+	dynamicClient.PrependReactor("list", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	dynamicClient.PrependReactor("list", "sandboxes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden: User cannot list sandboxes")
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{DynamicClient: dynamicClient}}
+
+	framework := agentRuntimeFramework()
+	resolver, discoveryFailures := newDiscoveryResourceResolver(agentRuntimeDiscovery())
+	require.Empty(t, discoveryFailures)
+	resourceToControls := map[string][]string{}
+	setComplexKSResourceMap([]reporthandling.Framework{framework}, resourceToControls, resolver)
+	require.Contains(t, resourceToControls, "agents.x-k8s.io/v1alpha1/sandboxes",
+		"the excluded kind is a control dependency, so a failed pull of it would be reported")
+
+	queryable := agentRuntimeQueryableResources(t, &cautils.ScanInfo{ExcludeKinds: "Sandbox"})
+	k8sResources, _, failedQueries := handler.pullResources(context.Background(), queryable, &EmptySelector{}, "")
+
+	infoMap := map[string]apis.StatusInfo{}
+	require.Empty(t, recordFailedQueryStatuses(failedQueries, k8sResources, infoMap))
+	assert.Empty(t, infoMap, "an excluded kind must not be reported as a failed dependency")
+
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControls, nil, nil, nil)
+	coverage.ComputeCoverageScore(1)
+	assert.Empty(t, coverage.FailedGVRPulls)
+	assert.Empty(t, coverage.NotEvaluatedControls)
+	assert.False(t, coverage.Degraded)
+}
+
+// TestPreflightSkipsAccessReviewForKindFilteredResource keeps the dry-run in
+// step with collection, the same way it already skips unlistable resources: a
+// kind the scan will not list must not read as a permission problem.
+func TestPreflightSkipsAccessReviewForKindFilteredResource(t *testing.T) {
+	client := fakeclientset.NewClientset()
+	var reviewed []string
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		reviewed = append(reviewed, ssar.Spec.ResourceAttributes.Resource)
+		ssar.Status.Allowed = ssar.Spec.ResourceAttributes.Resource != "sandboxes"
+		return true, ssar, nil
+	})
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		KubernetesClient: client,
+		DiscoveryClient:  agentRuntimeDiscovery(),
+	}}
+
+	scanInfo := &cautils.ScanInfo{ExcludeKinds: "Sandbox"}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{agentRuntimeFramework()}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.NotContains(t, reviewed, "sandboxes")
+	assert.Empty(t, result.Denied())
+	assert.NotEmpty(t, result.Checks)
+}

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -67,12 +67,17 @@ var ErrPreflightNotSupported = errors.New("dry-run RBAC preflight is only suppor
 // against the returned items, not via a namespaced list call), so a
 // cluster-wide "list" access review is the same check the real collection
 // would need to pass, regardless of --include-namespaces/--exclude-namespaces.
+//
+// --include-kinds/--exclude-kinds are honored, unlike the namespace filters:
+// they decide which resource types get listed at all, so reviewing access to an
+// excluded kind would fail the dry-run over a listing that never happens.
 func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error) {
 	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)
 
 	resourceToControl := make(map[string][]string)
 	scanningScope := cautils.GetScanningScope(sessionObj.Metadata.ContextMetadata)
 	queryableResources, _ := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
+	filterQueryableResourcesByKind(queryableResources, scanInfo)
 	setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 
 	result := &PreflightResult{DiscoveryFailures: discoveryFailures}

--- a/core/pkg/resourcehandler/queryableresource.go
+++ b/core/pkg/resourcehandler/queryableresource.go
@@ -17,6 +17,10 @@ type QueryableResource struct {
 	// Namespaced carries authoritative discovery scope when available. A nil
 	// value preserves the existing k8s-interface scope lookup.
 	Namespaced *bool
+	// Kind is the Kind the API server serves this resource as, empty when the
+	// resolver could not name it. It lets query planning honor the kind filters
+	// before the LIST runs (see filterQueryableResourcesByKind).
+	Kind string
 }
 
 func (qr *QueryableResource) String() string {
@@ -31,6 +35,7 @@ func (qr *QueryableResource) Copy() QueryableResource {
 		GroupVersionResourceTriplet: qr.GroupVersionResourceTriplet,
 		FieldSelectors:              qr.FieldSelectors,
 		Namespaced:                  qr.Namespaced,
+		Kind:                        qr.Kind,
 	}
 }
 

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -214,6 +214,7 @@ func updateQueryableResourcesMapFromRuleMatchObject(match *reporthandling.RuleMa
 					queryableResource := QueryableResource{
 						GroupVersionResourceTriplet: resolved.groupVersionResourceTriplet,
 						Namespaced:                  resolved.namespaced,
+						Kind:                        resolved.kind,
 					}
 					queryableResource.AddFieldSelector(globalFieldSelector)
 

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -22,6 +22,10 @@ type resolvedResource struct {
 	groupVersionResourceTriplet string
 	comparisonTriplets          []string
 	namespaced                  *bool
+	// kind is the Kind the resource is served as, empty when the resolver had no
+	// authoritative source for it — only discovery and a file scan's manifests
+	// know it, and a guess would be worse than reporting it unknown.
+	kind string
 }
 
 type resourceResolver func(group, version, resource string) []resolvedResource
@@ -113,6 +117,7 @@ func newOfflineManifestResourceResolver(mappedResources map[string][]workloadint
 				groupVersionResourceTriplet: primary,
 				comparisonTriplets:          comparisons,
 				namespaced:                  &namespaced,
+				kind:                        manifestResource.kind,
 			})
 		}
 		return resolved
@@ -227,6 +232,7 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 			resolved = append(resolved, resolvedResource{
 				groupVersionResourceTriplet: k8sinterface.GroupVersionResourceToString(&candidate.gvr),
 				namespaced:                  &namespaced,
+				kind:                        candidate.kind,
 			})
 		}
 		if len(resolved) > 0 {


### PR DESCRIPTION
`--include-kinds` and `--exclude-kinds` only prune resources after collection has finished. The flags exist for large clusters, but nothing about collection changes when you use them: every excluded kind is still listed cluster wide, and only then removed from the resource maps.

That also leaks into the report. A listing that runs anyway can still fail, and a failed pull lands in `InfoMap`, where `BuildScanCoverage` turns it into a failed GVR pull, marks the dependent controls as not evaluated, and docks the coverage score. So on a cluster where, say, Jobs are not readable, `--exclude-kinds Job` still ends up with degraded coverage over a kind the scan was explicitly told to leave out, and with `--fail-coverage-threshold` set that can fail the run. The `--dry-run` RBAC preflight has the same problem: it reviews list access for kinds the scan will never ask for.

The fix moves the filter to query planning. Kubernetes discovery already tells the resolver the Kind behind every group/version/resource it resolves, so that Kind is now carried through `resolvedResource` onto `QueryableResource`, and `filterQueryableResourcesByKind` drops the queries whose Kind the filters reject before any LIST happens. It runs in the eager path, the streaming path, and the preflight. A query whose Kind the resolver could not name is deliberately kept, since offline resolution and Kubescape's own served resources have no discovery answer to go on; `applyKindFilter` still prunes those objects after collection, so nothing that was filtered before is unfiltered now.

One smaller thing while in here: when the filters leave nothing at all to scan, the error used to be a bare "no resources found to scan", which reads like an empty cluster. It now names the flags that emptied it.

The detail most likely to regress is the kept unknown Kind. If a future resolver starts populating `Kind` on a path that is not authoritative, query planning would begin dropping resources on a guess instead of on discovery, and the drop is silent by nature. That is why `resolvedResource.kind` is left empty by `defaultResourceResolver` rather than derived from the plural.

Tests cover the filter itself over include, exclude, both, casing and field selector variants, the end to end assertion that the excluded GVRs never reach the fake dynamic client, the coverage regression (a forbidden listing of an excluded kind no longer reaches `InfoMap` or `ScanCoverage`), and the preflight skipping the access review. I checked each new test fails against the pre-fix behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including or excluding Kubernetes resources by kind across resource collection, preflight checks, and query execution.
  * Improved empty-result errors by identifying the kind filters responsible.
  * Added clearer filter hints for command-line users.

* **Documentation**
  * Added a comprehensive SwaVid founding-engineer interview preparation guide.

* **Tests**
  * Expanded coverage for kind filtering, query handling, access reviews, and filter-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->