### PR TITLE
feat(scan): extend --kube-contexts fleet mode to framework/control/workload

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -51,9 +52,6 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
-			defer cancel()
-
 			if err := shared.ValidateCommonScanFlags(cmd, scanInfo, shared.ScanFormats); err != nil {
 				return err
 			}
@@ -91,37 +89,52 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
-			}
-			if err := results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-			if !scanInfo.VerboseMode {
-				logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
-			}
-			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
-			}
-			if err := enforceSeverityThresholds(&results.GetResults().SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runControlScan)
 			}
 
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
+			return runControlScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
+}
+
+// runControlScan runs one cluster's control scan to completion: Scan,
+// HandleResults, then every threshold/drift enforcement the control command
+// performs for the single-context path. Factored out so fleetScan can run
+// the exact same per-cluster behavior once per --kube-contexts entry,
+// instead of a parallel, divergent copy of this logic.
+func runControlScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+	if err := results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+	if !scanInfo.VerboseMode {
+		logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
+	}
+	if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
+		return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
+	}
+	if err := enforceSeverityThresholds(&results.GetResults().SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+
+	return enforceBaselineDrift(ctx, results, scanInfo)
 }
 
 // validateControlScanInfo validates the ScanInfo struct for the `control` command

--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -22,10 +23,11 @@ import (
 // --kube-contexts is registered on scanCmd's persistent flags, so cobra
 // inherits it onto every subcommand (control/framework/workload/image) and
 // it's accepted by --view=resource|control too, but only the default
-// security view's securityScan currently calls fleetScan. cmd here is the
-// actual leaf command being invoked (cobra passes the target command to an
-// inherited PersistentPreRunE, not the command it's defined on), so
-// cmd.Name() reliably reports which one that is.
+// security view's securityScan, plus the framework/control/workload
+// subcommands, currently call fleetScan. cmd here is the actual leaf
+// command being invoked (cobra passes the target command to an inherited
+// PersistentPreRunE, not the command it's defined on), so cmd.Name()
+// reliably reports which one that is.
 func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInfo) error {
 	if len(scanInfo.KubeContexts) == 0 {
 		return nil
@@ -35,15 +37,29 @@ func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInf
 		if scanInfo.View != string(cautils.SecurityViewType) {
 			return fmt.Errorf("--kube-contexts is not yet supported with --view=%s; only the default security view (no --view, or --view=%s) supports scanning multiple contexts in one run", scanInfo.View, cautils.SecurityViewType)
 		}
+	case "framework", "control", "workload":
+		// These subcommands wire --kube-contexts through to fleetScan
+		// themselves; nothing more to reject here.
 	default:
-		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'; only the default 'scan' command (security view) supports scanning multiple contexts in one run", cmd.Name())
+		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'; only the default 'scan' command (security view), 'scan framework', 'scan control', and 'scan workload' support scanning multiple contexts in one run", cmd.Name())
 	}
 	return nil
 }
 
-// fleetScan runs securityScan's per-cluster behavior once for every context
-// in baseScanInfo.KubeContexts, sequentially, writing one report per
-// context. It's the --kube-contexts entry point invoked from securityScan.
+// fleetRunner runs one cluster's scan to completion for a specific scan
+// subcommand - Scan/ScanContext, HandleResults, and every threshold/drift
+// enforcement that subcommand's non-fleet RunE performs - exactly as if
+// scanInfo.KubeContexts had never been set. securityScan, the framework
+// command, the control command, and the workload command each pass their
+// own such function (runSecurityScan, runFrameworkScan, runControlScan,
+// runWorkloadScan) to fleetScan so every --kube-contexts-aware subcommand
+// runs the exact per-cluster behavior its single-context path always ran,
+// instead of a parallel, divergent copy of that logic.
+type fleetRunner func(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error
+
+// fleetScan runs run once for every context in baseScanInfo.KubeContexts,
+// sequentially, writing one report per context. It's the --kube-contexts
+// entry point shared by every scan subcommand that supports fleet mode.
 //
 // Contexts are scanned one at a time, not concurrently: k8sinterface's
 // process-global connection state (K8SConfig, clientConfigAPI,
@@ -59,7 +75,7 @@ func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInf
 // error - and therefore its exit code - reflects whether any context
 // failed, matching the single-context command's existing all-or-nothing
 // exit-code semantics from the caller's point of view.
-func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier, run fleetRunner) error {
 	if baseScanInfo.GetScanningContext() != cautils.ContextCluster {
 		return fmt.Errorf("--kube-contexts requires a live-cluster scan: it selects which cluster to connect to, so it can't be combined with scanning local files/directories")
 	}
@@ -82,7 +98,7 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 
 		leave := cautils.EnterClusterContext(kubeContext)
 		ctx, cancel := deriveTimeoutContext(contextScanInfo, ks)
-		err = runSecurityScan(ctx, contextScanInfo, ks, policyIdentifiers)
+		err = run(ctx, contextScanInfo, ks, policyIdentifiers)
 		cancel()
 		leave()
 

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -95,6 +95,24 @@ func TestFleetScan_RejectsCollidingContextsBeforeScanningAny(t *testing.T) {
 	assert.Empty(t, ks.callsOutputs, "no context should be scanned once a collision is detected up front")
 }
 
+// TestValidateKubeContextsSupported_FrameworkControlWorkloadAllowed guards
+// against a real regression this PR's own dispatch tests can't catch: they
+// all call cmd.RunE directly, bypassing scanCmd's PersistentPreRunE, which
+// is where validateKubeContextsSupported actually runs against a real CLI
+// invocation. Before framework/control/workload were added to its switch,
+// validateKubeContextsSupported's default case rejected --kube-contexts for
+// exactly the three subcommands this PR exists to support, breaking the
+// feature end to end despite every dispatch test passing.
+func TestValidateKubeContextsSupported_FrameworkControlWorkloadAllowed(t *testing.T) {
+	for _, name := range []string{"framework", "control", "workload"} {
+		cmd := &cobra.Command{Use: name}
+		scanInfo := &cautils.ScanInfo{KubeContexts: []string{"ctx-a"}}
+		if err := validateKubeContextsSupported(cmd, scanInfo); err != nil {
+			t.Errorf("cmd.Name()=%q: validateKubeContextsSupported returned error, want nil: %v", name, err)
+		}
+	}
+}
+
 func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
 	scanInfo := cautils.ScanInfo{
 		KubeContexts:  []string{"ctx-a"},

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/meta"
 	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +41,16 @@ func TestPerContextOutputPath(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// scanContextOnlyRunner is a minimal fleetRunner used by tests that exercise
+// fleetScan's own loop/validation behavior in isolation, without pulling in
+// runSecurityScan/runFrameworkScan/runControlScan/runWorkloadScan's
+// threshold-enforcement logic (covered separately by each command's own
+// tests).
+func scanContextOnlyRunner(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	_, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	return err
 }
 
 // TestPerContextOutputPaths_RejectsCollidingContexts is a regression test
@@ -76,7 +88,7 @@ func TestFleetScan_RejectsCollidingContextsBeforeScanningAny(t *testing.T) {
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, scanContextOnlyRunner)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "colliding")
@@ -90,7 +102,7 @@ func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
 		InputPatterns: []string{"."}, // makes GetScanningContext() resolve to a non-cluster context
 	}
 
-	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil, scanContextOnlyRunner)
 	require.ErrorContains(t, err, "live-cluster scan")
 }
 
@@ -99,7 +111,7 @@ func TestFleetScan_RequiresOutput(t *testing.T) {
 		KubeContexts: []string{"ctx-a"},
 	}
 
-	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil, scanContextOnlyRunner)
 	require.ErrorContains(t, err, "--output")
 }
 
@@ -134,7 +146,7 @@ func TestFleetScan_ScansEveryContextAndDerivesDistinctOutputPaths(t *testing.T) 
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, scanContextOnlyRunner)
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
@@ -152,7 +164,7 @@ func TestFleetScan_ContinuesPastFailingContextAndReportsIt(t *testing.T) {
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, scanContextOnlyRunner)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "1 of 3 context(s) failed")
@@ -174,7 +186,7 @@ func TestFleetScan_EachContextGetsAFreshScanID(t *testing.T) {
 	}
 	scanInfo.ScanID = "should-not-be-reused"
 
-	require.NoError(t, fleetScan(scanInfo, ks, nil))
+	require.NoError(t, fleetScan(scanInfo, ks, nil, scanContextOnlyRunner))
 
 	require.Len(t, scanIDs, 2)
 	assert.NotEqual(t, "should-not-be-reused", scanIDs[0])
@@ -200,4 +212,54 @@ func (m *fleetIDTrackingKubescape) ScanContext(_ context.Context, scanInfo *caut
 	results := resultshandling.NewResultsHandler(nil, nil, &fakePrinter{})
 	results.SetData(cautils.NewOPASessionObjMock())
 	return results, nil
+}
+
+// TestGetFrameworkCmd_KubeContextsDispatchesToFleetScan, TestGetControlCmd_*,
+// and TestGetWorkloadCmd_* below exercise each command's real RunE end to
+// end with --kube-contexts set, proving the dispatch added alongside
+// runFrameworkScan/runControlScan/runWorkloadScan actually reaches
+// fleetScan and scans every requested context - not just that fleetScan
+// itself works in isolation (covered above) or that the single-context path
+// still works (covered by each command's own pre-existing tests).
+
+func TestGetFrameworkCmd_KubeContextsDispatchesToFleetScan(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b"},
+		Output:       "report.json",
+	}
+
+	cmd := getFrameworkCmd(ks, &scanInfo)
+	err := cmd.RunE(&cobra.Command{}, []string{"nsa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json"}, ks.callsOutputs)
+}
+
+func TestGetControlCmd_KubeContextsDispatchesToFleetScan(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b"},
+		Output:       "report.json",
+	}
+
+	cmd := getControlCmd(ks, &scanInfo)
+	err := cmd.RunE(&cobra.Command{}, []string{"C-0058"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json"}, ks.callsOutputs)
+}
+
+func TestGetWorkloadCmd_KubeContextsDispatchesToFleetScan(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b"},
+		Output:       "report.json",
+	}
+
+	cmd := getWorkloadCmd(ks, &scanInfo)
+	err := cmd.RunE(&cobra.Command{}, []string{"Deployment/nginx"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json"}, ks.callsOutputs)
 }

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -65,9 +66,6 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
-			defer cancel()
-
 			if err := shared.ValidateCommonScanFlags(cmd, scanInfo, shared.ScanFormats); err != nil {
 				return err
 			}
@@ -110,37 +108,52 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 			policyIdentifiers := cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runFrameworkScan)
 			}
 
-			if err = results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-
-			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
-			}
-
-			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
-			}
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
+			return runFrameworkScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
 
+}
+
+// runFrameworkScan runs one cluster's framework scan to completion: Scan,
+// HandleResults, then every threshold/drift enforcement the framework
+// command performs for the single-context path. Factored out so fleetScan
+// can run the exact same per-cluster behavior once per --kube-contexts
+// entry, instead of a parallel, divergent copy of this logic.
+func runFrameworkScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+
+	if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
+		return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
+	}
+
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+	return enforceBaselineDrift(ctx, results, scanInfo)
 }
 
 // countersExceedSeverityThreshold returns true if a failed control has severity

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -382,7 +382,7 @@ func deriveTimeoutContext(scanInfo *cautils.ScanInfo, ks meta.IKubescape) (conte
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
 	if len(scanInfo.KubeContexts) > 0 {
-		return fleetScan(scanInfo, ks, policyIdentifiers)
+		return fleetScan(scanInfo, ks, policyIdentifiers, runSecurityScan)
 	}
 
 	ctx, cancel := deriveTimeoutContext(&scanInfo, ks)

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -534,19 +534,20 @@ func TestGetScanCommand_PersistentFlagValidation(t *testing.T) {
 // TestGetScanCommand_KubeContextsRejectedWhereUnsupported is a regression
 // test for a real review finding on #3438: --kube-contexts is registered on
 // scanCmd's persistent flags, so every subcommand and --view inherits it,
-// but only the default security view's securityScan actually calls
-// fleetScan. Before this fix, every other combination silently accepted
-// the flag and scanned only one context - the same silently-wrong-cluster
-// failure mode #3217/#3218 closed for sequential scans, recurring as "the
-// flag had no effect."
+// but only the default security view's securityScan (and, since #3439, the
+// framework/control/workload subcommands) actually call fleetScan. Before
+// this fix, every other combination silently accepted the flag and scanned
+// only one context - the same silently-wrong-cluster failure mode
+// #3217/#3218 closed for sequential scans, recurring as "the flag had no
+// effect." scan image and the resource/control views remain genuinely
+// unsupported; framework/control/workload moved to
+// TestGetScanCommand_KubeContextsAcceptedForFrameworkControlWorkload below
+// once #3439 added real fleet support for them.
 func TestGetScanCommand_KubeContextsRejectedWhereUnsupported(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
 	}{
-		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b"}},
-		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b"}},
-		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan image", args: []string{"image", "nginx:latest", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan --view=resource", args: []string{"--view=resource", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan --view=control", args: []string{"--view=control", "--kube-contexts=ctx-a,ctx-b"}},
@@ -579,6 +580,41 @@ func TestGetScanCommand_KubeContextsAcceptedForDefaultSecurityView(t *testing.T)
 	// the guard's error text must not appear here.
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "is not yet supported")
+}
+
+// TestGetScanCommand_KubeContextsAcceptedForFrameworkControlWorkload proves,
+// through the real CLI entrypoint (GetScanCommand -> cmd.Execute, which
+// exercises scanCmd's PersistentPreRunE and therefore
+// validateKubeContextsSupported for real), that framework/control/workload
+// now reach fleetScan instead of being rejected. The dispatch tests in
+// fleetscan_test.go call each subcommand's RunE directly and so never
+// exercise PersistentPreRunE at all - they would keep passing even if
+// validateKubeContextsSupported still rejected these three subcommands,
+// which is exactly what happened before "framework", "control", "workload"
+// were added to its switch.
+func TestGetScanCommand_KubeContextsAcceptedForFrameworkControlWorkload(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &scanCallCounter{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "is not yet supported")
+			assert.Equal(t, 2, ks.calls, "ScanContext should be reached once per requested context")
+		})
+	}
 }
 
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -66,9 +67,6 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			return validateWorkloadArgs(args, scanInfo)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
-			defer cancel()
-
 			if err := validateWorkloadArgs(args, scanInfo); err != nil {
 				return err
 			}
@@ -105,35 +103,13 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runWorkloadScan)
 			}
 
-			if err = results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-
-			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
-			}
-
-			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
-			}
-
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
+			return runWorkloadScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
 
@@ -143,6 +119,43 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 	workloadCmd.PersistentFlags().StringVar(&apiVersion, "api-version", "", "API version of the workload (e.g. apps/v1). Default will be empty.")
 
 	return workloadCmd
+}
+
+// runWorkloadScan runs one cluster's workload scan to completion: Scan,
+// HandleResults, then every threshold/drift enforcement the workload
+// command performs for the single-context path. Factored out so fleetScan
+// can run the exact same per-cluster behavior once per --kube-contexts
+// entry, instead of a parallel, divergent copy of this logic.
+func runWorkloadScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+
+	if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
+		return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
+	}
+
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+
+	return enforceBaselineDrift(ctx, results, scanInfo)
 }
 
 func validateWorkloadArgs(args []string, scanInfo *cautils.ScanInfo) error {


### PR DESCRIPTION
## Summary

Extends `--kube-contexts` fleet mode (#3437/#3438) to `scan framework`, `scan control`, and `scan workload` — explicitly called out as a follow-up in #3438's "Scope (v1)" section to keep that PR bounded.

**Depends on #3438** (not yet merged): this branch is stacked on `feat-fleet-scan-3437` because it extends `fleetScan`/`CloneForContext`/`EnterClusterContext` wiring that PR adds. I'll rebase onto `master` once #3438 merges — same recovery #3438 itself needed after #3432 merged (a real merge conflict showed up there from stacking on an in-flight PR; documented in that PR's history for anyone hitting the same thing).

## What changed

- **`cmd/scan/fleetscan.go`**: `fleetScan` now takes a `fleetRunner` callback parameter instead of being hardcoded to call `runSecurityScan`. `fleetRunner` is the same shape `runSecurityScan` already had: `func(ctx, scanInfo, ks, policyIdentifiers) error`.
- **`cmd/scan/framework.go`**: extracted `runFrameworkScan` (Scan, HandleResults, compliance-score/severity/coverage/policy-degradation/baseline-drift enforcement — unchanged logic, just factored out of `RunE`); `RunE` now checks `len(scanInfo.KubeContexts) > 0` and dispatches to `fleetScan(*scanInfo, ks, policyIdentifiers, runFrameworkScan)`.
- **`cmd/scan/control.go`**: same pattern, `runControlScan`.
- **`cmd/scan/workload.go`**: same pattern, `runWorkloadScan`.
- **`cmd/scan/scan.go`**: updated its own `fleetScan(...)` call site to pass `runSecurityScan` explicitly now that the parameter exists.

No new flag: `--kube-contexts` is a `PersistentFlags()` entry on the parent `scan` command, already inherited by these subcommands.

`scan image` is still excluded — `ScanImage` has no `ScanContext`-style explicit-context entry point yet, same reason #3438 left it out.

## Test plan

### Unit tests
New: `TestGetFrameworkCmd_KubeContextsDispatchesToFleetScan`, `TestGetControlCmd_KubeContextsDispatchesToFleetScan`, `TestGetWorkloadCmd_KubeContextsDispatchesToFleetScan` (`cmd/scan/fleetscan_test.go`) — each calls the real `cobra.Command.RunE` with `--kube-contexts`-equivalent `ScanInfo` state and a tracking mock, confirming the dispatch actually reaches `fleetScan` and scans every requested context (not just that `fleetScan` works in isolation, already covered) and that the single-context path is unaffected (existing `framework_test.go`/`control_test.go`/`workload_test.go` all still pass unmodified, since the extracted runners are byte-for-byte the same logic that used to sit inline in `RunE`).

### Real dual-cluster verification
Reused the `fleet-test-a`/`fleet-test-b` `kind` clusters from #3438. Built the actual binary and ran:

```
./kubescape scan framework clusterscan \
  --use-from clusterscan.json --controls-config ... --exceptions ... \
  --kube-contexts kind-fleet-test-a,kind-fleet-test-b \
  --output framework-fleet-report.json --format json
```
Exit 0. Two files, each correctly labeled (`targetMetadata.clusterContextMetadata.contextName` = `kind-fleet-test-a` / `kind-fleet-test-b` respectively).

```
./kubescape scan control C-0057 \
  --controls-config ... --exceptions ... \
  --kube-contexts kind-fleet-test-a,kind-fleet-test-b \
  --output control-fleet-report.json --format json
```
This one used a **real built-in control** (C-0057, from the actual regolibrary — no local override), not a synthetic fixture. Exit 0, two correctly-labeled output files.

### Full suite
- `go build ./...`, `go vet ./...` — clean
- `go test -race ./core/cautils/... ./cmd/scan/...` — clean
- `go test ./...` — full repo suite, clean
- `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- `gofmt -l` on every changed file — clean

## Scope

Not in this PR (per #3439): `scan image` (blocked on `ScanImage` needing its own explicit-context entry point first — a separate, larger change), and everything else #3438 already scoped out (combined/aggregated fleet report, concurrent per-cluster scanning).

Fixes #3439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-context Kubernetes scanning for framework, control, workload, and security scans.
  * Added support for scanning each requested context with aggregated results and continued execution after individual failures.
  * Preserved scan thresholds, coverage checks, policy degradation checks, and baseline-drift enforcement across single- and multi-context scans.

* **Bug Fixes**
  * Improved validation and output handling for multi-context scans, including unique scan identifiers and context-specific output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->