### PR TITLE
fix(anonymizer): anonymize container names and images on scanned workloads

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -21,12 +21,6 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 		return nil
 	}
 
-	if wl, ok := resource.(workloadinterface.IWorkload); ok {
-		if err := transformTypedWorkloadContainers(wl, transformer); err != nil {
-			return err
-		}
-	}
-
 	obj := resource.GetObject()
 	if obj == nil {
 		return nil
@@ -37,34 +31,6 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 	}
 
 	resource.SetObject(obj)
-
-	return nil
-}
-
-func transformTypedWorkloadContainers(wl workloadinterface.IWorkload, transformer Transformer) error {
-	kind := wl.GetKind()
-	scope := workloadinterface.PodSpec(kind)
-
-	if containers, err := wl.GetContainers(); err == nil && len(containers) > 0 {
-		if err := transformTypedContainerList(containers, transformer); err != nil {
-			return err
-		}
-		workloadinterface.SetInMap(wl.GetObject(), scope, "containers", containers)
-	}
-
-	if initContainers, err := wl.GetInitContainers(); err == nil && len(initContainers) > 0 {
-		if err := transformTypedContainerList(initContainers, transformer); err != nil {
-			return err
-		}
-		workloadinterface.SetInMap(wl.GetObject(), scope, "initContainers", initContainers)
-	}
-
-	if ephemeralContainers, err := wl.GetEphemeralContainers(); err == nil && len(ephemeralContainers) > 0 {
-		if err := transformTypedEphemeralContainerList(ephemeralContainers, transformer); err != nil {
-			return err
-		}
-		workloadinterface.SetInMap(wl.GetObject(), scope, "ephemeralContainers", ephemeralContainers)
-	}
 
 	return nil
 }
@@ -258,7 +224,8 @@ func transformContainerList(obj map[string]any, key string, transformer Transfor
 		return nil
 	}
 
-	if containers, ok := rawContainers.([]any); ok {
+	switch containers := rawContainers.(type) {
+	case []any:
 		for _, item := range containers {
 			container, ok := item.(map[string]any)
 			if !ok {
@@ -271,6 +238,10 @@ func transformContainerList(obj map[string]any, key string, transformer Transfor
 		}
 
 		obj[key] = containers
+	case []corev1.Container:
+		if err := transformTypedContainerList(containers, transformer); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -290,7 +261,8 @@ func transformEphemeralContainerList(obj map[string]any, key string, transformer
 		return nil
 	}
 
-	if containers, ok := rawContainers.([]any); ok {
+	switch containers := rawContainers.(type) {
+	case []any:
 		for _, item := range containers {
 			container, ok := item.(map[string]any)
 			if !ok {
@@ -303,6 +275,10 @@ func transformEphemeralContainerList(obj map[string]any, key string, transformer
 		}
 
 		obj[key] = containers
+	case []corev1.EphemeralContainer:
+		if err := transformTypedEphemeralContainerList(containers, transformer); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -988,3 +988,66 @@ func TestTransformUnstructuredEnv_LeaksAPIKeyValue(t *testing.T) {
 		t.Fatalf("env var APIKEY value was not transformed; secret leaked into output")
 	}
 }
+
+func TestTransformContainerList_TypedSlice(t *testing.T) {
+	obj := map[string]any{
+		"containers": []corev1.Container{
+			{
+				Name:  "my-container",
+				Image: "registry.internal.corp/team/app:1.0",
+				Env:   []corev1.EnvVar{{Name: "API_KEY", Value: "s3cret"}},
+			},
+		},
+	}
+
+	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
+
+	containers, ok := obj["containers"].([]corev1.Container)
+	assert.True(t, ok)
+	assert.NotEqual(t, "my-container", containers[0].Name)
+	assert.NotEqual(t, "registry.internal.corp/team/app:1.0", containers[0].Image)
+	assert.NotEqual(t, "s3cret", containers[0].Env[0].Value)
+}
+
+func TestTransformEphemeralContainerList_TypedSlice(t *testing.T) {
+	obj := map[string]any{
+		"ephemeralContainers": []corev1.EphemeralContainer{
+			{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:  "debugger",
+					Image: "registry.internal.corp/team/debug:1.0",
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, transformEphemeralContainerList(obj, "ephemeralContainers", NewMappingTransformer()))
+
+	containers, ok := obj["ephemeralContainers"].([]corev1.EphemeralContainer)
+	assert.True(t, ok)
+	assert.NotEqual(t, "debugger", containers[0].Name)
+	assert.NotEqual(t, "registry.internal.corp/team/debug:1.0", containers[0].Image)
+}
+
+func TestTransformPodSpecs_TypedContainersFromScanPipeline(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"containers": []corev1.Container{
+				{Name: "app", Image: "registry.internal.corp/team/app:1.0"},
+			},
+			"initContainers": []corev1.Container{
+				{Name: "migrate", Image: "registry.internal.corp/team/migrate:1.0"},
+			},
+		},
+	}
+
+	assert.NoError(t, transformPodSpecs(obj, NewMappingTransformer()))
+
+	spec := obj["spec"].(map[string]any)
+	containers := spec["containers"].([]corev1.Container)
+	initContainers := spec["initContainers"].([]corev1.Container)
+	assert.NotEqual(t, "app", containers[0].Name)
+	assert.NotEqual(t, "migrate", initContainers[0].Name)
+	assert.NotContains(t, containers[0].Image, "registry.internal.corp")
+	assert.NotContains(t, initContainers[0].Image, "registry.internal.corp")
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `removePodData` writes typed `[]corev1.Container` back into the workload object during scan processing, so by the time `--hide` or `--encrypt` runs, `spec.containers` is no longer `[]any` — and `transformContainerList` asserted `[]any` and silently returned without transforming anything.

- **Files changed:**
  - `core/pkg/anonymizer/container.go`: `transformContainerList` and `transformEphemeralContainerList` now walk typed slices through `transformTypedContainerList` / `transformTypedEphemeralContainerList`, which the package already had. The `IWorkload` branch in `transformContainerMetadata` and its `transformTypedWorkloadContainers` helper are removed as redundant (see reviewer notes).

- **What the fix does:** stops container names and image references leaking out of an anonymized or encrypted report. Everything around them was already transformed, which is what made the gap easy to miss:

  ```
  kubescape scan framework nsa ./manifests --hide --format json

  before:
    metadata.name        res-4b5e57f6eb2f...
    serviceAccountName   sa-44bd3efdb870...
    imagePullSecrets[]   ref-e72fb833e52c...
    containers[0].name   my-container                              <- plaintext
    containers[0].image  registry.internal.corp/team/app:1.25      <- plaintext

  after:
    containers[0].name   ctr-f907e278af7c...
    containers[0].image  img-251ad31786ba...
  ```

  Image references routinely carry internal registry hostnames and team or project names, so this is among the fields most worth hiding before a report leaves the cluster. Reproduces on a minimal Pod, no special fields needed and on a Deployment through `spec.template.spec`, for `containers` and `initContainers` alike.

- **What was tested:**
  - `TestTransformContainerList_TypedSlice`: a typed `containers` slice is transformed and stays typed
  - `TestTransformEphemeralContainerList_TypedSlice`: same for `ephemeralContainers`
  - `TestTransformPodSpecs_TypedContainersFromScanPipeline`: the shape the scan pipeline actually produces, covering `containers` and `initContainers`
  - All three fail against the unmodified file
  - Verified end to end against binaries built from `upstream/master` and from this branch: minimal Pod and Deployment under `--hide`, plus `--encrypt` followed by `decrypt` restoring the originals
  - Full `go test ./... -count=1 -short` passes

- **Related issues:** none. Earlier anonymizer work (#3417 pseudo-ID collisions, #3364 env var names referencing secrets/configmaps) has a different root cause.

**Which issue(s) this PR fixes:**
None filed.

**Special notes for your reviewer:**

The removal of the `IWorkload` typed pass is deliberate, and it is what keeps the encrypt/decrypt round trip working. Teaching the shared walkers to handle typed slices while leaving that pass in place makes both passes fire on the same values and double-encrypts them; `TestEncryptedReportProducerConsumerRoundTrip` catches it with `encrypted value remains at ...containers[0].env[0].value`. `transformPodSpecs` already recurses through every child map, so it reaches `spec.template.spec` and nested templates on its own - the typed pass was redundant coverage, and the redundancy is what broke the round trip.

Worth knowing how the gap survived: the scanned resource is not an `IWorkload` at anonymization time, so the typed pass never ran on it, while the unstructured walker could not read the typed slice `removePodData` had just written. Neither half covered the real path.

`removePodData` is the only place in the tree that writes typed slices into a workload object map, and it covers exactly `containers`, `initContainers` and `ephemeralContainers`; the three keys handled here, so there is no fourth case left open. The typed and unstructured env helpers were compared before routing through the typed one: both apply the same `isSensitiveEnvName`/`isSensitiveEnvValue` rule, the same `"ref"` prefix for `secretKeyRef`/`configMapKeyRef`, and both carry the #3364 env-name fix, so nothing is under-anonymized by the change.

The typed branches deliberately omit an `obj[key] = containers` write-back: the typed helpers mutate the backing array by index, so the map already sees the change and the assignment would be a no-op that implies otherwise.

**Does this PR introduce a user-facing change?**
Yes, `--hide` now pseudonymizes container names and image references, and `--encrypt` encrypts them, on scanned workloads where they were previously emitted in plaintext. `decrypt` reverses them as expected. Reports produced without those flags are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymization of container metadata across standard, initialization, and ephemeral containers.
  * Ensured container names, images, and sensitive environment values are consistently transformed.
  * Prevented original registry and credential data from being retained in processed resources.

* **Tests**
  * Added coverage for typed container and pod specification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->