### PR TITLE
fix: remove secrets from cluster size estimation to tighten RBAC

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1215,7 +1215,6 @@ var namespacedResourcesToEstimate = []schema.GroupVersionResource{
 	{Group: "", Version: "v1", Resource: "pods"},
 	{Group: "", Version: "v1", Resource: "services"},
 	{Group: "", Version: "v1", Resource: "configmaps"},
-	{Group: "", Version: "v1", Resource: "secrets"},
 	{Group: "", Version: "v1", Resource: "serviceaccounts"},
 	{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
 	{Group: "apps", Version: "v1", Resource: "deployments"},

--- a/core/pkg/resourcehandler/k8sresources_estimate_test.go
+++ b/core/pkg/resourcehandler/k8sresources_estimate_test.go
@@ -136,8 +136,8 @@ func TestEstimateClusterSize_SmallCluster(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 50+10+5+20 + (12 other GVRs * 10 each) + 16 returned items = 221
-	assert.Equal(t, 221, size)
+	// 50+10+5+20 + (11 other GVRs * 10 each) + 15 returned items = 210
+	assert.Equal(t, 210, size)
 }
 
 func TestEstimateClusterSize_LargeCluster(t *testing.T) {
@@ -153,8 +153,8 @@ func TestEstimateClusterSize_LargeCluster(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 16 GVRs * (500 remaining + 1 returned) = 8016
-	assert.Equal(t, 8016, size)
+	// 15 GVRs * (500 remaining + 1 returned) = 7515
+	assert.Equal(t, 7515, size)
 }
 
 func TestEstimateClusterSize_ListErrors(t *testing.T) {
@@ -173,8 +173,8 @@ func TestEstimateClusterSize_ListErrors(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 15 GVRs * (100 remaining + 1 returned) = 1515 (pods error is skipped)
-	assert.Equal(t, 1515, size)
+	// 14 GVRs * (100 remaining + 1 returned) = 1414 (pods error is skipped)
+	assert.Equal(t, 1414, size)
 }
 
 func TestEstimateClusterSize_AllListErrors(t *testing.T) {
@@ -235,6 +235,6 @@ func TestEstimateClusterSize_NilRemainingItemCount(t *testing.T) {
 
 	size, err := handler.EstimateClusterSize(context.Background(), &cautils.ScanInfo{})
 	require.NoError(t, err)
-	// 15 GVRs * (200 remaining + 1 returned) + 1 returned pod = 3016.
-	assert.Equal(t, 3016, size)
+	// 14 GVRs * (200 remaining + 1 returned) + 1 returned pod = 2815.
+	assert.Equal(t, 2815, size)
 }


### PR DESCRIPTION
## Description
This PR removes `secrets` from the `namespacedResourcesToEstimate` list. 

Previously, `EstimateClusterSize` included `secrets` when listing a single item of various resources to gauge cluster size. Because fetching a secret returns the entire object (including its sensitive `data`), this unnecessarily required cluster-wide secret read access (`get`/`list`) just to estimate the size of the cluster.

By removing it from the estimation array, we adhere much more closely to the principle of least privilege, tightening Kubescape's overall RBAC footprint without negatively impacting the accuracy of the cluster size estimation.

## Environment
OS: macOS / Linux (any)
Version: `master` 

## Expected behavior
Kubescape estimates cluster size correctly without demanding or utilizing cluster-wide secret read permissions.

## Additional context
Category: Security / RBAC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes cluster size estimation by excluding secrets from representative resource calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->