### PR TITLE
fix(printer): unify output path resolution across all printers

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"

--- a/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -25,6 +27,35 @@ func TestSetWriter_Yaml(t *testing.T) {
 	yp.SetWriter(context.TODO(), "")
 	assert.NotNil(t, yp.writer)
 	yp.CloseWriter()
+
+	tests := []struct {
+		name       string
+		outputFile string
+		wantFile   string
+	}{
+		{"bare name", "scan-result", "scan-result.yaml"},
+		{"whitespace padded", "  scan-result  ", "scan-result.yaml"},
+		{"whitespace only", "   ", "report.yaml"},
+		{"preserve .yaml", "scan-result.yaml", "scan-result.yaml"},
+		{"preserve .yml", "scan-result.yml", "scan-result.yml"},
+		{"preserve .YML", "scan-result.YML", "scan-result.YML"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := t.TempDir()
+			originalDir, err := os.Getwd()
+			require.NoError(t, err)
+			require.NoError(t, os.Chdir(workingDir))
+			t.Cleanup(func() { require.NoError(t, os.Chdir(originalDir)) })
+
+			p := NewYamlPrinter()
+			require.NoError(t, p.SetWriter(context.Background(), tt.outputFile))
+			defer p.CloseWriter()
+			assert.Equal(t, tt.wantFile, filepath.Base(p.writer.Name()))
+			assert.FileExists(t, filepath.Join(workingDir, tt.wantFile))
+		})
+	}
 }
 
 func TestScore_Yaml(t *testing.T) {


### PR DESCRIPTION
## Description

Resolves #3491

Kubescape printers previously resolved output file paths independently. Most v2 printers and the v1 JSON printer each trimmed, defaulted, and appended extensions in their own `SetWriter` implementation, leading to inconsistent behavior for explicit output values (especially whitespace-padded paths and alternate YAML suffixes).

### Changes
- Implemented centralized `printer.ResolveOutputPath(format, outputFile)` in `printer` package:
  - Trims leading and trailing whitespace from explicit output paths.
  - Defaults whitespace-only inputs (`"   "`) to the format's default report name (e.g. `report.json`, `report.yaml`).
  - Maps format extensions via central `FormatOutputExt` table.
  - Supports `.yml` extension case-insensitively for YAML formats (`yaml`, `policyreport`).
  - Preserves special destinations such as `os.DevNull`.
- Updated all v1 and v2 printer `SetWriter` implementations to use `printer.ResolveOutputPath`.
- Preserved existing non-stdout fallback behavior for implicit PDF, HTML, and Markdown outputs.
- Synchronized collision detection in `core/scan.go` and `core/diff.go`.
- Added comprehensive regression tests across all formats in `printresults_test.go` and `yamlprinter_test.go`.

### Checklist
- [x] Code passes all unit tests (`go test ./...`)
- [x] Code compiles cleanly (`go build ./...`)
- [x] Signed-off commits (DCO compliant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - PolicyReport names and cluster labels are now sanitized to meet Kubernetes naming and length requirements.
  - Report names consistently use lowercase formatting.
  - Cluster-scoped report names retain their original formatting where applicable.

- **Improvements**
  - YAML output filenames now handle whitespace, default names, and `.yaml`/`.yml` extensions consistently.
  - Existing uppercase `.YML` extensions are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->