### PR TITLE
fix(opaprocessor): make --skip-controls and --include-controls case-insensitive

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -619,6 +619,13 @@ func ruleEnumeratorData(rule *reporthandling.PolicyRule) string {
 // --skip-controls or --include-controls filters. The resulting map marks
 // individual rule names with `true` so that convertFrameworksToPolicies drops
 // them. Include is a whitelist; skip is a blacklist and wins over include.
+//
+// Matching is case-insensitive, mirroring --exclude-controls (see
+// policyhandler/controlfilter.go's normalizeExclusions/matchIdentifier):
+// without this, a lowercase control ID silently matches nothing, and since
+// --include-controls treats "not in the include set" as "exclude", a single
+// mistyped case produces a silently empty scan instead of the requested
+// control.
 func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling.Framework, skip, include []string) map[string]bool {
 	excludedRules := make(map[string]bool, len(base)+4)
 	for k, v := range base {
@@ -631,7 +638,7 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 
 	skipSet := make(map[string]struct{}, len(skip))
 	for _, id := range skip {
-		id = strings.TrimSpace(id)
+		id = strings.ToLower(strings.TrimSpace(id))
 		if id != "" {
 			skipSet[id] = struct{}{}
 		}
@@ -639,7 +646,7 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 
 	includeSet := make(map[string]struct{}, len(include))
 	for _, id := range include {
-		id = strings.TrimSpace(id)
+		id = strings.ToLower(strings.TrimSpace(id))
 		if id != "" {
 			includeSet[id] = struct{}{}
 		}
@@ -648,7 +655,7 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 	knownIDs := make(map[string]struct{})
 	for _, fw := range frameworks {
 		for i := range fw.Controls {
-			knownIDs[fw.Controls[i].ControlID] = struct{}{}
+			knownIDs[strings.ToLower(fw.Controls[i].ControlID)] = struct{}{}
 		}
 	}
 
@@ -666,7 +673,7 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 	if len(include) > 0 {
 		for _, fw := range frameworks {
 			for i := range fw.Controls {
-				if _, keep := includeSet[fw.Controls[i].ControlID]; keep {
+				if _, keep := includeSet[strings.ToLower(fw.Controls[i].ControlID)]; keep {
 					continue
 				}
 				for r := range fw.Controls[i].Rules {
@@ -678,7 +685,7 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 
 	for _, fw := range frameworks {
 		for i := range fw.Controls {
-			if _, skip := skipSet[fw.Controls[i].ControlID]; !skip {
+			if _, skip := skipSet[strings.ToLower(fw.Controls[i].ControlID)]; !skip {
 				continue
 			}
 			for r := range fw.Controls[i].Rules {

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1206,6 +1206,18 @@ func TestBuildControlExcludedRules(t *testing.T) {
 			excludedRules: nil,
 			notExcluded:   []string{"rule-a", "rule-b", "rule-c"},
 		},
+		{
+			name:          "include matches regardless of case",
+			include:       []string{"c-0002"},
+			excludedRules: []string{"rule-a", "rule-c"},
+			notExcluded:   []string{"rule-b"},
+		},
+		{
+			name:          "skip matches regardless of case",
+			skip:          []string{"c-0002"},
+			excludedRules: []string{"rule-b"},
+			notExcluded:   []string{"rule-a", "rule-c"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Summary

`--include-controls`/`--skip-controls` (added in #3480) compare control IDs case-sensitively against the canonical stored `ControlID`, unlike `--exclude-controls`, which already normalizes to lowercase for this exact reason.

Fixes #3507

## Why this matters

`--include-controls` is a whitelist — anything not matched gets excluded. So `--include-controls c-0002` (lowercase, a completely natural way to type a control ID) doesn't just fail to include `C-0002` — it silently produces an **empty scan**, since every control fails the case-sensitive match and gets excluded. The only signal is a `Warning` log line, easy to misread as "control not found" rather than "you got the case wrong and now nothing ran."

## Fix

`buildControlExcludedRules` in `core/pkg/opaprocessor/processorhandlerutils.go` now lowercases both the requested skip/include IDs and the `ControlID`s they're compared against — matching `--exclude-controls`' existing behavior in `policyhandler/controlfilter.go`.

## Test plan

Added two cases to the existing `TestBuildControlExcludedRules` table (`core/pkg/opaprocessor/processorhandlerutils_test.go`) covering lowercase input for both `--include-controls` and `--skip-controls`. Confirmed the bug first with a standalone reproduction directly against the production function before writing the fix.

```
=== RUN   TestBuildControlExcludedRules
    --- PASS: TestBuildControlExcludedRules/include_matches_regardless_of_case (0.00s)
    --- PASS: TestBuildControlExcludedRules/skip_matches_regardless_of_case (0.00s)
--- PASS: TestBuildControlExcludedRules (0.00s)
```

Full suite:
- `go build ./...`, `go vet ./...` — clean
- `go test -race ./core/pkg/opaprocessor/...` — clean
- `golangci-lint run --new-from-rev=upstream/master ./core/pkg/opaprocessor/...` — 0 issues
- `gofmt -l` on changed files — clean

Note: a clean `upstream/master` checkout currently fails `go build ./...` for an unrelated reason (`policyreportprinter.go` missing a `strings` import from #3492) — filed and fixed separately as #3509 / #3510, not part of this PR's diff.

---
**Update:** rebased onto the fix-master-build branch (#3510, still pending review) so CI runs clean here instead of inheriting master's current build break. The extra "restore missing strings import" commit will drop out of this diff once #3510 merges and this branch is rebased onto master again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control ID filters now ignore differences in capitalization and surrounding whitespace.
  * Include and skip filters apply consistently when matching framework controls.
  * Improved handling of unknown controls and rule exclusions during filtering.

* **Tests**
  * Added coverage for case-insensitive include and skip filter matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->