### PR TITLE
fix(resourcehandler): treat an undecided access review as unchecked, not denied

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -841,7 +841,13 @@ func printPreflightResult(result *resourcehandler.PreflightResult) {
 	}
 
 	for _, c := range denied {
-		fmt.Printf("DENIED  list %s\n", c.GVR)
+		// The API server's reason is what tells a user which binding to fix, so
+		// print it when there is one; RBAC often answers with none.
+		if c.Reason != "" {
+			fmt.Printf("DENIED  list %s: %s\n", c.GVR, c.Reason)
+		} else {
+			fmt.Printf("DENIED  list %s\n", c.GVR)
+		}
 		if len(c.AffectedControls) > 0 {
 			fmt.Printf("        -> %s will not evaluate\n", strings.Join(c.AffectedControls, ", "))
 		}

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -123,7 +123,12 @@ func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTr
 		return check
 	}
 
-	check.Allowed = resp.Status.Allowed
-	check.Reason = resp.Status.Reason
+	applyAccessReviewStatus(&check, resp.Status)
 	return check
+}
+
+// applyAccessReviewStatus records the API server's access decision on the check.
+func applyAccessReviewStatus(check *GVRCheck, status authorizationv1.SubjectAccessReviewStatus) {
+	check.Allowed = status.Allowed
+	check.Reason = status.Reason
 }

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -12,10 +12,12 @@ import (
 )
 
 // GVRCheck is the preflight result for a single resource type the scan needs to list.
-// Errored is set when the SelfSubjectAccessReview request itself could not be
-// completed (timeout, API failure, ...), which is not the same as the API
-// server answering that "list" is denied — Allowed stays false in both cases,
-// so callers must check Errored before treating a check as a real denial.
+// Errored is set when no access decision was obtained: the
+// SelfSubjectAccessReview request itself could not be completed (timeout, API
+// failure, ...), or the API server answered without one of its authorizers
+// reaching a verdict. Neither is the same as the API server answering that
+// "list" is denied — Allowed stays false in all of these cases, so callers must
+// check Errored before treating a check as a real denial.
 type GVRCheck struct {
 	GVR              string
 	Allowed          bool
@@ -44,8 +46,8 @@ func (r *PreflightResult) Denied() []GVRCheck {
 	return denied
 }
 
-// Errored returns the checks whose SelfSubjectAccessReview request itself
-// failed, so no access decision was obtained.
+// Errored returns the checks for which no access decision was obtained, whether
+// the request failed or an authorizer never reached a verdict.
 func (r *PreflightResult) Errored() []GVRCheck {
 	var errored []GVRCheck
 	for _, c := range r.Checks {
@@ -128,7 +130,22 @@ func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTr
 }
 
 // applyAccessReviewStatus records the API server's access decision on the check.
+//
+// Allowed=false with Denied=false means no authorizer had an opinion, which is a
+// real denial only when they all actually reached one. An EvaluationError says
+// one of them did not: a webhook authorizer that times out or errors produces
+// exactly this shape, and reporting it as a denial fails the dry-run over access
+// the credentials may well have. An explicit Denied, or no opinion with every
+// authorizer reporting cleanly, stays the denial it is.
 func applyAccessReviewStatus(check *GVRCheck, status authorizationv1.SubjectAccessReviewStatus) {
 	check.Allowed = status.Allowed
 	check.Reason = status.Reason
+	if status.Allowed || status.Denied || status.EvaluationError == "" {
+		return
+	}
+	check.Errored = true
+	check.Reason = status.EvaluationError
+	if status.Reason != "" {
+		check.Reason = status.Reason + ": " + status.EvaluationError
+	}
 }

--- a/core/pkg/resourcehandler/preflight_test.go
+++ b/core/pkg/resourcehandler/preflight_test.go
@@ -173,3 +173,144 @@ func TestPreflight_SkipsExternalResources(t *testing.T) {
 		assert.NotContains(t, check.GVR, "hostdata.kubescape.cloud")
 	}
 }
+
+// TestApplyAccessReviewStatus covers the access decisions a SubjectAccessReview
+// can carry. Allowed=false with Denied=false is "no authorizer had an opinion",
+// which is only a denial when they all reached one; an EvaluationError means a
+// verdict was never reached and the check is unchecked rather than denied.
+func TestApplyAccessReviewStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      authorizationv1.SubjectAccessReviewStatus
+		wantAllowed bool
+		wantErrored bool
+		wantReason  string
+	}{
+		{
+			name:        "allowed",
+			status:      authorizationv1.SubjectAccessReviewStatus{Allowed: true, Reason: "RBAC: allowed by ClusterRole/view"},
+			wantAllowed: true,
+			wantReason:  "RBAC: allowed by ClusterRole/view",
+		},
+		{
+			name:        "allowed despite a partial evaluation error",
+			status:      authorizationv1.SubjectAccessReviewStatus{Allowed: true, EvaluationError: "role.rbac.authorization.k8s.io \"missing\" not found"},
+			wantAllowed: true,
+		},
+		{
+			name:       "no opinion with every authorizer reporting cleanly is a denial",
+			status:     authorizationv1.SubjectAccessReviewStatus{},
+			wantReason: "",
+		},
+		{
+			name:       "explicit denial",
+			status:     authorizationv1.SubjectAccessReviewStatus{Denied: true, Reason: "denied by webhook"},
+			wantReason: "denied by webhook",
+		},
+		{
+			name:       "explicit denial outranks an evaluation error",
+			status:     authorizationv1.SubjectAccessReviewStatus{Denied: true, Reason: "denied by webhook", EvaluationError: "second authorizer timed out"},
+			wantReason: "denied by webhook",
+		},
+		{
+			name:        "no opinion with an evaluation error is unchecked",
+			status:      authorizationv1.SubjectAccessReviewStatus{EvaluationError: "webhook: dial tcp 10.0.0.1:443 i/o timeout"},
+			wantErrored: true,
+			wantReason:  "webhook: dial tcp 10.0.0.1:443 i/o timeout",
+		},
+		{
+			name:        "an evaluation error keeps the reason alongside it",
+			status:      authorizationv1.SubjectAccessReviewStatus{Reason: "no RBAC policy matched", EvaluationError: "webhook timed out"},
+			wantErrored: true,
+			wantReason:  "no RBAC policy matched: webhook timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := GVRCheck{GVR: "agents.x-k8s.io/v1alpha1/sandboxes"}
+			applyAccessReviewStatus(&check, tt.status)
+
+			assert.Equal(t, tt.wantAllowed, check.Allowed)
+			assert.Equal(t, tt.wantErrored, check.Errored)
+			assert.Equal(t, tt.wantReason, check.Reason)
+
+			result := &PreflightResult{Checks: []GVRCheck{check}}
+			switch {
+			case tt.wantAllowed:
+				assert.Empty(t, result.Denied())
+				assert.Empty(t, result.Errored())
+			case tt.wantErrored:
+				assert.Empty(t, result.Denied(), "an undecided check must not fail the dry-run")
+				assert.Len(t, result.Errored(), 1)
+			default:
+				assert.Len(t, result.Denied(), 1)
+				assert.Empty(t, result.Errored())
+			}
+		})
+	}
+}
+
+// TestPreflight_UndecidedAccessReviewIsNotADenial covers a cluster whose webhook
+// authorizer never answers: the API server returns no opinion plus an evaluation
+// error, which must not fail the dry-run as missing RBAC.
+func TestPreflight_UndecidedAccessReviewIsNotADenial(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ssar.Status.EvaluationError = "webhook authorizer: dial tcp 10.0.0.1:443 i/o timeout"
+		return true, ssar, nil
+	})
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
+	framework := mockFramework("test-framework", []reporthandling.Control{podControl})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Denied(), "an undecided access review must not be reported as a denial")
+	require.NotEmpty(t, result.Errored())
+	for _, c := range result.Errored() {
+		assert.Contains(t, c.Reason, "i/o timeout")
+	}
+}
+
+// TestPreflight_ExplicitDenialStillFailsTheDryRun guards the other direction:
+// treating undecided reviews as unchecked must not soften a real denial.
+func TestPreflight_ExplicitDenialStillFailsTheDryRun(t *testing.T) {
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatalf("preflight must not list resources: %s", action.GetResource().Resource)
+		return true, nil, nil
+	})
+	fakeClient := handler.k8s.KubernetesClient.(*fakeclientset.Clientset)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ssar.Status.Denied = true
+		ssar.Status.Reason = "denied by webhook"
+		return true, ssar, nil
+	})
+
+	podRule := mockRule("pod-rule", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	podControl := mockControl("C-0001", []reporthandling.PolicyRule{podRule})
+	framework := mockFramework("test-framework", []reporthandling.Control{podControl})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), []reporthandling.Framework{*framework}, nil, scanInfo, nil)
+
+	result, err := handler.Preflight(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Errored())
+	require.NotEmpty(t, result.Denied())
+	for _, c := range result.Denied() {
+		assert.Equal(t, "denied by webhook", c.Reason)
+	}
+}


### PR DESCRIPTION
## Overview

While looking at how the dry run mode of `scan` decides whether the current credentials can list everything the selected policies need, I noticed the preflight check only reads two of the four fields a `SelfSubjectAccessReview` answers with. It takes `Status.Allowed` and `Status.Reason` and ignores `Status.Denied` and `Status.EvaluationError`.

That matters because of how Kubernetes models an authorization answer. `Allowed=false` on its own does not mean "denied", it means "not allowed", and the `Denied` field is what separates an explicit refusal from no authorizer having an opinion at all. When an authorizer never manages to reach a verdict, the API server sets `EvaluationError` and leaves both booleans false. A webhook authorizer that times out or cannot be dialled produces exactly that shape, and those are common on managed clusters.

Kubescape currently files that answer as a hard denial. Since a denial makes the dry run return an error and exit non zero, a flaky authz webhook makes the dry run report that your credentials cannot list a resource type when authorization was never actually decided. The reason string is empty in that case too, so the output gives no hint that a webhook was involved. This is the exact distinction `GVRCheck.Errored` already documents itself as preserving, so the struct's contract and its behaviour had drifted apart.

## What changed

`applyAccessReviewStatus` now classifies the answer the way the API server means it. No opinion with an `EvaluationError` present becomes an unchecked result, which prints as `CHECK FAILED` and leaves the dry run passing, and the evaluation error travels in the reason so the webhook is visible. An explicit `Denied`, and no opinion where every authorizer reported cleanly, both stay denials exactly as before. `Allowed=true` also stays allowed even when a partial evaluation error is attached, which the upstream field docs call out as a legitimate combination.

I also made a denied resource type print its reason when the API server supplies one. Previously the reason was collected and then dropped at print time, so a user got the GVR and nothing about which binding to go fix.

## Risk

The one thing worth a careful look is that this must not soften a real denial into a pass, since that would turn the dry run into a false all clear. The table test walks every status shape for that reason, and `TestPreflight_ExplicitDenialStillFailsTheDryRun` covers the direction from the other side. I confirmed the new tests fail against the current code before the fix and pass after it.

Nothing here changes what an actual scan collects. It only affects how the dry run classifies and reports an access answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run RBAC messages by including the API server’s denial reason when available.
  * More accurately reports access-review evaluation errors as errors instead of denials.
  * Preserves explicit access denials as preflight failures.
  * Retains concise messaging when no denial reason is provided.

* **Tests**
  * Added coverage for allowed, denied, undecided, and error access-review outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->