### PR TITLE
feat(scan): wire up sequential multi-cluster scanning via --kube-contexts

### DIFF
--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -1,0 +1,91 @@
+package scan
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/meta"
+)
+
+// fleetScan runs securityScan's per-cluster behavior once for every context
+// in baseScanInfo.KubeContexts, sequentially, writing one report per
+// context. It's the --kube-contexts entry point invoked from securityScan.
+//
+// Contexts are scanned one at a time, not concurrently: k8sinterface's
+// process-global connection state (K8SConfig, clientConfigAPI,
+// clusterContextName) has no locking around it, confirmed by go test -race
+// while working on #3237 — running two contexts' scans concurrently would
+// race on that state regardless of cautils.EnterClusterContext, which only
+// makes *sequential* context switches safe.
+//
+// One context failing (connection error, threshold breach, degraded policy
+// inputs, etc.) does not stop the remaining contexts from being attempted:
+// a fleet scan should surface as much of the fleet's posture as it can
+// rather than aborting on the first bad cluster. The command's overall
+// error - and therefore its exit code - reflects whether any context
+// failed, matching the single-context command's existing all-or-nothing
+// exit-code semantics from the caller's point of view.
+func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	if baseScanInfo.GetScanningContext() != cautils.ContextCluster {
+		return fmt.Errorf("--kube-contexts requires a live-cluster scan: it selects which cluster to connect to, so it can't be combined with scanning local files/directories")
+	}
+	if strings.TrimSpace(baseScanInfo.Output) == "" {
+		return fmt.Errorf("--kube-contexts requires --output: each context's report is written to its own file, derived from --output, since only one context's results can be printed to stdout at a time")
+	}
+
+	var failed []string
+	for _, kubeContext := range baseScanInfo.KubeContexts {
+		outputPath, err := perContextOutputPath(baseScanInfo.Output, kubeContext)
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
+			logger.L().Error("fleet scan: skipping context, could not derive an output path", helpers.String("context", kubeContext), helpers.Error(err))
+			continue
+		}
+
+		contextScanInfo := baseScanInfo.CloneForContext(kubeContext, outputPath)
+
+		logger.L().Info("fleet scan: scanning context", helpers.String("context", kubeContext), helpers.String("output", outputPath))
+
+		leave := cautils.EnterClusterContext(kubeContext)
+		ctx, cancel := deriveTimeoutContext(contextScanInfo, ks)
+		err = runSecurityScan(ctx, contextScanInfo, ks, policyIdentifiers)
+		cancel()
+		leave()
+
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
+			logger.L().Error("fleet scan: context failed", helpers.String("context", kubeContext), helpers.Error(err))
+			continue
+		}
+		logger.L().Success("fleet scan: context completed", helpers.String("context", kubeContext))
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("fleet scan: %d of %d context(s) failed:\n%s", len(failed), len(baseScanInfo.KubeContexts), strings.Join(failed, "\n"))
+	}
+	return nil
+}
+
+// perContextOutputPath derives context's own report path from the
+// --output the user gave for the fleet as a whole, by inserting a
+// filesystem-safe form of context before the final extension: report.json +
+// "kind-fleet-test-a" -> report.kind-fleet-test-a.json. Path separators in
+// context (which kube context names can technically contain, e.g. some
+// cloud-provider-generated names) are replaced so the result can't escape
+// the output directory or be misread as one.
+func perContextOutputPath(output, kubeContext string) (string, error) {
+	sanitized := strings.NewReplacer("/", "_", "\\", "_", string(filepath.Separator), "_").Replace(kubeContext)
+	sanitized = strings.TrimSpace(sanitized)
+	if sanitized == "" {
+		return "", fmt.Errorf("empty kube context name")
+	}
+
+	dir, base := filepath.Split(output)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	return filepath.Join(dir, stem+"."+sanitized+ext), nil
+}

--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -3,13 +3,43 @@ package scan
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/meta"
+	"github.com/spf13/cobra"
 )
+
+// validateKubeContextsSupported rejects --kube-contexts up front for any
+// invocation that won't actually reach fleetScan, instead of silently
+// accepting the flag and scanning only one (default) context - the same
+// silently-wrong-cluster failure mode #3217/#3218 closed for sequential
+// scans in one process, recurring here as "the flag had no effect."
+//
+// --kube-contexts is registered on scanCmd's persistent flags, so cobra
+// inherits it onto every subcommand (control/framework/workload/image) and
+// it's accepted by --view=resource|control too, but only the default
+// security view's securityScan currently calls fleetScan. cmd here is the
+// actual leaf command being invoked (cobra passes the target command to an
+// inherited PersistentPreRunE, not the command it's defined on), so
+// cmd.Name() reliably reports which one that is.
+func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInfo) error {
+	if len(scanInfo.KubeContexts) == 0 {
+		return nil
+	}
+	switch cmd.Name() {
+	case "scan":
+		if scanInfo.View != string(cautils.SecurityViewType) {
+			return fmt.Errorf("--kube-contexts is not yet supported with --view=%s; only the default security view (no --view, or --view=%s) supports scanning multiple contexts in one run", scanInfo.View, cautils.SecurityViewType)
+		}
+	default:
+		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'; only the default 'scan' command (security view) supports scanning multiple contexts in one run", cmd.Name())
+	}
+	return nil
+}
 
 // fleetScan runs securityScan's per-cluster behavior once for every context
 // in baseScanInfo.KubeContexts, sequentially, writing one report per
@@ -37,14 +67,14 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 		return fmt.Errorf("--kube-contexts requires --output: each context's report is written to its own file, derived from --output, since only one context's results can be printed to stdout at a time")
 	}
 
+	outputPaths, err := perContextOutputPaths(baseScanInfo.Output, baseScanInfo.KubeContexts)
+	if err != nil {
+		return err
+	}
+
 	var failed []string
 	for _, kubeContext := range baseScanInfo.KubeContexts {
-		outputPath, err := perContextOutputPath(baseScanInfo.Output, kubeContext)
-		if err != nil {
-			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
-			logger.L().Error("fleet scan: skipping context, could not derive an output path", helpers.String("context", kubeContext), helpers.Error(err))
-			continue
-		}
+		outputPath := outputPaths[kubeContext]
 
 		contextScanInfo := baseScanInfo.CloneForContext(kubeContext, outputPath)
 
@@ -70,13 +100,52 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 	return nil
 }
 
+// perContextOutputPaths derives every context's own report path from the
+// --output the user gave for the fleet as a whole, and rejects the whole
+// batch up front if any two contexts would derive the same path. Two
+// distinct context names can sanitize to the same string (e.g.
+// "prod/us-east-1" and "prod_us-east-1" both become "prod_us-east-1"), which
+// would otherwise make the second scan's report silently overwrite the
+// first's - both scans "succeed" from fleetScan's point of view, so nothing
+// would ever surface the clobbered report as an error. Failing fast here
+// with the colliding context names named explicitly is far more useful than
+// discovering it later from a report that doesn't match its own context.
+func perContextOutputPaths(output string, kubeContexts []string) (map[string]string, error) {
+	paths := make(map[string]string, len(kubeContexts))
+	collisions := make(map[string][]string) // output path -> contexts that derived it
+
+	for _, kubeContext := range kubeContexts {
+		path, err := perContextOutputPath(output, kubeContext)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", kubeContext, err)
+		}
+		paths[kubeContext] = path
+		collisions[path] = append(collisions[path], kubeContext)
+	}
+
+	var conflicts []string
+	for path, contexts := range collisions {
+		if len(contexts) > 1 {
+			conflicts = append(conflicts, fmt.Sprintf("%s -> %s", strings.Join(contexts, ", "), path))
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return nil, fmt.Errorf("--kube-contexts: %d context(s) derive a colliding --output path with another context, so their reports would silently overwrite each other:\n%s", len(conflicts), strings.Join(conflicts, "\n"))
+	}
+
+	return paths, nil
+}
+
 // perContextOutputPath derives context's own report path from the
 // --output the user gave for the fleet as a whole, by inserting a
 // filesystem-safe form of context before the final extension: report.json +
 // "kind-fleet-test-a" -> report.kind-fleet-test-a.json. Path separators in
 // context (which kube context names can technically contain, e.g. some
 // cloud-provider-generated names) are replaced so the result can't escape
-// the output directory or be misread as one.
+// the output directory or be misread as one. Callers scanning a batch of
+// contexts should use perContextOutputPaths instead, which also rejects
+// collisions between two different contexts' derived paths.
 func perContextOutputPath(output, kubeContext string) (string, error) {
 	sanitized := strings.NewReplacer("/", "_", "\\", "_", string(filepath.Separator), "_").Replace(kubeContext)
 	sanitized = strings.TrimSpace(sanitized)

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -41,6 +41,48 @@ func TestPerContextOutputPath(t *testing.T) {
 	}
 }
 
+// TestPerContextOutputPaths_RejectsCollidingContexts is a regression test
+// for a real review finding on #3438: perContextOutputPath's sanitization
+// isn't injective, so two distinct context names - e.g. "prod/us-east-1"
+// and "prod_us-east-1" - can derive the same output path and silently
+// overwrite each other's report, with fleetScan never noticing since both
+// individual scans "succeed." perContextOutputPaths must catch this before
+// any scanning starts, not after.
+func TestPerContextOutputPaths_RejectsCollidingContexts(t *testing.T) {
+	_, err := perContextOutputPaths("report.json", []string{"prod/us-east-1", "prod_us-east-1", "ctx-c"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "prod/us-east-1")
+	assert.ErrorContains(t, err, "prod_us-east-1")
+	assert.ErrorContains(t, err, "report.prod_us-east-1.json")
+}
+
+func TestPerContextOutputPaths_NoCollisions(t *testing.T) {
+	paths, err := perContextOutputPaths("report.json", []string{"ctx-a", "ctx-b", "ctx-c"})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"ctx-a": "report.ctx-a.json",
+		"ctx-b": "report.ctx-b.json",
+		"ctx-c": "report.ctx-c.json",
+	}, paths)
+}
+
+func TestFleetScan_RejectsCollidingContextsBeforeScanningAny(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"prod/us-east-1", "prod_us-east-1"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "colliding")
+	assert.Empty(t, ks.callsOutputs, "no context should be scanned once a collision is detected up front")
+}
+
 func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
 	scanInfo := cautils.ScanInfo{
 		KubeContexts:  []string{"ctx-a"},

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -1,0 +1,161 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerContextOutputPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		kubeContext string
+		want        string
+		wantErr     bool
+	}{
+		{name: "simple", output: "report.json", kubeContext: "ctx-a", want: "report.ctx-a.json"},
+		{name: "no extension", output: "report", kubeContext: "ctx-a", want: "report.ctx-a"},
+		{name: "with directory", output: filepath.Join("out", "report.yaml"), kubeContext: "ctx-a", want: filepath.Join("out", "report.ctx-a.yaml")},
+		{name: "context contains path separators", output: "report.json", kubeContext: "prod/us-east-1", want: "report.prod_us-east-1.json"},
+		{name: "empty context rejected", output: "report.json", kubeContext: "", wantErr: true},
+		{name: "whitespace-only context rejected", output: "report.json", kubeContext: "   ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := perContextOutputPath(tt.output, tt.kubeContext)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
+	scanInfo := cautils.ScanInfo{
+		KubeContexts:  []string{"ctx-a"},
+		Output:        "report.json",
+		InputPatterns: []string{"."}, // makes GetScanningContext() resolve to a non-cluster context
+	}
+
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	require.ErrorContains(t, err, "live-cluster scan")
+}
+
+func TestFleetScan_RequiresOutput(t *testing.T) {
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a"},
+	}
+
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	require.ErrorContains(t, err, "--output")
+}
+
+// fleetTrackingKubescape is a test-local IKubescape recording, per
+// ScanContext call, the output path it was given (which encodes the
+// context, via perContextOutputPath) - and optionally failing for
+// caller-chosen output paths, so tests can assert fleetScan continues past
+// a failing context instead of aborting the loop.
+type fleetTrackingKubescape struct {
+	mocks.MockIKubescape
+	callsOutputs []string
+	failOutputs  map[string]error
+}
+
+func (m *fleetTrackingKubescape) Context() context.Context { return context.Background() }
+
+func (m *fleetTrackingKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	m.callsOutputs = append(m.callsOutputs, scanInfo.Output)
+	if err, ok := m.failOutputs[scanInfo.Output]; ok {
+		return nil, err
+	}
+	results := resultshandling.NewResultsHandler(nil, nil, &fakePrinter{})
+	results.SetData(cautils.NewOPASessionObjMock())
+	return results, nil
+}
+
+func TestFleetScan_ScansEveryContextAndDerivesDistinctOutputPaths(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b", "ctx-c"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
+}
+
+func TestFleetScan_ContinuesPastFailingContextAndReportsIt(t *testing.T) {
+	ks := &fleetTrackingKubescape{
+		failOutputs: map[string]error{
+			"report.ctx-b.json": errors.New("cluster unreachable"),
+		},
+	}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b", "ctx-c"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "1 of 3 context(s) failed")
+	assert.ErrorContains(t, err, "ctx-b")
+	assert.ErrorContains(t, err, "cluster unreachable")
+	// ctx-a and ctx-c must still have been attempted despite ctx-b failing.
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
+}
+
+func TestFleetScan_EachContextGetsAFreshScanID(t *testing.T) {
+	var scanIDs []string
+	ks := &fleetIDTrackingKubescape{onScan: func(si *cautils.ScanInfo) {
+		scanIDs = append(scanIDs, si.ScanID)
+	}}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+	scanInfo.ScanID = "should-not-be-reused"
+
+	require.NoError(t, fleetScan(scanInfo, ks, nil))
+
+	require.Len(t, scanIDs, 2)
+	assert.NotEqual(t, "should-not-be-reused", scanIDs[0])
+	assert.NotEqual(t, "should-not-be-reused", scanIDs[1])
+	assert.NotEqual(t, scanIDs[0], scanIDs[1], "each context must get its own ScanID, not share one across the fleet")
+}
+
+type fleetIDTrackingKubescape struct {
+	mocks.MockIKubescape
+	onScan func(*cautils.ScanInfo)
+}
+
+func (m *fleetIDTrackingKubescape) Context() context.Context { return context.Background() }
+
+func (m *fleetIDTrackingKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	// Mirrors what the real Scan/ScanContext does via scanInfo.Init: assign a
+	// ScanID if one isn't already set. CloneForContext is what's under test
+	// here - it must have cleared ScanID before this call ever sees it.
+	if scanInfo.ScanID == "" {
+		scanInfo.ScanID = "generated-" + scanInfo.Output
+	}
+	m.onScan(scanInfo)
+	results := resultshandling.NewResultsHandler(nil, nil, &fakePrinter{})
+	results.SetData(cautils.NewOPASessionObjMock())
+	return results, nil
+}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -257,6 +257,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go
 	scanCmd.PersistentFlags().AddGoFlag(flag.Lookup("kubeconfig"))
 
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.KubeContexts, "kube-contexts", nil, "Scan each of these kube contexts in one run (comma-separated, or repeat the flag), writing one report per context to a context-suffixed --output path. Requires --output. Distinct from --kube-context, which selects a single context; when --kube-contexts is set it takes over the scan instead.")
+
 	scanCmd.PersistentFlags().StringVar(&scanInfo.Baseline, "baseline", "", "Path to a saved JSON scan report to diff the fresh scan against.")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.BaselineFailOnNew, "baseline-fail-on-new", false, "With --baseline, exit with code 1 when new failures are found versus the baseline.")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.BaselineSeverityThreshold, "baseline-severity-threshold", "", "With --baseline, only count new failures at or above this severity when using --baseline-fail-on-new.")
@@ -352,34 +354,46 @@ func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
 }
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	if len(scanInfo.KubeContexts) > 0 {
+		return fleetScan(scanInfo, ks, policyIdentifiers)
+	}
+
 	ctx, cancel := deriveTimeoutContext(&scanInfo, ks)
 	defer cancel()
+	return runSecurityScan(ctx, &scanInfo, ks, policyIdentifiers)
+}
 
-	results, err := ks.ScanContext(ctx, &scanInfo, policyIdentifiers)
+// runSecurityScan runs one cluster's scan to completion: Scan, HandleResults,
+// then every threshold/drift enforcement securityScan performs for the
+// single-context path. It's factored out so fleetScan (cmd/scan/fleetscan.go)
+// can run the exact same per-cluster behavior once per requested context,
+// instead of a parallel, divergent copy of this logic.
+func runSecurityScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 	if err != nil {
 		return err
 	}
 
-	if err = results.HandleResults(ctx, &scanInfo); err != nil {
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
 		return err
 	}
 
-	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, &scanInfo); err != nil {
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
 		return err
 	}
 	if scanInfo.ScanImages {
-		if err := enforceImageSeverityThresholds(results.ImageScanData, &scanInfo); err != nil {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
 			return err
 		}
 	}
-	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), &scanInfo); err != nil {
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
 		return err
 	}
-	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, &scanInfo); err != nil {
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
 		return err
 	}
 
-	return enforceBaselineDrift(ctx, results, &scanInfo)
+	return enforceBaselineDrift(ctx, results, scanInfo)
 }
 
 func enforceBaselineDrift(ctx context.Context, results *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo) error {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -93,6 +93,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			if err := validateKubeContextsSupported(cmd, &scanInfo); err != nil {
+				return err
+			}
 			captureKubeconfigSelection(cmd, &scanInfo)
 			applyRegistryCredentialsFromEnv(cmd, &scanInfo)
 			return nil

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -516,6 +516,56 @@ func TestGetScanCommand_PersistentFlagValidation(t *testing.T) {
 	}
 }
 
+// TestGetScanCommand_KubeContextsRejectedWhereUnsupported is a regression
+// test for a real review finding on #3438: --kube-contexts is registered on
+// scanCmd's persistent flags, so every subcommand and --view inherits it,
+// but only the default security view's securityScan actually calls
+// fleetScan. Before this fix, every other combination silently accepted
+// the flag and scanned only one context - the same silently-wrong-cluster
+// failure mode #3217/#3218 closed for sequential scans, recurring as "the
+// flag had no effect."
+func TestGetScanCommand_KubeContextsRejectedWhereUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan image", args: []string{"image", "nginx:latest", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan --view=resource", args: []string{"--view=resource", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan --view=control", args: []string{"--view=control", "--kube-contexts=ctx-a,ctx-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &scanCallCounter{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			require.ErrorContains(t, err, "--kube-contexts is not yet supported")
+			assert.Equal(t, 0, ks.calls, "scan must not run when --kube-contexts is rejected up front")
+		})
+	}
+}
+
+func TestGetScanCommand_KubeContextsAcceptedForDefaultSecurityView(t *testing.T) {
+	ks := &scanCallCounter{}
+	cmd := GetScanCommand(ks)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--kube-contexts=ctx-a,ctx-b", "--output=report.json"})
+
+	err := cmd.Execute()
+
+	// Reaches fleetScan (which then reaches ScanContext once per context via
+	// the scanCallCounter mock) rather than being rejected by the guard -
+	// the guard's error text must not appear here.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "is not yet supported")
+}
+
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -202,6 +202,7 @@ type ScanInfo struct {
 	BaselineFailOnNew         bool              // Exit with code 1 when the baseline diff finds new or incomparable failures
 	BaselineSeverityThreshold string            // Only count new/incomparable baseline failures at or above this severity when enforcing BaselineFailOnNew
 	BaselineGranularity       string            // Comparison unit for the baseline diff: "evidence" (default) or "control"
+	KubeContexts              []string          // --kube-contexts: scan each of these kube contexts sequentially, one report per context (fleet mode)
 }
 
 type Getters struct {
@@ -466,6 +467,31 @@ func (scanInfo *ScanInfo) SetKubeconfigSelection(path, contextName string) {
 	scanInfo.kubeContextOverride = contextName
 	scanInfo.clusterContextName = ""
 	scanInfo.contextResolved = false
+}
+
+// CloneForContext returns a copy of scanInfo prepared for scanning one kube
+// context as part of a multi-context ("fleet") scan, reusing the same
+// kubeconfig file the parent ScanInfo was configured with (fleet mode
+// switches context within one kubeconfig, not the file itself) but
+// targeting kubeContext. Every field is copied verbatim except the three
+// that must not be shared across sibling scans sharing one parent ScanInfo:
+//   - ScanID: cleared, so Init generates a fresh one for this context instead
+//     of reusing whichever sibling happened to run first.
+//   - cleanups: dropped, so this context's Cleanup() doesn't re-invoke
+//     closures another sibling already ran (or hasn't registered yet).
+//   - Output: replaced with the caller-supplied path (fleet mode gives each
+//     context its own report file; see cmd/scan/fleetscan.go).
+//
+// SetKubeconfigSelection also resets clusterContextName/contextResolved so
+// each clone re-resolves its own context rather than inheriting the
+// parent's.
+func (scanInfo *ScanInfo) CloneForContext(kubeContext, output string) *ScanInfo {
+	clone := *scanInfo
+	clone.ScanID = ""
+	clone.cleanups = nil
+	clone.Output = output
+	clone.SetKubeconfigSelection(scanInfo.kubeconfigPath, kubeContext)
+	return &clone
 }
 
 // ResolveClusterContextName resolves the context from the same kubeconfig

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -138,6 +138,33 @@ contexts:
 	})
 }
 
+func TestCloneForContext(t *testing.T) {
+	kubeconfig := writeScanInfoMultiContextKubeconfig(t)
+	parent := &ScanInfo{
+		ScanID:  "parent-scan-id",
+		Output:  "report.json",
+		Format:  "json",
+		ScanAll: true,
+	}
+	parent.SetKubeconfigSelection(kubeconfig, "context-current")
+	require.NoError(t, parent.ResolveClusterContextName())
+	require.Equal(t, "context-current", parent.GetClusterContextName())
+	parent.AddCleanup(func() { t.Fatal("parent's cleanup must not run from the clone") })
+
+	clone := parent.CloneForContext("context-selected", "report.context-selected.json")
+
+	assert.Empty(t, clone.ScanID, "ScanID must be cleared so Init generates a fresh one per context")
+	assert.Equal(t, "report.context-selected.json", clone.Output)
+	assert.Equal(t, "json", clone.Format, "unrelated fields must be copied verbatim")
+	assert.True(t, clone.ScanAll)
+
+	require.NoError(t, clone.ResolveClusterContextName())
+	assert.Equal(t, "context-selected", clone.GetClusterContextName(), "clone must resolve its own context, not inherit the parent's")
+	assert.Equal(t, "context-current", parent.GetClusterContextName(), "cloning must not mutate the parent's already-resolved context")
+
+	clone.Cleanup() // must not panic or invoke the parent's registered cleanup
+}
+
 func TestResolveClusterContextNameUsesDefaultLoadingRulesForOverride(t *testing.T) {
 	defaultPath := writeScanInfoMultiContextKubeconfig(t)
 	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, defaultPath)


### PR DESCRIPTION
## Summary

`kubescape scan` can only target one cluster per invocation. This wires up sequential multi-cluster scanning via a new `--kube-contexts` flag, using the isolation primitive #3217/#3218 already built and proved but never actually called from production code.

Builds on `ks.ScanContext`/`deriveTimeoutContext` from #3432 (#3237), now merged into `master` — this PR is rebased cleanly on top of it and #3422/#3419 (also since merged), so the diff below is just the fleet-scan change.

**Edit:** this PR briefly showed a merge conflict against `master` — it was originally stacked on my then-unmerged `fix-scan-context-3237` branch, and by the time #3432 (and two unrelated PRs, #3419/#3422) merged, `master` and my branch had diverged on `cmd/scan/scan.go`. Fixed by cherry-picking just the fleet-scan commit onto current `master` and force-pushing; verified clean (`mergeable: MERGEABLE`) and re-ran the full test suite plus the real dual-cluster check below against the rebased commit.

## Why this is safe to build now

#3217 ("Sequential multi-cluster scanning in one process silently reports the wrong cluster") found that looping scans over kube contexts in one process silently kept talking to the first cluster, because `k8sinterface`'s REST-config and API-discovery caches aren't invalidated by just updating the context name. #3218 fixed the root cause and added `cautils.EnterClusterContext(targetContext)`, verified against two real `kind` clusters in `TestEnterClusterContext_TwoRealClusters` (opt-in, `KUBESCAPE_INTEGRATION_KIND=1`).

**`EnterClusterContext` was never called anywhere outside its own tests.** That's the gap #3437 (this PR) closes.

I looked for a `proposals/multi-cluster-fleet-posture-aggregation.md` design doc referenced in #3217's body as the reason a fleet-scan implementation was blocked — it was never actually added to the repo (checked full git history). So there's no existing design to defer to; #3437/this PR proposes and implements a bounded v1.

## What changed

- **`core/cautils/scaninfo.go`**: `ScanInfo.KubeContexts []string` (the new flag's target) and `CloneForContext(kubeContext, output string) *ScanInfo` — copies a `ScanInfo` for one context in a fleet, clearing `ScanID` and `cleanups` (both must not be shared across sibling scans: `ScanID` is only generated once-if-empty by `Init`, and `cleanups` accumulates closures across the parent's lifetime) and resolving the given context/output via `SetKubeconfigSelection`.
- **`cmd/scan/scan.go`**: new `--kube-contexts` flag. `securityScan` now checks `len(scanInfo.KubeContexts) > 0` and delegates to `fleetScan`; the existing single-context body is factored out unchanged into `runSecurityScan(ctx, scanInfo, ks, policyIdentifiers)` so both paths run identical per-cluster behavior (Scan, HandleResults, every threshold enforcement) instead of a parallel, divergent copy.
- **`cmd/scan/fleetscan.go`** (new): `fleetScan` validates fleet mode requires a live-cluster scan and `--output`, then loops contexts sequentially — `EnterClusterContext(ctx)` → `runSecurityScan` on a per-context clone → `leave()` — continuing past a failing context and aggregating failures into one error naming every context that failed. `perContextOutputPath` derives each context's report path (`report.json` + `kind-fleet-test-a` → `report.kind-fleet-test-a.json`), sanitizing path separators out of context names.

Sequential only, deliberately: `k8sinterface`'s connection-state globals (`K8SConfig`, `clientConfigAPI`, `clusterContextName`) have no locking — confirmed for real via `-race` while working on #3237/#3432 — so concurrent contexts would race regardless of `EnterClusterContext`, which only makes *sequential* switches safe.

## Test plan

### Unit tests
- `core/cautils/scaninfo_test.go`: `TestCloneForContext` — clears `ScanID`, copies unrelated fields verbatim, resolves the clone's own context independently of the parent, doesn't invoke the parent's cleanup.
- `cmd/scan/fleetscan_test.go`: `TestPerContextOutputPath` (path derivation incl. sanitizing `/` in context names), `TestFleetScan_RequiresClusterScanningContext`, `TestFleetScan_RequiresOutput`, `TestFleetScan_ScansEveryContextAndDerivesDistinctOutputPaths`, `TestFleetScan_ContinuesPastFailingContextAndReportsIt`, `TestFleetScan_EachContextGetsAFreshScanID`.

### Real dual-cluster verification (not just mocks)

Started Docker and reused the `fleet-test-a`/`fleet-test-b` `kind` clusters already set up for #3218's integration test (each with its own CRD). First ran the existing, previously-unexercised-in-CI integration test to confirm the underlying primitive itself is still correct:

```
KUBESCAPE_INTEGRATION_KIND=1 go test -v -run TestEnterClusterContext_TwoRealClusters ./core/cautils/...
--- PASS: TestEnterClusterContext_TwoRealClusters (0.04s)
```

Then built the actual binary and ran a real fleet scan against both live clusters with a local offline policy bundle (no cloud/GitHub dependency, so the run is fast and deterministic):

```
./kubescape scan \
  --use-from clusterscan.json,mitre.json,nsa.json \
  --controls-config controls-inputs.json --exceptions exceptions.json \
  --kube-contexts kind-fleet-test-a,kind-fleet-test-b \
  --output fleet-report.json --format json
```

Exit code 0. Two distinct report files were written, and each one's own metadata confirms it came from the right cluster — no cross-talk:

```json
// fleet-report.kind-fleet-test-a.json
"targetMetadata": { "clusterContextMetadata": { "contextName": "kind-fleet-test-a", ... } }

// fleet-report.kind-fleet-test-b.json
"targetMetadata": { "clusterContextMetadata": { "contextName": "kind-fleet-test-b", ... } }
```

The scan log also shows each context independently probing its own cluster (host-sensor/node-agent CRD detection ran once per context, each against that context's live API server) rather than any state leaking from the first context into the second.

### Full suite
- `go build ./...`, `go vet ./...` — clean (repo root)
- `go test -race ./core/cautils/... ./cmd/scan/...` — clean
- `go test ./...` — full repo suite, clean
- `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- `gofmt -l` on every changed file — clean

## Scope (v1, per #3437)

Not in this PR:
- A single combined/aggregated report across clusters (no existing merge path across `ResultsHandler`/`OPASessionObj`; a separate, bigger lift if there's demand).
- Concurrent per-cluster scanning.
- Extending `--kube-contexts` to `scan workload` / `scan control` / `scan framework` / `scan image` — same pattern, natural follow-up, kept out to match #3237's precedent of leaving `scan image` for later.

Fixes #3437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-context Kubernetes scanning with the `--kube-contexts` option.
  * Generates separate reports for each configured context.
  * Continues scanning when one context fails and reports an aggregate result.
  * Added custom-rule and path-exclusion options, including support for ignoring repository ignore files.

* **Bug Fixes**
  * Validates supported scan modes, views, required cluster-scanning context, and output configuration.
  * Detects conflicting context output paths before scanning begins.
  * Ensures each context receives an independent scan identifier and isolated settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->