### PR TITLE
fix(imagescan): bound registry API responses

### DIFF
--- a/pkg/imagescan/adaptor_utils.go
+++ b/pkg/imagescan/adaptor_utils.go
@@ -2,11 +2,30 @@ package imagescan
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 )
+
+const maxRegistryAPIResponseBytes int64 = 64 << 20
+
+func readRegistryAPIResponse(body io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		limit = maxRegistryAPIResponseBytes
+	}
+
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registry api response: %w", err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("registry api response exceeds the %d-byte limit", limit)
+	}
+	return data, nil
+}
 
 // FetchImagesInformation provides a shared implementation for GetImagesInformation across adaptors.
 func FetchImagesInformation(imageIDs []ContainerImageIdentifier) ([]ContainerImageInformation, error) {

--- a/pkg/imagescan/adaptor_utils_test.go
+++ b/pkg/imagescan/adaptor_utils_test.go
@@ -3,10 +3,70 @@ package imagescan
 import (
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type failingRegistryReader struct {
+	data []byte
+	err  error
+}
+
+func (r *failingRegistryReader) Read(p []byte) (int, error) {
+	if len(r.data) > 0 {
+		n := copy(p, r.data)
+		r.data = r.data[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+func TestReadRegistryAPIResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		reader    io.Reader
+		limit     int64
+		want      string
+		wantError string
+	}{
+		{name: "body below limit", reader: strings.NewReader("payload"), limit: 8, want: "payload"},
+		{name: "body exactly at limit", reader: strings.NewReader("12345678"), limit: 8, want: "12345678"},
+		{
+			name:      "body exceeds limit by one byte",
+			reader:    strings.NewReader("123456789"),
+			limit:     8,
+			wantError: "exceeds the 8-byte limit",
+		},
+		{
+			name: "reader failure",
+			reader: &failingRegistryReader{
+				data: []byte("partial"),
+				err:  errors.New("connection reset"),
+			},
+			limit:     64,
+			wantError: "connection reset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readRegistryAPIResponse(tt.reader, tt.limit)
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
 
 func TestProcessImages(t *testing.T) {
 	t.Run("HappyPath", func(t *testing.T) {

--- a/pkg/imagescan/gitlab_adaptor.go
+++ b/pkg/imagescan/gitlab_adaptor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -21,9 +20,10 @@ type GitlabAPI interface {
 }
 
 type gitlabAPIWrapper struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
+	baseURL         string
+	token           string
+	httpClient      *http.Client
+	maxResponseSize int64
 }
 
 func (w *gitlabAPIWrapper) DoGraphQL(ctx context.Context, query string, variables map[string]interface{}) ([]byte, error) {
@@ -50,7 +50,7 @@ func (w *gitlabAPIWrapper) DoGraphQL(ctx context.Context, query string, variable
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := readRegistryAPIResponse(resp.Body, w.maxResponseSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -92,9 +92,10 @@ func (a *GitlabAdaptor) Login(ctx context.Context, registry string, credentials 
 	baseURL := fmt.Sprintf("%s://%s", scheme, host)
 
 	wrapper := &gitlabAPIWrapper{
-		baseURL:    baseURL,
-		token:      credentials.Token,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL:         baseURL,
+		token:           credentials.Token,
+		httpClient:      &http.Client{Timeout: 15 * time.Second},
+		maxResponseSize: maxRegistryAPIResponseBytes,
 	}
 
 	data, err := wrapper.DoGraphQL(ctx, `query { currentUser { username } }`, nil)

--- a/pkg/imagescan/gitlab_adaptor_test.go
+++ b/pkg/imagescan/gitlab_adaptor_test.go
@@ -131,6 +131,26 @@ func TestGitlabAdaptor_Login(t *testing.T) {
 	}
 }
 
+func TestGitlabAPIWrapperRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("123456789"))
+	}))
+	defer server.Close()
+
+	wrapper := &gitlabAPIWrapper{
+		baseURL:         server.URL,
+		token:           "token",
+		httpClient:      server.Client(),
+		maxResponseSize: 8,
+	}
+
+	body, err := wrapper.DoGraphQL(context.Background(), "query { currentUser { username } }", nil)
+
+	assert.Nil(t, body)
+	assert.ErrorContains(t, err, "exceeds the 8-byte limit")
+}
+
 func TestSplitGitLabProjectPath(t *testing.T) {
 	tests := []struct {
 		repo             string

--- a/pkg/imagescan/harbor_adaptor.go
+++ b/pkg/imagescan/harbor_adaptor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,11 +16,12 @@ type HarborAPI interface {
 }
 
 type harborAPIWrapper struct {
-	baseURL    string
-	username   string
-	password   string
-	token      string
-	httpClient *http.Client
+	baseURL         string
+	username        string
+	password        string
+	token           string
+	httpClient      *http.Client
+	maxResponseSize int64
 }
 
 func (w *harborAPIWrapper) DoRequest(ctx context.Context, method, path string) ([]byte, error) {
@@ -48,7 +48,7 @@ func (w *harborAPIWrapper) DoRequest(ctx context.Context, method, path string) (
 		return nil, fmt.Errorf("harbor api returned status %d for %s", resp.StatusCode, path)
 	}
 
-	return io.ReadAll(resp.Body)
+	return readRegistryAPIResponse(resp.Body, w.maxResponseSize)
 }
 
 // HarborAdaptor implements IContainerImageVulnerabilityAdaptor for Harbor Container Registry.
@@ -77,8 +77,9 @@ func (a *HarborAdaptor) Login(ctx context.Context, registry string, credentials 
 	baseURL := fmt.Sprintf("%s://%s", scheme, a.host)
 
 	wrapper := &harborAPIWrapper{
-		baseURL:    baseURL,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL:         baseURL,
+		httpClient:      &http.Client{Timeout: 15 * time.Second},
+		maxResponseSize: maxRegistryAPIResponseBytes,
 	}
 
 	if credentials.hasAuthenticator() {

--- a/pkg/imagescan/harbor_adaptor_test.go
+++ b/pkg/imagescan/harbor_adaptor_test.go
@@ -91,6 +91,25 @@ func TestHarborAdaptor_Login(t *testing.T) {
 	}
 }
 
+func TestHarborAPIWrapperRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("123456789"))
+	}))
+	defer server.Close()
+
+	wrapper := &harborAPIWrapper{
+		baseURL:         server.URL,
+		httpClient:      server.Client(),
+		maxResponseSize: 8,
+	}
+
+	body, err := wrapper.DoRequest(context.Background(), http.MethodGet, "/vulnerabilities")
+
+	assert.Nil(t, body)
+	assert.ErrorContains(t, err, "exceeds the 8-byte limit")
+}
+
 func TestExtractProjectAndRepo(t *testing.T) {
 	tests := []struct {
 		repo            string


### PR DESCRIPTION
## What happened

The Harbor and GitLab image-scanning adaptors previously loaded complete HTTP response bodies into memory without applying a size limit.

A compromised registry, faulty reverse proxy, or unexpectedly large response could therefore make Kubescape continue allocating memory until the response ended or the process ran out of memory. This is especially risky when Kubescape is used as a long-running service that accepts repeated scan requests.

HTTP timeouts do not address this problem because a server can continuously deliver data within the timeout window.

## What this changes

This update introduces a shared bounded response reader for registry API traffic.

It now:

- limits decompressed Harbor and GitLab API responses to 64 MiB
- reads only one byte beyond the limit to detect oversized responses
- returns a clear error when the response exceeds the configured boundary
- preserves existing handling for valid responses
- preserves underlying network and reader errors
- applies the protection during both authentication and vulnerability requests

The limit is intentionally large enough for legitimate vulnerability reports while preventing unbounded memory growth.

## Why this needs an immediate fix

Registry responses cross a network trust boundary. Kubescape should not allow a remote service to control how much process memory is allocated for a single API response.

Without this protection, one malformed response can terminate the complete scan process and disrupt every scan sharing that service instance.

## Testing

Added coverage for:

- responses below the limit
- responses exactly at the limit
- responses exceeding the limit by one byte
- underlying connection and reader failures
- oversized Harbor responses
- oversized GitLab GraphQL responses

Validation completed with:

```sh
go test ./pkg/imagescan
go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 64 MiB limit for registry API responses.
  * Oversized responses are now rejected with a clear error instead of being fully read.
  * Response read failures are reported with additional context.

* **Tests**
  * Added coverage for response-size limits, boundary cases, oversized responses, and read failures across GitLab and Harbor integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->