### PR TITLE
fix(opaprocessor): honor namespace scope on incremental cache hits

### DIFF
--- a/core/pkg/opaprocessor/incremental_cache_namespace_test.go
+++ b/core/pkg/opaprocessor/incremental_cache_namespace_test.go
@@ -1,0 +1,135 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/scancache"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// denyEveryPodRule fails every Pod it is given, so each pod's presence or
+// absence in the result map is purely a question of whether it was scoped in.
+const denyEveryPodRule = `package armo_builtins
+import rego.v1
+
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	msga := {
+		"alertMessage": sprintf("pod %v denied", [pod.metadata.name]),
+		"packagename":  "armo_builtins",
+		"alertScore":   5,
+		"fixPaths":     [],
+		"failedPaths":  [],
+		"alertObject":  {"k8sApiObjects": [pod]},
+	}
+}
+`
+
+func nsCacheControl() *reporthandling.Control {
+	rule := reporthandling.PolicyRule{
+		Rule:         denyEveryPodRule,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}},
+		},
+	}
+	rule.Name = "deny-every-pod"
+	ctrl := &reporthandling.Control{ControlID: "C-NSCACHE", Rules: []reporthandling.PolicyRule{rule}}
+	ctrl.Name = "deny every pod"
+	return ctrl
+}
+
+// nsCacheSession builds a session holding one Pod in "prod" and one in "dev".
+func nsCacheSession(t *testing.T) (sess *cautils.OPASessionObj, prodID, devID string) {
+	t.Helper()
+	podProd := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "p-prod", "namespace": "prod"},
+	})
+	podDev := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "p-dev", "namespace": "dev"},
+	})
+
+	sess = cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{"/v1/pods": {podProd.GetID(), podDev.GetID()}}
+	sess.AllResources[podProd.GetID()] = podProd
+	sess.AllResources[podDev.GetID()] = podDev
+
+	ctrl := nsCacheControl()
+	sess.AllPolicies = cautils.NewPolicies()
+	sess.AllPolicies.Controls[ctrl.ControlID] = *ctrl
+
+	return sess, podProd.GetID(), podDev.GetID()
+}
+
+// TestIncrementalCache_NoCacheHonorsExcludedNamespace is the baseline: without
+// the incremental cache, a resource in an excluded namespace never reaches the
+// result map. This pins the contract the cached path must match.
+func TestIncrementalCache_NoCacheHonorsExcludedNamespace(t *testing.T) {
+	sess, prodID, devID := nsCacheSession(t)
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "dev", "", false, nil)
+
+	got, err := opap.processControl(context.Background(), nsCacheControl(), evaluationScope{})
+	require.NoError(t, err)
+
+	_, hasProd := got[prodID]
+	_, hasDev := got[devID]
+	t.Logf("no cache, --exclude-namespaces dev -> prod=%v dev=%v", hasProd, hasDev)
+
+	require.True(t, hasProd, "prod pod is in scope and must be evaluated")
+	require.False(t, hasDev, "dev pod is in an excluded namespace and must be absent")
+}
+
+// TestIncrementalCache_HonorsExcludedNamespaceOnCacheHit proves that attaching
+// the incremental cache must not change which namespaces are in scope.
+//
+// The cache-read loop in processRuleOnScope writes a cached verdict straight
+// into the result map and removes the resource from resourceToScan, so the
+// skipNamespace guards further down the function never see it. A resource
+// cached by an earlier unfiltered scan is therefore resurrected into a later
+// scan that explicitly excluded its namespace.
+func TestIncrementalCache_HonorsExcludedNamespaceOnCacheHit(t *testing.T) {
+	dir := t.TempDir()
+
+	// Scan 1: no namespace filter, cache attached. Primes the cache with both pods.
+	sess1, _, _ := nsCacheSession(t)
+	store1, err := scancache.Load(dir, "v1")
+	require.NoError(t, err)
+	opap1 := NewOPAProcessor(sess1, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap1.SetIncrementalCache(store1)
+
+	got1, err := opap1.processControl(context.Background(), nsCacheControl(), evaluationScope{})
+	require.NoError(t, err)
+	require.Len(t, got1, 2, "unfiltered scan must evaluate both pods")
+	require.NoError(t, store1.Flush())
+
+	// Scan 2: same resources, same cache, now with --exclude-namespaces dev.
+	sess2, prodID, devID := nsCacheSession(t)
+	store2, err := scancache.Load(dir, "v1")
+	require.NoError(t, err)
+	opap2 := NewOPAProcessor(sess2, resources.NewRegoDependenciesDataMock(), "test", "dev", "", false, nil)
+	opap2.SetIncrementalCache(store2)
+
+	got2, err := opap2.processControl(context.Background(), nsCacheControl(), evaluationScope{})
+	require.NoError(t, err)
+
+	_, hasProd := got2[prodID]
+	devResult, hasDev := got2[devID]
+	t.Logf("with cache, --exclude-namespaces dev -> prod=%v dev=%v", hasProd, hasDev)
+	if hasDev {
+		t.Logf("dev pod served from cache with status=%q", devResult.GetStatus(nil).Status())
+	}
+
+	require.True(t, hasProd, "prod pod is in scope and must be evaluated")
+	require.False(t, hasDev,
+		"dev pod is in an excluded namespace: the incremental cache must not resurrect it")
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1055,6 +1055,9 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		var toEvaluate []workloadinterface.IMetadata
 		cacheHitIDs = make(map[string]struct{})
 		for _, r := range resourceToScan {
+			if opap.skipNamespace(r.GetNamespace()) {
+				continue
+			}
 			hash := scancache.ResourceHash(r.GetObject())
 			if cached, ok := opap.incrementalCache.Get(controlID, r.GetID(), hash); ok {
 				for _, cr := range cached.ResourceAssociatedRules {

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Overview

I found that combining --incremental with --exclude-namespaces or --include-namespaces silently drops the namespace filter for any resource served from the cache.

In `processRuleOnScope`, the cache-read loop writes a cached verdict straight into the result map and removes that resource from the list still awaiting evaluation. Every other write path in the same function checks `skipNamespace` first, but this one does not, so it never gets a chance to filter the resource out.

```go
for _, r := range resourceToScan {
    hash := scancache.ResourceHash(r.GetObject())
    if cached, ok := opap.incrementalCache.Get(controlID, r.GetID(), hash); ok {
```

The practical effect: run a scan once with `--incremental` to prime the cache, then run it again with `--exclude-namespaces dev` and `--incremental`. Any unchanged resource in `dev` still shows up in the report, because its cached verdict bypasses the filter that would otherwise remove it. The `--incremental` flag documents itself as "scan output is unaffected", which this breaks.

I checked and this mainly affects file and repo scans, since live-cluster scans already filter excluded namespaces at collection time through the API field selector.

## Fix

I added the same `skipNamespace` guard the rest of the function already uses, right at the top of the cache-read loop, so a resource out of namespace scope is skipped before either a cache lookup or a fresh evaluation happens.

## Test

I wrote two tests. The first pins the existing no-cache behavior as a baseline: an excluded namespace never appears in the result. The second primes the cache with an unfiltered scan, then re-runs with the namespace excluded and the same cache attached. Before the fix it fails, since the excluded resource reappears. After the fix both pass. I ran the full opaprocessor suite with -race and it stays green.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace exclusions are now respected during incremental-cache processing.
  * Resources in excluded namespaces are skipped before cache lookup and policy evaluation.
  * Cached results no longer reintroduce resources from excluded namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->