### PR TITLE
fix(anonymizer): anonymize env var names referencing fieldRef and resourceFieldRef

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -360,6 +360,12 @@ func transformTypedEnv(envVars []corev1.EnvVar, transformer Transformer) error {
 			hasRef = true
 		}
 
+		if envVar.ValueFrom.FieldRef != nil {
+			hasRef = true
+		}
+		if envVar.ValueFrom.ResourceFieldRef != nil {
+			hasRef = true
+		}
 		if hasRef && envVar.Name != "" {
 			envVar.Name, err = transformValue(transformer, "env", envVar.Name)
 			if err != nil {
@@ -436,6 +442,12 @@ func transformUnstructuredEnv(container map[string]any, transformer Transformer)
 			return err
 		}
 		if _, ok := valueFrom["configMapKeyRef"]; ok {
+			hasRef = true
+		}
+		if _, ok := valueFrom["fieldRef"]; ok {
+			hasRef = true
+		}
+		if _, ok := valueFrom["resourceFieldRef"]; ok {
 			hasRef = true
 		}
 

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -484,6 +484,118 @@ func TestTransformContainerMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "typed container env var names with fieldRef should be anonymized",
+			object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"spec": map[string]any{
+					"containers": []corev1.Container{
+						{
+							Name:  "app",
+							Image: "busybox:latest",
+							Env: []corev1.EnvVar{
+								{
+									Name: "MY_NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name: "MY_CPU_LIMIT",
+									ValueFrom: &corev1.EnvVarSource{
+										ResourceFieldRef: &corev1.ResourceFieldSelector{
+											Resource: "limits.cpu",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]any) {
+				containers, ok := spec["containers"].([]corev1.Container)
+				if !assert.True(t, ok, "expected typed containers") {
+					return
+				}
+				if !assert.Len(t, containers, 1) {
+					return
+				}
+				assert.NotEqual(t, "MY_NODE_NAME", containers[0].Env[0].Name,
+					"env var name referencing fieldRef should be anonymized")
+				assert.Contains(t, containers[0].Env[0].Name, "env-")
+				assert.NotEqual(t, "MY_CPU_LIMIT", containers[0].Env[1].Name,
+					"env var name referencing resourceFieldRef should be anonymized")
+				assert.Contains(t, containers[0].Env[1].Name, "env-")
+			},
+		},
+		{
+			name: "unstructured container env var names with fieldRef should be anonymized",
+			object: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "busybox:latest",
+							"env": []any{
+								map[string]any{
+									"name": "MY_POD_NAME",
+									"valueFrom": map[string]any{
+										"fieldRef": map[string]any{
+											"fieldPath": "metadata.name",
+										},
+									},
+								},
+								map[string]any{
+									"name": "MY_MEM_LIMIT",
+									"valueFrom": map[string]any{
+										"resourceFieldRef": map[string]any{
+											"resource": "limits.memory",
+										},
+									},
+								},
+								map[string]any{
+									"name":  "PLAIN",
+									"value": "not-a-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, spec map[string]any) {
+				containers, ok := spec["containers"].([]any)
+				if !assert.True(t, ok, "expected unstructured containers") {
+					return
+				}
+				container, ok := containers[0].(map[string]any)
+				if !assert.True(t, ok) {
+					return
+				}
+				env, ok := container["env"].([]any)
+				if !assert.True(t, ok) {
+					return
+				}
+				if !assert.Len(t, env, 3) {
+					return
+				}
+				fieldEnv := env[0].(map[string]any)
+				resourceEnv := env[1].(map[string]any)
+				plainEnv := env[2].(map[string]any)
+				assert.NotEqual(t, "MY_POD_NAME", fieldEnv["name"],
+					"env var name referencing fieldRef should be anonymized")
+				assert.Contains(t, fieldEnv["name"], "env-")
+				assert.NotEqual(t, "MY_MEM_LIMIT", resourceEnv["name"],
+					"env var name referencing resourceFieldRef should be anonymized")
+				assert.Contains(t, resourceEnv["name"], "env-")
+				assert.Equal(t, "PLAIN", plainEnv["name"],
+					"plain env var name should not be anonymized")
+			},
+		},
+
+		{
 			name: "typed container envFrom references should be anonymized",
 			object: map[string]any{
 				"apiVersion": "v1",


### PR DESCRIPTION
## Overview

small follow-up to #3364.

that PR wired up env var name anonymization when `SecretKeyRef` or `ConfigMapKeyRef` is present, which was a good fix. noticed that `fieldRef` and `resourceFieldRef` (downward API) were missed -- env vars like `MY_NODE_NAME` or `MY_POD_IP` that expose pod topology info were left untransformed.

the fix is the same pattern as #3364 -- set `hasRef = true` when either ref is present, both in the typed and unstructured paths.

## changes

- `transformTypedEnv`: check `envVar.ValueFrom.FieldRef != nil` and `envVar.ValueFrom.ResourceFieldRef != nil`
- `transformUnstructuredEnv`: check `valueFrom["fieldRef"]` and `valueFrom["resourceFieldRef"]`
- tests for both typed and unstructured paths covering fieldRef (spec.nodeName / metadata.name) and resourceFieldRef (limits.cpu / limits.memory)

## how to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment variable names are now anonymized when sourced from field or resource references.
  - Referenced field values remain unchanged.
  - Plain literal environment variable names continue to be preserved.

- **Tests**
  - Added coverage for typed and unstructured environment variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->