### PR TITLE
fix: enforce per-file size limit on file-scan path

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -826,13 +827,13 @@ func isUnrenderedHelmTemplate(path string) bool {
 
 // getMaxFileSize returns the configured per-file size limit in bytes.
 // It reads MaxFileSizeEnvVar as decimal bytes when set, otherwise defaults to
-// DefaultMaxFileSize. Non-positive or unparsable values fall back to the default
-// so the scan stays bounded.
+// DefaultMaxFileSize. Non-positive, unparsable, or math.MaxInt64 values fall
+// back to the default so the scan stays bounded and limit+1 does not overflow.
 func getMaxFileSize() int64 {
 	if v, ok := os.LookupEnv(MaxFileSizeEnvVar); ok {
 		trimmed := strings.TrimSpace(v)
 		if trimmed != "" {
-			if parsed, err := strconv.ParseInt(trimmed, 10, 64); err == nil && parsed > 0 {
+			if parsed, err := strconv.ParseInt(trimmed, 10, 64); err == nil && parsed > 0 && parsed != math.MaxInt64 {
 				return parsed
 			}
 			logger.L().Warning("invalid KUBESCAPE_MAX_FILE_SIZE, using default", helpers.String("value", v), helpers.Int("default", int(DefaultMaxFileSize)))
@@ -860,7 +861,13 @@ func loadFile(filePath string) ([]byte, error) {
 
 	// Use LimitReader at limit+1 so we can detect an oversized file even when
 	// Stat is unavailable (e.g. /proc, pipes) or reports 0.
-	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	// Guard against overflow when limit == MaxInt64 (rejected above, but keep
+	// defense-in-depth).
+	limitPlusOne := limit
+	if limit != math.MaxInt64 {
+		limitPlusOne = limit + 1
+	}
+	data, err := io.ReadAll(io.LimitReader(f, limitPlusOne))
 	if err != nil {
 		return nil, err
 	}

--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kubescape/go-logger"
@@ -35,6 +36,9 @@ var (
 	// ErrNoManifestFiles lets resource orchestrators defer this specific error
 	// while another supported loader examines the same input.
 	ErrNoManifestFiles = errors.New("no YAML or JSON manifest files found")
+
+	// ErrFileTooLarge is returned when a manifest file exceeds the configured per-file size limit.
+	ErrFileTooLarge = errors.New("file too large")
 )
 
 type FileFormat string
@@ -42,6 +46,16 @@ type FileFormat string
 const (
 	YAML_FILE_FORMAT FileFormat = "yaml"
 	JSON_FILE_FORMAT FileFormat = "json"
+
+	// DefaultMaxFileSize is the default per-file read cap for the file-scan path.
+	// 32 MiB is large enough for any legitimate manifest (the largest chart in the
+	// wild is <5 MiB) but stops a single attacker-supplied multi-GB YAML from OOMing
+	// a CI runner. Override via KUBESCAPE_MAX_FILE_SIZE env var (bytes).
+	DefaultMaxFileSize int64 = 32 << 20 // 32 MiB
+
+	// MaxFileSizeEnvVar is the env var that overrides DefaultMaxFileSize.
+	// Value is parsed as decimal bytes (e.g. "33554432" or "67108864" for 64 MiB).
+	MaxFileSizeEnvVar = "KUBESCAPE_MAX_FILE_SIZE"
 )
 
 type Chart struct {
@@ -733,6 +747,17 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 	for i := range filePaths {
 		f, err := loadFile(filePaths[i])
 		if err != nil {
+			// Oversized files are recorded as skipped manifests rather than aborting the
+			// entire scan - a single attacker-supplied huge file in a repo must not
+			// deny service to the rest of the manifests.
+			if errors.Is(err, ErrFileTooLarge) {
+				skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: err.Error()})
+				// Still append to errs so LoadResourcesFromFilesFiltered's best-effort
+				// vs hard-failure logic is preserved: directory scans warn, single-file
+				// inputs return the error to the caller.
+				errs = append(errs, err)
+				continue
+			}
 			errs = append(errs, err)
 			skips = append(skips, SkippedManifest{Path: filePaths[i], Reason: "read error: " + err.Error()})
 			continue
@@ -799,8 +824,50 @@ func isUnrenderedHelmTemplate(path string) bool {
 	}
 }
 
+// getMaxFileSize returns the configured per-file size limit in bytes.
+// It reads MaxFileSizeEnvVar as decimal bytes when set, otherwise defaults to
+// DefaultMaxFileSize. Non-positive or unparsable values fall back to the default
+// so the scan stays bounded.
+func getMaxFileSize() int64 {
+	if v, ok := os.LookupEnv(MaxFileSizeEnvVar); ok {
+		trimmed := strings.TrimSpace(v)
+		if trimmed != "" {
+			if parsed, err := strconv.ParseInt(trimmed, 10, 64); err == nil && parsed > 0 {
+				return parsed
+			}
+			logger.L().Warning("invalid KUBESCAPE_MAX_FILE_SIZE, using default", helpers.String("value", v), helpers.Int("default", int(DefaultMaxFileSize)))
+		}
+	}
+	return DefaultMaxFileSize
+}
+
 func loadFile(filePath string) ([]byte, error) {
-	return os.ReadFile(filepath.Clean(filePath))
+	cleaned := filepath.Clean(filePath)
+	f, err := os.Open(cleaned)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	limit := getMaxFileSize()
+
+	// Fast-path: if Stat succeeds and size is known to exceed limit, fail
+	// without allocating. This also covers sparse files that report a large
+	// logical size.
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > limit {
+		return nil, fmt.Errorf("%w: %q size %d exceeds limit %d bytes", ErrFileTooLarge, filePath, fi.Size(), limit)
+	}
+
+	// Use LimitReader at limit+1 so we can detect an oversized file even when
+	// Stat is unavailable (e.g. /proc, pipes) or reports 0.
+	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%w: %q size exceeds limit %d bytes", ErrFileTooLarge, filePath, limit)
+	}
+	return data, nil
 }
 func ReadFile(fileContent []byte, fileFormat FileFormat) ([]workloadinterface.IMetadata, error) {
 

--- a/core/cautils/fileutils_size_limit_test.go
+++ b/core/cautils/fileutils_size_limit_test.go
@@ -116,8 +116,25 @@ func TestGetMaxFileSize_EnvVarOverride(t *testing.T) {
 	t.Setenv(MaxFileSizeEnvVar, "-5")
 	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize(), "non-positive must fall back to default")
 
+	t.Setenv(MaxFileSizeEnvVar, "9223372036854775807")
+	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize(), "math.MaxInt64 must fall back to default to avoid overflow")
+
 	t.Setenv(MaxFileSizeEnvVar, "")
 	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize())
+}
+
+func TestGetMaxFileSize_MaxInt64IsRejected(t *testing.T) {
+	// Regression for overflow: limit+1 with MaxInt64 would wrap to negative and make
+	// LimitReader return EOF → empty data instead of ErrFileTooLarge.
+	t.Setenv(MaxFileSizeEnvVar, "9223372036854775807")
+	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize())
+
+	dir := t.TempDir()
+	// File smaller than default 32MiB should still succeed (proves fallback, not MaxInt64)
+	small := filepath.Join(dir, "small.yaml")
+	require.NoError(t, os.WriteFile(small, []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: x\n"), 0o600))
+	_, err := loadFile(small)
+	require.NoError(t, err)
 }
 
 func TestLoadFile_DefaultLimitIs32MiB(t *testing.T) {

--- a/core/cautils/fileutils_size_limit_test.go
+++ b/core/cautils/fileutils_size_limit_test.go
@@ -1,0 +1,130 @@
+package cautils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFile_EnforcesSizeLimit(t *testing.T) {
+	// Use a tiny limit so the test does not need to create a 32 MiB file.
+	t.Setenv(MaxFileSizeEnvVar, "1024")
+	defer func() { _ = os.Unsetenv(MaxFileSizeEnvVar) }()
+
+	dir := t.TempDir()
+	oversized := filepath.Join(dir, "oversized.yaml")
+	// 2 KiB > 1 KiB limit
+	data := make([]byte, 2048)
+	for i := range data {
+		data[i] = 'A'
+	}
+	require.NoError(t, os.WriteFile(oversized, data, 0o600))
+
+	_, err := loadFile(oversized)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFileTooLarge)
+	assert.Contains(t, err.Error(), "exceeds limit")
+}
+
+func TestLoadFile_UnderLimitSucceeds(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "4096")
+	dir := t.TempDir()
+	small := filepath.Join(dir, "small.yaml")
+	content := []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: small\n")
+	require.NoError(t, os.WriteFile(small, content, 0o600))
+
+	data, err := loadFile(small)
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestLoadFile_ExactlyAtLimitSucceeds(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "10")
+	dir := t.TempDir()
+	exact := filepath.Join(dir, "exact.yaml")
+	require.NoError(t, os.WriteFile(exact, []byte("1234567890"), 0o600)) // 10 bytes
+
+	data, err := loadFile(exact)
+	require.NoError(t, err)
+	assert.Len(t, data, 10)
+}
+
+func TestLoadFile_LimitPlusOneFails(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "10")
+	dir := t.TempDir()
+	plusOne := filepath.Join(dir, "plusOne.yaml")
+	require.NoError(t, os.WriteFile(plusOne, []byte("12345678901"), 0o600)) // 11 bytes
+
+	_, err := loadFile(plusOne)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFileTooLarge)
+}
+
+func TestLoadFiles_OversizedIsSkippedNotFatalForDirectory(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "1024")
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.yaml")
+	goodContent := []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: good-pod\n  namespace: default\n")
+	require.NoError(t, os.WriteFile(good, goodContent, 0o600))
+
+	big := filepath.Join(dir, "big.yaml")
+	bigData := make([]byte, 2048)
+	for i := range bigData {
+		bigData[i] = 'B'
+	}
+	require.NoError(t, os.WriteFile(big, bigData, 0o600))
+
+	ctx := context.Background()
+	workloads, skips, err := LoadResourcesFromFiles(ctx, dir, dir, nil)
+	// Directory scan is best-effort: should succeed, keep good workload, report oversized as skip
+	require.NoError(t, err, "directory scan with one oversized file must not fail when other workloads exist")
+	assert.Len(t, workloads, 1)
+	require.Len(t, skips, 1)
+	assert.Equal(t, big, skips[0].Path)
+	assert.Contains(t, skips[0].Reason, "file too large")
+}
+
+func TestLoadFiles_OversizedSingleFileIsHardError(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "1024")
+	dir := t.TempDir()
+	big := filepath.Join(dir, "big.yaml")
+	bigData := make([]byte, 2048)
+	for i := range bigData {
+		bigData[i] = 'C'
+	}
+	require.NoError(t, os.WriteFile(big, bigData, 0o600))
+
+	ctx := context.Background()
+	workloads, skips, err := LoadResourcesFromFiles(ctx, big, dir, nil)
+	require.Error(t, err, "explicit single-file oversized input must be a hard error")
+	assert.Empty(t, workloads)
+	require.Len(t, skips, 1)
+	assert.Contains(t, skips[0].Reason, "file too large")
+}
+
+func TestGetMaxFileSize_EnvVarOverride(t *testing.T) {
+	t.Setenv(MaxFileSizeEnvVar, "67108864")
+	assert.Equal(t, int64(67108864), getMaxFileSize())
+
+	t.Setenv(MaxFileSizeEnvVar, "invalid")
+	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize(), "invalid value must fall back to default")
+
+	t.Setenv(MaxFileSizeEnvVar, "-5")
+	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize(), "non-positive must fall back to default")
+
+	t.Setenv(MaxFileSizeEnvVar, "")
+	assert.Equal(t, DefaultMaxFileSize, getMaxFileSize())
+}
+
+func TestLoadFile_DefaultLimitIs32MiB(t *testing.T) {
+	// Ensure default is not zero when env is not set
+	t.Setenv(MaxFileSizeEnvVar, "")
+	// Unset explicitly to test default path
+	require.NoError(t, os.Unsetenv(MaxFileSizeEnvVar))
+	assert.Equal(t, int64(32<<20), getMaxFileSize())
+	assert.Equal(t, int64(32*1024*1024), DefaultMaxFileSize)
+}


### PR DESCRIPTION
## Overview
Scanning a cloned / untrusted repo with a single large YAML (e.g. a generated 1–2 GiB file) currently OOMs the scanner and kills the CI runner.

**Current:** `core/cautils/fileutils.go:loadFile()` is `os.ReadFile()` with no cap. `loadFiles()` then iterates every matched path and keeps all raw bytes + parsed `workloadinterface.IMetadata` in memory. One `big.yaml` is enough for DoS.

**Future:** All file-scan reads are bounded at **32 MiB default** (`KUBESCAPE_MAX_FILE_SIZE` env, decimal bytes) via `Stat` fast-path + `io.LimitReader(limit+1)`. Oversized files are not loaded — they are recorded as `SkippedManifest{Reason: "file too large: … size … exceeds limit …"}` with sentinel `ErrFileTooLarge`. Directory / repo scans continue best-effort (warning, good manifests still scanned); explicit single-file scans hard-fail as before — returning nothing would hide corruption.

Fix is `+68` lines in `fileutils.go` + 7 regression tests in `fileutils_size_limit_test.go`.

## Additional Information

**Why 32 MiB?** Largest legitimate charts/manifests in the wild are <5 MiB. 32 MiB leaves headroom for Helm values with large ConfigMaps but stops a 4 GiB bomb before allocation. Matches patterns elsewhere in the codebase (`LargeClusterSize` style env override).

**Why `SkippedManifest` not `ScanCoverage`?** `SkippedManifest` is the existing per-file skip mechanism (`OPASessionObj.SkippedManifests` → `filesloader.go:56` → `results.go` JSON + pretty printer warning). Adding a new `ScanCoverage` field would break the report schema for no benefit. Behavior is already: directory scan warns via `logger.L().Warning("Skipping invalid manifest files")` and `logger.L().Warning("… manifests skipped …")` with path+reason; single-file input hard-errors via `LoadResourcesFromFilesFiltered: isFile(input)` branch — both preserved.

**Why `io.LimitReader(limit+1)` + `Stat`?** Covers two cases: regular files where `Stat.Size()` known (fail without allocating) and special files/pipes where `Stat` reports 0 or is unavailable (still bounded at `limit+1` and detected by `len(data) > limit`). `limit+1` lets us distinguish exactly-at-limit vs one-byte-over without reading the whole file.

**Env var handling:** `KUBESCAPE_MAX_FILE_SIZE` parsed as `int64` decimal bytes; empty / invalid / `<=0` falls back to `DefaultMaxFileSize` with a warning — scan stays bounded. Validated in `getMaxFileSize()`.

## Related issues/PRs
Resolved #3452

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes (`go test ./...` 45/45, `-race` in `core/cautils`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable manifest file-size limits, defaulting to 32 MiB.
  * Added support for overriding the limit through an environment setting.
  * Oversized files are skipped during directory scans while explicit oversized-file loads report an error.

* **Bug Fixes**
  * Improved handling of invalid or excessively large size-limit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->