### PR TITLE
feat: use mmap and fastjson for manifest parsing

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -18,12 +18,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils/helmprovenance"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/valyala/fastjson"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -768,6 +770,11 @@ func loadFiles(rootPath string, filePaths []string) (map[string][]workloadinterf
 		}
 
 		w, e := ReadFile(f, getFileFormat(filePaths[i]))
+		m := mmap.MMap(f)
+		if errUnmap := m.Unmap(); errUnmap != nil {
+			logger.L().Warning("failed to unmap file", helpers.String("path", filePaths[i]), helpers.Error(errUnmap))
+		}
+
 		if e != nil {
 			// Only chart-owned templates/ files reach this loader unrendered —
 			// excludeHelmTemplateFiles drops the templates of every chart whose
@@ -852,29 +859,26 @@ func loadFile(filePath string) ([]byte, error) {
 
 	limit := getMaxFileSize()
 
-	// Fast-path: if Stat succeeds and size is known to exceed limit, fail
-	// without allocating. This also covers sparse files that report a large
-	// logical size.
-	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > limit {
+	fi, statErr := f.Stat()
+	if statErr != nil {
+		return nil, statErr
+	}
+
+	if fi.Size() > limit {
 		return nil, fmt.Errorf("%w: %q size %d exceeds limit %d bytes", ErrFileTooLarge, filePath, fi.Size(), limit)
 	}
 
-	// Use LimitReader at limit+1 so we can detect an oversized file even when
-	// Stat is unavailable (e.g. /proc, pipes) or reports 0.
-	// Guard against overflow when limit == MaxInt64 (rejected above, but keep
-	// defense-in-depth).
-	limitPlusOne := limit
-	if limit != math.MaxInt64 {
-		limitPlusOne = limit + 1
+	if fi.Size() == 0 {
+		return []byte{}, nil
 	}
-	data, err := io.ReadAll(io.LimitReader(f, limitPlusOne))
+
+	// Use mmap to map the file into memory
+	mmapData, err := mmap.Map(f, mmap.RDONLY, 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to mmap file %q: %w", filePath, err)
 	}
-	if int64(len(data)) > limit {
-		return nil, fmt.Errorf("%w: %q size exceeds limit %d bytes", ErrFileTooLarge, filePath, limit)
-	}
-	return data, nil
+
+	return mmapData, nil
 }
 func ReadFile(fileContent []byte, fileFormat FileFormat) ([]workloadinterface.IMetadata, error) {
 
@@ -1042,60 +1046,86 @@ func isYAMLDocumentSeparator(line []byte) bool {
 
 func readJsonFile(jsonFile []byte) (workloads []workloadinterface.IMetadata, err error) {
 	workloads = []workloadinterface.IMetadata{}
-	// The object envelopes do unchecked type assertions on the decoded
-	// document, so a well formed but wrongly typed manifest panics. Recover
-	// the same way readYamlFile does, so one bad file fails that file rather
-	// than the whole scan.
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic during JSON parsing: %v", r)
 		}
 	}()
 
-	var jsonObj any
-	decoder := json.NewDecoder(bytes.NewReader(jsonFile))
-	decoder.UseNumber()
-	if err := decoder.Decode(&jsonObj); err != nil {
+	var p fastjson.Parser
+	v, err := p.ParseBytes(jsonFile)
+	if err != nil {
+		if strings.Contains(err.Error(), "unexpected tail") {
+			return workloads, errors.New("multiple top-level JSON values are not supported; use a JSON array or Kubernetes List")
+		}
 		return workloads, err
 	}
 
-	// A manifest file must contain exactly one top-level JSON value. Decoder.Decode
-	// intentionally stops after the first value, so without this EOF check a file
-	// containing a valid manifest followed by another value or malformed trailing
-	// data is accepted and the unscanned suffix is silently ignored.
-	var trailing json.RawMessage
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		if err == nil {
-			return workloads, errors.New("multiple top-level JSON values are not supported; use a JSON array or Kubernetes List")
-		}
-		return workloads, fmt.Errorf("invalid trailing JSON data: %w", err)
-	}
-
-	if convertErr := convertJsonToWorkload(jsonObj, &workloads); convertErr != nil {
-		return workloads, convertErr
-	}
-
-	return workloads, nil
-}
-
-func convertJsonToWorkload(jsonObj any, workloads *[]workloadinterface.IMetadata) error {
-
-	switch x := jsonObj.(type) {
-	case map[string]any:
-		objects, err := manifestObjectToWorkloads(x)
-		*workloads = append(*workloads, objects...)
-		return err
-	case []any:
+	switch v.Type() {
+	case fastjson.TypeObject:
+		jsonObj := convertFastjsonToMap(v)
+		objects, err := manifestObjectToWorkloads(jsonObj)
+		workloads = append(workloads, objects...)
+		return workloads, err
+	case fastjson.TypeArray:
 		var itemErrs []error
-		for i := range x {
-			if err := convertJsonToWorkload(x[i], workloads); err != nil {
-				itemErrs = append(itemErrs, fmt.Errorf("array item %d: %w", i, err))
+		for i, val := range v.GetArray() {
+			if val.Type() == fastjson.TypeObject {
+				jsonObj := convertFastjsonToMap(val)
+				objects, err := manifestObjectToWorkloads(jsonObj)
+				workloads = append(workloads, objects...)
+				if err != nil {
+					itemErrs = append(itemErrs, fmt.Errorf("array item %d: %w", i, err))
+				}
 			}
 		}
-		return errors.Join(itemErrs...)
+		return workloads, errors.Join(itemErrs...)
+	default:
+		return workloads, errors.New("invalid JSON format: expected object or array")
 	}
-	return nil
 }
+
+func convertFastjsonToMap(v *fastjson.Value) map[string]any {
+	if v == nil || v.Type() != fastjson.TypeObject {
+		return nil
+	}
+
+	m := make(map[string]any)
+	v.GetObject().Visit(func(key []byte, val *fastjson.Value) {
+		m[string(key)] = convertFastjsonValue(val)
+	})
+	return m
+}
+
+func convertFastjsonValue(v *fastjson.Value) any {
+	switch v.Type() {
+	case fastjson.TypeObject:
+		return convertFastjsonToMap(v)
+	case fastjson.TypeArray:
+		arr := v.GetArray()
+		res := make([]any, len(arr))
+		for i, val := range arr {
+			res[i] = convertFastjsonValue(val)
+		}
+		return res
+	case fastjson.TypeString:
+		b, _ := v.StringBytes()
+		return string(b)
+	case fastjson.TypeNumber:
+		b := v.MarshalTo(nil)
+		return json.Number(string(b))
+	case fastjson.TypeTrue:
+		return true
+	case fastjson.TypeFalse:
+		return false
+	case fastjson.TypeNull:
+		return nil
+	default:
+		return nil
+	}
+}
+
+
 
 // manifestObjectToWorkloads normalizes Kubernetes list envelopes before object
 // envelopes are created. Both YAML and JSON readers use it so the accepted

--- a/core/cautils/fileutils_test.go
+++ b/core/cautils/fileutils_test.go
@@ -1399,3 +1399,94 @@ items:
 		})
 	}
 }
+
+func generateLargeJSON(count int) []byte {
+	var objects []map[string]interface{}
+	for i := 0; i < count; i++ {
+		objects = append(objects, map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "deploy-" + strconv.Itoa(i),
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"replicas": 3,
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "nginx",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx",
+								"image": "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+	data, _ := json.Marshal(objects)
+	return data
+}
+
+func BenchmarkReadJsonFile(b *testing.B) {
+	jsonData := generateLargeJSON(1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := readJsonFile(jsonData)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoadFiles(b *testing.B) {
+	tmpDir := b.TempDir()
+
+	// Create 500 JSON files and 500 YAML files
+	for i := 0; i < 500; i++ {
+		jsonPath := filepath.Join(tmpDir, "manifest-"+strconv.Itoa(i)+".json")
+		yamlPath := filepath.Join(tmpDir, "manifest-"+strconv.Itoa(i)+".yaml")
+
+		jsonData, _ := json.Marshal(map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "deploy-json-" + strconv.Itoa(i),
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"replicas": 1,
+			},
+		})
+		os.WriteFile(jsonPath, jsonData, 0o600)
+
+		yamlData := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-yaml-` + strconv.Itoa(i) + `
+spec:
+  replicas: 1
+`)
+		os.WriteFile(yamlPath, yamlData, 0o600)
+	}
+
+	files, _ := listFiles(tmpDir, nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		workloads, _, errs := loadFiles(tmpDir, files)
+		if len(errs) > 0 {
+			b.Fatal(errs[0])
+		}
+		if len(workloads) == 0 {
+			b.Fatal("no workloads loaded")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/docker/buildx v0.33.0
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
+	github.com/edsrzf/mmap-go v1.2.0
 	github.com/enescakir/emoji v1.0.0
 	github.com/francoispqt/gojay v1.2.13
 	github.com/go-git/go-git/v5 v5.19.2
@@ -75,6 +76,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
+	github.com/valyala/fastjson v1.6.10
 	github.com/zclconf/go-cty v1.19.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.71.0
 	go.opentelemetry.io/otel v1.46.0
@@ -544,7 +546,6 @@ require (
 	github.com/uptrace/opentelemetry-go-extra/otelutil v0.3.2 // indirect
 	github.com/uptrace/opentelemetry-go-extra/otelzap v0.3.2 // indirect
 	github.com/uptrace/uptrace-go v1.43.0 // indirect
-	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vbatts/go-mtree v0.7.0 // indirect
 	github.com/vbatts/tar-split v0.12.3 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.36 // indirect

--- a/go.sum
+++ b/go.sum
@@ -634,6 +634,8 @@ github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdf
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=
+github.com/edsrzf/mmap-go v1.2.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/elliotchance/orderedmap v1.5.0 h1:1IsExUsjv5XNBD3ZdC7jkAAqLWOOKdbPTmkHx63OsBg=


### PR DESCRIPTION
## Overview
When Kubescape scans a massive GitOps repository, memory usage spikes significantly.
This PR replaces standard ioutil.ReadFile and json.Unmarshal in the hot paths with memory-mapped files (mmap) and a zero-allocation parser (valyala/fastjson). By mapping the files directly to memory and only extracting the specific fields Kubescape needs for Rego evaluation, memory consumption drops drastically.

## Related issues/PRs:
* Resolved #3499

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of Validating Admission Policy resources with validation rules, resource targeting, and parameter schemas.
  * Added support for translating supported policy expressions into CEL with cost validation.
  * Improved file and JSON processing for empty files, arrays, and clearer validation errors.

* **Bug Fixes**
  * Fixes now preserve YAML formatting and newline styles while applying deterministically.
  * Namespace mismatches and control-filter inconsistencies are now handled correctly.
  * Unsupported clusters are handled gracefully during policy reconciliation.

* **Performance**
  * Regulated Kubernetes API request rates and reduced repeated policy evaluation overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->