### PR TITLE
ci: bound pr-scanner job runtime with timeout-minutes

### DIFF
--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -33,6 +33,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-large
+    timeout-minutes: 20
     steps:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Adds `timeout-minutes: 20` to the `unit-tests` job in `.github/workflows/a-pr-scanner.yaml` as a hard backstop, independent of any single step's own timeout handling.

## Why

**Note:** the acute cause of the hang I originally observed is already fixed by @matthyx in #3429 (golangci-lint v2.13.0's upstream `staticcheck` regression, golangci/golangci-lint#6732 — pinned back to v2.12.2). I'd filed a duplicate issue (#3430, now closed) before spotting that #3429 had already merged. This PR is no longer "fixing an active outage" — it's a smaller, independent hardening follow-up.

The underlying gap it addresses still exists regardless of #3429: this job has no `timeout-minutes` anywhere, so its only backstop is GitHub Actions' default 360-minute job cap. That's what let the golangci-lint regression (and would let any future hang, from any step, for any reason) occupy an `ubuntu-large` runner for up to 6 hours while a PR check just sits "pending" with no indication anything's wrong. What I actually reproduced this time — before #3429 was spotted — was 3 unrelated PRs whose `golangci-lint` step ran 50–60 minutes before self-timing-out:

- [run 32339683976](https://github.com/kubescape/kubescape/actions/runs/32339683976) (PR #3416): ~50.3 min
- [run 32339579573](https://github.com/kubescape/kubescape/actions/runs/32339579573): ~60.7 min
- [run 32340538221](https://github.com/kubescape/kubescape/actions/runs/32340538221): ~60.3 min

`timeout-minutes: 20` gives real headroom above normal runtime (successful runs of this job typically finish in well under 10 minutes) while cutting off a hang — from this or any other cause — in minutes instead of up to six hours.

## Test plan

- [x] Confirmed the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` and a Ruby YAML parse as a second check) — `timeout-minutes` is a documented top-level job key ([GitHub Actions docs](https://docs.github.com/en/actions/using-jobs/setting-a-timeout-for-a-job)), so no functional change to any other step.
- [x] Diff is a single added line; no other workflow behavior changed.
- [ ] CI on this PR itself will exercise the same `a-pr-scanner.yaml` workflow this change lives in.
