### PR TITLE
fix(cel): refuse a control whose paramKind the scan has no binding to resolve

### DIFF
--- a/core/pkg/opaprocessor/cel/dispatch_test.go
+++ b/core/pkg/opaprocessor/cel/dispatch_test.go
@@ -171,3 +171,27 @@ func TestEvaluateControlResolvesParamsEndToEnd(t *testing.T) {
 		}
 	})
 }
+
+// TestEvaluateControlRefusesUnresolvableParams pins the outcome for a control
+// taking params the scan cannot resolve (C-0281 reads an ate.dev WorkerPool).
+// Before the refusal the ControlConfiguration was bound instead, and the
+// params.spec read errored under failurePolicy Fail, so every matching
+// ActorTemplate was reported as violating a policy admission never denied.
+// An error here is the scanner's skip path, which is the honest answer.
+func TestEvaluateControlRefusesUnresolvableParams(t *testing.T) {
+	e, err := NewEvaluator()
+	require.NoError(t, err)
+
+	actorTemplate := map[string]any{
+		"apiVersion": "ate.dev/v1alpha1",
+		"kind":       "ActorTemplate",
+		"metadata":   map[string]any{"name": "agent", "namespace": "default"},
+		"spec":       map[string]any{"egress": "marginal"},
+	}
+
+	eval, err := e.EvaluateControl(context.Background(), "C-0281", actorTemplate, nil)
+	require.Error(t, err, "a control whose params cannot be resolved must be refused, not evaluated")
+	assert.Contains(t, err.Error(), "C-0281")
+	assert.Contains(t, err.Error(), "WorkerPool")
+	assert.Empty(t, eval.Results, "a refused control reports no verdict")
+}

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -98,6 +98,13 @@ func (v *VAP) failOnError() bool {
 // GUARANTEED to exist; the seam for honoring it is guaranteeing Namespace
 // collection whenever a loaded policy needs it.
 //
+// A paramKind is refused for the same reason. Live, a binding's ParamRef points
+// the policy at real objects of that kind, so a policy taking anything other
+// than the ControlConfiguration the bundle ships has no offline params at all.
+// Evaluating it anyway reads params.* off the wrong object, and every such read
+// is a verdict admission never made. The seam for honoring one is resolving a
+// ParamRef against objects the scan collected.
+//
 // The other matchConstraints narrowings do not need refusing, because their
 // inputs are on the scanned object itself and appliesTo evaluates them:
 // objectSelector (the object's own labels) and a resource rule's operations
@@ -105,6 +112,15 @@ func (v *VAP) failOnError() bool {
 func (v *VAP) requireSupported() error {
 	if v.matchConstraints != nil && selectorNarrows(v.matchConstraints.NamespaceSelector) {
 		return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, whose input (namespace labels) the scan cannot guarantee to have; refusing it to preserve scan/admission parity", v.ControlID)
+	}
+	if v.paramKind != nil {
+		shipped, err := controlConfigParamKind()
+		if err != nil {
+			return err
+		}
+		if *v.paramKind != *shipped {
+			return fmt.Errorf("control %q takes params of kind %s %s, which the scan has no binding to resolve (only the bundled %s %s is available); refusing it to preserve scan/admission parity", v.ControlID, v.paramKind.APIVersion, v.paramKind.Kind, shipped.APIVersion, shipped.Kind)
+		}
 	}
 	return nil
 }

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -306,6 +306,11 @@ func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 // Otherwise the whole ControlConfiguration is returned so expressions can reach
 // params.settings.<field>, exactly what a live ParamRef would supply.
 //
+// A paramKind the shipped file does not answer is an error rather than the
+// config: binding the wrong object would answer the policy's params.* reads
+// with another kind's fields. loadVAP refuses such a policy before we get here
+// (see requireSupported), so this is the invariant kept where params are bound.
+//
 // The returned map is shared across calls (see controlConfig) and is treated as
 // read-only: the evaluator only binds it into a CEL activation, which never
 // mutates it.
@@ -313,11 +318,30 @@ func resolveParams(vap *VAP) (any, error) {
 	if vap.paramKind == nil {
 		return nil, nil
 	}
-	params, err := controlConfig()
+	shipped, err := controlConfigParamKind()
 	if err != nil {
 		return nil, err
 	}
-	return params, nil
+	if *vap.paramKind != *shipped {
+		return nil, fmt.Errorf("control %q takes params of kind %s %s, which the bundled %s %s cannot supply", vap.ControlID, vap.paramKind.APIVersion, vap.paramKind.Kind, shipped.APIVersion, shipped.Kind)
+	}
+	return controlConfig()
+}
+
+// controlConfigParamKind is the paramKind the embedded params file answers,
+// read off the file's own apiVersion and kind so a `make sync-vap` that bumps
+// the ControlConfiguration version carries the check with it.
+func controlConfigParamKind() (*admissionregistrationv1.ParamKind, error) {
+	config, err := controlConfig()
+	if err != nil {
+		return nil, err
+	}
+	apiVersion, _ := config["apiVersion"].(string)
+	kind, _ := config["kind"].(string)
+	if apiVersion == "" || kind == "" {
+		return nil, fmt.Errorf("embedded control configuration %q declares no apiVersion/kind, so no policy's paramKind can be matched against it", controlConfigFile)
+	}
+	return &admissionregistrationv1.ParamKind{APIVersion: apiVersion, Kind: kind}, nil
 }
 
 // controlConfig parses the embedded ControlConfiguration once and caches it. It

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
 // TestLoadVAPParamlessControl loads a known paramless control and checks the
@@ -295,4 +296,123 @@ spec:
 			assert.Contains(t, err.Error(), tc.refusedFor)
 		})
 	}
+}
+
+// TestLoadVAPRefusesForeignParamKind pins the paramKind refusal. Only the
+// ControlConfiguration the bundle ships can be resolved offline; any other kind
+// would come from a binding's ParamRef the scan does not have, so it is refused
+// (a loud skip) rather than evaluated against whatever params.* happens to be
+// bound.
+func TestLoadVAPRefusesForeignParamKind(t *testing.T) {
+	policy := func(paramKindYAML string) string {
+		return `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kubescape-c-1003
+  labels:
+    controlId: C-1003
+spec:
+` + paramKindYAML + `  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  validations:
+  - expression: "false"
+`
+	}
+
+	cases := []struct {
+		name          string
+		paramKindYAML string
+		refused       bool
+	}{
+		{
+			name:          "no paramKind is supported",
+			paramKindYAML: "",
+		},
+		{
+			name: "the bundled ControlConfiguration is supported",
+			paramKindYAML: `  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+`,
+		},
+		{
+			name: "another kind in the bundled group is refused",
+			paramKindYAML: `  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ScanConfiguration
+`,
+			refused: true,
+		},
+		{
+			name: "another version of the bundled kind is refused",
+			paramKindYAML: `  paramKind:
+    apiVersion: kubescape.io/v2
+    kind: ControlConfiguration
+`,
+			refused: true,
+		},
+		{
+			name: "a cluster CRD kind is refused",
+			paramKindYAML: `  paramKind:
+    apiVersion: ate.dev/v1alpha1
+    kind: WorkerPool
+`,
+			refused: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog, err := parseVAPBundle([]byte(policy(tc.paramKindYAML)))
+			require.NoError(t, err)
+			vap := catalog.byControl["C-1003"]
+			require.NotNil(t, vap)
+
+			err = vap.requireSupported()
+			if !tc.refused {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err, "a paramKind the bundle cannot supply must be refused")
+			assert.Contains(t, err.Error(), "C-1003")
+			assert.Contains(t, err.Error(), vap.paramKind.Kind)
+		})
+	}
+}
+
+// TestResolveParamsRefusesForeignParamKind covers the same invariant where the
+// params are actually bound: a foreign paramKind must not silently receive the
+// ControlConfiguration, whose fields belong to another kind entirely.
+func TestResolveParamsRefusesForeignParamKind(t *testing.T) {
+	vap := &VAP{
+		ControlID: "C-1004",
+		paramKind: &admissionregistrationv1.ParamKind{APIVersion: "ate.dev/v1alpha1", Kind: "WorkerPool"},
+	}
+
+	params, err := resolveParams(vap)
+	require.Error(t, err, "resolveParams must not fall back to the ControlConfiguration")
+	assert.Nil(t, params)
+	assert.Contains(t, err.Error(), "WorkerPool")
+}
+
+// TestControlConfigParamKindMatchesShippedFile keeps the check honest against
+// the file it reads: the GVK comes off basic-control-configuration.yaml, so a
+// `make sync-vap` that renames or re-versions it moves the check with it rather
+// than refusing every params-bearing control.
+func TestControlConfigParamKindMatchesShippedFile(t *testing.T) {
+	shipped, err := controlConfigParamKind()
+	require.NoError(t, err)
+
+	config, err := controlConfig()
+	require.NoError(t, err)
+	assert.Equal(t, config["apiVersion"], shipped.APIVersion)
+	assert.Equal(t, config["kind"], shipped.Kind)
+
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+	assert.Equal(t, *shipped, *vap.paramKind, "the bundle's params-bearing controls must still resolve")
 }

--- a/core/pkg/opaprocessor/cel/vapdata_test.go
+++ b/core/pkg/opaprocessor/cel/vapdata_test.go
@@ -147,3 +147,46 @@ func TestBundleParamsSettingsAreShipped(t *testing.T) {
 			"knownMissingSettings lists params.settings.%s but no bundle policy reads it any more; remove the entry", key)
 	}
 }
+
+// knownUnresolvableParamKinds names the bundle policies whose paramKind the
+// offline engine refuses, with what the refusal costs. Offline there is no
+// binding, so only the shipped ControlConfiguration can answer a params.* read.
+var knownUnresolvableParamKinds = map[string]string{
+	"C-0281": "kubescape-c-0281-agent-runtime-hardening reads params.spec.networkAccess off an ate.dev WorkerPool, " +
+		"which a live binding's ParamRef supplies and a scan cannot. The control is skipped on every ActorTemplate " +
+		"until the scan can resolve a ParamRef against collected objects.",
+}
+
+// TestBundleParamKindsAreResolvable asserts every params-bearing policy in the
+// bundle takes the ControlConfiguration the bundle ships, so requireSupported
+// can honor it offline. A sync introducing another paramKind fails here rather
+// than silently turning that control into a skip.
+func TestBundleParamKindsAreResolvable(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	shipped, err := controlConfigParamKind()
+	require.NoError(t, err)
+
+	refused := map[string]bool{}
+	for name, vap := range catalog.byName {
+		if vap.paramKind == nil || *vap.paramKind == *shipped {
+			continue
+		}
+		refused[vap.ControlID] = true
+		reason, known := knownUnresolvableParamKinds[vap.ControlID]
+		assert.Truef(t, known,
+			"policy %s (control %q) takes params of kind %s %s, which the scan has no binding to resolve, so "+
+				"requireSupported refuses it and the control is skipped on every object it matches. Point its "+
+				"paramKind at the shipped %s %s, or add it to knownUnresolvableParamKinds with the consequence spelled out.",
+			name, vap.ControlID, vap.paramKind.APIVersion, vap.paramKind.Kind, shipped.APIVersion, shipped.Kind)
+		if known {
+			t.Logf("known gap: control %s, %s", vap.ControlID, reason)
+		}
+	}
+
+	for id := range knownUnresolvableParamKinds {
+		assert.Containsf(t, refused, id,
+			"knownUnresolvableParamKinds lists control %s but its paramKind now resolves (or it left the bundle); remove the entry", id)
+	}
+}


### PR DESCRIPTION
C-0281 landed in #3466 with a `paramKind` of `ate.dev/v1alpha1 WorkerPool`, and that is the first policy in the bundle whose params are not the `ControlConfiguration` the bundle ships. The offline resolver never checked: `resolveParams` returns the `ControlConfiguration` for any policy that declares a `paramKind` at all, so the WorkerPool read got answered by a completely different object.

The effect is a false violation, not a skip. The validation is

```
!(has(object.spec.egress) && object.spec.egress == 'marginal' && has(params.spec.networkAccess) && params.spec.networkAccess == 'broad')
```

and the shipped `ControlConfiguration` has no `spec`, so `has(params.spec.networkAccess)` errors with `no such key: spec` once an ActorTemplate actually sets `spec.egress: marginal`. `failurePolicy: Fail` turns that into a reported violation. So every ActorTemplate the control exists to look at gets flagged, attributed to a WorkerPool the scan never resolved, while admission with a real binding would have compared against the actual pool and mostly passed it. An ActorTemplate without marginal egress short circuits before the params read and passes, which is right by accident.

Live this policy is fine: a binding's `paramRef` points it at real WorkerPool objects. Offline there is no binding and no cross object lookup, so there is nothing correct to bind. That makes it the same shape as the `namespaceSelector` case already handled here, and it gets the same treatment: `requireSupported` refuses the policy at load, the scanner reports the control as skipped, and no verdict is invented. `resolveParams` refuses too, so the invariant is also held at the point where params get bound.

The GVK to compare against is read off `basic-control-configuration.yaml` itself rather than hardcoded, so a `make sync-vap` that re-versions the ControlConfiguration carries the check along instead of refusing every params bearing control at once.

Binding generation is untouched. The `cmd/vap` catalog helpers deliberately bypass `requireSupported`, so `kubescape vap create-policy-binding` still emits a C-0281 binding and still reports that it needs a `paramRef`, which is correct because on a cluster the policy works.

The detail most likely to regress is the sweep in `TestNoEvalErrorOnMinimalWorkloads`: it treats a load error as an already intentional skip and `continue`s, so it will not notice if a control starts being refused for the wrong reason. `TestBundleParamKindsAreResolvable` is the counterweight, listing C-0281 as a known gap with the cost written out and failing if a sync adds another unresolvable paramKind or if C-0281's becomes resolvable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to reject policies with missing or incompatible parameter kinds.
  - Prevented controls from being evaluated when required parameters cannot be resolved.
  - Added clearer errors identifying the affected control and resource type.

- **Tests**
  - Added coverage for parameter compatibility, unresolved parameters, and known policy exceptions.
  - Verified bundled policies align with their shipped control configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->