### PR TITLE
fix(printer): centralize output path resolution

### DIFF
--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -72,6 +72,41 @@ func HasOutputExt(outputFile, ext string) bool {
 	return strings.EqualFold(outputFile[len(outputFile)-len(ext):], ext)
 }
 
+// ResolveOutputFile applies Kubescape's shared output-path rules for a format:
+// blank or whitespace-only explicit paths use defaultBaseName, missing
+// extensions are appended from FormatOutputExt, and YAML accepts either .yaml
+// or .yml. The returned bool tells callers whether the user explicitly asked
+// for an output path before trimming, so whitespace-only paths still take the
+// explicit-output error path instead of silently falling back to stdout.
+func ResolveOutputFile(format, outputFile, defaultBaseName string) (string, bool) {
+	explicitOutput := outputFile != ""
+	if !explicitOutput {
+		return outputFile, false
+	}
+
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile == "" {
+		outputFile = defaultBaseName
+	}
+
+	ext, ok := FormatOutputExt[format]
+	if !ok || ext == "" {
+		return outputFile, true
+	}
+	if ext == YamlOutputExt && HasOutputExt(outputFile, ".yml") {
+		return outputFile, true
+	}
+	if HasOutputExt(outputFile, ext) {
+		return outputFile, true
+	}
+	return outputFile + ext, true
+}
+
+func ResolveDefaultOutputFile(format, defaultBaseName string) string {
+	outputFile, _ := ResolveOutputFile(format, " ", defaultBaseName)
+	return outputFile
+}
+
 // FormatOutputExt maps a format to the extension its printer enforces in
 // SetWriter. Callers resolving an --output path must read it from here rather
 // than re-deriving it, so a format can never resolve to a path its printer

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -236,3 +236,102 @@ func TestHasOutputExt(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveOutputFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		format       string
+		outputFile   string
+		defaultBase  string
+		wantFile     string
+		wantExplicit bool
+	}{
+		{
+			name:         "empty output remains implicit",
+			format:       JsonFormat,
+			outputFile:   "",
+			defaultBase:  "report",
+			wantFile:     "",
+			wantExplicit: false,
+		},
+		{
+			name:         "whitespace explicit output uses default base",
+			format:       JsonFormat,
+			outputFile:   "   ",
+			defaultBase:  "report",
+			wantFile:     "report.json",
+			wantExplicit: true,
+		},
+		{
+			name:         "trims explicit output before appending extension",
+			format:       JsonFormat,
+			outputFile:   "  reports/scan  ",
+			defaultBase:  "report",
+			wantFile:     filepath.Join("reports", "scan.json"),
+			wantExplicit: true,
+		},
+		{
+			name:         "keeps existing extension case-insensitively",
+			format:       JsonFormat,
+			outputFile:   "Report.JSON",
+			defaultBase:  "report",
+			wantFile:     "Report.JSON",
+			wantExplicit: true,
+		},
+		{
+			name:         "keeps yaml extension",
+			format:       YamlFormat,
+			outputFile:   "report.yaml",
+			defaultBase:  "report",
+			wantFile:     "report.yaml",
+			wantExplicit: true,
+		},
+		{
+			name:         "keeps yml extension",
+			format:       YamlFormat,
+			outputFile:   "report.yml",
+			defaultBase:  "report",
+			wantFile:     "report.yml",
+			wantExplicit: true,
+		},
+		{
+			name:         "appends compound cyclonedx extension",
+			format:       CycloneDXFormat,
+			outputFile:   "sbom",
+			defaultBase:  "report",
+			wantFile:     "sbom.cdx.json",
+			wantExplicit: true,
+		},
+		{
+			name:         "keeps compound spdx extension case-insensitively",
+			format:       SPDXFormat,
+			outputFile:   "Report.SPDX.JSON",
+			defaultBase:  "report",
+			wantFile:     "Report.SPDX.JSON",
+			wantExplicit: true,
+		},
+		{
+			name:         "unknown format only trims and marks explicit",
+			format:       "custom",
+			outputFile:   "  report.custom  ",
+			defaultBase:  "report",
+			wantFile:     "report.custom",
+			wantExplicit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFile, gotExplicit := ResolveOutputFile(tt.format, tt.outputFile, tt.defaultBase)
+			assert.Equal(t, tt.wantFile, gotFile)
+			assert.Equal(t, tt.wantExplicit, gotExplicit)
+		})
+	}
+}
+
+func TestResolveDefaultOutputFile(t *testing.T) {
+	assert.Equal(t, "report.html", ResolveDefaultOutputFile(HtmlFormat, "report"))
+	assert.Equal(t, "report.pdf", ResolveDefaultOutputFile(PdfFormat, "report"))
+	assert.Equal(t, "report.md", ResolveDefaultOutputFile(MarkdownFormat, "report"))
+	assert.Equal(t, "report.yaml", ResolveDefaultOutputFile(PolicyReportFormat, "report"))
+}

--- a/core/pkg/resultshandling/printer/v1/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v1/jsonprinter.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
@@ -14,7 +12,6 @@ import (
 
 const (
 	jsonOutputFile = "report"
-	jsonOutputExt  = ".json"
 )
 
 var _ printer.IPrinter = &JsonPrinter{}
@@ -28,15 +25,7 @@ func NewJsonPrinter() *JsonPrinter {
 }
 
 func (jsonPrinter *JsonPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = jsonOutputFile
-		}
-		if filepath.Ext(strings.TrimSpace(outputFile)) != jsonOutputExt {
-			outputFile = outputFile + jsonOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.JsonFormat, outputFile, jsonOutputFile)
 	if explicitOutput {
 		var err error
 		jsonPrinter.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v1/printer_extra_test.go
+++ b/core/pkg/resultshandling/printer/v1/printer_extra_test.go
@@ -28,13 +28,19 @@ func TestJsonPrinterSetWriter(t *testing.T) {
 		},
 		{
 			name:       "blank output uses default report name",
-			outputFile: filepath.Join(t.TempDir(), "   "),
-			wantSuffix: "   .json",
+			outputFile: "   ",
+			wantSuffix: "report.json",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+			originalDir, err := os.Getwd()
+			assert.NoError(t, err)
+			assert.NoError(t, os.Chdir(workingDir))
+			t.Cleanup(func() { assert.NoError(t, os.Chdir(originalDir)) })
+
 			p := NewJsonPrinter()
 			p.SetWriter(context.Background(), tt.outputFile)
 			defer p.writer.Close()

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -31,15 +31,7 @@ func NewCsvPrinter() *CsvPrinter {
 }
 
 func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = csvOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.CsvOutputExt) {
-			outputFile = outputFile + printer.CsvOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.CsvFormat, outputFile, csvOutputFile)
 	if explicitOutput {
 		var err error
 		cp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
@@ -30,15 +29,7 @@ func NewCycloneDXPrinter() *CycloneDXPrinter {
 }
 
 func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = cyclonedxOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.CycloneDXOutputExt) {
-			outputFile = outputFile + printer.CycloneDXOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.CycloneDXFormat, outputFile, cyclonedxOutputFile)
 	if explicitOutput {
 		var err error
 		cp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -132,15 +132,7 @@ func (gp *GitLabSASTPrinter) Score(score float32) {
 
 // SetWriter opens outputFile for writing, defaulting the name and forcing a .json extension
 func (gp *GitLabSASTPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = gitLabSASTOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JsonOutputExt) {
-			outputFile = outputFile + printer.JsonOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.GitLabSASTFormat, outputFile, gitLabSASTOutputFile)
 	if explicitOutput {
 		var err error
 		gp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -69,15 +69,12 @@ func NewHtmlPrinter() *HtmlPrinter {
 }
 
 func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	outputFile = strings.TrimSpace(outputFile)
-	if outputFile == "" {
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.HtmlFormat, outputFile, htmlOutputFile)
+	if !explicitOutput {
 		// Raw HTML markup must never fall back to stdout on a TTY.
-		outputFile = htmlOutputFile + printer.HtmlOutputExt
+		outputFile = printer.ResolveDefaultOutputFile(printer.HtmlFormat, htmlOutputFile)
 		logger.L().Info("no --output specified for html format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if !printer.HasOutputExt(outputFile, printer.HtmlOutputExt) {
-		outputFile = outputFile + printer.HtmlOutputExt
 	}
 	if explicitOutput {
 		var err error

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/anchore/clio"
 	grypejson "github.com/anchore/grype/grype/presenter/json"
@@ -33,15 +32,7 @@ func NewJsonPrinter() *JsonPrinter {
 }
 
 func (jp *JsonPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = jsonOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JsonOutputExt) {
-			outputFile = outputFile + printer.JsonOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.JsonFormat, outputFile, jsonOutputFile)
 	if explicitOutput {
 		var err error
 		jp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -99,15 +99,7 @@ func NewJunitPrinter(verbose bool) *JunitPrinter {
 }
 
 func (jp *JunitPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = junitOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.JunitOutputExt) {
-			outputFile = outputFile + printer.JunitOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.JunitResultFormat, outputFile, junitOutputFile)
 	if explicitOutput {
 		var err error
 		jp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -32,14 +32,11 @@ func NewMarkdownPrinter() *MarkdownPrinter {
 }
 
 func (mp *MarkdownPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	outputFile = strings.TrimSpace(outputFile)
-	if outputFile == "" {
-		outputFile = markdownOutputFile + printer.MarkdownOutputExt
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.MarkdownFormat, outputFile, markdownOutputFile)
+	if !explicitOutput {
+		outputFile = printer.ResolveDefaultOutputFile(printer.MarkdownFormat, markdownOutputFile)
 		logger.L().Info("no --output specified for markdown format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if !printer.HasOutputExt(outputFile, printer.MarkdownOutputExt) {
-		outputFile = outputFile + printer.MarkdownOutputExt
 	}
 	if explicitOutput {
 		var err error

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -35,16 +35,13 @@ func NewPdfPrinter() *PdfPrinter {
 }
 
 func (pp *PdfPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	outputFile = strings.TrimSpace(outputFile)
-	if outputFile == "" {
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.PdfFormat, outputFile, pdfOutputFile)
+	if !explicitOutput {
 		// Binary PDF must never fall back to stdout: it corrupts TTYs and
 		// is rarely what the user intended. Default to ./report.pdf.
-		outputFile = pdfOutputFile + printer.PdfOutputExt
+		outputFile = printer.ResolveDefaultOutputFile(printer.PdfFormat, pdfOutputFile)
 		logger.L().Info("no --output specified for pdf format; writing to default file",
 			helpers.String("filename", outputFile))
-	} else if !printer.HasOutputExt(outputFile, printer.PdfOutputExt) {
-		outputFile = outputFile + printer.PdfOutputExt
 	}
 	if explicitOutput {
 		var err error

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"
@@ -92,13 +91,8 @@ func NewPolicyReportPrinter() *PolicyReportPrinter {
 }
 
 func (pp *PolicyReportPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = policyReportOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.YamlOutputExt) && !printer.HasOutputExt(strings.TrimSpace(outputFile), ".yml") {
-			outputFile = outputFile + printer.YamlOutputExt
-		}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.PolicyReportFormat, outputFile, policyReportOutputFile)
+	if explicitOutput {
 		var err error
 		pp.writer, err = printer.GetWriterNoFallback(outputFile)
 		return err

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -171,17 +171,12 @@ func (pp *PrettyPrinter) SetWriter(ctx context.Context, outputFile string) error
 		return nil
 	}
 
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		outputFile = strings.TrimSpace(outputFile)
-		if outputFile == "" {
-			outputFile = prettyOutputFile
-		}
-		// os.DevNull is used to silence the UI printer, appending an extension would turn it into a regular file
-		if outputFile != os.DevNull && !printer.HasOutputExt(outputFile, printer.PrettyOutputExt) {
-			outputFile = outputFile + printer.PrettyOutputExt
-		}
+	if outputFile == os.DevNull {
+		pp.writer = printer.GetWriter(ctx, outputFile)
+		pp.SetMainPrinter()
+		return nil
 	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.PrettyFormat, outputFile, prettyOutputFile)
 
 	if explicitOutput {
 		writer, err := printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/prometheus.go
+++ b/core/pkg/resultshandling/printer/v2/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -37,16 +36,7 @@ func (pp *PrometheusPrinter) PrintNextSteps() {
 }
 
 func (pp *PrometheusPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		outputFile = strings.TrimSpace(outputFile)
-		if outputFile == "" {
-			outputFile = prometheusOutputFile
-		}
-		if !printer.HasOutputExt(outputFile, printer.PrometheusOutputExt) {
-			outputFile = outputFile + printer.PrometheusOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.PrometheusFormat, outputFile, prometheusOutputFile)
 	if explicitOutput {
 		var err error
 		pp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -80,15 +80,7 @@ func (sp *SARIFPrinter) Score(score float32) {
 }
 
 func (sp *SARIFPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = sarifOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.SARIFOutputExt) {
-			outputFile = outputFile + printer.SARIFOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.SARIFFormat, outputFile, sarifOutputFile)
 	if explicitOutput {
 		var err error
 		sp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/setwriter_test.go
+++ b/core/pkg/resultshandling/printer/v2/setwriter_test.go
@@ -1,0 +1,222 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	baseprinter "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type writerCase struct {
+	name        string
+	format      string
+	baseName    string
+	newPrinter  func() setWriterPrinter
+	writerName  func(setWriterPrinter) string
+	closeWriter func(setWriterPrinter) error
+}
+
+type setWriterPrinter interface {
+	SetWriter(context.Context, string) error
+}
+
+func TestSetWriterUsesSharedOutputResolution(t *testing.T) {
+	cases := []writerCase{
+		{
+			name:       "json",
+			format:     baseprinter.JsonFormat,
+			baseName:   jsonOutputFile,
+			newPrinter: func() setWriterPrinter { return NewJsonPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*JsonPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*JsonPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "yaml",
+			format:     baseprinter.YamlFormat,
+			baseName:   yamlOutputFile,
+			newPrinter: func() setWriterPrinter { return NewYamlPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*YamlPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*YamlPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "csv",
+			format:     baseprinter.CsvFormat,
+			baseName:   csvOutputFile,
+			newPrinter: func() setWriterPrinter { return NewCsvPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*CsvPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*CsvPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "junit",
+			format:     baseprinter.JunitResultFormat,
+			baseName:   junitOutputFile,
+			newPrinter: func() setWriterPrinter { return NewJunitPrinter(false) },
+			writerName: func(p setWriterPrinter) string { return p.(*JunitPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*JunitPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "prometheus",
+			format:     baseprinter.PrometheusFormat,
+			baseName:   prometheusOutputFile,
+			newPrinter: func() setWriterPrinter { return NewPrometheusPrinter(false) },
+			writerName: func(p setWriterPrinter) string { return p.(*PrometheusPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*PrometheusPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "sarif",
+			format:     baseprinter.SARIFFormat,
+			baseName:   sarifOutputFile,
+			newPrinter: func() setWriterPrinter { return NewSARIFPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*SARIFPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*SARIFPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "gitlab-sast",
+			format:     baseprinter.GitLabSASTFormat,
+			baseName:   gitLabSASTOutputFile,
+			newPrinter: func() setWriterPrinter { return NewGitLabSASTPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*GitLabSASTPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*GitLabSASTPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "cyclonedx",
+			format:     baseprinter.CycloneDXFormat,
+			baseName:   cyclonedxOutputFile,
+			newPrinter: func() setWriterPrinter { return NewCycloneDXPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*CycloneDXPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*CycloneDXPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "spdx",
+			format:     baseprinter.SPDXFormat,
+			baseName:   spdxOutputFile,
+			newPrinter: func() setWriterPrinter { return NewSPDXPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*SPDXPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*SPDXPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "pretty",
+			format:     baseprinter.PrettyFormat,
+			baseName:   prettyOutputFile,
+			newPrinter: func() setWriterPrinter { return &PrettyPrinter{} },
+			writerName: func(p setWriterPrinter) string { return p.(*PrettyPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*PrettyPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "html",
+			format:     baseprinter.HtmlFormat,
+			baseName:   htmlOutputFile,
+			newPrinter: func() setWriterPrinter { return NewHtmlPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*HtmlPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*HtmlPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "pdf",
+			format:     baseprinter.PdfFormat,
+			baseName:   pdfOutputFile,
+			newPrinter: func() setWriterPrinter { return NewPdfPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*PdfPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*PdfPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "markdown",
+			format:     baseprinter.MarkdownFormat,
+			baseName:   markdownOutputFile,
+			newPrinter: func() setWriterPrinter { return NewMarkdownPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*MarkdownPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*MarkdownPrinter).CloseWriter()
+			},
+		},
+		{
+			name:       "policyreport",
+			format:     baseprinter.PolicyReportFormat,
+			baseName:   policyReportOutputFile,
+			newPrinter: func() setWriterPrinter { return NewPolicyReportPrinter() },
+			writerName: func(p setWriterPrinter) string { return p.(*PolicyReportPrinter).writer.Name() },
+			closeWriter: func(p setWriterPrinter) error {
+				return p.(*PolicyReportPrinter).CloseWriter()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/trims explicit output", func(t *testing.T) {
+			dir := t.TempDir()
+			base := filepath.Join(dir, "scan")
+			want, explicit := baseprinter.ResolveOutputFile(tc.format, "  "+base+"  ", tc.baseName)
+			require.True(t, explicit)
+
+			p := tc.newPrinter()
+			require.NoError(t, p.SetWriter(context.Background(), "  "+base+"  "))
+			t.Cleanup(func() { assert.NoError(t, tc.closeWriter(p)) })
+
+			assert.Equal(t, want, tc.writerName(p))
+			assert.NotContains(t, filepath.Base(tc.writerName(p)), " ")
+		})
+
+		t.Run(tc.name+"/whitespace explicit output uses default report name", func(t *testing.T) {
+			workingDir := t.TempDir()
+			originalDir, err := os.Getwd()
+			require.NoError(t, err)
+			require.NoError(t, os.Chdir(workingDir))
+			t.Cleanup(func() { require.NoError(t, os.Chdir(originalDir)) })
+
+			want, explicit := baseprinter.ResolveOutputFile(tc.format, "   ", tc.baseName)
+			require.True(t, explicit)
+
+			p := tc.newPrinter()
+			require.NoError(t, p.SetWriter(context.Background(), "   "))
+			t.Cleanup(func() { assert.NoError(t, tc.closeWriter(p)) })
+
+			assert.Equal(t, want, filepath.Base(tc.writerName(p)))
+			assert.FileExists(t, filepath.Join(workingDir, want))
+		})
+
+		t.Run(tc.name+"/keeps existing extension case", func(t *testing.T) {
+			dir := t.TempDir()
+			ext := baseprinter.FormatOutputExt[tc.format]
+			if tc.format == baseprinter.YamlFormat {
+				ext = ".yml"
+			}
+			target := filepath.Join(dir, "Report"+strings.ToUpper(ext))
+			want, explicit := baseprinter.ResolveOutputFile(tc.format, target, tc.baseName)
+			require.True(t, explicit)
+
+			p := tc.newPrinter()
+			require.NoError(t, p.SetWriter(context.Background(), target))
+			t.Cleanup(func() { assert.NoError(t, tc.closeWriter(p)) })
+
+			assert.Equal(t, want, tc.writerName(p))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/spdxjson"
@@ -30,15 +29,7 @@ func NewSPDXPrinter() *SPDXPrinter {
 }
 
 func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = spdxOutputFile
-		}
-		if !printer.HasOutputExt(strings.TrimSpace(outputFile), printer.SPDXOutputExt) {
-			outputFile = outputFile + printer.SPDXOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.SPDXFormat, outputFile, spdxOutputFile)
 	if explicitOutput {
 		var err error
 		sp.writer, err = printer.GetWriterNoFallback(outputFile)

--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/anchore/clio"
 	grypejson "github.com/anchore/grype/grype/presenter/json"
@@ -32,16 +31,7 @@ func NewYamlPrinter() *YamlPrinter {
 }
 
 func (yp *YamlPrinter) SetWriter(ctx context.Context, outputFile string) error {
-	explicitOutput := outputFile != ""
-	if outputFile != "" {
-		if strings.TrimSpace(outputFile) == "" {
-			outputFile = yamlOutputFile
-		}
-		trimmed := strings.TrimSpace(outputFile)
-		if !printer.HasOutputExt(trimmed, printer.YamlOutputExt) && !printer.HasOutputExt(trimmed, ".yml") {
-			outputFile = outputFile + printer.YamlOutputExt
-		}
-	}
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.YamlFormat, outputFile, yamlOutputFile)
 	if explicitOutput {
 		var err error
 		yp.writer, err = printer.GetWriterNoFallback(outputFile)


### PR DESCRIPTION
This pull request refactors how output file paths and extensions are resolved for all result printers. It introduces a new shared function, `ResolveOutputFile`, to centralize and standardize the logic for handling output file names, extensions, and explicit output detection. This change ensures consistent behavior across all printer implementations and simplifies their code.

The most important changes are:

**Core logic improvements:**

* Added `ResolveOutputFile` and `ResolveDefaultOutputFile` functions to `printresults.go`, encapsulating the rules for output file naming, extension handling, and explicit output detection. This includes proper handling for whitespace-only paths and format-specific extensions (e.g., `.yaml`/`.yml` for YAML).
* Added comprehensive unit tests for the new output file resolution logic in `printresults_test.go`, covering edge cases and all supported formats.

**Printer refactoring:**

* Refactored all printer `SetWriter` methods (e.g., JSON, CSV, CycloneDX, GitLab SAST, HTML, Markdown, PDF, PolicyReport, Pretty, Prometheus, SARIF) to use the new `ResolveOutputFile` function, removing duplicated logic and unnecessary imports. [[1]](diffhunk://#diff-47692b9e4911cdcf63cf87f6a141b54741756d028d7710d21776fe68d708a48cL31-R28) [[2]](diffhunk://#diff-7aa03b5b4d186747f9da92729158bc72d8084587a4aeacab67c7dac8702b1cd0L34-R34) [[3]](diffhunk://#diff-d7cda42ed072b5c2e9d919a2cf659ce0c18b7e4f60939d255fd51cabcf32ec35L33-R32) [[4]](diffhunk://#diff-889f4983e3412ca2a2efccb68ebcd91484f0e42233a6332379545b19afa44aa8L135-R135) [[5]](diffhunk://#diff-30dd328437a9324079d01df95c546f57ceafd1660e6d5e6c217f44ce53fc97edL72-L80) [[6]](diffhunk://#diff-ea71e1f7d9d9c734c4ab5f42b2d98a8d59dea2f730e3ff48fc9917dbdbc3bc66L35-L42) [[7]](diffhunk://#diff-77d9c43dfa8393d7a948d622cb625a08e25d820c4239bd4ac7f83cbac8c81ee4L38-L47) [[8]](diffhunk://#diff-e38e410a1609a992b15814f6fb5ea4644156dc904b28c1b34884cb889c922455L95-R95) [[9]](diffhunk://#diff-0071125e193bc38c2b564e557247c498ba7e84973142d0798dcb46cfab43a1f3L174-R179) [[10]](diffhunk://#diff-723be9c385bfbdf9442c6b94801f0e67fa18ce55513adb0d6b47701859cb45c6L40-R39) [[11]](diffhunk://#diff-6815eb444334e6245b19823c7d91a6a35ae8c0ed742172792cee0aac6dfa145dL83-R83)
* Cleaned up imports in affected printer files, removing unused packages like `strings` and `filepath`. [[1]](diffhunk://#diff-47692b9e4911cdcf63cf87f6a141b54741756d028d7710d21776fe68d708a48cL8-L17) [[2]](diffhunk://#diff-d7cda42ed072b5c2e9d919a2cf659ce0c18b7e4f60939d255fd51cabcf32ec35L8) [[3]](diffhunk://#diff-6c52364e93973c10e45bf3a765f082f55e92004a744438374dd212f188c4ff8aL8) [[4]](diffhunk://#diff-e38e410a1609a992b15814f6fb5ea4644156dc904b28c1b34884cb889c922455L8) [[5]](diffhunk://#diff-723be9c385bfbdf9442c6b94801f0e67fa18ce55513adb0d6b47701859cb45c6L7)

**Test updates:**

* Updated existing printer tests to match the new logic, ensuring correct output file naming and extension behavior, especially for whitespace and default cases.

These changes make the codebase more maintainable, reduce duplication, and ensure consistent output file handling across all result formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized output filename handling across supported report formats.
  * Trimmed whitespace from explicit paths and applied appropriate default filenames for blank paths.
  * Preserved valid extensions, including `.yml` for YAML, while adding missing format extensions.
  * Improved handling of explicit output paths, fallback writers, and special output targets.

* **Tests**
  * Added comprehensive coverage for output resolution, default filenames, path normalization, extensions, and file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->