### PR TITLE
fix(security): restrict directory and temporary folder creation permi…

### DIFF
--- a/core/core/download.go
+++ b/core/core/download.go
@@ -46,7 +46,7 @@ func DownloadSupportCommands() []string {
 
 func (ks *Kubescape) Download(downloadInfo *metav1.DownloadInfo) error {
 	setPathAndFilename(downloadInfo)
-	if err := os.MkdirAll(downloadInfo.Path, os.ModePerm); err != nil {
+	if err := os.MkdirAll(downloadInfo.Path, 0750); err != nil {
 		return err
 	}
 	if err := downloadArtifact(ks.Context(), downloadInfo, downloadFunc); err != nil {

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -215,11 +215,11 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 			return err
 		}
 		defer os.RemoveAll(workingFolder)
-		if err := os.Chmod(workingFolder, 0o744); err != nil {
+		if err := os.Chmod(workingFolder, 0o700); err != nil {
 			return err
 		}
 	} else {
-		if isNew, err := utils.EnsurePath(workingFolder, 0o744); err != nil {
+		if isNew, err := utils.EnsurePath(workingFolder, 0o700); err != nil {
 			log.Errorf("failed to create workingFolder %s", workingFolder)
 			return err
 		} else if isNew {

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -44,7 +44,7 @@ type IPrinter interface {
 
 func GetWriter(ctx context.Context, outputFile string) *os.File {
 	if outputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(outputFile), 0750); err != nil {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to create directory, reason: %s", err.Error()))
 			return os.Stdout
 		}
@@ -67,7 +67,7 @@ func GetWriter(ctx context.Context, outputFile string) *os.File {
 // It never returns os.Stdout.
 func GetWriterNoStdoutFallback(ctx context.Context, outputFile, tempPattern string) *os.File {
 	if outputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(outputFile), os.ModePerm); err == nil {
+		if err := os.MkdirAll(filepath.Dir(outputFile), 0750); err == nil {
 			if f, err := os.Create(outputFile); err == nil {
 				return f
 			} else {

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -299,7 +299,7 @@ func envToString(env string, defaultValue string) string {
 }
 
 func writeScanErrorToFile(err error, scanID string) (e error) {
-	if e = os.MkdirAll(FailedOutputDir, os.ModePerm); e != nil {
+	if e = os.MkdirAll(FailedOutputDir, 0750); e != nil {
 		return fmt.Errorf("failed to scan. reason: '%s'. failed to save error in file - failed to create directory. reason: %s", err.Error(), e.Error())
 	}
 	var f *os.File


### PR DESCRIPTION
## Description

Fixes #3485

This PR remediates insecure and overly broad directory/folder creation permissions across the codebase:
- Replaces `os.ModePerm` (`0777`) with `0750` for output directory creation (`printresults.go`, `requestshandlerutils.go`) and download directories (`download.go`).
- Hardens temporary image patching workspace permissions from `0o744` to `0o700` (`patch.go`) to prevent unauthorized local access to intermediate artifacts.

## Changes Made
- `core/pkg/resultshandling/printer/printresults.go`: Used `0750` in `GetWriter()` and `GetWriterNoStdoutFallback()`.
- `core/core/download.go`: Used `0750` in `Download()` for artifact download folders.
- `core/core/patch.go`: Used `0o700` in `patchWithContext()` for `workingFolder`.
- `httphandler/handlerequests/v1/requestshandlerutils.go`: Used `0750` in `writeScanErrorToFile()` for `FailedOutputDir`.

## How Has This Been Tested?
- Ran `make build`: compiled cleanly with zero errors.
- Ran all unit tests across `core/pkg/resultshandling/printer/...`, `core/core/...`, and `httphandler/...`: all passed.
- Verified directory creation permissions at runtime (`0750` / `drwxr-x---`).

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have signed off my commits (DCO).
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted access permissions for downloaded files, temporary working directories, scan results, and error output.
  * Generated directories are now accessible only to the owning user or authorized members, reducing the risk of unintended data exposure.
* **Bug Fixes**
  * Preserved existing download, output, and error-handling behavior while applying safer directory permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->