### PR TITLE
fix(printer): restore missing strings import in policyreportprinter.go

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Summary
`master` does not currently build. `go build ./...` fails:

```
core/pkg/resultshandling/printer/v2/policyreportprinter.go:325:8: undefined: strings
core/pkg/resultshandling/printer/v2/policyreportprinter.go:331:20: undefined: strings
core/pkg/resultshandling/printer/v2/policyreportprinter.go:345:9: undefined: strings
core/pkg/resultshandling/printer/v2/policyreportprinter.go:359:8: undefined: strings
core/pkg/resultshandling/printer/v2/policyreportprinter.go:386:9: undefined: strings
```

## Root cause
Two independently-correct PRs landed back to back and their combination broke the build:

- #3470 (merged) added `sanitizeDNS1123Subdomain` and `sanitizeLabelValue`, both built on `strings.Builder`, `strings.ToLower`, and `strings.TrimRight`.
- #3492 (merged the next day) separately replaced this file's *only other* use of `strings` (in `SetWriter`, for extension comparison) with `printer.ResolveOutputFile`, and dropped the `"strings"` import that then looked unused **in that PR's own diff**.

Each PR built and passed CI cleanly against the base it was tested on. Neither PR's author could have seen the conflict, since #3470's new functions weren't touched by #3492's diff — the import removal only becomes wrong once both are merged together.

## Fix
Restore the `"strings"` import.

## Test plan
- [x] `go build ./...` — fails on current `master`, passes with this change.
- [x] `go vet ./...` passes.
- [x] `go test ./...` passes (both Go modules — root and `httphandler`).
- [x] `golangci-lint run ./core/pkg/resultshandling/printer/v2/...` — 0 issues.

This is a one-line, minimal fix — no behavior change, just restoring a needed import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal string-processing support for policy report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->