### PR TITLE
fix: restore missing strings import breaking master build

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Summary

Restores a missing `"strings"` import that currently breaks `go build ./...` on `master`.

Fixes #3509

## Root cause

#3492 removed the `strings` import from `core/pkg/resultshandling/printer/v2/policyreportprinter.go` because `SetWriter` stopped using `strings.*` directly. The file still uses `strings.Builder`/`strings.ToLower`/`strings.TrimRight` elsewhere (from #3470's identifier sanitization), so master currently fails to compile at all.

## Fix

One-line: add `"strings"` back to the import block.

## Test plan

```
$ go build ./...
# clean

$ go test ./...
ok  	... (all packages)
```

Also ran, scoped to the changed package:
- `go vet ./...` — clean
- `go test -race ./core/pkg/resultshandling/printer/v2/...` — clean
- `golangci-lint run --new-from-rev=upstream/master ./core/pkg/resultshandling/printer/v2/...` — 0 issues
- `gofmt -l` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed a minor internal maintenance update to support existing policy report sanitization.
  * No user-facing behavior, configuration, or workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->