### PR TITLE
feat: support downloading all controls when no ID is specified

### DIFF
--- a/core/cautils/getter/getpoliciesutils.go
+++ b/core/cautils/getter/getpoliciesutils.go
@@ -27,8 +27,8 @@ func PolicyCacheFilename(identifier string) (string, error) {
 	if norm == "" {
 		return "", fmt.Errorf("policy identifier is empty")
 	}
-	if norm == "." || norm == ".." || strings.ContainsAny(norm, `/\`) {
-		return "", fmt.Errorf("policy identifier contains path separators")
+	if norm == "." || norm == ".." || strings.ContainsAny(norm, `/\|`) {
+		return "", fmt.Errorf("policy identifier contains path separators or invalid characters")
 	}
 	return norm + ".json", nil
 }

--- a/core/cautils/getter/getpoliciesutils_test.go
+++ b/core/cautils/getter/getpoliciesutils_test.go
@@ -100,6 +100,12 @@ func TestPolicyCacheFilename(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, got)
 	})
+
+	t.Run("should error on an identifier containing a pipe", func(t *testing.T) {
+		got, err := PolicyCacheFilename("C-0001|control name|frameworks")
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func TestPolicyCachePath(t *testing.T) {

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -320,8 +320,36 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]
 	}
 
 	if downloadInfo.Identifier == "" {
-		// TODO - support
-		return nil, fmt.Errorf("missing control ID")
+		// if control ID not specified - download all controls
+		controls, err := g.ListControls()
+		if err != nil {
+			return nil, err
+		}
+		var files []string
+		for _, controlID := range controls {
+			control, err := g.GetControl(controlID)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("failed to download control", helpers.String("ID", controlID), helpers.Error(err))
+				continue
+			}
+			if control == nil {
+				logger.L().Ctx(ctx).Warning("failed to download control - received empty objects", helpers.String("ID", controlID))
+				continue
+			}
+			filename, err := getter.PolicyCacheFilename(controlID)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("skipping control with invalid ID", helpers.String("ID", controlID), helpers.Error(err))
+				continue
+			}
+			downloadTo := filepath.Join(downloadInfo.Path, filename)
+			err = getter.SaveInFile(control, downloadTo)
+			if err != nil {
+				return nil, err
+			}
+			logger.L().Success("Downloaded", helpers.String("artifact", downloadInfo.Target), helpers.String("ID", controlID), helpers.String("path", downloadTo))
+			files = append(files, downloadTo)
+		}
+		return files, nil
 	}
 	if downloadInfo.FileName == "" {
 		filename, err := getter.PolicyCacheFilename(downloadInfo.Identifier)

--- a/core/core/download.go
+++ b/core/core/download.go
@@ -326,7 +326,8 @@ func downloadControl(ctx context.Context, downloadInfo *metav1.DownloadInfo) ([]
 			return nil, err
 		}
 		var files []string
-		for _, controlID := range controls {
+		for _, listEntry := range controls {
+			controlID := strings.Split(listEntry, "|")[0]
 			control, err := g.GetControl(controlID)
 			if err != nil {
 				logger.L().Ctx(ctx).Warning("failed to download control", helpers.String("ID", controlID), helpers.Error(err))

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -420,7 +420,10 @@ func (f *fakePolicyGetter) GetFramework(string) (*reporthandling.Framework, erro
 func (f *fakePolicyGetter) GetFrameworks() ([]reporthandling.Framework, error) {
 	return f.frameworks, f.frameworksErr
 }
-func (f *fakePolicyGetter) GetControl(string) (*reporthandling.Control, error) {
+func (f *fakePolicyGetter) GetControl(id string) (*reporthandling.Control, error) {
+	if f.control != nil && f.control.ControlID != "" && f.control.ControlID != id {
+		return nil, fmt.Errorf("control %q not found", id)
+	}
 	return f.control, f.controlErr
 }
 func (f *fakePolicyGetter) ListFrameworks() ([]string, error) { return nil, nil }
@@ -800,7 +803,7 @@ func TestDownloadControl(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
 		wantControl := &reporthandling.Control{ControlID: "C-0001"}
 		withPolicyGetter(t, &fakePolicyGetter{
-			controlsList: []string{"C-0001"},
+			controlsList: []string{"C-0001|control name|framework1, framework2"},
 			control:      wantControl,
 		}, nil)
 

--- a/core/core/download_test.go
+++ b/core/core/download_test.go
@@ -404,12 +404,14 @@ func TestDownload_ArtifactsJSONOutputWritesToCurrentDirectory(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type fakePolicyGetter struct {
-	frameworks    []reporthandling.Framework
-	frameworksErr error
-	framework     *reporthandling.Framework
-	frameworkErr  error
-	control       *reporthandling.Control
-	controlErr    error
+	frameworks      []reporthandling.Framework
+	frameworksErr   error
+	framework       *reporthandling.Framework
+	frameworkErr    error
+	control         *reporthandling.Control
+	controlErr      error
+	controlsList    []string
+	controlsListErr error
 }
 
 func (f *fakePolicyGetter) GetFramework(string) (*reporthandling.Framework, error) {
@@ -422,7 +424,7 @@ func (f *fakePolicyGetter) GetControl(string) (*reporthandling.Control, error) {
 	return f.control, f.controlErr
 }
 func (f *fakePolicyGetter) ListFrameworks() ([]string, error) { return nil, nil }
-func (f *fakePolicyGetter) ListControls() ([]string, error)   { return nil, nil }
+func (f *fakePolicyGetter) ListControls() ([]string, error)   { return f.controlsList, f.controlsListErr }
 
 type fakeExceptionsGetter struct {
 	exceptions []armotypes.PostureExceptionPolicy
@@ -786,12 +788,30 @@ func TestDownloadControl(t *testing.T) {
 		require.EqualError(t, err, "boom")
 	})
 
-	t.Run("returns error when the identifier is missing", func(t *testing.T) {
+	t.Run("returns error from ListControls when identifier is missing", func(t *testing.T) {
 		withTenantConfig(t, &fakeTenantConfig{})
-		withPolicyGetter(t, &fakePolicyGetter{}, nil)
+		withPolicyGetter(t, &fakePolicyGetter{controlsListErr: errors.New("list failed")}, nil)
 
 		_, err := downloadControl(context.Background(), &metav1.DownloadInfo{Target: TargetControl, Path: t.TempDir()})
-		require.EqualError(t, err, "missing control ID")
+		require.EqualError(t, err, "list failed")
+	})
+
+	t.Run("succeeds downloading all controls when identifier is missing", func(t *testing.T) {
+		withTenantConfig(t, &fakeTenantConfig{})
+		wantControl := &reporthandling.Control{ControlID: "C-0001"}
+		withPolicyGetter(t, &fakePolicyGetter{
+			controlsList: []string{"C-0001"},
+			control:      wantControl,
+		}, nil)
+
+		dir := t.TempDir()
+		info := &metav1.DownloadInfo{Target: TargetControl, Path: dir}
+		_, err := downloadControl(context.Background(), info)
+		require.NoError(t, err)
+
+		var got reporthandling.Control
+		readJSONFile(t, filepath.Join(dir, "c-0001.json"), &got)
+		assert.Equal(t, wantControl.ControlID, got.ControlID)
 	})
 
 	t.Run("returns error from PolicyCacheFilename", func(t *testing.T) {


### PR DESCRIPTION
## Overview
This PR implements an enhancement to `kubescape download control` by adding support to download all controls if no specific control ID is provided, aligning its behavior with `kubescape download framework`.

Currently, running `kubescape download control` without an identifier throws an error (`missing control ID`), which had a `TODO - support` comment in the codebase. This change addresses that TODO by listing all controls via `g.ListControls()` and iteratively fetching and saving each one when no identifier is provided.

## How to Test
1. Build Kubescape locally: `go build -o kubescape main.go`
2. Run the download control command without an ID: `./kubescape download control`
3. Verify that all controls are fetched and their respective `.json` files are successfully saved in the current directory.
4. Run the updated unit tests to ensure nothing is broken: `go test -v ./core/core/... -run TestDownloadControl`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for downloading all available controls when no specific control is selected.
  - Individual control retrieval failures are skipped so other controls can continue downloading.

- **Bug Fixes**
  - Improved handling of missing, invalid, or unavailable control identifiers.
  - Added clearer error handling when controls cannot be listed or downloaded files cannot be saved.
  - Prevented invalid characters in control identifiers from producing unsafe filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->