### PR TITLE
feat(getter): support --custom-rules for user-authored Rego rules

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -155,6 +155,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.AuditExceptions, "audit-exceptions", false, "Include an exception usage audit in supported scan outputs")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.CustomRules, "custom-rules", "", "Path to a directory containing user-authored *.rego custom rules")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. e.g: --exclude-namespaces ns-a,ns-b. Notice, when running with `exclude-namespace` kubescape does not scan cluster-scoped objects.")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.MinSeverity, "min-severity", "", "Only include controls at or above this severity (low, medium, high, critical) in the output")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.MaxSeverity, "max-severity", "", "Only include controls at or below this severity (low, medium, high, critical) in the output")

--- a/core/cautils/getter/customrules.go
+++ b/core/cautils/getter/customrules.go
@@ -1,0 +1,94 @@
+package getter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/opa-utils/reporthandling"
+)
+
+// LoadCustomRules discovers *.rego files under path and returns a synthetic
+// framework that wraps each file as a control. An empty or missing path is not
+// an error and returns a nil framework.
+func LoadCustomRules(path string) (*reporthandling.Framework, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("custom rules path %q: %w", path, err)
+	}
+
+	var files []string
+	if info.IsDir() {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return nil, fmt.Errorf("read custom rules directory %q: %w", path, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".rego") {
+				continue
+			}
+			files = append(files, filepath.Join(path, e.Name()))
+		}
+		// Readdir is unordered; sort for stable control IDs and reports.
+		sort.Strings(files)
+	} else if strings.HasSuffix(path, ".rego") {
+		files = []string{path}
+	}
+
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	controls := make([]reporthandling.Control, 0, len(files))
+	for _, file := range files {
+		name := strings.TrimSuffix(filepath.Base(file), ".rego")
+		controlID := "custom-" + name
+
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("read custom rule %q: %w", file, err)
+		}
+
+		rule := reporthandling.PolicyRule{
+			Rule: string(raw),
+			// Match all Kubernetes object kinds by default. Users can narrow
+			// selection by writing a ResourceEnumerator rego snippet inside the rule.
+			Match: []reporthandling.RuleMatchObjects{{
+				APIGroups:   []string{"*"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"*"},
+			}},
+			RuleLanguage: reporthandling.RegoLanguage,
+			Description:  fmt.Sprintf("User-authored custom rule from %s", file),
+			PortalBase: armotypes.PortalBase{
+				Name: name,
+			},
+		}
+
+		control := reporthandling.Control{
+			ControlID:   controlID,
+			Description: rule.Description,
+			Rules:       []reporthandling.PolicyRule{rule},
+			PortalBase: armotypes.PortalBase{
+				Name: controlID,
+			},
+		}
+		controls = append(controls, control)
+	}
+
+	return &reporthandling.Framework{
+		PortalBase: armotypes.PortalBase{
+			Name: "custom-rules",
+		},
+		Description: "User-authored custom rules",
+		TypeTags:    []string{"custom"},
+		Controls:    controls,
+	}, nil
+}

--- a/core/cautils/getter/customrules.go
+++ b/core/cautils/getter/customrules.go
@@ -40,10 +40,12 @@ func LoadCustomRules(path string) (*reporthandling.Framework, error) {
 		sort.Strings(files)
 	} else if strings.HasSuffix(path, ".rego") {
 		files = []string{path}
+	} else {
+		return nil, fmt.Errorf("custom rules path %q is not a .rego file or directory", path)
 	}
 
 	if len(files) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("no .rego files found in %q", path)
 	}
 
 	controls := make([]reporthandling.Control, 0, len(files))

--- a/core/cautils/getter/customrules_test.go
+++ b/core/cautils/getter/customrules_test.go
@@ -25,7 +25,16 @@ func TestLoadCustomRules_NoRegoFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-rule.txt"), []byte("hello"), 0o600))
 
 	fw, err := LoadCustomRules(dir)
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.Nil(t, fw)
+}
+
+func TestLoadCustomRules_WrongExtension(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-rule.txt")
+	require.NoError(t, os.WriteFile(f, []byte("hello"), 0o600))
+
+	fw, err := LoadCustomRules(f)
+	assert.Error(t, err)
 	assert.Nil(t, fw)
 }
 

--- a/core/cautils/getter/customrules_test.go
+++ b/core/cautils/getter/customrules_test.go
@@ -1,0 +1,67 @@
+package getter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCustomRules_EmptyPath(t *testing.T) {
+	fw, err := LoadCustomRules("")
+	assert.NoError(t, err)
+	assert.Nil(t, fw)
+}
+
+func TestLoadCustomRules_DirDoesNotExist(t *testing.T) {
+	_, err := LoadCustomRules("/does/not/exist/custom-rules")
+	assert.Error(t, err)
+}
+
+func TestLoadCustomRules_NoRegoFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-rule.txt"), []byte("hello"), 0o600))
+
+	fw, err := LoadCustomRules(dir)
+	assert.NoError(t, err)
+	assert.Nil(t, fw)
+}
+
+func TestLoadCustomRules_FromDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "no-privileged.rego"), []byte(`package armo_builtins
+
+deny[{"alertMessage": msg}] { msg := "privileged container found" }`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "no-root.rego"), []byte(`package armo_builtins
+
+deny[{"alertMessage": msg}] { msg := "root user found" }`), 0o600))
+
+	fw, err := LoadCustomRules(dir)
+	require.NoError(t, err)
+	require.NotNil(t, fw)
+
+	assert.Equal(t, "custom-rules", fw.Name)
+	assert.Len(t, fw.Controls, 2)
+	assert.Equal(t, "custom-no-privileged", fw.Controls[0].ControlID)
+	assert.Equal(t, "custom-no-root", fw.Controls[1].ControlID)
+	assert.Len(t, fw.Controls[0].Rules, 1)
+	assert.Contains(t, fw.Controls[0].Rules[0].Rule, "package armo_builtins")
+	assert.Equal(t, "Rego", string(fw.Controls[0].Rules[0].RuleLanguage))
+	assert.Len(t, fw.Controls[0].Rules[0].Match, 1)
+	assert.Equal(t, []string{"*"}, fw.Controls[0].Rules[0].Match[0].APIGroups)
+}
+
+func TestLoadCustomRules_FromSingleFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "no-privileged.rego")
+	require.NoError(t, os.WriteFile(f, []byte(`package armo_builtins
+
+deny[{"alertMessage": msg}] { msg := "ok" }`), 0o600))
+
+	fw, err := LoadCustomRules(f)
+	require.NoError(t, err)
+	require.NotNil(t, fw)
+	assert.Len(t, fw.Controls, 1)
+	assert.Equal(t, "custom-no-privileged", fw.Controls[0].ControlID)
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -117,6 +117,7 @@ type ScanInfo struct {
 	UseExceptions             string      // Load file with exceptions configuration
 	AuditExceptions           bool        // Include exception usage audit in supported scan outputs
 	HonorInlineExceptions     BoolPtrFlag // Honor kubescape.io/skip-* annotations as inline exception policies
+	CustomRules               string      // Path to a directory of custom *.rego rules
 	ControlsInputs            string      // Load file with inputs for controls
 	AttackTracks              string      // Load file with attack tracks
 	UseFrom                   []string    // Load framework from local file (instead of download). Use when running offline

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -95,6 +95,17 @@ func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyI
 		return opaSessionObj, err
 	}
 
+	// load user-authored custom rules, if any
+	if scanInfo.CustomRules != "" {
+		customFramework, err := getter.LoadCustomRules(scanInfo.CustomRules)
+		if err != nil {
+			return opaSessionObj, err
+		}
+		if customFramework != nil {
+			policies = append(policies, *customFramework)
+		}
+	}
+
 	opaSessionObj.Policies = policies
 	opaSessionObj.Exceptions = exceptions
 	if controlInputs == nil {

--- a/core/pkg/resourcehandler/resourcehandlerutils.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils.go
@@ -142,6 +142,11 @@ func filterRuleMatchesForResource(resourceKind string, matchObjects []reporthand
 
 	ruleApplies := false
 	for resource := range resourceMap {
+		// A wildcard resource matches any scanned resource kind.
+		if resource == "*" {
+			ruleApplies = true
+			break
+		}
 		if matchesInputResource(resource) {
 			ruleApplies = true
 			break

--- a/core/pkg/resourcehandler/resourcehandlerutils_test.go
+++ b/core/pkg/resourcehandler/resourcehandlerutils_test.go
@@ -167,6 +167,25 @@ func TestAddSingleResourceToResourceMaps_KnownApiVersion(t *testing.T) {
 	assert.Contains(t, k8sResources["apps/v1/deployments"], wl.GetID())
 }
 
+func TestFilterRuleMatchesForResource_Wildcard(t *testing.T) {
+	match := []reporthandling.RuleMatchObjects{{
+		APIGroups:   []string{"*"},
+		APIVersions: []string{"*"},
+		Resources:   []string{"*"},
+	}}
+
+	// wildcard should match any concrete resource kind, e.g. a single Pod scan
+	got := filterRuleMatchesForResource("Pod", match)
+	assert.NotNil(t, got)
+	assert.True(t, got["*"])
+
+	// a non-wildcard resource that does not match should still be filtered out
+	nonMatching := []reporthandling.RuleMatchObjects{{
+		Resources: []string{"ConfigMap"},
+	}}
+	assert.Nil(t, filterRuleMatchesForResource("Pod", nonMatching))
+}
+
 func TestAddSingleResourceToResourceMaps_NilWorkload(t *testing.T) {
 	k8sResources := cautils.K8SResources{}
 	allResources := map[string]workloadinterface.IMetadata{}


### PR DESCRIPTION
## Summary
close #3418 
Adds a `--custom-rules <dir>` flag that lets users point Kubescape at a directory of `.rego` files and have them evaluated alongside the official regolibrary. This closes the capability gap versus Checkov/Conftest for org-specific policies that cannot be upstreamed.

## Usage

```bash
kubescape scan --custom-rules ./my-rules/ .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading user-authored `.rego` custom rules from a file or directory during scans.
  * Added the `--custom-rules` scan option for specifying the custom rule location.
  * Custom rules are included alongside downloaded policies in a stable processing order.

* **Bug Fixes**
  * Added clear errors for invalid, inaccessible, or rule-free custom rule paths.
  * Wildcard resource rules now apply correctly across matching resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->