### PR TITLE
feat(scan): add --exclude-path and .kubescapeignore for local scans

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -29,6 +29,9 @@ var scanCmdExamples = fmt.Sprintf(`
   # Scan kubernetes manifest files
   %[1]s scan .
 
+  # Scan manifest files, leaving test fixtures and generated output out of the scan
+  %[1]s scan . --exclude-path 'test/**' --exclude-path '*.generated.yaml'
+
   # Scan and save the results in the JSON format
   %[1]s scan --format json --output results.json
 
@@ -191,6 +194,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeKinds, "include-kinds", "", "scan only the specified Kubernetes resource kinds (case-insensitive, Kind name only — not group/version qualified). e.g: --include-kinds Deployment,DaemonSet")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ExcludeKinds, "exclude-kinds", "", "exclude the specified Kubernetes resource kinds from the scan (case-insensitive, Kind name only — not group/version qualified). e.g: --exclude-kinds Job,CronJob")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.ExcludePaths, "exclude-path", nil, fmt.Sprintf("Exclude paths from file, directory and repository scans (repeat for more than one). Patterns use gitignore syntax and are relative to the scan root, e.g: --exclude-path 'test/**' --exclude-path '!test/prod.yaml'. Combined with the patterns in a %s file at the scan root. Helm charts, Kustomize configurations and Terraform modules are excluded as whole directories", cautils.IgnoreFileName))
+	scanCmd.PersistentFlags().BoolVar(&scanInfo.NoIgnoreFile, "no-ignore-file", false, fmt.Sprintf("Ignore the %s file at the scan root; only --exclude-path patterns apply", cautils.IgnoreFileName))
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -148,6 +148,17 @@ func ValidateCommonScanFlags(cmd *cobra.Command, scanInfo *cautils.ScanInfo, sup
 	if err := ValidateKindFilters(scanInfo); err != nil {
 		return err
 	}
+	if err := ValidateExcludePaths(scanInfo); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateExcludePaths fails the command on a malformed pattern before any resource is collected.
+func ValidateExcludePaths(scanInfo *cautils.ScanInfo) error {
+	if err := cautils.ValidateCommandLinePatterns(scanInfo.ExcludePaths); err != nil {
+		return fmt.Errorf("--exclude-path: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -298,3 +298,66 @@ func TestValidateKindFilters(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateExcludePaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		excludePaths []string
+		expectedErr  string
+	}{
+		{
+			name:         "no patterns is valid",
+			excludePaths: nil,
+			expectedErr:  "",
+		},
+		{
+			name:         "gitignore syntax is accepted",
+			excludePaths: []string{"test/**", "!test/prod.yaml", "/vendor/", "*.tmpl.yaml"},
+			expectedErr:  "",
+		},
+		{
+			name:         "a comment typed as an argument is rejected",
+			excludePaths: []string{"# a comment"},
+			expectedErr:  "carries no rule",
+		},
+		{
+			name:         "a blank argument is rejected",
+			excludePaths: []string{"  "},
+			expectedErr:  "carries no rule",
+		},
+		{
+			name:         "an anchored pattern is still accepted",
+			excludePaths: []string{"/vendor"},
+			expectedErr:  "",
+		},
+		{
+			name:         "unclosed character class is rejected",
+			excludePaths: []string{"pod[.yaml"},
+			expectedErr:  "invalid exclusion pattern",
+		},
+		{
+			name:         "pattern with nothing to match is rejected",
+			excludePaths: []string{"!"},
+			expectedErr:  "exclusion pattern is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExcludePaths(&cautils.ScanInfo{ExcludePaths: tt.excludePaths})
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+// Commas are significant inside a glob alternation, so --exclude-path must not split
+// on them the way a comma-separated flag would.
+func TestValidateExcludePathsAcceptsBraceAlternation(t *testing.T) {
+	err := ValidateExcludePaths(&cautils.ScanInfo{ExcludePaths: []string{"*.{yaml,json}"}})
+	assert.NoError(t, err)
+}

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -61,7 +61,7 @@ type Chart struct {
 // --set-file path, etc.) the error is returned to the caller. We deliberately do not silently
 // fall back to chart defaults — scanning the wrong manifests is worse than failing fast.
 func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
-	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, nil)
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, nil, nil)
 }
 
 // LoadResourcesFromHelmChartsExcludingDirectories behaves like LoadResourcesFromHelmCharts,
@@ -69,11 +69,17 @@ func LoadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts
 // The caller is responsible for including those directories in its plain-file exclusions once
 // that renderer succeeds.
 func LoadResourcesFromHelmChartsExcludingDirectories(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
-	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, excludedChartDirectories)
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, excludedChartDirectories, nil)
 }
 
-func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
-	helmDirectories, discoveryErrs := listHelmChartDirs(basePath)
+// LoadResourcesFromHelmChartsFiltered behaves like LoadResourcesFromHelmChartsExcludingDirectories,
+// and never renders a chart filter excludes.
+func LoadResourcesFromHelmChartsFiltered(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string, filter *PathFilter) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	return loadResourcesFromHelmCharts(ctx, basePath, valueOpts, excludedChartDirectories, filter)
+}
+
+func loadResourcesFromHelmCharts(ctx context.Context, basePath string, valueOpts HelmValueOptions, excludedChartDirectories []string, filter *PathFilter) (map[string][]workloadinterface.IMetadata, map[string]Chart, []string, error) {
+	helmDirectories, discoveryErrs := listHelmChartDirs(basePath, filter)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Helm charts", helpers.Error(err))
 	}
@@ -182,8 +188,8 @@ func pathDepth(path string) int {
 
 // listHelmChartDirs scans a given path (recursively) and returns the directories holding a helm chart.
 // Subcharts are picked up by the same walk, since each carries its own Chart.yaml.
-func listHelmChartDirs(basePath string) ([]string, []error) {
-	directories, errs := listDirs(basePath)
+func listHelmChartDirs(basePath string, filter *PathFilter) ([]string, []error) {
+	directories, errs := listDirs(basePath, filter)
 	helmDirectories := make([]string, 0)
 	for _, dir := range directories {
 		chartFile := filepath.Join(dir, "Chart.yaml")
@@ -209,8 +215,8 @@ func listHelmChartDirs(basePath string) ([]string, []error) {
 // Kustomize configuration (a kustomization.yaml/kustomization.yml/Kustomization file). Each
 // carries its own Kustomization file, so an overlay nested below basePath is found on its own
 // even when basePath itself is not a Kustomize directory.
-func listKustomizeDirs(basePath string) ([]string, []error) {
-	directories, errs := listDirs(basePath)
+func listKustomizeDirs(basePath string, filter *PathFilter) ([]string, []error) {
+	directories, errs := listDirs(basePath, filter)
 	kustomizeDirectories := make([]string, 0)
 	for _, dir := range directories {
 		if isKustomizeDirectory(dir) {
@@ -224,8 +230,8 @@ func listKustomizeDirs(basePath string) ([]string, []error) {
 // Terraform (.tf) files. A module nested below basePath (e.g. modules/<name>/) is found on
 // its own the same way an overlay nested below a Kustomize root is, even when basePath itself
 // has no .tf files directly in it.
-func listTerraformDirs(basePath string) ([]string, []error) {
-	directories, errs := listDirs(basePath)
+func listTerraformDirs(basePath string, filter *PathFilter) ([]string, []error) {
+	directories, errs := listDirs(basePath, filter)
 	terraformDirectories := make([]string, 0)
 	for _, dir := range directories {
 		if isTerraformDirectory(dir) {
@@ -493,7 +499,13 @@ func (result KustomizeRenderResult) OwnsPlainFile(path string) bool {
 // as best-effort misses; an explicitly selected Kustomize input remains a hard
 // error, preserving its existing behavior.
 func LoadResourcesFromKustomizeDirectories(ctx context.Context, basePath string) (KustomizeRenderResult, error) {
-	kustomizeInputs, discoveryErrs := listKustomizeInputs(basePath)
+	return LoadResourcesFromKustomizeDirectoriesFiltered(ctx, basePath, nil)
+}
+
+// LoadResourcesFromKustomizeDirectoriesFiltered behaves like LoadResourcesFromKustomizeDirectories,
+// leaving out the configurations filter excludes.
+func LoadResourcesFromKustomizeDirectoriesFiltered(ctx context.Context, basePath string, filter *PathFilter) (KustomizeRenderResult, error) {
+	kustomizeInputs, discoveryErrs := listKustomizeInputs(basePath, filter)
 	explicitKustomizeInput := IsKustomizeFile(basePath) || isKustomizeDirectory(basePath)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize configurations", helpers.Error(err))
@@ -554,8 +566,11 @@ func appendUniquePaths(destination *[]string, seen map[string]struct{}, paths ..
 // listKustomizeInputs preserves exact selection for a Kustomize file or
 // directory. For a broader input it discovers child configurations recursively,
 // matching repository-wide Helm and manifest discovery.
-func listKustomizeInputs(basePath string) ([]string, []error) {
+func listKustomizeInputs(basePath string, filter *PathFilter) ([]string, []error) {
 	if IsKustomizeFile(basePath) || isKustomizeDirectory(basePath) {
+		if filter.Excluded(basePath, isKustomizeDirectory(basePath)) {
+			return nil, nil
+		}
 		return []string{basePath}, nil
 	}
 	// A concrete non-Kustomize file is an exact scan target. listDirs interprets
@@ -565,7 +580,7 @@ func listKustomizeInputs(basePath string) ([]string, []error) {
 		return nil, nil
 	}
 
-	directories, errs := listDirs(basePath)
+	directories, errs := listDirs(basePath, filter)
 	kustomizeDirectories := make([]string, 0)
 	for _, directory := range directories {
 		if isKustomizeDirectory(directory) {
@@ -583,7 +598,7 @@ func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath s
 		return nil, nil
 	}
 
-	kustomizeDirs, discoveryErrs := listKustomizeDirs(basePath)
+	kustomizeDirs, discoveryErrs := listKustomizeDirs(basePath, nil)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Kustomize directories", helpers.Error(err))
 	}
@@ -610,7 +625,16 @@ func LoadResourcesFromNestedKustomizeDirectories(ctx context.Context, basePath s
 // input is discovered recursively: every directory under basePath that contains .tf files is
 // scanned, so a module nested below the scan root (e.g. modules/<name>/) is not silently skipped.
 func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[string][]workloadinterface.IMetadata, error) {
+	return LoadResourcesFromTerraformFiltered(ctx, basePath, nil)
+}
+
+// LoadResourcesFromTerraformFiltered behaves like LoadResourcesFromTerraform, leaving out
+// the files and directories filter excludes.
+func LoadResourcesFromTerraformFiltered(ctx context.Context, basePath string, filter *PathFilter) (map[string][]workloadinterface.IMetadata, error) {
 	if IsTerraformFile(basePath) {
+		if filter.Excluded(basePath, false) {
+			return nil, nil
+		}
 		dir := filepath.Dir(basePath)
 		td := NewTerraformDirectory(dir)
 		wls, errs := td.GetWorkloads(dir)
@@ -620,7 +644,7 @@ func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[strin
 		return wls, nil
 	}
 
-	dirs, discoveryErrs := listTerraformDirs(basePath)
+	dirs, discoveryErrs := listTerraformDirs(basePath, filter)
 	for _, err := range discoveryErrs {
 		logger.L().Ctx(ctx).Warning("Skipping path while discovering Terraform directories", helpers.Error(err))
 	}
@@ -650,12 +674,18 @@ func LoadResourcesFromTerraform(ctx context.Context, basePath string) (map[strin
 // are the chart directories LoadResourcesFromHelmCharts already rendered; their templates are left
 // to that render and skipped here. Pass nil to scan everything (e.g. when no charts were rendered).
 func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, renderedCharts []string) (map[string][]workloadinterface.IMetadata, []SkippedManifest, error) {
+	return LoadResourcesFromFilesFiltered(ctx, input, rootPath, renderedCharts, nil)
+}
+
+// LoadResourcesFromFilesFiltered behaves like LoadResourcesFromFiles, leaving out the
+// manifests filter excludes.
+func LoadResourcesFromFilesFiltered(ctx context.Context, input, rootPath string, renderedCharts []string, filter *PathFilter) (map[string][]workloadinterface.IMetadata, []SkippedManifest, error) {
 	// skip the plain-YAML glob for a kustomize directory; the kustomize render handles it
 	if isKustomizeDirectory(input) {
 		return nil, nil, nil
 	}
 
-	files, errs := listFiles(input)
+	files, errs := listFiles(input, filter)
 	if len(errs) > 0 {
 		discoveryErr := fmt.Errorf("failed to discover all manifest files for %q: %w", input, errors.Join(errs...))
 		if len(files) == 0 {
@@ -664,6 +694,9 @@ func LoadResourcesFromFiles(ctx context.Context, input, rootPath string, rendere
 		logger.L().Ctx(ctx).Warning("Continuing with manifest files found before a discovery error", helpers.Error(discoveryErr))
 	}
 	if len(files) == 0 {
+		if filter != nil {
+			return nil, nil, fmt.Errorf("%w for input %q; path exclusions are in effect", ErrNoManifestFiles, input)
+		}
 		return nil, nil, fmt.Errorf("%w for input %q", ErrNoManifestFiles, input)
 	}
 
@@ -782,16 +815,16 @@ func ReadFile(fileContent []byte, fileFormat FileFormat) ([]workloadinterface.IM
 }
 
 // listFiles returns the list of absolute paths, full file path and list of errors. The list of abs paths and full path have the same length
-func listFiles(pattern string) ([]string, []error) {
-	return listFilesOrDirectories(pattern, false)
+func listFiles(pattern string, filter *PathFilter) ([]string, []error) {
+	return listFilesOrDirectories(pattern, false, filter)
 }
 
 // listDirs returns the list of absolute paths, full directories path and list of errors. The list of abs paths and full path have the same length
-func listDirs(pattern string) ([]string, []error) {
-	return listFilesOrDirectories(pattern, true)
+func listDirs(pattern string, filter *PathFilter) ([]string, []error) {
+	return listFilesOrDirectories(pattern, true, filter)
 }
 
-func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []error) {
+func listFilesOrDirectories(pattern string, onlyDirectories bool, filter *PathFilter) ([]string, []error) {
 	var paths []string
 	errs := []error{}
 
@@ -801,7 +834,9 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 	}
 
 	if !onlyDirectories && isFile(pattern) {
-		paths = append(paths, pattern)
+		if !filter.Excluded(pattern, false) {
+			paths = append(paths, pattern)
+		}
 		return paths, errs
 	}
 	// A concrete path is an exact scan target. Do not reinterpret a missing
@@ -820,7 +855,7 @@ func listFilesOrDirectories(pattern string, onlyDirectories bool) ([]string, []e
 		shouldMatch = "*"
 	}
 
-	f, err := glob(root, shouldMatch, onlyDirectories)
+	f, err := glob(root, shouldMatch, onlyDirectories, filter)
 	paths = append(paths, f...)
 	if err != nil {
 		errs = append(errs, err)
@@ -1216,12 +1251,19 @@ func IsJson(filePath string) bool {
 	return slices.Contains(JSON_PREFIX, strings.ToLower(strings.TrimPrefix(filepath.Ext(filePath), ".")))
 }
 
-func glob(root, pattern string, onlyDirectories bool) ([]string, error) {
+func glob(root, pattern string, onlyDirectories bool, filter *PathFilter) ([]string, error) {
 	var matches []string
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if filter.Excluded(path, info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		// listing only directories

--- a/core/cautils/fileutils_errors_test.go
+++ b/core/cautils/fileutils_errors_test.go
@@ -151,7 +151,7 @@ func TestListHelmChartDirsReportsMetadataIOErrorsAndKeepsValidCharts(t *testing.
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	charts, errs := listHelmChartDirs(dir)
+	charts, errs := listHelmChartDirs(dir, nil)
 
 	assert.Contains(t, charts, validChart)
 	require.NotEmpty(t, errs)

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -29,7 +29,7 @@ func TestListFiles(t *testing.T) {
 
 	filesPath := onlineBoutiquePath()
 
-	files, errs := listFiles(filesPath)
+	files, errs := listFiles(filesPath, nil)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 13, len(files))
 }
@@ -631,18 +631,18 @@ func TestExcludeHelmTemplateFiles_PreservesLexicalOwnershipOfSymlinkedTemplate(t
 }
 
 func TestLoadFiles(t *testing.T) {
-	files, _ := listFiles(onlineBoutiquePath())
+	files, _ := listFiles(onlineBoutiquePath(), nil)
 	_, _, errs := loadFiles("", files)
 	assert.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), "invalid.yaml")
 }
 
 func TestListDirs(t *testing.T) {
-	dirs, _ := listDirs(filepath.Join(onlineBoutiquePath(), "adservice.yaml"))
+	dirs, _ := listDirs(filepath.Join(onlineBoutiquePath(), "adservice.yaml"), nil)
 	assert.Equal(t, 0, len(dirs))
 
 	expectedDirs := []string{filepath.Join("examples", "helm_chart"), filepath.Join("examples", "helm_chart", "templates")}
-	dirs, _ = listDirs(helmChartPath())
+	dirs, _ = listDirs(helmChartPath(), nil)
 	assert.Equal(t, len(expectedDirs), len(dirs))
 	for i := range expectedDirs {
 		assert.Contains(t, dirs[i], expectedDirs[i])
@@ -650,7 +650,7 @@ func TestListDirs(t *testing.T) {
 }
 
 func TestLoadFile(t *testing.T) {
-	files, _ := listFiles(filepath.Join(onlineBoutiquePath(), "adservice.yaml"))
+	files, _ := listFiles(filepath.Join(onlineBoutiquePath(), "adservice.yaml"), nil)
 	assert.Equal(t, 1, len(files))
 
 	_, err := loadFile(files[0])

--- a/core/cautils/kustomize_discovery_test.go
+++ b/core/cautils/kustomize_discovery_test.go
@@ -22,7 +22,7 @@ helmCharts:
     releaseName: app
 `)
 
-	inputs, errs := listKustomizeInputs(repoRoot)
+	inputs, errs := listKustomizeInputs(repoRoot, nil)
 	require.Empty(t, errs)
 	require.Equal(t, []string{appDir}, inputs)
 

--- a/core/cautils/kustomizedirectory.go
+++ b/core/cautils/kustomizedirectory.go
@@ -331,7 +331,11 @@ func appendUniquePath(path string, seen map[string]struct{}, paths *[]string) {
 type helmChartDirectoryLister func(string) ([]string, []error)
 
 func appendOwnedHelmChartTree(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string) {
-	appendOwnedHelmChartTreeWithLister(ctx, directory, seen, directories, listHelmChartDirs)
+	// Unfiltered on purpose: an excluded chart leaves discovery, not the record of
+	// what the build owns.
+	appendOwnedHelmChartTreeWithLister(ctx, directory, seen, directories, func(path string) ([]string, []error) {
+		return listHelmChartDirs(path, nil)
+	})
 }
 
 func appendOwnedHelmChartTreeWithLister(ctx context.Context, directory string, seen map[string]struct{}, directories *[]string, discover helmChartDirectoryLister) {

--- a/core/cautils/pathfilter.go
+++ b/core/cautils/pathfilter.go
@@ -1,0 +1,345 @@
+package cautils
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// IgnoreFileName is the optional file, read from the scan root, listing paths to
+// keep out of a local scan.
+const IgnoreFileName = ".kubescapeignore"
+
+var (
+	ErrEmptyIgnorePattern    = errors.New("exclusion pattern is empty")
+	ErrInvalidIgnorePattern  = errors.New("invalid exclusion pattern")
+	ErrUnusableIgnorePattern = errors.New("exclusion pattern carries no rule")
+)
+
+type ignoreRule struct {
+	pattern  string
+	negate   bool
+	dirOnly  bool
+	anchored bool
+	// descendantPrefix is set for a "dir/**" pattern, which covers everything below
+	// dir without covering dir itself, so a later "!dir/keep.yaml" can re-include.
+	descendantPrefix string
+}
+
+// PathFilter keeps paths out of a local scan. Patterns follow gitignore syntax: "#"
+// starts a comment, "!" re-includes, a trailing "/" restricts a pattern to directories,
+// a leading or embedded "/" anchors it to the scan root, and "**" spans any number of
+// directories. The last pattern that matches a path decides it, and a path below an
+// excluded directory cannot be re-included.
+//
+// Two deliberate differences from git: one ignore file is read, at the scan root, not
+// one per directory; and surrounding whitespace is trimmed, so an indented line applies.
+//
+// Helm charts, Kustomize configurations and Terraform modules are excluded whole, because
+// their own renderers decide which files they read. A pattern naming a single file inside
+// one of them has no effect unless it excludes the directory.
+type PathFilter struct {
+	root  string
+	rules []ignoreRule
+}
+
+// NewPathFilter compiles patterns into a filter anchored at root, returning nil when no
+// pattern carries a rule.
+func NewPathFilter(root string, patterns []string) (*PathFilter, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	rules := make([]ignoreRule, 0, len(patterns))
+	for _, pattern := range patterns {
+		rule, ok, err := parseIgnoreRule(pattern)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			rules = append(rules, rule)
+		}
+	}
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	return &PathFilter{root: filepath.Clean(absRoot), rules: rules}, nil
+}
+
+// NewScanPathFilter builds the filter for a scan of input, combining the ignore file at
+// the scan root with the patterns given on the command line. Command line patterns are
+// applied last so they can re-include what the ignore file excluded.
+func NewScanPathFilter(input string, patterns []string, useIgnoreFile bool) (*PathFilter, error) {
+	root := ignoreRoot(input)
+
+	var combined []string
+	if useIgnoreFile {
+		filePatterns, err := LoadIgnoreFilePatterns(root)
+		if err != nil {
+			return nil, err
+		}
+		if err := ValidateIgnorePatterns(filePatterns); err != nil {
+			return nil, fmt.Errorf("%s: %w", filepath.Join(root, IgnoreFileName), err)
+		}
+		combined = append(combined, filePatterns...)
+	}
+	combined = append(combined, patterns...)
+	if len(combined) == 0 {
+		return nil, nil
+	}
+
+	return NewPathFilter(root, combined)
+}
+
+// ValidateIgnorePatterns returns the first pattern that does not compile.
+func ValidateIgnorePatterns(patterns []string) error {
+	for _, pattern := range patterns {
+		if _, _, err := parseIgnoreRule(pattern); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateCommandLinePatterns is ValidateIgnorePatterns plus the checks that only make
+// sense for a typed argument: a blank or commented pattern is a formatting choice in a
+// file, but on the command line it is a mistake that would silently exclude nothing.
+func ValidateCommandLinePatterns(patterns []string) error {
+	for _, pattern := range patterns {
+		_, ok, err := parseIgnoreRule(pattern)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: %q is blank or a comment", ErrUnusableIgnorePattern, pattern)
+		}
+	}
+	return nil
+}
+
+// LoadIgnoreFilePatterns reads the ignore file at root. A missing file is not an error.
+func LoadIgnoreFilePatterns(root string) ([]string, error) {
+	path := filepath.Join(root, IgnoreFileName)
+	file, err := os.Open(path) // #nosec G304 -- the path is the ignore file at the user's own scan root
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	defer file.Close()
+
+	var patterns []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		patterns = append(patterns, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	return patterns, nil
+}
+
+// Excluded reports whether path is kept out of the scan. Paths outside the filter root
+// are never excluded.
+func (f *PathFilter) Excluded(path string, isDir bool) bool {
+	if f == nil || len(f.rules) == 0 {
+		return false
+	}
+
+	relative, ok := f.relative(path)
+	if !ok {
+		return false
+	}
+
+	// relative[:i] is the ancestor at this level, relative[start:i] its own name.
+	excluded := false
+	start := 0
+	for i := 0; i <= len(relative); i++ {
+		if i < len(relative) && relative[i] != '/' {
+			continue
+		}
+		isLeaf := i == len(relative)
+		for _, rule := range f.rules {
+			if rule.matches(relative[:i], relative[start:i], !isLeaf || isDir) {
+				excluded = !rule.negate
+			}
+		}
+		// Nothing below an excluded directory can be re-included.
+		if excluded && !isLeaf {
+			return true
+		}
+		start = i + 1
+	}
+
+	return excluded
+}
+
+// Patterns returns the compiled patterns, in the order they are applied.
+func (f *PathFilter) Patterns() []string {
+	if f == nil {
+		return nil
+	}
+	patterns := make([]string, 0, len(f.rules))
+	for _, rule := range f.rules {
+		patterns = append(patterns, rule.String())
+	}
+	return patterns
+}
+
+// Root returns the directory the patterns are matched against.
+func (f *PathFilter) Root() string {
+	if f == nil {
+		return ""
+	}
+	return f.root
+}
+
+func (f *PathFilter) relative(path string) (string, bool) {
+	absolute := path
+	if !filepath.IsAbs(absolute) {
+		var err error
+		if absolute, err = filepath.Abs(absolute); err != nil {
+			return "", false
+		}
+	}
+
+	relative, err := filepath.Rel(f.root, filepath.Clean(absolute))
+	if err != nil {
+		return "", false
+	}
+	relative = filepath.ToSlash(relative)
+	if relative == "." || relative == ".." || strings.HasPrefix(relative, "../") {
+		return "", false
+	}
+
+	return relative, true
+}
+
+func (r ignoreRule) matches(target, segment string, isDir bool) bool {
+	if r.dirOnly && !isDir {
+		return false
+	}
+	subject := segment
+	if r.anchored {
+		subject = target
+	}
+	// "dir/**" covers what is below dir, not dir itself. The prefix can carry its own
+	// glob metadata, so it has to be matched against the subject, not compared to it.
+	if r.descendantPrefix != "" && globMatch(r.descendantPrefix, subject) {
+		return false
+	}
+	return globMatch(r.pattern, subject)
+}
+
+func globMatch(pattern, subject string) bool {
+	matched, err := doublestar.Match(pattern, subject)
+	return err == nil && matched
+}
+
+func (r ignoreRule) String() string {
+	var builder strings.Builder
+	if r.negate {
+		builder.WriteString("!")
+	}
+	if r.anchored {
+		builder.WriteString("/")
+	}
+	builder.WriteString(r.pattern)
+	if r.dirOnly {
+		builder.WriteString("/")
+	}
+	return builder.String()
+}
+
+// parseIgnoreRule compiles a single line. The second return value is false for a blank
+// line or a comment, which carry no rule.
+func parseIgnoreRule(line string) (ignoreRule, bool, error) {
+	pattern := strings.TrimSpace(line)
+	if pattern == "" || strings.HasPrefix(pattern, "#") {
+		return ignoreRule{}, false, nil
+	}
+
+	var rule ignoreRule
+	if strings.HasPrefix(pattern, "!") {
+		rule.negate = true
+		pattern = strings.TrimSpace(pattern[1:])
+	}
+	if strings.HasSuffix(pattern, "/") {
+		rule.dirOnly = true
+		pattern = strings.TrimRight(pattern, "/")
+	}
+	pattern = strings.TrimPrefix(pattern, "./")
+	if strings.HasPrefix(pattern, "/") {
+		rule.anchored = true
+		pattern = strings.TrimLeft(pattern, "/")
+	} else if strings.Contains(pattern, "/") {
+		rule.anchored = true
+	}
+
+	if pattern == "" {
+		return ignoreRule{}, false, fmt.Errorf("%w: %q", ErrEmptyIgnorePattern, line)
+	}
+	if !doublestar.ValidatePattern(pattern) {
+		return ignoreRule{}, false, fmt.Errorf("%w: %q", ErrInvalidIgnorePattern, line)
+	}
+
+	rule.pattern = pattern
+	rule.descendantPrefix = descendantPrefix(rule)
+	return rule, true, nil
+}
+
+// descendantPrefix returns what a "dir/**" pattern sits below, so the directory itself can
+// be told apart from its contents. Repeated trailing "/**" collapse, the way git treats them.
+// A prefix that matches any path at all leaves nothing to tell apart, so it carries no guard.
+func descendantPrefix(rule ignoreRule) string {
+	if !rule.anchored {
+		return ""
+	}
+	prefix := rule.pattern
+	for strings.HasSuffix(prefix, "/**") {
+		prefix = strings.TrimSuffix(prefix, "/**")
+	}
+	if prefix == rule.pattern || prefix == "" || prefix == "**" {
+		return ""
+	}
+	return prefix
+}
+
+// ignoreRoot resolves the directory a scan input is anchored at. A file or a glob is
+// anchored at its parent directory, so patterns stay relative to the same place.
+
+func ignoreRoot(input string) string {
+	if input == "" {
+		return "."
+	}
+	if clonedRepo := GetClonedPath(input); clonedRepo != "" {
+		input = clonedRepo
+	}
+	if isDir(input) {
+		return input
+	}
+	return literalDir(input)
+}
+
+// literalDir returns the deepest ancestor directory of path that carries no glob
+// metadata, so "manifests/**/*.yaml" anchors at "manifests" rather than "manifests/**".
+func literalDir(path string) string {
+	dir := filepath.Dir(path)
+	for hasGlobMeta(filepath.Base(dir)) {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return dir
+}

--- a/core/cautils/pathfilter_test.go
+++ b/core/cautils/pathfilter_test.go
@@ -1,0 +1,450 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	giturl "github.com/kubescape/go-git-url"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathFilterExcluded(t *testing.T) {
+	root := t.TempDir()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		isDir    bool
+		want     bool
+	}{
+		{
+			name:     "basename matches at any depth",
+			patterns: []string{"secret.yaml"},
+			path:     "deploy/overlays/secret.yaml",
+			want:     true,
+		},
+		{
+			name:     "basename matches at the root",
+			patterns: []string{"secret.yaml"},
+			path:     "secret.yaml",
+			want:     true,
+		},
+		{
+			name:     "unrelated path is kept",
+			patterns: []string{"secret.yaml"},
+			path:     "deploy/deployment.yaml",
+			want:     false,
+		},
+		{
+			name:     "wildcard matches the extension",
+			patterns: []string{"*.json"},
+			path:     "manifests/pod.json",
+			want:     true,
+		},
+		{
+			name:     "directory pattern excludes its contents",
+			patterns: []string{"testdata/"},
+			path:     "testdata/fixtures/pod.yaml",
+			want:     true,
+		},
+		{
+			name:     "directory pattern does not match a file of the same name",
+			patterns: []string{"testdata/"},
+			path:     "testdata",
+			want:     false,
+		},
+		{
+			name:     "directory pattern matches the directory itself",
+			patterns: []string{"testdata/"},
+			path:     "testdata",
+			isDir:    true,
+			want:     true,
+		},
+		{
+			name:     "anchored pattern only matches at the root",
+			patterns: []string{"/vendor"},
+			path:     "charts/vendor/pod.yaml",
+			want:     false,
+		},
+		{
+			name:     "anchored pattern matches at the root",
+			patterns: []string{"/vendor"},
+			path:     "vendor/pod.yaml",
+			want:     true,
+		},
+		{
+			name:     "embedded separator anchors the pattern",
+			patterns: []string{"charts/values.yaml"},
+			path:     "charts/values.yaml",
+			want:     true,
+		},
+		{
+			name:     "embedded separator does not match deeper",
+			patterns: []string{"charts/values.yaml"},
+			path:     "nested/charts/values.yaml",
+			want:     false,
+		},
+		{
+			name:     "doublestar spans directories",
+			patterns: []string{"charts/**/values.yaml"},
+			path:     "charts/redis/subchart/values.yaml",
+			want:     true,
+		},
+		{
+			name:     "leading doublestar matches at any depth",
+			patterns: []string{"**/generated/*.yaml"},
+			path:     "apps/web/generated/pod.yaml",
+			want:     true,
+		},
+		{
+			name:     "later pattern wins over an earlier one",
+			patterns: []string{"test/**", "!test/prod.yaml"},
+			path:     "test/prod.yaml",
+			want:     false,
+		},
+		{
+			name:     "negation is limited to what it names",
+			patterns: []string{"test/**", "!test/prod.yaml"},
+			path:     "test/dev.yaml",
+			want:     true,
+		},
+		{
+			name:     "descendant pattern keeps the directory scannable",
+			patterns: []string{"test/**"},
+			path:     "test",
+			isDir:    true,
+			want:     false,
+		},
+		{
+			name:     "negation survives a descendant prefix carrying glob metadata",
+			patterns: []string{"**/build/**", "!**/build/final.yaml"},
+			path:     "sub/build/final.yaml",
+			want:     false,
+		},
+		{
+			name:     "a glob-metadata descendant prefix still excludes its other contents",
+			patterns: []string{"**/build/**", "!**/build/final.yaml"},
+			path:     "sub/build/other.yaml",
+			want:     true,
+		},
+		{
+			name:     "repeated trailing globstars do not exempt the contents",
+			patterns: []string{"build/**/**"},
+			path:     "build/other.yaml",
+			want:     true,
+		},
+		{
+			name:     "an excluded directory cannot be re-included from below",
+			patterns: []string{"test/", "!test/prod.yaml"},
+			path:     "test/prod.yaml",
+			want:     true,
+		},
+		{
+			name:     "comments and blank lines carry no rule",
+			patterns: []string{"# secret.yaml", "   ", "pod.yaml"},
+			path:     "secret.yaml",
+			want:     false,
+		},
+		{
+			name:     "trailing separators are normalized",
+			patterns: []string{"testdata///"},
+			path:     "testdata/pod.yaml",
+			want:     true,
+		},
+		{
+			name:     "explicit relative prefix is accepted",
+			patterns: []string{"./testdata"},
+			path:     "testdata/pod.yaml",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := NewPathFilter(root, tt.patterns)
+			require.NoError(t, err)
+			require.NotNil(t, filter)
+
+			got := filter.Excluded(filepath.Join(root, filepath.FromSlash(tt.path)), tt.isDir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPathFilterIgnoresPathsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	filter, err := NewPathFilter(root, []string{"pod.yaml"})
+	require.NoError(t, err)
+
+	assert.False(t, filter.Excluded(filepath.Join(filepath.Dir(root), "pod.yaml"), false))
+	assert.False(t, filter.Excluded(root, true))
+}
+
+func TestPathFilterNilIsInert(t *testing.T) {
+	var filter *PathFilter
+
+	assert.False(t, filter.Excluded("/any/path.yaml", false))
+	assert.Nil(t, filter.Patterns())
+	assert.Empty(t, filter.Root())
+}
+
+func TestNewPathFilterRejectsMalformedPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr error
+	}{
+		{name: "unclosed character class", pattern: "pod[.yaml", wantErr: ErrInvalidIgnorePattern},
+		{name: "negation with no pattern", pattern: "!", wantErr: ErrEmptyIgnorePattern},
+		{name: "separator only", pattern: "/", wantErr: ErrEmptyIgnorePattern},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := NewPathFilter(t.TempDir(), []string{tt.pattern})
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Nil(t, filter)
+		})
+	}
+}
+
+func TestNewPathFilterWithoutRulesReturnsNil(t *testing.T) {
+	filter, err := NewPathFilter(t.TempDir(), []string{"# only a comment", ""})
+	require.NoError(t, err)
+	assert.Nil(t, filter)
+}
+
+func TestNewScanPathFilterReadsIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, root, "# generated manifests\ngenerated/\n\n*.tmpl.yaml\n")
+
+	filter, err := NewScanPathFilter(root, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.Equal(t, []string{"generated/", "*.tmpl.yaml"}, filter.Patterns())
+	assert.True(t, filter.Excluded(filepath.Join(root, "generated", "pod.yaml"), false))
+	assert.True(t, filter.Excluded(filepath.Join(root, "deploy", "pod.tmpl.yaml"), false))
+	assert.False(t, filter.Excluded(filepath.Join(root, "deploy", "pod.yaml"), false))
+}
+
+func TestNewScanPathFilterCommandLinePatternsWinOverIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, root, "test/**\n")
+
+	filter, err := NewScanPathFilter(root, []string{"!test/prod.yaml"}, true)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.False(t, filter.Excluded(filepath.Join(root, "test", "prod.yaml"), false))
+	assert.True(t, filter.Excluded(filepath.Join(root, "test", "dev.yaml"), false))
+}
+
+func TestNewScanPathFilterSkipsIgnoreFileWhenDisabled(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, root, "test/**\n")
+
+	filter, err := NewScanPathFilter(root, nil, false)
+	require.NoError(t, err)
+	assert.Nil(t, filter)
+}
+
+func TestNewScanPathFilterAnchorsAFileInputAtItsDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, root, "skipped.yaml\n")
+	manifest := filepath.Join(root, "pod.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("kind: Pod\n"), 0o600))
+
+	filter, err := NewScanPathFilter(manifest, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.Equal(t, filepath.Clean(root), filter.Root())
+	assert.True(t, filter.Excluded(filepath.Join(root, "skipped.yaml"), false))
+}
+
+func TestLoadIgnoreFilePatternsWithoutFile(t *testing.T) {
+	patterns, err := LoadIgnoreFilePatterns(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, patterns)
+}
+
+func writeIgnoreFile(t *testing.T, root, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, IgnoreFileName), []byte(content), 0o600))
+}
+
+func TestLoadResourcesFromFilesFilteredSkipsExcludedManifests(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata"), 0o750))
+	writeManifest(t, filepath.Join(root, "pod.yaml"), "scanned")
+	writeManifest(t, filepath.Join(root, "testdata", "pod.yaml"), "fixture")
+
+	filter, err := NewPathFilter(root, []string{"testdata/"})
+	require.NoError(t, err)
+
+	workloads, _, err := LoadResourcesFromFilesFiltered(context.Background(), root, root, nil, filter)
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+
+	for source := range workloads {
+		assert.Equal(t, filepath.Join(root, "pod.yaml"), source)
+	}
+}
+
+func TestLoadResourcesFromFilesFilteredRejectsAnExcludedFileInput(t *testing.T) {
+	root := t.TempDir()
+	manifest := filepath.Join(root, "pod.yaml")
+	writeManifest(t, manifest, "scanned")
+
+	filter, err := NewPathFilter(root, []string{"pod.yaml"})
+	require.NoError(t, err)
+
+	_, _, err = LoadResourcesFromFilesFiltered(context.Background(), manifest, root, nil, filter)
+	require.ErrorIs(t, err, ErrNoManifestFiles)
+	assert.Contains(t, err.Error(), "path exclusions are in effect")
+}
+
+func TestLoadResourcesFromHelmChartsFilteredSkipsExcludedCharts(t *testing.T) {
+	root := filepath.Join("testdata", "helm_chart_layout")
+
+	filter, err := NewPathFilter(root, []string{"mychart/"})
+	require.NoError(t, err)
+
+	workloads, charts, rendered, err := LoadResourcesFromHelmChartsFiltered(context.Background(), root, HelmValueOptions{}, nil, filter)
+	require.NoError(t, err)
+	assert.Empty(t, workloads)
+	assert.Empty(t, charts)
+	assert.Empty(t, rendered)
+}
+
+func TestLoadResourcesFromHelmChartsFilteredKeepsUnexcludedCharts(t *testing.T) {
+	root := filepath.Join("testdata", "helm_chart_layout")
+
+	filter, err := NewPathFilter(root, []string{"plain-pod.yaml"})
+	require.NoError(t, err)
+
+	_, charts, rendered, err := LoadResourcesFromHelmChartsFiltered(context.Background(), root, HelmValueOptions{}, nil, filter)
+	require.NoError(t, err)
+	assert.NotEmpty(t, charts)
+	assert.NotEmpty(t, rendered)
+}
+
+func writeManifest(t *testing.T, path, name string) {
+	t.Helper()
+	manifest := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: " + name + "\n  namespace: default\n"
+	require.NoError(t, os.WriteFile(path, []byte(manifest), 0o600))
+}
+
+// TestPathFilterMatchesGitignoreSemantics checks the syntax promise the flag help makes,
+// against git itself.
+func TestPathFilterMatchesGitignoreSemantics(t *testing.T) {
+	patterns := []string{
+		"test/", "!test/prod.yaml",
+		"*.tmpl.yaml", "!keep.tmpl.yaml",
+		"/vendor",
+		"**/generated/",
+		"charts/*/values.yaml",
+		"a/**/b.yaml",
+		"node_modules",
+		"build/**", "!build/final.yaml",
+		"**/dist/**", "!**/dist/final.yaml",
+		"a/*/gen/**", "!a/*/gen/keep.yaml",
+	}
+	paths := []string{
+		"pod.yaml", "test/prod.yaml", "test/dev.yaml", "test/deep/x.yaml",
+		"app.tmpl.yaml", "keep.tmpl.yaml", "sub/keep.tmpl.yaml",
+		"vendor/x.yaml", "sub/vendor/x.yaml",
+		"generated/x.yaml", "a/generated/x.yaml",
+		"charts/redis/values.yaml", "charts/a/b/values.yaml",
+		"a/b.yaml", "a/x/b.yaml", "a/x/y/b.yaml",
+		"node_modules/p.yaml", "sub/node_modules/p.yaml",
+		"build/final.yaml", "build/other.yaml", "build/deep/final.yaml",
+		"dist/final.yaml", "dist/other.yaml",
+		"sub/dist/final.yaml", "sub/dist/other.yaml", "deep/sub/dist/final.yaml",
+		"a/x/gen/keep.yaml", "a/x/gen/drop.yaml",
+	}
+
+	root := t.TempDir()
+	// Pin git to an empty configuration; a global core.excludesFile would otherwise
+	// decide part of the comparison.
+	noConfig := filepath.Join(t.TempDir(), "gitconfig-none")
+	git := func(args ...string) *exec.Cmd {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...) //nolint:gosec // G204: test-only; args are literals from this test and root is a t.TempDir().
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL="+noConfig,
+			"GIT_CONFIG_SYSTEM="+noConfig,
+			"GIT_CONFIG_NOSYSTEM=1",
+		)
+		return cmd
+	}
+	if out, err := git("init", "-q").CombinedOutput(); err != nil {
+		t.Skipf("git is unavailable: %v: %s", err, out)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte(strings.Join(patterns, "\n")+"\n"), 0o600))
+	for _, path := range paths {
+		full := filepath.Join(root, filepath.FromSlash(path))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+		require.NoError(t, os.WriteFile(full, []byte("kind: Pod\n"), 0o600))
+	}
+
+	filter, err := NewPathFilter(root, patterns)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			gitIgnores := git("check-ignore", "-q", path).Run() == nil
+			assert.Equal(t, gitIgnores, filter.Excluded(filepath.Join(root, filepath.FromSlash(path)), false))
+		})
+	}
+}
+
+func TestNewScanPathFilterAnchorsAGlobInputAtItsLiteralDirectory(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "manifests"), 0o750))
+	writeIgnoreFile(t, filepath.Join(root, "manifests"), "app/**\n")
+
+	filter, err := NewScanPathFilter(filepath.Join(root, "manifests", "**", "*.yaml"), nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.Equal(t, filepath.Join(root, "manifests"), filter.Root())
+	assert.True(t, filter.Excluded(filepath.Join(root, "manifests", "app", "pod.yaml"), false))
+}
+
+// A repository input is scanned from its clone, so the filter has to anchor there too:
+// the ignore file lives in the clone, not next to the URL the user typed.
+func TestNewScanPathFilterAnchorsARepositoryInputAtItsClone(t *testing.T) {
+	const repoURL = "https://github.com/kubescape/example-path-filter"
+
+	clone := t.TempDir()
+	writeIgnoreFile(t, clone, "testdata/\n")
+
+	gitURL, err := giturl.NewGitAPI(repoURL)
+	require.NoError(t, err)
+	key := repoWorkspaceKey(gitURL)
+
+	tmpDirPathsMu.Lock()
+	tmpDirPaths[key] = clone
+	tmpDirPathsMu.Unlock()
+	t.Cleanup(func() {
+		tmpDirPathsMu.Lock()
+		delete(tmpDirPaths, key)
+		tmpDirPathsMu.Unlock()
+	})
+
+	filter, err := NewScanPathFilter(repoURL, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.Equal(t, filepath.Clean(clone), filter.Root())
+	assert.True(t, filter.Excluded(filepath.Join(clone, "testdata", "pod.yaml"), false))
+	assert.False(t, filter.Excluded(filepath.Join(clone, "pod.yaml"), false))
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -136,6 +136,8 @@ type ScanInfo struct {
 	IncludeKinds              string                       // comma-separated Kubernetes kinds to include (case-insensitive, Kind name only); e.g. "Deployment,DaemonSet"
 	ExcludeKinds              string                       // comma-separated Kubernetes kinds to exclude (case-insensitive, Kind name only); e.g. "Job,CronJob"
 	LabelSelector             string                       // filter collected resources by Kubernetes label selector (e.g. "app=nginx,env!=dev")
+	ExcludePaths              []string                     // gitignore-style patterns excluding paths from file, directory and repository scans
+	NoIgnoreFile              bool                         // do not read the .kubescapeignore file at the scan root
 	Namespace                 string                       // target namespace for workload scans
 	InputPatterns             []string                     // Yaml files input patterns
 	Silent                    bool                         // Silent mode - Do not print progress logs

--- a/core/core/initutils.go
+++ b/core/core/initutils.go
@@ -168,6 +168,10 @@ func getResourceHandler(ctx context.Context, scanInfo *cautils.ScanInfo, tenantC
 		return resourcehandler.NewFileResourceHandler()
 	}
 
+	if len(scanInfo.ExcludePaths) > 0 {
+		logger.L().Ctx(ctx).Warning("--exclude-path has no effect on a cluster scan; it applies to file, directory and repository scans")
+	}
+
 	// Only initialize cloud connector if not in air-gapped mode
 	// This call initializes the global cloud API connector for later use
 	if !isAirGappedMode(scanInfo) {

--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -44,9 +44,14 @@ func (fileHandler *FileResourceHandler) GetResources(ctx context.Context, sessio
 
 		helmValueOpts := helmValueOptionsFromScanInfo(scanInfo)
 		if scanInfo.ChartPath != "" && scanInfo.FilePath != "" {
+			// A chart-and-file input names one workload, leaving nothing to narrow.
 			workloadIDToSource, workloads, err = getWorkloadFromHelmChart(ctx, scanInfo.InputPatterns[path], scanInfo.ChartPath, scanInfo.FilePath, helmValueOpts)
 		} else {
-			workloadIDToSource, workloads, skipped, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts)
+			pathFilter, filterErr := pathFilterFromScanInfo(ctx, scanInfo.InputPatterns[path], scanInfo)
+			if filterErr != nil {
+				return nil, allResources, nil, nil, filterErr
+			}
+			workloadIDToSource, workloads, skipped, err = getResourcesFromPath(ctx, scanInfo.InputPatterns[path], helmValueOpts, pathFilter)
 		}
 		sessionObj.SkippedManifests = append(sessionObj.SkippedManifests, skipped...)
 		if err != nil {
@@ -197,6 +202,27 @@ func helmValueOptionsFromScanInfo(scanInfo *cautils.ScanInfo) cautils.HelmValueO
 	}
 }
 
+// pathFilterFromScanInfo compiles the exclusions that apply to a single scan input, from the
+// ignore file at its root and from --exclude-path. It returns nil when nothing is excluded.
+func pathFilterFromScanInfo(ctx context.Context, input string, scanInfo *cautils.ScanInfo) (*cautils.PathFilter, error) {
+	if scanInfo == nil {
+		return nil, nil
+	}
+
+	filter, err := cautils.NewScanPathFilter(input, scanInfo.ExcludePaths, !scanInfo.NoIgnoreFile)
+	if err != nil {
+		return nil, err
+	}
+	if filter != nil {
+		logger.L().Ctx(ctx).Info("Path exclusions in effect",
+			helpers.String("root", filter.Root()),
+			helpers.Int("patterns", len(filter.Patterns())))
+		logger.L().Debug("Path exclusion patterns", helpers.Interface("patterns", filter.Patterns()))
+	}
+
+	return filter, nil
+}
+
 func getWorkloadFromHelmChart(ctx context.Context, path, helmPath, workloadPath string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, error) {
 	clonedRepo := cautils.GetClonedPath(path)
 
@@ -308,7 +334,7 @@ func excludeFilesUnderDirectories(sourceToWorkloads map[string][]workloadinterfa
 // getResourcesFromPath loads every scannable resource under path, from plain
 // manifests, helm charts and kustomize directories, and maps each workload to the
 // source file it came from.
-func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions) (map[string]reporthandling.Source, []workloadinterface.IMetadata, []cautils.SkippedManifest, error) {
+func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautils.HelmValueOptions, pathFilter *cautils.PathFilter) (map[string]reporthandling.Source, []workloadinterface.IMetadata, []cautils.SkippedManifest, error) {
 	workloadIDToSource := make(map[string]reporthandling.Source)
 	var workloads []workloadinterface.IMetadata
 	var allSkips []cautils.SkippedManifest
@@ -331,14 +357,14 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// A broad directory input may contain Kustomize configurations below its root.
 	// Render them first so the generic Helm and plain-manifest passes can respect
 	// only the configurations whose builds actually succeeded.
-	kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectories(ctx, path)
+	kustomizeResult, err := cautils.LoadResourcesFromKustomizeDirectoriesFiltered(ctx, path, pathFilter)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	// Charts owned by a successful Kustomize build must not also be rendered as
 	// standalone Helm releases. Unreferenced charts remain in generic discovery.
-	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsExcludingDirectories(ctx, path, helmValueOpts, kustomizeResult.OwnedHelmChartDirectories)
+	helmSourceToWorkloads, helmSourceToChart, renderedCharts, err := cautils.LoadResourcesFromHelmChartsFiltered(ctx, path, helmValueOpts, kustomizeResult.OwnedHelmChartDirectories, pathFilter)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -348,13 +374,13 @@ func getResourcesFromPath(ctx context.Context, path string, helmValueOpts cautil
 	// generic Helm renderer left them alone. CRDs are filtered separately according
 	// to includeCRDs, so an omitted CRD remains available to the raw-file pass.
 	coveredChartDirectories := append(append([]string{}, renderedCharts...), kustomizeResult.OwnedHelmChartDirectories...)
-	sourceToWorkloads, fileSkips, err := cautils.LoadResourcesFromFiles(ctx, path, repoRoot, coveredChartDirectories)
+	sourceToWorkloads, fileSkips, err := cautils.LoadResourcesFromFilesFiltered(ctx, path, repoRoot, coveredChartDirectories, pathFilter)
 	allSkips = append(allSkips, fileSkips...)
 	filesErr := err
 	if err != nil && !errors.Is(err, cautils.ErrNoManifestFiles) {
 		return nil, nil, allSkips, err
 	}
-	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraform(ctx, path)
+	terraformSourceToWorkloads, err := cautils.LoadResourcesFromTerraformFiltered(ctx, path, pathFilter)
 	if err != nil {
 		return nil, nil, allSkips, err
 	}

--- a/core/pkg/resourcehandler/filesloader_test.go
+++ b/core/pkg/resourcehandler/filesloader_test.go
@@ -221,7 +221,7 @@ items:
 
 // A single-file scan must yield a repository-relative RelativePath: the SARIF and GitLab SAST printers build the finding's file location from it, and the GitLab printer drops findings whose path is empty, absolute, or escaping the repo root. See #2496.
 func TestGetResourcesFromPath_SingleFileRelativePathIsRepositoryRelative(t *testing.T) {
-	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/mixed_extensions/pod.yaml", cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, workloads, "the single-file scan must discover the pod")
 
@@ -277,7 +277,7 @@ spec:
           image: nginx:1.27
 `), 0o600))
 
-	_, workloads, _, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), manifestPath, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 	require.Len(t, workloads, 1, "an exact file scan must not add resources from its parent tree")
 	assert.Equal(t, "ConfigMap", workloads[0].GetKind())
@@ -326,7 +326,7 @@ func TestGetResourcesFromPath_AnchorsOnRepositoryRootWithoutUsableGitMetadata(t 
 		t.Run(tt.name, func(t *testing.T) {
 			repoRoot := newRepoWithUnusableGitMetadata(t, manifest)
 
-			workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), filepath.Join(repoRoot, filepath.FromSlash(tt.scanPath)), cautils.HelmValueOptions{})
+			workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), filepath.Join(repoRoot, filepath.FromSlash(tt.scanPath)), cautils.HelmValueOptions{}, nil)
 			require.NoError(t, err)
 			require.NotEmpty(t, workloads)
 
@@ -355,7 +355,7 @@ spec:
 // would make those resources reach neither loader and vanish silently. Regression guard for the #2501
 // review: templates/ is excluded only for charts that rendered without errors.
 func TestGetResourcesFromPath_ScansTemplatesOfChartThatFailedToRender(t *testing.T) {
-	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_broken", cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_broken", cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	var found bool
@@ -441,7 +441,7 @@ func TestResolveHelmRemotePath(t *testing.T) {
 // not scan them again (no duplicate, no malformed-template warnings), while crds/ and files outside
 // templates/ stay plainly scanned.
 func TestGetResourcesFromPath_RenderedChartTemplatesLoadedOnce(t *testing.T) {
-	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_layout", cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/helm_chart_layout", cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -460,7 +460,7 @@ func TestGetResourcesFromPath_RenderedChartTemplatesLoadedOnce(t *testing.T) {
 
 // Deduplicates resources discovered by both kustomize render and the plain-YAML glob.
 func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
-	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/base", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/base", cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	var deployments []string
@@ -476,7 +476,7 @@ func TestGetResourcesFromPath_DeduplicatesKustomizeAndPlainYaml(t *testing.T) {
 
 // Kustomize transformers mutate identity fields, so path-based exclusion (not identity dedup) must keep the result single.
 func TestGetResourcesFromPath_KustomizeTransformersDoNotDuplicate(t *testing.T) {
-	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/transformed", cautils.HelmValueOptions{})
+	workloadIDToSource, workloads, _, err := getResourcesFromPath(context.TODO(), "../../cautils/testdata/kustomize/transformed", cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	var deploymentIDs []string
@@ -520,7 +520,7 @@ metadata:
   name: {{ .Release.Name }}
 `), 0o600))
 
-	sources, workloads, _, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), root, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -627,7 +627,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -680,7 +680,7 @@ helmCharts:
     releaseName: app
 `), 0o600))
 
-	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -779,7 +779,7 @@ helmCharts:
 				assert.Equal(t, 1, rawCRDs, "the raw pass must retain the omitted CRD")
 			}
 
-			sources, workloads, _, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{})
+			sources, workloads, _, err := getResourcesFromPath(ctx, repoRoot, cautils.HelmValueOptions{}, nil)
 			require.NoError(t, err)
 
 			var crds []workloadinterface.IMetadata
@@ -819,7 +819,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -840,7 +840,7 @@ func TestGetResourcesFromPathRejectsDirectoryWithoutKubernetesResources(t *testi
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("replicas: 3\n"), 0o600))
 
-	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, sources)
@@ -875,7 +875,7 @@ func TestGetResourcesFromPathLoadsTerraformOnlyDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTerraformFixture(t, dir, terraformPodFixture)
 
-	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, skips)
@@ -891,7 +891,7 @@ func TestGetResourcesFromPathLoadsExplicitTerraformFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTerraformFixture(t, dir, terraformPodFixture)
 
-	_, workloads, _, err := getResourcesFromPath(context.Background(), path, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), path, cautils.HelmValueOptions{}, nil)
 
 	require.NoError(t, err)
 	require.Len(t, workloads, 1)
@@ -919,7 +919,7 @@ metadata:
   name: yaml-config
 `), 0o600))
 
-	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, skips)
@@ -944,7 +944,7 @@ func TestGetResourcesFromPathReturnsTerraformErrorForMalformedTerraformOnlyDirec
 	dir := t.TempDir()
 	writeTerraformFixture(t, dir, `resource "kubernetes_pod_v1" "broken" {`)
 
-	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, sources)
@@ -958,7 +958,7 @@ func TestGetResourcesFromPathKeepsNoManifestErrorForUnsupportedTerraformOnlyDire
 	dir := t.TempDir()
 	writeTerraformFixture(t, dir, `resource "null_resource" "example" {}`)
 
-	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, skips, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, cautils.ErrNoManifestFiles)
@@ -977,7 +977,7 @@ metadata:
   name: yaml-config
 `), 0o600))
 
-	_, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.NoError(t, err)
 	resources := map[string]bool{}
@@ -999,7 +999,7 @@ resources:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(kustomization), 0o600))
 
-	sources, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{})
+	sources, workloads, _, err := getResourcesFromPath(context.Background(), dir, cautils.HelmValueOptions{}, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, sources)
@@ -1035,7 +1035,7 @@ spec:
           image: nginx:1.27
 `), 0o600))
 
-	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}
@@ -1080,7 +1080,7 @@ metadata:
   name: standalone
 `), 0o600))
 
-	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{})
+	_, workloads, _, err := getResourcesFromPath(context.Background(), repoRoot, cautils.HelmValueOptions{}, nil)
 	require.NoError(t, err)
 
 	counts := map[string]int{}

--- a/core/pkg/resourcehandler/pathfilter_test.go
+++ b/core/pkg/resourcehandler/pathfilter_test.go
@@ -1,0 +1,129 @@
+package resourcehandler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func podPolicyFramework() reporthandling.Framework {
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{""},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"pods"},
+	}
+	return *mockFramework("path-filter-input", []reporthandling.Control{
+		mockControl("path-filter-input", []reporthandling.PolicyRule{
+			mockRule("path-filter-input", []reporthandling.RuleMatchObjects{match}, ""),
+		}),
+	})
+}
+
+func writePodManifest(t *testing.T, path, name string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	manifest := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: " + name + "\n  namespace: default\n"
+	require.NoError(t, os.WriteFile(path, []byte(manifest), 0o600))
+}
+
+func scannedPodNames(t *testing.T, scanInfo *cautils.ScanInfo) []string {
+	t.Helper()
+
+	session := cautils.NewOPASessionObj(
+		context.Background(), []reporthandling.Framework{podPolicyFramework()}, nil, scanInfo, nil,
+	)
+	_, allResources, _, _, err := NewFileResourceHandler().GetResources(context.Background(), session, scanInfo)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(allResources))
+	for _, resource := range allResources {
+		names = append(names, resource.GetName())
+	}
+	return names
+}
+
+func TestFileResourceHandlerExcludesPathsFromIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	writePodManifest(t, filepath.Join(root, "pod.yaml"), "scanned")
+	writePodManifest(t, filepath.Join(root, "testdata", "pod.yaml"), "fixture")
+	require.NoError(t, os.WriteFile(filepath.Join(root, cautils.IgnoreFileName), []byte("testdata/\n"), 0o600))
+
+	names := scannedPodNames(t, &cautils.ScanInfo{InputPatterns: []string{root}})
+
+	assert.Equal(t, []string{"scanned"}, names)
+}
+
+func TestFileResourceHandlerExcludesPathsFromFlag(t *testing.T) {
+	root := t.TempDir()
+	writePodManifest(t, filepath.Join(root, "pod.yaml"), "scanned")
+	writePodManifest(t, filepath.Join(root, "generated", "deep", "pod.yaml"), "generated")
+
+	names := scannedPodNames(t, &cautils.ScanInfo{
+		InputPatterns: []string{root},
+		ExcludePaths:  []string{"generated/**"},
+	})
+
+	assert.Equal(t, []string{"scanned"}, names)
+}
+
+func TestFileResourceHandlerReIncludesNegatedPath(t *testing.T) {
+	root := t.TempDir()
+	writePodManifest(t, filepath.Join(root, "test", "prod.yaml"), "prod")
+	writePodManifest(t, filepath.Join(root, "test", "dev.yaml"), "dev")
+
+	names := scannedPodNames(t, &cautils.ScanInfo{
+		InputPatterns: []string{root},
+		ExcludePaths:  []string{"test/**", "!test/prod.yaml"},
+	})
+
+	assert.Equal(t, []string{"prod"}, names)
+}
+
+func TestFileResourceHandlerHonorsNoIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	writePodManifest(t, filepath.Join(root, "pod.yaml"), "scanned")
+	writePodManifest(t, filepath.Join(root, "testdata", "pod.yaml"), "fixture")
+	require.NoError(t, os.WriteFile(filepath.Join(root, cautils.IgnoreFileName), []byte("testdata/\n"), 0o600))
+
+	names := scannedPodNames(t, &cautils.ScanInfo{
+		InputPatterns: []string{root},
+		NoIgnoreFile:  true,
+	})
+
+	assert.ElementsMatch(t, []string{"scanned", "fixture"}, names)
+}
+
+func TestPathFilterFromScanInfo(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, cautils.IgnoreFileName), []byte("testdata/\n"), 0o600))
+
+	t.Run("combines the ignore file with the flag patterns", func(t *testing.T) {
+		filter, err := pathFilterFromScanInfo(context.Background(), root, &cautils.ScanInfo{
+			ExcludePaths: []string{"*.tmpl.yaml"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, filter)
+
+		assert.Equal(t, []string{"testdata/", "*.tmpl.yaml"}, filter.Patterns())
+	})
+
+	t.Run("rejects a malformed pattern", func(t *testing.T) {
+		filter, err := pathFilterFromScanInfo(context.Background(), root, &cautils.ScanInfo{
+			ExcludePaths: []string{"pod[.yaml"},
+		})
+		require.ErrorIs(t, err, cautils.ErrInvalidIgnorePattern)
+		assert.Nil(t, filter)
+	})
+
+	t.Run("returns no filter without a scan info", func(t *testing.T) {
+		filter, err := pathFilterFromScanInfo(context.Background(), root, nil)
+		require.NoError(t, err)
+		assert.Nil(t, filter)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
@@ -209,7 +210,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect


### PR DESCRIPTION
## Summary

Local scans glob every manifest under the input path and there is no way to leave any of it out. Repositories that keep CI fixtures, generated output or vendored charts next to the manifests they actually deploy have to scan all of it, so findings no cluster will ever see land in every report and every CI gate.

This adds two ways to narrow a local scan:

- `--exclude-path`: repeatable, gitignore syntax, relative to the scan root
- `.kubescapeignore`: an optional file at the scan root, disabled with `--no-ignore-file`

Command line patterns are applied after the ignore file, so they can re-include what it excluded.

**Files changed**

- `core/cautils/pathfilter.go` - new `PathFilter`: gitignore-syntax parser and matcher (`#` comments, `!` negation, trailing `/` for directories, leading or embedded `/` to anchor, `**` for any depth, last match wins, no re-inclusion under an excluded directory). Matching allocates nothing on the hot path
- `core/cautils/fileutils.go` - the filter is applied inside the single `filepath.Walk` that all discovery goes through, so an excluded directory is pruned from the walk. `*Filtered` variants of the four loader entry points; existing exported signatures are unchanged
- `core/pkg/resourcehandler/filesloader.go` - builds the filter per scan input and threads it through Helm, Kustomize, Terraform and plain-manifest discovery
- `cmd/scan/scan.go`, `cmd/shared/scan.go` - flags and up-front pattern validation
- `core/core/initutils.go` warn when `--exclude-path` is passed on a cluster scan, where it does not apply
- `go.mod` promotes `bmatcuk/doublestar/v4` from indirect to direct; it was already in the module graph via Helm, so no new dependency is pulled in

Because exclusions are applied during discovery rather than after loading, an excluded directory's Helm charts, Kustomize configurations and Terraform modules are never rendered, not merely dropped from the results. The streaming path (`--enable-streaming`) delegates to `GetResources`, so it is covered by the same filter rather than bypassing it.

**Behavior when exclusions are active**

- One info line per scan input records that exclusions are in effect, with the root and the pattern count; the patterns themselves are logged at debug. Files do not vanish from a scan silently
- A malformed pattern fails the command before any resource is collected, and the error names its source: `--exclude-path: ...` for the flag, the ignore file's path for the file
- If exclusions leave nothing to scan, the "no manifest files found" error says so rather than looking like an empty directory

**Two deliberate differences from git**, both documented on the type:

- One ignore file is read, at the scan root, rather than one per directory. This matches how comparable scanners handle their ignore files
- Surrounding whitespace is trimmed from a pattern, so an indented line in an ignore file still applies

**What was tested**

- `core/cautils/pathfilter_test.go`: 20-case matcher table (anchoring, directory-only, `**`, negation ordering, re-inclusion under an excluded directory, comments, malformed patterns); ignore-file loading and precedence; root anchoring for a file input; loader-level tests that an excluded chart is never rendered and that an excluded file input reports `ErrNoManifestFiles` with the exclusion hint
- `TestPathFilterMatchesGitignoreSemantics`: compares 21 paths against 11 patterns with `git check-ignore` on a real repository, so the syntax promise in the flag help is checked against git rather than against a reading of its documentation. Skips when git is unavailable
- `core/pkg/resourcehandler/pathfilter_test.go`: end-to-end `FileResourceHandler.GetResources` cases for the ignore file, the flag, negation and `--no-ignore-file`
- `cmd/shared/scan_test.go`, `TestValidateExcludePaths`, plus `TestValidateExcludePathsAcceptsBraceAlternation` pinning that `*.{yaml,json}` survives flag parsing
- Full `go test ./... -count=1 -short` passes

**Which issue(s) this PR fixes:**
None, filed as a new capability.

**Special notes for your reviewer:**
Pattern semantics deliberately follow gitignore rather than inventing a dialect, including the rule that a file under an excluded directory cannot be re-included by a later `!` pattern. `--exclude-path` uses `StringArrayVar` rather than `StringSliceVar` because a comma is significant inside a glob alternation; repeat the flag for more than one pattern, the way `--set` works. `--exclude-path` has no effect on cluster scans and warns rather than failing, matching how the other local-only flags behave.

**Does this PR introduce a user-facing change?**
Yes, two new `scan` flags (`--exclude-path`, `--no-ignore-file`) and support for a `.kubescapeignore` file at the scan root. Default behavior with neither present is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--exclude-path` for gitignore-style file and directory exclusions.
  - Added `.kubescapeignore` support for local scans.
  - Added `--no-ignore-file` to disable ignore-file processing.
  - Applied exclusions to Helm, Kustomize, Terraform, and manifest discovery.
  - Supports ordered patterns, directory matching, and negated paths.

- **Bug Fixes**
  - Improved validation and error reporting for invalid exclusion patterns.
  - Added warnings when exclusions are used with unsupported cluster scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->