### PR TITLE
fix(resultshandling): recompute score and counters after severity filtering

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -146,7 +146,6 @@ type reportSnapshot struct {
 	// restored so the caller (cmd/scan) evaluates exit thresholds against the
 	// true unfiltered score while printers and submission saw the filtered one.
 	complianceScore            float32
-	score                      float32
 	frameworksComplianceScores []float32
 	controlsSeverityCounters   reportsummary.SeverityCounters
 	resourcesSeverityCounters  reportsummary.SeverityCounters
@@ -179,7 +178,6 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 		controls:                   controls,
 		associatedControls:         ac,
 		complianceScore:            sessionObj.Report.SummaryDetails.ComplianceScore,
-		score:                      sessionObj.Report.SummaryDetails.Score,
 		frameworksComplianceScores: fwScores,
 		controlsSeverityCounters:   sessionObj.Report.SummaryDetails.ControlsSeverityCounters,
 		resourcesSeverityCounters:  sessionObj.Report.SummaryDetails.ResourcesSeverityCounters,
@@ -192,7 +190,6 @@ func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
 	}
 	sessionObj.Report.SummaryDetails.Controls = snap.controls
 	sessionObj.Report.SummaryDetails.ComplianceScore = snap.complianceScore
-	sessionObj.Report.SummaryDetails.Score = snap.score
 	sessionObj.Report.SummaryDetails.ControlsSeverityCounters = snap.controlsSeverityCounters
 	sessionObj.Report.SummaryDetails.ResourcesSeverityCounters = snap.resourcesSeverityCounters
 	for i := range sessionObj.Report.SummaryDetails.Frameworks {
@@ -217,11 +214,11 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 
 	// Snapshot Report.SummaryDetails.Controls, every
 	// ResourcesResult[id].AssociatedControls, and the derived summary fields
-	// (compliance score, risk score, framework compliance scores, severity
-	// counters) before applying severity filters. ApplySeverityFilters mutates
-	// all of these in place; printers and submission see the recomputed set,
-	// but the caller (cmd/scan) evaluates exit thresholds and coverage counts
-	// after HandleResults returns and must see the full unfiltered report.
+	// (compliance score, framework compliance scores, severity counters) before
+	// applying severity filters. ApplySeverityFilters mutates all of these in
+	// place; printers and submission see the recomputed set, but the caller
+	// (cmd/scan) evaluates exit thresholds and coverage counts after
+	// HandleResults returns and must see the full unfiltered report.
 	// Other consumers of rh.ScanData (httphandler /v1/results,
 	// StorePostureReportResults) also read the report after this call and
 	// must not receive an internally inconsistent PostureReport.

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -142,6 +142,14 @@ type reportSnapshot struct {
 	controls map[string]reportsummary.ControlSummary
 	// Per-resource copies of AssociatedControls, keyed like ScanData.ResourcesResult.
 	associatedControls map[string][]resourcesresults.ResourceAssociatedControl
+	// Derived summary fields recomputed over the filtered control set. They are
+	// restored so the caller (cmd/scan) evaluates exit thresholds against the
+	// true unfiltered score while printers and submission saw the filtered one.
+	complianceScore            float32
+	score                      float32
+	frameworksComplianceScores []float32
+	controlsSeverityCounters   reportsummary.SeverityCounters
+	resourcesSeverityCounters  reportsummary.SeverityCounters
 }
 
 func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
@@ -162,7 +170,20 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 		ac[id] = copy_
 	}
 
-	return reportSnapshot{controls: controls, associatedControls: ac}
+	fwScores := make([]float32, len(sessionObj.Report.SummaryDetails.Frameworks))
+	for i := range sessionObj.Report.SummaryDetails.Frameworks {
+		fwScores[i] = sessionObj.Report.SummaryDetails.Frameworks[i].ComplianceScore
+	}
+
+	return reportSnapshot{
+		controls:                   controls,
+		associatedControls:         ac,
+		complianceScore:            sessionObj.Report.SummaryDetails.ComplianceScore,
+		score:                      sessionObj.Report.SummaryDetails.Score,
+		frameworksComplianceScores: fwScores,
+		controlsSeverityCounters:   sessionObj.Report.SummaryDetails.ControlsSeverityCounters,
+		resourcesSeverityCounters:  sessionObj.Report.SummaryDetails.ResourcesSeverityCounters,
+	}
 }
 
 func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
@@ -170,6 +191,15 @@ func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
 		return
 	}
 	sessionObj.Report.SummaryDetails.Controls = snap.controls
+	sessionObj.Report.SummaryDetails.ComplianceScore = snap.complianceScore
+	sessionObj.Report.SummaryDetails.Score = snap.score
+	sessionObj.Report.SummaryDetails.ControlsSeverityCounters = snap.controlsSeverityCounters
+	sessionObj.Report.SummaryDetails.ResourcesSeverityCounters = snap.resourcesSeverityCounters
+	for i := range sessionObj.Report.SummaryDetails.Frameworks {
+		if i < len(snap.frameworksComplianceScores) {
+			sessionObj.Report.SummaryDetails.Frameworks[i].ComplianceScore = snap.frameworksComplianceScores[i]
+		}
+	}
 	for id, ac := range snap.associatedControls {
 		if result, ok := sessionObj.ResourcesResult[id]; ok {
 			result.AssociatedControls = ac
@@ -185,12 +215,14 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 		vapreconcile.EnrichSummary(rh.ScanData.Report.SummaryDetails.Controls, index)
 	}
 
-	// Snapshot both Report.SummaryDetails.Controls and every
-	// ResourcesResult[id].AssociatedControls before applying severity filters.
-	// ApplySeverityFilters mutates both in place; printers and submission see
-	// the narrowed set, but the caller (cmd/scan) evaluates exit thresholds
-	// and coverage counts after HandleResults returns and must see the full
-	// unfiltered report. Other consumers of rh.ScanData (httphandler /v1/results,
+	// Snapshot Report.SummaryDetails.Controls, every
+	// ResourcesResult[id].AssociatedControls, and the derived summary fields
+	// (compliance score, risk score, framework compliance scores, severity
+	// counters) before applying severity filters. ApplySeverityFilters mutates
+	// all of these in place; printers and submission see the recomputed set,
+	// but the caller (cmd/scan) evaluates exit thresholds and coverage counts
+	// after HandleResults returns and must see the full unfiltered report.
+	// Other consumers of rh.ScanData (httphandler /v1/results,
 	// StorePostureReportResults) also read the report after this call and
 	// must not receive an internally inconsistent PostureReport.
 	snap := snapshotReport(rh.ScanData)

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	printerv2 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -1014,4 +1015,71 @@ func TestHandleResults_RestoresReportOnSubmitError(t *testing.T) {
 		"Controls must be restored after submit error")
 	assert.Len(t, rh.ScanData.ResourcesResult["resource-1"].AssociatedControls, 2,
 		"AssociatedControls must be restored after submit error")
+}
+
+// capturingScorePrinter records the summary values it observes while printing,
+// so tests can assert printers see the severity-filtered (recomputed) report.
+type capturingScorePrinter struct {
+	score         float32
+	controlsCount reportsummary.SeverityCounters
+}
+
+func (c *capturingScorePrinter) SetWriter(_ context.Context, _ string) error { return nil }
+func (c *capturingScorePrinter) PrintNextSteps()                             {}
+func (c *capturingScorePrinter) ActionPrint(_ context.Context, data *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
+	if data != nil && data.Report != nil {
+		c.score = data.Report.SummaryDetails.ComplianceScore
+		c.controlsCount = data.Report.SummaryDetails.ControlsSeverityCounters
+	}
+	return nil
+}
+func (c *capturingScorePrinter) Score(score float32) { c.score = score }
+
+// TestHandleResults_PrintsFilteredScoreAndRestoresUnfiltered verifies that a
+// severity filter makes printers (including p.Score(rh.GetComplianceScore()))
+// see the recomputed score over the retained controls, while the post-call
+// GetComplianceScore()/GetRiskScore() used by the exit gate return the
+// original unfiltered values. Restoring the recomputed fields is what keeps
+// --compliance-threshold semantics unchanged when --min-severity is set.
+func TestHandleResults_PrintsFilteredScoreAndRestoresUnfiltered(t *testing.T) {
+	compLow := float32(100)
+	compHigh := float32(20)
+	compCritical := float32(10)
+	sessionObj := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{
+					"C-low":      {ControlID: "C-low", ScoreFactor: 1, ComplianceScore: &compLow},
+					"C-high":     {ControlID: "C-high", ScoreFactor: 7, ComplianceScore: &compHigh, StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+					"C-critical": {ControlID: "C-critical", ScoreFactor: 9, ComplianceScore: &compCritical, StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+				},
+				ComplianceScore:          43.33, // stale full-set values, restored after HandleResults
+				Score:                    44.44,
+				ControlsSeverityCounters: reportsummary.SeverityCounters{HighSeverityCounter: 9, CriticalSeverityCounter: 1},
+			},
+		},
+	}
+
+	capture := &capturingScorePrinter{}
+	rh := &ResultsHandler{
+		ScanData:    sessionObj,
+		UiPrinter:   &SpyPrinter{},
+		PrinterObjs: []printer.IPrinter{capture},
+	}
+
+	require.NoError(t, rh.HandleResults(context.Background(), &cautils.ScanInfo{MinSeverity: "high"}))
+
+	// Printers ran inside the filtered window: score and counters must reflect
+	// only the retained (high/critical) controls.
+	assert.Equal(t, float32(15), capture.score, "printed score must be recomputed over retained controls")
+	assert.Equal(t, reportsummary.SeverityCounters{HighSeverityCounter: 1, CriticalSeverityCounter: 1}, capture.controlsCount,
+		"printed severity counters must be recomputed over retained controls")
+
+	// After HandleResults returns, the report is restored so the exit gate sees
+	// the true unfiltered score.
+	assert.Equal(t, float32(43.33), rh.GetComplianceScore(), "exit gate must see the unfiltered compliance score")
+	assert.Equal(t, float32(44.44), rh.GetRiskScore(), "exit gate must see the unfiltered risk score")
+	assert.Equal(t, reportsummary.SeverityCounters{HighSeverityCounter: 9, CriticalSeverityCounter: 1}, rh.ScanData.Report.SummaryDetails.ControlsSeverityCounters,
+		"severity counters must be restored after HandleResults")
+	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 3, "Controls must be unfiltered after HandleResults")
 }

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
 
@@ -45,6 +46,74 @@ func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSev
 		}
 		result.AssociatedControls = ac
 		sessionObj.ResourcesResult[id] = result
+	}
+
+	recomputeSummaryDetails(sessionObj)
+}
+
+// recomputeSummaryDetails refreshes every derived summary field that was
+// computed against the full control set before severity filtering. After
+// ApplySeverityFilters removes lower-severity controls, the compliance score,
+// risk score, framework compliance scores and severity counters would otherwise
+// describe controls that are no longer present in the report.
+func recomputeSummaryDetails(sessionObj *cautils.OPASessionObj) {
+	if sessionObj == nil || sessionObj.Report == nil {
+		return
+	}
+	summary := &sessionObj.Report.SummaryDetails
+
+	var scoreSum float32
+	var complianceSum float32
+	count := 0
+	for _, ctrl := range summary.Controls {
+		scoreSum += ctrl.GetScore()
+		complianceSum += ctrl.GetComplianceScore()
+		count++
+	}
+	if count > 0 {
+		summary.ComplianceScore = complianceSum / float32(count)
+		summary.Score = scoreSum / float32(count)
+	} else {
+		summary.ComplianceScore = 0
+		summary.Score = 0
+	}
+
+	for i := range summary.Frameworks {
+		var fSum float32
+		fCount := 0
+		for id, ctrl := range summary.Frameworks[i].Controls {
+			if _, ok := summary.Controls[id]; ok {
+				fSum += ctrl.GetComplianceScore()
+				fCount++
+			}
+		}
+		if fCount > 0 {
+			summary.Frameworks[i].ComplianceScore = fSum / float32(fCount)
+		} else {
+			summary.Frameworks[i].ComplianceScore = 0
+		}
+	}
+
+	summary.ControlsSeverityCounters = reportsummary.SeverityCounters{}
+	for _, ctrl := range summary.Controls {
+		if ctrl.GetStatus().IsFailed() {
+			summary.ControlsSeverityCounters.Increase(apis.ControlSeverityToString(ctrl.GetScoreFactor()), 1)
+		}
+	}
+
+	summary.ResourcesSeverityCounters = reportsummary.SeverityCounters{}
+	for _, result := range sessionObj.ResourcesResult {
+		if !result.GetStatus(nil).IsFailed() {
+			continue
+		}
+		for _, ac := range result.AssociatedControls {
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+			if ctrl, ok := summary.Controls[ac.GetID()]; ok {
+				summary.ResourcesSeverityCounters.Increase(apis.ControlSeverityToString(ctrl.GetScoreFactor()), 1)
+			}
+		}
 	}
 }
 

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -54,28 +54,27 @@ func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSev
 // recomputeSummaryDetails refreshes every derived summary field that was
 // computed against the full control set before severity filtering. After
 // ApplySeverityFilters removes lower-severity controls, the compliance score,
-// risk score, framework compliance scores and severity counters would otherwise
-// describe controls that are no longer present in the report.
+// framework compliance scores and severity counters would otherwise describe
+// controls that are no longer present in the report. The risk score
+// (SummaryDetails.Score) is deliberately left unrecomputed: it is a
+// WCS-weighted aggregate whose weights are not available at filter time, so a
+// plain average would not reproduce it.
 func recomputeSummaryDetails(sessionObj *cautils.OPASessionObj) {
 	if sessionObj == nil || sessionObj.Report == nil {
 		return
 	}
 	summary := &sessionObj.Report.SummaryDetails
 
-	var scoreSum float32
 	var complianceSum float32
 	count := 0
 	for _, ctrl := range summary.Controls {
-		scoreSum += ctrl.GetScore()
 		complianceSum += ctrl.GetComplianceScore()
 		count++
 	}
 	if count > 0 {
 		summary.ComplianceScore = complianceSum / float32(count)
-		summary.Score = scoreSum / float32(count)
 	} else {
 		summary.ComplianceScore = 0
-		summary.Score = 0
 	}
 
 	for i := range summary.Frameworks {

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -271,19 +271,21 @@ func TestApplySeverityFilters_RecomputesComplianceScore(t *testing.T) {
 	assert.Equal(t, float32(10), s.Report.SummaryDetails.ComplianceScore)
 }
 
-func TestApplySeverityFilters_RecomputesRiskScore(t *testing.T) {
+func TestApplySeverityFilters_DoesNotRecomputeRiskScore(t *testing.T) {
 	controls := map[string]reportsummary.ControlSummary{
 		"C-low":      {ControlID: "C-low", ScoreFactor: scoreLow, Score: 90},
 		"C-medium":   {ControlID: "C-medium", ScoreFactor: scoreMedium, Score: 50},
 		"C-critical": {ControlID: "C-critical", ScoreFactor: scoreCritical, Score: 20},
 	}
 	s := makeSessionWithControls(controls)
-	s.Report.SummaryDetails.Score = 53.3 // stale full-set value
+	s.Report.SummaryDetails.Score = 53.3
 
 	ApplySeverityFilters(s, "critical", "")
 
 	require.Len(t, s.Report.SummaryDetails.Controls, 1)
-	assert.Equal(t, float32(20), s.Report.SummaryDetails.Score)
+	// The risk score is a WCS-weighted aggregate whose weights are not available
+	// at filter time; a plain average would not reproduce it, so it is left as-is.
+	assert.Equal(t, float32(53.3), s.Report.SummaryDetails.Score)
 }
 
 func TestApplySeverityFilters_RecomputesFrameworkComplianceScores(t *testing.T) {
@@ -374,7 +376,7 @@ func TestApplySeverityFilters_RecomputesResourcesSeverityCounters(t *testing.T) 
 	assert.Equal(t, 1, got.CriticalSeverityCounter)
 }
 
-func TestApplySeverityFilters_ZeroRetainedZeroesScoresAndCounters(t *testing.T) {
+func TestApplySeverityFilters_ZeroRetainedZeroesComplianceScoreAndCounters(t *testing.T) {
 	controls := map[string]reportsummary.ControlSummary{
 		"C-low": makeCompliantControl("C-low", scoreLow, 100),
 	}
@@ -387,7 +389,8 @@ func TestApplySeverityFilters_ZeroRetainedZeroesScoresAndCounters(t *testing.T) 
 
 	require.Len(t, s.Report.SummaryDetails.Controls, 0)
 	assert.Equal(t, float32(0), s.Report.SummaryDetails.ComplianceScore)
-	assert.Equal(t, float32(0), s.Report.SummaryDetails.Score)
 	assert.Equal(t, reportsummary.SeverityCounters{}, s.Report.SummaryDetails.ControlsSeverityCounters)
 	assert.Equal(t, reportsummary.SeverityCounters{}, s.Report.SummaryDetails.ResourcesSeverityCounters)
+	// The risk score is not recomputed at filter time; it is left unchanged.
+	assert.Equal(t, float32(100), s.Report.SummaryDetails.Score)
 }

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -41,6 +42,20 @@ func makeResult(resourceID string, controlIDs ...string) resourcesresults.Result
 		})
 	}
 	return r
+}
+
+// makeCompliantControl builds a control with an explicit per-control compliance
+// score (nil ComplianceScore makes GetComplianceScore() return -1).
+func makeCompliantControl(id string, scoreFactor float32, compliance float32) reportsummary.ControlSummary {
+	c := makeControl(id, scoreFactor)
+	c.ComplianceScore = &compliance
+	return c
+}
+
+func makeFailedControl(id string, scoreFactor float32) reportsummary.ControlSummary {
+	c := makeControl(id, scoreFactor)
+	c.StatusInfo = apis.StatusInfo{InnerStatus: apis.StatusFailed}
+	return c
 }
 
 func TestApplySeverityFilters_NilSessionObj(t *testing.T) {
@@ -239,4 +254,140 @@ func TestApplySeverityFilters_UnknownSeverityExcluded_WhenMaxOnly(t *testing.T) 
 	assert.False(t, hasUnknown)
 	assert.True(t, hasMedium)
 	assert.True(t, hasLow)
+}
+
+func TestApplySeverityFilters_RecomputesComplianceScore(t *testing.T) {
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low":      makeCompliantControl("C-low", scoreLow, 100),
+		"C-medium":   makeCompliantControl("C-medium", scoreMedium, 60),
+		"C-critical": makeCompliantControl("C-critical", scoreCritical, 10),
+	}
+	s := makeSessionWithControls(controls)
+	s.Report.SummaryDetails.ComplianceScore = 56.7 // stale full-set value
+
+	ApplySeverityFilters(s, "critical", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 1)
+	assert.Equal(t, float32(10), s.Report.SummaryDetails.ComplianceScore)
+}
+
+func TestApplySeverityFilters_RecomputesRiskScore(t *testing.T) {
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low":      {ControlID: "C-low", ScoreFactor: scoreLow, Score: 90},
+		"C-medium":   {ControlID: "C-medium", ScoreFactor: scoreMedium, Score: 50},
+		"C-critical": {ControlID: "C-critical", ScoreFactor: scoreCritical, Score: 20},
+	}
+	s := makeSessionWithControls(controls)
+	s.Report.SummaryDetails.Score = 53.3 // stale full-set value
+
+	ApplySeverityFilters(s, "critical", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 1)
+	assert.Equal(t, float32(20), s.Report.SummaryDetails.Score)
+}
+
+func TestApplySeverityFilters_RecomputesFrameworkComplianceScores(t *testing.T) {
+	low := makeCompliantControl("C-low", scoreLow, 100)
+	high := makeCompliantControl("C-high", scoreHigh, 25)
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low":  low,
+		"C-high": high,
+	}
+	s := makeSessionWithControls(controls)
+	s.Report.SummaryDetails.Frameworks = []reportsummary.FrameworkSummary{
+		{
+			Name: "framework-a",
+			Controls: reportsummary.ControlSummaries{
+				"C-low":  low,
+				"C-high": high,
+			},
+			ComplianceScore: 62.5,
+		},
+		{
+			Name: "framework-b",
+			Controls: reportsummary.ControlSummaries{
+				"C-low": low,
+			},
+			ComplianceScore: 100,
+		},
+	}
+
+	ApplySeverityFilters(s, "high", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 1)
+	assert.Equal(t, float32(25), s.Report.SummaryDetails.Frameworks[0].ComplianceScore,
+		"framework score must be recomputed over retained framework controls")
+	assert.Equal(t, float32(0), s.Report.SummaryDetails.Frameworks[1].ComplianceScore,
+		"framework with no retained controls must score 0")
+}
+
+func TestApplySeverityFilters_RecomputesControlsSeverityCounters(t *testing.T) {
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low":      makeFailedControl("C-low", scoreLow),
+		"C-medium":   makeFailedControl("C-medium", scoreMedium),
+		"C-high":     makeFailedControl("C-high", scoreHigh),
+		"C-critical": makeFailedControl("C-critical", scoreCritical),
+		"C-passed":   makeControl("C-passed", scoreMedium),
+	}
+	s := makeSessionWithControls(controls)
+	s.Report.SummaryDetails.ControlsSeverityCounters = reportsummary.SeverityCounters{CriticalSeverityCounter: 9}
+
+	ApplySeverityFilters(s, "high", "")
+
+	got := s.Report.SummaryDetails.ControlsSeverityCounters
+	assert.Equal(t, 0, got.LowSeverityCounter)
+	assert.Equal(t, 0, got.MediumSeverityCounter)
+	assert.Equal(t, 1, got.HighSeverityCounter)
+	assert.Equal(t, 1, got.CriticalSeverityCounter)
+}
+
+func TestApplySeverityFilters_RecomputesResourcesSeverityCounters(t *testing.T) {
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low":      makeFailedControl("C-low", scoreLow),
+		"C-high":     makeFailedControl("C-high", scoreHigh),
+		"C-critical": makeFailedControl("C-critical", scoreCritical),
+	}
+	s := makeSessionWithControls(controls)
+	s.ResourcesResult = map[string]resourcesresults.Result{
+		"resource-1": {
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-low", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+				{ControlID: "C-high", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+				{ControlID: "C-critical", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+			},
+		},
+		"resource-2": {
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-high", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+			},
+		},
+	}
+	s.Report.SummaryDetails.ResourcesSeverityCounters = reportsummary.SeverityCounters{LowSeverityCounter: 7}
+
+	ApplySeverityFilters(s, "high", "")
+
+	// resource-1 keeps C-high + C-critical (2 x 1), resource-2 keeps C-high (1 x 1).
+	got := s.Report.SummaryDetails.ResourcesSeverityCounters
+	assert.Equal(t, 0, got.LowSeverityCounter)
+	assert.Equal(t, 0, got.MediumSeverityCounter)
+	assert.Equal(t, 2, got.HighSeverityCounter)
+	assert.Equal(t, 1, got.CriticalSeverityCounter)
+}
+
+func TestApplySeverityFilters_ZeroRetainedZeroesScoresAndCounters(t *testing.T) {
+	controls := map[string]reportsummary.ControlSummary{
+		"C-low": makeCompliantControl("C-low", scoreLow, 100),
+	}
+	s := makeSessionWithControls(controls)
+	s.Report.SummaryDetails.ComplianceScore = 100
+	s.Report.SummaryDetails.Score = 100
+	s.Report.SummaryDetails.ControlsSeverityCounters = reportsummary.SeverityCounters{LowSeverityCounter: 3}
+
+	ApplySeverityFilters(s, "critical", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 0)
+	assert.Equal(t, float32(0), s.Report.SummaryDetails.ComplianceScore)
+	assert.Equal(t, float32(0), s.Report.SummaryDetails.Score)
+	assert.Equal(t, reportsummary.SeverityCounters{}, s.Report.SummaryDetails.ControlsSeverityCounters)
+	assert.Equal(t, reportsummary.SeverityCounters{}, s.Report.SummaryDetails.ResourcesSeverityCounters)
 }


### PR DESCRIPTION
## Overview

**Current behavior:** `kubescape scan --min-severity/--max-severity` removes filtered-out controls from the report but leaves the derived summary fields (compliance score, framework compliance scores, severity counters) computed over the full control set. The report therefore shows only high/critical controls next to a compliance score that describes the whole scan.

**Future behavior:** after severity filtering, the compliance score, framework compliance scores and severity counters are recomputed over the retained controls, so the numbers always match the controls shown. The exit gate (`--compliance-threshold`) keeps evaluating against the unfiltered score via the existing snapshot/restore, so filtering never inflates or alters the pass/fail decision.

## Additional Information

- Compliance score and framework compliance scores use the same formulas as report generation (`score.SetPostureReportComplianceScores`: average of per-control `GetComplianceScore()`, 0 when no controls remain).
- Severity counters follow exact opa-utils semantics: `ControlsSeverityCounters` counts per failed retained control; `ResourcesSeverityCounters` counts per failed resource x failed retained control.
- The risk score (`SummaryDetails.Score`) is deliberately left unrecomputed. It is a WCS-weighted aggregate (`score.ScoreUtil.SetPostureReportComplianceScores -> CalculatePostureReportV2 -> ControlsSummariesScore -> ControlV2Score`) whose weighting inputs (resource workload weights, replica counts) are not available at filter time, so a plain average of per-control scores would not reproduce it. Per maintainer review of this PR, Score stays as-is while the fields above are recomputed.
- `reportSnapshot`/`restoreReport` (`results.go`) now also capture/restore these fields, so printers and the JSON report display filtered values while the caller (cmd/scan exit gate) sees the unfiltered score after `HandleResults`.
- Verification: `gofmt` clean, `go build ./...`, `go vet`, 2123 tests pass, golangci-lint clean on the touched package.

## How to Test

Run `kubescape scan --format json --min-severity high` and check `summaryDetails.complianceScore`, `frameworks[].complianceScore`, `controlsSeverityCounters`, `resourcesSeverityCounters` are consistent with the retained controls — or `go test ./core/pkg/resultshandling/...`.

## Related issues/PRs

Resolves #3434

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity-filtered reports now accurately recalculate compliance scores and framework scores.
  * Severity counters reflect only the controls retained after filtering.
  * Derived compliance metrics and counters reset correctly when no controls remain.
  * Risk scores remain unchanged when severity filters are applied.
  * Original report values are restored after filtered results are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->