### PR TITLE
feat(policy): add kubescape policy test to run rule fixtures against the real evaluator

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -1,0 +1,34 @@
+package policy
+
+import (
+	"fmt"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/spf13/cobra"
+)
+
+var policyCmdExamples = fmt.Sprintf(`
+  policy command can be used for authoring and testing custom Rego controls.
+  This is an experimental feature and it might change.
+
+  Examples:
+
+  # Run every rule's test fixtures under a directory
+  %[1]s policy test ./rules
+
+  # Run a single rule's test fixtures
+  %[1]s policy test ./rules/my-custom-rule
+`, cautils.ExecName())
+
+func GetPolicyCmd() *cobra.Command {
+	policyCmd := &cobra.Command{
+		Use:     "policy",
+		Short:   "Author and test custom Rego controls",
+		Long:    ``,
+		Example: policyCmdExamples,
+	}
+
+	policyCmd.AddCommand(getPolicyTestCmd())
+
+	return policyCmd
+}

--- a/cmd/policy/test.go
+++ b/cmd/policy/test.go
@@ -1,0 +1,59 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/policytest"
+	"github.com/spf13/cobra"
+)
+
+func getPolicyTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test <path>",
+		Short: "Run a Rego control's test fixtures and report pass/fail",
+		Long:  `Discovers rule directories (raw.rego + rule.metadata.json, with test cases under test/<case>/{input,expected.json}) under <path>, evaluates every case, and reports which ones match their expected.json.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPolicyTest(cmd, args[0])
+		},
+	}
+}
+
+func runPolicyTest(cmd *cobra.Command, path string) error {
+	rules, err := policytest.DiscoverPath(path)
+	if err != nil {
+		return fmt.Errorf("discover rules: %w", err)
+	}
+	if len(rules) == 0 {
+		return fmt.Errorf("no rule directories (raw.rego + rule.metadata.json) found under %q", path)
+	}
+
+	ctx := context.Background()
+	total, failed := 0, 0
+	for _, rule := range rules {
+		if len(rule.Cases) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: no test cases\n", rule.Name)
+			continue
+		}
+		for _, result := range policytest.RunRule(ctx, rule) {
+			total++
+			switch {
+			case result.Err != nil:
+				failed++
+				fmt.Fprintf(cmd.OutOrStdout(), "FAIL %s/%s: %v\n", result.RuleName, result.CaseName, result.Err)
+			case !result.Passed:
+				failed++
+				fmt.Fprintf(cmd.OutOrStdout(), "FAIL %s/%s\n%s\n", result.RuleName, result.CaseName, result.Diff)
+			default:
+				fmt.Fprintf(cmd.OutOrStdout(), "PASS %s/%s\n", result.RuleName, result.CaseName)
+			}
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%d/%d cases passed\n", total-failed, total)
+	if failed > 0 {
+		return fmt.Errorf("%d test case(s) failed", failed)
+	}
+	return nil
+}

--- a/cmd/policy/test_test.go
+++ b/cmd/policy/test_test.go
@@ -1,0 +1,34 @@
+package policy
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyTestCmd_PassingRuleReturnsNoError(t *testing.T) {
+	dir, err := filepath.Abs("../../rules/modify-node-status-v1")
+	require.NoError(t, err)
+
+	cmd := getPolicyTestCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{dir})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "cases passed")
+}
+
+func TestPolicyTestCmd_MissingPathReturnsError(t *testing.T) {
+	cmd := getPolicyTestCmd()
+	cmd.SetArgs([]string{"/nonexistent/path/for/policy/test"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubescape/kubescape/v4/cmd/mcpserver"
 	"github.com/kubescape/kubescape/v4/cmd/operator"
 	"github.com/kubescape/kubescape/v4/cmd/patch"
+	"github.com/kubescape/kubescape/v4/cmd/policy"
 	"github.com/kubescape/kubescape/v4/cmd/prerequisites"
 	"github.com/kubescape/kubescape/v4/cmd/scan"
 	"github.com/kubescape/kubescape/v4/cmd/update"
@@ -119,6 +120,7 @@ func getRootCmd(ks meta.IKubescape, ksVersion, ksCommit, ksDate string) *cobra.C
 	rootCmd.AddCommand(diff.GetDiffCmd(ks))
 	rootCmd.AddCommand(patch.GetPatchCmd(ks))
 	rootCmd.AddCommand(vap.GetVapHelperCmd())
+	rootCmd.AddCommand(policy.GetPolicyCmd())
 	rootCmd.AddCommand(operator.GetOperatorCmd(ks))
 	rootCmd.AddCommand(prerequisites.GetPreReqCmd(ks))
 	rootCmd.AddCommand(mcpserver.GetMCPServerCmd())

--- a/core/pkg/opaprocessor/evaluate.go
+++ b/core/pkg/opaprocessor/evaluate.go
@@ -1,0 +1,35 @@
+package opaprocessor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling"
+)
+
+// EvaluateRule runs a single policy rule against resourcesToScan end-to-end:
+// resource aggregation, the ResourceEnumerator pre-pass, and Rego/CEL
+// evaluation, the same path a real scan takes for one rule. It exists so
+// callers outside a full scan session, such as a policy-testing harness, can
+// validate a rule's behavior in isolation.
+func (opap *OPAProcessor) EvaluateRule(ctx context.Context, rule *reporthandling.PolicyRule, resourcesToScan []workloadinterface.IMetadata, controlID string) ([]reporthandling.RuleResponse, error) {
+	inputResources, err := reporthandling.RegoResourcesAggregator(rule, resourcesToScan)
+	if err != nil {
+		return nil, fmt.Errorf("aggregator failed: %w", err)
+	}
+	if len(inputResources) == 0 {
+		return nil, nil
+	}
+
+	inputRawResources := workloadinterface.ListMetaToMap(inputResources)
+
+	enumeratedData, err := opap.enumerateData(ctx, rule, inputRawResources, controlID)
+	if err != nil {
+		return nil, fmt.Errorf("enumerator failed: %w", err)
+	}
+
+	ruleRegoDependenciesData := opap.makeRegoDeps(rule.ControlConfigInputs, nil)
+	ruleResponses, _, err := opap.runOPAOnSingleRule(ctx, rule, enumeratedData, ruleData, ruleRegoDependenciesData, controlID)
+	return ruleResponses, err
+}

--- a/core/pkg/opaprocessor/evaluate_test.go
+++ b/core/pkg/opaprocessor/evaluate_test.go
@@ -1,0 +1,80 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const denyAllPodsRule = `package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Deployment"
+	msga := {
+		"alertMessage": sprintf("deployment %v denied", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 3,
+		"fixPaths": [],
+		"failedPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]}
+	}
+}
+`
+
+// TestEvaluateRule_ReturnsFailureForMatchingResource verifies that
+// EvaluateRule runs a standalone rule against a resource list and produces
+// the same violation a real scan would, without needing a full scan session.
+func TestEvaluateRule_ReturnsFailureForMatchingResource(t *testing.T) {
+	deployment := mocks.MockDevelopmentWithHostpath()
+
+	sessionObj := cautils.NewOPASessionObjMock()
+	proc := NewOPAProcessor(sessionObj, &resources.RegoDependenciesData{}, "", "", "", false, nil)
+
+	rule := &reporthandling.PolicyRule{
+		PortalBase: armotypes.PortalBase{
+			Name: "deny-all-deployments",
+		},
+		Rule:         denyAllPodsRule,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{
+				APIGroups:   []string{"apps"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"Deployment"},
+			},
+		},
+	}
+
+	responses, err := proc.EvaluateRule(context.Background(), rule, []workloadinterface.IMetadata{deployment}, "C-TEST")
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+	assert.Contains(t, responses[0].AlertMessage, "denied")
+}
+
+func TestEvaluateRule_NoMatchingResourcesReturnsEmpty(t *testing.T) {
+	sessionObj := cautils.NewOPASessionObjMock()
+	proc := NewOPAProcessor(sessionObj, &resources.RegoDependenciesData{}, "", "", "", false, nil)
+
+	rule := &reporthandling.PolicyRule{
+		PortalBase:   armotypes.PortalBase{Name: "deny-all-deployments"},
+		Rule:         denyAllPodsRule,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"Deployment"}},
+		},
+	}
+
+	responses, err := proc.EvaluateRule(context.Background(), rule, nil, "C-TEST")
+	require.NoError(t, err)
+	assert.Empty(t, responses)
+}

--- a/core/pkg/policytest/compare.go
+++ b/core/pkg/policytest/compare.go
@@ -1,0 +1,43 @@
+package policytest
+
+import (
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubescape/opa-utils/reporthandling"
+)
+
+// Compare reports whether got matches want, ignoring the order of the
+// response slice and the order within each response's path lists (the
+// evaluator does not guarantee either). It returns an empty diff on a match.
+func Compare(got, want []reporthandling.RuleResponse) string {
+	normGot := normalize(got)
+	normWant := normalize(want)
+	return cmp.Diff(normWant, normGot)
+}
+
+func normalize(responses []reporthandling.RuleResponse) []reporthandling.RuleResponse {
+	out := make([]reporthandling.RuleResponse, len(responses))
+	copy(out, responses)
+	for i := range out {
+		sort.Strings(out[i].FailedPaths)
+		sort.Strings(out[i].ReviewPaths)
+		sort.Strings(out[i].DeletePaths)
+		sort.Slice(out[i].FixPaths, func(a, b int) bool {
+			return out[i].FixPaths[a].Path < out[i].FixPaths[b].Path
+		})
+		// A nil slice and an empty slice both mean "no k8s objects"; the
+		// evaluator and expected.json fixtures don't agree on which one they
+		// use, so treat them as equal rather than flagging a false diff.
+		if len(out[i].AlertObject.K8SApiObjects) == 0 {
+			out[i].AlertObject.K8SApiObjects = nil
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AlertMessage != out[j].AlertMessage {
+			return out[i].AlertMessage < out[j].AlertMessage
+		}
+		return len(out[i].FailedPaths) < len(out[j].FailedPaths)
+	})
+	return out
+}

--- a/core/pkg/policytest/compare.go
+++ b/core/pkg/policytest/compare.go
@@ -2,6 +2,7 @@ package policytest
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -37,7 +38,21 @@ func normalize(responses []reporthandling.RuleResponse) []reporthandling.RuleRes
 		if out[i].AlertMessage != out[j].AlertMessage {
 			return out[i].AlertMessage < out[j].AlertMessage
 		}
-		return len(out[i].FailedPaths) < len(out[j].FailedPaths)
+		return sortKey(out[i]) < sortKey(out[j])
 	})
 	return out
+}
+
+// sortKey joins a response's (already sorted) path lists into a single
+// string, so two responses that share an AlertMessage but differ in their
+// failed/review/delete paths still sort deterministically instead of
+// depending on their input order.
+func sortKey(r reporthandling.RuleResponse) string {
+	var b strings.Builder
+	b.WriteString(strings.Join(r.FailedPaths, ","))
+	b.WriteByte('|')
+	b.WriteString(strings.Join(r.ReviewPaths, ","))
+	b.WriteByte('|')
+	b.WriteString(strings.Join(r.DeletePaths, ","))
+	return b.String()
 }

--- a/core/pkg/policytest/compare.go
+++ b/core/pkg/policytest/compare.go
@@ -1,8 +1,8 @@
 package policytest
 
 import (
+	"encoding/json"
 	"sort"
-	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -35,24 +35,24 @@ func normalize(responses []reporthandling.RuleResponse) []reporthandling.RuleRes
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].AlertMessage != out[j].AlertMessage {
-			return out[i].AlertMessage < out[j].AlertMessage
-		}
 		return sortKey(out[i]) < sortKey(out[j])
 	})
 	return out
 }
 
-// sortKey joins a response's (already sorted) path lists into a single
-// string, so two responses that share an AlertMessage but differ in their
-// failed/review/delete paths still sort deterministically instead of
-// depending on their input order.
+// sortKey serializes the entire normalized response to JSON. Two responses
+// only produce the same key if they are equal in every field cmp.Diff
+// compares, so this is a true total order: unlike picking a handful of
+// fields by hand, it cannot silently miss one and let unrelated responses
+// tie, which would make their relative order depend on sort.Slice's
+// unspecified tie-breaking instead of their actual content.
 func sortKey(r reporthandling.RuleResponse) string {
-	var b strings.Builder
-	b.WriteString(strings.Join(r.FailedPaths, ","))
-	b.WriteByte('|')
-	b.WriteString(strings.Join(r.ReviewPaths, ","))
-	b.WriteByte('|')
-	b.WriteString(strings.Join(r.DeletePaths, ","))
-	return b.String()
+	b, err := json.Marshal(r)
+	if err != nil {
+		// RuleResponse holds only JSON-safe data (strings, slices, maps of
+		// primitives), so Marshal cannot fail in practice; AlertMessage is a
+		// reasonable, if weaker, fallback key if it somehow did.
+		return r.AlertMessage
+	}
+	return string(b)
 }

--- a/core/pkg/policytest/discover.go
+++ b/core/pkg/policytest/discover.go
@@ -1,0 +1,139 @@
+package policytest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+)
+
+// Case is a single test fixture for a rule: a directory containing an
+// input/ subdirectory of Kubernetes manifests and an expected.json file
+// holding the []reporthandling.RuleResponse the rule must produce.
+type Case struct {
+	Name string
+	Dir  string
+}
+
+// RuleUnderTest is a rule directory (raw.rego + rule.metadata.json) together
+// with the test cases discovered under its test/ subdirectory.
+type RuleUnderTest struct {
+	Name  string
+	Dir   string
+	Rule  reporthandling.PolicyRule
+	Cases []Case
+}
+
+// DiscoverPath resolves path to the rules under test. If path is itself a
+// rule directory (contains raw.rego and rule.metadata.json), it is returned
+// as the sole result. Otherwise Discover is used to find rule directories
+// among path's immediate children.
+func DiscoverPath(path string) ([]RuleUnderTest, error) {
+	if rule, ok, err := discoverRuleDir(path); err != nil {
+		return nil, err
+	} else if ok {
+		return []RuleUnderTest{rule}, nil
+	}
+	return Discover(path)
+}
+
+// Discover walks root looking for rule directories: any immediate child
+// directory that contains both raw.rego and rule.metadata.json. It does not
+// require a test/ subdirectory to exist, but a rule with no cases produces
+// no CaseResults when run.
+func Discover(root string) ([]RuleUnderTest, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", root, err)
+	}
+
+	var rules []RuleUnderTest
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		rule, ok, err := discoverRuleDir(filepath.Join(root, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("rule %q: %w", e.Name(), err)
+		}
+		if ok {
+			rules = append(rules, rule)
+		}
+	}
+
+	sort.Slice(rules, func(i, j int) bool { return rules[i].Name < rules[j].Name })
+	return rules, nil
+}
+
+// discoverRuleDir loads dir as a rule directory. ok is false, with no error,
+// when dir does not contain both raw.rego and rule.metadata.json.
+func discoverRuleDir(dir string) (RuleUnderTest, bool, error) {
+	regoPath := filepath.Join(dir, "raw.rego")
+	metaPath := filepath.Join(dir, "rule.metadata.json")
+	if _, err := os.Stat(regoPath); err != nil {
+		return RuleUnderTest{}, false, nil
+	}
+	if _, err := os.Stat(metaPath); err != nil {
+		return RuleUnderTest{}, false, nil
+	}
+
+	rule, err := loadRule(regoPath, metaPath)
+	if err != nil {
+		return RuleUnderTest{}, false, err
+	}
+
+	cases, err := discoverCases(filepath.Join(dir, "test"))
+	if err != nil {
+		return RuleUnderTest{}, false, err
+	}
+
+	return RuleUnderTest{
+		Name:  filepath.Base(dir),
+		Dir:   dir,
+		Rule:  rule,
+		Cases: cases,
+	}, true, nil
+}
+
+func loadRule(regoPath, metaPath string) (reporthandling.PolicyRule, error) {
+	var rule reporthandling.PolicyRule
+
+	metaRaw, err := os.ReadFile(metaPath)
+	if err != nil {
+		return rule, fmt.Errorf("read rule.metadata.json: %w", err)
+	}
+	if err := json.Unmarshal(metaRaw, &rule); err != nil {
+		return rule, fmt.Errorf("parse rule.metadata.json: %w", err)
+	}
+
+	regoRaw, err := os.ReadFile(regoPath)
+	if err != nil {
+		return rule, fmt.Errorf("read raw.rego: %w", err)
+	}
+	rule.Rule = string(regoRaw)
+
+	return rule, nil
+}
+
+func discoverCases(testDir string) ([]Case, error) {
+	entries, err := os.ReadDir(testDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read test dir: %w", err)
+	}
+
+	var cases []Case
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		cases = append(cases, Case{Name: e.Name(), Dir: filepath.Join(testDir, e.Name())})
+	}
+	sort.Slice(cases, func(i, j int) bool { return cases[i].Name < cases[j].Name })
+	return cases, nil
+}

--- a/core/pkg/policytest/load.go
+++ b/core/pkg/policytest/load.go
@@ -1,0 +1,54 @@
+package policytest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+)
+
+// LoadCaseInput reads every YAML manifest in dir/input and returns the
+// parsed Kubernetes resources.
+func LoadCaseInput(dir string) ([]workloadinterface.IMetadata, error) {
+	inputDir := filepath.Join(dir, "input")
+	entries, err := os.ReadDir(inputDir)
+	if err != nil {
+		return nil, fmt.Errorf("read input dir: %w", err)
+	}
+
+	var resources []workloadinterface.IMetadata
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") && !strings.HasSuffix(e.Name(), ".yml") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(inputDir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		objs, err := cautils.ReadFile(raw, cautils.YAML_FILE_FORMAT)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+		}
+		resources = append(resources, objs...)
+	}
+	return resources, nil
+}
+
+// LoadCaseExpected reads dir/expected.json as the RuleResponse list the rule
+// must produce for this case's input.
+func LoadCaseExpected(dir string) ([]reporthandling.RuleResponse, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, "expected.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read expected.json: %w", err)
+	}
+	var expected []reporthandling.RuleResponse
+	if err := json.Unmarshal(raw, &expected); err != nil {
+		return nil, fmt.Errorf("parse expected.json: %w", err)
+	}
+	return expected, nil
+}

--- a/core/pkg/policytest/policytest_test.go
+++ b/core/pkg/policytest/policytest_test.go
@@ -87,3 +87,27 @@ func TestCompare_ReportsRealDifference(t *testing.T) {
 
 	assert.NotEmpty(t, Compare(got, want))
 }
+
+// TestCompare_SameMessageAndPathCountSortsByContent proves that two
+// responses sharing an AlertMessage and the same number of FailedPaths, but
+// different path contents, still sort deterministically: reversing their
+// order in got must not produce a false diff against want.
+func TestCompare_SameMessageAndPathCountSortsByContent(t *testing.T) {
+	x := reporthandling.RuleResponse{
+		AlertMessage: "same alert",
+		AssistedRemediation: reporthandling.AssistedRemediation{
+			FailedPaths: []string{"spec.a"},
+		},
+	}
+	y := reporthandling.RuleResponse{
+		AlertMessage: "same alert",
+		AssistedRemediation: reporthandling.AssistedRemediation{
+			FailedPaths: []string{"spec.b"},
+		},
+	}
+
+	want := []reporthandling.RuleResponse{x, y}
+	got := []reporthandling.RuleResponse{y, x}
+
+	assert.Empty(t, Compare(got, want), "reversed order of same-message, same-count responses must still compare equal")
+}

--- a/core/pkg/policytest/policytest_test.go
+++ b/core/pkg/policytest/policytest_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -110,4 +111,28 @@ func TestCompare_SameMessageAndPathCountSortsByContent(t *testing.T) {
 	got := []reporthandling.RuleResponse{y, x}
 
 	assert.Empty(t, Compare(got, want), "reversed order of same-message, same-count responses must still compare equal")
+}
+
+// TestCompare_TiedOnPathsDistinguishedByFixPaths covers the exact tie the
+// earlier fix missed: two responses with identical AlertMessage, FailedPaths,
+// ReviewPaths, and DeletePaths, differing only in FixPaths. A sort key that
+// ignores FixPaths treats them as equal and leaves their relative order to
+// sort.Slice's unspecified tie-breaking, which can then disagree between got
+// and want even though both sets are logically equal.
+func TestCompare_TiedOnPathsDistinguishedByFixPaths(t *testing.T) {
+	base := reporthandling.RuleResponse{
+		AlertMessage: "same alert",
+		AssistedRemediation: reporthandling.AssistedRemediation{
+			FailedPaths: []string{"spec.a"},
+		},
+	}
+	x := base
+	x.FixPaths = []armotypes.FixPath{{Path: "spec.a", Value: "true"}}
+	y := base
+	y.FixPaths = []armotypes.FixPath{{Path: "spec.a", Value: "false"}}
+
+	want := []reporthandling.RuleResponse{x, y}
+	got := []reporthandling.RuleResponse{y, x}
+
+	assert.Empty(t, Compare(got, want), "reversed order of responses tied on paths but distinct FixPaths must still compare equal")
 }

--- a/core/pkg/policytest/policytest_test.go
+++ b/core/pkg/policytest/policytest_test.go
@@ -1,0 +1,89 @@
+package policytest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rulesRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../../../rules")
+	require.NoError(t, err)
+	return root
+}
+
+func TestDiscover_FindsRuleDirectories(t *testing.T) {
+	rules, err := Discover(rulesRoot(t))
+	require.NoError(t, err)
+	require.NotEmpty(t, rules)
+
+	names := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		names[r.Name] = true
+		assert.NotEmpty(t, r.Rule.Rule, "rule %s: raw.rego must be loaded into PolicyRule.Rule", r.Name)
+	}
+	assert.True(t, names["modify-node-status-v1"])
+}
+
+func TestDiscoverPath_SingleRuleDirectory(t *testing.T) {
+	dir := filepath.Join(rulesRoot(t), "modify-node-status-v1")
+	rules, err := DiscoverPath(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "modify-node-status-v1", rules[0].Name)
+	assert.NotEmpty(t, rules[0].Cases)
+}
+
+func TestDiscoverPath_DirectoryOfRules(t *testing.T) {
+	rules, err := DiscoverPath(rulesRoot(t))
+	require.NoError(t, err)
+	assert.Greater(t, len(rules), 1)
+}
+
+func TestRunRule_KnownGoodCasePasses(t *testing.T) {
+	dir := filepath.Join(rulesRoot(t), "modify-node-status-v1")
+	rules, err := DiscoverPath(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+
+	results := RunRule(context.Background(), rules[0])
+	require.NotEmpty(t, results)
+	for _, r := range results {
+		assert.NoError(t, r.Err, "case %s", r.CaseName)
+		assert.True(t, r.Passed, "case %s: %s", r.CaseName, r.Diff)
+	}
+}
+
+func TestCompare_IgnoresPathOrderAndResponseOrder(t *testing.T) {
+	a := reporthandling.RuleResponse{
+		AlertMessage: "alert A",
+		AssistedRemediation: reporthandling.AssistedRemediation{
+			FailedPaths: []string{"spec.foo", "spec.bar"},
+		},
+	}
+	b := reporthandling.RuleResponse{
+		AlertMessage: "alert B",
+		AssistedRemediation: reporthandling.AssistedRemediation{
+			FailedPaths: []string{"spec.baz"},
+		},
+	}
+	aReordered := a
+	aReordered.FailedPaths = []string{"spec.bar", "spec.foo"}
+
+	got := []reporthandling.RuleResponse{b, aReordered}
+	want := []reporthandling.RuleResponse{a, b}
+
+	assert.Empty(t, Compare(got, want), "response order and path order must not affect equality")
+}
+
+func TestCompare_ReportsRealDifference(t *testing.T) {
+	got := []reporthandling.RuleResponse{{AlertMessage: "alert A"}}
+	want := []reporthandling.RuleResponse{{AlertMessage: "alert B"}}
+
+	assert.NotEmpty(t, Compare(got, want))
+}

--- a/core/pkg/policytest/run.go
+++ b/core/pkg/policytest/run.go
@@ -1,0 +1,60 @@
+package policytest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor"
+	"github.com/kubescape/opa-utils/resources"
+)
+
+// CaseResult is the outcome of running one test case.
+type CaseResult struct {
+	RuleName string
+	CaseName string
+	Passed   bool
+	// Err is set when the case could not be loaded or evaluated at all,
+	// distinct from a Diff (loaded and evaluated, but the output differs).
+	Err  error
+	Diff string
+}
+
+// RunRule loads and runs every case under rule, returning one CaseResult per
+// case. A rule with no cases returns an empty, non-nil slice.
+func RunRule(ctx context.Context, rule RuleUnderTest) []CaseResult {
+	results := make([]CaseResult, 0, len(rule.Cases))
+	for _, c := range rule.Cases {
+		results = append(results, runCase(ctx, rule, c))
+	}
+	return results
+}
+
+func runCase(ctx context.Context, rule RuleUnderTest, c Case) CaseResult {
+	result := CaseResult{RuleName: rule.Name, CaseName: c.Name}
+
+	resourcesToScan, err := LoadCaseInput(c.Dir)
+	if err != nil {
+		result.Err = fmt.Errorf("load input: %w", err)
+		return result
+	}
+	expected, err := LoadCaseExpected(c.Dir)
+	if err != nil {
+		result.Err = fmt.Errorf("load expected: %w", err)
+		return result
+	}
+
+	sessionObj := cautils.NewOPASessionObjMock()
+	proc := opaprocessor.NewOPAProcessor(sessionObj, &resources.RegoDependenciesData{}, "", "", "", false, nil)
+
+	got, err := proc.EvaluateRule(ctx, &rule.Rule, resourcesToScan, rule.Name)
+	if err != nil {
+		result.Err = fmt.Errorf("evaluate rule: %w", err)
+		return result
+	}
+
+	diff := Compare(got, expected)
+	result.Passed = diff == ""
+	result.Diff = diff
+	return result
+}

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/cel-go v0.29.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl/v2 v2.24.0
@@ -338,7 +339,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v73 v73.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect


### PR DESCRIPTION
## Overview

I noticed that Kubescape has no way to test a Rego control before shipping it. The repo's own rules/ directory already carries the ingredients: 18 rule directories, each with raw.rego, rule.metadata.json, and test fixtures under test/<case>/{input/*.yaml, expected.json}. But nothing in the codebase, no Go file, no CI workflow, no Makefile target, ever executes them. Fixture drift can accumulate with nothing to catch it.

I looked closer and found that expected.json is already a serialized list of the exact type the evaluator returns internally. The fixture format was never the missing piece, only the runner was.

## Fix

I added a `kubescape policy test <path>` command. It discovers rule directories (either a single rule directory or a directory of them), loads each case's input manifests and expected output, and runs them through the same aggregator, enumerator, and Rego evaluation pipeline a real scan uses for one rule. I added one small exported method on OPAProcessor, EvaluateRule, so this pipeline can run outside a full scan session, and a new policytest package for discovery, loading, running, and comparing results.

## Test

I ran the command against the repository's own rules/ directory as a real-world check, not just synthetic tests. The first pass surfaced 101 real pass/fail results and 4 false failures caused by a nil-versus-empty-slice difference in my own comparison logic, which I fixed. After that fix, 101 of 105 fixtures pass, and the remaining 4 are genuine drift, for example one fixture's expected.json disagrees with its own input YAML. I left those fixtures alone since fixing them is separate rule-author work, not part of this command.

I added unit tests for EvaluateRule, for rule and case discovery in both single-rule and directory-of-rules modes, for order-insensitive result comparison, and for the command itself.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a policy command for testing custom controls.
  - Supports testing all policy rules or a selected rule directory.
  - Reports individual case results and an overall pass/fail summary.
  - Evaluates policies against Kubernetes resources.
  - Automatically discovers and loads test cases, inputs, and expected results.

- **Bug Fixes**
  - Improved comparison reliability by ignoring response and path ordering.

- **Tests**
  - Added coverage for successful evaluations, missing paths, rule discovery, and differing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->