### PR TITLE
feat(scan): add --skip-controls and --include-controls filtering

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -227,6 +227,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.Hide, "hide", false, "Replace sensitive report metadata with deterministic pseudonyms")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.EncryptionEnabled, "encrypt", false, "Encrypt sensitive report metadata using the KUBESCAPE_MASTER_KEY environment variable")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.LabelsToCopy, "labels-to-copy", nil, "Labels to copy from workloads to scan reports for easy identification. e.g: --labels-to-copy=app,team,environment")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.SkipControls, "skip-controls", "", "Comma-separated control IDs to skip, e.g. --skip-controls C-0001,C-0020")
+	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeControls, "include-controls", "", "Comma-separated control IDs to include; all other controls are skipped, e.g. --include-controls C-0001,C-0002")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.ListingURL, "grype-db-url", "", "Grype vulnerability database URL")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.SkipDBUpdate, "skip-db-update", false, "Do not update the vulnerability database before scanning images. Uses the locally cached database; fails if none is cached.")
 	scanCmd.PersistentFlags().DurationVar(&scanInfo.ScanTimeout, "scan-timeout", 0, "Maximum duration for the scan (e.g. 5m, 30s, 1h). 0 means no timeout. When the timeout is reached the scan exits with a non-zero code.")

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -118,6 +118,8 @@ type OPASessionObj struct {
 	TopWorkloadsByScore   []reporthandling.IResource
 	TriggeredByCLI        bool
 	LabelsToCopy          []string                    // Labels to copy from workloads to scan reports
+	SkipControls          string                      // Comma-separated control IDs to skip
+	IncludeControls       string                      // Comma-separated control IDs to include (all others skipped)
 	VAPPolicies           []unstructured.Unstructured // ValidatingAdmissionPolicy resources collected from the cluster
 	VAPBindings           []unstructured.Unstructured // ValidatingAdmissionPolicyBinding resources collected from the cluster
 }
@@ -147,6 +149,8 @@ func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework
 		HonorInlineExceptions: scanInfo.HonorInlineExceptions.GetBool(),
 		TriggeredByCLI:        scanInfo.TriggeredByCLI,
 		LabelsToCopy:          scanInfo.LabelsToCopy,
+		SkipControls:          scanInfo.SkipControls,
+		IncludeControls:       scanInfo.IncludeControls,
 	}
 }
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -183,6 +183,8 @@ type ScanInfo struct {
 	HelmReleaseName           string   // --release-name: Helm release name made available as .Release.Name during render
 	HelmReleaseNamespace      string   // --release-namespace: Helm release namespace made available as .Release.Namespace
 	LabelsToCopy              []string // Labels to copy from workloads to scan reports
+	SkipControls              string   // Control IDs to skip, e.g. "C-0001,C-0020"
+	IncludeControls           string   // Control IDs to include (all others skipped), e.g. "C-0001,C-0002"
 	scanningContext           *ScanningContext
 	kubeconfigPath            string
 	kubeContextOverride       string

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -228,7 +228,13 @@ func (opap *OPAProcessor) SetIncrementalCache(cache *scancache.Store) {
 
 func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressListener IJobProgressNotificationClient) error {
 	scanningScope := cautils.GetScanningScope(opap.Metadata.ContextMetadata)
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.ExcludedRules, scanningScope)
+
+	excludedRules := opap.ExcludedRules
+	if opap.SkipControls != "" || opap.IncludeControls != "" {
+		excludedRules = buildControlExcludedRules(excludedRules, opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
+	}
+
+	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, scanningScope)
 
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -614,3 +614,78 @@ func ruleData(rule *reporthandling.PolicyRule) string {
 func ruleEnumeratorData(rule *reporthandling.PolicyRule) string {
 	return rule.ResourceEnumerator
 }
+
+// buildControlExcludedRules merges the existing rule-exclusion map with any
+// --skip-controls or --include-controls filters. The resulting map marks
+// individual rule names with `true` so that convertFrameworksToPolicies drops
+// them. Include is a whitelist; skip is a blacklist and wins over include.
+func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling.Framework, skip, include []string) map[string]bool {
+	excludedRules := make(map[string]bool, len(base)+4)
+	for k, v := range base {
+		excludedRules[k] = v
+	}
+
+	if len(skip) == 0 && len(include) == 0 {
+		return excludedRules
+	}
+
+	skipSet := make(map[string]struct{}, len(skip))
+	for _, id := range skip {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			skipSet[id] = struct{}{}
+		}
+	}
+
+	includeSet := make(map[string]struct{}, len(include))
+	for _, id := range include {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			includeSet[id] = struct{}{}
+		}
+	}
+
+	knownIDs := make(map[string]struct{})
+	for _, fw := range frameworks {
+		for i := range fw.Controls {
+			knownIDs[fw.Controls[i].ControlID] = struct{}{}
+		}
+	}
+
+	for id := range skipSet {
+		if _, ok := knownIDs[id]; !ok {
+			logger.L().Warning("skip control not found in loaded policies", helpers.String("control", id))
+		}
+	}
+	for id := range includeSet {
+		if _, ok := knownIDs[id]; !ok {
+			logger.L().Warning("include control not found in loaded policies", helpers.String("control", id))
+		}
+	}
+
+	if len(include) > 0 {
+		for _, fw := range frameworks {
+			for i := range fw.Controls {
+				if _, keep := includeSet[fw.Controls[i].ControlID]; keep {
+					continue
+				}
+				for r := range fw.Controls[i].Rules {
+					excludedRules[fw.Controls[i].Rules[r].Name] = true
+				}
+			}
+		}
+	}
+
+	for _, fw := range frameworks {
+		for i := range fw.Controls {
+			if _, skip := skipSet[fw.Controls[i].ControlID]; !skip {
+				continue
+			}
+			for r := range fw.Controls[i].Rules {
+				excludedRules[fw.Controls[i].Rules[r].Name] = true
+			}
+		}
+	}
+
+	return excludedRules
+}

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1157,3 +1157,66 @@ func TestGatherInlineExceptions(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "C-0001", got[0].PosturePolicies[0].ControlID)
 }
+
+func TestBuildControlExcludedRules(t *testing.T) {
+	framework := []reporthandling.Framework{{
+		Controls: []reporthandling.Control{
+			{ControlID: "C-0001", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
+			{ControlID: "C-0002", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-b"}}}},
+			{ControlID: "C-0003", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-c"}}}},
+		},
+	}}
+
+	tests := []struct {
+		name          string
+		base          map[string]bool
+		skip          []string
+		include       []string
+		excludedRules []string
+		notExcluded   []string
+	}{
+		{
+			name:          "no filters",
+			base:          map[string]bool{"rule-a": false},
+			excludedRules: nil,
+			notExcluded:   []string{"rule-a", "rule-b", "rule-c"},
+		},
+		{
+			name:          "skip one control",
+			skip:          []string{"C-0002"},
+			excludedRules: []string{"rule-b"},
+			notExcluded:   []string{"rule-a", "rule-c"},
+		},
+		{
+			name:          "include only two controls",
+			include:       []string{"C-0001", "C-0002"},
+			excludedRules: []string{"rule-c"},
+			notExcluded:   []string{"rule-a", "rule-b"},
+		},
+		{
+			name:          "include two and skip one of them",
+			include:       []string{"C-0001", "C-0002"},
+			skip:          []string{"C-0002"},
+			excludedRules: []string{"rule-b", "rule-c"},
+			notExcluded:   []string{"rule-a"},
+		},
+		{
+			name:          "unknown control ids are ignored",
+			skip:          []string{"C-9999"},
+			excludedRules: nil,
+			notExcluded:   []string{"rule-a", "rule-b", "rule-c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildControlExcludedRules(tt.base, framework, tt.skip, tt.include)
+			for _, rule := range tt.excludedRules {
+				assert.True(t, got[rule], "expected rule %q to be excluded", rule)
+			}
+			for _, rule := range tt.notExcluded {
+				assert.False(t, got[rule], "expected rule %q not to be excluded", rule)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
close #3479 

Exposes the existing rule-exclusion plumbing (`OPASessionObj.ExcludedRules`) through two new user-facing CLI flags:

- `--skip-controls C-0001,C-0020` — drop the listed controls from the selected frameworks.
- `--include-controls C-0001,C-0002` — keep only the listed controls; everything else is skipped.

When both are provided, `--include-controls` narrows the set first and `--skip-controls` is then applied on top of it, so an explicitly skipped control is excluded even if it is also in the include list.

## How

- Added `SkipControls` and `IncludeControls` to `cautils.ScanInfo` and `cautils.OPASessionObj`.
- Wired both as persistent flags on `kubescape scan` so they work with `scan framework`, `scan control`, and the default `scan` path.
- In `OPAProcessor.ProcessRulesListener`, the requested control IDs are translated to rule names and merged into the existing `ExcludedRules` map before `convertFrameworksToPolicies` runs.
- Unknown control IDs are logged as warnings instead of failing the scan.
- Added `TestBuildControlExcludedRules` covering:
  - no filters
  - single skip
  - include whitelist
  - include + skip interaction
  - unknown control IDs

## Test plan

- `go build ./...`
- `go test -count=1 ./core/pkg/opaprocessor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent scan options to include only specified controls or skip selected controls.
  * Control filters now apply during policy processing, with skip settings taking precedence.
  * Unknown control IDs generate warnings without interrupting scans.

* **Bug Fixes**
  * Improved handling of control-based rule exclusions during framework processing.
  * Improved resource scope and namespace handling for large clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->