### PR TITLE
fix(scan): fail explicitly on unmatched severity threshold

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -162,12 +162,21 @@ func countersExceedSeverityThreshold(severityCounters reportsummary.ISeverityCou
 		{reporthandlingapis.SeverityCriticalString, severityCounters.NumberOfCriticalSeverity},
 	}
 
+	normalizedTarget := strings.TrimSpace(targetSeverity)
+
 	targetSeverityIdx := 0
+	found := false
 	for idx, description := range getFailedResourcesFuncsBySeverity {
-		if strings.EqualFold(description.SeverityName, targetSeverity) {
+		if strings.EqualFold(description.SeverityName, normalizedTarget) {
 			targetSeverityIdx = idx
+			found = true
 			break
 		}
+	}
+	if !found {
+		// Defensive: ValidateSeverity passed but severity not in ordered slice.
+		// Return explicit error instead of silently falling back to lowest index.
+		return false, fmt.Errorf("%w: %q", shared.ErrUnknownSeverity, targetSeverity)
 	}
 
 	for _, description := range getFailedResourcesFuncsBySeverity[targetSeverityIdx:] {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -132,7 +132,7 @@ func TestExceedsSeverity(t *testing.T) {
 				t.Errorf("got: %v, want: %v", got, want)
 			}
 
-			if err != testCase.Error {
+			if !errors.Is(err, testCase.Error) {
 				t.Errorf(`got error "%v", want "%v"`, err, testCase.Error)
 			}
 		})


### PR DESCRIPTION
## Overview
`countersExceedSeverityThreshold` in `cmd/scan/framework.go:165` initialized `targetSeverityIdx := 0` and never checked if the loop actually found a match. If the threshold string didn't match any of `Low` / `Medium` / `High` / `Critical`, it silently fell through to `0` and checked every severity starting from `Low`.

Right now this is hidden because `shared.ValidateSeverity()` only allows those four values, which happen to exactly match the local ordered slice. But `reporthandling/apis.GetSupportedSeverities()` is the single source of truth and already defines `Unknown` and `Negligible`. If that list ever grows, or a caller bypasses validation, or a padded value like `" critical "` is passed (validator does `TrimSpace`, the loop didn't), the CI gate would silently become broader instead of failing loudly.

This PR normalizes the lookup the same way validation does (`TrimSpace` + case-insensitive `EqualFold`) and tracks `found`. If nothing matches after `ValidateSeverity`, it returns `fmt.Errorf("%w: %q", shared.ErrUnknownSeverity, targetSeverity)` instead of defaulting to `Low`.

Fixes #3454

## Additional Information
Small defensive diff. The ordering `Low(0) < Medium(1) < High(2) < Critical(3)` is preserved so `getFailedResourcesFuncsBySeverity[idx:]` still works correctly. No new dependencies, no output schema change, and no behavior change for the four supported severities.

Follow-up note: the long-term fix is to derive the ordered slice from `GetSupportedSeverities()` / `severityOrdinal` so the two lists can't drift — see issue for details.

## How to Test

```bash
go test ./cmd/scan -run "TestExceedsSeverity|Test_enforceSeverityThresholds" -v
go test ./cmd/shared -run TestValidateSeverity -v
go vet ./cmd/scan
```

Manual check for the gap that previously had no coverage:

- `threshold=" critical "` (padded) with only `Medium=1` — before: incorrectly `true` (treated as `Low`), after: correctly `false` (normalized to `Critical`)
- `threshold="negligible"` with `Critical=1` — before: would have returned `true` via fallback if validator ever allowed it, after: `errors.Is(err, ErrUnknownSeverity)` is true

Existing case `TestExceedsSeverity/Unknown_severity_returns_an_error` still passes via `ValidateSeverity`. An invariant test `every GetSupportedSeverities() value must be in the ordered slice` can now be added to catch future drift.

## Related issues/PRs:
* Resolved #3454

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Severity threshold matching now ignores surrounding whitespace and letter casing, providing more consistent results for valid severity values.
  * Invalid or unrecognized severity values now return a clear error instead of being treated as the lowest severity.
  * Error handling is now more reliable when reporting wrapped validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->