### PR TITLE
core: add ScanContext, an explicit-context scan entry point

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -51,7 +51,8 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			defer applyTimeout(scanInfo, ks)()
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
 
 			if err := shared.ValidateCommonScanFlags(cmd, scanInfo, shared.ScanFormats); err != nil {
 				return err
@@ -90,11 +91,11 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
-			results, err := ks.Scan(scanInfo, policyIdentifiers)
+			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err
 			}
-			if err := results.HandleResults(ks.Context(), scanInfo); err != nil {
+			if err := results.HandleResults(ctx, scanInfo); err != nil {
 				return err
 			}
 			if !scanInfo.VerboseMode {
@@ -118,7 +119,7 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
-			return enforceBaselineDrift(ks.Context(), results, scanInfo)
+			return enforceBaselineDrift(ctx, results, scanInfo)
 		},
 	}
 }

--- a/cmd/scan/explicit_image_threshold_test.go
+++ b/cmd/scan/explicit_image_threshold_test.go
@@ -63,6 +63,10 @@ func (m *explicitThresholdKubescape) Scan(scanInfo *cautils.ScanInfo, _ []cautil
 	return results, nil
 }
 
+func (m *explicitThresholdKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return m.Scan(scanInfo, policyIdentifiers)
+}
+
 func TestExplicitScanCommandsEnforceImageSeverityThreshold(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -66,7 +66,8 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			defer applyTimeout(scanInfo, ks)()
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
 
 			if err := shared.ValidateCommonScanFlags(cmd, scanInfo, shared.ScanFormats); err != nil {
 				return err
@@ -110,12 +111,12 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 			policyIdentifiers := cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
-			results, err := ks.Scan(scanInfo, policyIdentifiers)
+			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err
 			}
 
-			if err = results.HandleResults(ks.Context(), scanInfo); err != nil {
+			if err = results.HandleResults(ctx, scanInfo); err != nil {
 				return err
 			}
 
@@ -137,7 +138,7 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
 				return err
 			}
-			return enforceBaselineDrift(ks.Context(), results, scanInfo)
+			return enforceBaselineDrift(ctx, results, scanInfo)
 		},
 	}
 

--- a/cmd/scan/local_input_test.go
+++ b/cmd/scan/local_input_test.go
@@ -40,6 +40,10 @@ func (m *scanInputCaptureKubescape) Context() context.Context {
 	return context.Background()
 }
 
+func (m *scanInputCaptureKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return m.Scan(scanInfo, policyIdentifiers)
+}
+
 func TestPrepareScanLocalInput(t *testing.T) {
 	t.Run("positional inputs populate input patterns", func(t *testing.T) {
 		scanInfo := cautils.ScanInfo{}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -309,10 +309,27 @@ func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) []cautil
 	return cautils.BuildPolicyIdentifiers([]string{"clusterscan", "mitre", "nsa"}, v1.KindFramework)
 }
 
+// deriveTimeoutContext returns a context bound to ks.Context() with a
+// deadline of scanInfo.ScanTimeout, when that's > 0, and a cancel func the
+// caller must defer. When ScanTimeout <= 0 it returns ks.Context() unchanged
+// and a no-op cancel. Unlike the applyTimeout helper this replaces, it does
+// not call ks.SetContext: the derived context is threaded explicitly through
+// ScanContext/HandleResults/enforceBaselineDrift instead of being stashed on
+// the shared ks, so it can't be observed or clobbered by another operation
+// sharing the same *Kubescape instance.
+func deriveTimeoutContext(scanInfo *cautils.ScanInfo, ks meta.IKubescape) (context.Context, func()) {
+	if scanInfo.ScanTimeout <= 0 {
+		return ks.Context(), func() {}
+	}
+	return context.WithTimeout(ks.Context(), scanInfo.ScanTimeout)
+}
+
 // applyTimeout wraps ks with a deadline context when ScanTimeout > 0 and
 // returns a cleanup function that cancels the context and restores the
-// original. The caller must defer the returned function so the deadline
-// covers both ks.Scan() and results.HandleResults().
+// original. Only ks.ScanImage still needs this: unlike ScanContext, it has
+// no explicit-context entry point yet, so it can only observe a deadline via
+// ks.Context()/ks.SetContext() mutation. Prefer deriveTimeoutContext for any
+// path that can pass a context explicitly.
 //
 //	defer applyTimeout(scanInfo, ks)()
 func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
@@ -329,14 +346,15 @@ func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
 }
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
-	defer applyTimeout(&scanInfo, ks)()
+	ctx, cancel := deriveTimeoutContext(&scanInfo, ks)
+	defer cancel()
 
-	results, err := ks.Scan(&scanInfo, policyIdentifiers)
+	results, err := ks.ScanContext(ctx, &scanInfo, policyIdentifiers)
 	if err != nil {
 		return err
 	}
 
-	if err = results.HandleResults(ks.Context(), &scanInfo); err != nil {
+	if err = results.HandleResults(ctx, &scanInfo); err != nil {
 		return err
 	}
 
@@ -355,7 +373,7 @@ func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifie
 		return err
 	}
 
-	return enforceBaselineDrift(ks.Context(), results, &scanInfo)
+	return enforceBaselineDrift(ctx, results, &scanInfo)
 }
 
 func enforceBaselineDrift(ctx context.Context, results *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo) error {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -478,6 +478,11 @@ func (m *scanCallCounter) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier
 	return nil, errors.New("scan reached")
 }
 
+func (m *scanCallCounter) ScanContext(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandlingpkg.ResultsHandler, error) {
+	m.calls++
+	return nil, errors.New("scan reached")
+}
+
 func TestGetScanCommand_PersistentFlagValidation(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -583,20 +588,28 @@ func TestScanInfo_ScanTimeoutField(t *testing.T) {
 	}
 }
 
-// contextTrackingKubescape is a test-local IKubescape that records what
-// context was active when Scan() was called, so we can assert the deadline.
-// Scan() returns a sentinel error so securityScan exits before HandleResults,
-// avoiding a nil-pointer dereference on the stub ResultsHandler.
+// contextTrackingKubescape is a test-local IKubescape that records the ctx
+// argument ScanContext() was called with (rather than reading it back off
+// m.ctx, which is how the pre-fix version of this double worked when
+// securityScan mutated the shared context via SetContext), plus whether
+// SetContext was ever invoked, so tests can assert securityScan no longer
+// touches the receiver's own context at all. ScanContext() returns a
+// sentinel error so securityScan exits before HandleResults, avoiding a
+// nil-pointer dereference on the stub ResultsHandler.
 type contextTrackingKubescape struct {
 	mocks.MockIKubescape
-	ctx            context.Context
-	scanCalledWith context.Context
+	ctx              context.Context
+	setContextCalled bool
+	scanCalledWith   context.Context
 }
 
-func (m *contextTrackingKubescape) Context() context.Context       { return m.ctx }
-func (m *contextTrackingKubescape) SetContext(ctx context.Context) { m.ctx = ctx }
-func (m *contextTrackingKubescape) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandlingpkg.ResultsHandler, error) {
-	m.scanCalledWith = m.ctx
+func (m *contextTrackingKubescape) Context() context.Context { return m.ctx }
+func (m *contextTrackingKubescape) SetContext(ctx context.Context) {
+	m.setContextCalled = true
+	m.ctx = ctx
+}
+func (m *contextTrackingKubescape) ScanContext(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandlingpkg.ResultsHandler, error) {
+	m.scanCalledWith = ctx
 	return nil, errors.New("stub: scan not implemented in test")
 }
 
@@ -607,18 +620,18 @@ func TestSecurityScan_TimeoutDeadlineActiveForScan(t *testing.T) {
 	_ = securityScan(scanInfo, ks, nil)
 
 	_, hasDeadline := ks.scanCalledWith.Deadline()
-	assert.True(t, hasDeadline, "Scan() must receive a context with a deadline when ScanTimeout > 0")
+	assert.True(t, hasDeadline, "ScanContext() must receive a context with a deadline when ScanTimeout > 0")
 }
 
-func TestSecurityScan_TimeoutContextRestoredAfterReturn(t *testing.T) {
+func TestSecurityScan_TimeoutDoesNotMutateSharedContext(t *testing.T) {
 	originalCtx := context.Background()
 	ks := &contextTrackingKubescape{ctx: originalCtx}
 	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
 
 	_ = securityScan(scanInfo, ks, nil)
 
-	_, hasDeadline := ks.Context().Deadline()
-	assert.False(t, hasDeadline, "original context must be restored on ks after securityScan returns")
+	assert.False(t, ks.setContextCalled, "securityScan must not call SetContext on the shared Kubescape instance")
+	assert.Equal(t, originalCtx, ks.Context(), "the shared Kubescape's own context must be untouched by securityScan")
 }
 
 func TestSecurityScan_ZeroTimeoutNoDeadline(t *testing.T) {
@@ -628,7 +641,7 @@ func TestSecurityScan_ZeroTimeoutNoDeadline(t *testing.T) {
 	_ = securityScan(scanInfo, ks, nil)
 
 	_, hasDeadline := ks.scanCalledWith.Deadline()
-	assert.False(t, hasDeadline, "Scan() must not receive a deadline when ScanTimeout is 0")
+	assert.False(t, hasDeadline, "ScanContext() must not receive a deadline when ScanTimeout is 0")
 }
 
 func TestGetScanCommand_RegistryCredentialFlags(t *testing.T) {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -57,7 +57,8 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			return validateWorkloadArgs(args, scanInfo)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			defer applyTimeout(scanInfo, ks)()
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
 
 			if err := validateWorkloadArgs(args, scanInfo); err != nil {
 				return err
@@ -95,12 +96,12 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
-			results, err := ks.Scan(scanInfo, policyIdentifiers)
+			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err
 			}
 
-			if err = results.HandleResults(ks.Context(), scanInfo); err != nil {
+			if err = results.HandleResults(ctx, scanInfo); err != nil {
 				return err
 			}
 
@@ -119,7 +120,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
-			return enforceBaselineDrift(ks.Context(), results, scanInfo)
+			return enforceBaselineDrift(ctx, results, scanInfo)
 		},
 	}
 

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -40,6 +40,10 @@ func (m *workloadScanCaptureKubescape) Scan(scanInfo *cautils.ScanInfo, _ []caut
 	return results, nil
 }
 
+func (m *workloadScanCaptureKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return m.Scan(scanInfo, policyIdentifiers)
+}
+
 func TestSetWorkloadScanInfo(t *testing.T) {
 	tests := []struct {
 		Description  string
@@ -562,6 +566,10 @@ func (m *recordingKubescape) Scan(scanInfo *cautils.ScanInfo, _ []cautils.Policy
 	rh := resultshandling.NewResultsHandler(nil, []printer.IPrinter{&fakePrinter{}}, &fakePrinter{})
 	rh.SetData(cautils.NewOPASessionObjMock())
 	return rh, nil
+}
+
+func (m *recordingKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return m.Scan(scanInfo, policyIdentifiers)
 }
 
 func TestGetWorkloadCmd_ApiVersion(t *testing.T) {

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -29,6 +29,9 @@ func (s *stubKubescape) SetContext(ctx context.Context) {
 func (s *stubKubescape) Scan(*cautils.ScanInfo, []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
 	return nil, nil
 }
+func (s *stubKubescape) ScanContext(context.Context, *cautils.ScanInfo, []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return nil, nil
+}
 func (s *stubKubescape) List(*metav1.ListPolicies) (*metav1.ListResult, error) {
 	return nil, nil
 }

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -211,8 +211,27 @@ func collectPolicies(ctx context.Context, clusterName string, policyIdentifiers 
 	return policyHandler.CollectPolicies(ctx, policyIdentifiers, scanInfo, getters)
 }
 
+// Scan runs a scan using ks.Context() as the operation's context. It is a
+// compatibility wrapper around ScanContext for callers that have not
+// migrated to passing their own context explicitly; see ScanContext's
+// documentation for why that matters when a *Kubescape instance is reused
+// or scan operations can overlap.
 func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
-	ctxInit, spanInit := otel.Tracer("").Start(ks.Context(), "initialization")
+	return ks.ScanContext(ks.Context(), scanInfo, policyIdentifiers)
+}
+
+// ScanContext runs a scan bound to the given ctx for its complete execution
+// (initialization, policy/resource collection, OPA evaluation, image
+// scanning, prioritization, and teardown all observe this same ctx), rather
+// than re-reading ks.Context() at each stage. Callers that need a deadline
+// or cancellation should derive ctx themselves (e.g. context.WithTimeout)
+// and pass it in directly, instead of calling ks.SetContext beforehand:
+// mutating the shared *Kubescape's context is not safe if the instance is
+// reused or another operation could run concurrently against it, since a
+// mid-operation ks.Context() read could observe a different deadline than
+// the one that started the operation, or an already-restored/canceled one.
+func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	ctxInit, spanInit := otel.Tracer("").Start(ctx, "initialization")
 	logger.L().Start("Kubescape scanner initializing...")
 
 	// ===================== Initialization =====================
@@ -237,7 +256,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	// remove host scanner components
 	defer func() {
 		if err := interfaces.hostSensorHandler.TearDown(); err != nil {
-			logger.L().Ctx(ks.Context()).StopError("Failed to tear down host scanner", helpers.Error(err))
+			logger.L().Ctx(ctx).StopError("Failed to tear down host scanner", helpers.Error(err))
 		}
 	}()
 
@@ -350,7 +369,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 
 	// OPA context for both streaming and non-streaming paths
-	ctxOpa, spanOpa := otel.Tracer("").Start(ks.Context(), "opa testing")
+	ctxOpa, spanOpa := otel.Tracer("").Start(ctx, "opa testing")
 	defer spanOpa.End()
 
 	if enableStreaming {
@@ -391,7 +410,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	if scanInfo.PrintAttackTree || isPrioritizationScanType(scanInfo.ScanType) {
 		_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
 		if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, getters.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
-			logger.L().Ctx(ks.Context()).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
+			logger.L().Ctx(ctx).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
 		} else if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
 			return resultsHandling, fmt.Errorf("%w", err)
 		}
@@ -402,7 +421,7 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 	}
 
 	if scanInfo.ScanImages {
-		resultsHandling.SetScanError(scanImages(scanInfo.ScanType, scanData, ks.Context(), resultsHandling, scanInfo, interfaces.k8s))
+		resultsHandling.SetScanError(scanImages(scanInfo.ScanType, scanData, ctx, resultsHandling, scanInfo, interfaces.k8s))
 	}
 	// ========================= results handling =====================
 	resultsHandling.SetData(scanData)

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -25,7 +25,13 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-func TestScan_ReturnsFinalizedPartialDataOnOPAError(t *testing.T) {
+// buildBrokenRuleScanInfo writes a local, offline-loadable scan target (one
+// manifest, one framework with a deliberately invalid rego rule, and empty
+// controls-inputs/exceptions/attack-tracks so nothing needs a network call)
+// into its own temp dir, so callers get fully independent *cautils.ScanInfo
+// values suitable for running concurrently against a shared *Kubescape.
+func buildBrokenRuleScanInfo(t *testing.T) (*cautils.ScanInfo, []cautils.PolicyIdentifier, reporthandling.Control) {
+	t.Helper()
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "pod.yaml")
 	require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: v1
@@ -73,10 +79,17 @@ metadata:
 	}
 	scanInfo.Submit.SetBool(false)
 
-	results, err := NewKubescape(context.Background()).Scan(scanInfo, []cautils.PolicyIdentifier{{
+	policyIdentifiers := []cautils.PolicyIdentifier{{
 		Identifier: framework.Name,
 		Kind:       apisv1.KindFramework,
-	}})
+	}}
+	return scanInfo, policyIdentifiers, control
+}
+
+func TestScan_ReturnsFinalizedPartialDataOnOPAError(t *testing.T) {
+	scanInfo, policyIdentifiers, control := buildBrokenRuleScanInfo(t)
+
+	results, err := NewKubescape(context.Background()).Scan(scanInfo, policyIdentifiers)
 
 	require.ErrorContains(t, err, "broken-rule")
 	require.NotNil(t, results)
@@ -84,6 +97,57 @@ metadata:
 	require.Len(t, results.GetData().ResourcesResult, 1)
 	controlSummary := results.GetData().Report.SummaryDetails.Controls[control.ControlID]
 	assert.Equal(t, apis.StatusSkipped, controlSummary.GetStatus().Status())
+}
+
+// TestScanContext_ReturnsFinalizedPartialDataOnOPAError exercises the new
+// explicit-context entry point directly (#3237), mirroring
+// TestScan_ReturnsFinalizedPartialDataOnOPAError's assertions to confirm
+// ScanContext behaves identically to Scan when called with ks.Context().
+func TestScanContext_ReturnsFinalizedPartialDataOnOPAError(t *testing.T) {
+	scanInfo, policyIdentifiers, control := buildBrokenRuleScanInfo(t)
+	ks := NewKubescape(context.Background())
+
+	results, err := ks.ScanContext(ks.Context(), scanInfo, policyIdentifiers)
+
+	require.ErrorContains(t, err, "broken-rule")
+	require.NotNil(t, results)
+	require.NotNil(t, results.GetData(), "the finalized partial session must remain available alongside the scan error")
+	require.Len(t, results.GetData().ResourcesResult, 1)
+	controlSummary := results.GetData().Report.SummaryDetails.Controls[control.ControlID]
+	assert.Equal(t, apis.StatusSkipped, controlSummary.GetStatus().Status())
+}
+
+// TestScanContext_DoesNotMutateSharedKubescapeContext is a regression test
+// for #3237: ScanContext must operate purely on the ctx argument it's given
+// and never read or write ks's own Ctx field, so two operations sharing one
+// *Kubescape can't observe or clobber each other's context the way the old
+// Scan()+SetContext(timeout)+restore pattern could.
+//
+// This intentionally does not run two ScanContext calls concurrently under
+// -race: doing so trips an unrelated, pre-existing data race in
+// k8sinterface.IsConnectedToCluster/SetConnectedToCluster (a package-level
+// cache in github.com/kubescape/k8s-interface, exercised via getInterfaces
+// regardless of scan type). That's a real bug, but it's in a shared
+// dependency's global state, not in *Kubescape's context ownership, and
+// fixing it is out of scope here: #3237 explicitly does not claim the whole
+// scanner is safe for unrestricted parallel execution, only that Scan's own
+// context handling is.
+func TestScanContext_DoesNotMutateSharedKubescapeContext(t *testing.T) {
+	scanInfo, policyIdentifiers, control := buildBrokenRuleScanInfo(t)
+	ks := NewKubescape(context.Background())
+
+	type ctxKey struct{}
+	operationCtx := context.WithValue(context.Background(), ctxKey{}, "operation-owned")
+
+	results, err := ks.ScanContext(operationCtx, scanInfo, policyIdentifiers)
+
+	require.ErrorContains(t, err, "broken-rule")
+	require.NotNil(t, results)
+	require.NotNil(t, results.GetData())
+	controlSummary := results.GetData().Report.SummaryDetails.Controls[control.ControlID]
+	assert.Equal(t, apis.StatusSkipped, controlSummary.GetStatus().Status())
+
+	assert.Equal(t, context.Background(), ks.Context(), "ScanContext must not call SetContext or otherwise mutate ks's own context")
 }
 
 type recordingImageScanService struct {

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -14,6 +14,12 @@ type IKubescape interface {
 
 	Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) // TODO - use scanInfo from v1
 
+	// ScanContext runs a scan bound to ctx for its complete execution, instead of
+	// relying on the receiver's own Context()/SetContext() state. Prefer this over
+	// Scan when the caller can hold a *Kubescape across concurrent or overlapping
+	// operations, since Scan's context comes from mutable shared state.
+	ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error)
+
 	// policies
 	List(listPolicies *metav1.ListPolicies) (*metav1.ListResult, error)
 	Download(downloadInfo *metav1.DownloadInfo) (*metav1.DownloadResult, error)

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -20,6 +20,10 @@ func (m *MockIKubescape) Scan(_ *cautils.ScanInfo, _ []cautils.PolicyIdentifier)
 	return nil, nil
 }
 
+func (m *MockIKubescape) ScanContext(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	return nil, nil
+}
+
 func (m *MockIKubescape) List(_ *metav1.ListPolicies) (*metav1.ListResult, error) {
 	return &metav1.ListResult{}, nil
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 (core invariant) and Phase 2 (CLI ownership) of the bounded plan in #3237: adds `(*Kubescape).ScanContext(ctx, scanInfo, policyIdentifiers)`, an explicit-context scan entry point, and moves the CLI's `--scan-timeout` handling off the old mutate-`ks.Context()`-then-restore pattern.

## Why

`Kubescape.Scan` currently sources its context from `ks.Context()`, and the CLI implements `--scan-timeout` by temporarily replacing that shared field via `SetContext(timeoutCtx)` and restoring it afterward (`cmd/scan/scan.go`'s old `applyTimeout`). This is:

1. **A real data race.** `go test -race` on a minimal repro (two goroutines concurrently calling `SetContext`/`Context` on one `*Kubescape`) fails:
   ```
   WARNING: DATA RACE
   Write at 0x00c000f8ec00 by goroutine 35:
     github.com/kubescape/kubescape/v4/core/core.(*Kubescape).SetContext()
         /Users/lalit/kubescape/core/core/kscore.go:16 +0x9c
   Previous read at 0x00c000f8ec00 by goroutine 36:
     github.com/kubescape/kubescape/v4/core/core.(*Kubescape).Context()
         /Users/lalit/kubescape/core/core/kscore.go:12 +0x70
   --- FAIL: TestScratchRepro_ContextDataRace (0.00s)
   ```
2. **A semantic problem a mutex alone wouldn't fix.** `Scan` re-reads `ks.Context()` independently at five points (initialization, deferred host-scanner teardown, OPA evaluation, prioritization-failure logging, image scanning — `core/core/scan.go` lines 215/240/353/394/405 before this change) instead of using one context for its complete execution. If two operations ever overlap on the same `*Kubescape`, one can restore or cancel the context the other is mid-scan with.

## What changed

- **`core/core/scan.go`**: `Scan`'s body moves to a new `ScanContext(ctx, scanInfo, policyIdentifiers)` method that threads one caller-supplied `ctx` through every phase — no more re-reading `ks.Context()` internally. `Scan` becomes a one-line compatibility wrapper: `return ks.ScanContext(ks.Context(), scanInfo, policyIdentifiers)`. Existing callers of `Scan` keep compiling and behave the same.
- **`core/meta/ksinterface.go`**: `IKubescape` gains `ScanContext` as an additive method (doesn't break external implementations).
- **`core/mocks/cmd_mocks.go`**: `MockIKubescape` implements the new method.
- **`cmd/scan/scan.go`**: `applyTimeout` (mutate + restore) is replaced by `deriveTimeoutContext`, which returns a context derived from `ks.Context()` plus a cancel func, without ever calling `ks.SetContext`. `securityScan` now calls `ks.ScanContext(ctx, ...)` and passes the same `ctx` to `HandleResults` and `enforceBaselineDrift`.
- **`cmd/scan/{framework,control,workload}.go`**: same migration — `ks.Scan(...)` → `ks.ScanContext(ctx, ...)`, `ks.Context()` re-reads → the one derived `ctx`.
- **`cmd/scan/image.go`** is intentionally untouched: `ScanImage` has no explicit-context entry point yet, so `scan image` still relies on the old `applyTimeout` mutation (kept, now used only there). Migrating it is a larger, separate change — noted as out of scope in the issue's non-goals too.
- Test doubles that override `Scan` on an embedded `mocks.MockIKubescape` (`cmd/scan/{workload,explicit_image_threshold,local_input}_test.go`, `cmd/update/update_test.go`) now also implement `ScanContext`, delegating to the same `Scan` stub, so they keep exercising the code paths that now call the new method.

## Test plan

Added `TestScanContext_DoesNotMutateSharedKubescapeContext` (`core/core/scan_test.go`), asserting `ScanContext` never calls `SetContext` or otherwise touches `ks`'s own context field, plus `TestScanContext_ReturnsFinalizedPartialDataOnOPAError` (direct coverage of the new public method). Updated `cmd/scan/scan_test.go`'s timeout tests: `TestSecurityScan_TimeoutContextRestoredAfterReturn` (which asserted the old mutate-then-restore behavior) is replaced by `TestSecurityScan_TimeoutDoesNotMutateSharedContext`, asserting `SetContext` is never called by the timeout path at all.

**A note on concurrency testing.** I initially wrote a test running two `ScanContext` calls concurrently under `-race` to prove no cross-talk directly (mirroring the issue's own repro style). CI caught something real: that trips an unrelated, pre-existing data race in `k8sinterface.IsConnectedToCluster`/`SetConnectedToCluster` — a package-level cache in `github.com/kubescape/k8s-interface`, exercised via `getInterfaces` regardless of scan type — not in `*Kubescape`'s own context field. That's a genuine bug, but it's out of scope for this PR: #3237 explicitly doesn't claim the whole scanner is safe for unrestricted parallel execution, only that `Scan`'s own context ownership is. I dropped the full-pipeline concurrent test in favor of the single-threaded mutation-check above, which tests the actual invariant this PR establishes without depending on an unrelated dependency's thread-safety. Happy to file a separate issue for that k8s-interface race if maintainers want it tracked.

Full real output from this branch:

```
=== RUN   TestScan_ReturnsFinalizedPartialDataOnOPAError
--- PASS: TestScan_ReturnsFinalizedPartialDataOnOPAError (0.04s)
=== RUN   TestScanContext_ReturnsFinalizedPartialDataOnOPAError
--- PASS: TestScanContext_ReturnsFinalizedPartialDataOnOPAError (0.01s)
=== RUN   TestScanContext_DoesNotMutateSharedKubescapeContext
--- PASS: TestScanContext_DoesNotMutateSharedKubescapeContext (0.01s)
=== RUN   TestKubescape_SetContext
--- PASS: TestKubescape_SetContext (0.00s)
=== RUN   TestKubescape_SetContextRestoresOriginal
--- PASS: TestKubescape_SetContextRestoresOriginal (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/core/core	3.539s

=== RUN   TestGetScanCommand_PersistentFlagValidation
    --- PASS: TestGetScanCommand_PersistentFlagValidation/accepts_defaults (0.00s)
    --- PASS: TestGetScanCommand_PersistentFlagValidation/accepts_format_version_v1 (0.00s)
    --- PASS: TestGetScanCommand_PersistentFlagValidation/accepts_format_version_v2 (0.00s)
    --- PASS: TestGetScanCommand_PersistentFlagValidation/accepts_zero_timeouts (0.00s)
    --- PASS: TestGetScanCommand_PersistentFlagValidation/accepts_positive_timeouts (0.00s)
=== RUN   TestSecurityScan_TimeoutDeadlineActiveForScan
--- PASS: TestSecurityScan_TimeoutDeadlineActiveForScan (0.00s)
=== RUN   TestSecurityScan_TimeoutDoesNotMutateSharedContext
--- PASS: TestSecurityScan_TimeoutDoesNotMutateSharedContext (0.00s)
=== RUN   TestSecurityScan_ZeroTimeoutNoDeadline
--- PASS: TestSecurityScan_ZeroTimeoutNoDeadline (0.00s)
PASS
ok  	github.com/kubescape/kubescape/v4/cmd/scan	5.232s
```

Checklist:

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean (repo root and `httphandler/` module, which has its own `go.mod` with a local `replace` to this working tree)
- [x] `go test -race ./...` — full suite passes (all packages, repo root)
- [x] `go test ./...` in `httphandler/` — passes (unaffected; no files there changed)
- [x] `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- [x] Reproduced the pre-fix data race directly (`kscore.go`'s `Context`/`SetContext` are otherwise unchanged in this PR — locking them alone was explicitly not the fix per the issue, since it wouldn't address the context-cross-talk problem)
- [ ] CI on this PR itself

## Scope

Per the issue's phased plan and non-goals, this PR does **not**:
- Deprecate/remove `SetContext`/`Ctx` (Phase 3) — `ScanImage`, `Patch`, `Fix`, `List`, `Download`, `ViewCachedConfig` still use them, and migrating those is a separate, larger change.
- Declare the scanner safe for unrestricted parallel execution in general — only `Scan`/`ScanContext`'s own context ownership is addressed.
- Touch `ScanInfo` sharing, per-control timeout semantics, or Kubernetes target-selection behavior.

Fixes #3237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and cancellation handling for control, framework, workload, and security scans.
  * Prevented concurrent scans from affecting one another’s timeout or cancellation state.
  * Preserved finalized partial results when policy evaluation encounters errors.

* **Reliability**
  * Scan operations now consistently honor their configured timeout and cancellation settings.
  * Improved scan behavior when processing fails partway through an operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->