### PR TITLE
fix(vap): stop create-policy-binding silently rewriting the label selector it was given

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -393,6 +393,12 @@ func isSupportedValidationAction(action admissionv1.ValidationAction) bool {
 // Only equality selectors are accepted: matchLabels is an equality map, so an
 // Exists or In requirement has nowhere to go on the binding. "=" and "==" are
 // distinct operators in apimachinery but mean the same thing, so both pass.
+//
+// Naming one key twice with different values is refused rather than resolved.
+// matchLabels is ANDed, so no object can carry both, and letting the last one
+// win emitted a binding that enforced the policy on a set the caller never
+// asked for. Repeating a key with the same value is the same requirement twice,
+// so it is accepted.
 func parseObjectSelectorLabels(values []string) (map[string]string, error) {
 	matchLabels := make(map[string]string, len(values))
 	for _, value := range values {
@@ -411,6 +417,9 @@ func parseObjectSelectorLabels(values []string) (map[string]string, error) {
 			selected := requirement.Values().List()
 			if len(selected) != 1 {
 				return nil, fmt.Errorf("label selector %s must name exactly one value", value)
+			}
+			if existing, seen := matchLabels[requirement.Key()]; seen && existing != selected[0] {
+				return nil, fmt.Errorf("conflicting values for label %q: %q and %q; a binding requires both at once, so it would match nothing", requirement.Key(), existing, selected[0])
 			}
 			matchLabels[requirement.Key()] = selected[0]
 		}

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -148,17 +148,8 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 					return fmt.Errorf("invalid namespace %s: %w", namespace, err)
 				}
 			}
-			for _, label := range labelArr {
-				parsed, err := labels.Parse(label)
-				if err != nil {
-					return fmt.Errorf("invalid label selector: %s", label)
-				}
-				requirements, _ := parsed.Requirements()
-				for _, r := range requirements {
-					if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
-						return fmt.Errorf("only equality label selectors ('=' or '==') are supported: %s", label)
-					}
-				}
+			if _, err := parseObjectSelectorLabels(labelArr); err != nil {
+				return err
 			}
 			actions, err := parseValidationActions(actionArr)
 			if err != nil {
@@ -392,6 +383,39 @@ func isSupportedValidationAction(action admissionv1.ValidationAction) bool {
 		}
 	}
 	return false
+}
+
+// parseObjectSelectorLabels turns the --label values into the matchLabels of
+// the binding's objectSelector. The flag validation and the emitted binding
+// both read the labels through here, so what the command accepts and what it
+// writes cannot drift apart.
+//
+// Only equality selectors are accepted: matchLabels is an equality map, so an
+// Exists or In requirement has nowhere to go on the binding. "=" and "==" are
+// distinct operators in apimachinery but mean the same thing, so both pass.
+func parseObjectSelectorLabels(values []string) (map[string]string, error) {
+	matchLabels := make(map[string]string, len(values))
+	for _, value := range values {
+		parsed, err := labels.Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label selector: %s", value)
+		}
+		requirements, _ := parsed.Requirements()
+		for _, requirement := range requirements {
+			if requirement.Operator() != selection.Equals && requirement.Operator() != selection.DoubleEquals {
+				return nil, fmt.Errorf("only equality label selectors ('=' or '==') are supported: %s", value)
+			}
+			// An equality requirement carries exactly one value; anything else
+			// is refused rather than skipped, so no label can go missing from
+			// the selector without the command saying so.
+			selected := requirement.Values().List()
+			if len(selected) != 1 {
+				return nil, fmt.Errorf("label selector %s must name exactly one value", value)
+			}
+			matchLabels[requirement.Key()] = selected[0]
+		}
+	}
+	return matchLabels, nil
 }
 
 // resourceRuleParts is the group/version/resource form of --resource-rule. The
@@ -639,21 +663,12 @@ func createPolicyBinding(bindingName string, policyName string, actions []admiss
 		}
 	}
 
+	matchLabels, err := parseObjectSelectorLabels(labelMatch)
+	if err != nil {
+		return "", err
+	}
 	if len(labelMatch) > 0 {
-		policyBinding.Spec.MatchResources.ObjectSelector = &metav1.LabelSelector{}
-		policyBinding.Spec.MatchResources.ObjectSelector.MatchLabels = make(map[string]string)
-		for _, label := range labelMatch {
-			parsed, err := labels.Parse(label)
-			if err != nil {
-				continue
-			}
-			requirements, _ := parsed.Requirements()
-			for _, r := range requirements {
-				if len(r.Values().List()) > 0 {
-					policyBinding.Spec.MatchResources.ObjectSelector.MatchLabels[r.Key()] = r.Values().List()[0]
-				}
-			}
-		}
+		policyBinding.Spec.MatchResources.ObjectSelector = &metav1.LabelSelector{MatchLabels: matchLabels}
 	}
 
 	// Left empty, matchResources binds everything the policy matches, so a rule

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -399,9 +399,21 @@ func isSupportedValidationAction(action admissionv1.ValidationAction) bool {
 // win emitted a binding that enforced the policy on a set the caller never
 // asked for. Repeating a key with the same value is the same requirement twice,
 // so it is accepted.
+//
+// A --label that ends up selecting nothing is refused. labels.Parse reads a
+// blank value as the empty selector, which contributes no requirement, so a
+// flag made only of those emitted an objectSelector that matches every object
+// the policy matches — the opposite of the narrowing that was asked for, and
+// silent.
 func parseObjectSelectorLabels(values []string) (map[string]string, error) {
 	matchLabels := make(map[string]string, len(values))
 	for _, value := range values {
+		// The flag is comma-split, so a trailing or doubled comma leaves a blank
+		// entry behind. It carries no requirement of its own; the check after
+		// the loop catches the case where nothing else carried one either.
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
 		parsed, err := labels.Parse(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid label selector: %s", value)
@@ -423,6 +435,9 @@ func parseObjectSelectorLabels(values []string) (map[string]string, error) {
 			}
 			matchLabels[requirement.Key()] = selected[0]
 		}
+	}
+	if len(values) > 0 && len(matchLabels) == 0 {
+		return nil, fmt.Errorf("--label %q selects nothing; omit the flag to bind everything the policy matches", strings.Join(values, ","))
 	}
 	return matchLabels, nil
 }
@@ -676,7 +691,7 @@ func createPolicyBinding(bindingName string, policyName string, actions []admiss
 	if err != nil {
 		return "", err
 	}
-	if len(labelMatch) > 0 {
+	if len(matchLabels) > 0 {
 		policyBinding.Spec.MatchResources.ObjectSelector = &metav1.LabelSelector{MatchLabels: matchLabels}
 	}
 

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1400,3 +1400,128 @@ func TestCreatePolicyBindingCmdResourceRuleScope(t *testing.T) {
 		assert.Equal(t, []string{"cronjobs"}, binding.Spec.MatchResources.ResourceRules[0].Resources)
 	})
 }
+
+func TestParseObjectSelectorLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		want   map[string]string
+		errMsg string
+	}{
+		{name: "no labels", input: nil, want: map[string]string{}},
+		{name: "single equality", input: []string{"app=nginx"}, want: map[string]string{"app": "nginx"}},
+		{name: "double equals means the same thing", input: []string{"app==nginx"}, want: map[string]string{"app": "nginx"}},
+		{name: "whitespace around the operator is trimmed", input: []string{"app = nginx"}, want: map[string]string{"app": "nginx"}},
+		{name: "empty value is a real requirement", input: []string{"app="}, want: map[string]string{"app": ""}},
+		{name: "several keys", input: []string{"app=nginx", "env=prod"}, want: map[string]string{"app": "nginx", "env": "prod"}},
+		{name: "several requirements in one value", input: []string{"app=nginx,env=prod"}, want: map[string]string{"app": "nginx", "env": "prod"}},
+		{name: "repeated key with the same value", input: []string{"app=nginx", "app=nginx"}, want: map[string]string{"app": "nginx"}},
+		{name: "repeated key across operator spellings", input: []string{"app=nginx", "app==nginx"}, want: map[string]string{"app": "nginx"}},
+
+		{name: "repeated key with conflicting values", input: []string{"app=nginx", "app=redis"}, errMsg: "conflicting values for label"},
+		{name: "conflicting values in one value", input: []string{"app=nginx,app=redis"}, errMsg: "conflicting values for label"},
+		{name: "trailing comma leaves a blank entry", input: []string{"app=nginx", ""}, want: map[string]string{"app": "nginx"}},
+		{name: "leading comma leaves a blank entry", input: []string{"", "app=nginx"}, want: map[string]string{"app": "nginx"}},
+		{name: "only a blank entry", input: []string{""}, errMsg: "selects nothing"},
+		{name: "only whitespace", input: []string{"   "}, errMsg: "selects nothing"},
+		{name: "only blank entries", input: []string{"", ""}, errMsg: "selects nothing"},
+		{name: "set-based operator", input: []string{"app in (nginx)"}, errMsg: "only equality label selectors"},
+		{name: "exists operator", input: []string{"app"}, errMsg: "only equality label selectors"},
+		{name: "not-equal operator", input: []string{"app!=nginx"}, errMsg: "only equality label selectors"},
+		{name: "unparsable selector", input: []string{"app=val=extra"}, errMsg: "invalid label selector"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseObjectSelectorLabels(tt.input)
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreatePolicyBindingObjectSelector(t *testing.T) {
+	// A conflicting pair used to collapse onto the last value, emitting a
+	// binding that enforced the policy on a set the caller never asked for.
+	t.Run("conflicting labels emit no binding", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{"app=nginx", "app=redis"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting values for label")
+		assert.Empty(t, out)
+	})
+
+	// Blank values used to emit an empty objectSelector, which matches every
+	// object the policy matches rather than narrowing anything.
+	t.Run("labels that select nothing emit no binding", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{""}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "selects nothing")
+		assert.Empty(t, out)
+	})
+
+	t.Run("repeated label with the same value binds once", func(t *testing.T) {
+		out, err := createPolicyBinding("my-binding", "c-0016", []admissionv1.ValidationAction{admissionv1.Deny}, "", nil, []string{"app=nginx", "app=nginx"}, nil)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal([]byte(out), &binding))
+		require.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
+		assert.Equal(t, map[string]string{"app": "nginx"}, binding.Spec.MatchResources.ObjectSelector.MatchLabels)
+	})
+}
+
+func TestCreatePolicyBindingCmdLabelSelector(t *testing.T) {
+	t.Run("conflicting labels fail the command", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--label", "app=nginx", "--label", "app=redis"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting values for label")
+	})
+
+	// The flag is comma-split, so a lone comma is how a caller reaches a slice
+	// of nothing but blanks.
+	t.Run("labels that select nothing fail the command", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--label", ","})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "selects nothing")
+	})
+
+	t.Run("a trailing comma still binds the labels given", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--label", "app=nginx,", "--output", outputFile})
+		require.NoError(t, cmd.Execute())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal(content, &binding))
+		require.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
+		assert.Equal(t, map[string]string{"app": "nginx"}, binding.Spec.MatchResources.ObjectSelector.MatchLabels)
+	})
+
+	t.Run("labels are written to the binding", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "c-0016", "--label", "app=nginx", "--label", "env=prod", "--output", outputFile})
+		require.NoError(t, cmd.Execute())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal(content, &binding))
+		require.NotNil(t, binding.Spec.MatchResources.ObjectSelector)
+		assert.Equal(t, map[string]string{"app": "nginx", "env": "prod"}, binding.Spec.MatchResources.ObjectSelector.MatchLabels)
+	})
+}


### PR DESCRIPTION
`kubescape vap create-policy-binding` accepts a repeatable label flag to narrow a binding's objectSelector. The values are parsed twice: once in RunE to check the operator is an equality one, and again in createPolicyBinding to build matchLabels. Neither pass checks that the selector it ends up writing is the one that was asked for, and two ways of getting a wrong binding fall through the gap.

Naming the same key twice with different values collapses onto whichever came last. Asking for `app=nginx` and `app=redis` together writes `matchLabels: {app: redis}`, so the binding enforces the policy on the redis workloads and never says the other requirement was dropped. matchLabels is ANDed, so there is no binding that satisfies both, and picking one silently is the wrong answer either way.

The second one is worse because it goes in the widening direction. labels.Parse reads a blank value as the empty selector, which contributes no requirement, so a flag made up of nothing but blanks left an empty objectSelector on the binding. The apiserver reads that as matching everything, which means a caller trying to scope a Deny binding to a handful of labelled workloads got one that applies to every object the policy matches, cluster wide, with no error and nothing in the output to hint at it. The flag is comma split, so a lone comma is enough to reach it.

The fix pulls the parsing into one function that both the flag validation and the binding emission go through, so what the command accepts and what it writes cannot disagree. On top of that it refuses a conflicting pair, and refuses a flag that selects nothing rather than emitting a selector that matches everything. Repeating a key with the same value stays fine, since that is the same requirement twice.

The detail most likely to regress is the blank handling. Blank entries on their own are still skipped, not rejected, because a trailing or doubled comma leaves one behind, and a value written with a trailing comma has always worked and still needs to. The refusal fires only when the whole flag reduces to no requirements at all, which is the case that used to produce the match everything selector. There is a test for both halves of that.

Verified by restoring the old file and confirming the new negative cases fail against it, then restoring the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of label selectors when creating policy bindings.
  * Invalid, empty, conflicting, malformed, or unsupported selectors now return clear validation errors instead of being silently ignored.
  * Valid equality-based selectors are consistently applied to policy bindings.

* **Tests**
  * Added coverage for valid selector formats, whitespace, duplicate keys, conflicting values, malformed input, and unsupported operators.
  * Added command-level checks confirming valid labels are saved and invalid selectors do not produce output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->