### PR TITLE
ci: pin golangci-lint to v2.12.2 to avoid v2.13.0 timeout regression

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -79,5 +79,6 @@ jobs:
         continue-on-error: false
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
+          version: v2.12.2
           args: --timeout 10m
           only-new-issues: true


### PR DESCRIPTION
## Overview
`golangci-lint-action` in `.github/workflows/a-pr-scanner.yaml` had no `version:` input, so it always installed `latest`. golangci-lint **v2.13.0** (published 2026-08-19 23:29 UTC) has a `staticcheck` performance regression — currently an open upstream issue, [golangci/golangci-lint#6732](https://github.com/golangci/golangci-lint/issues/6732) — where a cold-cache lint run that used to take under a minute now takes 45–70 minutes. That blows straight through the workflow's `--timeout 10m`, and golangci-lint exits with `level=error msg="Timeout exceeded"` / exit code 4, even though the underlying analysis actually completes with `0 issues.`.

This has been failing/timing out `pr-scanner` runs on essentially every PR since ~04:38 UTC on 2026-08-20 (e.g. #3427, #3426, #3416, and many others), any time a branch hits a cold `golangci-lint` result cache.

This PR pins the linter version to the last known-good release, `v2.12.2`, so CI stops flaking on this. We should bump forward once the upstream regression is fixed.

## Related issues/PRs:
* Related: golangci/golangci-lint#6732 (upstream)

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the code quality checker to a specific version for more consistent automated validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->