### PR TITLE
feat(coverage): flag frameworks scored 100% purely from irrelevant controls

### DIFF
--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
 // ScanCoverage holds runtime gaps discovered during a scan: GVRs that could
@@ -38,6 +39,11 @@ type ScanCoverage struct {
 	// so the failure is not already accounted for by NotEvaluatedControls. It is
 	// computed by BuildScanCoverage and applied as a penalty by ComputeCoverageScore.
 	SilentFailedGVRCount int `json:"silentFailedGVRCount,omitempty"`
+	// VacuousFrameworks lists frameworks whose reported score is 100% only
+	// because every control in them was Irrelevant (no resource of the
+	// required type was found in the cluster), not because anything was
+	// actually checked. Populated by DetectVacuousFrameworks.
+	VacuousFrameworks []string `json:"vacuousFrameworks,omitempty"`
 }
 
 // Fixed penalties (in percentage points) applied to the coverage score for
@@ -282,4 +288,33 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 	})
 
 	return coverage
+}
+
+// DetectVacuousFrameworks returns the names of frameworks whose controls are
+// all Irrelevant (GetSubStatus() == apis.SubStatusIrrelevant with no matched
+// resources), mirroring the check the scoring library uses to award such a
+// framework a 100% score. A framework in this state was never meaningfully
+// evaluated - the resource types its controls target simply do not exist in
+// the cluster - so its perfect score is vacuous rather than earned. Empty
+// frameworks (no controls at all) are not included.
+func DetectVacuousFrameworks(frameworks []reportsummary.FrameworkSummary) []string {
+	var vacuous []string
+	for i := range frameworks {
+		controls := frameworks[i].Controls
+		if len(controls) == 0 {
+			continue
+		}
+		allIrrelevant := true
+		for id := range controls {
+			ctrl := controls[id]
+			if ctrl.GetSubStatus() != apis.SubStatusIrrelevant || ctrl.ListResourcesIDs(nil).Len() != 0 {
+				allIrrelevant = false
+				break
+			}
+		}
+		if allIrrelevant {
+			vacuous = append(vacuous, frameworks[i].Name)
+		}
+	}
+	return vacuous
 }

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -294,26 +294,26 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 // all Irrelevant (GetSubStatus() == apis.SubStatusIrrelevant with no matched
 // resources), mirroring the check the scoring library uses to award such a
 // framework a 100% score. A framework in this state was never meaningfully
-// evaluated - the resource types its controls target simply do not exist in
-// the cluster - so its perfect score is vacuous rather than earned. Empty
-// frameworks (no controls at all) are not included.
+// evaluated - no resource in the cluster matched any of its controls - so
+// its perfect score is vacuous rather than earned. Empty frameworks (no
+// controls at all) are not included.
 func DetectVacuousFrameworks(frameworks []reportsummary.FrameworkSummary) []string {
 	var vacuous []string
 	for i := range frameworks {
-		controls := frameworks[i].Controls
-		if len(controls) == 0 {
+		fw := frameworks[i]
+		if len(fw.Controls) == 0 {
 			continue
 		}
 		allIrrelevant := true
-		for id := range controls {
-			ctrl := controls[id]
+		for id := range fw.Controls {
+			ctrl := fw.Controls[id]
 			if ctrl.GetSubStatus() != apis.SubStatusIrrelevant || ctrl.ListResourcesIDs(nil).Len() != 0 {
 				allIrrelevant = false
 				break
 			}
 		}
 		if allIrrelevant {
-			vacuous = append(vacuous, frameworks[i].Name)
+			vacuous = append(vacuous, fw.Name)
 		}
 	}
 	return vacuous

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -420,6 +420,16 @@ func evaluatedControl(id string) reportsummary.ControlSummary {
 	return c
 }
 
+// irrelevantControlWithResources carries the Irrelevant sub-status but still
+// lists a matched resource, the shape a passed-and-irrelevant control cannot
+// actually take in a real report. It exists to prove DetectVacuousFrameworks
+// checks the resource count in addition to the sub-status.
+func irrelevantControlWithResources(id string) reportsummary.ControlSummary {
+	c := irrelevantControl(id)
+	c.ResourceIDs.Append(apis.StatusPassed, "resource-1")
+	return c
+}
+
 func TestDetectVacuousFrameworks_AllControlsIrrelevant(t *testing.T) {
 	frameworks := []reportsummary.FrameworkSummary{
 		{
@@ -444,6 +454,24 @@ func TestDetectVacuousFrameworks_MixedControlsNotFlagged(t *testing.T) {
 		},
 	}
 	assert.Empty(t, DetectVacuousFrameworks(frameworks))
+}
+
+func TestDetectVacuousFrameworks_IrrelevantWithResourcesNotFlagged(t *testing.T) {
+	frameworks := []reportsummary.FrameworkSummary{
+		{
+			Name: "istio-security",
+			Controls: reportsummary.ControlSummaries{
+				"C-ISTIO-1": irrelevantControlWithResources("C-ISTIO-1"),
+			},
+		},
+		{
+			Name: "nsa",
+			Controls: reportsummary.ControlSummaries{
+				"C-0001": irrelevantControl("C-0001"),
+			},
+		},
+	}
+	assert.Equal(t, []string{"nsa"}, DetectVacuousFrameworks(frameworks))
 }
 
 func TestDetectVacuousFrameworks_EmptyFrameworkNotFlagged(t *testing.T) {

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -396,4 +397,76 @@ func makeNotEvaluatedControls(n int) []NotEvaluatedControl {
 		ne[i] = NotEvaluatedControl{ControlID: string(rune('A' + i))}
 	}
 	return ne
+}
+
+func irrelevantControl(id string) reportsummary.ControlSummary {
+	return reportsummary.ControlSummary{
+		ControlID: id,
+		StatusInfo: apis.StatusInfo{
+			InnerStatus: apis.StatusPassed,
+			SubStatus:   apis.SubStatusIrrelevant,
+		},
+	}
+}
+
+func evaluatedControl(id string) reportsummary.ControlSummary {
+	c := reportsummary.ControlSummary{
+		ControlID: id,
+		StatusInfo: apis.StatusInfo{
+			InnerStatus: apis.StatusFailed,
+		},
+	}
+	c.ResourceIDs.Append(apis.StatusFailed, "resource-1")
+	return c
+}
+
+func TestDetectVacuousFrameworks_AllControlsIrrelevant(t *testing.T) {
+	frameworks := []reportsummary.FrameworkSummary{
+		{
+			Name: "istio-security",
+			Controls: reportsummary.ControlSummaries{
+				"C-ISTIO-1": irrelevantControl("C-ISTIO-1"),
+				"C-ISTIO-2": irrelevantControl("C-ISTIO-2"),
+			},
+		},
+	}
+	assert.Equal(t, []string{"istio-security"}, DetectVacuousFrameworks(frameworks))
+}
+
+func TestDetectVacuousFrameworks_MixedControlsNotFlagged(t *testing.T) {
+	frameworks := []reportsummary.FrameworkSummary{
+		{
+			Name: "nsa",
+			Controls: reportsummary.ControlSummaries{
+				"C-0001": irrelevantControl("C-0001"),
+				"C-0002": evaluatedControl("C-0002"),
+			},
+		},
+	}
+	assert.Empty(t, DetectVacuousFrameworks(frameworks))
+}
+
+func TestDetectVacuousFrameworks_EmptyFrameworkNotFlagged(t *testing.T) {
+	frameworks := []reportsummary.FrameworkSummary{
+		{Name: "empty", Controls: reportsummary.ControlSummaries{}},
+	}
+	assert.Empty(t, DetectVacuousFrameworks(frameworks))
+}
+
+func TestDetectVacuousFrameworks_OnlyVacuousFrameworksReturned(t *testing.T) {
+	frameworks := []reportsummary.FrameworkSummary{
+		{
+			Name: "istio-security",
+			Controls: reportsummary.ControlSummaries{
+				"C-ISTIO-1": irrelevantControl("C-ISTIO-1"),
+			},
+		},
+		{
+			Name: "nsa",
+			Controls: reportsummary.ControlSummaries{
+				"C-0001": evaluatedControl("C-0001"),
+			},
+		},
+	}
+	assert.Equal(t, []string{"istio-security"}, DetectVacuousFrameworks(frameworks))
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -236,6 +236,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	opap.updateResults(ctx)
 
 	opap.markNotEvaluatedControlsSkipped()
+	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
@@ -425,6 +426,7 @@ done:
 	// Update results
 	opap.updateResults(ctx)
 	opap.markNotEvaluatedControlsSkipped()
+	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -364,7 +364,7 @@ func isPrintSeparatorType(scanType cautils.ScanTypes) bool {
 // failures caused controls to be skipped or partial data was collected.
 // Nothing is printed on a clean scan.
 func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
-	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 && len(coverage.PolicyDegradations) == 0 {
+	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 && len(coverage.PolicyDegradations) == 0 && len(coverage.VacuousFrameworks) == 0 {
 		return
 	}
 
@@ -406,6 +406,13 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 			fmt.Fprintf(pp.writer, "  • %s: %s\n", d.Component, d.Reason)
 		}
 		fmt.Fprintf(pp.writer, "\nControls depending on these inputs were evaluated against default configuration, which may not reflect your environment.\n")
+	}
+
+	if len(coverage.VacuousFrameworks) > 0 {
+		fmt.Fprintf(pp.writer, "\nThe following frameworks scored 100%% because none of their target resource types were found in this cluster:\n")
+		for _, f := range coverage.VacuousFrameworks {
+			fmt.Fprintf(pp.writer, "  • %s\n", f)
+		}
 	}
 
 	if len(coverage.FailedGVRPulls) > 0 || len(coverage.PartialGVRPulls) > 0 {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -409,7 +409,7 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 	}
 
 	if len(coverage.VacuousFrameworks) > 0 {
-		fmt.Fprintf(pp.writer, "\nThe following frameworks scored 100%% because none of their target resource types were found in this cluster:\n")
+		fmt.Fprintf(pp.writer, "\nThe following frameworks scored 100%% because no matching resources were found in this cluster:\n")
 		for _, f := range coverage.VacuousFrameworks {
 			fmt.Fprintf(pp.writer, "  • %s\n", f)
 		}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -136,6 +136,22 @@ func TestPrintScanCoverage_AllSectionsRendered(t *testing.T) {
 	assert.Contains(t, out, "/v1/pods")
 }
 
+// TestPrintScanCoverage_VacuousFrameworksOnlyRendered verifies that a
+// ScanCoverage with only VacuousFrameworks (no GVR or policy failures) is
+// still rendered, and the framework name appears in the warning.
+func TestPrintScanCoverage_VacuousFrameworksOnlyRendered(t *testing.T) {
+	pp, read := newTestPrettyPrinterFile(t)
+
+	coverage := cautils.ScanCoverage{
+		VacuousFrameworks: []string{"istio-security"},
+	}
+	pp.printScanCoverage(coverage)
+
+	out := read()
+	assert.Contains(t, out, "Scan Coverage Warning", "header must appear for vacuous-framework-only coverage")
+	assert.Contains(t, out, "istio-security", "framework name must appear in output")
+}
+
 func TestSetWriter_Pretty(t *testing.T) {
 	sourceTreeArtifact := "customFilename.txt"
 	require.NoFileExists(t, sourceTreeArtifact, "test setup requires no leftover output file in the package directory")

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -179,7 +179,7 @@ func ConvertToPostureReportWithSeverityLabelsAndCoverage(report *reporthandlingv
 
 	// only attach coverage when there is something to show
 	var scanCoverage *cautils.ScanCoverage
-	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0) {
+	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0 || len(coverage.VacuousFrameworks) > 0) {
 		scanCoverage = coverage
 	}
 

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -1057,6 +1057,26 @@ func TestConvertToPostureReport_NilCoverageNotAttached(t *testing.T) {
 	assert.Nil(t, result.ScanCoverage)
 }
 
+// TestConvertToPostureReport_VacuousFrameworksOnlyCoverageAttached verifies
+// that a ScanCoverage containing only VacuousFrameworks (no GVR pull
+// failures, no NotEvaluatedControls) is still attached to the serialized
+// report, so a framework that scored 100% purely because its target
+// resource types are absent from the cluster is visible to JSON/API
+// consumers.
+func TestConvertToPostureReport_VacuousFrameworksOnlyCoverageAttached(t *testing.T) {
+	coverage := &cautils.ScanCoverage{
+		VacuousFrameworks: []string{"istio-security"},
+	}
+
+	result := ConvertToPostureReportWithSeverityLabelsAndCoverage(
+		minimalPostureReport(),
+		nil, nil, coverage,
+	)
+	require.NotNil(t, result)
+	require.NotNil(t, result.ScanCoverage, "ScanCoverage must be attached when VacuousFrameworks is non-empty")
+	assert.Equal(t, []string{"istio-security"}, result.ScanCoverage.VacuousFrameworks)
+}
+
 // TestFinalizeResults_SetsGenerationTimeWhenZero is the regression test for
 // kubescape/kubescape#2325: JSON reports were emitting
 // "generationTime":"0001-01-01T00:00:00Z" because nothing on the scan path

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -1075,6 +1075,16 @@ func TestConvertToPostureReport_VacuousFrameworksOnlyCoverageAttached(t *testing
 	require.NotNil(t, result)
 	require.NotNil(t, result.ScanCoverage, "ScanCoverage must be attached when VacuousFrameworks is non-empty")
 	assert.Equal(t, []string{"istio-security"}, result.ScanCoverage.VacuousFrameworks)
+
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	var decoded struct {
+		ScanCoverage struct {
+			VacuousFrameworks []string `json:"vacuousFrameworks"`
+		} `json:"scanCoverage"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, []string{"istio-security"}, decoded.ScanCoverage.VacuousFrameworks)
 }
 
 // TestFinalizeResults_SetsGenerationTimeWhenZero is the regression test for


### PR DESCRIPTION
## Overview

I noticed that a framework can report a 100% compliance score without a single control actually checking anything. The scoring library has a deliberate rule: when every control in a framework resolves to `Irrelevant` (no resource of the required type exists in the cluster, for example a service-mesh framework on a cluster with no Istio CRDs installed), it sets that framework's score to 100:

```go
// if all controls in framework are irrelevant, set framework score to 100
// except for empty frameworks (first check)
if len(report.SummaryDetails.Frameworks[i].Controls) > 0 && su.allControlsInFrameworkIrrelevant(...) {
    report.SummaryDetails.Frameworks[i].Score = 100
    continue
}
```

That is the right arithmetic choice, but nothing in Kubescape's output tells a user this happened. The existing `ScanCoverage` mechanism flags controls that could not be evaluated because a GVR pull failed, but a resource type that simply does not exist in the cluster never triggers that path. It produces a legitimate empty list, the control is marked `Passed/Irrelevant`, and the framework silently reads 100%.

## Fix

I added `ScanCoverage.VacuousFrameworks`, populated by a new `DetectVacuousFrameworks` function that checks whether every control in a framework is `Irrelevant` with zero matched resources, the same condition the scoring library already uses internally. I wired it into both scan paths right after results are finalized, and extended the pretty printer's coverage warning and the JSON/API `scanCoverage` attachment so the signal is not silently dropped.

## Test

I added unit tests for `DetectVacuousFrameworks` covering an all-irrelevant framework, a mixed framework, an empty framework, and multiple frameworks where only some are vacuous. I also added a pretty-printer test and a JSON-attachment test to confirm the new field surfaces correctly on its own, without any other coverage gap present. I ran the full test suites for the affected packages and did a full module build locally.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan coverage reporting for frameworks whose controls are all irrelevant because no matching resources were found.
  * Added clear warnings identifying these frameworks, including when they are the only coverage issue.
  * Ensured vacuous framework coverage is preserved in generated posture reports.

* **Tests**
  * Added coverage for single, multiple, mixed, empty, and report-only vacuous framework scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->