### PR TITLE
fix(vapreconcile): credit admission enforcement to the policy a binding names

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -211,8 +211,9 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 }
 
 // collectVAPResources records the cluster's admission enforcement state on the
-// session. Clusters that do not serve the VAP API are skipped without a warning,
-// since having no policies to reconcile is not a scan failure.
+// session. Clusters that do not serve the VAP API, and credentials that may not
+// read it, are skipped without a warning: enforcement state enriches the report
+// and its absence is not a scan failure.
 func (k8sHandler *K8sResourceHandler) collectVAPResources(ctx context.Context, sessionObj *cautils.OPASessionObj) {
 	if k8sHandler.k8s == nil {
 		return
@@ -222,6 +223,8 @@ func (k8sHandler *K8sResourceHandler) collectVAPResources(ctx context.Context, s
 	switch {
 	case errors.Is(err, vapreconcile.ErrUnsupported):
 		logger.L().Debug("skipping VAP reconciliation, cluster does not serve the API")
+	case errors.Is(err, vapreconcile.ErrForbidden):
+		logger.L().Debug("skipping VAP reconciliation, credentials may not list admission policies", helpers.Error(err))
 	case err != nil:
 		logger.L().Ctx(ctx).Warning("failed to collect VAP resources", helpers.Error(err))
 	default:

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -118,54 +119,73 @@ func list(ctx context.Context, client dynamic.Interface, version, resource strin
 // BuildIndex builds a map of controlId -> VAPEnforcementStatus by reading the
 // controlId label that cel-admission-library stamps on every VAP, then joining
 // bindings back via spec.policyName to determine the enforcement mode.
+//
+// More than one policy can carry the same control: an upgrade that renames the
+// library policy leaves the old one behind, and a hand-written policy can stamp
+// the same label. Enforcement is resolved per policy and only then reduced to
+// the control, so a binding is credited to the policy it names rather than to
+// whichever policy the listing ended on. Names are sorted so the reported
+// policy does not move between scans.
 func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*reportsummary.VAPEnforcementStatus {
-	// map policyName -> controlId so we can join bindings
-	policyNameToControlID := make(map[string]string, len(policies))
-	index := make(map[string]*reportsummary.VAPEnforcementStatus, len(policies))
+	controlByPolicy := make(map[string]string, len(policies))
+	policiesByControl := make(map[string][]string, len(policies))
 
 	for i := range policies {
-		vap := &policies[i]
-		controlID := vap.GetLabels()[controlIDLabel]
-		if controlID == "" {
+		name := policies[i].GetName()
+		controlID := policies[i].GetLabels()[controlIDLabel]
+		if name == "" || controlID == "" {
 			continue
 		}
-		policyNameToControlID[vap.GetName()] = controlID
-		index[controlID] = &reportsummary.VAPEnforcementStatus{
-			PolicyName: vap.GetName(),
-			Bound:      false,
+		if _, seen := controlByPolicy[name]; seen {
+			continue // a repeated name is the same policy listed twice
 		}
+		controlByPolicy[name] = controlID
+		policiesByControl[controlID] = append(policiesByControl[controlID], name)
 	}
 
-	seenActions := make(map[string]map[string]struct{})
-
+	// Presence in this map is what binds a policy: a binding declaring no
+	// action still binds the policy it names.
+	actionsByPolicy := make(map[string][]string, len(bindings))
 	for i := range bindings {
-		vapb := &bindings[i]
-		spec, ok := vapb.Object["spec"].(map[string]any)
+		spec, ok := bindings[i].Object["spec"].(map[string]any)
 		if !ok {
 			continue
 		}
 		policyName, _ := spec["policyName"].(string)
-		controlID, ok := policyNameToControlID[policyName]
-		if !ok {
+		if _, known := controlByPolicy[policyName]; !known {
 			continue
 		}
-
-		status, ok := index[controlID]
-		if !ok {
-			continue
-		}
-		status.Bound = true
-
-		if seenActions[controlID] == nil {
-			seenActions[controlID] = make(map[string]struct{})
-		}
+		actions := actionsByPolicy[policyName]
 		for _, action := range bindingActions(spec) {
-			if _, dup := seenActions[controlID][action]; dup {
+			if !slices.Contains(actions, action) {
+				actions = append(actions, action)
+			}
+		}
+		actionsByPolicy[policyName] = actions
+	}
+
+	index := make(map[string]*reportsummary.VAPEnforcementStatus, len(policiesByControl))
+	for controlID, names := range policiesByControl {
+		slices.Sort(names)
+		status := &reportsummary.VAPEnforcementStatus{PolicyName: names[0]}
+		for _, name := range names {
+			actions, bound := actionsByPolicy[name]
+			if !bound {
 				continue
 			}
-			seenActions[controlID][action] = struct{}{}
-			status.Actions = append(status.Actions, action)
+			if !status.Bound {
+				// The name has to be a bound policy, or the status reads as
+				// enforced by a policy nothing binds.
+				status.Bound = true
+				status.PolicyName = name
+			}
+			for _, action := range actions {
+				if !slices.Contains(status.Actions, action) {
+					status.Actions = append(status.Actions, action)
+				}
+			}
 		}
+		index[controlID] = status
 	}
 
 	return index

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -59,25 +59,33 @@ func Collect(ctx context.Context, k8s *k8sinterface.KubernetesApi) ([]unstructur
 // resolveVersion returns the first VAP version the cluster both advertises and
 // serves both resources for. Without a discovery client the newest version is
 // assumed, which is what the API server routing did before discovery existed.
+// A discovery error on one version does not stop the remaining ones from being
+// probed: an unreachable v1 must not hide a v1beta1 the cluster does serve.
 func resolveVersion(client discovery.DiscoveryInterface) (string, error) {
 	if client == nil {
 		return vapVersions[0], nil
 	}
 
+	// A version we could not ask about is not a version the cluster fails to
+	// serve, so keep probing and only report the error if nothing answers.
+	var probeErr error
 	for _, version := range vapVersions {
 		gv := schema.GroupVersion{Group: vapGroup, Version: version}
 		resources, err := client.ServerResourcesForGroupVersion(gv.String())
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
+			if !apierrors.IsNotFound(err) && probeErr == nil {
+				probeErr = fmt.Errorf("failed to discover %s: %w", gv.String(), err)
 			}
-			return "", fmt.Errorf("failed to discover %s: %w", gv.String(), err)
+			continue
 		}
 		if serves(resources, vapResource, vapBindingResource) {
 			return version, nil
 		}
 	}
 
+	if probeErr != nil {
+		return "", probeErr
+	}
 	return "", ErrUnsupported
 }
 

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -19,6 +19,10 @@ const (
 	vapGroup           = "admissionregistration.k8s.io"
 	vapResource        = "validatingadmissionpolicies"
 	vapBindingResource = "validatingadmissionpolicybindings"
+
+	// controlIDLabel is the label cel-admission-library stamps a control's
+	// policy with. Policies without it are not addressable by control.
+	controlIDLabel = "controlId"
 )
 
 // vapVersions lists the served versions of the VAP API in preference order:
@@ -121,9 +125,8 @@ func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*repo
 
 	for i := range policies {
 		vap := &policies[i]
-		labels := vap.GetLabels()
-		controlID, ok := labels["controlId"]
-		if !ok || controlID == "" {
+		controlID := vap.GetLabels()[controlIDLabel]
+		if controlID == "" {
 			continue
 		}
 		policyNameToControlID[vap.GetName()] = controlID
@@ -156,19 +159,33 @@ func BuildIndex(policies, bindings []unstructured.Unstructured) map[string]*repo
 		if seenActions[controlID] == nil {
 			seenActions[controlID] = make(map[string]struct{})
 		}
-		if actionsRaw, ok := spec["validationActions"].([]any); ok {
-			for _, a := range actionsRaw {
-				if s, ok := a.(string); ok {
-					if _, dup := seenActions[controlID][s]; !dup {
-						seenActions[controlID][s] = struct{}{}
-						status.Actions = append(status.Actions, s)
-					}
-				}
+		for _, action := range bindingActions(spec) {
+			if _, dup := seenActions[controlID][action]; dup {
+				continue
 			}
+			seenActions[controlID][action] = struct{}{}
+			status.Actions = append(status.Actions, action)
 		}
 	}
 
 	return index
+}
+
+// bindingActions reads a binding's spec.validationActions. An entry that is not
+// a string is dropped rather than failing the whole binding: the rest of its
+// actions still describe how the policy is enforced.
+func bindingActions(spec map[string]any) []string {
+	raw, ok := spec["validationActions"].([]any)
+	if !ok {
+		return nil
+	}
+	actions := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		if action, ok := entry.(string); ok {
+			actions = append(actions, action)
+		}
+	}
+	return actions
 }
 
 // EnrichSummary attaches VAPEnforcementStatus to each ControlSummary whose

--- a/core/pkg/vapreconcile/reconcile.go
+++ b/core/pkg/vapreconcile/reconcile.go
@@ -34,10 +34,16 @@ var vapVersions = []string{"v1", "v1beta1", "v1alpha1"}
 // there is no enforcement state to reconcile.
 var ErrUnsupported = errors.New("cluster does not serve ValidatingAdmissionPolicy resources")
 
+// ErrForbidden reports credentials that may not list the VAP API. Enforcement
+// state enriches a scan rather than feeding it, so being denied it leaves the
+// scan intact.
+var ErrForbidden = errors.New("not permitted to list ValidatingAdmissionPolicy resources")
+
 // Collect lists ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
 // resources from the live cluster, using whichever version of the API the
 // cluster serves. Both resource types are cluster-scoped so no namespace
-// selector is needed. Clusters without the API return ErrUnsupported.
+// selector is needed. A cluster without the API returns ErrUnsupported, and
+// credentials that may not list it ErrForbidden.
 func Collect(ctx context.Context, k8s *k8sinterface.KubernetesApi) ([]unstructured.Unstructured, []unstructured.Unstructured, error) {
 	version, err := resolveVersion(k8s.DiscoveryClient)
 	if err != nil {
@@ -110,13 +116,17 @@ func serves(resources *metav1.APIResourceList, names ...string) bool {
 
 // list pulls every object of one cluster-scoped VAP resource. A resource that
 // discovery advertised but the API server does not route is reported as
-// unsupported rather than as a scan failure.
+// unsupported, and one the credentials may not read as forbidden; neither is a
+// scan failure.
 func list(ctx context.Context, client dynamic.Interface, version, resource string) ([]unstructured.Unstructured, error) {
 	gvr := schema.GroupVersionResource{Group: vapGroup, Version: version, Resource: resource}
 	listed, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, ErrUnsupported
+		}
+		if apierrors.IsForbidden(err) {
+			return nil, fmt.Errorf("%w: %s", ErrForbidden, gvr.String())
 		}
 		return nil, fmt.Errorf("failed to list %s: %w", gvr.String(), err)
 	}

--- a/core/pkg/vapreconcile/reconcile_test.go
+++ b/core/pkg/vapreconcile/reconcile_test.go
@@ -2,6 +2,7 @@ package vapreconcile
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -303,4 +305,144 @@ func TestEnrichSummary_NoMatchingControl(t *testing.T) {
 		EnrichSummary(controls, index)
 	})
 	assert.Nil(t, controls["C-0041"].VAPEnforcement)
+}
+
+// erroringDiscovery answers one group version with an error instead of a
+// resource list, standing in for a cluster whose discovery for that version is
+// unreachable.
+type erroringDiscovery struct {
+	*discoveryfake.FakeDiscovery
+	failing string
+	err     error
+}
+
+func (d *erroringDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if groupVersion == d.failing {
+		return nil, d.err
+	}
+	return d.FakeDiscovery.ServerResourcesForGroupVersion(groupVersion)
+}
+
+func TestResolveVersion_DiscoveryErrorDoesNotHideOlderVersion(t *testing.T) {
+	client := &erroringDiscovery{
+		FakeDiscovery: discoveryServing("v1beta1"),
+		failing:       vapGroup + "/v1",
+		err:           apierrors.NewServiceUnavailable("discovery is down"),
+	}
+
+	version, err := resolveVersion(client)
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1beta1", version)
+}
+
+func TestResolveVersion_DiscoveryErrorSurfacesWhenNoVersionServes(t *testing.T) {
+	client := &erroringDiscovery{
+		FakeDiscovery: discoveryServing(),
+		failing:       vapGroup + "/v1",
+		err:           apierrors.NewServiceUnavailable("discovery is down"),
+	}
+
+	_, err := resolveVersion(client)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrUnsupported)
+	assert.Contains(t, err.Error(), vapGroup+"/v1")
+}
+
+func TestCollect_DeniedListingIsNotAFailure(t *testing.T) {
+	dynamicClient := dynamicServing("v1", servedVAP("v1", "kubescape-c-0041", "C-0041"))
+	dynamicClient.PrependReactor("list", vapResource, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: vapGroup, Resource: vapResource}, "", errors.New("no list access"))
+	})
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: discoveryServing("v1"),
+		DynamicClient:   dynamicClient,
+	}
+
+	policies, bindings, err := Collect(context.Background(), k8s)
+
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, policies)
+	assert.Nil(t, bindings)
+}
+
+func TestBuildIndex_DuplicateControlNamesTheBoundPolicy(t *testing.T) {
+	// the bound policy is listed first and sorts last, so neither listing order
+	// nor name order on its own picks the policy that actually enforces
+	policies := []unstructured.Unstructured{
+		makeVAP("team-c-0016-privilege-escalation", "C-0016"),
+		makeVAP("kubescape-c-0016-allow-privilege-escalation", "C-0016"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0016-binding", "team-c-0016-privilege-escalation", []string{"Deny"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	require.Contains(t, index, "C-0016")
+	assert.Equal(t, "team-c-0016-privilege-escalation", index["C-0016"].PolicyName)
+	assert.True(t, index["C-0016"].Bound)
+	assert.Equal(t, []string{"Deny"}, index["C-0016"].Actions)
+}
+
+func TestBuildIndex_DuplicateControlWithoutAnyBinding(t *testing.T) {
+	// nothing is bound, so the reported policy must not depend on listing order
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0016-allow-privilege-escalation", "C-0016"),
+		makeVAP("team-c-0016-privilege-escalation", "C-0016"),
+	}
+
+	index := BuildIndex(policies, nil)
+
+	assert.False(t, index["C-0016"].Bound)
+	assert.Equal(t, "kubescape-c-0016-allow-privilege-escalation", index["C-0016"].PolicyName)
+	assert.Nil(t, index["C-0016"].Actions)
+}
+
+func TestBuildIndex_DuplicateControlMergesActionsAcrossPolicies(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0016-allow-privilege-escalation", "C-0016"),
+		makeVAP("team-c-0016-privilege-escalation", "C-0016"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("library-binding", "kubescape-c-0016-allow-privilege-escalation", []string{"Audit"}),
+		makeVAPB("team-binding", "team-c-0016-privilege-escalation", []string{"Deny", "Audit"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.True(t, index["C-0016"].Bound)
+	assert.Equal(t, "kubescape-c-0016-allow-privilege-escalation", index["C-0016"].PolicyName)
+	assert.ElementsMatch(t, []string{"Audit", "Deny"}, index["C-0016"].Actions)
+}
+
+func TestBuildIndex_BindingWithoutActionsStillBinds(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0041-binding", "kubescape-c-0041-deny-host-network", nil),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.True(t, index["C-0041"].Bound)
+	assert.Empty(t, index["C-0041"].Actions)
+}
+
+func TestBuildIndex_PolicyListedTwiceIsOnePolicy(t *testing.T) {
+	policies := []unstructured.Unstructured{
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+		makeVAP("kubescape-c-0041-deny-host-network", "C-0041"),
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPB("c0041-binding", "kubescape-c-0041-deny-host-network", []string{"Deny"}),
+	}
+
+	index := BuildIndex(policies, bindings)
+
+	assert.Len(t, index, 1)
+	assert.True(t, index["C-0041"].Bound)
+	assert.Equal(t, []string{"Deny"}, index["C-0041"].Actions)
 }


### PR DESCRIPTION
Kubescape reads the cluster's ValidatingAdmissionPolicy objects at the end of a cluster scan and attaches an enforcement status to every control, so a report can say whether a failing control is already blocked at admission. Reading through that code I noticed the join between policies and bindings assumes one policy per control ID, and a real cluster breaks that assumption easily.

`BuildIndex` walks the policy list and writes `index[controlId]` on every iteration, so when two policies carry the same `controlId` label the last one listed wins. The policy name to control map keeps both names though, so a binding on the policy that got dropped still flips `Bound` to true on the surviving entry. The report then claims the control is enforced and names a policy that nothing is bound to. Two policies for one control is not exotic: a library upgrade that renames a policy leaves the old object behind until someone prunes it, and teams that hand write a policy for a control they care about stamp the same label on it.

The fix resolves enforcement per policy first and only then reduces it to the control. A binding is credited to the policy its `spec.policyName` names, a control is bound if any of its policies is, the reported name is a bound policy when there is one, and the action list is the union across them. Policy names are sorted so the reported name stays stable between scans regardless of the order the API server returned the list in.

Two smaller things in the same file came out of the same read.

Version resolution walked v1, v1beta1 and v1alpha1 and gave up on the first discovery error that was not a 404. If discovery for v1 is unreachable on a cluster that serves v1beta1, the whole enforcement section disappears and the scan logs a warning, even though the older version would have answered. It now keeps probing and only reports the error when no version served the resources.

A listing the scan's credentials are not allowed to make was reported as a collection failure. Enforcement state enriches the report rather than feeding the scan, and read only scan roles do not always carry `list` on `validatingadmissionpolicies`, so a 403 is now a quiet skip like an unsupported cluster, through a new `ErrForbidden` sentinel.

The thing most likely to regress is the reported policy name. It used to be whatever policy the API server listed last for a control, and it is now the lowest sorted name among the bound policies, or the lowest overall when nothing is bound. Anything that compares `policyName` across kubescape versions will see that change on clusters where a control has more than one policy. The single policy case, which is every cluster running only the shipped library, is unaffected.

The commits are split so each one reviews on its own: a refactor with no behavior change, the attribution fix, the two degradation fixes, then the tests. Every new test fails on master before its fix and passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when admission policy permissions are unavailable; collection now continues without treating access restrictions as fatal.
  - Added fallback across supported policy versions when one version cannot be accessed or discovered.
  - Improved policy and binding processing for multiple policies, duplicate entries, and incomplete action data.
  - Enforcement status and validation actions are now combined more reliably and selected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->