### PR TITLE
fix(resultshandling): apply severity filters to framework control maps

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -15,6 +15,7 @@ import (
 	printerv2 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/reporter"
 	"github.com/kubescape/kubescape/v4/core/pkg/vapreconcile"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -147,8 +148,13 @@ type reportSnapshot struct {
 	// true unfiltered score while printers and submission saw the filtered one.
 	complianceScore            float32
 	frameworksComplianceScores []float32
+	frameworksControls         []reportsummary.ControlSummaries
 	controlsSeverityCounters   reportsummary.SeverityCounters
 	resourcesSeverityCounters  reportsummary.SeverityCounters
+	statusCounters             reportsummary.StatusCounters
+	status                     apis.ScanningStatus
+	frameworksStatusCounters   []reportsummary.StatusCounters
+	frameworksStatuses         []apis.ScanningStatus
 }
 
 func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
@@ -170,8 +176,14 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 	}
 
 	fwScores := make([]float32, len(sessionObj.Report.SummaryDetails.Frameworks))
+	fwControls := make([]reportsummary.ControlSummaries, len(sessionObj.Report.SummaryDetails.Frameworks))
+	fwStatusCounters := make([]reportsummary.StatusCounters, len(sessionObj.Report.SummaryDetails.Frameworks))
+	fwStatuses := make([]apis.ScanningStatus, len(sessionObj.Report.SummaryDetails.Frameworks))
 	for i := range sessionObj.Report.SummaryDetails.Frameworks {
 		fwScores[i] = sessionObj.Report.SummaryDetails.Frameworks[i].ComplianceScore
+		fwControls[i] = sessionObj.Report.SummaryDetails.Frameworks[i].Controls
+		fwStatusCounters[i] = sessionObj.Report.SummaryDetails.Frameworks[i].StatusCounters
+		fwStatuses[i] = sessionObj.Report.SummaryDetails.Frameworks[i].Status
 	}
 
 	return reportSnapshot{
@@ -179,8 +191,13 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 		associatedControls:         ac,
 		complianceScore:            sessionObj.Report.SummaryDetails.ComplianceScore,
 		frameworksComplianceScores: fwScores,
+		frameworksControls:         fwControls,
 		controlsSeverityCounters:   sessionObj.Report.SummaryDetails.ControlsSeverityCounters,
 		resourcesSeverityCounters:  sessionObj.Report.SummaryDetails.ResourcesSeverityCounters,
+		statusCounters:             sessionObj.Report.SummaryDetails.StatusCounters,
+		status:                     sessionObj.Report.SummaryDetails.Status,
+		frameworksStatusCounters:   fwStatusCounters,
+		frameworksStatuses:         fwStatuses,
 	}
 }
 
@@ -192,9 +209,18 @@ func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
 	sessionObj.Report.SummaryDetails.ComplianceScore = snap.complianceScore
 	sessionObj.Report.SummaryDetails.ControlsSeverityCounters = snap.controlsSeverityCounters
 	sessionObj.Report.SummaryDetails.ResourcesSeverityCounters = snap.resourcesSeverityCounters
+	sessionObj.Report.SummaryDetails.StatusCounters = snap.statusCounters
+	sessionObj.Report.SummaryDetails.Status = snap.status
 	for i := range sessionObj.Report.SummaryDetails.Frameworks {
 		if i < len(snap.frameworksComplianceScores) {
 			sessionObj.Report.SummaryDetails.Frameworks[i].ComplianceScore = snap.frameworksComplianceScores[i]
+		}
+		if i < len(snap.frameworksControls) {
+			sessionObj.Report.SummaryDetails.Frameworks[i].Controls = snap.frameworksControls[i]
+		}
+		if i < len(snap.frameworksStatusCounters) {
+			sessionObj.Report.SummaryDetails.Frameworks[i].StatusCounters = snap.frameworksStatusCounters[i]
+			sessionObj.Report.SummaryDetails.Frameworks[i].Status = snap.frameworksStatuses[i]
 		}
 	}
 	for id, ac := range snap.associatedControls {

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -1083,3 +1083,40 @@ func TestHandleResults_PrintsFilteredScoreAndRestoresUnfiltered(t *testing.T) {
 		"severity counters must be restored after HandleResults")
 	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 3, "Controls must be unfiltered after HandleResults")
 }
+
+func TestResultsHandlerHandleResultsRestoresFrameworkControls(t *testing.T) {
+	scanData := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: map[string]reportsummary.ControlSummary{
+					"C-1": {ControlID: "C-1", ScoreFactor: 2},
+					"C-2": {ControlID: "C-2", ScoreFactor: 9},
+				},
+				StatusCounters: reportsummary.StatusCounters{FailedResources: 3},
+				Status:         apis.StatusFailed,
+				Frameworks: []reportsummary.FrameworkSummary{{
+					Name: "NSA",
+					Controls: map[string]reportsummary.ControlSummary{
+						"C-1": {ControlID: "C-1", ScoreFactor: 2},
+						"C-2": {ControlID: "C-2", ScoreFactor: 9},
+					},
+					StatusCounters: reportsummary.StatusCounters{FailedResources: 3},
+					Status:         apis.StatusFailed,
+				}},
+			},
+		},
+	}
+
+	spy := &SpyPrinter{}
+	rh := NewResultsHandler(&DummyReporter{}, nil, spy)
+	rh.SetData(scanData)
+
+	require.NoError(t, rh.HandleResults(context.Background(), &cautils.ScanInfo{MinSeverity: "high"}))
+
+	assert.Len(t, scanData.Report.SummaryDetails.Controls, 2)
+	assert.Len(t, scanData.Report.SummaryDetails.Frameworks[0].Controls, 2)
+	assert.Equal(t, 3, scanData.Report.SummaryDetails.StatusCounters.Failed())
+	assert.Equal(t, apis.StatusFailed, scanData.Report.SummaryDetails.Status)
+	assert.Equal(t, 3, scanData.Report.SummaryDetails.Frameworks[0].StatusCounters.Failed())
+	assert.Equal(t, apis.StatusFailed, scanData.Report.SummaryDetails.Frameworks[0].Status)
+}

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 )
@@ -35,6 +36,20 @@ func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSev
 		} else {
 			retained[id] = struct{}{}
 		}
+	}
+
+	for i := range sessionObj.Report.SummaryDetails.Frameworks {
+		controls := sessionObj.Report.SummaryDetails.Frameworks[i].Controls
+		if len(controls) == 0 {
+			continue
+		}
+		filtered := make(reportsummary.ControlSummaries, len(controls))
+		for id, ctrl := range controls {
+			if _, ok := retained[id]; ok {
+				filtered[id] = ctrl
+			}
+		}
+		sessionObj.Report.SummaryDetails.Frameworks[i].Controls = filtered
 	}
 
 	for id, result := range sessionObj.ResourcesResult {
@@ -100,6 +115,8 @@ func recomputeSummaryDetails(sessionObj *cautils.OPASessionObj) {
 		}
 	}
 
+	recomputeStatusCounters(summary)
+
 	summary.ResourcesSeverityCounters = reportsummary.SeverityCounters{}
 	for _, result := range sessionObj.ResourcesResult {
 		if !result.GetStatus(nil).IsFailed() {
@@ -113,6 +130,23 @@ func recomputeSummaryDetails(sessionObj *cautils.OPASessionObj) {
 				summary.ResourcesSeverityCounters.Increase(apis.ControlSeverityToString(ctrl.GetScoreFactor()), 1)
 			}
 		}
+	}
+}
+
+func recomputeStatusCounters(summary *reportsummary.SummaryDetails) {
+	l := helpersv1.GetAllListsFromPool()
+	defer helpersv1.PutAllListsToPool(l)
+
+	summary.StatusCounters = reportsummary.StatusCounters{}
+	summary.StatusCounters.Set(summary.ListResourcesIDs(l))
+	summary.CalculateStatus()
+
+	for i := range summary.Frameworks {
+		fl := helpersv1.GetAllListsFromPool()
+		summary.Frameworks[i].StatusCounters = reportsummary.StatusCounters{}
+		summary.Frameworks[i].StatusCounters.Set(summary.Frameworks[i].ListResourcesIDs(fl))
+		summary.Frameworks[i].CalculateStatus()
+		helpersv1.PutAllListsToPool(fl)
 	}
 }
 

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -394,3 +394,84 @@ func TestApplySeverityFilters_ZeroRetainedZeroesComplianceScoreAndCounters(t *te
 	// The risk score is not recomputed at filter time; it is left unchanged.
 	assert.Equal(t, float32(100), s.Report.SummaryDetails.Score)
 }
+
+func TestApplySeverityFilters_FrameworkControlsFilteredAlongWithSummary(t *testing.T) {
+	s := makeSessionWithControls(map[string]reportsummary.ControlSummary{
+		"C-1": makeControl("C-1", scoreLow),
+		"C-2": makeControl("C-2", scoreHigh),
+		"C-3": makeControl("C-3", scoreCritical),
+	})
+	s.Report.SummaryDetails.Frameworks = []reportsummary.FrameworkSummary{
+		{
+			Name: "NSA",
+			Controls: map[string]reportsummary.ControlSummary{
+				"C-1": makeControl("C-1", scoreLow),
+				"C-2": makeControl("C-2", scoreHigh),
+			},
+		},
+		{
+			Name: "MITRE",
+			Controls: map[string]reportsummary.ControlSummary{
+				"C-3": makeControl("C-3", scoreCritical),
+			},
+		},
+	}
+
+	ApplySeverityFilters(s, "high", "")
+
+	assert.ElementsMatch(t, []string{"C-2", "C-3"}, controlIDsOf(s.Report.SummaryDetails.Controls))
+	assert.ElementsMatch(t, []string{"C-2"}, controlIDsOf(s.Report.SummaryDetails.Frameworks[0].Controls))
+	assert.ElementsMatch(t, []string{"C-3"}, controlIDsOf(s.Report.SummaryDetails.Frameworks[1].Controls))
+}
+
+func TestApplySeverityFilters_FrameworkWithoutControls(t *testing.T) {
+	s := makeSessionWithControls(map[string]reportsummary.ControlSummary{
+		"C-1": makeControl("C-1", scoreCritical),
+	})
+	s.Report.SummaryDetails.Frameworks = []reportsummary.FrameworkSummary{{Name: "NSA"}}
+
+	ApplySeverityFilters(s, "high", "")
+
+	assert.Empty(t, s.Report.SummaryDetails.Frameworks[0].Controls)
+}
+
+func controlIDsOf(controls map[string]reportsummary.ControlSummary) []string {
+	ids := make([]string, 0, len(controls))
+	for id := range controls {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func makeControlWithResources(id string, scoreFactor float32, status apis.ScanningStatus, resourceIDs ...string) reportsummary.ControlSummary {
+	c := makeControl(id, scoreFactor)
+	c.Status = status
+	c.ResourceIDs.Append(status, resourceIDs...)
+	return c
+}
+
+func TestApplySeverityFilters_StatusCountersRecomputedOverRetainedControls(t *testing.T) {
+	lowFail := makeControlWithResources("C-1", scoreLow, apis.StatusFailed, "res-1")
+	criticalPass := makeControlWithResources("C-2", scoreCritical, apis.StatusPassed, "res-1")
+
+	s := makeSessionWithControls(map[string]reportsummary.ControlSummary{
+		"C-1": lowFail,
+		"C-2": criticalPass,
+	})
+	s.Report.SummaryDetails.Frameworks = []reportsummary.FrameworkSummary{{
+		Name: "NSA",
+		Controls: map[string]reportsummary.ControlSummary{
+			"C-1": lowFail,
+			"C-2": criticalPass,
+		},
+	}}
+
+	ApplySeverityFilters(s, "critical", "")
+
+	summary := &s.Report.SummaryDetails
+	assert.Equal(t, 0, summary.StatusCounters.Failed())
+	assert.Equal(t, 1, summary.StatusCounters.Passed())
+	assert.Equal(t, apis.StatusPassed, summary.Status)
+	assert.Equal(t, 0, summary.Frameworks[0].StatusCounters.Failed())
+	assert.Equal(t, apis.StatusPassed, summary.Frameworks[0].Status)
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `ApplySeverityFilters` removed controls from `SummaryDetails.Controls` and from every per-resource associated-control list, but left the per-framework control map and the resource status counters still describing the controls it had just dropped.

- **Files changed:**
  - `core/pkg/resultshandling/severity_filter.go`: rebuilds each `Frameworks[i].Controls` map from the same `retained` set the function already computes, then recomputes the summary and per-framework `StatusCounters`/`Status` over the surviving controls
  - `core/pkg/resultshandling/results.go`: snapshots and restores both, alongside the derived fields #3436 already snapshots, so the exit gate and the submitted report keep seeing the unfiltered report

- **What the fix does:** makes the filtered report internally consistent. `summaryDetails.frameworks[].controls`, `ResourceCounters` and `status` are all serialized, so before this fix a filtered scan contradicted itself:

  ```
  kubescape scan framework nsa ./manifests --min-severity high --format json
  before:  summaryDetails.controls = 8   frameworks[NSA].controls = 20   (12 filtered-out controls still listed)
  after:   summaryDetails.controls = 8   frameworks[NSA].controls = 8

  kubescape scan framework nsa ./manifests --min-severity critical --format json
  before:  controls = 0   frameworks[NSA].status = failed   ResourceCounters = {failedResources: 1}
  after:   controls = 0   frameworks[NSA].status = passed   ResourceCounters = {failedResources: 0}
  ```

  The counters are recomputed through the same opa-utils helpers report generation uses (`ListResourcesIDs` → `StatusCounters.Set` → `CalculateStatus`), so the filtered numbers come from the same formula as the unfiltered ones rather than a reimplementation. Framework compliance scores are untouched, they stay exactly as #3436 left them.

- **What was tested:**
  - `TestApplySeverityFilters_FrameworkControlsFilteredAlongWithSummary`: per-framework maps are filtered with the summary, across two frameworks
  - `TestApplySeverityFilters_FrameworkWithoutControls`: a framework carrying no controls is left alone
  - `TestApplySeverityFilters_StatusCountersRecomputedOverRetainedControls`: a resource failing only a low control and passing a critical one flips to passed at both summary and framework level under `--min-severity critical`
  - `TestResultsHandlerHandleResultsRestoresFrameworkControls`: the maps, counters and statuses are restored after `HandleResults`; verified it fails when the restore is removed
  - Manually against real scans: both cases above, plus the exit gate still evaluating the unfiltered score (unfiltered 55, displayed 62.50, `--min-severity high --compliance-threshold 60` exits 1)
  - Full `go test ./... -count=1 -short` passes

- **Related issues:** follows #3436 / #3434, which recomputed the compliance scores and severity counters after severity filtering but left the framework control map and the resource status counters untouched.

**Which issue(s) this PR fixes:**
None filed. This is the remaining half of the inconsistency #3436 addressed.

**Special notes for your reviewer:**

#3436 works around the stale map rather than pruning it, its framework score loop guards with `if _, ok := summary.Controls[id]; ok`. That guard is now redundant, but removing it would be a refactor of just-merged code, so it is left in place.

The `results.go` half is the part worth a careful look. Without it, filtering in place would leak past `HandleResults` into `--compliance-threshold`, the httphandler `/v1/results` response and `StorePostureReportResults`. The control maps are replaced rather than mutated, so the snapshot stores the original reference and needs no deep copy.

Worth agreeing on explicitly: recomputing the status counters means a filter that removes every finding now reports `status: passed`. That is the honest reading of a filtered report ("nothing at or above this severity") and it matches the direction #3436 already took with the compliance score, but it does change a field people read.

**Does this PR introduce a user-facing change?**
Yes with `--min-severity`/`--max-severity`, `summaryDetails.frameworks[].controls` now lists only the controls that survived the filter, and `ResourceCounters`/`status` at both the summary and framework level are recomputed over them. A filter that removes every finding reports `status: passed` with zero failed resources, where it previously reported `failed` beside an empty control list. Exit code, submitted report and `/v1/results` are unchanged — they still see the unfiltered report. Output without those flags is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity filtering now consistently updates controls and status information at both summary and framework levels.
  * Frameworks without matching controls remain available with empty control lists.
  * Status counters and pass/fail statuses are recalculated using only retained controls.
  * Filtered report data is fully restored after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->