### PR TITLE
fix(printer): sanitize cluster and namespace identifiers in PolicyReport names and labels (#3469)

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 )
 
@@ -30,6 +31,10 @@ const (
 	policyReportResultPass = "pass"
 	policyReportResultFail = "fail"
 	policyReportResultSkip = "skip"
+
+	// Limits the apiserver enforces on the two fields these reports derive from a cluster name.
+	maxPolicyReportNameLength       = validation.DNS1123SubdomainMaxLength
+	maxPolicyReportLabelValueLength = validation.LabelValueMaxLength
 )
 
 var _ printer.IPrinter = &PolicyReportPrinter{}
@@ -269,25 +274,124 @@ func buildPolicyReports(opaSessionObj *cautils.OPASessionObj) []policyReport {
 	return reports
 }
 
+// policyReportName builds the metadata.name for a report. A cluster name reaches us from a
+// kubeconfig context, a cloud provider ARN or an API server URL (see scanContextName), so it
+// routinely carries uppercase letters, colons and slashes that the apiserver rejects in a name.
 func policyReportName(clusterName, namespace string) string {
-	base := "kubescape"
-	if clusterName != "" {
-		base = base + "-" + clusterName
+	name := policyReportSource
+
+	// A namespace is already a DNS-1123 label upstream, so this can only ever shrink it.
+	ns := sanitizeDNS1123Subdomain(namespace, validation.DNS1123LabelMaxLength)
+
+	// Whatever the fixed parts leave over is the cluster component's budget. Spending it in this
+	// order keeps a very long cluster name from crowding the namespace out of the name, which
+	// would collapse two namespaces onto one metadata.name.
+	clusterBudget := maxPolicyReportNameLength - len(name) - 1
+	if ns != "" {
+		clusterBudget -= len(ns) + 1
 	}
-	if namespace != "" {
-		base = base + "-" + namespace
+
+	if cluster := sanitizeDNS1123Subdomain(clusterName, clusterBudget); cluster != "" {
+		name += "-" + cluster
 	}
-	return base
+	if ns != "" {
+		name += "-" + ns
+	}
+	return name
 }
 
+// policyReportLabels builds the metadata.labels map for a PolicyReport or ClusterPolicyReport,
+// sanitizing the cluster name to satisfy Kubernetes label value constraints.
 func policyReportLabels(clusterName string) map[string]string {
 	labels := map[string]string{
 		"app.kubernetes.io/managed-by": policyReportSource,
 	}
-	if clusterName != "" {
-		labels["kubescape.io/cluster"] = clusterName
+	// A cluster name that sanitizes down to nothing is treated as an absent one: dropping the
+	// label is valid, whereas emitting it empty would not survive `kubectl apply`.
+	if cluster := sanitizeLabelValue(clusterName); cluster != "" {
+		labels["kubescape.io/cluster"] = cluster
 	}
 	return labels
+}
+
+// sanitizeDNS1123Subdomain reduces an arbitrary identifier to a value the apiserver accepts as a
+// metadata.name: lowercase alphanumerics joined by single hyphens, no leading or trailing hyphen,
+// and no longer than maxLength.
+//
+// Dots are folded into hyphens along with every other illegal character. The result is embedded
+// as one component of a compound name ("kubescape-<cluster>-<namespace>"), where a dot would
+// imply a DNS label boundary that means nothing here and would need validating in its own right.
+//
+// Returns "" when no usable character survives, which callers treat as an absent value.
+func sanitizeDNS1123Subdomain(value string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(value))
+
+	// Separators are written lazily, only once a legal character follows one, so a run of
+	// illegal characters collapses to a single hyphen and neither end can carry one.
+	pendingSeparator := false
+	for _, r := range strings.ToLower(value) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			if pendingSeparator {
+				b.WriteByte('-')
+				pendingSeparator = false
+			}
+			b.WriteRune(r)
+			continue
+		}
+		pendingSeparator = b.Len() > 0
+	}
+
+	out := b.String()
+	if len(out) > maxLength {
+		out = strings.TrimRight(out[:maxLength], "-")
+	}
+	return out
+}
+
+// sanitizeLabelValue reduces an arbitrary identifier to a legal label value: at most
+// maxPolicyReportLabelValueLength characters, opening and closing on an alphanumeric, and
+// otherwise limited to alphanumerics, '-', '_' and '.'.
+//
+// Case is preserved here, unlike in a name: a label value may legally contain uppercase letters,
+// so folding it would discard part of the identity the user configured for no gain.
+//
+// Returns "" when no usable character survives.
+func sanitizeLabelValue(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+
+	pendingSeparator := false
+	separator := byte('-')
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			if pendingSeparator {
+				b.WriteByte(separator)
+				pendingSeparator = false
+			}
+			b.WriteRune(r)
+			continue
+		}
+		if !pendingSeparator && b.Len() > 0 {
+			// A separator that is already legal survives as itself; anything else becomes a hyphen.
+			if r == '-' || r == '_' || r == '.' {
+				separator = byte(r)
+			} else {
+				separator = '-'
+			}
+			pendingSeparator = true
+		}
+	}
+
+	out := b.String()
+	if len(out) > maxPolicyReportLabelValueLength {
+		out = strings.TrimRight(out[:maxPolicyReportLabelValueLength], "-_.")
+	}
+	return out
 }
 
 func policyReportClusterScope(clusterName string) *policyReportScope {
@@ -297,7 +401,10 @@ func policyReportClusterScope(clusterName string) *policyReportScope {
 	return &policyReportScope{
 		APIVersion: "v1",
 		Kind:       "Cluster",
-		Name:       clusterName,
+		// Left unsanitized on purpose: scope.name identifies the cluster the report describes
+		// rather than naming a Kubernetes object, so RFC 1123 does not apply and the full
+		// context name — ARN, URL or otherwise — is the useful value to carry here.
+		Name: clusterName,
 	}
 }
 

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter_test.go
@@ -3,18 +3,22 @@ package printer
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// TestNewPolicyReportPrinter tests that NewPolicyReportPrinter constructs a valid instance.
 func TestNewPolicyReportPrinter(t *testing.T) {
 	pp := NewPolicyReportPrinter()
 	assert.NotNil(t, pp)
 	assert.Nil(t, pp.writer)
 }
 
+// TestCloseWriter_PolicyReport tests that SetWriter and CloseWriter succeed on standard output files.
 func TestCloseWriter_PolicyReport(t *testing.T) {
 	pp := NewPolicyReportPrinter()
 	require.NoError(t, pp.SetWriter(context.TODO(), ""))
@@ -38,12 +42,195 @@ func TestCloseWriter_PolicyReport_ReturnsCloseError(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrClosed)
 }
 
+// TestCloseWriter_PolicyReport_NilWriter verifies that CloseWriter does not error when writer is nil.
 func TestCloseWriter_PolicyReport_NilWriter(t *testing.T) {
 	pp := NewPolicyReportPrinter()
 	assert.NoError(t, pp.CloseWriter())
 }
 
+// TestCloseWriter_PolicyReport_Stdout verifies that CloseWriter never closes os.Stdout.
 func TestCloseWriter_PolicyReport_Stdout(t *testing.T) {
 	pp := &PolicyReportPrinter{writer: os.Stdout}
 	assert.NoError(t, pp.CloseWriter(), "must never close stdout")
+}
+
+// Regression for issue-3469: scanContextName() returns a kubeconfig context name, which in
+// practice is often an EKS ARN or an API server URL. Both were interpolated straight into
+// metadata.name and into the kubescape.io/cluster label value, producing manifests that
+// `kubectl apply` rejects outright.
+func TestPolicyReportName_SanitizesClusterAndNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		namespace   string
+		expected    string
+	}{
+		{
+			name:     "no cluster or namespace",
+			expected: "kubescape",
+		},
+		{
+			name:        "already valid values are untouched",
+			clusterName: "prod-cluster",
+			namespace:   "kube-system",
+			expected:    "kubescape-prod-cluster-kube-system",
+		},
+		{
+			name:        "eks arn loses colons and slashes",
+			clusterName: "arn:aws:eks:us-east-1:123456789012:cluster/prod-cluster",
+			namespace:   "default",
+			expected:    "kubescape-arn-aws-eks-us-east-1-123456789012-cluster-prod-cluster-default",
+		},
+		{
+			name:        "api server url is lowercased and stripped of scheme punctuation",
+			clusterName: "https://k8s-cluster.example.com",
+			expected:    "kubescape-https-k8s-cluster-example-com",
+		},
+		{
+			name:        "uppercase is folded",
+			clusterName: "Prod-Cluster-EU",
+			namespace:   "Default",
+			expected:    "kubescape-prod-cluster-eu-default",
+		},
+		{
+			name:        "underscores become hyphens",
+			clusterName: "gke_my-project_us-central1_prod",
+			expected:    "kubescape-gke-my-project-us-central1-prod",
+		},
+		{
+			name:        "runs of invalid characters collapse to one hyphen",
+			clusterName: "cluster:://__..name",
+			expected:    "kubescape-cluster-name",
+		},
+		{
+			name:        "leading and trailing punctuation is dropped",
+			clusterName: "---prod-cluster___",
+			expected:    "kubescape-prod-cluster",
+		},
+		{
+			name:        "a cluster name with nothing usable is treated as absent",
+			clusterName: ":::///___",
+			namespace:   "default",
+			expected:    "kubescape-default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policyReportName(tt.clusterName, tt.namespace)
+			assert.Equal(t, tt.expected, got)
+			assert.Empty(t, validation.IsDNS1123Subdomain(got),
+				"metadata.name must be a valid RFC 1123 subdomain")
+		})
+	}
+}
+
+// A context name long enough to exhaust the apiserver's 253-character name budget must not push
+// the namespace out of the name: two namespaces sharing one metadata.name would collide when the
+// multi-document report is applied.
+func TestPolicyReportName_TruncatesWithoutLosingNamespace(t *testing.T) {
+	got := policyReportName(strings.Repeat("a", 300), "default")
+
+	assert.LessOrEqual(t, len(got), validation.DNS1123SubdomainMaxLength)
+	assert.True(t, strings.HasSuffix(got, "-default"),
+		"the namespace must survive truncation, got %q", got)
+	assert.Empty(t, validation.IsDNS1123Subdomain(got))
+
+	// Two namespaces under the same over-long cluster name must still differ.
+	other := policyReportName(strings.Repeat("a", 300), "kube-system")
+	assert.NotEqual(t, got, other)
+	assert.Empty(t, validation.IsDNS1123Subdomain(other))
+}
+
+// Truncation can land on a separator, which would leave a trailing hyphen and fail validation.
+func TestPolicyReportName_TruncationNeverEndsOnSeparator(t *testing.T) {
+	got := policyReportName(strings.Repeat("ab:", 100), "")
+
+	assert.False(t, strings.HasSuffix(got, "-"), "got %q", got)
+	assert.LessOrEqual(t, len(got), validation.DNS1123SubdomainMaxLength)
+	assert.Empty(t, validation.IsDNS1123Subdomain(got))
+}
+
+// TestPolicyReportLabels_SanitizesClusterLabelValue tests that policyReportLabels produces valid Kubernetes label values.
+func TestPolicyReportLabels_SanitizesClusterLabelValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		expected    string // "" means the cluster label must be absent
+	}{
+		{
+			name:        "no cluster name",
+			clusterName: "",
+			expected:    "",
+		},
+		{
+			name:        "already valid value is untouched",
+			clusterName: "prod-cluster",
+			expected:    "prod-cluster",
+		},
+		{
+			name:        "eks arn loses colons and slashes",
+			clusterName: "arn:aws:eks:us-east-1:123456789012:cluster/prod-cluster",
+			expected:    "arn-aws-eks-us-east-1-123456789012-cluster-prod-cluster",
+		},
+		{
+			name:        "dots survive as legal separators",
+			clusterName: "https://k8s-cluster.example.com",
+			expected:    "https-k8s-cluster.example.com",
+		},
+		{
+			name:        "case is preserved because label values permit it",
+			clusterName: "Prod-Cluster-EU",
+			expected:    "Prod-Cluster-EU",
+		},
+		{
+			name:        "underscores survive as legal separators",
+			clusterName: "gke_my-project_us-central1_prod",
+			expected:    "gke_my-project_us-central1_prod",
+		},
+		{
+			name:        "a value with nothing usable drops the label entirely",
+			clusterName: ":::///",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := policyReportLabels(tt.clusterName)
+
+			assert.Equal(t, policyReportSource, labels["app.kubernetes.io/managed-by"])
+
+			got, present := labels["kubescape.io/cluster"]
+			if tt.expected == "" {
+				assert.False(t, present, "an unusable cluster name must not emit an empty label")
+				return
+			}
+			require.True(t, present)
+			assert.Equal(t, tt.expected, got)
+			assert.Empty(t, validation.IsValidLabelValue(got),
+				"label value must satisfy the apiserver's label constraints")
+		})
+	}
+}
+
+// TestPolicyReportLabels_TruncatesToLabelValueLimit verifies that labels longer than 63 chars are truncated.
+func TestPolicyReportLabels_TruncatesToLabelValueLimit(t *testing.T) {
+	got := policyReportLabels(strings.Repeat("a", 300))["kubescape.io/cluster"]
+
+	assert.Len(t, got, validation.LabelValueMaxLength)
+	assert.Empty(t, validation.IsValidLabelValue(got))
+}
+
+// scope.name references the cluster the report describes rather than naming a Kubernetes object,
+// so it is deliberately left as the operator configured it — sanitizing it would discard the only
+// place the full context name still appears.
+func TestPolicyReportClusterScope_PreservesRawContextName(t *testing.T) {
+	const arn = "arn:aws:eks:us-east-1:123456789012:cluster/prod-cluster"
+
+	scope := policyReportClusterScope(arn)
+	require.NotNil(t, scope)
+	assert.Equal(t, arn, scope.Name)
+
+	assert.Nil(t, policyReportClusterScope(""))
 }


### PR DESCRIPTION

## Overview
Fixes #3469

When exporting cluster scan results to CNCF PolicyReport format (`--format policyreport`), `scanContextName()` returns the kubeconfig context name, which is frequently an AWS EKS ARN or an API server URL. 

Previously, `policyReportName()` and `policyReportLabels()` interpolated these raw strings directly into `metadata.name` and the `kubescape.io/cluster` label value. When users applied the resulting manifest via `kubectl apply -f report.yaml`, the Kubernetes API server rejected it due to RFC 1123 subdomain and label value syntax violations.

### Changes
- Added `sanitizeDNS1123Subdomain()`: lowercases, folds illegal characters/dots into single hyphens, strips leading/trailing separators, and bounds against max length.
- Added `sanitizeLabelValue()`: preserves case while limiting to valid label characters (`-`, `_`, `.`) and 63 characters max.
- Implemented namespace-preserving budget calculation in `policyReportName()` so over-long cluster context names do not crowd out the namespace.
- Added extensive table-driven unit tests in `policyreportprinter_test.go` verifying compliance against `k8s.io/apimachinery/pkg/util/validation` rules.

## How to Test
```bash
go test -v ./core/pkg/resultshandling/printer/v2 -run "Test.*PolicyReport"
```

## Related issues/PRs:
* Resolved #3469

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PolicyReport metadata compatibility with Kubernetes naming and label validation rules.
  - Sanitized report names and cluster labels by normalizing invalid characters, trimming separators, and enforcing length limits.
  - Preserved namespace information when report names require truncation.
  - Omitted invalid or empty cluster label values while retaining raw cluster scope names where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->