### PR TITLE
fix: implement chunked pagination for namespace counting

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1140,26 +1140,32 @@ func (k8sHandler *K8sResourceHandler) countNamespaces(ctx context.Context, scanI
 	if k8sHandler.k8s == nil || k8sHandler.k8s.KubernetesClient == nil {
 		return 0
 	}
-	nsList, err := k8sHandler.k8s.KubernetesClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
+
+	include := splitNamespaces(scanInfo.IncludeNamespaces)
+	exclude := splitNamespaces(scanInfo.ExcludedNamespaces)
+	count := 0
+
+	if err := getter.ListWithPagination(ctx, func(opts metav1.ListOptions) (string, error) {
+		chunk, err := k8sHandler.k8s.KubernetesClient.CoreV1().Namespaces().List(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+		for _, ns := range chunk.Items {
+			if len(include) > 0 {
+				if !slices.Contains(include, ns.Name) {
+					continue
+				}
+			} else if slices.Contains(exclude, ns.Name) {
+				continue
+			}
+			count++
+		}
+		return chunk.GetContinue(), nil
+	}); err != nil {
 		logger.L().Ctx(ctx).Debug("failed to list namespaces for progress estimate", helpers.Error(err))
 		return 0
 	}
 
-	include := splitNamespaces(scanInfo.IncludeNamespaces)
-	exclude := splitNamespaces(scanInfo.ExcludedNamespaces)
-
-	count := 0
-	for _, ns := range nsList.Items {
-		if len(include) > 0 {
-			if !slices.Contains(include, ns.Name) {
-				continue
-			}
-		} else if slices.Contains(exclude, ns.Name) {
-			continue
-		}
-		count++
-	}
 	return count
 }
 


### PR DESCRIPTION
## Description
This PR resolves an unbounded LIST request issue in `countNamespaces()`. 

Previously, `countNamespaces` issued a single `Namespaces().List()` request with an unbounded limit. On large clusters with thousands of namespaces, this single massive response could cause API server timeouts and excessive client-side memory spikes.

This change refactors the function to use the `getter.ListWithPagination` helper, ensuring we iterate through paginated chunks while maintaining the existing `--include-namespaces` and `--exclude-namespaces` filtering logic. This fully eliminates the last known unbounded LIST request in the resource handler.

## Environment
OS: macOS / Linux (any)
Version: `master` 

## Steps To Reproduce
Run a scan on a cluster with thousands of namespaces and observe the single, unbounded `Namespaces().List` call without this patch.

## Expected behavior
The namespace count is retrieved in paginated batches, preventing timeouts. 

## Actual Behavior
The namespace count was retrieved in a single massive batch. 

## Additional context
Category: Performance / Reliability
Related to the recent global chunked pagination implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace counts now remain accurate when results span multiple pages.
  * Include and exclude filters are applied consistently across all pages.
  * Pagination failures now safely return a count of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->