### PR TITLE
ci(comments): gate pr_agent on trusted commenter author_association

### DIFF
--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -5,6 +5,12 @@ on:
 
 jobs:
   pr_agent:
+    # issue_comment always runs with the base repo's token, even for a comment
+    # left on a fork's PR, and this job holds issues/pull-requests write
+    # access. Gate on the commenter's GitHub-computed relationship to the
+    # repo so an untrusted comment can't drive a write-scoped bot or reach
+    # OPENAI_KEY.
+    if: ${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) }}
     permissions:
       issues: write
       pull-requests: write

--- a/internal/ghworkflows/comments_test.go
+++ b/internal/ghworkflows/comments_test.go
@@ -1,0 +1,71 @@
+// This test guards a "pwn request" regression: comments.yaml's pr_agent job
+// ran on `issue_comment` with `issues: write` and `pull-requests: write` and
+// no filter on who left the comment. issue_comment always evaluates against
+// the base repository's token, even for a comment on a fork's pull request,
+// so any commenter - not a collaborator, not even a contributor - could drive
+// a write-scoped bot that feeds their comment and the PR diff to an LLM and
+// posts its output back with that token.
+//
+// Nothing failed. The job ran exactly as designed for every comment; the only
+// thing missing was a check on who was allowed to trigger it.
+package ghworkflows
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	commentsWorkflowName = "comments.yaml"
+	prAgentJobName       = "pr_agent"
+)
+
+// commentsWorkflow is the subset of comments.yaml these tests assert on.
+// Job-level `permissions` is a mapping, decoded the same way releaseWorkflow
+// decodes it above - Go field names cannot hold the hyphen in
+// "pull-requests", so a map sidesteps needing a struct tag for it.
+type commentsWorkflow struct {
+	Jobs map[string]struct {
+		If          string            `yaml:"if"`
+		Permissions map[string]string `yaml:"permissions"`
+	} `yaml:"jobs"`
+}
+
+// TestPRAgentJobRequiresTrustedCommenter is the direct regression test. It
+// asserts both halves of the shape, not just one: permissions alone would
+// fire this guard on a job that no longer needs it, and an `if:` alone would
+// not explain why one is required at all.
+func TestPRAgentJobRequiresTrustedCommenter(t *testing.T) {
+	var workflow commentsWorkflow
+	loadWorkflow(t, commentsWorkflowName, &workflow)
+
+	job, ok := workflow.Jobs[prAgentJobName]
+	require.Truef(t, ok, "%s has no %q job; this guard needs updating to follow it",
+		commentsWorkflowName, prAgentJobName)
+
+	assert.Equalf(t, "write", job.Permissions["issues"],
+		"%s's %q job no longer holds issues: write; if that's intentional this guard can be relaxed, "+
+			"but if it still writes to issues it still needs the trust gate below",
+		commentsWorkflowName, prAgentJobName)
+	assert.Equalf(t, "write", job.Permissions["pull-requests"],
+		"%s's %q job no longer holds pull-requests: write", commentsWorkflowName, prAgentJobName)
+
+	require.NotEmptyf(t, job.If,
+		"%s's %q job runs on `issue_comment` with issues/pull-requests write access and no `if:` gate - "+
+			"any commenter, not just a collaborator, can drive a write-scoped bot that feeds their comment "+
+			"and the PR diff to an LLM and posts its output back with that token",
+		commentsWorkflowName, prAgentJobName)
+
+	assert.Containsf(t, job.If, "author_association",
+		"%s's %q job gates on something other than the commenter's association with the repository; "+
+			"author_association is GitHub's own server-computed field and the only one of these inputs "+
+			"a commenter cannot forge", commentsWorkflowName, prAgentJobName)
+
+	for _, trusted := range []string{"OWNER", "MEMBER", "COLLABORATOR"} {
+		assert.Containsf(t, job.If, trusted,
+			"%s's %q job's trust gate no longer allows %q commenters",
+			commentsWorkflowName, prAgentJobName, trusted)
+	}
+}

--- a/internal/ghworkflows/comments_test.go
+++ b/internal/ghworkflows/comments_test.go
@@ -11,6 +11,8 @@
 package ghworkflows
 
 import (
+	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,9 +65,23 @@ func TestPRAgentJobRequiresTrustedCommenter(t *testing.T) {
 			"author_association is GitHub's own server-computed field and the only one of these inputs "+
 			"a commenter cannot forge", commentsWorkflowName, prAgentJobName)
 
-	for _, trusted := range []string{"OWNER", "MEMBER", "COLLABORATOR"} {
-		assert.Containsf(t, job.If, trusted,
-			"%s's %q job's trust gate no longer allows %q commenters",
-			commentsWorkflowName, prAgentJobName, trusted)
-	}
+	// Exact allowlist check — the previous substring loop (`Contains` each trusted value)
+	// would still pass if the gate were widened to also include "CONTRIBUTOR" (or any other
+	// association). That matters because CONTRIBUTOR (someone whose PR was once merged) is
+	// NOT repo-trusted the way COLLABORATOR is, so widening reopens a weaker version of the
+	// exact pwn-request hole this guard closes. Parse the fromJSON('[...]') payload and assert
+	// it equals {OWNER, MEMBER, COLLABORATOR} exactly.
+	expectedTrusted := []string{"OWNER", "MEMBER", "COLLABORATOR"}
+	re := regexp.MustCompile(`fromJSON\('([^']+)'\)`)
+	matches := re.FindStringSubmatch(job.If)
+	require.NotEmptyf(t, matches,
+		"%s's %q job's trust gate must use fromJSON('[...]') to list allowed associations; got %q",
+		commentsWorkflowName, prAgentJobName, job.If)
+	var actualTrusted []string
+	require.NoErrorf(t, json.Unmarshal([]byte(matches[1]), &actualTrusted),
+		"%s's %q job's fromJSON payload is not valid JSON; got %q",
+		commentsWorkflowName, prAgentJobName, matches[1])
+	assert.ElementsMatchf(t, expectedTrusted, actualTrusted,
+		"%s's %q job's trust gate allowlist must be exactly %v; got %v — adding %q (or any other association) would reopen the hole this guard closes",
+		commentsWorkflowName, prAgentJobName, expectedTrusted, actualTrusted, "CONTRIBUTOR")
 }

--- a/internal/ghworkflows/releasesigning_test.go
+++ b/internal/ghworkflows/releasesigning_test.go
@@ -86,6 +86,10 @@ var guardedFiles = append([]string{
 	krewTemplateName,
 	krewDocName,
 	filepath.Join("internal", "ghworkflows", "krew_test.go"),
+	// comments_test.go guards comments.yaml's trust gate; comments.yaml sits in
+	// the same "**.yaml" blind spot as everything else in this list.
+	filepath.Join(".github", "workflows", commentsWorkflowName),
+	filepath.Join("internal", "ghworkflows", "comments_test.go"),
 }, installScripts...)
 
 // goreleaserSign is the subset of a `signs` / `docker_signs` entry these tests


### PR DESCRIPTION
## Overview

Closes a "pwn request" regression in `.github/workflows/comments.yaml`: the `pr_agent` job was running on every `issue_comment` event with `issues: write` and `pull-requests: write` and no filter on who left the comment. Because `issue_comment` always evaluates against the **base** repository's `GITHUB_TOKEN` (including for comments left on a fork's PR), any GitHub user could reach a write-token workflow run, feed their comment and the PR diff to `Codium-ai/pr-agent` via `secrets.OPENAI_KEY`, and have the action post its output back using that write-scoped token.

This PR:

1. Adds a job-level `if:` gate on `github.event.comment.author_association` accepting only `OWNER`, `MEMBER`, `COLLABORATOR` — the three relationships GitHub itself treats as repository-trusted. The field is server-computed and unforgeable; `github.actor`, comment body, PR title, and branch name are all attacker-controllable.
2. Adds `internal/ghworkflows/comments_test.go::TestPRAgentJobRequiresTrustedCommenter` as the regression test. It asserts **both** halves of the shape - the write permissions are still present *and* the `if:` gate references `author_association` and lists all three trusted values - so either half being relaxed in isolation would re-trigger CI rather than silently re-open the hole.
3. Extends `guardedFiles` in `internal/ghworkflows/releasesigning_test.go` to cover the two new files, so `TestRepoHygieneWatchesTheFilesTheseTestsGuard` fails if a future edit drops them from `repo-hygiene.yaml`'s `pull_request.paths` allow-list. `.github/**` and `internal/ghworkflows/**` already cover both paths today; the extension just enforces that the new guard cannot silently sit outside CI coverage - the same failure class `releasesigning_test.go`'s package doc documents as a real past incident in this repo.

The SHA pin on `Codium-ai/pr-agent` (`@0bd56c0508504c718cc03d504cd4ceb6725ba3c7`) is preserved. The third-party action's reachability is now bounded by repository standing rather than by account existence.

## Files changed

```
┌────────────────────────────────┬─────────────────────────────┐
│              File              │           Change            │
├────────────────────────────────┼─────────────────────────────┤
│ .github/workflows/comments.yam │ Added 5-line block comment  │
│ l                              │ + 1-line if: gate to the    │
│                                │ pr_agent job                │
├────────────────────────────────┼─────────────────────────────┤
│ internal/ghworkflows/comments_ │ New file — TestPRAgentJobRe │
│ test.go                        │ quiresTrustedCommenter (72  │
│                                │ lines)                      │
├────────────────────────────────┼─────────────────────────────┤
│ internal/ghworkflows/releasesi │ 4-line addition to          │
│ gning_test.go                  │ guardedFiles + a 2-line     │
│                                │ comment explaining why      │
└────────────────────────────────┴─────────────────────────────┘
```

3 files changed, 81 insertions(+).

Related issues/PRs

- Resolves the issue tracking this bug: #3448 
- No prior PR addresses this — git log -- .github/workflows/comments.yaml shows the file's history is f36d8c31 (add) → 143a4d98 (top-level permissions) → 0b7d8cd4 (extra-permissions cleanup) → 354f565c (SHA pin). The per-job write overrides were never re-examined after the top-level read-all was added.

Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] The new test fails on the pre-fix code and passes on the post-fix code (verified via git stash round-trip)
- [x] gofmt, go vet, and golangci-lint are clean
- [x] Commit carries a Signed-off-by: trailer (DCO)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Restricted automated pull request actions triggered by issue comments to repository owners, members, and collaborators.
  - Excluded other repository associations from the approved commenter list.

- **Tests**
  - Added regression coverage to verify the approved commenter requirements.
  - Updated repository checks to monitor changes to the comments workflow and related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->