### PR TITLE
fix(mcpserver): guard getPolicyGetter's lazy init, matching its siblings

### DIFF
--- a/cmd/mcpserver/list_policies.go
+++ b/cmd/mcpserver/list_policies.go
@@ -11,10 +11,7 @@ import (
 )
 
 func (ksServer *KubescapeMcpserver) ListFrameworks(ctx context.Context) ([]byte, error) {
-	pg := ksServer.policyGetter
-	if pg == nil {
-		pg = getter.NewDownloadReleasedPolicy()
-	}
+	pg := ksServer.getPolicyGetter()
 	names, err := pg.ListFrameworks()
 	if err != nil {
 		names = getter.NativeFrameworks
@@ -26,10 +23,7 @@ func (ksServer *KubescapeMcpserver) ListFrameworks(ctx context.Context) ([]byte,
 }
 
 func (ksServer *KubescapeMcpserver) ListControls(ctx context.Context) ([]byte, error) {
-	pg := ksServer.policyGetter
-	if pg == nil {
-		pg = getter.NewDownloadReleasedPolicy()
-	}
+	pg := ksServer.getPolicyGetter()
 	pipes, err := pg.ListControls()
 	if err != nil {
 		return nil, err

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -86,18 +86,32 @@ type KubescapeMcpserver struct {
 	ksClient   spdxv1beta1.SpdxV1beta1Interface
 	// ksClientInit overrides newKsClient for this server instance; used by
 	// tests. Nil means use newKsClient.
-	ksClientInit func() (spdxv1beta1.SpdxV1beta1Interface, error)
-	k8sClientMu  sync.Mutex
-	k8sClient    *k8sinterface.KubernetesApi
-	policyGetter *getter.DownloadReleasedPolicy
-	scanSemMu    sync.Mutex
-	scanSem      *semaphore.Weighted
-	scanGroup    singleflight.Group
-	scanCtxMu    sync.Mutex
-	scanCtxs     map[string]*scanCtxState
+	ksClientInit   func() (spdxv1beta1.SpdxV1beta1Interface, error)
+	k8sClientMu    sync.Mutex
+	k8sClient      *k8sinterface.KubernetesApi
+	policyGetterMu sync.Mutex
+	policyGetter   *getter.DownloadReleasedPolicy
+	scanSemMu      sync.Mutex
+	scanSem        *semaphore.Weighted
+	scanGroup      singleflight.Group
+	scanCtxMu      sync.Mutex
+	scanCtxs       map[string]*scanCtxState
 }
 
+// getPolicyGetter lazily constructs policyGetter on first use, guarded so
+// concurrent MCP tool calls can't race on the check-then-set (the underlying
+// server dispatches each request on its own goroutine, same reason the
+// ksClient/k8sClient/scanSem/scanCtxs fields on this struct are already
+// guarded - this field wasn't, which was a real data race: go test -race
+// flags concurrent calls immediately, see #3444). A plain mutex, not
+// sync.Once, because mcpServerEntrypoint pre-populates policyGetter directly
+// in the struct literal and warms it via SetRegoObjectsWithFallback before
+// any tool call can reach this method - sync.Once wouldn't know that
+// initialization already happened, and would discard the warmed instance on
+// the first concurrent call.
 func (ksServer *KubescapeMcpserver) getPolicyGetter() *getter.DownloadReleasedPolicy {
+	ksServer.policyGetterMu.Lock()
+	defer ksServer.policyGetterMu.Unlock()
 	if ksServer.policyGetter == nil {
 		ksServer.policyGetter = getter.NewDownloadReleasedPolicy()
 	}

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
 )
 
@@ -485,6 +489,50 @@ func TestGetKsClient_DefaultInitializerIsUsedAndCached(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("expected default initializer to run once, got %d calls", calls)
 	}
+}
+
+// TestGetPolicyGetter_ConcurrentCallsDoNotRace is a regression test for
+// #3444: getPolicyGetter's check-then-set on policyGetter was unguarded,
+// unlike its ksClient/k8sClient/scanSem/scanCtxs siblings on the same
+// struct, and go test -race flagged concurrent calls immediately before the
+// fix.
+func TestGetPolicyGetter_ConcurrentCallsDoNotRace(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+	var wg sync.WaitGroup
+	wg.Add(8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer wg.Done()
+			_ = ksServer.getPolicyGetter()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetPolicyGetter_LazilyConstructsOnceAndCaches(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	first := ksServer.getPolicyGetter()
+	require.NotNil(t, first)
+	second := ksServer.getPolicyGetter()
+
+	assert.Same(t, first, second, "getPolicyGetter must return the same instance across calls instead of constructing a new one each time")
+}
+
+// TestGetPolicyGetter_DoesNotDiscardPreInitializedInstance is a regression
+// test for the fix's own correctness: mcpServerEntrypoint pre-populates
+// policyGetter directly in the struct literal and warms it via
+// SetRegoObjectsWithFallback before any tool call can reach getPolicyGetter.
+// A sync.Once-based fix (instead of the mutex this uses) would not know
+// that initialization already happened, and would discard the warmed
+// instance on the first call.
+func TestGetPolicyGetter_DoesNotDiscardPreInitializedInstance(t *testing.T) {
+	preInitialized := getter.NewDownloadReleasedPolicy()
+	ksServer := &KubescapeMcpserver{policyGetter: preInitialized}
+
+	got := ksServer.getPolicyGetter()
+
+	assert.Same(t, preInitialized, got, "getPolicyGetter must not replace an already-initialized policyGetter")
 }
 
 func TestGetK8sClient_NotConnectedReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

`KubescapeMcpserver.policyGetter` was lazily initialized with an unguarded check-then-set in `getPolicyGetter()` — the one field on this struct without a mutex, unlike every sibling: `ksClient` (`ksClientMu`), `k8sClient` (`k8sClientMu`), `scanSem` (`scanSemMu`), `scanCtxs` (`scanCtxMu`). A real, `-race`-confirmed data race under concurrent MCP tool calls.

Based on `upstream/master` directly, independent of my other open PRs.

## Evidence (from #3444, filed before this PR)

```go
func (ksServer *KubescapeMcpserver) getPolicyGetter() *getter.DownloadReleasedPolicy {
	if ksServer.policyGetter == nil {
		ksServer.policyGetter = getter.NewDownloadReleasedPolicy()
	}
	return ksServer.policyGetter
}
```
vs. its sibling right below it:
```go
func (ksServer *KubescapeMcpserver) getScanSem() *semaphore.Weighted {
	ksServer.scanSemMu.Lock()
	defer ksServer.scanSemMu.Unlock()
	...
}
```

Reproduction, fails on every run before this fix:
```go
func TestRepro_GetPolicyGetterDataRace(t *testing.T) {
	ksServer := &KubescapeMcpserver{}
	var wg sync.WaitGroup
	wg.Add(4)
	for i := 0; i < 4; i++ {
		go func() { defer wg.Done(); _ = ksServer.getPolicyGetter() }()
	}
	wg.Wait()
}
```

`getPolicyGetter()` is reachable from every scan-triggering MCP tool via `runScan` (`cmd/mcpserver/scan_helper.go:58`) — `run_rbac_scan`, `run_network_scan`, `run_framework_scan`, `run_control_scan`, IaC scan tools, etc. The already-mutex-guarded sibling fields on this struct show the maintainers already designed it assuming tool calls run concurrently (the underlying `mark3labs/mcp-go` server dispatches each request on its own goroutine) — `policyGetter` just didn't get the same treatment.

## What changed

- **`cmd/mcpserver/mcpserver.go`**: added `policyGetterMu sync.Mutex` guarding the check-then-set in `getPolicyGetter()`.
  - **Not `sync.Once`**, deliberately: `mcpServerEntrypoint` pre-populates `policyGetter` directly in the struct literal at startup and warms it via `SetRegoObjectsWithFallback()` (loading the `~/.kubescape` cache so scans don't hit GitHub directly). `sync.Once` has no way to know that initialization already happened outside its `Do` call — the first concurrent `getPolicyGetter()` call would fire `Do`'s function and silently overwrite the already-warmed instance with a fresh, cold one. A plain mutex-guarded nil-check doesn't have this problem. Verified this distinction with a dedicated test (see below).
- **`cmd/mcpserver/list_policies.go`**: found two more unguarded reads of the same field while fixing this — `ListFrameworks` and `ListControls` each had their own inline copy of the same nil-check-and-fallback logic (`pg := ksServer.policyGetter; if pg == nil { pg = getter.NewDownloadReleasedPolicy() }`), bypassing `getPolicyGetter()` (and now `policyGetterMu`) entirely. Both now just call `ksServer.getPolicyGetter()`, which also removes the duplicated fallback logic.

## Test plan

```
=== RUN   TestGetPolicyGetter_ConcurrentCallsDoNotRace
--- PASS: TestGetPolicyGetter_ConcurrentCallsDoNotRace (0.00s)
=== RUN   TestGetPolicyGetter_LazilyConstructsOnceAndCaches
--- PASS: TestGetPolicyGetter_LazilyConstructsOnceAndCaches (0.00s)
=== RUN   TestGetPolicyGetter_DoesNotDiscardPreInitializedInstance
--- PASS: TestGetPolicyGetter_DoesNotDiscardPreInitializedInstance (0.00s)
```

The third test is the one that would have caught a naive `sync.Once`-based fix — it pre-populates `policyGetter` via the struct literal (mirroring `mcpServerEntrypoint`'s real startup path) and asserts `getPolicyGetter()` returns that *same* instance rather than replacing it.

- `go test -race ./cmd/mcpserver/...` — clean, full package
- `go test -race ./...` / `go test ./...` — full repo suite, clean
- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- `gofmt -l` on every changed file — clean

Fixes #3444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple policy-related requests are processed at the same time.
  * Prevented inconsistent policy loading during concurrent framework and control listings.
  * Preserved preloaded policy data while ensuring policy information is initialized and reused correctly.

* **Tests**
  * Added coverage for concurrent requests, lazy policy loading, caching, and preloaded policy preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->