### PR TITLE
core: add ScanImageContext, closing the last explicit-context gap from #3237

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -45,7 +45,8 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			defer applyTimeout(scanInfo, ks)()
+			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
+			defer cancel()
 
 			if len(args) != 1 {
 				return fmt.Errorf("the command takes exactly one image name as an argument")
@@ -85,7 +86,7 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				UseDefaultMatchers: scanInfo.UseDefaultMatchers,
 			}
 
-			exceedsSeverityThreshold, err := ks.ScanImage(imgScanInfo, scanInfo)
+			exceedsSeverityThreshold, err := ks.ScanImageContext(ctx, imgScanInfo, scanInfo)
 			if err != nil {
 				return err
 			}

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -1,10 +1,12 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubescape/v4/cmd/shared"
 	"github.com/kubescape/kubescape/v4/core/cautils"
@@ -17,14 +19,25 @@ import (
 
 type imageScanCaptureKubescape struct {
 	mocks.MockIKubescape
-	imgScanInfo *metav1.ImageScanInfo
-	scanInfo    *cautils.ScanInfo
+	imgScanInfo      *metav1.ImageScanInfo
+	scanInfo         *cautils.ScanInfo
+	scanCalledWith   context.Context
+	setContextCalled bool
+}
+
+func (m *imageScanCaptureKubescape) SetContext(_ context.Context) {
+	m.setContextCalled = true
 }
 
 func (m *imageScanCaptureKubescape) ScanImage(imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
 	m.imgScanInfo = imgScanInfo
 	m.scanInfo = scanInfo
 	return false, nil
+}
+
+func (m *imageScanCaptureKubescape) ScanImageContext(ctx context.Context, imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
+	m.scanCalledWith = ctx
+	return m.ScanImage(imgScanInfo, scanInfo)
 }
 
 func TestGetImageCmd(t *testing.T) {
@@ -111,6 +124,44 @@ func TestGetImageCmd_RunE_Success(t *testing.T) {
 
 	err := cmd.RunE(cmd, []string{"nginx"})
 	assert.NoError(t, err)
+}
+
+// TestGetImageCmd_RunE_TimeoutDeadlineActiveForScan and
+// TestGetImageCmd_RunE_TimeoutDoesNotMutateSharedContext are regression tests
+// mirroring securityScan's own #3237 coverage (TestSecurityScan_
+// TimeoutDeadlineActiveForScan / TestSecurityScan_TimeoutDoesNotMutateShared
+// Context): now that `scan image` uses ScanImageContext instead of the old
+// applyTimeout(scanInfo, ks)()+ScanImage() pattern, --scan-timeout must still
+// produce a deadline context, and the shared *Kubescape's own context must
+// never be mutated via SetContext to get it there.
+func TestGetImageCmd_RunE_TimeoutDeadlineActiveForScan(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	require.NoError(t, cmd.RunE(cmd, []string{"nginx"}))
+
+	require.NotNil(t, mockKubescape.scanCalledWith)
+	_, hasDeadline := mockKubescape.scanCalledWith.Deadline()
+	assert.True(t, hasDeadline, "ScanImageContext must receive a context with a deadline when --scan-timeout is set")
+}
+
+func TestGetImageCmd_RunE_TimeoutDoesNotMutateSharedContext(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{ScanTimeout: time.Minute}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	require.NoError(t, cmd.RunE(cmd, []string{"nginx"}))
+
+	assert.False(t, mockKubescape.setContextCalled, "scan image must not call SetContext on the shared Kubescape instance")
 }
 
 func TestGetImageCmd_RunE_ForwardsRegistryTokenCredentials(t *testing.T) {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -318,37 +318,15 @@ func setSecurityViewScanInfo(args []string, scanInfo *cautils.ScanInfo) []cautil
 // deriveTimeoutContext returns a context bound to ks.Context() with a
 // deadline of scanInfo.ScanTimeout, when that's > 0, and a cancel func the
 // caller must defer. When ScanTimeout <= 0 it returns ks.Context() unchanged
-// and a no-op cancel. Unlike the applyTimeout helper this replaces, it does
-// not call ks.SetContext: the derived context is threaded explicitly through
-// ScanContext/HandleResults/enforceBaselineDrift instead of being stashed on
-// the shared ks, so it can't be observed or clobbered by another operation
-// sharing the same *Kubescape instance.
+// and a no-op cancel. It never calls ks.SetContext: the derived context is
+// threaded explicitly through ScanContext/HandleResults/enforceBaselineDrift
+// instead of being stashed on the shared ks, so it can't be observed or
+// clobbered by another operation sharing the same *Kubescape instance.
 func deriveTimeoutContext(scanInfo *cautils.ScanInfo, ks meta.IKubescape) (context.Context, func()) {
 	if scanInfo.ScanTimeout <= 0 {
 		return ks.Context(), func() {}
 	}
 	return context.WithTimeout(ks.Context(), scanInfo.ScanTimeout)
-}
-
-// applyTimeout wraps ks with a deadline context when ScanTimeout > 0 and
-// returns a cleanup function that cancels the context and restores the
-// original. Only ks.ScanImage still needs this: unlike ScanContext, it has
-// no explicit-context entry point yet, so it can only observe a deadline via
-// ks.Context()/ks.SetContext() mutation. Prefer deriveTimeoutContext for any
-// path that can pass a context explicitly.
-//
-//	defer applyTimeout(scanInfo, ks)()
-func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
-	if scanInfo.ScanTimeout <= 0 {
-		return func() {}
-	}
-	originalCtx := ks.Context()
-	timeoutCtx, cancel := context.WithTimeout(originalCtx, scanInfo.ScanTimeout)
-	ks.SetContext(timeoutCtx)
-	return func() {
-		cancel()
-		ks.SetContext(originalCtx)
-	}
 }
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -53,6 +53,9 @@ func (s *stubKubescape) Patch(*metav1.PatchInfo, *cautils.ScanInfo) (bool, error
 func (s *stubKubescape) ScanImage(*metav1.ImageScanInfo, *cautils.ScanInfo) (bool, error) {
 	return false, nil
 }
+func (s *stubKubescape) ScanImageContext(context.Context, *metav1.ImageScanInfo, *cautils.ScanInfo) (bool, error) {
+	return false, nil
+}
 
 var _ meta.IKubescape = (*stubKubescape)(nil)
 

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -356,7 +356,24 @@ func scanWithRegistryMapping(
 	return nil, lastErr
 }
 
+// ScanImage scans imgScanInfo.Image using ks.Context() as the operation's
+// context. It is a compatibility wrapper around ScanImageContext for callers
+// that have not migrated to passing their own context explicitly; see
+// ScanImageContext's documentation for why that matters when a *Kubescape
+// instance is reused or scan operations can overlap.
 func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
+	return ks.ScanImageContext(ks.Context(), imgScanInfo, scanInfo)
+}
+
+// ScanImageContext scans imgScanInfo.Image bound to the given ctx for its
+// complete execution, rather than re-reading ks.Context() at each stage as
+// ScanImage's predecessor did (matching Kubescape.Scan's own ScanContext
+// migration, #3237). Callers that need a deadline or cancellation should
+// derive ctx themselves and pass it in directly, instead of calling
+// ks.SetContext beforehand: mutating the shared *Kubescape's context is not
+// safe if the instance is reused or another operation could run
+// concurrently against it.
+func (ks *Kubescape) ScanImageContext(ctx context.Context, imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
 	logger.L().Start(fmt.Sprintf("Scanning image %s...", imgScanInfo.Image))
 
 	distCfg, installCfg, shouldUpdate, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL, scanInfo.SkipDBUpdate)
@@ -391,7 +408,7 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 	}
 
 	imageScanData, err := scanWithRegistryMapping(
-		ks.Context(), svc, imgScanInfo.Image, []imagescan.RegistryCredentials{creds},
+		ctx, svc, imgScanInfo.Image, []imagescan.RegistryCredentials{creds},
 		scanInfo.RegistryMapping, vulnerabilityExceptions, severityExceptions, imgScanInfo.Platform,
 	)
 	if err != nil {
@@ -403,18 +420,18 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 
 	scanInfo.SetScanType(cautils.ScanTypeImage)
 
-	outputPrinters, err := GetOutputPrinters(scanInfo, ks.Context(), "")
+	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, "")
 	if err != nil {
 		return false, err
 	}
 
-	uiPrinter := GetUIPrinter(ks.Context(), scanInfo, "")
+	uiPrinter := GetUIPrinter(ctx, scanInfo, "")
 
 	resultsHandler := resultshandling.NewResultsHandler(nil, outputPrinters, uiPrinter)
 
 	resultsHandler.ImageScanData = []cautils.ImageScanData{*imageScanData}
 
-	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), imageScanData.Matches, scanInfo.OnlyFixable), resultsHandler.HandleResults(ks.Context(), scanInfo)
+	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), imageScanData.Matches, scanInfo.OnlyFixable), resultsHandler.HandleResults(ctx, scanInfo)
 }
 
 // ScanErrorCategory defines distinct vulnerability scan failure categories.

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -40,4 +40,11 @@ type IKubescape interface {
 
 	// scan image
 	ScanImage(imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error)
+
+	// ScanImageContext scans an image bound to ctx for its complete execution,
+	// instead of relying on the receiver's own Context()/SetContext() state. Prefer
+	// this over ScanImage when the caller can hold a *Kubescape across concurrent or
+	// overlapping operations, since ScanImage's context comes from mutable shared
+	// state.
+	ScanImageContext(ctx context.Context, imgScanInfo *metav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error)
 }

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -59,3 +59,7 @@ func (m *MockIKubescape) Patch(_ *metav1.PatchInfo, _ *cautils.ScanInfo) (bool, 
 func (m *MockIKubescape) ScanImage(_ *metav1.ImageScanInfo, _ *cautils.ScanInfo) (bool, error) {
 	return false, nil
 }
+
+func (m *MockIKubescape) ScanImageContext(_ context.Context, _ *metav1.ImageScanInfo, _ *cautils.ScanInfo) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
## Summary

Closes the last explicit-context gap #3237 (merged as #3432) left behind: `ScanImage` still sourced its context from `ks.Context()` at four separate points, and `scan image` still implemented `--scan-timeout` via the old mutate-`ks.Context()`-then-restore pattern (`applyTimeout`), which #3432 removed from every other scan path.

Based on `upstream/master` directly (independent of the still-open #3438/#3440 fleet-scan PRs — this doesn't need anything from them).

## Why

#3432 and #3438 both explicitly called this out as deferred:

> `cmd/scan/image.go` is intentionally untouched: `ScanImage` has no explicit-context entry point yet, so `scan image` still relies on the old `applyTimeout` mutation (kept, now used only there). Migrating it is a larger, separate change

`applyTimeout` had exactly one remaining caller after #3432 migrated the rest of the CLI off it. Filed as #3442 before this PR.

## What changed

- **`core/core/image_scan.go`**: `ScanImage`'s body moves to `ScanImageContext(ctx, imgScanInfo, scanInfo)`, threading one caller-supplied `ctx` through image scanning, output-printer setup, and result handling instead of re-reading `ks.Context()`. `ScanImage` becomes a one-line wrapper: `return ks.ScanImageContext(ks.Context(), imgScanInfo, scanInfo)`.
- **`core/meta/ksinterface.go`**: `IKubescape` gains `ScanImageContext` as an additive method.
- **`core/mocks/cmd_mocks.go`**, **`cmd/update/update_test.go`**: implement the new method on the two hand-written `IKubescape` test doubles.
- **`cmd/scan/image.go`**: `RunE` now uses `deriveTimeoutContext` + `ks.ScanImageContext(ctx, ...)`, matching every other scan subcommand.
- **`cmd/scan/scan.go`**: `applyTimeout` deleted — no remaining callers.
- **`cmd/scan/image_test.go`**: the existing `imageScanCaptureKubescape` test double gains a `ScanImageContext` override (delegating to `ScanImage`, capturing the `ctx` it's called with) so it still exercises the code paths that now call the new method.

## Test plan

New tests (mirroring #3237's own `TestSecurityScan_TimeoutDeadlineActiveForScan` / `TestSecurityScan_TimeoutDoesNotMutateSharedContext` coverage):

```
=== RUN   TestGetImageCmd_RunE_TimeoutDeadlineActiveForScan
--- PASS: TestGetImageCmd_RunE_TimeoutDeadlineActiveForScan (0.00s)
=== RUN   TestGetImageCmd_RunE_TimeoutDoesNotMutateSharedContext
--- PASS: TestGetImageCmd_RunE_TimeoutDoesNotMutateSharedContext (0.00s)
```

All pre-existing `cmd/scan/image_test.go` tests pass unmodified against the new wiring (18 tests, full file).

**Real end-to-end run**, not just mocks — built the actual binary and ran:
```
kubescape scan image alpine:3.19 --scan-timeout=2m
```
Exit 0, real vulnerability data:
```
14 vulnerabilities found
* 0 Critical  * 2 High  * 6 Medium  * 6 Other
CVE-2026-40200 (musl, musl-utils) ...
```
Confirms `ScanImageContext` works correctly in production.

### Full suite
- `go build ./...`, `go vet ./...` — clean (repo root and `httphandler/` module)
- `go test -race ./cmd/scan/... ./core/core/... ./core/meta/... ./core/mocks/... ./cmd/update/...` — clean
- `go test ./...` — full repo suite, clean
- `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- `gofmt -l` on every changed file — clean

## Scope

**Correction:** I originally wrote here that this PR "unblocks" extending `--kube-contexts` fleet mode to `scan image`. That was wrong and I want to flag my own mistake rather than leave it standing: `ScanImage`/`ScanImageContext` never reads any Kubernetes client/cluster state at all (confirmed — grepped for any k8s/cluster reference in `core/core/image_scan.go`, none exist). Image scanning talks to a container registry, not the Kubernetes API, so which `--kube-context` is active has no effect on it. Fleet mode for `scan image` wouldn't be a meaningful feature — it would just re-run the identical image scan N times against N irrelevant contexts. Not proposing that follow-up after all.

Fixes #3442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-scan timeout handling for more reliable cancellation.
  * Prevented timeout settings from altering shared scan state.
  * Ensured deadlines are applied consistently throughout image scanning and result processing.

* **Tests**
  * Added regression coverage validating timeout contexts and shared-state protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
