### PR TITLE
fix(printer): printTopComponents corrupts output when a package has no recorded severities

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils.go
@@ -198,7 +198,13 @@ func printTopComponents(writer *os.File, summary imageprinter.ImageScanSummary) 
 			output += fmt.Sprintf(" %d %s,", topPkg.MapSeverityToCVEsNumber[sortedCVEs[j]], utils.GetColorForVulnerabilitySeverity(sortedCVEs[j])(sortedCVEs[j]))
 		}
 
-		output = output[:len(output)-1]
+		// Only the per-severity loop above appends a trailing comma to strip.
+		// With no recorded severities it never runs, so output still ends in
+		// the seed string's own trailing "-" - stripping unconditionally would
+		// eat that dash instead of a comma.
+		if len(sortedCVEs) > 0 {
+			output = output[:len(output)-1]
+		}
 
 		cautils.StarDisplay(writer, "%s\n", output)
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/utils_test.go
@@ -118,6 +118,57 @@ func capturePrintImagesCommands(t *testing.T, images []string) string {
 	return string(contents)
 }
 
+func capturePrintTopComponents(t *testing.T, summary imageprinter.ImageScanSummary) string {
+	t.Helper()
+
+	output, err := os.CreateTemp(t.TempDir(), "top-components-*.txt")
+	require.NoError(t, err)
+	defer output.Close()
+
+	printTopComponents(output, summary)
+	require.NoError(t, output.Sync())
+	_, err = output.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	contents, err := io.ReadAll(output)
+	require.NoError(t, err)
+	return string(contents)
+}
+
+// TestPrintTopComponents_EmptySeverityMapKeepsTrailingDash is a regression
+// test for #3450: the function assumed its output always ended in the
+// trailing comma appended by the per-severity loop, and stripped the last
+// character unconditionally. With no recorded severities that loop never
+// runs, so it stripped the seed string's own trailing "-" instead, leaving
+// a dangling space ("* pkg (1.0.0) " instead of "* pkg (1.0.0) -").
+func TestPrintTopComponents_EmptySeverityMapKeepsTrailingDash(t *testing.T) {
+	summary := imageprinter.ImageScanSummary{
+		PackageScores: map[string]*imageprinter.PackageScore{
+			"pkg": {Name: "pkg", Version: "1.0.0"}, // no MapSeverityToCVEsNumber entries
+		},
+	}
+
+	got := capturePrintTopComponents(t, summary)
+
+	assert.Contains(t, got, "pkg (1.0.0) -")
+}
+
+func TestPrintTopComponents_WithSeveritiesStripsTrailingComma(t *testing.T) {
+	summary := imageprinter.ImageScanSummary{
+		PackageScores: map[string]*imageprinter.PackageScore{
+			"pkg": {
+				Name:                    "pkg",
+				Version:                 "1.0.0",
+				MapSeverityToCVEsNumber: map[string]int{"Critical": 2},
+			},
+		},
+	}
+
+	got := capturePrintTopComponents(t, summary)
+
+	assert.Contains(t, got, "pkg (1.0.0) - 2 Critical")
+	assert.NotContains(t, got, "Critical,\n", "trailing comma before the newline must still be stripped when severities are present")
+}
+
 func TestGetWorkloadPrefixForCmd(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

`printTopComponents` (`core/pkg/resultshandling/printer/v2/prettyprinter/utils.go`) assumed its output line always ends in the trailing comma its per-severity loop appends, and stripped the last character unconditionally. When a package has no recorded severities, that loop never runs, so the strip eats the seed string's own trailing `"-"` instead, leaving a dangling space.

Based on `upstream/master` directly, independent of my other open PRs.

## Evidence

```go
output := fmt.Sprintf("%s (%s) -", topPkg.Name, topPkg.Version)
for j := range sortedCVEs {
	output += fmt.Sprintf(" %d %s,", ...)
}
output = output[:len(output)-1]
```

Calling this with a `PackageScore` that has no `MapSeverityToCVEsNumber` entries produces:
```
* pkg (1.0.0) 
```
instead of `* pkg (1.0.0) -`.

## Reachability — being upfront about this

The one production constructor of `PackageScores`, `setPkgNameToScoreMap` (`core/pkg/resultshandling/printer/v2/utils.go`), only ever adds a package-score entry in the same loop iteration that also increments `MapSeverityToCVEsNumber` for that package's first matched vulnerability. So today's single call graph (`kubescape scan image` / `--scan-images`) can't actually produce an empty map for an entry that reaches `PackageScores` — this bug is real and verified, but currently latent rather than end-to-end triggerable from the CLI today. Filed as #3450 with that caveat stated explicitly; fixing it removes a trap that would silently corrupt output the moment that implicit invariant changes (e.g. a future caller building `PackageScores` a different way).

## What changed

Only strip the trailing separator when the per-severity loop actually appended one:
```go
if len(sortedCVEs) > 0 {
	output = output[:len(output)-1]
}
```

## Test plan

New tests:
- `TestPrintTopComponents_EmptySeverityMapKeepsTrailingDash` — reproduces the bug directly against the exported behavior (bypassing the currently-safe production constructor on purpose, since that's exactly the scenario the fix protects against)
- `TestPrintTopComponents_WithSeveritiesStripsTrailingComma` — confirms the non-empty case still strips the trailing comma correctly

```
=== RUN   TestPrintTopComponents_EmptySeverityMapKeepsTrailingDash
--- PASS: TestPrintTopComponents_EmptySeverityMapKeepsTrailingDash (0.01s)
=== RUN   TestPrintTopComponents_WithSeveritiesStripsTrailingComma
--- PASS: TestPrintTopComponents_WithSeveritiesStripsTrailingComma (0.01s)
```

- `go test ./core/pkg/resultshandling/...` (incl. `-race`) — clean
- `go test ./...` — full repo suite, clean
- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run --new-from-rev=upstream/master ./...` — 0 issues
- `gofmt -l` on both changed files — clean

Fixes #3450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component output formatting when severity details are unavailable.
  * Preserved trailing dashes for components without severity entries.
  * Correctly removes trailing commas when severity entries are present.
  * Ensured package names containing formatting characters are displayed literally.

* **Tests**
  * Added regression coverage for component and package-name formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->