### PR TITLE
fix(httphandler): add optional bearer auth and trust boundary docs for /v1 endpoints

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -305,6 +305,7 @@ Configure the HTTP handler using environment variables:
 | `KS_SCAN_REQUEST_MAX_BYTES` | Maximum size in bytes of a `POST /v1/scan` request body | `1048576` |
 | `KS_PPROF_ENABLED` | Enable the pprof debug server (off by default; binds to loopback only) | `true`, `false` |
 | `KS_PPROF_ADDR` | Address the pprof debug server binds to when enabled | `127.0.0.1:6060` |
+| `KS_API_TOKEN` | Bearer token for `/v1/*` API authentication (optional, off by default). When set, every `/v1/scan`, `/v1/results` and `/v1/status` request must present `Authorization: Bearer <token>` or it gets `401`. Health probes `/livez`/`/readyz` and OpenAPI docs stay open. If you expose `:8080` beyond the cluster, set this to a random value and serve over TLS (`KS_CERT_FILE`/`KS_KEY_FILE`) or a TLS-terminating ingress. | `openssl rand -hex 32` |
 
 ---
 

--- a/httphandler/listener/auth_test.go
+++ b/httphandler/listener/auth_test.go
@@ -85,12 +85,45 @@ func TestBearerAuthMiddleware_UnauthenticatedBlocks(t *testing.T) {
 	rtr.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Health probes remain open even with token set — they live on the root router, not v1SubRouter
-	health := mux.NewRouter()
-	health.HandleFunc(livePath, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	// Lowercase bearer scheme (RFC 7235: scheme is case-insensitive) => 200
+	req = httptest.NewRequest(http.MethodGet, "/v1/results?id=abc", nil)
+	req.Header.Set("Authorization", "bearer s3cr3t")
 	rec = httptest.NewRecorder()
-	health.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, livePath, nil))
-	require.Equal(t, http.StatusOK, rec.Code, "health probes must stay unauthenticated")
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "Bearer scheme must be case-insensitive")
+
+	// Mixed-case Bearer + extra spaces around token => 200 (TrimSpace)
+	req = httptest.NewRequest(http.MethodGet, "/v1/results?id=abc", nil)
+	req.Header.Set("Authorization", "BeArEr   s3cr3t   ")
+	rec = httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHealthProbesOnProductionRouter proves /livez stays open on the real
+// wiring where /livez is on rtr directly and only /v1/* is under
+// bearerAuthMiddleware. Previous version built a disconnected mux that never
+// had the middleware, so it was tautologically true.
+func TestHealthProbesOnProductionRouter(t *testing.T) {
+	t.Setenv(authTokenEnv, "s3cr3t")
+	// Build a router the same way SetupHTTPListener does: health on root, v1 with middleware.
+	rtr := mux.NewRouter()
+	rtr.HandleFunc(livePath, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	rtr.HandleFunc(readyPath, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	v1 := rtr.PathPrefix(v1PathPrefix).Subrouter()
+	v1.Use(bearerAuthMiddleware)
+	v1.HandleFunc(v1ScanPath, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }).Methods(http.MethodPost)
+
+	// Health without token => 200 even though v1 needs it
+	for _, path := range []string{livePath, readyPath} {
+		rec := httptest.NewRecorder()
+		rtr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusOK, rec.Code, "%s must stay unauthenticated", path)
+	}
+	// v1 without token => 401
+	rec := httptest.NewRecorder()
+	rtr.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/scan", nil))
+	require.Equal(t, http.StatusUnauthorized, rec.Code, "/v1/scan must require token")
 }
 
 func TestBearerAuthMiddleware_ConstantTimeAndTrim(t *testing.T) {

--- a/httphandler/listener/auth_test.go
+++ b/httphandler/listener/auth_test.go
@@ -1,0 +1,114 @@
+package listener
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestV1Router(next http.Handler) *mux.Router {
+	r := mux.NewRouter()
+	sub := r.PathPrefix(v1PathPrefix).Subrouter()
+	sub.Use(bearerAuthMiddleware)
+	sub.Handle(v1ScanPath, next).Methods(http.MethodPost)
+	sub.Handle(v1ScanPath, next).Methods(http.MethodDelete)
+	sub.Handle(v1ResultsPath, next).Methods(http.MethodGet)
+	sub.Handle(v1ResultsPath, next).Methods(http.MethodDelete)
+	sub.Handle(v1StatusPath, next).Methods(http.MethodGet)
+	return r
+}
+
+func TestGetAuthToken_TrimsSpaces(t *testing.T) {
+	t.Setenv(authTokenEnv, "  s3cr3t  ")
+	assert.Equal(t, "s3cr3t", getAuthToken())
+	t.Setenv(authTokenEnv, "   ")
+	assert.Equal(t, "", getAuthToken())
+	t.Setenv(authTokenEnv, "")
+	assert.Equal(t, "", getAuthToken())
+}
+
+func TestBearerAuthMiddleware_DisabledIsNoop(t *testing.T) {
+	t.Setenv(authTokenEnv, "")
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	rtr := newTestV1Router(next)
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/v1/scan"},
+		{http.MethodDelete, "/v1/scan"},
+		{http.MethodGet, "/v1/results"},
+		{http.MethodDelete, "/v1/results"},
+		{http.MethodGet, "/v1/status"},
+	} {
+		rec := httptest.NewRecorder()
+		rtr.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		require.Equal(t, http.StatusOK, rec.Code, "%s %s should be open when token unset", tc.method, tc.path)
+	}
+}
+
+func TestBearerAuthMiddleware_UnauthenticatedBlocks(t *testing.T) {
+	t.Setenv(authTokenEnv, "s3cr3t")
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	rtr := newTestV1Router(next)
+
+	// No header => 401
+	rec := httptest.NewRecorder()
+	rtr.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/scan", nil))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), "Bearer")
+	assert.Contains(t, rec.Body.String(), "Authorization")
+
+	// Wrong token => 401 (would be 200 on buggy code)
+	req := httptest.NewRequest(http.MethodGet, "/v1/results?id=abc", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec = httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Wrong scheme => 401
+	req = httptest.NewRequest(http.MethodPost, "/v1/scan", nil)
+	req.Header.Set("Authorization", "Basic s3cr3t")
+	rec = httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Correct token => 200
+	req = httptest.NewRequest(http.MethodGet, "/v1/results?id=abc", nil)
+	req.Header.Set("Authorization", "Bearer s3cr3t")
+	rec = httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Health probes remain open even with token set — they live on the root router, not v1SubRouter
+	health := mux.NewRouter()
+	health.HandleFunc(livePath, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	rec = httptest.NewRecorder()
+	health.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, livePath, nil))
+	require.Equal(t, http.StatusOK, rec.Code, "health probes must stay unauthenticated")
+}
+
+func TestBearerAuthMiddleware_ConstantTimeAndTrim(t *testing.T) {
+	t.Setenv(authTokenEnv, "s3cr3t")
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	rtr := newTestV1Router(next)
+
+	// Token with surrounding spaces should still pass (TrimSpace)
+	req := httptest.NewRequest(http.MethodPost, "/v1/scan", nil)
+	req.Header.Set("Authorization", "Bearer   s3cr3t   ")
+	rec := httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Empty bearer value => 401
+	req = httptest.NewRequest(http.MethodPost, "/v1/scan", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	rec = httptest.NewRecorder()
+	rtr.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -181,7 +181,8 @@ func getAuthToken() string {
 
 // bearerAuthMiddleware enforces `Authorization: Bearer <token>` when KS_API_TOKEN is set.
 // When the env var is unset/empty it is a no-op for backward compatibility.
-// It uses subtle.ConstantTimeCompare to avoid timing side-channels.
+// It uses subtle.ConstantTimeCompare to avoid timing side-channels and accepts
+// the Bearer scheme case-insensitively per RFC 7235 (e.g. `bearer` is valid).
 func bearerAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		expected := getAuthToken()
@@ -190,13 +191,13 @@ func bearerAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		hdr := r.Header.Get("Authorization")
-		const prefix = "Bearer "
-		if !strings.HasPrefix(hdr, prefix) {
+		scheme, token, ok := strings.Cut(hdr, " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="kubescape"`)
 			http.Error(w, `{"error":"missing or invalid Authorization header"}`, http.StatusUnauthorized)
 			return
 		}
-		got := strings.TrimSpace(strings.TrimPrefix(hdr, prefix))
+		got := strings.TrimSpace(token)
 		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="kubescape"`)
 			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"crypto/subtle"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -31,6 +32,11 @@ const (
 	// healthcheck paths
 	livePath  = "/livez"
 	readyPath = "/readyz"
+
+	// authTokenEnv gates optional bearer-token auth for /v1/*. When set, every
+	// /v1/* request must present `Authorization: Bearer <token>`. When unset the
+	// listener remains unauthenticated for backward compatibility (in-cluster only).
+	authTokenEnv = "KS_API_TOKEN"
 )
 
 // SetupHTTPListener set up listening http servers
@@ -65,15 +71,41 @@ func SetupHTTPListener() error {
 
 	rtr := mux.NewRouter()
 
-	// non-monitored endpoints
+	// Health probes are intentionally unauthenticated — kubelet needs them without credentials.
 	rtr.HandleFunc(livePath, httpHandler.Live)
 	rtr.HandleFunc(readyPath, httpHandler.Ready)
 	rtr.PathPrefix(docs.OpenAPIV2Prefix).Methods("GET").Handler(openApiHandler)
 
-	// OpenTelemetry middleware for monitored endpoints
+	// -------------------------------------------------------------------------
+	// Trust boundary for /v1/* (scan trigger + results):
+	// By default the listener is unauthenticated and intended to be reachable
+	// only inside the cluster (ClusterIP / port-forward). This matches the
+	// historical in-cluster microservice deployment and preserves backward
+	// compatibility.
+	//
+	// If the operator exposes :8080 beyond the cluster (LoadBalancer, Ingress,
+	// NodePort on a public node), set KS_API_TOKEN to a cryptographically
+	// random bearer token. When set, every /v1/* request must present
+	// `Authorization: Bearer <token>`; otherwise 401 is returned. This is
+	// opt-in so existing in-cluster installs do not break on upgrade — see
+	// getAuthToken / bearerAuthMiddleware below. Unlike pprof (servePprof),
+	// which is off by default, the scan API is on by default because it is
+	// the product surface; the hardening is therefore additive and env-gated.
+	//
+	// Rate limiting is intentionally not added here: scan admission already
+	// enforces bounded queue depth (KS_SCAN_QUEUE_CAPACITY, default 10) with
+	// 429 + Retry-After and a 1 MiB body cap (KS_SCAN_REQUEST_MAX_BYTES).
+	// External L7 rate limiting should be done at the Ingress if needed.
+	// -------------------------------------------------------------------------
 	otelMiddleware := otelmux.Middleware("kubescape-svc")
 	v1SubRouter := rtr.PathPrefix(v1PathPrefix).Subrouter()
 	v1SubRouter.Use(otelMiddleware)
+	if tok := getAuthToken(); tok != "" {
+		logger.L().Info("API token authentication enabled for /v1/* endpoints", helpers.String("env", authTokenEnv))
+	} else {
+		logger.L().Warning("API token not configured — /v1/* endpoints are unauthenticated; ensure the service is not exposed beyond the cluster", helpers.String("env", authTokenEnv))
+	}
+	v1SubRouter.Use(bearerAuthMiddleware)
 	v1SubRouter.HandleFunc(v1PrometheusMetricsPath, httpHandler.Metrics) // deprecated
 	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.Scan).Methods(http.MethodPost)
 	v1SubRouter.HandleFunc(v1ScanPath, httpHandler.CancelScan).Methods(http.MethodDelete)
@@ -141,6 +173,37 @@ func getPprofAddr() string {
 		return a
 	}
 	return "127.0.0.1:6060"
+}
+
+func getAuthToken() string {
+	return strings.TrimSpace(os.Getenv(authTokenEnv))
+}
+
+// bearerAuthMiddleware enforces `Authorization: Bearer <token>` when KS_API_TOKEN is set.
+// When the env var is unset/empty it is a no-op for backward compatibility.
+// It uses subtle.ConstantTimeCompare to avoid timing side-channels.
+func bearerAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expected := getAuthToken()
+		if expected == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		hdr := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(hdr, prefix) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="kubescape"`)
+			http.Error(w, `{"error":"missing or invalid Authorization header"}`, http.StatusUnauthorized)
+			return
+		}
+		got := strings.TrimSpace(strings.TrimPrefix(hdr, prefix))
+		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="kubescape"`)
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // servePprof starts the net/http/pprof debug server, but only when


### PR DESCRIPTION
## Overview

This PR hardens the `ksserver` HTTP service without breaking existing in-cluster installs.

Before, `POST /v1/scan`, `DELETE /v1/scan`, `GET /v1/results` and `DELETE /v1/results` were registered on the `v1SubRouter` with only the OpenTelemetry middleware (`httphandler/listener/setup.go:77-82`). Anyone who could reach `:8080` could trigger a scan or read/delete results. That is fine for the intended `ClusterIP`/port-forward use, but `setup.go` never said so — unlike `servePprof`, which has a long comment explaining `KS_PPROF_ENABLED=true` + loopback `127.0.0.1:6060`.

Changes:

* Adds a trust-boundary comment next to the `v1` route registration, same style as `servePprof`, explaining the in-cluster-only intent and what to do when exposing the port.
* Adds an **opt-in** `Authorization: Bearer` middleware gated on `KS_API_TOKEN`. When `KS_API_TOKEN` is unset/empty the listener behaves exactly as before (no auth). When it is set, every `/v1/*` request must present `Authorization: Bearer <token>` or it gets `401` with `WWW-Authenticate: Bearer`.
* Health checks `/livez` and `/readyz` stay unauthenticated for the kubelet.
* Uses `subtle.ConstantTimeCompare` and `TrimSpace` so Helm-rendered values with whitespace do not break.

No new dependency, no config file, no breaking change for current deployments.

## Additional Information

* Scope is data-leakage/low severity — defensible as in-cluster-only today, risky if someone puts a `LoadBalancer`/`Ingress` in front of `8080` (as shown in `httphandler/examples/microservice/ks-deployment.yaml`).
* Rate limiting is not added here. Scan admission already bounds work via `KS_SCAN_QUEUE_CAPACITY` (default 10, 429 + `Retry-After`) and the 1 MiB body cap `KS_SCAN_REQUEST_MAX_BYTES`. External L7 throttling should live at the Ingress if needed — noted in the trust-boundary comment.
* Logging: when `KS_API_TOKEN` is set we log `Info` that auth is enabled; when it is not set we log a `Warning` that `/v1/*` is unauthenticated and the service should not be exposed beyond the cluster. This is visible at startup without being noisy per request.
* `#2028` (results-lookup substring issue) is out of scope and not touched here.

## Related issues/PRs

* Resolves #3459
* Not addressing #2028 (tracked separately)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas (trust-boundary comment + middleware godoc)
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests (`httphandler/listener/auth_test.go`)
- [x] New and existing unit tests pass locally with my changes (`go test ./...` in both modules, `-race` clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for `/v1/*` API endpoints using the `KS_API_TOKEN` environment setting.
  * Supports case-insensitive Bearer schemes and surrounding whitespace in credentials.
  * Invalid or missing credentials receive a `401 Unauthorized` response with authentication guidance.
  * Health checks and OpenAPI routes remain accessible without authentication.
  * Existing unauthenticated behavior is preserved when no token is configured.

* **Documentation**
  * Added configuration and security guidance for API authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->