### PR TITLE
fix(imagescan): stop stalled GitLab pagination

### DIFF
--- a/pkg/imagescan/gitlab_adaptor.go
+++ b/pkg/imagescan/gitlab_adaptor.go
@@ -302,6 +302,26 @@ type vulnCacheEntry struct {
 	err   error
 }
 
+const maxGitLabVulnerabilityPages = 1000
+
+func nextGitLabVulnerabilityCursor(hasNextPage bool, endCursor string, seen map[string]struct{}, pagesFetched int) (string, bool, error) {
+	if !hasNextPage {
+		return "", false, nil
+	}
+	if endCursor == "" {
+		return "", false, fmt.Errorf("gitlab vulnerability pagination reported another page without an end cursor")
+	}
+	if _, exists := seen[endCursor]; exists {
+		return "", false, fmt.Errorf("gitlab vulnerability pagination repeated cursor %q", endCursor)
+	}
+	if pagesFetched >= maxGitLabVulnerabilityPages {
+		return "", false, fmt.Errorf("gitlab vulnerability pagination exceeded the %d-page safety limit", maxGitLabVulnerabilityPages)
+	}
+
+	seen[endCursor] = struct{}{}
+	return endCursor, true, nil
+}
+
 // imageMatches provides a boundary-safe match for the image location.
 func imageMatches(locationImage string, imageID ContainerImageIdentifier) bool {
 	if imageID.Hash != "" {
@@ -383,6 +403,8 @@ func (a *GitlabAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 			var afterCursor string
 			hasNextPage := true
 			var fetchErr error
+			seenCursors := make(map[string]struct{})
+			pagesFetched := 0
 
 			for hasNextPage {
 				variables := map[string]interface{}{
@@ -419,9 +441,18 @@ func (a *GitlabAdaptor) GetImagesVulnerabilities(ctx context.Context, imageIDs [
 				}
 
 				projectNodes = append(projectNodes, resp.Data.Project.Vulnerabilities.Nodes...)
+				pagesFetched++
 
-				hasNextPage = resp.Data.Project.Vulnerabilities.PageInfo.HasNextPage
-				afterCursor = resp.Data.Project.Vulnerabilities.PageInfo.EndCursor
+				afterCursor, hasNextPage, fetchErr = nextGitLabVulnerabilityCursor(
+					resp.Data.Project.Vulnerabilities.PageInfo.HasNextPage,
+					resp.Data.Project.Vulnerabilities.PageInfo.EndCursor,
+					seenCursors,
+					pagesFetched,
+				)
+				if fetchErr != nil {
+					logger.L().Warning("stopping invalid gitlab vulnerability pagination", helpers.Error(fetchErr))
+					break
+				}
 			}
 
 			cache[fullPath] = vulnCacheEntry{nodes: projectNodes, err: fetchErr}

--- a/pkg/imagescan/gitlab_adaptor_test.go
+++ b/pkg/imagescan/gitlab_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockGitlabAPI struct {
@@ -353,6 +354,148 @@ func TestGitlabAdaptor_GetImagesVulnerabilities(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, reportsUnmatched, 1)
 	assert.Len(t, reportsUnmatched[0].Vulnerabilities, 0) // Should match nothing because the digest isn't present
+}
+
+func TestGitlabAdaptor_GetImagesVulnerabilitiesRejectsStalledPagination(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses map[string][]byte
+		wantError string
+		wantCalls map[string]int
+	}{
+		{
+			name: "missing cursor",
+			responses: map[string][]byte{
+				"my-group/my-project": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":""},
+						"nodes":[]
+					}}}
+				}`),
+			},
+			wantError: "without an end cursor",
+			wantCalls: map[string]int{"my-group/my-project": 1},
+		},
+		{
+			name: "immediately repeated cursor",
+			responses: map[string][]byte{
+				"my-group/my-project": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":"cursor-a"},
+						"nodes":[]
+					}}}
+				}`),
+				"my-group/my-project_cursor-a": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":"cursor-a"},
+						"nodes":[]
+					}}}
+				}`),
+			},
+			wantError: "repeated cursor \"cursor-a\"",
+			wantCalls: map[string]int{
+				"my-group/my-project":          1,
+				"my-group/my-project_cursor-a": 1,
+			},
+		},
+		{
+			name: "cursor cycle",
+			responses: map[string][]byte{
+				"my-group/my-project": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":"cursor-a"},
+						"nodes":[]
+					}}}
+				}`),
+				"my-group/my-project_cursor-a": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":"cursor-b"},
+						"nodes":[]
+					}}}
+				}`),
+				"my-group/my-project_cursor-b": []byte(`{
+					"data":{"project":{"vulnerabilities":{
+						"pageInfo":{"hasNextPage":true,"endCursor":"cursor-a"},
+						"nodes":[]
+					}}}
+				}`),
+			},
+			wantError: "repeated cursor \"cursor-a\"",
+			wantCalls: map[string]int{
+				"my-group/my-project":          1,
+				"my-group/my-project_cursor-a": 1,
+				"my-group/my-project_cursor-b": 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAPI := &mockGitlabAPI{responses: tt.responses}
+			adaptor := NewGitlabAdaptor()
+			adaptor.client = mockAPI
+
+			reports, err := adaptor.GetImagesVulnerabilities(context.Background(), []ContainerImageIdentifier{{
+				Repository: "my-group/my-project/app",
+				Tag:        "latest",
+			}})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+			require.Len(t, reports, 1)
+			assert.Empty(t, reports[0].Vulnerabilities)
+			assert.Equal(t, tt.wantCalls, mockAPI.callCount)
+		})
+	}
+}
+
+func TestNextGitLabVulnerabilityCursorEnforcesPageLimit(t *testing.T) {
+	seen := make(map[string]struct{})
+
+	cursor, more, err := nextGitLabVulnerabilityCursor(true, "final-cursor", seen, maxGitLabVulnerabilityPages)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1000-page safety limit")
+	assert.Empty(t, cursor)
+	assert.False(t, more)
+	assert.Empty(t, seen)
+}
+
+func TestNextGitLabVulnerabilityCursorAcceptsValidProgress(t *testing.T) {
+	tests := []struct {
+		name        string
+		hasNextPage bool
+		endCursor   string
+		wantCursor  string
+		wantMore    bool
+	}{
+		{
+			name:       "terminal page",
+			endCursor:  "ignored-terminal-cursor",
+			wantCursor: "",
+		},
+		{
+			name:        "fresh next page",
+			hasNextPage: true,
+			endCursor:   "cursor-2",
+			wantCursor:  "cursor-2",
+			wantMore:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := map[string]struct{}{"cursor-1": {}}
+			cursor, more, err := nextGitLabVulnerabilityCursor(tt.hasNextPage, tt.endCursor, seen, 1)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCursor, cursor)
+			assert.Equal(t, tt.wantMore, more)
+			if tt.wantMore {
+				assert.Contains(t, seen, tt.wantCursor)
+			}
+		})
+	}
 }
 
 func TestNormalizeGitlabSeverity(t *testing.T) {


### PR DESCRIPTION
## What happened

Kubescape follows GitLab's GraphQL pagination metadata while collecting container vulnerabilities.

Previously, the pagination loop trusted `hasNextPage` and `endCursor` without checking whether the cursor was actually moving forward. If GitLab, a proxy, or a compatible GraphQL service returned `hasNextPage: true` with an empty or repeated cursor, Kubescape would request the same page indefinitely.

Because every response could complete successfully, the HTTP timeout did not stop the overall loop. A single malformed pagination response could leave an image scan running forever while repeatedly consuming API quota and system resources.

## What this changes

This update makes GitLab vulnerability pagination fail safely when progress becomes impossible.

It now:

- rejects `hasNextPage: true` when no end cursor is returned
- detects immediately repeated cursors
- detects longer cursor cycles such as `A -> B -> A`
- applies a generous 1,000-page safety limit
- returns a clear error instead of continuing indefinitely
- preserves the vulnerability data collected before the invalid pagination response

Normal multi-page responses continue to work exactly as before.

## Why this needs an immediate fix

Image scanning commonly runs inside CI pipelines and long-running Kubescape services. An endless pagination loop can block scan completion, consume GitLab API quota, and keep workers occupied until an operator manually cancels the scan.

The bug is triggered by an invalid remote response, so callers cannot reliably prevent it through configuration.

## Testing

Added regression coverage for:

- an empty cursor with another page reported
- an immediately repeated cursor
- a multi-page cursor cycle
- the maximum page safety limit
- valid cursor progression
- normal terminal pages

Validation completed with:

```sh
go test ./pkg/imagescan
go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving GitLab vulnerability results across multiple pages.
  * Added safeguards to detect invalid, repeated, or missing pagination cursors.
  * Limited vulnerability retrieval to 1,000 pages to prevent runaway requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->