### PR TITLE
fix(cautils): propagate scan errors from splitYAMLDocuments instead of truncating silently

### DIFF
--- a/core/cautils/fileformat_test.go
+++ b/core/cautils/fileformat_test.go
@@ -1,9 +1,11 @@
 package cautils
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsYAMLDocumentSeparator(t *testing.T) {
@@ -96,8 +98,46 @@ func TestSplitYAMLDocuments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			docs := splitYAMLDocuments([]byte(tt.input))
+			docs, err := splitYAMLDocuments([]byte(tt.input))
+			require.NoError(t, err)
 			assert.Len(t, docs, tt.wantLen)
 		})
 	}
+}
+
+// erroringReader yields data once, then fails with a fixed error instead of
+// io.EOF, simulating a read failure partway through a multi-document file
+// (e.g. a truncated stream or an I/O error on the underlying source).
+type erroringReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (e *erroringReader) Read(p []byte) (int, error) {
+	if e.pos >= len(e.data) {
+		return 0, e.err
+	}
+	n := copy(p, e.data[e.pos:])
+	e.pos += n
+	return n, nil
+}
+
+// TestScanYAMLDocuments_PropagatesReaderError guards against a scan failure
+// being silently swallowed: a multi-document file with a read error after the
+// first document must surface that error to the caller, not just return the
+// documents seen before the failure as if they were the whole file.
+func TestScanYAMLDocuments_PropagatesReaderError(t *testing.T) {
+	wantErr := errors.New("boom: connection reset")
+	input := "apiVersion: v1\nkind: Pod\n---\napiVersion: v1\nkind: Service"
+	r := &erroringReader{data: []byte(input), err: wantErr}
+
+	docs, err := scanYAMLDocuments(r, len(input)+1)
+
+	require.Error(t, err, "a scan failure must be reported, not swallowed")
+	assert.ErrorIs(t, err, wantErr)
+	// The first document, terminated by a real "---" separator before the
+	// failure, is still valid and returned; the second was never read and
+	// must not appear as if the file only ever had one document.
+	assert.Len(t, docs, 1)
 }

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -846,8 +846,17 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err 
 		}
 	}()
 
+	docs, splitErr := splitYAMLDocuments(yamlFile)
+
 	var parseErrs []error
-	for i, doc := range splitYAMLDocuments(yamlFile) {
+	if splitErr != nil {
+		// The scanner stopped before reaching the end of input. Any documents
+		// already split out are still reported below, but the caller must be
+		// told the file was not read in full rather than silently receiving
+		// what looks like a complete document list.
+		parseErrs = append(parseErrs, splitErr)
+	}
+	for i, doc := range docs {
 		var t any
 		if unmarshalErr := yaml.Unmarshal(doc, &t); unmarshalErr != nil {
 			parseErrs = append(parseErrs, fmt.Errorf("document %d: %w", i+1, unmarshalErr))
@@ -872,12 +881,20 @@ func readYamlFile(yamlFile []byte) (yamlObjs []workloadinterface.IMetadata, err 
 	return yamlObjs, errors.Join(parseErrs...)
 }
 
-func splitYAMLDocuments(data []byte) [][]byte {
+func splitYAMLDocuments(data []byte) ([][]byte, error) {
+	return scanYAMLDocuments(bytes.NewReader(data), len(data)+1)
+}
+
+// scanYAMLDocuments is the reader-based core of splitYAMLDocuments, split out
+// so a scan failure mid-stream can be exercised directly in tests: with a
+// bytes.Reader the underlying Read never fails, so there is no way to observe
+// this error path through splitYAMLDocuments alone.
+func scanYAMLDocuments(r io.Reader, bufMax int) ([][]byte, error) {
 	var docs [][]byte
 	var current bytes.Buffer
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), len(data)+1)
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), bufMax)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if isYAMLDocumentSeparator(line) {
@@ -891,12 +908,18 @@ func splitYAMLDocuments(data []byte) [][]byte {
 		current.WriteByte('\n')
 	}
 	if err := scanner.Err(); err != nil {
-		logger.L().Warning(fmt.Sprintf("error scanning YAML input: %v", err))
+		// The scan stopped before reaching the end of input, so any bytes
+		// still buffered in current belong to a document that was never
+		// fully read; discard them rather than treat a truncated document as
+		// complete. Documents already appended to docs were each terminated
+		// by a real "---" separator and remain valid, but the caller must
+		// still be told the read did not finish.
+		return docs, fmt.Errorf("scanning YAML input: %w", err)
 	}
 	if doc := bytes.TrimSpace(current.Bytes()); len(doc) > 0 {
 		docs = append(docs, append([]byte{}, doc...))
 	}
-	return docs
+	return docs, nil
 }
 
 func isYAMLDocumentSeparator(line []byte) bool {


### PR DESCRIPTION
## Overview

`splitYAMLDocuments` (`core/cautils/fileutils.go`) splits a multi-document YAML file with a `bufio.Scanner`. If the scanner ever fails mid-read, the old code just logged a warning and returned whatever documents it had split out so far — with no error in the signature at all. It even flushed the trailing in-progress buffer as if it were a finished document. `readYamlFile`, the only caller, had no way to tell "this file really only had N documents" apart from "reading it stopped partway through."

This PR changes `splitYAMLDocuments` to return `([][]byte, error)`, threads that error into `readYamlFile`'s existing `errors.Join(parseErrs...)` handling (the same mechanism it already uses for per-document parse errors, so no new error-handling style is introduced), and stops treating an unfinished trailing buffer as a complete document.

One thing worth being upfront about: with the current call site (`bytes.Reader` + a buffer max of `len(data)+1`), this exact failure isn't reachable through the CLI today — `bufio.ErrTooLong` can't fire when the max is guaranteed to fit the whole input, and `bytes.Reader` never returns a non-EOF error. So this is a defensive-code correctness fix, not a fix for something you can currently trigger by handing kubescape a crafted file. It still matters: the error-handling shape was wrong regardless, and becomes a real, triggerable bug the moment this scan loop is reused against any other `io.Reader`. To make the fix actually testable, I extracted the reader-based core into a small `scanYAMLDocuments(r io.Reader, bufMax int)` helper, which lets the test inject a reader that fails mid-stream and assert the error comes back instead of being swallowed.

## How to Test

```
go build ./...
go vet ./core/cautils/...
go test ./core/cautils/... -run 'TestSplitYAMLDocuments|TestScanYAMLDocuments_PropagatesReaderError|TestReadYamlFile' -v
go test ./core/cautils/...
```

I ran all of the above against this branch (all green), and separately confirmed the new test actually catches the regression: reverting just the source change while keeping the test causes a build failure (the test calls the new two-return-value signature and the new `scanYAMLDocuments` helper, neither of which exist on the old code).

## Related issues/PRs

Resolved #3420

Related, different layer: #2033 / #2034 fixed silent truncation on a *parse* error inside the per-document loop. This fixes the *scan*-error path underneath it in `splitYAMLDocuments`, which looks like it was left out of that earlier fix rather than addressed by it.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YAML file processing now reports errors encountered while reading documents instead of silently ignoring them.
  * Successfully completed documents remain available when a later read fails.
  * Incomplete documents are no longer returned after an interrupted read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->