### PR TITLE
fix(hostsensor): enforce bounded decompression read in cache to prevent OOM (CWE-400)

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcache.go
+++ b/core/pkg/hostsensorutils/hostsensorcache.go
@@ -25,6 +25,10 @@ import (
 // sensor data is live node state that a scan is expected to reflect.
 const HostSensorCacheTtlEnvVar = "HOSTSENSOR_CACHE_TTL"
 
+// maxHostSensorCachePayloadBytes bounds decompressed cache reads to prevent
+// memory exhaustion / decompression bombs from corrupted or oversized cache files.
+const maxHostSensorCachePayloadBytes = 50 * 1024 * 1024 // 50 MB
+
 var DefaultCacheDir string
 
 func init() {
@@ -111,7 +115,7 @@ func loadFromCache(clusterName, resourceName string) ([]hostsensor.HostSensorDat
 	}
 	defer gr.Close()
 
-	data, err := io.ReadAll(gr)
+	data, err := io.ReadAll(io.LimitReader(gr, maxHostSensorCachePayloadBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/core/pkg/hostsensorutils/hostsensorcache_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcache_test.go
@@ -221,3 +221,34 @@ func TestLoadFromCache_UnresolvedClusterIdentityIsRejected(t *testing.T) {
 	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
+
+// TestLoadFromCache_BoundedDecompressionRead guards against decompression bombs
+// or corrupted oversized cache files triggering unbounded memory allocation.
+func TestLoadFromCache_BoundedDecompressionRead(t *testing.T) {
+	withTempCacheDir(t)
+	t.Setenv(HostSensorCacheTtlEnvVar, "1h")
+	withK8sHost(t, "https://cluster-a.example.com")
+
+	path, err := getCacheFilePath("kubernetes-admin@kubernetes", "KubeletInfo")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write([]byte(`[{"name":"test"},`))
+	require.NoError(t, err)
+
+	paddingChunk := bytes.Repeat([]byte(" "), 1024*1024)
+	for range maxHostSensorCachePayloadBytes/(1024*1024) + 1 {
+		_, err = gw.Write(paddingChunk)
+		require.NoError(t, err)
+	}
+
+	_, err = gw.Write([]byte(`{"name":"end"}]`))
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0600))
+
+	_, err = loadFromCache("kubernetes-admin@kubernetes", "KubeletInfo")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Description

Fixes #3489

In `core/pkg/hostsensorutils/hostsensorcache.go`, `loadFromCache()` previously decompressed `.json.gz` cached host sensor envelopes using `io.ReadAll(gr)` without an upper bound on memory allocation.

This PR wraps the decompression reader with `io.LimitReader(gr, maxHostSensorCachePayloadBytes)` (capped at 50 MB) to prevent uncontrolled memory allocation or Out-Of-Memory (OOM) crashes from corrupted/oversized cache files or decompression bombs (CWE-400).

## Changes Made
- Added `maxHostSensorCachePayloadBytes = 50 * 1024 * 1024` constant (50 MB) in `core/pkg/hostsensorutils/hostsensorcache.go`.
- Wrapped `gzip.NewReader` with `io.LimitReader` in `loadFromCache()`.
- Added unit test `TestLoadFromCache_BoundedDecompressionRead` in `core/pkg/hostsensorutils/hostsensorcache_test.go`.

## How Has This Been Tested?
- Ran `go test -v ./core/pkg/hostsensorutils/...` — all unit tests passed.
- Ran `make build` — binary compiled successfully.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have signed off my commits (DCO).
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host sensor cache handling by limiting decompressed data to 50 MB.
  * Prevented oversized or malicious compressed cache files from consuming excessive memory.
  * Added validation to ensure oversized cache data returns an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->