### PR TITLE
fix(diff): emit CI regression artifacts

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -29,6 +29,9 @@ var diffCmdExamples = fmt.Sprintf(`
 	# Compare resource-and-control aggregates while keeping safety checks
 	%[1]s diff base.json head.json --granularity control
 
+  # Output only new and incomparable regressions as SARIF for GitHub Code Scanning
+  %[1]s diff base.json head.json --format sarif --output kubescape-diff
+
   # Output diff as JSON
   %[1]s diff base.json head.json --format json --output diff.json
 `, cautils.ExecName())
@@ -47,7 +50,7 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 			diffInfo.HeadFile = args[1]
 
 			// diff honors a single output format, so validate against the exact value rather than scan's comma-separated multi-format set.
-			supportedFormats := []string{printer.PrettyFormat, printer.JsonFormat, printer.YamlFormat}
+			supportedFormats := diffFormats()
 			if !slices.Contains(supportedFormats, diffInfo.Format) {
 				return fmt.Errorf("invalid format %q, supported formats: %s", diffInfo.Format, strings.Join(supportedFormats, ", "))
 			}
@@ -77,7 +80,7 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 
 	diffCmd.Flags().BoolVar(&diffInfo.FailOnNew, "fail-on-new", false, "Exit with code 1 when new or incomparable failures are found (combine with --severity-threshold to limit the gate)")
 	diffCmd.Flags().StringVar(&diffInfo.SeverityThreshold, "severity-threshold", "", "Only count new and incomparable failures at or above this severity when using --fail-on-new (low, medium, high, critical)")
-	diffCmd.Flags().StringVarP(&diffInfo.Format, "format", "f", "pretty-printer", `Output format: "pretty-printer", "json", or "yaml"`)
+	diffCmd.Flags().StringVarP(&diffInfo.Format, "format", "f", "pretty-printer", fmt.Sprintf(`Output format: "%s"`, strings.Join(diffFormats(), `", "`)))
 	diffCmd.Flags().StringVarP(&diffInfo.Output, "output", "o", "", "Output file; defaults to stdout")
 	diffCmd.Flags().StringVar(&diffInfo.Granularity, "granularity", string(resultsdiff.GranularityEvidence), `Comparison unit: "evidence" or "control"`)
 
@@ -89,4 +92,16 @@ func severityLabel(s string) string {
 		return "all"
 	}
 	return s
+}
+
+func diffFormats() []string {
+	return []string{
+		printer.PrettyFormat,
+		printer.JsonFormat,
+		printer.YamlFormat,
+		printer.SARIFFormat,
+		printer.JunitResultFormat,
+		printer.GitLabSASTFormat,
+		printer.MarkdownFormat,
+	}
 }

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -32,8 +32,13 @@ func TestGetDiffCmd_FormatValidation(t *testing.T) {
 		{"default pretty-printer", "pretty-printer", false},
 		{"json", "json", false},
 		{"yaml", "yaml", false},
+		{"sarif", "sarif", false},
+		{"junit", "junit", false},
+		{"gitlab-sast", "gitlab-sast", false},
+		{"markdown", "markdown", false},
 		{"unsupported format is rejected", "html", true},
-		{"scan-only format is rejected", "sarif", true},
+		{"scan report format is rejected", "pdf", true},
+		{"image sbom format is rejected", "spdx-json", true},
 		{"comma-separated multi-format is rejected", "json,pretty-printer", true},
 	}
 
@@ -128,6 +133,8 @@ func TestGetDiffCmd_HelpExplainsEvidenceComparison(t *testing.T) {
 	assert.Contains(t, help, `"evidence" or "control"`)
 	assert.Contains(t, help, "failed rules and paths are compared")
 	assert.Contains(t, help, "--granularity control")
+	assert.Contains(t, help, `--format string`)
+	assert.Contains(t, help, `"pretty-printer", "json", "yaml", "sarif", "junit", "gitlab-sast", "markdown"`)
 }
 
 func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {

--- a/core/core/diff.go
+++ b/core/core/diff.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/diff"
@@ -22,7 +23,7 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (newFailures int, err error
 
 	w := os.Stdout
 	if diffInfo.Output != "" {
-		w, err = printer.GetWriterNoFallback(diffInfo.Output)
+		w, err = printer.GetWriterNoFallback(diffOutputPath(diffInfo.Format, diffInfo.Output))
 		if err != nil {
 			return 0, fmt.Errorf("opening diff output: %w", err)
 		}
@@ -40,6 +41,22 @@ func (ks *Kubescape) Diff(diffInfo *metav1.DiffInfo) (newFailures int, err error
 		if err := diff.PrintYAML(w, cs); err != nil {
 			return 0, fmt.Errorf("writing YAML diff: %w", err)
 		}
+	case printer.SARIFFormat:
+		if err := diff.PrintSARIF(w, cs, diffInfo.SeverityThreshold); err != nil {
+			return 0, fmt.Errorf("writing SARIF diff: %w", err)
+		}
+	case printer.JunitResultFormat:
+		if err := diff.PrintJUnit(w, cs, diffInfo.SeverityThreshold); err != nil {
+			return 0, fmt.Errorf("writing JUnit diff: %w", err)
+		}
+	case printer.GitLabSASTFormat:
+		if err := diff.PrintGitLabSAST(w, cs, diffInfo.SeverityThreshold); err != nil {
+			return 0, fmt.Errorf("writing GitLab SAST diff: %w", err)
+		}
+	case printer.MarkdownFormat:
+		if err := diff.PrintMarkdown(w, cs, diffInfo.SeverityThreshold); err != nil {
+			return 0, fmt.Errorf("writing Markdown diff: %w", err)
+		}
 	default:
 		if err := diff.PrintPretty(w, cs); err != nil {
 			return 0, fmt.Errorf("writing pretty diff: %w", err)
@@ -54,4 +71,25 @@ func closeDiffOutput(closer io.Closer, err error) error {
 		return errors.Join(err, fmt.Errorf("closing diff output: %w", closeErr))
 	}
 	return err
+}
+
+func diffOutputPath(format, outputFile string) string {
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile == "" {
+		return ""
+	}
+	if format == printer.PrettyFormat {
+		return outputFile
+	}
+	ext, ok := printer.FormatOutputExt[format]
+	if !ok || ext == "" {
+		return outputFile
+	}
+	if ext == printer.YamlOutputExt && strings.HasSuffix(outputFile, ".yml") {
+		return outputFile
+	}
+	if printer.HasOutputExt(outputFile, ext) {
+		return outputFile
+	}
+	return outputFile + ext
 }

--- a/core/core/diff_test.go
+++ b/core/core/diff_test.go
@@ -140,6 +140,104 @@ func TestDiff_PrettyFormatWritesOutput(t *testing.T) {
 	assert.Contains(t, string(data), "New failures")
 }
 
+func TestDiff_MachineFormatsWriteExpectedOutputFiles(t *testing.T) {
+	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
+	head := writeReport(t, `{
+		"results":[{"resourceID":"res1","controls":[
+			{"controlID":"C-HIGH","name":"High","status":{"status":"failed"}}
+		]}],
+		"summaryDetails":{"controls":{"C-HIGH":{"scoreFactor":7.0}}}
+	}`)
+
+	tests := []struct {
+		name       string
+		format     string
+		outputBase string
+		wantFile   string
+		wantText   string
+	}{
+		{
+			name:       "sarif appends extension",
+			format:     "sarif",
+			outputBase: "kubescape-diff",
+			wantFile:   "kubescape-diff.sarif",
+			wantText:   `"version": "2.1.0"`,
+		},
+		{
+			name:       "junit appends extension",
+			format:     "junit",
+			outputBase: "kubescape-diff",
+			wantFile:   "kubescape-diff.xml",
+			wantText:   `<testsuites name="Kubescape Diff" tests="1" failures="1" errors="0">`,
+		},
+		{
+			name:       "gitlab-sast appends json extension",
+			format:     "gitlab-sast",
+			outputBase: "gl-sast-report",
+			wantFile:   "gl-sast-report.json",
+			wantText:   `"version": "15.2.4"`,
+		},
+		{
+			name:       "markdown appends extension",
+			format:     "markdown",
+			outputBase: "kubescape-diff",
+			wantFile:   "kubescape-diff.md",
+			wantText:   "# Kubescape Diff Regressions",
+		},
+		{
+			name:       "yaml accepts yml extension",
+			format:     "yaml",
+			outputBase: "kubescape-diff.yml",
+			wantFile:   "kubescape-diff.yml",
+			wantText:   "new:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			ks := NewKubescape(context.Background())
+			count, err := ks.Diff(&metav1.DiffInfo{
+				BaseFile: base,
+				HeadFile: head,
+				Format:   test.format,
+				Output:   filepath.Join(outDir, test.outputBase),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, count)
+
+			data, err := os.ReadFile(filepath.Join(outDir, test.wantFile))
+			require.NoError(t, err)
+			assert.Contains(t, string(data), test.wantText)
+		})
+	}
+}
+
+func TestDiffOutputPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		format     string
+		outputFile string
+		want       string
+	}{
+		{"empty output stays empty", "sarif", "", ""},
+		{"whitespace is trimmed", "sarif", " report ", "report.sarif"},
+		{"known extension is appended", "sarif", "report", "report.sarif"},
+		{"existing extension is preserved", "sarif", "report.sarif", "report.sarif"},
+		{"existing extension comparison is case-insensitive", "sarif", "report.SARIF", "report.SARIF"},
+		{"pretty output path stays exact", "pretty-printer", "pretty.out", "pretty.out"},
+		{"yaml accepts yml", "yaml", "report.yml", "report.yml"},
+		{"unknown format is untouched", "unknown", "report", "report"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, diffOutputPath(test.format, test.outputFile))
+		})
+	}
+}
+
 func TestDiff_ExplicitOutputSetupFailureIsReturned(t *testing.T) {
 	base := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)
 	head := writeReport(t, `{"results":[],"summaryDetails":{"controls":{}}}`)

--- a/core/meta/datastructures/v1/diff.go
+++ b/core/meta/datastructures/v1/diff.go
@@ -3,7 +3,7 @@ package v1
 type DiffInfo struct {
 	BaseFile          string // path to base scan JSON report
 	HeadFile          string // path to head scan JSON report
-	Format            string // output format: "pretty-printer" or "json"
+	Format            string // output format: "pretty-printer", "json", "yaml", "sarif", "junit", "gitlab-sast", or "markdown"
 	Output            string // output file path; empty means stdout
 	FailOnNew         bool   // exit code 1 when new failures are found
 	SeverityThreshold string // only count failures at or above this severity when enforcing --fail-on-new

--- a/core/pkg/resultshandling/diff/ci_printer.go
+++ b/core/pkg/resultshandling/diff/ci_printer.go
@@ -1,0 +1,680 @@
+package diff
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	diffToolName    = "Kubescape"
+	diffToolURI     = "https://kubescape.io"
+	diffGitLabVer   = "15.2.4"
+	diffGitLabTime  = "1970-01-01T00:00:00"
+	diffScannerID   = "kubescape"
+	diffScanType    = "sast"
+	diffControlType = "kubescape_control_id"
+)
+
+// RegressionSet is the machine-reportable subset of a ChangeSet. Human output
+// can show all buckets, but CI ingestion should focus on items that should keep
+// a pull request red: conclusive new failures and failures that are unsafe to
+// classify as resolved/new because scan coverage or scope changed.
+type RegressionSet struct {
+	New          []ControlChange `json:"new"`
+	Incomparable []ControlChange `json:"incomparable,omitempty"`
+	Warnings     []string        `json:"warnings,omitempty"`
+}
+
+// Regressions returns the new and incomparable diff findings after applying the
+// same severity threshold used by --fail-on-new. It clones slices so serializers
+// cannot accidentally mutate the full ChangeSet.
+func Regressions(cs *ChangeSet, threshold string) RegressionSet {
+	if cs == nil {
+		return RegressionSet{}
+	}
+	return RegressionSet{
+		New:          cloneChanges(FilterBySeverity(cs.New, threshold)),
+		Incomparable: cloneChanges(FilterBySeverity(cs.Incomparable, threshold)),
+		Warnings:     append([]string(nil), cs.Warnings...),
+	}
+}
+
+func cloneChanges(changes []ControlChange) []ControlChange {
+	out := make([]ControlChange, len(changes))
+	copy(out, changes)
+	return out
+}
+
+func (r RegressionSet) count() int {
+	return len(r.New) + len(r.Incomparable)
+}
+
+func (r RegressionSet) all() []ciFinding {
+	findings := make([]ciFinding, 0, r.count())
+	for _, change := range r.New {
+		findings = append(findings, ciFinding{Change: change, Kind: "new"})
+	}
+	for _, change := range r.Incomparable {
+		findings = append(findings, ciFinding{Change: change, Kind: "incomparable"})
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		left, right := findings[i], findings[j]
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		return compareChange(left.Change, right.Change) < 0
+	})
+	return findings
+}
+
+type ciFinding struct {
+	Change ControlChange
+	Kind   string
+}
+
+func compareChange(left, right ControlChange) int {
+	if leftRank, rightRank := severityRank(left.Severity), severityRank(right.Severity); leftRank != rightRank {
+		return rightRank - leftRank
+	}
+	for _, pair := range [][2]string{
+		{left.ResourceID, right.ResourceID},
+		{left.ControlID, right.ControlID},
+		{left.RuleName, right.RuleName},
+		{left.EvidenceType, right.EvidenceType},
+		{left.Path, right.Path},
+		{left.EvidenceResourceID, right.EvidenceResourceID},
+		{left.Reason, right.Reason},
+	} {
+		if pair[0] != pair[1] {
+			return strings.Compare(pair[0], pair[1])
+		}
+	}
+	return 0
+}
+
+// PrintMarkdown writes a compact PR-friendly regression report. It intentionally
+// omits resolved and unchanged items because those are useful in local review
+// but noisy in a pull request comment.
+func PrintMarkdown(w io.Writer, cs *ChangeSet, threshold string) error {
+	regressions := Regressions(cs, threshold)
+	ew := errWriter{w: w}
+	ew.printf("# Kubescape Diff Regressions\n\n")
+	ew.printf("| Bucket | Count |\n")
+	ew.printf("|---|---:|\n")
+	ew.printf("| New | %d |\n", len(regressions.New))
+	ew.printf("| Incomparable | %d |\n", len(regressions.Incomparable))
+	ew.printf("| Warnings | %d |\n\n", len(regressions.Warnings))
+
+	if threshold == "" {
+		ew.printf("Severity threshold: all\n\n")
+	} else {
+		ew.printf("Severity threshold: %s\n\n", threshold)
+	}
+
+	if len(regressions.Warnings) > 0 {
+		ew.printf("## Warnings\n\n")
+		for _, warning := range regressions.Warnings {
+			ew.printf("- %s\n", markdownEscape(warning))
+		}
+		ew.printf("\n")
+	}
+
+	writeMarkdownFindings(&ew, "New Failures", regressions.New)
+	writeMarkdownFindings(&ew, "Incomparable Failures", regressions.Incomparable)
+	if regressions.count() == 0 {
+		ew.printf("No new or incomparable failures matched the severity threshold.\n")
+	}
+	return ew.err
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+func writeMarkdownFindings(ew *errWriter, title string, changes []ControlChange) {
+	if len(changes) == 0 {
+		return
+	}
+	ew.printf("## %s\n\n", title)
+	ew.printf("| Severity | Control | Resource | Evidence | Reason |\n")
+	ew.printf("|---|---|---|---|---|\n")
+	for _, change := range changes {
+		ew.printf("| %s | %s | %s | %s | %s |\n",
+			markdownEscape(change.Severity),
+			markdownEscape(fmt.Sprintf("%s (%s)", change.ControlName, change.ControlID)),
+			markdownEscape(change.ResourceID),
+			markdownEscape(evidenceLabel(change)),
+			markdownEscape(change.Reason),
+		)
+	}
+	ew.printf("\n")
+}
+
+func markdownEscape(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+// PrintJUnit writes new and incomparable diff findings as failing test cases,
+// which lets CI systems annotate pull requests without re-reporting unchanged
+// posture failures.
+func PrintJUnit(w io.Writer, cs *ChangeSet, threshold string) error {
+	regressions := Regressions(cs, threshold)
+	suites := diffJUnitSuites{
+		Name:     "Kubescape Diff",
+		Tests:    regressions.count(),
+		Failures: regressions.count(),
+		Suites: []diffJUnitSuite{
+			diffJUnitBucketSuite(0, "new", regressions.New),
+			diffJUnitBucketSuite(1, "incomparable", regressions.Incomparable),
+		},
+	}
+	suites.Suites = nonEmptyJUnitSuites(suites.Suites)
+	data, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(xml.Header)); err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+type diffJUnitSuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Name     string           `xml:"name,attr,omitempty"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Errors   int              `xml:"errors,attr"`
+	Suites   []diffJUnitSuite `xml:"testsuite"`
+}
+
+type diffJUnitSuite struct {
+	XMLName   xml.Name            `xml:"testsuite"`
+	ID        int                 `xml:"id,attr"`
+	Name      string              `xml:"name,attr"`
+	Tests     int                 `xml:"tests,attr"`
+	Failures  int                 `xml:"failures,attr"`
+	TestCases []diffJUnitTestCase `xml:"testcase"`
+}
+
+type diffJUnitTestCase struct {
+	XMLName   xml.Name          `xml:"testcase"`
+	Classname string            `xml:"classname,attr"`
+	Name      string            `xml:"name,attr"`
+	Failure   *diffJUnitFailure `xml:"failure,omitempty"`
+}
+
+type diffJUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+func diffJUnitBucketSuite(id int, name string, changes []ControlChange) diffJUnitSuite {
+	testCases := make([]diffJUnitTestCase, 0, len(changes))
+	for _, change := range changes {
+		testCases = append(testCases, diffJUnitTestCase{
+			Classname: "kubescape.diff/" + change.ControlID,
+			Name:      junitCaseName(change),
+			Failure: &diffJUnitFailure{
+				Type:     name,
+				Message:  findingTitle(name, change),
+				Contents: findingDetails(change),
+			},
+		})
+	}
+	return diffJUnitSuite{
+		ID:        id,
+		Name:      "kubescape diff " + name,
+		Tests:     len(testCases),
+		Failures:  len(testCases),
+		TestCases: testCases,
+	}
+}
+
+func nonEmptyJUnitSuites(suites []diffJUnitSuite) []diffJUnitSuite {
+	out := suites[:0]
+	for _, suite := range suites {
+		if suite.Tests > 0 {
+			out = append(out, suite)
+		}
+	}
+	return out
+}
+
+func junitCaseName(change ControlChange) string {
+	parts := []string{change.ControlName, change.ResourceID}
+	if evidence := evidenceLabel(change); evidence != "" {
+		parts = append(parts, evidence)
+	}
+	return strings.Join(nonEmpty(parts), " / ")
+}
+
+// PrintSARIF writes a SARIF 2.1.0 report for new/incomparable diff findings.
+// Locations use the Kubescape resource ID as the artifact URI because diff
+// reports are computed from JSON scan reports and do not always retain a source
+// manifest path.
+func PrintSARIF(w io.Writer, cs *ChangeSet, threshold string) error {
+	regressions := Regressions(cs, threshold)
+	report := diffSARIFReport{
+		Version: "2.1.0",
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Runs: []diffSARIFRun{{
+			Tool: diffSARIFTool{Driver: diffSARIFDriver{
+				Name:           diffToolName,
+				InformationURI: diffToolURI,
+				Rules:          sarifRules(regressions.all()),
+			}},
+			Results: sarifResults(regressions.all()),
+		}},
+	}
+	return encodeJSON(w, report)
+}
+
+type diffSARIFReport struct {
+	Version string         `json:"version"`
+	Schema  string         `json:"$schema,omitempty"`
+	Runs    []diffSARIFRun `json:"runs"`
+}
+
+type diffSARIFRun struct {
+	Tool    diffSARIFTool     `json:"tool"`
+	Results []diffSARIFResult `json:"results"`
+}
+
+type diffSARIFTool struct {
+	Driver diffSARIFDriver `json:"driver"`
+}
+
+type diffSARIFDriver struct {
+	Name           string          `json:"name"`
+	InformationURI string          `json:"informationUri,omitempty"`
+	Rules          []diffSARIFRule `json:"rules,omitempty"`
+}
+
+type diffSARIFRule struct {
+	ID                   string                   `json:"id"`
+	Name                 string                   `json:"name,omitempty"`
+	ShortDescription     diffSARIFMessage         `json:"shortDescription,omitempty"`
+	DefaultConfiguration diffSARIFConfiguration   `json:"defaultConfiguration,omitempty"`
+	Properties           map[string]string        `json:"properties,omitempty"`
+	Help                 *diffSARIFMessage        `json:"help,omitempty"`
+	FullDescription      *diffSARIFMessage        `json:"fullDescription,omitempty"`
+	Relationships        []map[string]interface{} `json:"relationships,omitempty"`
+}
+
+type diffSARIFConfiguration struct {
+	Level string `json:"level,omitempty"`
+}
+
+type diffSARIFResult struct {
+	RuleID       string              `json:"ruleId"`
+	Level        string              `json:"level,omitempty"`
+	Message      diffSARIFMessage    `json:"message"`
+	Locations    []diffSARIFLocation `json:"locations,omitempty"`
+	Properties   map[string]string   `json:"properties,omitempty"`
+	Fingerprints map[string]string   `json:"partialFingerprints,omitempty"`
+}
+
+type diffSARIFMessage struct {
+	Text string `json:"text,omitempty"`
+}
+
+type diffSARIFLocation struct {
+	PhysicalLocation diffSARIFPhysicalLocation `json:"physicalLocation"`
+}
+
+type diffSARIFPhysicalLocation struct {
+	ArtifactLocation diffSARIFArtifactLocation `json:"artifactLocation"`
+	Region           diffSARIFRegion           `json:"region,omitempty"`
+}
+
+type diffSARIFArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type diffSARIFRegion struct {
+	StartLine int `json:"startLine,omitempty"`
+}
+
+func sarifRules(findings []ciFinding) []diffSARIFRule {
+	byID := make(map[string]ControlChange)
+	for _, finding := range findings {
+		if _, exists := byID[finding.Change.ControlID]; !exists {
+			byID[finding.Change.ControlID] = finding.Change
+		}
+	}
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	rules := make([]diffSARIFRule, 0, len(ids))
+	for _, id := range ids {
+		change := byID[id]
+		rules = append(rules, diffSARIFRule{
+			ID:               change.ControlID,
+			Name:             change.ControlName,
+			ShortDescription: diffSARIFMessage{Text: change.ControlName},
+			DefaultConfiguration: diffSARIFConfiguration{
+				Level: sarifLevel(change.Severity),
+			},
+			Properties: map[string]string{
+				"security-severity": sarifSecuritySeverity(change.Severity),
+				"kubescapeSeverity": change.Severity,
+			},
+		})
+	}
+	return rules
+}
+
+func sarifResults(findings []ciFinding) []diffSARIFResult {
+	results := make([]diffSARIFResult, 0, len(findings))
+	for _, finding := range findings {
+		change := finding.Change
+		results = append(results, diffSARIFResult{
+			RuleID:  change.ControlID,
+			Level:   sarifLevel(change.Severity),
+			Message: diffSARIFMessage{Text: findingTitle(finding.Kind, change) + "\n\n" + findingDetails(change)},
+			Locations: []diffSARIFLocation{{
+				PhysicalLocation: diffSARIFPhysicalLocation{
+					ArtifactLocation: diffSARIFArtifactLocation{URI: change.ResourceID},
+					Region:           diffSARIFRegion{StartLine: 1},
+				},
+			}},
+			Properties: map[string]string{
+				"changeType":         finding.Kind,
+				"resourceID":         change.ResourceID,
+				"controlID":          change.ControlID,
+				"controlName":        change.ControlName,
+				"severity":           change.Severity,
+				"baseStatus":         change.BaseStatus,
+				"headStatus":         change.HeadStatus,
+				"ruleName":           change.RuleName,
+				"evidenceType":       change.EvidenceType,
+				"evidencePath":       change.Path,
+				"evidenceResourceID": change.EvidenceResourceID,
+				"incomparableReason": change.Reason,
+			},
+			Fingerprints: map[string]string{
+				"kubescapeDiffFingerprint": stableFindingID(finding.Kind, change),
+			},
+		})
+	}
+	return results
+}
+
+// PrintGitLabSAST writes a GitLab SAST-compatible report containing only new
+// and incomparable diff findings.
+func PrintGitLabSAST(w io.Writer, cs *ChangeSet, threshold string) error {
+	regressions := Regressions(cs, threshold)
+	scanner := diffGitLabScanner{
+		ID:      diffScannerID,
+		Name:    diffToolName,
+		URL:     diffToolURI,
+		Version: "diff",
+		Vendor:  diffGitLabVendor{Name: diffToolName},
+	}
+	report := diffGitLabReport{
+		Version: diffGitLabVer,
+		Scan: diffGitLabScan{
+			Analyzer:  scanner,
+			Scanner:   scanner,
+			Type:      diffScanType,
+			StartTime: diffGitLabTime,
+			EndTime:   diffGitLabTime,
+			Status:    "success",
+		},
+		Vulnerabilities: gitLabVulnerabilities(regressions.all()),
+	}
+	return encodeJSON(w, report)
+}
+
+type diffGitLabReport struct {
+	Version         string           `json:"version"`
+	Scan            diffGitLabScan   `json:"scan"`
+	Vulnerabilities []diffGitLabVuln `json:"vulnerabilities"`
+}
+
+type diffGitLabScan struct {
+	Analyzer  diffGitLabScanner `json:"analyzer"`
+	Scanner   diffGitLabScanner `json:"scanner"`
+	Type      string            `json:"type"`
+	StartTime string            `json:"start_time"`
+	EndTime   string            `json:"end_time"`
+	Status    string            `json:"status"`
+}
+
+type diffGitLabScanner struct {
+	ID      string           `json:"id"`
+	Name    string           `json:"name"`
+	URL     string           `json:"url,omitempty"`
+	Version string           `json:"version"`
+	Vendor  diffGitLabVendor `json:"vendor"`
+}
+
+type diffGitLabVendor struct {
+	Name string `json:"name"`
+}
+
+type diffGitLabVuln struct {
+	ID          string                 `json:"id"`
+	Category    string                 `json:"category"`
+	Name        string                 `json:"name"`
+	Message     string                 `json:"message"`
+	Description string                 `json:"description"`
+	Severity    string                 `json:"severity"`
+	Scanner     diffGitLabScannerRef   `json:"scanner"`
+	Location    diffGitLabLocation     `json:"location"`
+	Identifiers []diffGitLabIdentifier `json:"identifiers"`
+	Solution    string                 `json:"solution,omitempty"`
+}
+
+type diffGitLabScannerRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type diffGitLabLocation struct {
+	File      string `json:"file"`
+	StartLine int    `json:"start_line"`
+}
+
+type diffGitLabIdentifier struct {
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	URL   string `json:"url,omitempty"`
+}
+
+func gitLabVulnerabilities(findings []ciFinding) []diffGitLabVuln {
+	vulns := make([]diffGitLabVuln, 0, len(findings))
+	for _, finding := range findings {
+		change := finding.Change
+		vulns = append(vulns, diffGitLabVuln{
+			ID:          stableFindingID(finding.Kind, change),
+			Category:    diffScanType,
+			Name:        findingTitle(finding.Kind, change),
+			Message:     findingTitle(finding.Kind, change),
+			Description: findingDetails(change),
+			Severity:    gitLabSeverity(change.Severity),
+			Scanner:     diffGitLabScannerRef{ID: diffScannerID, Name: diffToolName},
+			Location:    diffGitLabLocation{File: change.ResourceID, StartLine: 1},
+			Identifiers: []diffGitLabIdentifier{{
+				Type:  diffControlType,
+				Name:  emptyAsUnknown(change.ControlID),
+				Value: emptyAsUnknown(change.ControlID),
+				URL:   controlDocsURL(change.ControlID),
+			}},
+			Solution: diffSolution(finding.Kind, change),
+		})
+	}
+	return vulns
+}
+
+func encodeJSON(w io.Writer, value any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}
+
+func findingTitle(kind string, change ControlChange) string {
+	prefix := "New Kubescape failure"
+	if kind == "incomparable" {
+		prefix = "Incomparable Kubescape failure"
+	}
+	if change.ControlName != "" {
+		return fmt.Sprintf("%s: %s (%s)", prefix, change.ControlName, change.ControlID)
+	}
+	return fmt.Sprintf("%s: %s", prefix, change.ControlID)
+}
+
+func findingDetails(change ControlChange) string {
+	lines := []string{
+		"Resource: " + change.ResourceID,
+		"Control: " + strings.TrimSpace(change.ControlName+" ("+change.ControlID+")"),
+		"Severity: " + emptyAsUnknown(change.Severity),
+		"Base status: " + emptyAsUnknown(change.BaseStatus),
+		"Head status: " + emptyAsUnknown(change.HeadStatus),
+	}
+	if change.RuleName != "" {
+		lines = append(lines, "Rule: "+change.RuleName)
+	}
+	if evidence := evidenceLabel(change); evidence != "" {
+		lines = append(lines, "Evidence: "+evidence)
+	}
+	if change.EvidenceResourceID != "" && change.EvidenceResourceID != change.ResourceID {
+		lines = append(lines, "Evidence resource: "+change.EvidenceResourceID)
+	}
+	if change.Reason != "" {
+		lines = append(lines, "Reason: "+change.Reason)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func evidenceLabel(change ControlChange) string {
+	parts := []string{}
+	if change.RuleName != "" {
+		parts = append(parts, "rule="+change.RuleName)
+	}
+	if change.EvidenceType != "" && change.EvidenceType != evidenceTypeControl {
+		parts = append(parts, "type="+change.EvidenceType)
+	}
+	if change.Path != "" {
+		parts = append(parts, "path="+change.Path)
+	}
+	return strings.Join(parts, " ")
+}
+
+func diffSolution(kind string, change ControlChange) string {
+	if kind == "incomparable" {
+		if change.Reason != "" {
+			return "Review scan coverage and scope before treating this finding as resolved: " + change.Reason
+		}
+		return "Review scan coverage and scope before treating this finding as resolved."
+	}
+	return "Fix the failed control or add a reviewed Kubescape exception if the risk is accepted."
+}
+
+func emptyAsUnknown(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func nonEmpty(values []string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func stableFindingID(kind string, change ControlChange) string {
+	hash := sha256.Sum256([]byte(strings.Join([]string{
+		kind,
+		change.ResourceID,
+		change.ControlID,
+		change.RuleName,
+		change.EvidenceType,
+		change.Path,
+		change.EvidenceResourceID,
+		change.Reason,
+	}, "\x00")))
+	return "kubescape-diff-" + hex.EncodeToString(hash[:])[:32]
+}
+
+func sarifLevel(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical", "high":
+		return "error"
+	case "medium":
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+func sarifSecuritySeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "9.0"
+	case "high":
+		return "7.0"
+	case "medium":
+		return "4.0"
+	case "low":
+		return "1.0"
+	default:
+		return "0.0"
+	}
+}
+
+func gitLabSeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "Critical"
+	case "high":
+		return "High"
+	case "medium":
+		return "Medium"
+	case "low":
+		return "Low"
+	case "negligible":
+		return "Info"
+	default:
+		return "Unknown"
+	}
+}
+
+func controlDocsURL(controlID string) string {
+	if strings.TrimSpace(controlID) == "" {
+		return diffToolURI
+	}
+	return "https://hub.armosec.io/docs/" + strings.TrimSpace(controlID)
+}

--- a/core/pkg/resultshandling/diff/ci_printer_edges_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_edges_test.go
@@ -1,0 +1,212 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIPrinters_HandleMinimalControlChanges(t *testing.T) {
+	change := ControlChange{
+		ResourceID: "resource-only",
+		ControlID:  "C-MIN",
+		Severity:   "Low",
+		HeadStatus: "failed",
+	}
+	cs := &ChangeSet{New: []ControlChange{change}}
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, ""))
+	assert.Contains(t, markdown.String(), "C-MIN")
+	assert.Contains(t, markdown.String(), "resource-only")
+	assert.NotContains(t, markdown.String(), "rule=")
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, cs, ""))
+	decodedJUnit := decodeJUnit(t, junit.Bytes())
+	require.Len(t, decodedJUnit.Suites, 1)
+	require.Len(t, decodedJUnit.Suites[0].TestCases, 1)
+	assert.Equal(t, "kubescape.diff/C-MIN", decodedJUnit.Suites[0].TestCases[0].Classname)
+	assert.Equal(t, "resource-only", decodedJUnit.Suites[0].TestCases[0].Name)
+	assert.Contains(t, decodedJUnit.Suites[0].TestCases[0].Failure.Contents, "Control: (C-MIN)")
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, ""))
+	decodedSARIF := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, decodedSARIF.Runs, 1)
+	require.Len(t, decodedSARIF.Runs[0].Results, 1)
+	assert.Equal(t, "C-MIN", decodedSARIF.Runs[0].Results[0].RuleID)
+	assert.Equal(t, "resource-only", decodedSARIF.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, ""))
+	decodedGitLab := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	require.Len(t, decodedGitLab.Vulnerabilities, 1)
+	assert.Equal(t, "C-MIN", decodedGitLab.Vulnerabilities[0].Identifiers[0].Value)
+	assert.Equal(t, "resource-only", decodedGitLab.Vulnerabilities[0].Location.File)
+}
+
+func TestCIPrinters_HandlePathlessRuleChanges(t *testing.T) {
+	change := ciChange("C-RULE", "apps/v1/default/Deployment/rule", "Medium")
+	change.EvidenceType = evidenceTypeRule
+	change.Path = ""
+	change.EvidenceResourceID = ""
+	cs := &ChangeSet{New: []ControlChange{change}}
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, ""))
+	assert.Contains(t, markdown.String(), "rule=rule-c-rule")
+	assert.NotContains(t, markdown.String(), "path=")
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, cs, ""))
+	assert.Contains(t, junit.String(), "Evidence: rule=rule-c-rule")
+	assert.NotContains(t, junit.String(), "Evidence resource:")
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, ""))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, sarifReport.Runs[0].Results, 1)
+	assert.Equal(t, "rule", sarifReport.Runs[0].Results[0].Properties["evidenceType"])
+	assert.Equal(t, "", sarifReport.Runs[0].Results[0].Properties["evidencePath"])
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, ""))
+	gitlabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	require.Len(t, gitlabReport.Vulnerabilities, 1)
+	assert.Contains(t, gitlabReport.Vulnerabilities[0].Description, "Evidence: rule=rule-c-rule")
+	assert.NotContains(t, gitlabReport.Vulnerabilities[0].Description, "Evidence resource:")
+}
+
+func TestCIPrinters_HandleResourceScopedControlChanges(t *testing.T) {
+	change := ciChange("C-CONTROL", "apps/v1/default/Deployment/control", "High")
+	change.RuleName = ""
+	change.EvidenceType = evidenceTypeControl
+	change.Path = ""
+	change.EvidenceResourceID = change.ResourceID
+	cs := &ChangeSet{New: []ControlChange{change}}
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, ""))
+	assert.Contains(t, markdown.String(), "| - |")
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, cs, ""))
+	decodedJUnit := decodeJUnit(t, junit.Bytes())
+	require.Len(t, decodedJUnit.Suites[0].TestCases, 1)
+	assert.Equal(t, "Control C-CONTROL / apps/v1/default/Deployment/control", decodedJUnit.Suites[0].TestCases[0].Name)
+	assert.NotContains(t, decodedJUnit.Suites[0].TestCases[0].Failure.Contents, "Evidence:")
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, ""))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, sarifReport.Runs[0].Results, 1)
+	assert.Equal(t, "control", sarifReport.Runs[0].Results[0].Properties["evidenceType"])
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, ""))
+	gitlabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	require.Len(t, gitlabReport.Vulnerabilities, 1)
+	assert.NotContains(t, gitlabReport.Vulnerabilities[0].Description, "Evidence:")
+}
+
+func TestStableFindingID_UsesReasonOnlyForIncomparableIdentity(t *testing.T) {
+	change := ciChange("C-ID", "resource", "High")
+	baseID := stableFindingID("new", change)
+
+	reasonChanged := change
+	reasonChanged.Reason = "scope changed"
+
+	assert.NotEqual(t, baseID, stableFindingID("new", reasonChanged))
+	assert.NotEqual(t, stableFindingID("incomparable", change), stableFindingID("incomparable", reasonChanged))
+}
+
+func TestCIJSONPrintersEmitIndentedJSON(t *testing.T) {
+	cs := &ChangeSet{New: []ControlChange{ciChange("C-JSON", "resource", "High")}}
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, ""))
+	assert.Contains(t, sarif.String(), "\n  ")
+	assert.True(t, json.Valid(sarif.Bytes()))
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, ""))
+	assert.Contains(t, gitlab.String(), "\n  ")
+	assert.True(t, json.Valid(gitlab.Bytes()))
+}
+
+func TestCIJUnitPrinterEmitsValidXMLDocument(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, ciChangeSet(), "high"))
+
+	assert.True(t, bytes.HasPrefix(output.Bytes(), []byte(xml.Header)))
+	payload := bytes.TrimPrefix(output.Bytes(), []byte(xml.Header))
+	assert.NoError(t, xml.Unmarshal(payload, &diffJUnitSuites{}))
+}
+
+func TestCIPrintersSeverityThresholdWithOnlyFilteredWarnings(t *testing.T) {
+	cs := &ChangeSet{
+		New:      []ControlChange{ciChange("C-LOW", "resource", "Low")},
+		Warnings: []string{"scope differs"},
+	}
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, "critical"))
+	assert.Contains(t, markdown.String(), "| New | 0 |")
+	assert.Contains(t, markdown.String(), "| Warnings | 1 |")
+	assert.Contains(t, markdown.String(), "scope differs")
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, "critical"))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, sarifReport.Runs, 1)
+	assert.Empty(t, sarifReport.Runs[0].Results)
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, "critical"))
+	gitlabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	assert.Empty(t, gitlabReport.Vulnerabilities)
+}
+
+func TestCIPrintersDoNotMutateInputChangeSet(t *testing.T) {
+	cs := ciChangeSet()
+	before, err := json.Marshal(cs)
+	require.NoError(t, err)
+
+	var markdown bytes.Buffer
+	var junit bytes.Buffer
+	var sarif bytes.Buffer
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, "high"))
+	require.NoError(t, PrintJUnit(&junit, cs, "high"))
+	require.NoError(t, PrintSARIF(&sarif, cs, "high"))
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, "high"))
+
+	after, err := json.Marshal(cs)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after))
+}
+
+func TestCIPrintersHandleNilChangeSet(t *testing.T) {
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, nil, ""))
+	assert.Contains(t, markdown.String(), "| New | 0 |")
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, nil, ""))
+	assert.Equal(t, 0, decodeJUnit(t, junit.Bytes()).Tests)
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, nil, ""))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	assert.Empty(t, sarifReport.Runs[0].Results)
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, nil, ""))
+	gitlabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	assert.Empty(t, gitlabReport.Vulnerabilities)
+}

--- a/core/pkg/resultshandling/diff/ci_printer_formats_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_formats_test.go
@@ -1,0 +1,448 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIPrinters_RespectSeverityThresholds(t *testing.T) {
+	tests := []struct {
+		name        string
+		threshold   string
+		wantNew     []string
+		wantIncomp  []string
+		wantSARIF   []string
+		wantGitLab  []string
+		wantJUnit   int
+		wantDetails []string
+	}{
+		{
+			name:        "all severities",
+			threshold:   "",
+			wantNew:     []string{"C-LOW", "C-CRITICAL", "C-MEDIUM", "C-HIGH"},
+			wantIncomp:  []string{"C-INCOMPARABLE"},
+			wantSARIF:   []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH", "C-MEDIUM", "C-LOW"},
+			wantGitLab:  []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH", "C-MEDIUM", "C-LOW"},
+			wantJUnit:   5,
+			wantDetails: []string{"Control C-CRITICAL", "Control C-HIGH", "Control C-MEDIUM", "Control C-LOW"},
+		},
+		{
+			name:        "medium and above",
+			threshold:   "medium",
+			wantNew:     []string{"C-CRITICAL", "C-MEDIUM", "C-HIGH"},
+			wantIncomp:  []string{"C-INCOMPARABLE"},
+			wantSARIF:   []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH", "C-MEDIUM"},
+			wantGitLab:  []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH", "C-MEDIUM"},
+			wantJUnit:   4,
+			wantDetails: []string{"Control C-CRITICAL", "Control C-HIGH", "Control C-MEDIUM"},
+		},
+		{
+			name:        "high and above",
+			threshold:   "high",
+			wantNew:     []string{"C-CRITICAL", "C-HIGH"},
+			wantIncomp:  []string{"C-INCOMPARABLE"},
+			wantSARIF:   []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH"},
+			wantGitLab:  []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH"},
+			wantJUnit:   3,
+			wantDetails: []string{"Control C-CRITICAL", "Control C-HIGH"},
+		},
+		{
+			name:        "critical only",
+			threshold:   "critical",
+			wantNew:     []string{"C-CRITICAL"},
+			wantIncomp:  []string{},
+			wantSARIF:   []string{"C-CRITICAL"},
+			wantGitLab:  []string{"C-CRITICAL"},
+			wantJUnit:   1,
+			wantDetails: []string{"Control C-CRITICAL"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			regressions := Regressions(ciChangeSet(), test.threshold)
+			assert.Equal(t, test.wantNew, controlIDs(regressions.New))
+			assert.Equal(t, test.wantIncomp, controlIDs(regressions.Incomparable))
+
+			var sarif bytes.Buffer
+			require.NoError(t, PrintSARIF(&sarif, ciChangeSet(), test.threshold))
+			sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+			require.Len(t, sarifReport.Runs, 1)
+			assert.Equal(t, test.wantSARIF, sarifResultRuleIDs(sarifReport.Runs[0].Results))
+
+			var gitlab bytes.Buffer
+			require.NoError(t, PrintGitLabSAST(&gitlab, ciChangeSet(), test.threshold))
+			gitLabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+			assert.Equal(t, test.wantGitLab, gitLabVulnerabilityControlIDs(gitLabReport.Vulnerabilities))
+
+			var junit bytes.Buffer
+			require.NoError(t, PrintJUnit(&junit, ciChangeSet(), test.threshold))
+			junitReport := decodeJUnit(t, junit.Bytes())
+			assert.Equal(t, test.wantJUnit, junitReport.Tests)
+			assert.Equal(t, test.wantJUnit, junitReport.Failures)
+
+			var markdown bytes.Buffer
+			require.NoError(t, PrintMarkdown(&markdown, ciChangeSet(), test.threshold))
+			markdownText := markdown.String()
+			for _, detail := range test.wantDetails {
+				assert.Contains(t, markdownText, detail)
+			}
+			if test.threshold != "" {
+				assert.Contains(t, markdownText, "Severity threshold: "+test.threshold)
+			}
+		})
+	}
+}
+
+func TestCIPrinters_ExcludeResolvedAndUnchangedFindings(t *testing.T) {
+	cs := ciChangeSet()
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, ""))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, sarifReport.Runs, 1)
+	sarifJSON := sarif.String()
+	assert.NotContains(t, sarifJSON, "C-RESOLVED")
+	assert.NotContains(t, sarifJSON, "C-UNCHANGED")
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, ""))
+	gitlabJSON := gitlab.String()
+	assert.NotContains(t, gitlabJSON, "C-RESOLVED")
+	assert.NotContains(t, gitlabJSON, "C-UNCHANGED")
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, cs, ""))
+	junitXML := junit.String()
+	assert.NotContains(t, junitXML, "C-RESOLVED")
+	assert.NotContains(t, junitXML, "C-UNCHANGED")
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, ""))
+	markdownText := markdown.String()
+	assert.NotContains(t, markdownText, "C-RESOLVED")
+	assert.NotContains(t, markdownText, "C-UNCHANGED")
+}
+
+func TestPrintSARIF_ResultPropertiesSurviveJSONRoundTrip(t *testing.T) {
+	change := ciChange("C-ROUNDTRIP", "apps/v1/default/Deployment/roundtrip", "Medium")
+	change.BaseStatus = "absent"
+	change.HeadStatus = "failed"
+	change.EvidenceResourceID = "apps/v1/default/Pod/roundtrip"
+	change.Reason = "base report did not include this control"
+
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, &ChangeSet{Incomparable: []ControlChange{change}}, ""))
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+	runs := raw["runs"].([]any)
+	run := runs[0].(map[string]any)
+	results := run["results"].([]any)
+	result := results[0].(map[string]any)
+	properties := result["properties"].(map[string]any)
+	fingerprints := result["partialFingerprints"].(map[string]any)
+
+	assert.Equal(t, "incomparable", properties["changeType"])
+	assert.Equal(t, "apps/v1/default/Deployment/roundtrip", properties["resourceID"])
+	assert.Equal(t, "C-ROUNDTRIP", properties["controlID"])
+	assert.Equal(t, "Control C-ROUNDTRIP", properties["controlName"])
+	assert.Equal(t, "Medium", properties["severity"])
+	assert.Equal(t, "absent", properties["baseStatus"])
+	assert.Equal(t, "failed", properties["headStatus"])
+	assert.Equal(t, "rule-c-roundtrip", properties["ruleName"])
+	assert.Equal(t, "failedPath", properties["evidenceType"])
+	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", properties["evidencePath"])
+	assert.Equal(t, "apps/v1/default/Pod/roundtrip", properties["evidenceResourceID"])
+	assert.Equal(t, "base report did not include this control", properties["incomparableReason"])
+	assert.NotEmpty(t, fingerprints["kubescapeDiffFingerprint"])
+}
+
+func TestPrintSARIF_RulesUseHighestSeveritySortedControlMetadata(t *testing.T) {
+	first := ciChange("C-DUPLICATE", "apps/v1/default/Deployment/a", "Medium")
+	first.ControlName = "First name"
+	second := ciChange("C-DUPLICATE", "apps/v1/default/Deployment/b", "Critical")
+	second.ControlName = "Second name"
+
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, &ChangeSet{New: []ControlChange{first, second}}, ""))
+
+	report := decodeJSON[diffSARIFReport](t, output.Bytes())
+	require.Len(t, report.Runs, 1)
+	require.Len(t, report.Runs[0].Tool.Driver.Rules, 1)
+	rule := report.Runs[0].Tool.Driver.Rules[0]
+	assert.Equal(t, "C-DUPLICATE", rule.ID)
+	assert.Equal(t, "Second name", rule.Name)
+	assert.Equal(t, "Second name", rule.ShortDescription.Text)
+	assert.Equal(t, "9.0", rule.Properties["security-severity"])
+	assert.Equal(t, "Critical", rule.Properties["kubescapeSeverity"])
+}
+
+func TestPrintSARIF_ResultOrderingIsStableAcrossRuns(t *testing.T) {
+	var first bytes.Buffer
+	var second bytes.Buffer
+
+	require.NoError(t, PrintSARIF(&first, ciChangeSet(), ""))
+	require.NoError(t, PrintSARIF(&second, ciChangeSet(), ""))
+
+	assert.Equal(t, first.String(), second.String())
+}
+
+func TestPrintGitLabSAST_VulnerabilityIDsAreStableAcrossRuns(t *testing.T) {
+	var first bytes.Buffer
+	var second bytes.Buffer
+
+	require.NoError(t, PrintGitLabSAST(&first, ciChangeSet(), ""))
+	require.NoError(t, PrintGitLabSAST(&second, ciChangeSet(), ""))
+
+	firstReport := decodeJSON[diffGitLabReport](t, first.Bytes())
+	secondReport := decodeJSON[diffGitLabReport](t, second.Bytes())
+	require.Len(t, firstReport.Vulnerabilities, len(secondReport.Vulnerabilities))
+	for i := range firstReport.Vulnerabilities {
+		assert.Equal(t, firstReport.Vulnerabilities[i].ID, secondReport.Vulnerabilities[i].ID)
+	}
+}
+
+func TestPrintGitLabSAST_MapsUnknownOrEmptyControlIDToToolURL(t *testing.T) {
+	change := ciChange("", "apps/v1/default/Deployment/no-control-id", "Unknown")
+	change.ControlName = ""
+
+	var output bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&output, &ChangeSet{New: []ControlChange{change}}, ""))
+
+	report := decodeJSON[diffGitLabReport](t, output.Bytes())
+	require.Len(t, report.Vulnerabilities, 1)
+	vuln := report.Vulnerabilities[0]
+	assert.Equal(t, "Unknown", vuln.Severity)
+	require.Len(t, vuln.Identifiers, 1)
+	assert.Equal(t, diffToolURI, vuln.Identifiers[0].URL)
+	assert.Equal(t, "unknown", vuln.Identifiers[0].Name)
+	assert.Equal(t, "unknown", vuln.Identifiers[0].Value)
+	assert.Equal(t, "New Kubescape failure: ", vuln.Name)
+}
+
+func TestPrintGitLabSAST_ProducesRequiredScannerFields(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&output, ciChangeSet(), "critical"))
+
+	report := decodeJSON[diffGitLabReport](t, output.Bytes())
+	assert.Equal(t, diffScannerID, report.Scan.Analyzer.ID)
+	assert.Equal(t, diffScannerID, report.Scan.Scanner.ID)
+	assert.Equal(t, diffToolName, report.Scan.Analyzer.Name)
+	assert.Equal(t, diffToolName, report.Scan.Scanner.Name)
+	assert.Equal(t, diffToolURI, report.Scan.Analyzer.URL)
+	assert.Equal(t, diffToolURI, report.Scan.Scanner.URL)
+	assert.Equal(t, "diff", report.Scan.Analyzer.Version)
+	assert.Equal(t, "diff", report.Scan.Scanner.Version)
+	assert.Equal(t, diffGitLabTime, report.Scan.StartTime)
+	assert.Equal(t, diffGitLabTime, report.Scan.EndTime)
+}
+
+func TestPrintJUnit_XMLEscapesAttributesAndBody(t *testing.T) {
+	change := ciChange("C-XML", `apps/v1/default/Deployment/a&b`, "High")
+	change.ControlName = `Control "quoted" & angled <name>`
+	change.Reason = `reason "quoted" & angled <body>`
+
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, &ChangeSet{Incomparable: []ControlChange{change}}, ""))
+
+	raw := output.String()
+	assert.Contains(t, raw, `Control &#34;quoted&#34; &amp; angled &lt;name&gt;`)
+	assert.Contains(t, raw, `reason &#34;quoted&#34; &amp; angled &lt;body&gt;`)
+
+	decoded := decodeJUnit(t, output.Bytes())
+	require.Len(t, decoded.Suites, 1)
+	require.Len(t, decoded.Suites[0].TestCases, 1)
+	assert.Contains(t, decoded.Suites[0].TestCases[0].Name, `Control "quoted" & angled <name>`)
+	assert.Contains(t, decoded.Suites[0].TestCases[0].Failure.Contents, `reason "quoted" & angled <body>`)
+}
+
+func TestPrintJUnit_ClassnameFallsBackToKubescapeDiffPrefix(t *testing.T) {
+	change := ciChange("", "apps/v1/default/Deployment/no-control-id", "High")
+
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, &ChangeSet{New: []ControlChange{change}}, ""))
+
+	decoded := decodeJUnit(t, output.Bytes())
+	require.Len(t, decoded.Suites, 1)
+	require.Len(t, decoded.Suites[0].TestCases, 1)
+	assert.Equal(t, "kubescape.diff/", decoded.Suites[0].TestCases[0].Classname)
+}
+
+func TestPrintMarkdown_WritesWarningsWithoutFindings(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintMarkdown(&output, &ChangeSet{Warnings: []string{"scope differs"}}, "high"))
+
+	actual := output.String()
+	assert.Contains(t, actual, "| Warnings | 1 |")
+	assert.Contains(t, actual, "## Warnings")
+	assert.Contains(t, actual, "- scope differs")
+	assert.Contains(t, actual, "No new or incomparable failures matched the severity threshold.")
+}
+
+func TestPrintMarkdown_EmptyThresholdIsRenderedAsAll(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintMarkdown(&output, &ChangeSet{New: []ControlChange{ciChange("C-HIGH", "resource", "High")}}, ""))
+
+	assert.Contains(t, output.String(), "Severity threshold: all")
+}
+
+func TestMarkdownEscape_NormalizesEmptyAndWhitespace(t *testing.T) {
+	assert.Equal(t, "-", markdownEscape(""))
+	assert.Equal(t, "-", markdownEscape(" \n\t "))
+	assert.Equal(t, "a b", markdownEscape("a\nb"))
+	assert.Equal(t, `a\\b`, markdownEscape(`a\b`))
+	assert.Equal(t, `a\|b`, markdownEscape(`a|b`))
+}
+
+func TestJUnitCaseName_UsesOnlyNonEmptyParts(t *testing.T) {
+	assert.Equal(t, "Control C-1 / resource / rule=rule-c-1 type=failedPath path=spec.template.spec.containers[0].securityContext.privileged", junitCaseName(ciChange("C-1", "resource", "High")))
+	assert.Equal(t, "resource", junitCaseName(ControlChange{ResourceID: "resource"}))
+	assert.Equal(t, "", junitCaseName(ControlChange{}))
+}
+
+func TestDiffSolution(t *testing.T) {
+	newChange := ciChange("C-HIGH", "resource", "High")
+	assert.Equal(t, "Fix the failed control or add a reviewed Kubescape exception if the risk is accepted.", diffSolution("new", newChange))
+
+	incomparable := newChange
+	incomparable.Reason = "scope changed"
+	assert.Equal(t, "Review scan coverage and scope before treating this finding as resolved: scope changed", diffSolution("incomparable", incomparable))
+
+	incomparable.Reason = ""
+	assert.Equal(t, "Review scan coverage and scope before treating this finding as resolved.", diffSolution("incomparable", incomparable))
+}
+
+func TestNonEmpty_TrimsWithoutMutatingValues(t *testing.T) {
+	input := []string{"a", " ", "\t", "b"}
+
+	got := nonEmpty(input)
+
+	assert.Equal(t, []string{"a", "b"}, got)
+}
+
+func TestCompareChange_OrdersBySeverityThenIdentity(t *testing.T) {
+	critical := ciChange("C-CRITICAL", "resource", "Critical")
+	high := ciChange("C-HIGH", "resource", "High")
+	mediumA := ciChange("C-MEDIUM-A", "resource-a", "Medium")
+	mediumB := ciChange("C-MEDIUM-B", "resource-b", "Medium")
+
+	assert.Less(t, compareChange(critical, high), 0)
+	assert.Greater(t, compareChange(high, critical), 0)
+	assert.Less(t, compareChange(mediumA, mediumB), 0)
+	assert.Equal(t, 0, compareChange(mediumA, mediumA))
+}
+
+func TestCIOutputContainsNoResolvedOrUnchangedForEachFormat(t *testing.T) {
+	formats := []struct {
+		name  string
+		print func(*bytes.Buffer) error
+	}{
+		{"markdown", func(buf *bytes.Buffer) error { return PrintMarkdown(buf, ciChangeSet(), "") }},
+		{"junit", func(buf *bytes.Buffer) error { return PrintJUnit(buf, ciChangeSet(), "") }},
+		{"sarif", func(buf *bytes.Buffer) error { return PrintSARIF(buf, ciChangeSet(), "") }},
+		{"gitlab", func(buf *bytes.Buffer) error { return PrintGitLabSAST(buf, ciChangeSet(), "") }},
+	}
+
+	for _, format := range formats {
+		t.Run(format.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, format.print(&output))
+			assert.NotContains(t, output.String(), "apps/v1/default/Deployment/resolved")
+			assert.NotContains(t, output.String(), "apps/v1/default/Deployment/unchanged")
+		})
+	}
+}
+
+func TestCIOutputRoundTripsLargeRegressionSet(t *testing.T) {
+	cs := &ChangeSet{}
+	for i := 0; i < 50; i++ {
+		severity := "Low"
+		if i%2 == 0 {
+			severity = "High"
+		}
+		change := ciChange(fmt.Sprintf("C-%04d", i), fmt.Sprintf("apps/v1/ns/Deployment/workload-%02d", i), severity)
+		if i%5 == 0 {
+			change.Reason = "coverage changed"
+			cs.Incomparable = append(cs.Incomparable, change)
+		} else {
+			cs.New = append(cs.New, change)
+		}
+	}
+
+	var sarif bytes.Buffer
+	require.NoError(t, PrintSARIF(&sarif, cs, "high"))
+	sarifReport := decodeJSON[diffSARIFReport](t, sarif.Bytes())
+	require.Len(t, sarifReport.Runs, 1)
+	assert.Len(t, sarifReport.Runs[0].Results, 25)
+
+	var gitlab bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&gitlab, cs, "high"))
+	gitlabReport := decodeJSON[diffGitLabReport](t, gitlab.Bytes())
+	assert.Len(t, gitlabReport.Vulnerabilities, 25)
+
+	var junit bytes.Buffer
+	require.NoError(t, PrintJUnit(&junit, cs, "high"))
+	junitReport := decodeJUnit(t, junit.Bytes())
+	assert.Equal(t, 25, junitReport.Tests)
+	assert.Equal(t, 25, junitReport.Failures)
+
+	var markdown bytes.Buffer
+	require.NoError(t, PrintMarkdown(&markdown, cs, "high"))
+	assert.Contains(t, markdown.String(), "| New | 20 |")
+	assert.Contains(t, markdown.String(), "| Incomparable | 5 |")
+}
+
+func TestSARIFRulesRemainSortedWhenResultsAreNot(t *testing.T) {
+	cs := &ChangeSet{New: []ControlChange{
+		ciChange("C-Z", "resource-z", "High"),
+		ciChange("C-A", "resource-a", "High"),
+		ciChange("C-M", "resource-m", "High"),
+	}}
+
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, cs, ""))
+
+	report := decodeJSON[diffSARIFReport](t, output.Bytes())
+	require.Len(t, report.Runs, 1)
+	assert.Equal(t, []string{"C-A", "C-M", "C-Z"}, sarifRuleIDs(report.Runs[0].Tool.Driver.Rules))
+}
+
+func TestGitLabVulnerabilitiesPreserveSortedFindingOrder(t *testing.T) {
+	cs := &ChangeSet{New: []ControlChange{
+		ciChange("C-LOW", "resource-low", "Low"),
+		ciChange("C-HIGH", "resource-high", "High"),
+		ciChange("C-CRITICAL", "resource-critical", "Critical"),
+	}}
+
+	var output bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&output, cs, ""))
+
+	report := decodeJSON[diffGitLabReport](t, output.Bytes())
+	assert.Equal(t, []string{"C-CRITICAL", "C-HIGH", "C-LOW"}, gitLabVulnerabilityControlIDs(report.Vulnerabilities))
+}
+
+func sarifResultRuleIDs(results []diffSARIFResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, result := range results {
+		ids = append(ids, result.RuleID)
+	}
+	return ids
+}
+
+func gitLabVulnerabilityControlIDs(vulns []diffGitLabVuln) []string {
+	ids := make([]string, 0, len(vulns))
+	for _, vuln := range vulns {
+		if len(vuln.Identifiers) == 0 {
+			ids = append(ids, "")
+			continue
+		}
+		ids = append(ids, vuln.Identifiers[0].Value)
+	}
+	return ids
+}

--- a/core/pkg/resultshandling/diff/ci_printer_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_test.go
@@ -1,0 +1,512 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ciChange(controlID, resourceID, severity string) ControlChange {
+	return ControlChange{
+		ResourceID:         resourceID,
+		ControlID:          controlID,
+		ControlName:        "Control " + controlID,
+		Severity:           severity,
+		BaseStatus:         "passed",
+		HeadStatus:         "failed",
+		RuleName:           "rule-" + strings.ToLower(controlID),
+		EvidenceType:       evidenceTypeFailedPath,
+		Path:               "spec.template.spec.containers[0].securityContext.privileged",
+		EvidenceResourceID: resourceID + "/pod",
+	}
+}
+
+func ciChangeSet() *ChangeSet {
+	low := ciChange("C-LOW", "apps/v1/default/Deployment/low", "Low")
+	medium := ciChange("C-MEDIUM", "apps/v1/default/Deployment/medium", "Medium")
+	high := ciChange("C-HIGH", "apps/v1/default/Deployment/high", "High")
+	critical := ciChange("C-CRITICAL", "apps/v1/default/Deployment/critical", "Critical")
+	incomparable := ciChange("C-INCOMPARABLE", "apps/v1/default/Deployment/incomparable", "High")
+	incomparable.BaseStatus = "failed"
+	incomparable.Reason = "reports use different failed evidence detail"
+	resolved := ciChange("C-RESOLVED", "apps/v1/default/Deployment/resolved", "Critical")
+	resolved.BaseStatus = "failed"
+	resolved.HeadStatus = "passed"
+	unchanged := ciChange("C-UNCHANGED", "apps/v1/default/Deployment/unchanged", "Critical")
+	unchanged.BaseStatus = "failed"
+
+	return &ChangeSet{
+		New:          []ControlChange{low, critical, medium, high},
+		Resolved:     []ControlChange{resolved},
+		Unchanged:    []ControlChange{unchanged},
+		Incomparable: []ControlChange{incomparable},
+		Warnings:     []string{"included namespaces differ", "target names differ"},
+	}
+}
+
+func decodeJSON[T any](t *testing.T, raw []byte) T {
+	t.Helper()
+	var value T
+	require.NoError(t, json.Unmarshal(raw, &value))
+	return value
+}
+
+func TestRegressions_FiltersNewAndIncomparableOnly(t *testing.T) {
+	regressions := Regressions(ciChangeSet(), "high")
+
+	require.Len(t, regressions.New, 2)
+	assert.Equal(t, []string{"C-CRITICAL", "C-HIGH"}, controlIDs(regressions.New))
+	require.Len(t, regressions.Incomparable, 1)
+	assert.Equal(t, "C-INCOMPARABLE", regressions.Incomparable[0].ControlID)
+	assert.Equal(t, []string{"included namespaces differ", "target names differ"}, regressions.Warnings)
+}
+
+func TestRegressions_ClonesReturnedSlices(t *testing.T) {
+	cs := ciChangeSet()
+
+	regressions := Regressions(cs, "")
+	regressions.New[0].ControlID = "changed"
+	regressions.Incomparable[0].ControlID = "changed"
+	regressions.Warnings[0] = "changed"
+
+	assert.Equal(t, "C-LOW", cs.New[0].ControlID)
+	assert.Equal(t, "C-INCOMPARABLE", cs.Incomparable[0].ControlID)
+	assert.Equal(t, "included namespaces differ", cs.Warnings[0])
+}
+
+func TestRegressions_NilChangeSetIsEmpty(t *testing.T) {
+	regressions := Regressions(nil, "")
+
+	assert.Empty(t, regressions.New)
+	assert.Empty(t, regressions.Incomparable)
+	assert.Empty(t, regressions.Warnings)
+}
+
+func TestRegressionSetAll_SortsFindingsDeterministically(t *testing.T) {
+	cs := &ChangeSet{
+		New: []ControlChange{
+			ciChange("C-LOW", "b", "Low"),
+			ciChange("C-HIGH", "c", "High"),
+			ciChange("C-CRITICAL", "a", "Critical"),
+			ciChange("C-MEDIUM", "d", "Medium"),
+		},
+		Incomparable: []ControlChange{
+			ciChange("C-INCOMPARABLE", "z", "Critical"),
+		},
+	}
+
+	findings := Regressions(cs, "").all()
+
+	require.Len(t, findings, 5)
+	assert.Equal(t, []string{"incomparable", "new", "new", "new", "new"}, findingKinds(findings))
+	assert.Equal(t, []string{"C-INCOMPARABLE", "C-CRITICAL", "C-HIGH", "C-MEDIUM", "C-LOW"}, findingControlIDs(findings))
+}
+
+func TestRegressionSetAll_UsesStableTieBreakers(t *testing.T) {
+	changes := []ControlChange{
+		{ResourceID: "resource-b", ControlID: "C-2", Severity: "High", RuleName: "rule-b", EvidenceType: "rule", Path: "b", Reason: "b"},
+		{ResourceID: "resource-a", ControlID: "C-2", Severity: "High", RuleName: "rule-b", EvidenceType: "rule", Path: "b", Reason: "b"},
+		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-b", EvidenceType: "rule", Path: "b", Reason: "b"},
+		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-a", EvidenceType: "rule", Path: "b", Reason: "b"},
+		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-a", EvidenceType: "failedPath", Path: "a", Reason: "a"},
+	}
+
+	findings := Regressions(&ChangeSet{New: changes}, "").all()
+
+	require.Len(t, findings, len(changes))
+	assert.Equal(t, "resource-a", findings[0].Change.ResourceID)
+	assert.Equal(t, "C-1", findings[0].Change.ControlID)
+	assert.Equal(t, "rule-a", findings[0].Change.RuleName)
+	assert.Equal(t, "failedPath", findings[0].Change.EvidenceType)
+	assert.Equal(t, "a", findings[0].Change.Path)
+	assert.Equal(t, "resource-b", findings[len(findings)-1].Change.ResourceID)
+}
+
+func TestPrintMarkdown_WritesPRFriendlyRegressionSummary(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintMarkdown(&output, ciChangeSet(), "high"))
+
+	actual := output.String()
+	assert.Contains(t, actual, "# Kubescape Diff Regressions")
+	assert.Contains(t, actual, "| New | 2 |")
+	assert.Contains(t, actual, "| Incomparable | 1 |")
+	assert.Contains(t, actual, "| Warnings | 2 |")
+	assert.Contains(t, actual, "Severity threshold: high")
+	assert.Contains(t, actual, "## Warnings")
+	assert.Contains(t, actual, "- included namespaces differ")
+	assert.Contains(t, actual, "## New Failures")
+	assert.Contains(t, actual, "## Incomparable Failures")
+	assert.Contains(t, actual, "Control C-CRITICAL (C-CRITICAL)")
+	assert.Contains(t, actual, "reports use different failed evidence detail")
+	assert.NotContains(t, actual, "C-LOW")
+	assert.NotContains(t, actual, "C-MEDIUM")
+	assert.NotContains(t, actual, "C-RESOLVED")
+	assert.NotContains(t, actual, "C-UNCHANGED")
+}
+
+func TestPrintMarkdown_ReportsNoMatchingRegressions(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintMarkdown(&output, ciChangeSet(), "critical"))
+
+	actual := output.String()
+	assert.Contains(t, actual, "| New | 1 |")
+	assert.Contains(t, actual, "| Incomparable | 0 |")
+	assert.Contains(t, actual, "C-CRITICAL")
+	assert.NotContains(t, actual, "No new or incomparable failures")
+
+	output.Reset()
+	require.NoError(t, PrintMarkdown(&output, &ChangeSet{}, "high"))
+	assert.Contains(t, output.String(), "No new or incomparable failures matched the severity threshold.")
+}
+
+func TestPrintMarkdown_EscapesTableCells(t *testing.T) {
+	change := ciChange("C-PIPE", "apps/v1/default/Deployment/a|b", "High")
+	change.ControlName = "Control | pipe\nnewline"
+	change.Reason = "reason | pipe\nnewline"
+
+	var output bytes.Buffer
+	require.NoError(t, PrintMarkdown(&output, &ChangeSet{New: []ControlChange{change}}, ""))
+
+	actual := output.String()
+	assert.Contains(t, actual, "Control \\| pipe newline")
+	assert.Contains(t, actual, "apps/v1/default/Deployment/a\\|b")
+	assert.Contains(t, actual, "reason \\| pipe newline")
+}
+
+func TestPrintMarkdown_PropagatesWriterError(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	err := PrintMarkdown(failingWriter{err: errBoom}, ciChangeSet(), "")
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestPrintJUnit_WritesFailingTestCases(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, ciChangeSet(), "high"))
+
+	assert.True(t, strings.HasPrefix(output.String(), xml.Header))
+	decoded := decodeJUnit(t, output.Bytes())
+
+	assert.Equal(t, "Kubescape Diff", decoded.Name)
+	assert.Equal(t, 3, decoded.Tests)
+	assert.Equal(t, 3, decoded.Failures)
+	require.Len(t, decoded.Suites, 2)
+	assert.Equal(t, "kubescape diff new", decoded.Suites[0].Name)
+	assert.Equal(t, 2, decoded.Suites[0].Tests)
+	assert.Equal(t, 2, decoded.Suites[0].Failures)
+	assert.Equal(t, "kubescape diff incomparable", decoded.Suites[1].Name)
+	assert.Equal(t, 1, decoded.Suites[1].Tests)
+	assert.Equal(t, 1, decoded.Suites[1].Failures)
+
+	newCases := decoded.Suites[0].TestCases
+	require.Len(t, newCases, 2)
+	assert.Equal(t, "kubescape.diff/C-CRITICAL", newCases[0].Classname)
+	assert.Contains(t, newCases[0].Name, "Control C-CRITICAL")
+	require.NotNil(t, newCases[0].Failure)
+	assert.Equal(t, "new", newCases[0].Failure.Type)
+	assert.Contains(t, newCases[0].Failure.Message, "New Kubescape failure")
+	assert.Contains(t, newCases[0].Failure.Contents, "Resource: apps/v1/default/Deployment/critical")
+	assert.Contains(t, newCases[0].Failure.Contents, "Evidence: rule=rule-c-critical")
+
+	incomparableCases := decoded.Suites[1].TestCases
+	require.Len(t, incomparableCases, 1)
+	assert.Equal(t, "incomparable", incomparableCases[0].Failure.Type)
+	assert.Contains(t, incomparableCases[0].Failure.Message, "Incomparable Kubescape failure")
+}
+
+func TestPrintJUnit_OmitsEmptySuites(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, &ChangeSet{New: []ControlChange{ciChange("C-HIGH", "resource", "High")}}, "high"))
+
+	decoded := decodeJUnit(t, output.Bytes())
+
+	require.Len(t, decoded.Suites, 1)
+	assert.Equal(t, "kubescape diff new", decoded.Suites[0].Name)
+}
+
+func TestPrintJUnit_EmptyReportHasNoSuites(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintJUnit(&output, &ChangeSet{}, ""))
+
+	decoded := decodeJUnit(t, output.Bytes())
+
+	assert.Equal(t, 0, decoded.Tests)
+	assert.Equal(t, 0, decoded.Failures)
+	assert.Empty(t, decoded.Suites)
+}
+
+func TestPrintJUnit_PropagatesWriterError(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	err := PrintJUnit(failingWriter{err: errBoom}, ciChangeSet(), "")
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestPrintSARIF_WritesCodeScanningReport(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, ciChangeSet(), "high"))
+
+	report := decodeJSON[diffSARIFReport](t, output.Bytes())
+
+	assert.Equal(t, "2.1.0", report.Version)
+	assert.Equal(t, "https://json.schemastore.org/sarif-2.1.0.json", report.Schema)
+	require.Len(t, report.Runs, 1)
+	run := report.Runs[0]
+	assert.Equal(t, diffToolName, run.Tool.Driver.Name)
+	assert.Equal(t, diffToolURI, run.Tool.Driver.InformationURI)
+
+	require.Len(t, run.Tool.Driver.Rules, 3)
+	assert.Equal(t, []string{"C-CRITICAL", "C-HIGH", "C-INCOMPARABLE"}, sarifRuleIDs(run.Tool.Driver.Rules))
+	assert.Equal(t, "9.0", run.Tool.Driver.Rules[0].Properties["security-severity"])
+	assert.Equal(t, "error", run.Tool.Driver.Rules[0].DefaultConfiguration.Level)
+
+	require.Len(t, run.Results, 3)
+	first := run.Results[0]
+	assert.Equal(t, "C-INCOMPARABLE", first.RuleID)
+	assert.Equal(t, "error", first.Level)
+	assert.Contains(t, first.Message.Text, "Incomparable Kubescape failure")
+	assert.Equal(t, "incomparable", first.Properties["changeType"])
+	assert.Equal(t, "C-INCOMPARABLE", first.Properties["controlID"])
+	assert.Equal(t, "reports use different failed evidence detail", first.Properties["incomparableReason"])
+	require.Len(t, first.Locations, 1)
+	assert.Equal(t, "apps/v1/default/Deployment/incomparable", first.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, 1, first.Locations[0].PhysicalLocation.Region.StartLine)
+	assert.NotEmpty(t, first.Fingerprints["kubescapeDiffFingerprint"])
+}
+
+func TestPrintSARIF_DeduplicatesRulesByControlID(t *testing.T) {
+	first := ciChange("C-DUP", "apps/v1/default/Deployment/a", "High")
+	second := ciChange("C-DUP", "apps/v1/default/Deployment/b", "Medium")
+
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, &ChangeSet{New: []ControlChange{first, second}}, ""))
+
+	report := decodeJSON[diffSARIFReport](t, output.Bytes())
+	require.Len(t, report.Runs, 1)
+	assert.Len(t, report.Runs[0].Tool.Driver.Rules, 1)
+	assert.Len(t, report.Runs[0].Results, 2)
+}
+
+func TestPrintSARIF_EmptyReportIsValid(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintSARIF(&output, &ChangeSet{}, ""))
+
+	report := decodeJSON[diffSARIFReport](t, output.Bytes())
+	require.Len(t, report.Runs, 1)
+	assert.Empty(t, report.Runs[0].Tool.Driver.Rules)
+	assert.Empty(t, report.Runs[0].Results)
+}
+
+func TestPrintSARIF_PropagatesWriterError(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	err := PrintSARIF(failingWriter{err: errBoom}, ciChangeSet(), "")
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestPrintGitLabSAST_WritesGitLabSecurityReport(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&output, ciChangeSet(), "high"))
+
+	report := decodeJSON[diffGitLabReport](t, output.Bytes())
+
+	assert.Equal(t, diffGitLabVer, report.Version)
+	assert.Equal(t, diffScanType, report.Scan.Type)
+	assert.Equal(t, "success", report.Scan.Status)
+	assert.Equal(t, diffScannerID, report.Scan.Scanner.ID)
+	assert.Equal(t, diffToolName, report.Scan.Scanner.Vendor.Name)
+	require.Len(t, report.Vulnerabilities, 3)
+
+	first := report.Vulnerabilities[0]
+	assert.Equal(t, "sast", first.Category)
+	assert.Contains(t, first.Name, "Incomparable Kubescape failure")
+	assert.Equal(t, "High", first.Severity)
+	assert.Equal(t, diffScannerID, first.Scanner.ID)
+	assert.Equal(t, "apps/v1/default/Deployment/incomparable", first.Location.File)
+	assert.Equal(t, 1, first.Location.StartLine)
+	require.Len(t, first.Identifiers, 1)
+	assert.Equal(t, diffControlType, first.Identifiers[0].Type)
+	assert.Equal(t, "C-INCOMPARABLE", first.Identifiers[0].Value)
+	assert.Equal(t, "https://hub.armosec.io/docs/C-INCOMPARABLE", first.Identifiers[0].URL)
+	assert.Contains(t, first.Solution, "Review scan coverage")
+
+	newVuln := report.Vulnerabilities[1]
+	assert.Equal(t, "Critical", newVuln.Severity)
+	assert.Contains(t, newVuln.Solution, "Fix the failed control")
+	assert.NotEmpty(t, newVuln.ID)
+}
+
+func TestPrintGitLabSAST_EmptyReportIsValid(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, PrintGitLabSAST(&output, &ChangeSet{}, ""))
+
+	report := decodeJSON[diffGitLabReport](t, output.Bytes())
+
+	assert.Equal(t, "success", report.Scan.Status)
+	assert.Empty(t, report.Vulnerabilities)
+}
+
+func TestPrintGitLabSAST_PropagatesWriterError(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	err := PrintGitLabSAST(failingWriter{err: errBoom}, ciChangeSet(), "")
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestFindingDetails_IncludesUsefulFieldsAndOmitsEmptyFields(t *testing.T) {
+	change := ciChange("C-HIGH", "resource", "High")
+
+	details := findingDetails(change)
+
+	assert.Contains(t, details, "Resource: resource")
+	assert.Contains(t, details, "Control: Control C-HIGH (C-HIGH)")
+	assert.Contains(t, details, "Severity: High")
+	assert.Contains(t, details, "Base status: passed")
+	assert.Contains(t, details, "Head status: failed")
+	assert.Contains(t, details, "Rule: rule-c-high")
+	assert.Contains(t, details, "Evidence: rule=rule-c-high type=failedPath path=spec.template.spec.containers[0].securityContext.privileged")
+	assert.Contains(t, details, "Evidence resource: resource/pod")
+	assert.NotContains(t, details, "Reason:")
+
+	change.RuleName = ""
+	change.EvidenceType = ""
+	change.Path = ""
+	change.EvidenceResourceID = ""
+	change.Severity = ""
+	change.BaseStatus = ""
+	change.HeadStatus = ""
+
+	details = findingDetails(change)
+	assert.Contains(t, details, "Severity: unknown")
+	assert.Contains(t, details, "Base status: unknown")
+	assert.Contains(t, details, "Head status: unknown")
+	assert.NotContains(t, details, "Rule:")
+	assert.NotContains(t, details, "Evidence:")
+	assert.NotContains(t, details, "Evidence resource:")
+}
+
+func TestFindingTitle_HandlesUnnamedControls(t *testing.T) {
+	change := ControlChange{ControlID: "C-EMPTY"}
+
+	assert.Equal(t, "New Kubescape failure: C-EMPTY", findingTitle("new", change))
+	assert.Equal(t, "Incomparable Kubescape failure: C-EMPTY", findingTitle("incomparable", change))
+}
+
+func TestEvidenceLabel(t *testing.T) {
+	assert.Equal(t, "rule=rule-a type=failedPath path=spec.containers[0].image", evidenceLabel(ControlChange{
+		RuleName:     "rule-a",
+		EvidenceType: evidenceTypeFailedPath,
+		Path:         "spec.containers[0].image",
+	}))
+	assert.Equal(t, "rule=rule-a", evidenceLabel(ControlChange{
+		RuleName:     "rule-a",
+		EvidenceType: evidenceTypeControl,
+	}))
+	assert.Empty(t, evidenceLabel(ControlChange{}))
+}
+
+func TestStableFindingID_IsDeterministicAndSensitiveToFindingIdentity(t *testing.T) {
+	change := ciChange("C-HIGH", "resource", "High")
+
+	first := stableFindingID("new", change)
+	second := stableFindingID("new", change)
+
+	assert.Equal(t, first, second)
+	assert.True(t, strings.HasPrefix(first, "kubescape-diff-"))
+	assert.Len(t, first, len("kubescape-diff-")+32)
+
+	changed := change
+	changed.Path = "other-path"
+	assert.NotEqual(t, first, stableFindingID("new", changed))
+	assert.NotEqual(t, first, stableFindingID("incomparable", change))
+}
+
+func TestSeverityMappings(t *testing.T) {
+	tests := []struct {
+		severity        string
+		wantSARIFLevel  string
+		wantSARIFScore  string
+		wantGitLabLevel string
+	}{
+		{"Critical", "error", "9.0", "Critical"},
+		{"High", "error", "7.0", "High"},
+		{"Medium", "warning", "4.0", "Medium"},
+		{"Low", "note", "1.0", "Low"},
+		{"Negligible", "note", "0.0", "Info"},
+		{"Unknown", "note", "0.0", "Unknown"},
+		{"", "note", "0.0", "Unknown"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.severity, func(t *testing.T) {
+			assert.Equal(t, test.wantSARIFLevel, sarifLevel(test.severity))
+			assert.Equal(t, test.wantSARIFScore, sarifSecuritySeverity(test.severity))
+			assert.Equal(t, test.wantGitLabLevel, gitLabSeverity(test.severity))
+		})
+	}
+}
+
+func TestControlDocsURL(t *testing.T) {
+	assert.Equal(t, "https://hub.armosec.io/docs/C-0001", controlDocsURL(" C-0001 "))
+	assert.Equal(t, diffToolURI, controlDocsURL(" "))
+}
+
+func TestEncodeJSON_PropagatesWriterError(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	err := encodeJSON(failingWriter{err: errBoom}, map[string]string{"hello": "world"})
+
+	require.ErrorIs(t, err, errBoom)
+}
+
+func controlIDs(changes []ControlChange) []string {
+	ids := make([]string, 0, len(changes))
+	for _, change := range changes {
+		ids = append(ids, change.ControlID)
+	}
+	return ids
+}
+
+func findingKinds(findings []ciFinding) []string {
+	kinds := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		kinds = append(kinds, finding.Kind)
+	}
+	return kinds
+}
+
+func findingControlIDs(findings []ciFinding) []string {
+	ids := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		ids = append(ids, finding.Change.ControlID)
+	}
+	return ids
+}
+
+func sarifRuleIDs(rules []diffSARIFRule) []string {
+	ids := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		ids = append(ids, rule.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func decodeJUnit(t *testing.T, raw []byte) diffJUnitSuites {
+	t.Helper()
+	raw = bytes.TrimPrefix(raw, []byte(xml.Header))
+	var suites diffJUnitSuites
+	require.NoError(t, xml.Unmarshal(raw, &suites))
+	return suites
+}


### PR DESCRIPTION
## Summary

- add CI-focused kubescape diff serializers for SARIF, JUnit XML, GitLab SAST JSON, and markdown
- wire the new formats into kubescape diff --format and output extension handling
- include regression coverage for severity filtering, stable ordering, fingerprints, escaping, and edge cases

Closes #3487.

## Testing

- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SARIF, JUnit, GitLab SAST, and Markdown formats to diff output.
  * Added severity filtering for CI-compatible reports.
  * Added structured regression summaries with findings, warnings, evidence, metadata, and remediation details.
  * Improved output filenames by preserving or adding the appropriate format extension.
* **Documentation**
  * Updated diff format help and field documentation to list all supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->