### PR TITLE
fix(scan): validate --label-selector in ValidateCommonScanFlags

### DIFF
--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -17,7 +17,6 @@ import (
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -283,11 +282,6 @@ func validateFrameworkScanInfo(scanInfo *cautils.ScanInfo) error {
 		return err
 	}
 
-	if scanInfo.LabelSelector != "" {
-		if _, err := labels.Parse(scanInfo.LabelSelector); err != nil {
-			return fmt.Errorf("invalid --label-selector %q: %w", scanInfo.LabelSelector, err)
-		}
-	}
 
 	// Validate the user's credentials
 	return cautils.ValidateAccountID(scanInfo.AccountID)

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
-	"k8s.io/apimachinery/pkg/labels"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // ScanFormats and ImageScanFormats are derived from printer.AllFormats and
@@ -167,6 +167,10 @@ func ValidateExcludeControls(scanInfo *cautils.ScanInfo) error {
 	for _, control := range scanInfo.ExcludeControls {
 		if strings.TrimSpace(control) == "" {
 			return fmt.Errorf("--exclude-controls contains an empty control identifier")
+		}
+	}
+	return nil
+}
 
 // ValidateExcludePaths fails the command on a malformed pattern before any resource is collected.
 func ValidateExcludePaths(scanInfo *cautils.ScanInfo) error {

--- a/cmd/shared/scan.go
+++ b/cmd/shared/scan.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"k8s.io/apimachinery/pkg/labels"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/spf13/cobra"
@@ -151,6 +152,11 @@ func ValidateCommonScanFlags(cmd *cobra.Command, scanInfo *cautils.ScanInfo, sup
 	if err := ValidateExcludePaths(scanInfo); err != nil {
 		return err
 	}
+	if scanInfo.LabelSelector != "" {
+		if _, err := labels.Parse(scanInfo.LabelSelector); err != nil {
+			return fmt.Errorf("invalid --label-selector %q: %w", scanInfo.LabelSelector, err)
+		}
+	}
 	if err := ValidateExcludeControls(scanInfo); err != nil {
 		return err
 	}
@@ -161,10 +167,6 @@ func ValidateExcludeControls(scanInfo *cautils.ScanInfo) error {
 	for _, control := range scanInfo.ExcludeControls {
 		if strings.TrimSpace(control) == "" {
 			return fmt.Errorf("--exclude-controls contains an empty control identifier")
-		}
-	}
-	return nil
-}
 
 // ValidateExcludePaths fails the command on a malformed pattern before any resource is collected.
 func ValidateExcludePaths(scanInfo *cautils.ScanInfo) error {

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -393,6 +393,16 @@ func TestValidateExcludeControls(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateExcludeControls(&cautils.ScanInfo{ExcludeControls: tt.excludeControls})
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
 func TestValidateLabelSelector(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/shared/scan_test.go
+++ b/cmd/shared/scan_test.go
@@ -393,6 +393,52 @@ func TestValidateExcludeControls(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateExcludeControls(&cautils.ScanInfo{ExcludeControls: tt.excludeControls})
+func TestValidateLabelSelector(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSelector string
+		expectedErr   string
+	}{
+		{
+			name:          "empty selector is accepted",
+			labelSelector: "",
+			expectedErr:   "",
+		},
+		{
+			name:          "simple key=value is accepted",
+			labelSelector: "app=nginx",
+			expectedErr:   "",
+		},
+		{
+			name:          "multiple selectors are accepted",
+			labelSelector: "app=nginx,env!=dev",
+			expectedErr:   "",
+		},
+		{
+			name:          "set-based selector is accepted",
+			labelSelector: "env in (prod,staging)",
+			expectedErr:   "",
+		},
+		{
+			name:          "invalid selector is rejected",
+			labelSelector: "invalid!!selector",
+			expectedErr:   "invalid --label-selector",
+		},
+		{
+			name:          "invalid operator is rejected",
+			labelSelector: "app==nginx==bad",
+			expectedErr:   "invalid --label-selector",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("format", "", "")
+			scanInfo := &cautils.ScanInfo{
+				LabelSelector: tt.labelSelector,
+				Format:        "pretty-printer",
+			}
+			err := ValidateCommonScanFlags(cmd, scanInfo, ScanFormats)
 			if tt.expectedErr == "" {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
## Overview

small consistency fix -- `--label-selector` was only validated in `kubescape scan framework` via a local `labels.Parse` call. other subcommands (`scan control`, `scan image`, etc.) all route through `ValidateCommonScanFlags` but that function had no label selector check, so passing something like `--label-selector "invalid!!"` to `scan control` would skip validation entirely and hit the kubernetes api with a bad selector, returning a cryptic server-side error instead of a clean message upfront.

moved the check into `ValidateCommonScanFlags` so every subcommand gets it for free. removed the now-redundant local block from `framework.go` and its stale import.

## how to test

go test ./cmd/shared/ -run TestValidateLabelSelector -v


## checklist

- [x] my code follows the style guidelines of this project
- [x] i have performed a self-review of my code
- [x] i have added thorough tests
- [x] new and existing unit tests pass locally with my changes

## related

`--label-selector` was added alongside `--include-kinds`/`--exclude-kinds` in #3372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Kubernetes label selectors in scan options.
  * Invalid selectors now produce clear validation errors before scanning.
  * Empty selectors and valid equality, inequality, multi-condition, and set-based formats are accepted consistently.
  * Validation behavior is now consistent across supported scan commands.

* **Tests**
  * Added coverage for empty, valid, multi-condition, set-based, and malformed label-selector inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->