### PR TITLE
feat(operator): add findings-driven targeting to the remediate CLI

### DIFF
--- a/cmd/operator/remediate.go
+++ b/cmd/operator/remediate.go
@@ -47,12 +47,21 @@ var operatorRemediateExamples = fmt.Sprintf(`
   # Revert a previously applied action (removes the annotation and/or NetworkPolicy on the target)
   %[1]s operator remediate revert --kind Deployment --target-namespace payments --name api --confirm
 
+  # Findings-driven: preview every workload failing a control at High or above.
+  # Targets are resolved from scan results already stored in the cluster — no re-scan.
+  %[1]s operator remediate quarantine --control C-0016 --min-severity High
+
+  # Apply it once the previewed plan has been reviewed
+  %[1]s operator remediate quarantine --control C-0016 --min-severity High --confirm
+
 `, cautils.ExecName())
 
 // getOperatorRemediateCmd wires the `operator remediate <action>` subcommand.
-// The action (annotate|revert) is a positional argument, matching the proposal's
-// CLI surface; remediation reuses the existing operator-scan transport, so the
-// command only assembles a RemediationInfo and hands it to the OperatorAdapter.
+// The action is a positional argument, matching the proposal's CLI surface;
+// remediation reuses the existing operator-scan transport, so the command only
+// assembles a RemediationInfo and hands it to the OperatorAdapter. The target is
+// either explicit (--kind/--name) or findings-driven (--control/--min-severity),
+// the latter resolved in-cluster by the operator from stored scan results.
 func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorInfo) *cobra.Command {
 	remediationInfo := &cautils.RemediationInfo{}
 
@@ -90,6 +99,13 @@ func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorIn
 				logger.L().Warning(fmt.Sprintf("no --reason provided; %s records an audit trail, consider adding --reason to justify the action", remediationInfo.Action))
 			}
 
+			// A confirmed selector run resolves cluster-wide and can write to many
+			// workloads at once; say so before it happens, since the caller named
+			// no single object and cannot see the resolved set from here.
+			if remediationInfo.HasSelector() && !remediationInfo.IsDryRun() {
+				logger.L().Warning(fmt.Sprintf("applying %q to every workload matching the selector, across all namespaces", remediationInfo.Action))
+			}
+
 			operatorAdapter, err := core.NewOperatorAdapter(operatorInfo.OperatorScanInfo, operatorInfo.Namespace)
 			if err != nil {
 				return err
@@ -108,7 +124,13 @@ func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorIn
 			// endpoint acknowledges receipt and queues the work), so the outcome is
 			// not returned here. It is emitted as a "KubescapeRemediation" Kubernetes
 			// Event on the target namespace and recorded in the operator logs.
-			eventsHint := fmt.Sprintf("kubectl get events -n %s --field-selector reason=KubescapeRemediation", remediationInfo.Namespace)
+			// A selector resolves targets across namespaces, so its audit Events are
+			// not confined to the one namespace an explicit target would name.
+			eventsScope := fmt.Sprintf("-n %s", remediationInfo.Namespace)
+			if remediationInfo.HasSelector() {
+				eventsScope = "--all-namespaces"
+			}
+			eventsHint := fmt.Sprintf("kubectl get events %s --field-selector reason=KubescapeRemediation", eventsScope)
 			if remediationInfo.IsDryRun() {
 				logger.L().StopSuccess(fmt.Sprintf("Submitted remediation (dry-run) — no changes are applied. Check the plan via '%s' or the operator logs; re-run with --confirm to apply.", eventsHint))
 			} else {
@@ -122,6 +144,8 @@ func getOperatorRemediateCmd(ks meta.IKubescape, operatorInfo cautils.OperatorIn
 	remediateCmd.PersistentFlags().StringVar(&remediationInfo.Kind, "kind", "", "target workload kind: Deployment, StatefulSet, DaemonSet or Pod")
 	remediateCmd.PersistentFlags().StringVar(&remediationInfo.Namespace, "target-namespace", "", "namespace of the target workload")
 	remediateCmd.PersistentFlags().StringVar(&remediationInfo.Name, "name", "", "name of the target workload")
+	remediateCmd.PersistentFlags().StringVar(&remediationInfo.Control, "control", "", "act on workloads failing this control, e.g. C-0016 (resolved from stored scan results; mutually exclusive with --kind/--name)")
+	remediateCmd.PersistentFlags().StringVar(&remediationInfo.MinSeverity, "min-severity", "", "act on workloads with a failing finding at or above this severity: Critical, High, Medium, Low or Unknown (mutually exclusive with --kind/--name)")
 	remediateCmd.PersistentFlags().StringVar(&remediationInfo.Reason, "reason", "", "human-readable justification recorded in the audit trail")
 	remediateCmd.PersistentFlags().StringVar(&remediationInfo.FindingRef, "finding-ref", "", "scan-result reference that justifies the action, e.g. workloadconfigurationscansummaries/payments/api")
 	remediateCmd.PersistentFlags().BoolVar(&remediationInfo.Confirm, "confirm", false, "perform the real cluster write; without it the action is a dry-run preview")

--- a/cmd/operator/remediate_test.go
+++ b/cmd/operator/remediate_test.go
@@ -32,8 +32,16 @@ func TestGetOperatorRemediateCmd(t *testing.T) {
 	assert.Error(t, err)
 
 	// expected flags are registered
-	for _, name := range []string{"namespace", "kind", "target-namespace", "name", "reason", "finding-ref", "confirm"} {
+	for _, name := range []string{"namespace", "kind", "target-namespace", "name", "control", "min-severity", "reason", "finding-ref", "confirm"} {
 		assert.NotNil(t, cmd.PersistentFlags().Lookup(name), "flag --%s should be registered", name)
+	}
+
+	// the findings-driven flags default to empty, so a plain invocation is never
+	// silently a cluster-wide selector run
+	for _, name := range []string{"control", "min-severity"} {
+		value, err := cmd.PersistentFlags().GetString(name)
+		assert.NoError(t, err)
+		assert.Empty(t, value, "flag --%s should default to empty", name)
 	}
 
 	// confirm defaults to false (dry-run is the default; --confirm is the only apply switch)

--- a/core/cautils/operatorscaninfo.go
+++ b/core/cautils/operatorscaninfo.go
@@ -107,7 +107,7 @@ func (c *ConfigScanInfo) GetRequestPayload() *apis.Commands {
 	}
 }
 
-// remediationTargetKinds are the workload kinds the Phase-1 operator can act on
+// remediationTargetKinds are the workload kinds the operator can act on
 // (see operator mainhandler/remediators/annotate.go). All are namespaced.
 var remediationTargetKinds = map[string]bool{
 	"deployment":  true,
@@ -116,14 +116,32 @@ var remediationTargetKinds = map[string]bool{
 	"pod":         true,
 }
 
+// remediationSeverities are the --min-severity values the operator's
+// findings-driven targeting understands. It deliberately mirrors the operator's
+// severityRank (mainhandler/findings.go) rather than
+// reporthandlingapis.GetSupportedSeverities, which omits "Unknown": rejecting
+// here a value the operator accepts would be a gratuitous divergence between
+// the two ends of one contract.
+var remediationSeverities = []string{"Critical", "High", "Medium", "Low", "Unknown"}
+
+func isSupportedRemediationSeverity(severity string) bool {
+	for _, s := range remediationSeverities {
+		if strings.EqualFold(strings.TrimSpace(severity), s) {
+			return true
+		}
+	}
+	return false
+}
+
 // RemediationInfo carries a single `kubescape operator remediate <action>`
 // invocation. It implements OperatorScanInfo so it reuses the existing
 // OperatorAdapter transport (POST apis.Commands to v1/triggerAction) — a
 // remediation is a new verb on that pipeline, not a new endpoint.
 //
-// Supported actions: `annotate` + `revert` (Phase 1) and `quarantine` (Phase 2),
-// all on an explicit target. Findings-driven targeting (--control /
-// --min-severity) and the `cordon` action arrive in later phases.
+// Supported actions: `annotate`, `quarantine` and `revert`; the `cordon` action
+// arrives in a later phase. A target is given either explicitly (--kind/--name)
+// or as a findings-driven selector (--control/--min-severity) that the operator
+// resolves against the scan results already stored in the cluster.
 type RemediationInfo struct {
 	// Action is the operation to perform: "annotate", "quarantine" or "revert".
 	Action string
@@ -131,12 +149,27 @@ type RemediationInfo struct {
 	Kind      string
 	Namespace string
 	Name      string
+	// Selector (findings-driven): the operator resolves these against the stored
+	// configuration-scan summaries, so no re-scan is performed. Mutually
+	// exclusive with the explicit target above.
+	Control     string
+	MinSeverity string
 	// Audit metadata.
 	Reason     string
 	FindingRef string
 	// Confirm (the --confirm flag) is the only way to perform a real cluster
 	// write; absent it, the action is a dry-run. See IsDryRun.
 	Confirm bool
+}
+
+// HasSelector reports whether findings-driven targeting was requested.
+func (r *RemediationInfo) HasSelector() bool {
+	return r.Control != "" || r.MinSeverity != ""
+}
+
+// HasExplicitTarget reports whether a single concrete object was named.
+func (r *RemediationInfo) HasExplicitTarget() bool {
+	return r.Kind != "" || r.Name != ""
 }
 
 // IsDryRun reports whether the action should be sent as a plan-only dry-run.
@@ -157,6 +190,41 @@ func (r *RemediationInfo) ValidatePayload(*apis.Commands) error {
 		return fmt.Errorf("unknown remediation action %q (supported: annotate, quarantine, revert)", r.Action)
 	}
 
+	// A remediation is aimed either at one named object or at whatever the
+	// stored findings resolve to — never both, since the two would describe
+	// different target sets and there is no sensible way to reconcile them.
+	switch {
+	case r.HasExplicitTarget() && r.HasSelector():
+		return errors.New("--kind/--name and --control/--min-severity are mutually exclusive: pass either an explicit target or a findings selector")
+	case r.HasSelector():
+		return r.validateSelector()
+	case r.HasExplicitTarget():
+		return r.validateExplicitTarget()
+	default:
+		return errors.New("remediation requires a target: --kind and --name for one workload, or --control and/or --min-severity to select workloads from stored scan findings")
+	}
+}
+
+// validateSelector checks findings-driven targeting. The target set itself is
+// resolved in-cluster by the operator against the stored scan results, so the
+// CLI validates only what it can know locally.
+func (r *RemediationInfo) validateSelector() error {
+	if r.MinSeverity != "" && !isSupportedRemediationSeverity(r.MinSeverity) {
+		return fmt.Errorf("unsupported --min-severity %q (supported: %s)", r.MinSeverity, strings.Join(remediationSeverities, ", "))
+	}
+	// The operator resolves a selector across every namespace and has no
+	// namespace filter yet (resolveSelectorTargets in mainhandler/findings.go
+	// ignores selector.namespace), so honouring --target-namespace here would
+	// silently widen the blast radius from one namespace to the whole cluster.
+	// Reject it rather than mislead the caller into thinking they scoped it.
+	if r.Namespace != "" {
+		return errors.New("--target-namespace cannot be combined with --control/--min-severity: the operator resolves a findings selector cluster-wide and cannot scope it to a namespace yet")
+	}
+	return nil
+}
+
+// validateExplicitTarget checks a single named object.
+func (r *RemediationInfo) validateExplicitTarget() error {
 	if r.Kind == "" || r.Name == "" {
 		return errors.New("remediation target requires --kind and --name")
 	}
@@ -172,15 +240,26 @@ func (r *RemediationInfo) ValidatePayload(*apis.Commands) error {
 func (r *RemediationInfo) GetRequestPayload() *apis.Commands {
 	dryRun := r.IsDryRun()
 	args := apis.OperatorActionArgs{
-		Action: apis.OperatorActionType(r.Action),
-		Target: &apis.OperatorActionTarget{
-			Kind:      r.Kind,
-			Namespace: r.Namespace,
-			Name:      r.Name,
-		},
+		Action:     apis.OperatorActionType(r.Action),
 		Reason:     r.Reason,
 		FindingRef: r.FindingRef,
 		DryRun:     &dryRun,
+	}
+	// ValidatePayload guarantees exactly one of the two is set. Emit them
+	// independently anyway so an unvalidated call cannot ship an empty Target,
+	// which the operator would take as a request to act on a nameless object.
+	if r.HasExplicitTarget() {
+		args.Target = &apis.OperatorActionTarget{
+			Kind:      r.Kind,
+			Namespace: r.Namespace,
+			Name:      r.Name,
+		}
+	}
+	if r.HasSelector() {
+		args.Selector = &apis.OperatorActionSelector{
+			Control:     r.Control,
+			MinSeverity: r.MinSeverity,
+		}
 	}
 	// ToArgs marshals a plain struct, so it cannot fail in practice; an empty
 	// Args map would be rejected by the operator with a clear error anyway.

--- a/core/cautils/remediationinfo_test.go
+++ b/core/cautils/remediationinfo_test.go
@@ -104,7 +104,8 @@ func TestRemediationInfo_GetRequestPayload_Quarantine(t *testing.T) {
 	assert.Equal(t, "C-0016", args.Reason)
 	// dry-run by default; only --confirm applies
 	assert.True(t, args.IsDryRun())
-	// the Phase-1 CLI never sends findings-driven selectors/ttl (operator rejects those)
+	// an explicit target carries no selector, and the CLI never sends a ttl
+	// (the operator rejects ttl until auto-revert ships)
 	assert.Nil(t, args.Selector)
 	assert.Empty(t, args.TTL)
 
@@ -131,7 +132,108 @@ func TestRemediationInfo_GetRequestPayload_Revert(t *testing.T) {
 	assert.Equal(t, "nginx", args.Target.Name)
 	// revert defaults to a dry-run preview too (operator honors it post-#383 fix)
 	assert.True(t, args.IsDryRun())
-	// no selector/ttl is ever sent by the Phase-1 CLI (operator rejects those)
+	// an explicit target carries no selector, and the CLI never sends a ttl
 	assert.Nil(t, args.Selector)
 	assert.Empty(t, args.TTL)
+}
+
+func TestRemediationInfo_HasTargetAndSelector(t *testing.T) {
+	assert.False(t, (&RemediationInfo{}).HasExplicitTarget())
+	assert.False(t, (&RemediationInfo{}).HasSelector())
+
+	// a partial explicit target still counts as one, so validation can report
+	// the missing half instead of falling through to "no target given"
+	assert.True(t, (&RemediationInfo{Kind: "Deployment"}).HasExplicitTarget())
+	assert.True(t, (&RemediationInfo{Name: "api"}).HasExplicitTarget())
+
+	// either selector axis alone is a selector
+	assert.True(t, (&RemediationInfo{Control: "C-0016"}).HasSelector())
+	assert.True(t, (&RemediationInfo{MinSeverity: "High"}).HasSelector())
+}
+
+func TestRemediationInfo_ValidatePayload_Selector(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    RemediationInfo
+		wantErr bool
+	}{
+		{"control only", RemediationInfo{Action: "quarantine", Control: "C-0016"}, false},
+		{"min-severity only", RemediationInfo{Action: "quarantine", MinSeverity: "High"}, false},
+		{"control and min-severity", RemediationInfo{Action: "quarantine", Control: "C-0016", MinSeverity: "Critical"}, false},
+		{"severity is case-insensitive", RemediationInfo{Action: "annotate", MinSeverity: "high"}, false},
+		{"severity is trimmed", RemediationInfo{Action: "annotate", MinSeverity: " High "}, false},
+		// the operator's severityRank accepts Unknown, so the CLI must too
+		{"unknown severity rank is valid", RemediationInfo{Action: "annotate", MinSeverity: "Unknown"}, false},
+		// revert by selector re-selects the set that was acted on: a quarantined
+		// workload still fails the control that justified quarantining it
+		{"revert by selector", RemediationInfo{Action: "revert", Control: "C-0016"}, false},
+		{"bogus severity", RemediationInfo{Action: "quarantine", MinSeverity: "Extreme"}, true},
+		// selector and explicit target describe different target sets
+		{"selector with kind", RemediationInfo{Action: "quarantine", Control: "C-0016", Kind: "Deployment"}, true},
+		{"selector with name", RemediationInfo{Action: "quarantine", Control: "C-0016", Name: "api"}, true},
+		// the operator ignores selector.namespace, so accepting it would silently
+		// widen a namespace-scoped request to the whole cluster
+		{"selector with target-namespace", RemediationInfo{Action: "quarantine", Control: "C-0016", Namespace: "payments"}, true},
+		{"no target at all", RemediationInfo{Action: "quarantine"}, true},
+		// the action is still validated ahead of the target
+		{"selector with later-phase action", RemediationInfo{Action: "cordon", Control: "C-0016"}, true},
+		{"selector with unknown action", RemediationInfo{Action: "explode", Control: "C-0016"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.info.ValidatePayload(nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRemediationInfo_GetRequestPayload_Selector(t *testing.T) {
+	r := &RemediationInfo{
+		Action:      "quarantine",
+		Control:     "C-0016",
+		MinSeverity: "High",
+		Reason:      "CI gate",
+	}
+	require.NoError(t, r.ValidatePayload(nil))
+
+	args, err := apis.OperatorActionArgsFromMap(r.GetRequestPayload().Commands[0].Args)
+	require.NoError(t, err)
+	assert.Equal(t, apis.OperatorActionQuarantine, args.Action)
+
+	// the selector reaches the operator's findings-driven targeting verbatim
+	require.NotNil(t, args.Selector)
+	assert.Equal(t, "C-0016", args.Selector.Control)
+	assert.Equal(t, "High", args.Selector.MinSeverity)
+	assert.Equal(t, "CI gate", args.Reason)
+
+	// no empty Target rides along: the operator prefers Target when both are
+	// set, so an empty one would shadow the selector entirely
+	assert.Nil(t, args.Target)
+
+	// dry-run by default, even cluster-wide
+	assert.True(t, args.IsDryRun())
+	assert.Empty(t, args.TTL)
+
+	// --confirm is still the only thing that applies
+	r.Confirm = true
+	args, err = apis.OperatorActionArgsFromMap(r.GetRequestPayload().Commands[0].Args)
+	require.NoError(t, err)
+	assert.False(t, args.IsDryRun())
+	require.NotNil(t, args.Selector)
+	assert.Equal(t, "C-0016", args.Selector.Control)
+}
+
+func TestRemediationInfo_GetRequestPayload_NoTargetSendsNeither(t *testing.T) {
+	// ValidatePayload rejects this, but the payload builder must not invent an
+	// empty Target for an unvalidated call — the operator would read it as a
+	// request to act on a nameless object rather than erroring cleanly.
+	args, err := apis.OperatorActionArgsFromMap((&RemediationInfo{Action: "annotate"}).GetRequestPayload().Commands[0].Args)
+	require.NoError(t, err)
+	assert.Nil(t, args.Target)
+	assert.Nil(t, args.Selector)
+	assert.True(t, args.IsDryRun())
 }


### PR DESCRIPTION
## What this does

Adds `--control` and `--min-severity` to `kubescape operator remediate`, so an action can target the set of workloads the operator resolves from scan results already stored in the cluster, instead of naming a single workload with `--kind`/`--name`.

```bash
# Preview every workload failing C-0016 at High or above. Nothing is changed.
kubescape operator remediate quarantine --control C-0016 --min-severity High

# Apply it once the plan has been reviewed
kubescape operator remediate quarantine --control C-0016 --min-severity High --confirm
```

## Why now

The operator side of findings-driven targeting already merged in kubescape/operator#391. It reads the stored `workloadconfigurationscansummaries` and resolves a `selector` into a concrete target set, with no re-scan.

The CLI could not reach any of it. `RemediationInfo` had no selector fields, `GetRequestPayload` only ever emitted a `Target`, and `ValidatePayload` hard-required `--kind` and `--name`. So the code in kubescape/operator#391 was only reachable through the `OperatorCommand` CRD path, and Story 1 of the proposal (the CI gate, which is the use case that motivated the issue in the first place) could not be run from the CLI at all.

This PR is the missing client half. No new operator behaviour, no new transport, no contract changes.

## Context

Part of the phased `operatorAction` remediation framework from the design proposal:

- Proposal: kubescape/designs-and-proposals#5
- Original issue: #1770
- Command contract and typed args: armosec/armoapi-go#655
- Operator dispatch, annotate, dry run: kubescape/operator#383
- Quarantine action: kubescape/operator#388
- Findings-driven targeting in the operator, which this PR unlocks: kubescape/operator#391
- Opt-in `capabilities.remediation` RBAC: kubescape/helm-charts#855
- Earlier CLI work this builds on: #2448 and #2461

This covers item 0 of the proposal's Phase 3. Cordon, TTL/auto-revert, and operator-native auto-remediation are still outstanding and are not touched here.

## Behaviour details

**A selector and an explicit target are mutually exclusive.** They describe different target sets and there is no sensible way to reconcile them, so passing both is rejected with a clear message rather than silently preferring one.

**The payload never carries an empty target next to a selector.** The operator's `resolveTargets` checks `args.Target != nil` before it looks at the selector, so an empty-but-present `Target` would shadow the selector completely and the action would run against a nameless object. `GetRequestPayload` now emits each field only when it is actually populated.

**Dry run stays the default.** A selector run can resolve to many workloads across many namespaces, so this matters more here than it did for a single named target. `--confirm` is still the only thing that performs a real write, and a confirmed selector run logs an explicit warning that it is about to act cluster-wide.

**`--min-severity` accepts Critical, High, Medium, Low and Unknown.** This deliberately mirrors the operator's `severityRank` rather than `reporthandlingapis.GetSupportedSeverities`, which leaves out Unknown. Rejecting on the client a value the server accepts would just be a gratuitous split between the two ends of one contract.

**The events hint switches to `--all-namespaces`** for selector runs, since the audit events are no longer confined to the one namespace an explicit target would have named.

## One restriction worth flagging for review

`OperatorActionSelector.Namespace` exists in the contract and is documented as scoping a selector to a single namespace, but `resolveSelectorTargets` in the operator never actually reads it. It always lists `WorkloadConfigurationScanSummaries("")`, which is cluster-wide.

That means honouring `--target-namespace` on a selector here would be actively dangerous: someone scoping a quarantine to `payments` would get every matching workload in the cluster instead, and nothing in the output would tell them. So this PR rejects that combination with an explicit error rather than shipping the illusion of scoping.

The operator side of this is now up as kubescape/operator#407, which scopes the listing to `selector.Namespace`.

The guard in this PR should still stay until that fix is in a release, though. Every operator released so far ignores `selector.Namespace`, so a CLI that started sending it would hit exactly the silent widening described above on any cluster that has not upgraded yet. Once the fixed operator ships, lifting the guard here is a two line passthrough.

## Testing

- Full `core/cautils` and `cmd/operator` suites pass
- Five new tests, including a fourteen case validation table covering the mutual exclusion rules, severity validation, case insensitivity and trimming, and the payload shape for both targeting modes
- Verified the JSON that actually goes over the wire matches the args schema in the proposal
- Smoke tested the built binary: help output, and every rejection path exits non-zero with a readable message
- Ran the accept path against a live kind cluster with kubescape installed. The command validated, connected, and posted to the operator successfully. The cluster is running the released `operator:v0.2.142`, which predates kubescape/operator#383, so it logs `Command operatorAction not found` as expected. This confirms the transport, not the remediation itself.
