### PR TITLE
fix(metrics): export ResetForTest so external packages can rebind instruments

### DIFF
--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"testing"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -53,6 +54,37 @@ func Init() {
 		lastValueMu.Lock()
 		kubernetesResourcesCount = resourcesCounter
 		workerNodesCount = workersCounter
+		lastValueMu.Unlock()
+	})
+}
+
+// ResetForTest re-arms initOnce and clears delta baselines so that a
+// subsequent Init call binds to whatever MeterProvider is current at that
+// time. It registers a cleanup function that restores the previous state.
+// This is intended only for use in tests outside the metrics package.
+func ResetForTest(t *testing.T) {
+	t.Helper()
+
+	lastValueMu.Lock()
+	savedKubernetesResourcesCount := kubernetesResourcesCount
+	savedWorkerNodesCount := workerNodesCount
+	savedLastKubernetesResourcesCount := lastKubernetesResourcesCount
+	savedLastWorkerNodesCount := lastWorkerNodesCount
+	kubernetesResourcesCount = nil
+	workerNodesCount = nil
+	lastKubernetesResourcesCount = 0
+	lastWorkerNodesCount = 0
+	lastValueMu.Unlock()
+
+	initOnce = sync.Once{}
+
+	t.Cleanup(func() {
+		initOnce = sync.Once{}
+		lastValueMu.Lock()
+		kubernetesResourcesCount = savedKubernetesResourcesCount
+		workerNodesCount = savedWorkerNodesCount
+		lastKubernetesResourcesCount = savedLastKubernetesResourcesCount
+		lastWorkerNodesCount = savedLastWorkerNodesCount
 		lastValueMu.Unlock()
 	})
 }

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -14,29 +14,7 @@ import (
 
 func resetMetricsForTest(t *testing.T) {
 	t.Helper()
-
-	lastValueMu.Lock()
-	savedKubernetesResourcesCount := kubernetesResourcesCount
-	savedWorkerNodesCount := workerNodesCount
-	savedLastKubernetesResourcesCount := lastKubernetesResourcesCount
-	savedLastWorkerNodesCount := lastWorkerNodesCount
-	kubernetesResourcesCount = nil
-	workerNodesCount = nil
-	lastKubernetesResourcesCount = 0
-	lastWorkerNodesCount = 0
-	lastValueMu.Unlock()
-
-	initOnce = sync.Once{}
-
-	t.Cleanup(func() {
-		initOnce = sync.Once{}
-		lastValueMu.Lock()
-		kubernetesResourcesCount = savedKubernetesResourcesCount
-		workerNodesCount = savedWorkerNodesCount
-		lastKubernetesResourcesCount = savedLastKubernetesResourcesCount
-		lastWorkerNodesCount = savedLastWorkerNodesCount
-		lastValueMu.Unlock()
-	})
+	ResetForTest(t)
 }
 
 func setMeterProviderForTest(t *testing.T, provider *sdkmetric.MeterProvider) {

--- a/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
+++ b/core/pkg/resourcehandler/k8sresources_streaming_failures_test.go
@@ -295,6 +295,7 @@ func TestStreamingKubernetesResourceCount_DeduplicatesResidentOverlap(t *testing
 }
 
 func TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails(t *testing.T) {
+	metrics.ResetForTest(t)
 	previousProvider := otel.GetMeterProvider()
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))


### PR DESCRIPTION
## Overview

`TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails` fails under `-count=2` because `metrics.Init()` is wrapped in a `sync.Once` — on the second iteration the instruments are still bound to the first iteration's discarded reader.

The internal `resetMetricsForTest` already solves this for tests inside `core/metrics`, but it's unexported. This exports it as `ResetForTest` so external packages can rearm `initOnce` and rebind instruments to a fresh provider.

## How to Test

```
go test ./core/pkg/resourcehandler/ -run TestCollectAndStreamBatches_ReportsAllKubernetesResourcesWhenNodeCountFails -count=2
go test ./core/metrics/... -count=1
```

## Related issues/PRs

* Resolves #3471

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for resource-count metrics.
  * Added support for resetting metric state and automatically restoring it after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->