### PR TITLE
fix(mcpserver): scan_resource_slice returns [] not null for an empty result set

### DIFF
--- a/cmd/mcpserver/advanced_tools.go
+++ b/cmd/mcpserver/advanced_tools.go
@@ -89,8 +89,11 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 
 		nextContinueToken := list.GetContinue()
 
-		// strip out noisy fields to save tokens
-		var simplifiedItems []map[string]any
+		// strip out noisy fields to save tokens. Initialized (not nil) so an
+		// empty result set marshals to "[]", not "null" -- MCP clients that
+		// validate the response against the tool's declared array schema
+		// reject a null.
+		simplifiedItems := make([]map[string]any, 0, len(list.Items))
 		for _, item := range list.Items {
 			simplifiedItems = append(simplifiedItems, map[string]any{
 				"apiVersion": item.GetAPIVersion(),

--- a/cmd/mcpserver/advanced_tools_test.go
+++ b/cmd/mcpserver/advanced_tools_test.go
@@ -1,0 +1,43 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray guards against a
+// nil-slice regression: when the cluster has zero matching resources, the
+// "resources" field must serialize as [], not JSON null. A null there fails
+// MCP clients that validate the response against the tool's declared array
+// schema.
+func TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray(t *testing.T) {
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createAdvancedTools(ksServer)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "scan_resource_slice", map[string]any{
+		"resource_kind": "pods",
+	}))
+	require.False(t, result.IsError)
+
+	raw := toolResultText(t, result)
+	require.JSONEq(t, `{"resources":[],"continue":"","count":0}`, raw)
+}

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Summary

`scan_resource_slice` (added in #3375) serializes `"resources": null` instead of `"resources": []` whenever a cluster/namespace has zero matching resources.

Fixes #3505

## Root cause

`cmd/mcpserver/advanced_tools.go` builds the response items into `var simplifiedItems []map[string]any`, only appending inside the loop over `list.Items`. When the list is empty the slice stays `nil`, and `json.Marshal` serializes that as `null`.

## Fix

Initialize the slice with `make([]map[string]any, 0, len(list.Items))` so an empty result set marshals to `[]`.

## Test plan

New test `TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray` calls the real tool handler through the MCP protocol layer (`server.NewMCPServer` + `HandleMessage`, the same pattern already used by `mcpserver_arguments_test.go`), backed by a `k8s.io/client-go/dynamic/fake` client with zero pods registered, and asserts the exact JSON body.

```
=== RUN   TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray
--- PASS: TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray (0.00s)
```

Before the fix, the same test fails:
```
{"continue":"","count":0,"resources":null}
```

Scoped checks (clean):
- `go build ./cmd/mcpserver/...`, `go test -race ./cmd/mcpserver/...` — clean
- `golangci-lint run --new-from-rev=upstream/master ./cmd/mcpserver/...` — 0 issues
- `gofmt -l` on changed files — clean

**Correction:** an earlier version of this description claimed a clean unscoped `go build ./...`/`go vet ./...`. That wasn't actually verified on this branch and is false — a fresh `go build ./...` here fails, but for a reason unrelated to this diff: `upstream/master`'s current HEAD is missing a `strings` import in `policyreportprinter.go` (filed/fixed separately as #3509 / #3510). CI on this PR will show that same failure until #3510 merges.

---
**Update:** rebased onto the fix-master-build branch (#3510, still pending review) so CI runs clean here instead of inheriting master's current build break. The extra "restore missing strings import" commit will drop out of this diff once #3510 merges and this branch is rebased onto master again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty resource results now display as an empty JSON array (`[]`) instead of `null`.
  * Empty scans correctly report zero matching resources and no continuation token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->