### PR TITLE
feat(scan): add generic webhook notifications

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -58,6 +58,9 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			if len(scanInfo.ExcludeControls) > 0 {
 				return fmt.Errorf("--exclude-controls is not supported for image scans: an image scan evaluates vulnerabilities, not posture controls")
 			}
+			if len(scanInfo.NotifyURLs) > 0 {
+				return fmt.Errorf("--notify is not supported for image-only scans yet")
+			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -75,6 +75,15 @@ func TestGetImageCmd(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGetImageCmdRejectsNotify(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{NotifyURLs: []string{"https://example.com/webhook"}}
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	err := cmd.RunE(cmd, []string{"nginx"})
+	require.EqualError(t, err, "--notify is not supported for image-only scans yet")
+	assert.Nil(t, mockKubescape.imgScanInfo)
+}
+
 func TestGetImageCmd_RunE_InvalidSeverity(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	scanInfo := cautils.ScanInfo{FailThresholdSeverity: "unknown"}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -208,6 +208,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.NotifyURLs, "notify", nil, "POST the scan summary as JSON to this webhook URL; repeat for multiple destinations")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ShowEvidence, "show-evidence", "E", false, "Show evidence paths with current field values for each failed control (pretty-printer only)")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.ShowSecrets, "show-secrets", false, "Show secret field values in evidence output. By default secret values are redacted. Only effective with --show-evidence")

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -145,7 +145,7 @@ func TestScanNotifyFlagIsRepeatableAndInherited(t *testing.T) {
 	require.NotNil(t, flag)
 	require.NoError(t, flag.Value.Set("https://one.example/hook?a=b,c"))
 	require.NoError(t, flag.Value.Set("https://two.example/hook"))
-	assert.Equal(t, "[https://one.example/hook?a=b,c,https://two.example/hook]", flag.Value.String())
+	assert.Equal(t, `["https://one.example/hook?a=b,c",https://two.example/hook]`, flag.Value.String())
 
 	for _, name := range []string{"framework", "control", "workload"} {
 		sub, _, err := cmd.Find([]string{name})

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -139,6 +139,21 @@ func TestExceedsSeverity(t *testing.T) {
 	}
 }
 
+func TestScanNotifyFlagIsRepeatableAndInherited(t *testing.T) {
+	cmd := GetScanCommand(&mocks.MockIKubescape{})
+	flag := cmd.PersistentFlags().Lookup("notify")
+	require.NotNil(t, flag)
+	require.NoError(t, flag.Value.Set("https://one.example/hook?a=b,c"))
+	require.NoError(t, flag.Value.Set("https://two.example/hook"))
+	assert.Equal(t, "[https://one.example/hook?a=b,c,https://two.example/hook]", flag.Value.String())
+
+	for _, name := range []string{"framework", "control", "workload"} {
+		sub, _, err := cmd.Find([]string{name})
+		require.NoError(t, err)
+		require.NotNil(t, sub.InheritedFlags().Lookup("notify"), "%s should inherit --notify", name)
+	}
+}
+
 func Test_enforceSeverityThresholds(t *testing.T) {
 	testCases := []struct {
 		Description    string

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -130,6 +130,7 @@ type ScanInfo struct {
 	View                      string                       //
 	Format                    string                       // Format results (table, json, junit ...)
 	Output                    string                       // Store results in an output file, Output file name
+	NotifyURLs                []string                     // Generic webhook destinations that receive the posture summary JSON
 	FormatVersion             string                       // Output object can be different between versions, this is for testing and backward compatibility
 	CustomClusterName         string                       // Set the custom name of the cluster
 	ExcludedNamespaces        string                       // used for host scanner namespace

--- a/core/pkg/resultshandling/notification/notification.go
+++ b/core/pkg/resultshandling/notification/notification.go
@@ -1,0 +1,79 @@
+// Package notification delivers generic scan summary webhooks.
+package notification
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultTimeout  = 5 * time.Second
+	maxResponseBody = 4 << 10
+)
+
+// Doer is implemented by http.Client and makes delivery testable.
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// NewClient returns the bounded, no-redirect client used by scan notifications.
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// SafeTarget returns only non-secret endpoint components suitable for logs.
+func SafeTarget(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" || u.User != nil {
+		return "invalid endpoint"
+	}
+	host := u.Hostname()
+	if port := u.Port(); port != "" {
+		host += ":" + port
+	}
+	return u.Scheme + "://" + host
+}
+
+func validateEndpoint(endpoint string) (*url.URL, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" || u.User != nil || u.Fragment != "" {
+		return nil, fmt.Errorf("invalid notification endpoint")
+	}
+	return u, nil
+}
+
+// Send POSTs already-marshaled JSON to endpoint. Errors never include secrets
+// from endpoint paths, queries, fragments, or userinfo.
+func Send(ctx context.Context, client Doer, endpoint string, payload []byte) error {
+	u, err := validateEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create notification request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send notification to %s failed", SafeTarget(endpoint))
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBody))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("notification endpoint %s returned %s", SafeTarget(endpoint), strings.TrimSpace(resp.Status))
+	}
+	return nil
+}

--- a/core/pkg/resultshandling/notification/notification_test.go
+++ b/core/pkg/resultshandling/notification/notification_test.go
@@ -1,0 +1,174 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingDoer struct{}
+
+func (failingDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, &url.Error{Op: "Post", URL: "https://example.com/secret/path?token=secret", Err: errors.New("connection refused")}
+}
+
+type staticDoer struct {
+	response *http.Response
+}
+
+func (d staticDoer) Do(*http.Request) (*http.Response, error) { return d.response, nil }
+
+type trackingReadCloser struct {
+	reader bytes.Reader
+	read   int
+	closed bool
+}
+
+func newTrackingReadCloser(body []byte) *trackingReadCloser {
+	return &trackingReadCloser{reader: *bytes.NewReader(body)}
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestSendPostsJSON(t *testing.T) {
+	var method, contentType string
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, contentType = r.Method, r.Header.Get("Content-Type")
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	payload := []byte(`{"summary":"ok"}`)
+	require.NoError(t, Send(context.Background(), NewClient(time.Second), srv.URL+"/secret?token=123", payload))
+	assert.Equal(t, http.MethodPost, method)
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, payload, body)
+}
+
+func TestSendRejectsUnsafeEndpointsWithoutSecrets(t *testing.T) {
+	for _, endpoint := range []string{
+		"ftp://example.com/hook", "https:///hook", "https://user:secret@example.com/hook", "https://example.com/hook#fragment",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			err := Send(context.Background(), NewClient(time.Second), endpoint, []byte(`{}`))
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "secret")
+			assert.NotContains(t, err.Error(), "/hook")
+		})
+	}
+}
+
+func TestSendFailsForRedirectAndNon2xx(t *testing.T) {
+	redirectTargetCalled := make(chan struct{}, 1)
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetCalled <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer redirectTarget.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL+"/secret", http.StatusFound)
+	}))
+	defer redirect.Close()
+	err := Send(context.Background(), NewClient(time.Second), redirect.URL+"/token", []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "302")
+	assert.NotContains(t, err.Error(), "/token")
+	select {
+	case <-redirectTargetCalled:
+		t.Fatal("notification client followed redirect")
+	default:
+	}
+
+	failure := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("secret response"))
+	}))
+	defer failure.Close()
+	err = Send(context.Background(), NewClient(time.Second), failure.URL+"/token", []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.NotContains(t, err.Error(), "secret response")
+}
+
+func TestSendAcceptsEvery2xxAndClosesBoundedResponse(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusNoContent, 299} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			body := newTrackingReadCloser(bytes.Repeat([]byte("x"), maxResponseBody+1))
+			err := Send(context.Background(), staticDoer{response: &http.Response{
+				StatusCode: status,
+				Body:       body,
+			}}, "https://example.com/webhook?token=secret", []byte(`{}`))
+			require.NoError(t, err)
+			assert.True(t, body.closed)
+			assert.Equal(t, maxResponseBody, body.read)
+		})
+	}
+}
+
+func TestSafeTarget(t *testing.T) {
+	assert.Equal(t, "https://example.com:8443", SafeTarget("https://example.com:8443/path?token=secret"))
+	assert.Equal(t, "invalid endpoint", SafeTarget("%%%"))
+	assert.False(t, strings.Contains(SafeTarget("https://example.com/a?b=c"), "?"))
+}
+
+func TestSendRedactsTransportURL(t *testing.T) {
+	err := Send(context.Background(), failingDoer{}, "https://example.com/secret/path?token=secret", []byte(`{}`))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), "/path")
+	assert.Contains(t, err.Error(), "https://example.com")
+}
+
+func TestSendHonorsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Send(ctx, NewClient(time.Second), srv.URL+"/secret", []byte(`{}`))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "/secret")
+}
+
+func TestSendHonorsClientTimeout(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseServer := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-releaseServer
+	}))
+	defer func() {
+		close(releaseServer)
+		srv.Close()
+	}()
+
+	started := time.Now()
+	err := Send(context.Background(), NewClient(20*time.Millisecond), srv.URL+"/secret", []byte(`{}`))
+	require.Error(t, err)
+	<-requestStarted
+	assert.Less(t, time.Since(started), time.Second)
+	assert.NotContains(t, err.Error(), "/secret")
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/notification"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	printerv1 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v1"
 	printerv2 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2"
@@ -311,6 +312,26 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 		}
 		if err := closePrinter(p); err != nil {
 			printErr = errors.Join(printErr, fmt.Errorf("output printer %T close: %w", p, err))
+		}
+	}
+
+	// Deliver the same summary seen by output printers. Delivery is deliberately
+	// best-effort: a notification endpoint must never alter scan results or exit
+	// status.
+	if len(scanInfo.NotifyURLs) > 0 && rh.ScanData != nil && rh.ScanData.Report != nil {
+		payload, err := json.Marshal(rh.ScanData.Report.SummaryDetails)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("Failed to marshal scan summary for notification", helpers.Error(err))
+		} else {
+			client := notification.NewClient(notification.DefaultTimeout)
+			for _, endpoint := range scanInfo.NotifyURLs {
+				requestCtx, cancel := context.WithTimeout(ctx, notification.DefaultTimeout)
+				err := notification.Send(requestCtx, client, endpoint, payload)
+				cancel()
+				if err != nil {
+					logger.L().Ctx(ctx).Warning("Failed to deliver scan notification", helpers.String("target", notification.SafeTarget(endpoint)), helpers.Error(err))
+				}
+			}
 		}
 	}
 

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -132,6 +135,39 @@ func TestResultsHandlerHandleResultsImageScanNilScanData(t *testing.T) {
 	assert.Equal(t, 1, outputPrinter.ActionPrintCalls)
 	// ...but the compliance score is skipped, as it requires ScanData.
 	assert.Equal(t, 0, outputPrinter.ScoreCalls)
+}
+
+func TestResultsHandlerNotifyIsBestEffortAndDeliversOnlySummary(t *testing.T) {
+	var received []byte
+	success := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var err error
+		received, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer success.Close()
+
+	failure := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failure.Close()
+
+	scanData := cautils.NewOPASessionObjMock()
+	want, err := json.Marshal(scanData.Report.SummaryDetails)
+	require.NoError(t, err)
+	handler := NewResultsHandler(nil, nil, &SpyPrinter{})
+	handler.SetData(scanData)
+
+	require.NoError(t, handler.HandleResults(context.Background(), &cautils.ScanInfo{
+		NotifyURLs: []string{failure.URL + "/first?token=secret", success.URL + "/second?token=secret"},
+	}))
+	assert.JSONEq(t, string(want), string(received))
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(received, &payload))
+	assert.NotContains(t, payload, "results")
+	assert.NotContains(t, payload, "rawResources")
 }
 
 func TestResultsHandlerHandleResultsReturnsPrinterErrors(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -51,6 +51,7 @@ kubescape scan [target] [flags]
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
 | `--label-selector <selector>` | Filter collected resources by Kubernetes label selector. Accepts any expression `kubectl -l` supports, e.g. `app=nginx,env!=dev` or `env in (prod,staging)`. Syntax is validated before scanning begins; filtering is applied during live cluster collection and ignored when scanning local files. | - |
 | `--keep-local` | Don't report results to backend | `false` |
+| `--notify <url>` | POST the posture scan's JSON summary to a trusted generic webhook URL. Repeat the flag for multiple endpoints. Delivery is best-effort and does not affect scan exit status. Not supported by `scan image`. | - |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
 | `--otel-endpoint <endpoint>` | Export scan traces and metrics to an OTLP collector — see [OpenTelemetry export](#opentelemetry-export). Accepts `host:port` (plaintext) or a `http(s)://` URL. | `OTEL_EXPORTER_OTLP_ENDPOINT` |
@@ -63,6 +64,19 @@ kubescape scan [target] [flags]
 | `--use-from <path>` | Load specific policy from path | - |
 | `-v, --verbose` | Display all resources, not just failed ones | `false` |
 | `--view <type>` | View type: `security`, `control`, `resource` | `security` |
+
+### Generic webhook notifications
+
+Use `--notify` to POST the existing JSON `summaryDetails` object after a posture scan:
+
+```bash
+kubescape scan manifests/ --notify https://hooks.example.com/kubescape
+kubescape scan manifests/ --notify https://ops.example.com/kubescape --notify https://audit.example.com/kubescape
+```
+
+Each destination gets one synchronous request with `Content-Type: application/json`; Kubescape allows up to five seconds per destination and does not follow redirects. Failures are logged as warnings and never override the scan's own exit status. The payload follows `--min-severity` and `--max-severity` output filtering. `--severity-threshold` continues to affect only the exit status.
+
+The summary may contain resource identifiers in control summaries. Use `--hide` where appropriate and send only to trusted webhook endpoints. Slack Block Kit and Microsoft Teams Adaptive Card formatting are not included in this generic phase.
 
 ### Exception Audit
 


### PR DESCRIPTION
## Summary

- add repeatable `kubescape scan --notify <url>` for generic JSON webhooks
- send the existing posture `SummaryDetails` after output rendering
- keep delivery best-effort so notification failures never change the scan exit code
- reject `--notify` for image-only scans, which do not produce a posture summary
- document payload and filtering behavior

Refs #3401.

This PR intentionally implements phase 1 only. Slack Block Kit and Microsoft Teams Adaptive Card formatting are out of scope and can follow separately.

## Security and delivery behavior

- five-second timeout per destination
- redirects disabled
- no automatic retries, avoiding duplicate webhook events
- webhook paths and query tokens redacted from errors and logs
- only HTTP(S) endpoints without embedded userinfo are accepted
- response bodies are drained with a 4 KiB bound and closed
- notification failures are warnings and do not override scan, printer, threshold, baseline, or submission results

## Tests

- `git diff --check`
- `go test -timeout 30s ./core/pkg/resultshandling/notification` using Go 1.26 in Docker

The broader `go test ./core/pkg/resultshandling ./cmd/scan` run is currently blocked by a pre-existing upstream compile error in `core/pkg/resultshandling/printer/v2/policyreportprinter.go`: the file uses `strings` but does not import it. This PR does not modify that file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `--notify <url>` option for posting scan posture summaries as JSON to webhook endpoints.
  * Notifications support multiple destinations and are delivered on a best-effort basis without affecting scan results.

* **Bug Fixes**
  * Image-only scans now clearly reject the unsupported `--notify` option.

* **Documentation**
  * Documented notification behavior, delivery limits, filtering, severity thresholds, and sensitive-data considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->