### PR TITLE
feat(scan): validate repository scan contracts

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -72,6 +72,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		Long:    `Scan a Kubernetes cluster, YAML files, Helm charts, Kustomize directories, Git repositories, or container images for security misconfigurations and vulnerabilities.`,
 		Example: scanCmdExamples,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == "validate-contract" {
+				return nil
+			}
 			// runs for the bare scan command and all subcommands (framework, control, workload, image)
 			if scanInfo.FormatVersion != "v1" && scanInfo.FormatVersion != "v2" {
 				return fmt.Errorf("invalid --format-version %q: supported versions are v1 and v2", scanInfo.FormatVersion)
@@ -269,6 +272,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.AddCommand(getWorkloadCmd(ks, &scanInfo))
 
 	scanCmd.AddCommand(getImageCmd(ks, &scanInfo))
+	scanCmd.AddCommand(getValidateContractCmd(&scanInfo))
 
 	return scanCmd
 }

--- a/cmd/scan/validate_contract.go
+++ b/cmd/scan/validate_contract.go
@@ -1,0 +1,68 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/kubescape/v4/cmd/shared"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
+	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/spf13/cobra"
+)
+
+func getValidateContractCmd(scanInfo *cautils.ScanInfo) *cobra.Command {
+	var contractName string
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "validate-contract <file>",
+		Short: "Validate and select a repository scan contract without running a scan",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selected, err := contractv1alpha1.LoadFile(args[0], contractv1alpha1.LoadOptions{
+				ContractName:        contractName,
+				RunningVersion:      versioncheck.BuildNumber,
+				SupportedFormats:    shared.ScanFormats,
+				SupportedSeverities: reporthandlingapis.GetSupportedSeverities(),
+			})
+			if err != nil {
+				return err
+			}
+
+			var output []byte
+			switch outputFormat {
+			case "text":
+				output = []byte(fmt.Sprintf("Scan contract %q is valid\nSelected contract: %s\nContract digest: %s\n", selected.Metadata.Name, selected.ContractName, selected.ContractDigest))
+			case "json":
+				output, err = json.MarshalIndent(selected, "", "  ")
+				if err != nil {
+					return fmt.Errorf("encode validated contract: %w", err)
+				}
+				output = append(output, '\n')
+			default:
+				return fmt.Errorf("unsupported format %q, supported: text, json", outputFormat)
+			}
+
+			if scanInfo.Output != "" {
+				if err := os.WriteFile(scanInfo.Output, output, 0o600); err != nil {
+					return fmt.Errorf("write validation output: %w", err)
+				}
+				return nil
+			}
+			_, err = cmd.OutOrStdout().Write(output)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&contractName, "contract", "", "Named contract to validate; defaults to spec.defaultContract")
+	cmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json"`)
+	cmd.Example = strings.Join([]string{
+		"  kubescape scan validate-contract kubescape.yaml",
+		"  kubescape scan validate-contract kubescape.yaml --contract ci --format json",
+	}, "\n")
+	return cmd
+}

--- a/cmd/scan/validate_contract_test.go
+++ b/cmd/scan/validate_contract_test.go
@@ -58,6 +58,22 @@ func TestValidateContractCommand(t *testing.T) {
 	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, selected.ContractDigest)
 }
 
+func TestValidateContractCommandAcceptsDevelopmentBuild(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "dev"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	require.NoError(t, os.WriteFile(contractPath, []byte(commandContract), 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetArgs([]string{"validate-contract", contractPath})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, output.String(), `Scan contract "example" is valid`)
+}
+
 func TestValidateContractCommandWritesOutputFile(t *testing.T) {
 	originalBuildNumber := versioncheck.BuildNumber
 	versioncheck.BuildNumber = "v4.1.0"

--- a/cmd/scan/validate_contract_test.go
+++ b/cmd/scan/validate_contract_test.go
@@ -1,0 +1,96 @@
+package scan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/kubescape/v4/core/core"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const commandContract = `
+apiVersion: config.kubescape.io/v1alpha1
+kind: ScanContract
+metadata:
+  name: example
+spec:
+  minimumKubescapeVersion: v4.0.0
+  defaultContract: developer
+  contracts:
+    developer:
+      policy:
+        frameworks: [nsa]
+      output:
+        formats: [pretty-printer]
+    ci:
+      failure:
+        severityAtLeast: high
+        coverageBelow: 95
+      output:
+        formats: [json]
+`
+
+func TestValidateContractCommand(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	require.NoError(t, os.WriteFile(contractPath, []byte(commandContract), 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--contract", "ci", "--format", "json"})
+	require.NoError(t, cmd.Execute())
+
+	var selected contractv1alpha1.SelectedContract
+	require.NoError(t, json.Unmarshal(output.Bytes(), &selected))
+	assert.Equal(t, "ci", selected.ContractName)
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, selected.ContractDigest)
+}
+
+func TestValidateContractCommandWritesOutputFile(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	temporaryDirectory := t.TempDir()
+	contractPath := filepath.Join(temporaryDirectory, "kubescape.yaml")
+	outputPath := filepath.Join(temporaryDirectory, "selected.json")
+	require.NoError(t, os.WriteFile(contractPath, []byte(commandContract), 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "json", "--output", outputPath})
+	require.NoError(t, cmd.Execute())
+
+	contents, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	var selected contractv1alpha1.SelectedContract
+	require.NoError(t, json.Unmarshal(contents, &selected))
+	assert.Equal(t, "developer", selected.ContractName)
+}
+
+func TestValidateContractCommandReportsStrictErrors(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	invalid := bytes.Replace([]byte(commandContract), []byte("frameworks"), []byte("frameworkz"), 1)
+	require.NoError(t, os.WriteFile(contractPath, invalid, 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	cmd.SetArgs([]string{"validate-contract", contractPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field frameworkz not found")
+}

--- a/core/pkg/scancontract/v1alpha1/digest.go
+++ b/core/pkg/scancontract/v1alpha1/digest.go
@@ -1,0 +1,41 @@
+package v1alpha1
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	jsoncanonicalizer "github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+type digestInput struct {
+	APIVersion              string   `json:"apiVersion"`
+	Kind                    string   `json:"kind"`
+	Metadata                Metadata `json:"metadata"`
+	MinimumKubescapeVersion string   `json:"minimumKubescapeVersion"`
+	ContractName            string   `json:"contractName"`
+	Contract                Contract `json:"contract"`
+}
+
+func Digest(selected *SelectedContract) (string, error) {
+	input := digestInput{
+		APIVersion:              selected.APIVersion,
+		Kind:                    selected.Kind,
+		Metadata:                selected.Metadata,
+		MinimumKubescapeVersion: selected.MinimumKubescapeVersion,
+		ContractName:            selected.ContractName,
+		Contract:                selected.Contract,
+	}
+	raw, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("marshal selected contract for digest: %w", err)
+	}
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize selected contract for digest: %w", err)
+	}
+	hashInput := append([]byte(DigestSchema+"\x00"), canonical...)
+	sum := sha256.Sum256(hashInput)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/core/pkg/scancontract/v1alpha1/loader.go
+++ b/core/pkg/scancontract/v1alpha1/loader.go
@@ -1,0 +1,96 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type LoadOptions struct {
+	ContractName        string
+	RunningVersion      string
+	SupportedFormats    []string
+	SupportedSeverities []string
+}
+
+func LoadFile(path string, options LoadOptions) (*SelectedContract, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read scan contract: %w", err)
+	}
+	selected, err := Load(contents, options)
+	if err != nil {
+		return nil, fmt.Errorf("validate scan contract %q: %w", path, err)
+	}
+	return selected, nil
+}
+
+func Load(contents []byte, options LoadOptions) (*SelectedContract, error) {
+	if len(bytes.TrimSpace(contents)) == 0 {
+		return nil, errors.New("contract document is empty")
+	}
+
+	var envelope struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Spec       struct {
+			MinimumKubescapeVersion string `yaml:"minimumKubescapeVersion"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(contents, &envelope); err != nil {
+		return nil, fmt.Errorf("decode version envelope: %w", err)
+	}
+	if err := validateVersionEnvelope(envelope.APIVersion, envelope.Kind, envelope.Spec.MinimumKubescapeVersion, options.RunningVersion); err != nil {
+		return nil, err
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(contents))
+	decoder.KnownFields(true)
+	var document Document
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("strictly decode %s %s: %w", APIVersion, Kind, err)
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("contract file must contain exactly one YAML document")
+		}
+		return nil, fmt.Errorf("decode trailing YAML document: %w", err)
+	}
+
+	if err := validateDocument(&document, options); err != nil {
+		return nil, err
+	}
+
+	contractName := options.ContractName
+	if contractName == "" {
+		contractName = document.Spec.DefaultContract
+	}
+	if contractName == "" {
+		return nil, errors.New("no contract selected: pass --contract or set spec.defaultContract")
+	}
+	contract, ok := document.Spec.Contracts[contractName]
+	if !ok {
+		return nil, fmt.Errorf("contract %q does not exist", contractName)
+	}
+
+	selected := &SelectedContract{
+		APIVersion:              document.APIVersion,
+		Kind:                    document.Kind,
+		Metadata:                document.Metadata,
+		MinimumKubescapeVersion: document.Spec.MinimumKubescapeVersion,
+		ContractName:            contractName,
+		Contract:                contract,
+		DigestSchema:            DigestSchema,
+	}
+	digest, err := Digest(selected)
+	if err != nil {
+		return nil, err
+	}
+	selected.ContractDigest = digest
+	return selected, nil
+}

--- a/core/pkg/scancontract/v1alpha1/loader_test.go
+++ b/core/pkg/scancontract/v1alpha1/loader_test.go
@@ -1,0 +1,169 @@
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validContract = `
+apiVersion: config.kubescape.io/v1alpha1
+kind: ScanContract
+metadata:
+  name: payments-service
+spec:
+  minimumKubescapeVersion: v4.0.0
+  defaultContract: developer
+  contracts:
+    developer:
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307
+      evaluation:
+        controlTimeout: 30s
+      output:
+        formats: [pretty-printer]
+    ci:
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307
+      scope:
+        excludeNamespaces: [kube-system]
+      evaluation:
+        scanTimeout: 10m
+        controlTimeout: 30s
+      failure:
+        severityAtLeast: high
+        complianceBelow: 80
+        coverageBelow: 95
+        degradedPolicyInput: fail
+      output:
+        formats: [json, sarif]
+        omitRawResources: true
+`
+
+func testOptions() LoadOptions {
+	return LoadOptions{
+		RunningVersion:      "v4.1.0",
+		SupportedFormats:    []string{"pretty-printer", "json", "sarif"},
+		SupportedSeverities: []string{"low", "medium", "high", "critical"},
+	}
+}
+
+func TestLoadSelectsAndDigestsContract(t *testing.T) {
+	selected, err := Load([]byte(validContract), testOptions())
+	require.NoError(t, err)
+
+	assert.Equal(t, "developer", selected.ContractName)
+	assert.Equal(t, DigestSchema, selected.DigestSchema)
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, selected.ContractDigest)
+	require.NotNil(t, selected.Contract.Policy)
+	require.NotNil(t, selected.Contract.Policy.Frameworks)
+	assert.Equal(t, []string{"nsa"}, *selected.Contract.Policy.Frameworks)
+}
+
+func TestLoadContractOverride(t *testing.T) {
+	options := testOptions()
+	options.ContractName = "ci"
+	selected, err := Load([]byte(validContract), options)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ci", selected.ContractName)
+	require.NotNil(t, selected.Contract.Failure)
+	require.NotNil(t, selected.Contract.Failure.CoverageBelow)
+	assert.Equal(t, 95.0, *selected.Contract.Failure.CoverageBelow)
+}
+
+func TestLoadRejectsUnknownFieldsStrictly(t *testing.T) {
+	input := strings.Replace(validContract, "        frameworks: [nsa]", "        frameworkz: [nsa]", 1)
+	_, err := Load([]byte(input), testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field frameworkz not found")
+}
+
+func TestLoadChecksVersionBeforeFullSchema(t *testing.T) {
+	input := strings.Replace(validContract, APIVersion, "config.kubescape.io/v2", 1)
+	input = strings.Replace(input, "        frameworks: [nsa]", "        frameworkz: [nsa]", 1)
+	_, err := Load([]byte(input), testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported apiVersion")
+	assert.NotContains(t, err.Error(), "frameworkz")
+}
+
+func TestLoadRejectsNewerMinimumVersion(t *testing.T) {
+	options := testOptions()
+	options.RunningVersion = "v4.0.0"
+	input := strings.Replace(validContract, "v4.0.0", "v4.1.0", 1)
+	_, err := Load([]byte(input), options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires Kubescape v4.1.0 or newer")
+}
+
+func TestLoadRejectsDuplicateKeys(t *testing.T) {
+	input := strings.Replace(validContract, "  name: payments-service", "  name: payments-service\n  name: duplicate", 1)
+	_, err := Load([]byte(input), testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+}
+
+func TestLoadRejectsMultipleDocuments(t *testing.T) {
+	_, err := Load([]byte(validContract+"\n---\n{}\n"), testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one YAML document")
+}
+
+func TestLoadValidatesAllNamedContracts(t *testing.T) {
+	input := strings.Replace(validContract, "        coverageBelow: 95", "        coverageBelow: 101", 1)
+	_, err := Load([]byte(input), testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec.contracts.ci.failure.coverageBelow")
+}
+
+func TestDigestIgnoresUnusedContractsAndYAMLFormatting(t *testing.T) {
+	options := testOptions()
+	first, err := Load([]byte(validContract), options)
+	require.NoError(t, err)
+
+	withoutCI := validContract[:strings.Index(validContract, "    ci:\n")]
+	second, err := Load([]byte(withoutCI), options)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ContractDigest, second.ContractDigest)
+}
+
+func TestDigestPreservesExplicitEmptyValues(t *testing.T) {
+	withOmittedControls := validContract
+	withEmptyControls := strings.Replace(validContract, "        frameworks: [nsa]", "        frameworks: [nsa]\n        controls: []", 1)
+
+	omitted, err := Load([]byte(withOmittedControls), testOptions())
+	require.NoError(t, err)
+	explicit, err := Load([]byte(withEmptyControls), testOptions())
+	require.NoError(t, err)
+
+	assert.NotEqual(t, omitted.ContractDigest, explicit.ContractDigest)
+}
+
+func TestLoadRejectsInvalidContractValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+		want        string
+	}{
+		{"unknown format", "formats: [json, sarif]", "formats: [json, xml]", "unsupported format"},
+		{"unknown severity", "severityAtLeast: high", "severityAtLeast: urgent", "unsupported; supported severities"},
+		{"negative timeout", "controlTimeout: 30s", "controlTimeout: -1s", "must be zero or positive"},
+		{"both namespace scopes", "excludeNamespaces: [kube-system]", "includeNamespaces: [default]\n        excludeNamespaces: [kube-system]", "cannot both be set"},
+		{"unknown degradation mode", "degradedPolicyInput: fail", "degradedPolicyInput: warn", "supported values: allow, fail"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := strings.Replace(validContract, tt.old, tt.replacement, 1)
+			_, err := Load([]byte(input), testOptions())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}

--- a/core/pkg/scancontract/v1alpha1/loader_test.go
+++ b/core/pkg/scancontract/v1alpha1/loader_test.go
@@ -101,6 +101,17 @@ func TestLoadRejectsNewerMinimumVersion(t *testing.T) {
 	assert.Contains(t, err.Error(), "requires Kubescape v4.1.0 or newer")
 }
 
+func TestLoadSkipsCompatibilityForNonReleaseBuilds(t *testing.T) {
+	for _, runningVersion := range []string{"", "dev", "unknown", "(devel)"} {
+		t.Run(runningVersion, func(t *testing.T) {
+			options := testOptions()
+			options.RunningVersion = runningVersion
+			_, err := Load([]byte(validContract), options)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestLoadRejectsDuplicateKeys(t *testing.T) {
 	input := strings.Replace(validContract, "  name: payments-service", "  name: payments-service\n  name: duplicate", 1)
 	_, err := Load([]byte(input), testOptions())

--- a/core/pkg/scancontract/v1alpha1/types.go
+++ b/core/pkg/scancontract/v1alpha1/types.go
@@ -1,0 +1,110 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	APIVersion = "config.kubescape.io/v1alpha1"
+	Kind       = "ScanContract"
+
+	DigestSchema = "kubescape-scan-contract:v1"
+)
+
+// Document is the v1alpha1 repository scan-contract document.
+// Pointer fields preserve the difference between omitted values and explicit
+// zero or empty values for later precedence resolution.
+type Document struct {
+	APIVersion string   `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string   `json:"kind" yaml:"kind"`
+	Metadata   Metadata `json:"metadata" yaml:"metadata"`
+	Spec       Spec     `json:"spec" yaml:"spec"`
+}
+
+type Metadata struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+type Spec struct {
+	MinimumKubescapeVersion string              `json:"minimumKubescapeVersion" yaml:"minimumKubescapeVersion"`
+	DefaultContract         string              `json:"defaultContract,omitempty" yaml:"defaultContract,omitempty"`
+	Contracts               map[string]Contract `json:"contracts" yaml:"contracts"`
+}
+
+type Contract struct {
+	Policy     *Policy     `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Scope      *Scope      `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Evaluation *Evaluation `json:"evaluation,omitempty" yaml:"evaluation,omitempty"`
+	Failure    *Failure    `json:"failure,omitempty" yaml:"failure,omitempty"`
+	Output     *Output     `json:"output,omitempty" yaml:"output,omitempty"`
+}
+
+type Policy struct {
+	Frameworks      *[]string `json:"frameworks,omitempty" yaml:"frameworks,omitempty"`
+	Controls        *[]string `json:"controls,omitempty" yaml:"controls,omitempty"`
+	ControlsVersion *string   `json:"controlsVersion,omitempty" yaml:"controlsVersion,omitempty"`
+}
+
+type Scope struct {
+	IncludeNamespaces *[]string `json:"includeNamespaces,omitempty" yaml:"includeNamespaces,omitempty"`
+	ExcludeNamespaces *[]string `json:"excludeNamespaces,omitempty" yaml:"excludeNamespaces,omitempty"`
+}
+
+type Evaluation struct {
+	ScanTimeout    *Duration `json:"scanTimeout,omitempty" yaml:"scanTimeout,omitempty"`
+	ControlTimeout *Duration `json:"controlTimeout,omitempty" yaml:"controlTimeout,omitempty"`
+}
+
+type Failure struct {
+	SeverityAtLeast     *string                  `json:"severityAtLeast,omitempty" yaml:"severityAtLeast,omitempty"`
+	ComplianceBelow     *float64                 `json:"complianceBelow,omitempty" yaml:"complianceBelow,omitempty"`
+	CoverageBelow       *float64                 `json:"coverageBelow,omitempty" yaml:"coverageBelow,omitempty"`
+	DegradedPolicyInput *DegradedPolicyInputMode `json:"degradedPolicyInput,omitempty" yaml:"degradedPolicyInput,omitempty"`
+}
+
+type DegradedPolicyInputMode string
+
+const (
+	DegradedPolicyInputAllow DegradedPolicyInputMode = "allow"
+	DegradedPolicyInputFail  DegradedPolicyInputMode = "fail"
+)
+
+type Output struct {
+	Formats          *[]string `json:"formats,omitempty" yaml:"formats,omitempty"`
+	OmitRawResources *bool     `json:"omitRawResources,omitempty" yaml:"omitRawResources,omitempty"`
+}
+
+// Duration retains the human-readable contract representation while exposing
+// the parsed value to the eventual scan-option adapter.
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
+	var raw string
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		return err
+	}
+	d.Duration = parsed
+	return nil
+}
+
+type SelectedContract struct {
+	APIVersion              string   `json:"apiVersion"`
+	Kind                    string   `json:"kind"`
+	Metadata                Metadata `json:"metadata"`
+	MinimumKubescapeVersion string   `json:"minimumKubescapeVersion"`
+	ContractName            string   `json:"contractName"`
+	Contract                Contract `json:"contract"`
+	DigestSchema            string   `json:"digestSchema"`
+	ContractDigest          string   `json:"contractDigest"`
+}

--- a/core/pkg/scancontract/v1alpha1/validation.go
+++ b/core/pkg/scancontract/v1alpha1/validation.go
@@ -1,0 +1,174 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+
+	"golang.org/x/mod/semver"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+func validateVersionEnvelope(apiVersion, kind, minimumVersion, runningVersion string) error {
+	if apiVersion != APIVersion {
+		return fmt.Errorf("unsupported apiVersion %q: this Kubescape build supports %q", apiVersion, APIVersion)
+	}
+	if kind != Kind {
+		return fmt.Errorf("unsupported kind %q: expected %q", kind, Kind)
+	}
+	if !semver.IsValid(minimumVersion) {
+		return fmt.Errorf("spec.minimumKubescapeVersion %q is not a valid semantic version", minimumVersion)
+	}
+	if runningVersion == "" {
+		return nil
+	}
+	if !semver.IsValid(runningVersion) {
+		return fmt.Errorf("running Kubescape version %q is not a valid semantic version", runningVersion)
+	}
+	if semver.Compare(runningVersion, minimumVersion) < 0 {
+		return fmt.Errorf("contract requires Kubescape %s or newer; running %s", minimumVersion, runningVersion)
+	}
+	return nil
+}
+
+func validateDocument(document *Document, options LoadOptions) error {
+	if document.Metadata.Name == "" {
+		return fmt.Errorf("metadata.name is required")
+	}
+	if problems := k8svalidation.IsDNS1123Label(document.Metadata.Name); len(problems) > 0 {
+		return fmt.Errorf("metadata.name %q is invalid: %s", document.Metadata.Name, strings.Join(problems, "; "))
+	}
+	if len(document.Spec.Contracts) == 0 {
+		return fmt.Errorf("spec.contracts must contain at least one named contract")
+	}
+	if document.Spec.DefaultContract != "" {
+		if _, ok := document.Spec.Contracts[document.Spec.DefaultContract]; !ok {
+			return fmt.Errorf("spec.defaultContract %q does not name an entry in spec.contracts", document.Spec.DefaultContract)
+		}
+	}
+	for name, contract := range document.Spec.Contracts {
+		if problems := k8svalidation.IsDNS1123Label(name); len(problems) > 0 {
+			return fmt.Errorf("spec.contracts key %q is invalid: %s", name, strings.Join(problems, "; "))
+		}
+		if err := validateContract(name, contract, options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateContract(name string, contract Contract, options LoadOptions) error {
+	prefix := fmt.Sprintf("spec.contracts.%s", name)
+	if contract.Policy != nil {
+		if err := validateStringList(prefix+".policy.frameworks", contract.Policy.Frameworks); err != nil {
+			return err
+		}
+		if err := validateStringList(prefix+".policy.controls", contract.Policy.Controls); err != nil {
+			return err
+		}
+		if contract.Policy.ControlsVersion != nil {
+			value := strings.TrimSpace(*contract.Policy.ControlsVersion)
+			if value == "" {
+				return fmt.Errorf("%s.policy.controlsVersion cannot be empty", prefix)
+			}
+			if strings.Contains(value, "/") {
+				return fmt.Errorf("%s.policy.controlsVersion %q cannot contain '/'", prefix, value)
+			}
+		}
+	}
+	if contract.Scope != nil {
+		if err := validateStringList(prefix+".scope.includeNamespaces", contract.Scope.IncludeNamespaces); err != nil {
+			return err
+		}
+		if err := validateStringList(prefix+".scope.excludeNamespaces", contract.Scope.ExcludeNamespaces); err != nil {
+			return err
+		}
+		if contract.Scope.IncludeNamespaces != nil && len(*contract.Scope.IncludeNamespaces) > 0 &&
+			contract.Scope.ExcludeNamespaces != nil && len(*contract.Scope.ExcludeNamespaces) > 0 {
+			return fmt.Errorf("%s.scope.includeNamespaces and excludeNamespaces cannot both be set", prefix)
+		}
+	}
+	if contract.Evaluation != nil {
+		if contract.Evaluation.ScanTimeout != nil && contract.Evaluation.ScanTimeout.Duration < 0 {
+			return fmt.Errorf("%s.evaluation.scanTimeout must be zero or positive", prefix)
+		}
+		if contract.Evaluation.ControlTimeout != nil && contract.Evaluation.ControlTimeout.Duration < 0 {
+			return fmt.Errorf("%s.evaluation.controlTimeout must be zero or positive", prefix)
+		}
+		if contract.Evaluation.ScanTimeout != nil && contract.Evaluation.ControlTimeout != nil &&
+			contract.Evaluation.ScanTimeout.Duration > 0 && contract.Evaluation.ControlTimeout.Duration >= contract.Evaluation.ScanTimeout.Duration {
+			return fmt.Errorf("%s.evaluation.controlTimeout must be lower than scanTimeout when both are set", prefix)
+		}
+	}
+	if contract.Failure != nil {
+		if contract.Failure.SeverityAtLeast != nil {
+			severity := strings.TrimSpace(*contract.Failure.SeverityAtLeast)
+			if !containsFold(options.SupportedSeverities, severity) {
+				return fmt.Errorf("%s.failure.severityAtLeast %q is unsupported; supported severities: %s", prefix, severity, strings.Join(options.SupportedSeverities, ", "))
+			}
+		}
+		if err := validatePercentage(prefix+".failure.complianceBelow", contract.Failure.ComplianceBelow); err != nil {
+			return err
+		}
+		if err := validatePercentage(prefix+".failure.coverageBelow", contract.Failure.CoverageBelow); err != nil {
+			return err
+		}
+		if contract.Failure.DegradedPolicyInput != nil &&
+			*contract.Failure.DegradedPolicyInput != DegradedPolicyInputAllow &&
+			*contract.Failure.DegradedPolicyInput != DegradedPolicyInputFail {
+			return fmt.Errorf("%s.failure.degradedPolicyInput %q is unsupported; supported values: allow, fail", prefix, *contract.Failure.DegradedPolicyInput)
+		}
+	}
+	if contract.Output != nil {
+		if err := validateStringList(prefix+".output.formats", contract.Output.Formats); err != nil {
+			return err
+		}
+		if contract.Output.Formats != nil {
+			for _, format := range *contract.Output.Formats {
+				if !slices.Contains(options.SupportedFormats, format) {
+					return fmt.Errorf("%s.output.formats contains unsupported format %q; supported formats: %s", prefix, format, strings.Join(options.SupportedFormats, ", "))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateStringList(path string, values *[]string) error {
+	if values == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(*values))
+	for _, value := range *values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return fmt.Errorf("%s contains an empty value", path)
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%s contains duplicate value %q", path, value)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validatePercentage(path string, value *float64) error {
+	if value == nil {
+		return nil
+	}
+	if math.IsNaN(*value) || math.IsInf(*value, 0) || *value < 0 || *value > 100 {
+		return fmt.Errorf("%s must be between 0 and 100", path)
+	}
+	return nil
+}
+
+func containsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/pkg/scancontract/v1alpha1/validation.go
+++ b/core/pkg/scancontract/v1alpha1/validation.go
@@ -20,11 +20,11 @@ func validateVersionEnvelope(apiVersion, kind, minimumVersion, runningVersion st
 	if !semver.IsValid(minimumVersion) {
 		return fmt.Errorf("spec.minimumKubescapeVersion %q is not a valid semantic version", minimumVersion)
 	}
-	if runningVersion == "" {
-		return nil
-	}
 	if !semver.IsValid(runningVersion) {
-		return fmt.Errorf("running Kubescape version %q is not a valid semantic version", runningVersion)
+		// Development and other non-release builds use values such as "dev",
+		// "unknown", or "(devel)". There is no meaningful ordering for those
+		// identifiers, so validate the contract schema but skip compatibility.
+		return nil
 	}
 	if semver.Compare(runningVersion, minimumVersion) < 0 {
 		return fmt.Errorf("contract requires Kubescape %s or newer; running %s", minimumVersion, runningVersion)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/containerd/platforms v1.0.0-rc.2
+	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/deckarep/golang-set/v2 v2.8.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/buildx v0.33.0
@@ -253,7 +254,6 @@ require (
 	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/cpuguy83/go-docker v0.3.0 // indirect
-	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect


### PR DESCRIPTION
## What this adds

This is the first implementation step from the repository scan contracts design discussed and merged in [kubescape/designs-and-proposals#12](https://github.com/kubescape/designs-and-proposals/pull/12).

It introduces the `config.kubescape.io/v1alpha1` contract model and a new command for validating contracts before they are used:

```bash
kubescape scan validate-contract kubescape.yaml
kubescape scan validate-contract kubescape.yaml --contract ci --format json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and validating scan contracts in YAML.
  * Added `scan validate-contract <file>` with named-contract selection, text or indented JSON output, and optional output-file writing.
  * Added compatibility checks, detailed validation errors, and deterministic SHA-256 digests.
  * Supports policies, scopes, evaluations, failures, outputs, severities, formats, and durations.

* **Bug Fixes**
  * The validation command no longer requires unrelated scan flag validation.
  * Development builds can validate contracts without release-version compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->