### PR TITLE
feat: Implement global chunked pagination for Kubernetes resource retrieval

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -249,6 +249,9 @@ func createVulnerabilityToolsAndResources(ksServer *KubescapeMcpserver) {
 			mcp.Description("Type of vulnerability manifests to list"),
 			mcp.Enum("image", "workload", "both"),
 		),
+		mcp.WithString("continue",
+			mcp.Description("Optional Kubernetes continuation token for pagination"),
+		),
 	)
 
 	ksServer.s.AddTool(listManifestsTool, ksServer.toolHandler(listManifestsTool.Name))
@@ -304,6 +307,9 @@ func createConfigurationsToolsAndResources(ksServer *KubescapeMcpserver) {
 		mcp.WithString("namespace",
 			mcp.Description("Filter by namespace (optional)"),
 		),
+		mcp.WithString("continue",
+			mcp.Description("Optional Kubernetes continuation token for pagination"),
+		),
 	)
 
 	ksServer.s.AddTool(listConfigsTool, ksServer.toolHandler(listConfigsTool.Name))
@@ -339,6 +345,9 @@ func createRuntimeToolsAndResources(ksServer *KubescapeMcpserver) {
 		mcp.WithDescription("Discover available container profiles at workload level (this returns a list of profiles, not the profile results themselves, to get the profile results, use the get_container_profile tool)"),
 		mcp.WithString("namespace",
 			mcp.Description("Filter by namespace (optional)"),
+		),
+		mcp.WithString("continue",
+			mcp.Description("Optional Kubernetes continuation token for pagination"),
 		),
 	)
 
@@ -720,26 +729,33 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			labelSelector = "kubescape.io/context=non-filtered"
 		}
 
-		var manifests *v1beta1.VulnerabilityManifestList
-		var err error
-		if labelSelector == "" {
-			client, ksErr := ksServer.getKsClient()
-			if ksErr != nil {
-				return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+		continueToken := ""
+		if c, ok := arguments["continue"]; ok {
+			if cStr, ok := c.(string); ok {
+				continueToken = cStr
 			}
-			manifests, err = client.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{})
-		} else {
-			client, ksErr := ksServer.getKsClient()
-			if ksErr != nil {
-				return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
-			}
-			manifests, err = client.VulnerabilityManifests(namespace).List(ctx, metav1.ListOptions{
-				LabelSelector: labelSelector,
-			})
 		}
+
+		client, ksErr := ksServer.getKsClient()
+		if ksErr != nil {
+			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
+		}
+
+		listOpts := metav1.ListOptions{Limit: 100, Continue: continueToken}
+		if labelSelector != "" {
+			listOpts.LabelSelector = labelSelector
+		}
+		chunk, err := client.VulnerabilityManifests(namespace).List(ctx, listOpts)
 		if err != nil {
 			return nil, err
 		}
+
+		if chunk.GetContinue() != "" {
+			result["continue"] = chunk.GetContinue()
+		}
+
+		var manifests v1beta1.VulnerabilityManifestList
+		manifests.Items = chunk.Items
 
 		logger.L().Info(fmt.Sprintf("Found %d manifests", len(manifests.Items)))
 
@@ -886,10 +902,20 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if ksErr != nil {
 			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
 		}
-		manifests, err := client.WorkloadConfigurationScans(namespaceStr).List(ctx, metav1.ListOptions{})
+		continueToken := ""
+		if c, ok := arguments["continue"]; ok {
+			if cStr, ok := c.(string); ok {
+				continueToken = cStr
+			}
+		}
+
+		chunk, err := client.WorkloadConfigurationScans(namespaceStr).List(ctx, metav1.ListOptions{Limit: 100, Continue: continueToken})
 		if err != nil {
 			return nil, err
 		}
+
+		var manifests v1beta1.WorkloadConfigurationScanList
+		manifests.Items = chunk.Items
 		logger.L().Info(fmt.Sprintf("Found %d configuration manifests", len(manifests.Items)))
 		configManifests := []map[string]any{}
 		for _, manifest := range manifests.Items {
@@ -907,6 +933,9 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			"available_templates": map[string]string{
 				"configuration_manifest_details": "kubescape://configuration-manifests/{namespace}/{manifest_name}",
 			},
+		}
+		if chunk.GetContinue() != "" {
+			result["continue"] = chunk.GetContinue()
 		}
 		content, err := json.Marshal(result)
 		if err != nil {
@@ -972,10 +1001,20 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if ksErr != nil {
 			return nil, fmt.Errorf("failed to connect to Kubernetes cluster: %w", ksErr)
 		}
-		profiles, err := client.ContainerProfiles(namespace).List(ctx, metav1.ListOptions{})
+		continueToken := ""
+		if c, ok := arguments["continue"]; ok {
+			if cStr, ok := c.(string); ok {
+				continueToken = cStr
+			}
+		}
+
+		chunk, err := client.ContainerProfiles(namespace).List(ctx, metav1.ListOptions{Limit: 100, Continue: continueToken})
 		if err != nil {
 			return nil, err
 		}
+
+		var profiles v1beta1.ContainerProfileList
+		profiles.Items = chunk.Items
 		logger.L().Info(fmt.Sprintf("Found %d container profiles", len(profiles.Items)))
 		containerProfilesList := []map[string]any{}
 		for _, profile := range profiles.Items {
@@ -993,6 +1032,9 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			"available_templates": map[string]string{
 				"container_profile_details": "kubescape://container-profiles/{namespace}/{profile_name}",
 			},
+		}
+		if chunk.GetContinue() != "" {
+			result["continue"] = chunk.GetContinue()
 		}
 		content, err := json.Marshal(result)
 		if err != nil {

--- a/core/cautils/getter/pagination.go
+++ b/core/cautils/getter/pagination.go
@@ -1,0 +1,76 @@
+package getter
+
+import (
+	"context"
+	"time"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListFunc performs a single paginated request and returns the continuation token or an error.
+type ListFunc func(metav1.ListOptions) (string, error)
+
+// ListWithPagination executes a Kubernetes API list operation with chunked pagination,
+// exponential backoff for rate limits, and context cancellation.
+func ListWithPagination(ctx context.Context, listFunc ListFunc) error {
+	limit := int64(100)
+	continueToken := ""
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		listOptions := metav1.ListOptions{Limit: limit, Continue: continueToken}
+		var nextToken string
+		var err error
+
+		retries := 5
+		backoff := 1 * time.Second
+		for i := 0; i < retries; i++ {
+			nextToken, err = listFunc(listOptions)
+			if err != nil {
+				if k8serrors.IsTooManyRequests(err) {
+					logger.L().Warning("Rate limited (429) when listing resources, retrying",
+						helpers.Int("retry", i+1))
+
+					if i == retries-1 {
+						break
+					}
+
+					delay, ok := k8serrors.SuggestsClientDelay(err)
+					currentBackoff := backoff
+					if ok && delay > 0 {
+						currentBackoff = time.Duration(delay) * time.Second
+					}
+
+					timer := time.NewTimer(currentBackoff)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return ctx.Err()
+					case <-timer.C:
+						if !ok || delay <= 0 {
+							backoff *= 2
+						}
+						continue
+					}
+				}
+				break
+			}
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if nextToken == "" {
+			break
+		}
+		continueToken = nextToken
+	}
+	return nil
+}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	"github.com/kubescape/kubescape/v4/core/metrics"
 	"github.com/kubescape/kubescape/v4/core/pkg/hostsensorutils"
 	"github.com/kubescape/kubescape/v4/core/pkg/vapreconcile"
@@ -1179,23 +1180,26 @@ func splitNamespaces(s string) []string {
 }
 
 func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber(ctx context.Context) (int, error) {
-	nodesList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	scheduableNodes := v1.NodeList{}
-	if nodesList != nil {
-		for _, node := range nodesList.Items {
-			if len(node.Spec.Taints) == 0 {
-				scheduableNodes.Items = append(scheduableNodes.Items, node)
-			} else {
-				if !isMasterNodeTaints(node.Spec.Taints) {
-					scheduableNodes.Items = append(scheduableNodes.Items, node)
+	schedulableCount := 0
+	err := getter.ListWithPagination(ctx, func(opts metav1.ListOptions) (string, error) {
+		chunk, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+		if chunk != nil {
+			for _, node := range chunk.Items {
+				if len(node.Spec.Taints) == 0 || !isMasterNodeTaints(node.Spec.Taints) {
+					schedulableCount++
 				}
 			}
+			return chunk.GetContinue(), nil
 		}
-	}
+		return "", nil
+	})
 	if err != nil {
 		return 0, err
 	}
-	return len(scheduableNodes.Items), nil
+	return schedulableCount, nil
 }
 
 // namespacedResourcesToEstimate is the set of common namespaced GVRs used to
@@ -1255,11 +1259,25 @@ func (k8sHandler *K8sResourceHandler) EstimateClusterSize(ctx context.Context, s
 }
 
 func (k8sHandler *K8sResourceHandler) setCloudProvider(ctx context.Context) error {
-	nodeList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	var provider string
+	err := getter.ListWithPagination(ctx, func(opts metav1.ListOptions) (string, error) {
+		chunk, err := k8sHandler.k8s.KubernetesClient.CoreV1().Nodes().List(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+		if chunk != nil {
+			provider = cloudsupport.GetCloudProvider(chunk)
+			if provider != "" {
+				return "", nil
+			}
+			return chunk.GetContinue(), nil
+		}
+		return "", nil
+	})
 	if err != nil {
 		return err
 	}
-	k8sHandler.cloudProvider = cloudsupport.GetCloudProvider(nodeList)
+	k8sHandler.cloudProvider = provider
 	return nil
 }
 

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,18 +121,27 @@ func serves(resources *metav1.APIResourceList, names ...string) bool {
 // scan failure.
 func list(ctx context.Context, client dynamic.Interface, version, resource string) ([]unstructured.Unstructured, error) {
 	gvr := schema.GroupVersionResource{Group: vapGroup, Version: version, Resource: resource}
-	listed, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, ErrUnsupported
+
+	var items []unstructured.Unstructured
+	listFunc := func(opts metav1.ListOptions) (string, error) {
+		listed, err := client.Resource(gvr).List(ctx, opts)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", ErrUnsupported
+			}
+			if apierrors.IsForbidden(err) {
+				return "", fmt.Errorf("%w: %s", ErrForbidden, gvr.String())
+			}
+			return "", fmt.Errorf("failed to list %s: %w", gvr.String(), err)
 		}
-		if apierrors.IsForbidden(err) {
-			return nil, fmt.Errorf("%w: %s", ErrForbidden, gvr.String())
-		}
-		return nil, fmt.Errorf("failed to list %s: %w", gvr.String(), err)
+		items = append(items, listed.Items...)
+		return listed.GetContinue(), nil
 	}
 
-	return listed.Items, nil
+	if err := getter.ListWithPagination(ctx, listFunc); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 // BuildIndex builds a map of controlId -> VAPEnforcementStatus by reading the


### PR DESCRIPTION
This PR implements chunked pagination across the entire Kubescape codebase for Kubernetes resource retrieval to fix OOMs and API server timeouts.

We added a reusable `ListWithPagination` utility in `core/cautils/getter/pagination.go` and refactored the unpaginated List calls in:
- `cmd/mcpserver/mcpserver.go`
- `core/pkg/resourcehandler/k8sresources.go`
- `core/pkg/vapreconcile/reconcile.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listing tools now support continuation tokens for retrieving results across multiple pages.
  * Kubernetes resource collection supports paginated retrieval, streaming batches, and improved progress estimates for larger environments.
  * Resource discovery, filtering, cluster resource handling, and supported security resource scans have been improved.
* **Bug Fixes**
  * Added retry handling for rate-limited requests, including server-provided delays and cancellation support.
  * Improved handling of missing resource handlers, collection errors, and unsupported secret scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->