### PR TITLE
fix(vap): refuse a parameter reference that does not match the bound policy's paramKind

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -112,30 +112,9 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// A policy that declares a paramKind needs a ParamRef on its binding
-			// to be functional, so refuse to emit a silently broken binding. The
-			// check covers both flags: --control reads the paramKind off the
-			// control's policy, --policy off the named policy (a name outside
-			// the embedded bundle is left unchecked — we know nothing about it).
 			normalizedControlID := strings.ToUpper(strings.TrimSpace(controlID))
-			if parameterReference == "" {
-				if normalizedControlID != "" {
-					paramKind, err := cel.ParamKindForControl(normalizedControlID)
-					if err != nil {
-						return err
-					}
-					if paramKind != nil {
-						return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", normalizedControlID)
-					}
-				} else {
-					paramKind, found, err := cel.ParamKindForPolicy(resolvedPolicyName)
-					if err != nil {
-						return err
-					}
-					if found && paramKind != nil {
-						return fmt.Errorf("policy %s requires --parameter-reference because it uses params", resolvedPolicyName)
-					}
-				}
+			if err := checkParameterReference(parameterReference, normalizedControlID, resolvedPolicyName); err != nil {
+				return err
 			}
 			if err := isValidK8sObjectName(resolvedPolicyName); err != nil {
 				return fmt.Errorf("invalid policy name %s: %w", resolvedPolicyName, err)
@@ -502,6 +481,40 @@ func validateRuleSegment(kind string, value string, validate func(string) []stri
 		return fmt.Errorf("invalid %s %q: %s", kind, value, strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// checkParameterReference refuses a --parameter-reference that does not agree
+// with the bound policy's spec.paramKind. A policy declaring one needs a ParamRef
+// on its binding to be functional, so emitting a binding without one is silently
+// broken.
+func checkParameterReference(parameterReference, controlID, policyName string) error {
+	paramKind, err := policyParamKind(controlID, policyName)
+	if err != nil {
+		return err
+	}
+	if parameterReference == "" && paramKind != nil {
+		if controlID != "" {
+			return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", controlID)
+		}
+		return fmt.Errorf("policy %s requires --parameter-reference because it uses params", policyName)
+	}
+	return nil
+}
+
+// policyParamKind resolves the bound policy's spec.paramKind, nil when it takes
+// no params. The lookup mirrors policyMatchConstraints: --control reads it off
+// the control's policy, --policy off the named one, and a policy we know nothing
+// about — a name outside the embedded bundle — is left unchecked rather than
+// blocked.
+func policyParamKind(controlID, policyName string) (*admissionv1.ParamKind, error) {
+	if controlID != "" {
+		return cel.ParamKindForControl(controlID)
+	}
+	paramKind, found, err := cel.ParamKindForPolicy(policyName)
+	if err != nil || !found {
+		return nil, err
+	}
+	return paramKind, nil
 }
 
 // checkResourceRulesInPolicyScope refuses a --resource-rule the bound policy can

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -41,6 +41,8 @@ var vapHelperCmdExamples = fmt.Sprintf(`
   %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --action Audit --action Warn | kubectl apply -f -
   # Narrow a policy binding to specific resources, including custom ones
   %[1]s vap create-policy-binding --name my-policy-binding --control C-0016 --resource-rule apps/v1/deployments --resource-rule /v1/pods | kubectl apply -f -
+  # Bind a control that reads params, pointing it at the object it takes
+  %[1]s vap create-policy-binding --name my-policy-binding --control C-0009 --parameter-reference basic-control-configuration | kubectl apply -f -
 `, cautils.ExecName())
 
 func GetVapHelperCmd() *cobra.Command {
@@ -156,7 +158,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringSliceVarP(&actionArr, "action", "a", []string{string(admissionv1.Deny)}, "Action to take when policy fails, repeatable (Deny, Warn, Audit). Deny and Warn cannot be combined")
 	createPolicyBindingCmd.Flags().StringSliceVar(&resourceRuleArr, "resource-rule", []string{}, "Restrict the binding to a group/version/resource the policy already matches, repeatable (e.g. apps/v1/deployments, /v1/pods). Omit to bind everything the policy matches")
-	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Parameter reference object name")
+	createPolicyBindingCmd.Flags().StringVarP(&parameterReference, "parameter-reference", "r", "", "Name of the object the policy reads as params. Required for a policy declaring a paramKind, and rejected for one that declares none")
 	createPolicyBindingCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
 
 	return createPolicyBindingCmd

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -487,18 +487,31 @@ func validateRuleSegment(kind string, value string, validate func(string) []stri
 // with the bound policy's spec.paramKind. A policy declaring one needs a ParamRef
 // on its binding to be functional, so emitting a binding without one is silently
 // broken.
+//
+// The refusal names the paramKind because the library no longer takes only one:
+// most policies want the ControlConfiguration it ships, but C-0281 wants an
+// ate.dev WorkerPool. "uses params" alone sent the caller to the wrong object,
+// which the apiserver accepts and then resolves to nothing.
 func checkParameterReference(parameterReference, controlID, policyName string) error {
 	paramKind, err := policyParamKind(controlID, policyName)
 	if err != nil {
 		return err
 	}
 	if parameterReference == "" && paramKind != nil {
-		if controlID != "" {
-			return fmt.Errorf("control %s requires --parameter-reference because its CEL policy uses params", controlID)
-		}
-		return fmt.Errorf("policy %s requires --parameter-reference because it uses params", policyName)
+		return fmt.Errorf("%s requires --parameter-reference naming an object of kind %s %s, which its CEL policy takes as params",
+			describeBoundPolicy(controlID, policyName), paramKind.APIVersion, paramKind.Kind)
 	}
 	return nil
+}
+
+// describeBoundPolicy names the binding's target the way the caller asked for it,
+// so a refusal echoes the flag that was typed rather than a resolved name they
+// never mentioned.
+func describeBoundPolicy(controlID, policyName string) string {
+	if controlID != "" {
+		return "control " + controlID
+	}
+	return "policy " + policyName
 }
 
 // policyParamKind resolves the bound policy's spec.paramKind, nil when it takes

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -492,14 +492,26 @@ func validateRuleSegment(kind string, value string, validate func(string) []stri
 // most policies want the ControlConfiguration it ships, but C-0281 wants an
 // ate.dev WorkerPool. "uses params" alone sent the caller to the wrong object,
 // which the apiserver accepts and then resolves to nothing.
+//
+// The reverse is refused too. A policy declaring no paramKind has the apiserver
+// ignore the binding's ParamRef outright and evaluate the rules without params,
+// so a caller who narrowed a control by pointing at a configuration object got a
+// binding enforcing the library defaults instead, with nothing saying so.
 func checkParameterReference(parameterReference, controlID, policyName string) error {
-	paramKind, err := policyParamKind(controlID, policyName)
+	paramKind, known, err := policyParamKind(controlID, policyName)
 	if err != nil {
 		return err
 	}
-	if parameterReference == "" && paramKind != nil {
+	if !known {
+		return nil
+	}
+	switch {
+	case parameterReference == "" && paramKind != nil:
 		return fmt.Errorf("%s requires --parameter-reference naming an object of kind %s %s, which its CEL policy takes as params",
 			describeBoundPolicy(controlID, policyName), paramKind.APIVersion, paramKind.Kind)
+	case parameterReference != "" && paramKind == nil:
+		return fmt.Errorf("%s takes no --parameter-reference: its CEL policy declares no paramKind, so the apiserver would ignore the binding's paramRef and evaluate the rules without params",
+			describeBoundPolicy(controlID, policyName))
 	}
 	return nil
 }
@@ -516,18 +528,22 @@ func describeBoundPolicy(controlID, policyName string) string {
 
 // policyParamKind resolves the bound policy's spec.paramKind, nil when it takes
 // no params. The lookup mirrors policyMatchConstraints: --control reads it off
-// the control's policy, --policy off the named one, and a policy we know nothing
-// about — a name outside the embedded bundle — is left unchecked rather than
-// blocked.
-func policyParamKind(controlID, policyName string) (*admissionv1.ParamKind, error) {
+// the control's policy, --policy off the named one.
+//
+// known reports whether the policy is in the embedded bundle at all. A name from
+// outside it (--policy pointing at a custom policy) tells us nothing about the
+// params it takes, so both directions of the check have to stay off it rather
+// than read the absent paramKind as "takes none". A control that is absent is an
+// error from the lookup instead, so a resolved control is always known.
+func policyParamKind(controlID, policyName string) (paramKind *admissionv1.ParamKind, known bool, err error) {
 	if controlID != "" {
-		return cel.ParamKindForControl(controlID)
+		paramKind, err := cel.ParamKindForControl(controlID)
+		if err != nil {
+			return nil, false, err
+		}
+		return paramKind, true, nil
 	}
-	paramKind, found, err := cel.ParamKindForPolicy(policyName)
-	if err != nil || !found {
-		return nil, err
-	}
-	return paramKind, nil
+	return cel.ParamKindForPolicy(policyName)
 }
 
 // checkResourceRulesInPolicyScope refuses a --resource-rule the bound policy can

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -803,6 +803,83 @@ func TestCreatePolicyBindingCmdValidation(t *testing.T) {
 		err := cmd.Execute()
 		assert.NoError(t, err)
 	})
+
+	t.Run("non-parameterized control refuses a parameter reference", func(t *testing.T) {
+		// C-0016 declares no paramKind, so the apiserver ignores the paramRef
+		// and evaluates without params. This used to emit that binding silently,
+		// leaving the caller believing the reference had configured the control.
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0016", "--parameter-reference", "basic-control-configuration"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "takes no --parameter-reference")
+	})
+
+	t.Run("non-parameterized policy by name refuses a parameter reference", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "kubescape-c-0016-allow-privilege-escalation", "--parameter-reference", "basic-control-configuration"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "takes no --parameter-reference")
+	})
+
+	t.Run("policy name outside the bundle accepts a parameter reference", func(t *testing.T) {
+		// Neither direction of the check may fire on a policy we know nothing
+		// about: its paramKind is unreadable, not absent.
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--policy", "some-custom-policy", "--parameter-reference", "my-params"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("params refusal names the paramKind the policy takes", func(t *testing.T) {
+		// C-0281 takes an ate.dev WorkerPool, not the ControlConfiguration the
+		// library ships, so the refusal has to say which kind to point at.
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0281"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ate.dev/v1alpha1 WorkerPool")
+	})
+
+	t.Run("params refusal names the shipped ControlConfiguration kind", func(t *testing.T) {
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0009"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kubescape.io/v1 ControlConfiguration")
+	})
+}
+
+func TestPolicyParamKind(t *testing.T) {
+	t.Run("control resolves its paramKind and is always known", func(t *testing.T) {
+		paramKind, known, err := policyParamKind("C-0281", "")
+		require.NoError(t, err)
+		assert.True(t, known)
+		require.NotNil(t, paramKind)
+		assert.Equal(t, "ate.dev/v1alpha1", paramKind.APIVersion)
+		assert.Equal(t, "WorkerPool", paramKind.Kind)
+	})
+
+	t.Run("non-parameterized control is known with no paramKind", func(t *testing.T) {
+		paramKind, known, err := policyParamKind("C-0016", "")
+		require.NoError(t, err)
+		assert.True(t, known)
+		assert.Nil(t, paramKind)
+	})
+
+	t.Run("control absent from the bundle errors instead of reading as unknown", func(t *testing.T) {
+		_, known, err := policyParamKind("C-9999", "")
+		require.Error(t, err)
+		assert.False(t, known)
+	})
+
+	t.Run("policy outside the bundle is not known", func(t *testing.T) {
+		paramKind, known, err := policyParamKind("", "some-custom-policy")
+		require.NoError(t, err)
+		assert.False(t, known)
+		assert.Nil(t, paramKind)
+	})
 }
 
 func TestGetDeployLibraryCmd(t *testing.T) {


### PR DESCRIPTION
`kubescape vap create-policy-binding` already refuses to emit a binding when the policy being bound declares a `spec.paramKind` and no parameter reference was given, since that binding is broken the moment the apiserver evaluates it. The opposite case was never checked. Pass a `parameter-reference` for a policy that declares no paramKind and the command happily writes a binding carrying a `paramRef`, which the Kubernetes API contract then throws away:

> If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.

So you end up with a binding enforcing the library defaults while believing you pointed the control at your own configuration object, and nothing tells you otherwise. Same class of silent misconfiguration as #3468, where the label selector was being quietly rewritten.

The other thing that bothered me here was the wording of the existing refusal. It said the policy "uses params" and stopped there. That read fine while every parameterized policy in the bundle wanted the `ControlConfiguration` the library ships, but that stopped being true when C-0281 landed in #3466 taking params of kind `ate.dev/v1alpha1 WorkerPool`. Anyone hitting that refusal would reasonably reach for `basic-control-configuration`, the only params object the library installs, and the apiserver would accept the binding and then resolve the reference to nothing. The refusal now names the kind it wants, so C-0281 says up front that it needs a WorkerPool.

Both directions read the paramKind through a single helper that mirrors the existing `policyMatchConstraints` seam, so the `control` path and the `policy` path cannot drift apart again.

The detail most likely to regress is that a policy name from outside the embedded bundle has to stay exempt from both checks. Its paramKind is unreadable rather than absent, so treating a missed lookup as "takes no params" would start rejecting perfectly good bindings against custom policies. That is why the helper reports whether the policy was found at all instead of collapsing the miss into a nil paramKind, and there is a test pinning it.

I confirmed the new tests fail against master before the fix and pass after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a parameter-reference example to the VAP command help.
  - Improved validation for policies that require parameters, including clearer error messages showing the expected parameter type.

- **Bug Fixes**
  - VAP now rejects parameter references for policies that do not support them.
  - References to unknown external policies continue to be handled appropriately.
  - Validation now consistently supports parameterized controls and embedded policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->