### PR TITLE
fix: initialize all vulnerability severities with placeholders

### DIFF
--- a/core/pkg/containerscan/elasticadapters.go
+++ b/core/pkg/containerscan/elasticadapters.go
@@ -33,6 +33,9 @@ func (scanresult *ScanResultReport) Summarize() *ElasticContainerScanSummaryResu
 	summary.PackagesName = make([]string, 0)
 
 	severitiesStats := map[string]SeverityStats{}
+	for severity := range KnownSeverities {
+		severitiesStats[severity] = SeverityStats{Severity: severity}
+	}
 
 	uniqueVulsMap := make(map[string]bool)
 	for _, layer := range scanresult.Layers {
@@ -43,7 +46,6 @@ func (scanresult *ScanResultReport) Summarize() *ElasticContainerScanSummaryResu
 			}
 			uniqueVulsMap[vul.Name] = true
 
-			// TODO: maybe add all severities just to have a placeholders
 			if !KnownSeverities[vul.Severity] {
 				vul.Severity = UnknownSeverity
 			}

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Overview
Currently, the `severitiesStats` map in `elasticadapters.go` only adds vulnerability severities as they are encountered in the image scan layers. This PR initializes all `KnownSeverities` (Critical, High, Medium, Low, Unknown, Negligible) with placeholders (default `0` counts) before iterating over vulnerabilities. This ensures a consistent and stable output schema for the container scan results, fulfilling an existing `TODO` in the codebase.

## Additional Information
- Addressed a `TODO` in `core/pkg/containerscan/elasticadapters.go`.
- Ensures downstream consumers and UI components always receive the full spectrum of severities in the summary output even when their count is `0`.

## How to Test
1. Run `go test ./core/pkg/containerscan/...` locally to ensure all unit tests pass successfully.
2. Run an image scan and verify that the `SeveritiesStats` array in the JSON output contains entries for all known severities, including those with zero occurrences.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Severity summaries now include all recognized severity levels, including those with no vulnerabilities.
  * Unrecognized vulnerability severities continue to appear as “Unknown.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->