### PR TITLE
feat(anonymizer): detect pseudo-ID collisions in Mapping.GetOrCreate

### DIFF
--- a/core/pkg/anonymizer/mapping.go
+++ b/core/pkg/anonymizer/mapping.go
@@ -3,6 +3,10 @@ package anonymizer
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 )
 
 // pseudoIDHashLength is the number of hex characters of the SHA-256 digest
@@ -22,12 +26,14 @@ import (
 const pseudoIDHashLength = 32
 
 type Mapping struct {
-	data map[string]string
+	data map[string]string // "prefix:value" -> pseudo-ID, the forward cache GetOrCreate reads/writes
+	seen map[string]string // pseudo-ID -> the value that first produced it, kept only to detect a hash collision
 }
 
 func NewMapping() *Mapping {
 	return &Mapping{
 		data: make(map[string]string),
+		seen: make(map[string]string),
 	}
 }
 
@@ -83,9 +89,40 @@ func (m *Mapping) GetOrCreate(prefix, value string) string {
 	// this function exists to preserve. That combined trade-off needs an
 	// explicit decision, not a change made incidentally here.
 	hash := sha256.Sum256([]byte(value))
-	pseudo := prefix + "-" + hex.EncodeToString(hash[:])[:pseudoIDHashLength]
+	suffix := hex.EncodeToString(hash[:])[:pseudoIDHashLength]
+	pseudo := prefix + "-" + suffix
+
+	// A 128-bit suffix (see pseudoIDHashLength) puts a genuine SHA-256
+	// collision far beyond the reach of any realistic report, but returning
+	// a colliding pseudo-ID unchanged would merge two distinct resources
+	// into one report entry - the exact failure that suffix width exists to
+	// prevent - so detect it defensively rather than trust the odds alone.
+	//
+	// A hit in m.seen here can only be a genuine collision, never the
+	// intentional same-value/different-prefix suffix sharing documented
+	// above: that sharing ties suffixes together, not full pseudo-IDs, and
+	// an identical (prefix, value) pair would already have returned via the
+	// m.data lookup at the top of this function.
+	//
+	// Disambiguating trades away one property: if two colliding values are
+	// never scanned together, each keeps the plain "<prefix>-<suffix>" form
+	// across runs as documented; only the run where both happen to appear
+	// gives the later one an appended counter, so this one pseudo-ID is not
+	// guaranteed identical across every future report. That is an
+	// acceptable trade for never silently merging two resources.
+	for attempt := 1; ; attempt++ {
+		if _, collided := m.seen[pseudo]; !collided {
+			break
+		}
+
+		logger.L().Warning("anonymizer: pseudo-ID collision detected, disambiguating to avoid merging distinct resources",
+			helpers.String("prefix", prefix), helpers.String("pseudo", pseudo))
+
+		pseudo = prefix + "-" + suffix + "-" + strconv.Itoa(attempt)
+	}
 
 	m.data[key] = pseudo
+	m.seen[pseudo] = value
 
 	return pseudo
 }

--- a/core/pkg/anonymizer/mapping_test.go
+++ b/core/pkg/anonymizer/mapping_test.go
@@ -1,6 +1,8 @@
 package anonymizer
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"testing"
 
@@ -131,6 +133,35 @@ func TestMapping_GetOrCreate_SuffixRetainsEnoughDigest(t *testing.T) {
 	assert.Len(t, suffix, pseudoIDHashLength)
 	assert.GreaterOrEqual(t, len(suffix), 32,
 		"a suffix shorter than 128 bits brings collisions back within reach of a single large report")
+}
+
+// TestMapping_GetOrCreate_DisambiguatesOnSeenCollision covers the defensive
+// check added alongside pseudoIDHashLength: even at 128 bits, GetOrCreate
+// must not merge two distinct values that ever do produce the same
+// pseudo-ID. A real SHA-256 collision cannot be brute-forced for a test
+// fixture the way the 32-bit case in
+// TestMapping_GetOrCreate_TruncatedHashDoesNotCollide could (~90k tries), so
+// this seeds m.seen directly to simulate one: "as if" some earlier value
+// already claimed the exact pseudo-ID a different value is about to compute.
+func TestMapping_GetOrCreate_DisambiguatesOnSeenCollision(t *testing.T) {
+	mapping := NewMapping()
+
+	const collidingValue = "value-that-will-collide"
+	hash := sha256.Sum256([]byte(collidingValue))
+	naivePseudo := "res-" + hex.EncodeToString(hash[:])[:pseudoIDHashLength]
+
+	mapping.seen[naivePseudo] = "some-other-already-seen-value"
+
+	result := mapping.GetOrCreate("res", collidingValue)
+
+	assert.NotEqual(t, naivePseudo, result,
+		"GetOrCreate must not return a pseudo-ID already claimed by a different value")
+	assert.True(t, strings.HasPrefix(result, naivePseudo+"-"),
+		"a disambiguated pseudo-ID should extend the colliding one, not replace it unrecognizably")
+
+	// A repeat call for the same (prefix, value) must stay stable - the
+	// forward cache, not re-derivation, is what guarantees that.
+	assert.Equal(t, result, mapping.GetOrCreate("res", collidingValue))
 }
 
 func TestMapping_GetOrCreate_PrefixIsolationAcrossMultiplePrefixes(t *testing.T) {


### PR DESCRIPTION
## Overview

`Mapping.GetOrCreate` (`core/pkg/anonymizer/mapping.go`) has relied entirely on the 128-bit suffix width #3221 introduced to keep two distinct values from ever landing on the same `--hide` pseudo-ID - nothing in the function itself ever actually checked for that. This adds a second index (pseudo-ID -> the value that first produced it) and disambiguates with an appended counter instead of silently handing back a colliding ID.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know
-->

This is closing a structural gap, not fixing a reachable bug - a genuine SHA-256 collision at 128 bits isn't something a real scan will ever hit, the same margin as a UUIDv4. But the function had zero runtime signal if that margin ever eroded (e.g. `pseudoIDHashLength` narrowed again without tripping the one test that pins the width, or `Mapping` reused somewhere with far higher cardinality than a single scan report). Full reasoning and the alternatives I considered (hard-failing the scan on a detected collision instead of disambiguating - rejected as disproportionate) are in #3415.

## How to Test

```
go test -race -v ./core/pkg/anonymizer/...
```

The new test, `TestMapping_GetOrCreate_DisambiguatesOnSeenCollision`, seeds the new index directly to simulate a collision rather than brute-forcing a real one (not feasible at 128 bits). I checked it's actually meaningful, not just passing regardless, by temporarily stripping the disambiguation check and confirming it fails:

```
--- FAIL: TestMapping_GetOrCreate_DisambiguatesOnSeenCollision
    Error:      	Should not be: "res-8880966229952a3dbc2228d835237e7d"
    Messages:   	GetOrCreate must not return a pseudo-ID already claimed by a different value
```

then restored it and reran to confirm green. The rest of the package's suite - including `TestTransformSession_CollidingNamesKeepDistinctResources` and `TestMapping_GetOrCreate_SameValueSharesHashSuffixAcrossPrefixes`, which pins the intentional cross-prefix suffix sharing this change has to not break - still passes clean under `-race`.

## Related issues/PRs:

* Resolved #3415

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymized identifier generation to safely handle extremely rare hash collisions.
  * Ensured generated identifiers remain consistent when the same value is processed repeatedly.
* **Tests**
  * Added coverage confirming collision disambiguation and repeat-call stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->